### PR TITLE
Stop harness promotion without measured gain

### DIFF
--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -462,7 +462,8 @@ def optimize(
         _console.print(f"  \\[{tag}] {escape(variant)}: success_rate={score:.3f} {state}")
 
     def _note(message: str) -> None:
-        # Dead proposals narrate here; scored proposals use the structured callback below.
+        # Lightweight search notes narrate dead proposals and perfect-score early stops.
+        # Scored proposals use the structured callback below.
         _console.print(f"  [dim]{message}[/dim]")
 
     def _proposal(record: ProposalRecord) -> None:

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -501,10 +501,16 @@ def optimize(
         on_note=_note,
         on_proposal=_proposal,
     )
-    saved = store.save_version(result.best, alias=CHAMPION_ALIAS)
+    champion_version = store.aliases(name).get(CHAMPION_ALIAS)
+    current = (
+        store.load(name, str(champion_version)) if champion_version is not None else None
+    )
+    unchanged = current is not None and current.doc_hash == result.best.doc_hash
+    saved = current if unchanged else store.save_version(result.best, alias=CHAMPION_ALIAS)
     selected = len(result.archive.accepted())
+    publication = "unchanged" if unchanged else "created"
     _console.print(
-        f"[green]created[/green] [bold]{name}[/bold] v{saved.version} (champion) "
+        f"[green]{publication}[/green] [bold]{name}[/bold] v{saved.version} (champion) "
         f"success_rate={result.best_score:.3f}: {len(result.archive.deltas)} delta(s) audited, "
         f"{selected} selected, {result.skipped} skipped -> {store.dir_for(name)}"
     )

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -28,7 +28,7 @@ from wmo.harness.population import CandidateProposal, EvaluatedCandidate, candid
 from wmo.harness.proposer import ProviderDeltaProposer
 from wmo.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
 from wmo.harness.source_tree import HarnessSourceFile, HarnessSourceTree
-from wmo.harness.store import HarnessStore
+from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmo.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 # The Typer object `harness_app` shadows the submodule name on plain attribute access; go
@@ -298,6 +298,8 @@ def test_create_default_local_loads_the_world_model(
     assert call["eval_concurrency"] is None  # backend default decided downstream (local -> 1)
     assert call["e2b_template"] is None
     flat = " ".join(result.output.split())
+    assert HarnessStore(project_root / ".wmo").versions("made") == [1]
+    assert "created made v1 (champion)" in flat
     assert "world model" in flat and "wm-alpha" in flat
     assert "sandbox" not in flat  # no sandbox note on the local path
     expected = shlex.join(
@@ -319,6 +321,44 @@ def test_create_default_local_loads_the_world_model(
     )
     assert expected in flat
     assert "--harness-backend" not in flat  # and the run-it hint stays plain
+
+
+def test_unchanged_search_reuses_the_destination_champion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A no-gain run must not append an identical immutable version."""
+    recorder = _CreateRecorder()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    _patch_load(monkeypatch, object(), _Provider())
+    store = HarnessStore(tmp_path / ".wmo")
+    original = store.save_version(HarnessDoc.baseline("made"), alias=CHAMPION_ALIAS)
+
+    result = _invoke(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    assert store.versions("made") == [original.version]
+    assert store.aliases("made") == {CHAMPION_ALIAS: original.version}
+    flat = " ".join(result.output.split())
+    assert "unchanged made v1 (champion)" in flat
+    assert "created made" not in flat
+
+
+def test_unchanged_search_publishes_when_the_destination_has_no_champion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Latest is only a load fallback, not an existing champion publication."""
+    recorder = _CreateRecorder()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    _patch_load(monkeypatch, object(), _Provider())
+    store = HarnessStore(tmp_path / ".wmo")
+    store.save_version(HarnessDoc.baseline("made"))
+
+    result = _invoke(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    assert store.versions("made") == [1, 2]
+    assert store.aliases("made") == {CHAMPION_ALIAS: 2}
+    assert "created made v2 (champion)" in " ".join(result.output.split())
 
 
 def test_optimize_accepts_world_model_as_second_argument(

--- a/wmo/harness/create.py
+++ b/wmo/harness/create.py
@@ -3,8 +3,8 @@
 Each iteration freezes the current champion, clusters its failures into mechanisms, and asks the
 proposer for a sibling batch of `HarnessDelta` objects against one size-weighted,
 expansion-discounted cluster. Every sibling is applied and evaluated against that same frozen
-champion. After the full batch resolves, at most one gate-eligible sibling becomes the next
-iteration's champion:
+champion. After the full batch resolves, at most one gate-eligible, strictly improving sibling
+becomes the next iteration's champion:
 
 - **Tier 1 — regression suite**: the child's score on the suite (tasks the search has already
   mastered) must not drop below the champion's. Newly-passing tasks promote into the suite on
@@ -14,10 +14,12 @@ iteration's champion:
   the champion on tasks the proposer never saw evidence from.
 
 Ties pass every gate tier: with k passes per task, scores are coarse, and "no worse" is the
-eligibility contract. When multiple siblings are eligible, full success wins, then assertion
-fraction, then lower proposal index. Every proposed delta, whether selected, rejected, or invalid
-before eval, is recorded in the archive with its verdict. The run as a whole is only as
-reproducible as its providers because proposals and rollouts sample real models at temperature.
+eligibility contract. Promotion still requires a strict gain in full success or, when success
+ties, full assertion fraction. When multiple improving siblings are eligible, full success wins,
+then assertion fraction, then lower proposal index. Every proposed delta, whether selected,
+rejected, or invalid before eval, is recorded in the archive with its verdict. The run as a whole
+is only as reproducible as its providers because proposals and rollouts sample real models at
+temperature.
 """
 
 from __future__ import annotations
@@ -95,7 +97,7 @@ class ProposalRecord(BaseModel):
 
     A dead proposal (every outcome but ``scored``) ends before a full-split evaluation. Scored
     proposals distinguish gate eligibility from final selection: several siblings may satisfy
-    the frozen non-regression gate, but only the best eligible sibling is selected. The
+    the frozen non-regression gate, but only the best strictly improving sibling is selected. The
     ``champion_score`` is always the frozen pre-iteration champion score, which is the comparison
     baseline and the honest plotting level for a dead proposal.
     """
@@ -148,7 +150,7 @@ class CreateResult(BaseModel):
     proposal_records: list[ProposalRecord] = Field(default_factory=list)
     screened: int = 0  # deltas rejected at the cheap trigger-cluster screen (no full eval spent)
     confirmations: int = 0  # narrow vetoes retried at higher k (see `narrow_failing_tiers`)
-    iterations: int = 0
+    iterations: int = 0  # proposal batches completed before budget exhaustion or a perfect score
     proposal_batch_size: int = 1
     # Spend meters over the WHOLE search (seed, screens, full splits, holdout, confirmations).
     # worker_usage: worker-LLM tokens from self-metering runtimes (the pi worker path; None on
@@ -382,6 +384,22 @@ def gate_delta(
     )
 
 
+def _is_perfect(report: ClosedLoopReport) -> bool:
+    """Return whether every task and every assertion passed."""
+    return (
+        report.success_rate >= 1.0 - _TIE_EPS
+        and report.mean_fraction >= 1.0 - _TIE_EPS
+    )
+
+
+def _strictly_improves_full_objective(verdict: GateRecord) -> bool:
+    """Require positive full-split evidence after non-regression gates pass."""
+    return verdict.full_delta > _TIE_EPS or (
+        abs(verdict.full_delta) <= _TIE_EPS
+        and verdict.full_fraction_delta > _TIE_EPS
+    )
+
+
 def create_harness(
     name: str,
     seed_doc: HarnessDoc,
@@ -415,9 +433,10 @@ def create_harness(
     (unusable, invalid, or screened out on its trigger cluster) ends early and cheaply. It is
     counted, recorded in ``proposal_records``, and narrated via ``on_note`` without aborting its
     siblings. ``on_proposal`` receives every final record in stable proposal order after
-    selection. ``on_progress`` receives the seed plus exactly one champion point per iteration,
-    including an unchanged point when no proposal wins. ``on_accept`` fires at most once per
-    iteration with the selected champion, its final delta verdict, and its full-suite score.
+    selection. ``on_progress`` receives the seed plus exactly one champion point per completed
+    iteration, including an unchanged point when no proposal wins. A perfect champion stops the
+    search before another proposal batch is bought. ``on_accept`` fires at most once per iteration
+    with the selected champion, its final delta verdict, and its full-suite score.
     ``on_note`` is an eager diagnostic stream, so dead-proposal and feedback-error notes may fire
     while siblings are still evaluating. ``on_proposal`` waits for batch selection and then fires
     in stable proposal order. The iteration's ``on_progress`` checkpoint follows those records.
@@ -576,6 +595,7 @@ def create_harness(
         )
 
         proposal_records: list[ProposalRecord] = []
+        completed_iterations = 0
 
         def _stage_dead(records: list[ProposalRecord], record: ProposalRecord) -> None:
             """Stage one dead proposal for ordered publication after batch selection."""
@@ -590,15 +610,22 @@ def create_harness(
 
         for iteration_index in range(1, iterations + 1):
             _check_cancelled()
+            frozen_champion_hash = champion_hash
+            parent = docs[frozen_champion_hash]
+            parent_report = reports[frozen_champion_hash]
+            if _is_perfect(parent_report):
+                subject = "seed" if completed_iterations == 0 else "champion"
+                _note(
+                    f"{subject} already passes every task and assertion; "
+                    "stopping before proposals"
+                )
+                break
             # Eval runners from the previous iteration would otherwise sit idle through the
             # potentially long proposer call. Sibling score waves still share the newly warmed
             # pool for this whole iteration.
             if sandbox_pool is not None:
                 sandbox_pool.retire_idle()
 
-            frozen_champion_hash = champion_hash
-            parent = docs[frozen_champion_hash]
-            parent_report = reports[frozen_champion_hash]
             frozen_champion_score = parent_report.success_rate
             frozen_best_full = best_full
             frozen_suite = list(suite)
@@ -987,16 +1014,21 @@ def create_harness(
 
             _check_cancelled()
             eligible = [candidate for candidate in scored_proposals if candidate.gate.accepted]
+            improving = [
+                candidate
+                for candidate in eligible
+                if _strictly_improves_full_objective(candidate.gate)
+            ]
             winner = (
                 max(
-                    eligible,
+                    improving,
                     key=lambda candidate: (
                         candidate.report.success_rate,
                         candidate.report.mean_fraction,
                         -candidate.proposal_index,
                     ),
                 )
-                if eligible
+                if improving
                 else None
             )
             for candidate in scored_proposals:
@@ -1004,15 +1036,22 @@ def create_harness(
                 if winner is candidate:
                     final_gate = candidate.gate
                 elif gate_eligible:
-                    assert winner is not None
+                    if not _strictly_improves_full_objective(candidate.gate):
+                        selection_reason = (
+                            "gate eligible but not selected: no measured improvement over "
+                            "the champion"
+                        )
+                    else:
+                        assert winner is not None
+                        selection_reason = (
+                            "gate eligible but not selected: "
+                            f"proposal {winner.proposal_index} ranked higher by full success, "
+                            "assertion fraction, then proposal order"
+                        )
                     final_gate = candidate.gate.model_copy(
                         update={
                             "accepted": False,
-                            "reason": (
-                                "gate eligible but not selected: "
-                                f"proposal {winner.proposal_index} ranked higher by full success, "
-                                "assertion fraction, then proposal order | " + candidate.gate.reason
-                            ),
+                            "reason": selection_reason + " | " + candidate.gate.reason,
                         }
                     )
                 else:
@@ -1070,6 +1109,7 @@ def create_harness(
                     reports[champion_hash].success_rate,
                     winner is not None,
                 )
+            completed_iterations = iteration_index
 
         _check_cancelled()
         best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
@@ -1084,7 +1124,7 @@ def create_harness(
             proposal_records=proposal_records,
             screened=screened,
             confirmations=confirmations,
-            iterations=iterations,
+            iterations=completed_iterations,
             proposal_batch_size=proposal_batch_size,
             worker_usage=combine_usage(worker_usages),
         )

--- a/wmo/harness/create_test.py
+++ b/wmo/harness/create_test.py
@@ -213,26 +213,36 @@ def test_archive_reconstructs_children_by_folding_deltas() -> None:
         result.archive.reconstruct("0" * 32)
 
 
-def test_create_rejects_regressing_delta_and_keeps_champion() -> None:
-    # The seed already passes; the proposed prompt makes the agent submit a broken answer.
+def test_create_stops_before_proposing_when_seed_is_perfect() -> None:
+    """A perfect seed needs no candidate spend and must remain the champion."""
     seed = HarnessDoc.baseline("seed")
     provider = RoleProvider(
         meta_reply=_meta_reply(seed, "You are a broken agent."),
         judge_fn=lambda user: "done-broken" not in user,
     )
-    result = _run(provider)
+    progress: list[tuple[int, str, float, bool]] = []
+    crowned: list[str] = []
+    notes: list[str] = []
+    result = _run(
+        provider,
+        iterations=3,
+        on_progress=lambda i, n, r, a: progress.append((i, n, r, a)),
+        on_accept=lambda doc, delta, score: crowned.append(doc.doc_hash),
+        on_note=notes.append,
+    )
 
     assert result.skipped == 0
-    [delta] = result.archive.deltas
-    assert delta.verdict is not None and not delta.verdict.accepted
-    assert "full split" in delta.verdict.reason
+    assert provider.meta_users == []
+    assert result.archive.deltas == []
     assert result.archive.accepted() == []
-    # The champion never moved: the winner is the (renamed) seed at its original score.
     assert result.best_score == 1.0
     assert result.best.system_prompt() == seed.system_prompt()
-    assert result.suite == ["t1"]  # and the suite kept the seed's win
-    # An all-pass parent gets the generalization trigger, not a fabricated failure.
-    assert delta.trigger.mechanism == "none: all tasks pass"
+    assert result.suite == ["t1"]
+    assert result.iterations == 0
+    assert len(result.reports) == 1
+    assert crowned == []
+    assert progress == [(0, "seed", 1.0, True)]
+    assert notes == ["seed already passes every task and assertion; stopping before proposals"]
 
 
 def test_create_skips_unusable_proposals() -> None:
@@ -715,6 +725,85 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
 
     assert verdict.accepted is True
     assert verdict.full_fraction_delta == pytest.approx(0.25)
+
+
+def test_exact_full_objective_tie_is_audited_but_not_promoted() -> None:
+    """Trigger progress cannot crown a child with zero net measured improvement."""
+
+    class ExactTieProvider(RoleProvider):
+        """Trade equal assertion credit between two still-failing tasks."""
+
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 2048,
+        ) -> Completion:
+            user = messages[-1].content
+            if "grade whether an agent completed a task" in system:
+                child = "done-verified" in user
+                target = "target task" in user
+                results = []
+                for assertion in _gold_assertions(user):
+                    passed = (
+                        child and target and assertion == "a target improvement"
+                    ) or (
+                        not child and not target and assertion == "kept partial credit"
+                    )
+                    results.append({"assertion": assertion, "passed": passed, "why": "x"})
+                return Completion(text=json.dumps({"assertions": results, "passed": False}))
+            return super().complete(
+                system,
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+
+    seed = HarnessDoc.baseline("seed")
+    provider = ExactTieProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    tasks = [
+        TaskSpec(
+            task_id="target",
+            instruction="target task",
+            gold=["a target improvement", "still incomplete"],
+        ),
+        TaskSpec(
+            task_id="other",
+            instruction="other task",
+            gold=["kept partial credit", "z still incomplete"],
+        ),
+    ]
+    crowned: list[str] = []
+
+    result = create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=1,
+        k=1,
+        on_accept=lambda doc, delta, score: crowned.append(doc.doc_hash),
+    )
+
+    [delta] = result.archive.deltas
+    [record] = result.proposal_records
+    assert record.outcome == "scored"
+    assert record.gate_eligible is True
+    assert record.selected is False
+    assert record.screen_child_fraction == pytest.approx(0.5)
+    assert record.screen_parent_fraction == 0.0
+    assert delta.verdict is not None and delta.verdict.accepted is False
+    assert delta.verdict.full_delta == 0.0
+    assert delta.verdict.full_fraction_delta == 0.0
+    assert "no measured improvement over the champion" in delta.verdict.reason
+    assert result.archive.accepted() == []
+    assert result.best.system_prompt() == seed.system_prompt()
+    assert crowned == []
 
 
 def test_search_records_screen_and_full_trace_feedback_for_project_proposers() -> None:
@@ -1729,8 +1818,9 @@ class _RankedMetaProvider(_SequencedMetaProvider):
 class _ParentRecordingProposer:
     """Propose against the live parent and remember each iteration's parent hash."""
 
-    def __init__(self) -> None:
+    def __init__(self, prompts: list[str]) -> None:
         self.parent_hashes: list[str] = []
+        self.prompts = prompts
 
     def propose_batch(
         self,
@@ -1744,7 +1834,7 @@ class _ParentRecordingProposer:
     ) -> list[HarnessDelta | ProposalFailure | None]:
         del evidence, history, should_cancel
         self.parent_hashes.append(parent.doc_hash)
-        prompt = f"{_CAREFUL_PROMPT} Iteration {len(self.parent_hashes)}."
+        prompt = self.prompts[len(self.parent_hashes) - 1]
         proposal = parse_delta(parent, trigger, _meta_reply(parent, prompt))
         assert proposal is not None and count == 1
         return [proposal]
@@ -2074,28 +2164,36 @@ def test_sibling_holdout_gates_use_frozen_iteration_champion(
     assert [record.selected for record in result.proposal_records] == [True, False]
 
 
-def test_next_iteration_proposes_from_previous_iteration_winner() -> None:
-    """The selected winner is the next parent, with no stepping-stone parent pool."""
+def test_next_iteration_uses_winner_then_stops_when_perfect() -> None:
+    """Search advances through an improving parent and buys nothing after perfection."""
     seed = HarnessDoc.baseline("seed")
-    provider = RoleProvider()
-    proposer = _ParentRecordingProposer()
+    provider = _RankedMetaProvider([])
+    proposer = _ParentRecordingProposer(
+        ["You are a weak agent.", "You are a strong agent."]
+    )
+    tasks = [
+        TaskSpec(task_id="t1", instruction="task one", gold=["the work completed"]),
+        TaskSpec(task_id="t2", instruction="task two", gold=["the work completed"]),
+    ]
 
     result = create_harness(
         "winner",
         seed,
-        _tasks(),
+        tasks,
         _wm(provider),
         provider,
         proposer,
         GoldJudge(provider),
-        iterations=2,
+        iterations=3,
         proposal_batch_size=1,
     )
 
     assert len(result.archive.accepted()) == 2
     first_winner_hash = result.proposal_records[0].candidate_doc_hash
+    assert first_winner_hash is not None
     assert proposer.parent_hashes == [seed.doc_hash, first_winner_hash]
     assert [record.selected for record in result.proposal_records] == [True, True]
+    assert result.iterations == 2
 
 
 def test_on_accept_delivers_the_new_champion_the_moment_it_is_crowned() -> None:


### PR DESCRIPTION
## Summary

- stop world-model harness search before another proposal batch when the seed or current champion passes every task and assertion
- keep exact ties eligible for non-regression gates, but require a strict gain in full success or full assertion fraction before promotion
- preserve honest proposal records and delta verdicts when a candidate passes gates but has zero measured gain
- report the number of proposal batches actually completed after an early perfect-score stop
- reuse an identical current destination champion instead of appending and repointing a duplicate immutable version

## Root cause

The non-regression gate treated exact ties as accepted, and winner selection promoted every accepted candidate. An all-pass seed therefore triggered a generalization proposal, spent on candidate rollouts, and moved the champion even when every measured delta was zero. After the search stopped correctly, the CLI publication path still appended the unchanged result unconditionally.

## User impact

A perfect seed now performs only its seed evaluation. The optimizer emits a clear early-stop note, makes no proposer call, and archives no candidate delta. Non-perfect searches still preserve trigger screening, regression-suite, full-split, holdout, confirmation, and sibling-ranking behavior. Exact zero-gain candidates remain visible as gate eligible but are not selected or added to accepted lineage.

When the destination already has an explicit champion alias with the same document hash, the command reports it unchanged and reuses that immutable version without moving the alias. Fresh output names and destinations with no champion alias still publish normally.

## Validation

- focused harness and CLI suite: 101 passed
- full repository suite: 4,478 passed, 20 skipped
- `uv run ruff check .`
- `uv run ty check`
- local OpenAI-compatible stub CLI run: perfect seed stopped before proposals, wrote an empty delta archive, and produced no meta-agent request