### PR TITLE
Reuse completed route sweep matrices

### DIFF
--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -411,12 +411,12 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     )
     try:
         # A stage decision to run is explicit replacement authority for this pipeline's fixed
-        # matrix path. If the stage is current, the completed matrix instead participates in
-        # resume and is validated before the plan table or any spend question.
+        # matrix path. A skipped sweep does not resume anything: its manifest already established
+        # that the completed matrix is current, and older identity-less matrices must remain
+        # usable by downstream stages after an upgrade.
         replace_completed_sweep = _will_sweep(decisions)
-        already_measured = resumable_cells(
-            plan,
-            replace_completed=replace_completed_sweep,
+        already_measured = (
+            resumable_cells(plan, replace_completed=True) if replace_completed_sweep else 0
         )
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -774,17 +774,11 @@ def _live_inputs(
     match stage:
         case Stage.SWEEP:
             return _StageInputs(
-                fingerprint={
-                    "pool": file_sha256(pool_file),
-                    "scenarios": _scenario_identity(plan),
-                    "episodes": str(plan.episodes),
-                    "max_steps": str(plan.max_steps),
-                    # A matrix's rewards belong to ONE D-COMPRESS arm, so a changed compressor
-                    # means different evidence and the cells have to be bought again. This is the
-                    # fingerprint that makes `--compressor` re-measure rather than reuse cells
-                    # that ran under a different arm.
-                    "compression": compression_signature(plan.compression),
-                },
+                fingerprint=_sweep_fingerprint(
+                    plan,
+                    pool_file,
+                    complete_identity=_matrix_has_complete_sweep_identity(paths.matrix),
+                ),
                 artifact=paths.matrix,
                 artifact_identity=file_sha256(paths.matrix),
                 skip_summary="same pool, same scenarios, same episodes",
@@ -853,6 +847,57 @@ def _report_anchor(policy_path: Path, *, baseline: str | None, fallback: str | N
 def _scenario_identity(plan: SweepPlan) -> str:
     """The scenario SET the sweep will measure, as an id list a change is visible in."""
     return ",".join(scenario_id(scenario) for scenario in plan.scenarios)
+
+
+def _sweep_fingerprint(
+    plan: SweepPlan,
+    pool_file: Path,
+    *,
+    complete_identity: bool = True,
+) -> dict[str, str]:
+    """Inputs that decide whether `optimize model` must buy the sweep again.
+
+    The original keys stay unchanged for a legacy matrix with no complete sweep identity. Its
+    existing manifest can therefore keep skipping the paid stage while fit/report consume it.
+    Every newly written matrix adds the content identities, so changed instructions, tool hints,
+    corpus, config, runtime files, or history window rerun the sweep instead of silently reusing
+    stale evidence.
+    """
+    fingerprint = {
+        "pool": file_sha256(pool_file),
+        "scenarios": _scenario_identity(plan),
+        "episodes": str(plan.episodes),
+        "max_steps": str(plan.max_steps),
+        "compression": compression_signature(plan.compression),
+    }
+    if complete_identity:
+        identity = plan.identity
+        fingerprint.update(
+            {
+                "scenario_content": identity.scenario_content,
+                "tools_hint": identity.tools_hint,
+                "corpus": identity.corpus,
+                "world_model": identity.world_model,
+                "history_chars": str(identity.history_chars),
+            }
+        )
+    return fingerprint
+
+
+def _matrix_has_complete_sweep_identity(path: Path) -> bool:
+    """Whether a matrix can participate in the expanded optimizer fingerprint.
+
+    Missing and unreadable outputs are replacement cases, so they use the current fingerprint.
+    A readable legacy output keeps the old fingerprint shape solely to preserve downstream use;
+    active route-sweep resume still refuses it because unknown paid rows cannot be merged safely.
+    """
+    if not path.is_file():
+        return True
+    try:
+        identity = OutcomeMatrix.load(path).sweep_identity
+    except (OSError, ValueError):
+        return True
+    return identity is not None and identity.complete
 
 
 def _policy_fit_identity(policy_path: Path) -> str:
@@ -1253,13 +1298,7 @@ def _stage_sweep(
     print_world_model_spend(_console, run)
     record = StageRecord(
         stage=Stage.SWEEP,
-        fingerprint={
-            "pool": file_sha256(pool_file),
-            "scenarios": _scenario_identity(plan),
-            "episodes": str(plan.episodes),
-            "max_steps": str(plan.max_steps),
-            "compression": compression_signature(plan.compression),
-        },
+        fingerprint=_sweep_fingerprint(plan, pool_file),
         artifact_path=str(plan.out_path),
         artifact_identity=file_sha256(plan.out_path),
         completed_at=_now(),

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -443,6 +443,14 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         _console.print("\ndry run: nothing was run and nothing was spent")
         raise typer.Exit(0)
 
+    manifest = _migrate_legacy_sweep_fingerprint(
+        manifest,
+        decisions=decisions,
+        paths=paths,
+        plan=plan,
+        pool_file=Path(pool_file),
+    )
+
     # One throwaway embedding before anything is bought, and only when a fit will actually happen:
     # `--embedder auto` turns the mere presence of AZURE_OPENAI_* into a network dependency, and
     # those variables routinely point at a resource that serves chat but hosts no embedding
@@ -656,6 +664,10 @@ def _plan_stages(
     """
     decisions: list[StageDecision] = []
     running: Stage | None = None
+    sweep_record = manifest.record_for(Stage.SWEEP)
+    complete_sweep_identity = _matrix_has_complete_sweep_identity(
+        paths.matrix
+    ) or _sweep_record_has_content_identity(sweep_record)
     for stage in stages:
         if stage is Stage.PREFLIGHT:
             continue
@@ -679,6 +691,7 @@ def _plan_stages(
             baseline=baseline,
             cost_quality=cost_quality,
             allow_uneven=allow_uneven,
+            complete_sweep_identity=complete_sweep_identity,
         )
         decision = decide_stage(
             stage,
@@ -769,6 +782,7 @@ def _live_inputs(
     baseline: str | None,
     cost_quality: float,
     allow_uneven: bool,
+    complete_sweep_identity: bool,
 ) -> _StageInputs:
     """What `stage` would consume and produce right now, read off the filesystem."""
     match stage:
@@ -777,7 +791,7 @@ def _live_inputs(
                 fingerprint=_sweep_fingerprint(
                     plan,
                     pool_file,
-                    complete_identity=_matrix_has_complete_sweep_identity(paths.matrix),
+                    complete_identity=complete_sweep_identity,
                 ),
                 artifact=paths.matrix,
                 artifact_identity=file_sha256(paths.matrix),
@@ -882,6 +896,64 @@ def _sweep_fingerprint(
             }
         )
     return fingerprint
+
+
+_SWEEP_CONTENT_IDENTITY_KEYS = frozenset(
+    {"scenario_content", "tools_hint", "corpus", "world_model", "history_chars"}
+)
+
+
+def _sweep_record_has_content_identity(record: StageRecord | None) -> bool:
+    """Whether a sweep record already pins the post-upgrade measurement inputs."""
+    return record is not None and _SWEEP_CONTENT_IDENTITY_KEYS <= record.fingerprint.keys()
+
+
+def _migrate_legacy_sweep_fingerprint(
+    manifest: RunManifest,
+    *,
+    decisions: list[StageDecision],
+    paths: _RunPaths,
+    plan: SweepPlan,
+    pool_file: Path,
+) -> RunManifest:
+    """Snapshot today's inputs after one free skip of a legacy completed matrix.
+
+    A pre-identity matrix remains valid input to fit/report, and its existing manifest proves the
+    paid sweep is current under the old fingerprint. That grants exactly one compatibility skip.
+    Recording the expanded fingerprint now means future instruction, tool, corpus, model, or
+    history changes rerun the sweep instead of trusting that legacy exception forever. The matrix
+    itself stays identity-less, so direct active resume still refuses to merge unknown paid rows.
+    """
+    sweep_decision = next(
+        (decision for decision in decisions if decision.stage is Stage.SWEEP),
+        None,
+    )
+    record = manifest.record_for(Stage.SWEEP)
+    if (
+        sweep_decision is None
+        or sweep_decision.will_run
+        or record is None
+        or _matrix_has_complete_sweep_identity(paths.matrix)
+        or _sweep_record_has_content_identity(record)
+    ):
+        return manifest
+    migrated = record.model_copy(
+        update={"fingerprint": _sweep_fingerprint(plan, pool_file, complete_identity=True)}
+    )
+    updated = manifest.model_copy(
+        update={
+            "stages": [
+                migrated if existing.stage is Stage.SWEEP else existing
+                for existing in manifest.stages
+            ]
+        }
+    )
+    updated.save(paths.manifest)
+    _console.print(
+        "  recorded current content identity for the legacy matrix; this invocation keeps the "
+        "sweep free, and later measurement-input changes will re-run it"
+    )
+    return updated
 
 
 def _matrix_has_complete_sweep_identity(path: Path) -> bool:

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -412,8 +412,9 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     try:
         # A stage decision to run is explicit replacement authority for this pipeline's fixed
         # matrix path. A skipped sweep does not resume anything: its manifest already established
-        # that the completed matrix is current, and older identity-less matrices must remain
-        # usable by downstream stages after an upgrade.
+        # that the completed matrix is current. A readable identity-less matrix is still valid
+        # downstream data, but this orchestrator plans one consented replacement because it
+        # cannot prove which historical measurement inputs produced those rows.
         replace_completed_sweep = _will_sweep(decisions)
         already_measured = (
             resumable_cells(plan, replace_completed=True) if replace_completed_sweep else 0
@@ -442,14 +443,6 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     if dry_run:
         _console.print("\ndry run: nothing was run and nothing was spent")
         raise typer.Exit(0)
-
-    manifest = _migrate_legacy_sweep_fingerprint(
-        manifest,
-        decisions=decisions,
-        paths=paths,
-        plan=plan,
-        pool_file=Path(pool_file),
-    )
 
     # One throwaway embedding before anything is bought, and only when a fit will actually happen:
     # `--embedder auto` turns the mere presence of AZURE_OPENAI_* into a network dependency, and
@@ -664,10 +657,7 @@ def _plan_stages(
     """
     decisions: list[StageDecision] = []
     running: Stage | None = None
-    sweep_record = manifest.record_for(Stage.SWEEP)
-    complete_sweep_identity = _matrix_has_complete_sweep_identity(
-        paths.matrix
-    ) or _sweep_record_has_content_identity(sweep_record)
+    matrix_has_complete_identity = _matrix_has_complete_sweep_identity(paths.matrix)
     for stage in stages:
         if stage is Stage.PREFLIGHT:
             continue
@@ -691,7 +681,6 @@ def _plan_stages(
             baseline=baseline,
             cost_quality=cost_quality,
             allow_uneven=allow_uneven,
-            complete_sweep_identity=complete_sweep_identity,
         )
         decision = decide_stage(
             stage,
@@ -702,6 +691,15 @@ def _plan_stages(
             artifact_identity=live.artifact_identity,
             skip_summary=live.skip_summary,
         )
+        if stage is Stage.SWEEP and not matrix_has_complete_identity and stage not in redo:
+            decision = StageDecision(
+                stage=stage,
+                status=StageStatus.RUN,
+                reason=(
+                    f"{paths.matrix.name} has no complete sweep identity; one measured "
+                    "replacement is required"
+                ),
+            )
         decisions.append(decision)
         if decision.will_run:
             running = stage
@@ -782,17 +780,12 @@ def _live_inputs(
     baseline: str | None,
     cost_quality: float,
     allow_uneven: bool,
-    complete_sweep_identity: bool,
 ) -> _StageInputs:
     """What `stage` would consume and produce right now, read off the filesystem."""
     match stage:
         case Stage.SWEEP:
             return _StageInputs(
-                fingerprint=_sweep_fingerprint(
-                    plan,
-                    pool_file,
-                    complete_identity=complete_sweep_identity,
-                ),
+                fingerprint=_sweep_fingerprint(plan, pool_file),
                 artifact=paths.matrix,
                 artifact_identity=file_sha256(paths.matrix),
                 skip_summary="same pool, same scenarios, same episodes",
@@ -866,102 +859,36 @@ def _scenario_identity(plan: SweepPlan) -> str:
 def _sweep_fingerprint(
     plan: SweepPlan,
     pool_file: Path,
-    *,
-    complete_identity: bool = True,
 ) -> dict[str, str]:
     """Inputs that decide whether `optimize model` must buy the sweep again.
 
-    The original keys stay unchanged for a legacy matrix with no complete sweep identity. Its
-    existing manifest can therefore keep skipping the paid stage while fit/report consume it.
-    Every newly written matrix adds the content identities, so changed instructions, tool hints,
-    corpus, config, runtime files, or history window rerun the sweep instead of silently reusing
-    stale evidence.
+    Content identities make changed instructions, tool hints, corpus, config, runtime files, or
+    history window rerun the sweep instead of silently reusing stale evidence. Legacy manifests
+    lack these keys and legacy matrices lack a complete identity, so they get one explicit,
+    consented replacement rather than having unknown historical inputs blessed as current.
     """
+    identity = plan.identity
     fingerprint = {
         "pool": file_sha256(pool_file),
         "scenarios": _scenario_identity(plan),
         "episodes": str(plan.episodes),
         "max_steps": str(plan.max_steps),
         "compression": compression_signature(plan.compression),
+        "scenario_content": identity.scenario_content,
+        "tools_hint": identity.tools_hint,
+        "corpus": identity.corpus,
+        "world_model": identity.world_model,
+        "history_chars": str(identity.history_chars),
     }
-    if complete_identity:
-        identity = plan.identity
-        fingerprint.update(
-            {
-                "scenario_content": identity.scenario_content,
-                "tools_hint": identity.tools_hint,
-                "corpus": identity.corpus,
-                "world_model": identity.world_model,
-                "history_chars": str(identity.history_chars),
-            }
-        )
     return fingerprint
 
 
-_SWEEP_CONTENT_IDENTITY_KEYS = frozenset(
-    {"scenario_content", "tools_hint", "corpus", "world_model", "history_chars"}
-)
-
-
-def _sweep_record_has_content_identity(record: StageRecord | None) -> bool:
-    """Whether a sweep record already pins the post-upgrade measurement inputs."""
-    return record is not None and _SWEEP_CONTENT_IDENTITY_KEYS <= record.fingerprint.keys()
-
-
-def _migrate_legacy_sweep_fingerprint(
-    manifest: RunManifest,
-    *,
-    decisions: list[StageDecision],
-    paths: _RunPaths,
-    plan: SweepPlan,
-    pool_file: Path,
-) -> RunManifest:
-    """Snapshot today's inputs after one free skip of a legacy completed matrix.
-
-    A pre-identity matrix remains valid input to fit/report, and its existing manifest proves the
-    paid sweep is current under the old fingerprint. That grants exactly one compatibility skip.
-    Recording the expanded fingerprint now means future instruction, tool, corpus, model, or
-    history changes rerun the sweep instead of trusting that legacy exception forever. The matrix
-    itself stays identity-less, so direct active resume still refuses to merge unknown paid rows.
-    """
-    sweep_decision = next(
-        (decision for decision in decisions if decision.stage is Stage.SWEEP),
-        None,
-    )
-    record = manifest.record_for(Stage.SWEEP)
-    if (
-        sweep_decision is None
-        or sweep_decision.will_run
-        or record is None
-        or _matrix_has_complete_sweep_identity(paths.matrix)
-        or _sweep_record_has_content_identity(record)
-    ):
-        return manifest
-    migrated = record.model_copy(
-        update={"fingerprint": _sweep_fingerprint(plan, pool_file, complete_identity=True)}
-    )
-    updated = manifest.model_copy(
-        update={
-            "stages": [
-                migrated if existing.stage is Stage.SWEEP else existing
-                for existing in manifest.stages
-            ]
-        }
-    )
-    updated.save(paths.manifest)
-    _console.print(
-        "  recorded current content identity for the legacy matrix; this invocation keeps the "
-        "sweep free, and later measurement-input changes will re-run it"
-    )
-    return updated
-
-
 def _matrix_has_complete_sweep_identity(path: Path) -> bool:
-    """Whether a matrix can participate in the expanded optimizer fingerprint.
+    """Whether a present readable matrix proves the complete measurement plan that produced it.
 
-    Missing and unreadable outputs are replacement cases, so they use the current fingerprint.
-    A readable legacy output keeps the old fingerprint shape solely to preserve downstream use;
-    active route-sweep resume still refuses it because unknown paid rows cannot be merged safely.
+    Missing and unreadable outputs are already replacement cases in stage planning, so they do
+    not need the legacy override. A readable identity-less matrix remains valid input to manual
+    downstream commands, but `optimize model` replaces it once with explicit spend consent.
     """
     if not path.is_file():
         return True

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -365,9 +365,6 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             compression=compression,
             max_concurrency=concurrency,
         )
-        # Read before the plan table so the sweep row can say how much of the grid a previous
-        # attempt already bought, and so a sidecar from a different plan is refused for free.
-        already_measured = resumable_cells(plan)
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
     try:
@@ -412,6 +409,17 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         allow_uneven=allow_uneven_coverage,
         redo=redo,
     )
+    try:
+        # A stage decision to run is explicit replacement authority for this pipeline's fixed
+        # matrix path. If the stage is current, the completed matrix instead participates in
+        # resume and is validated before the plan table or any spend question.
+        replace_completed_sweep = _will_sweep(decisions)
+        already_measured = resumable_cells(
+            plan,
+            replace_completed=replace_completed_sweep,
+        )
+    except SweepError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     _print_plan(
         _console,
         model_dir.name,
@@ -478,6 +486,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             cost_quality=cost_quality,
             allow_uneven_coverage=allow_uneven_coverage,
             already_measured=already_measured,
+            replace_completed_sweep=replace_completed_sweep,
         )
     except BudgetExceeded as exc:
         _print_budget_stop(model_dir.name, exc)
@@ -1149,6 +1158,7 @@ def _run_stages(
     cost_quality: float,
     allow_uneven_coverage: bool,
     already_measured: int = 0,
+    replace_completed_sweep: bool = False,
 ) -> RunManifest:
     """Walk the plan, running what it said would run and recording each stage as it completes.
 
@@ -1175,6 +1185,7 @@ def _run_stages(
                     model_dir=model_dir,
                     pool_file=pool_file,
                     already_measured=already_measured,
+                    replace_completed=replace_completed_sweep,
                 )
                 ledger.record(record.total_spend_usd)
             case Stage.COMPACT:
@@ -1203,7 +1214,12 @@ def _now() -> str:
 
 
 def _stage_sweep(
-    plan: SweepPlan, *, model_dir: Path, pool_file: Path, already_measured: int = 0
+    plan: SweepPlan,
+    *,
+    model_dir: Path,
+    pool_file: Path,
+    already_measured: int = 0,
+    replace_completed: bool = False,
 ) -> StageRecord:
     """Measure every candidate closed-loop and record what it cost.
 
@@ -1223,6 +1239,7 @@ def _stage_sweep(
         world_model=world_model,
         env_factory=lambda: WorldModelEnv(world_model, score_on_close=True),
         on_outcome=cell_progress(_console, plan.cells - already_measured),
+        replace_completed=replace_completed,
     )
     matrix = run.matrix
     scored = sum(1 for outcome in matrix.outcomes if outcome.scored)

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -34,6 +34,7 @@ from wmo.optimize.pipeline import (
     REPORT_FILENAME,
     RunManifest,
     Stage,
+    file_sha256,
 )
 from wmo.optimize.policy import (
     AZURE_EMBEDDER_DEPLOYMENT,
@@ -403,6 +404,56 @@ def test_a_second_run_skips_every_stage_and_says_why(
     assert "everystageiscurrent" in flat
     # A run with nothing to do asks nothing and spends nothing.
     assert "estimatedcandidatespend" not in flat
+
+
+def test_a_legacy_identityless_matrix_stays_usable_when_the_sweep_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An upgrade must not turn a current, downstream-readable matrix into a paid rerun."""
+    world_model = _patch_seams(monkeypatch, rewards={"cheap-1": 0.4, "pricey-1": 0.9})
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes").exit_code == 0
+    episodes_after_first = len(world_model.tasks)
+    matrix_path, _policy_path, _report_path, manifest_path = _paths(root)
+
+    matrix_payload = json.loads(matrix_path.read_text(encoding="utf-8"))
+    matrix_payload.pop("sweep_identity")
+    matrix_path.write_text(json.dumps(matrix_payload), encoding="utf-8")
+    manifest = RunManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+    sweep = manifest.record_for(Stage.SWEEP)
+    assert sweep is not None
+    legacy_sweep = sweep.model_copy(
+        update={
+            "fingerprint": {
+                key: value
+                for key, value in sweep.fingerprint.items()
+                if key
+                not in {
+                    "scenario_content",
+                    "tools_hint",
+                    "corpus",
+                    "world_model",
+                    "history_chars",
+                }
+            },
+            "artifact_identity": file_sha256(matrix_path),
+        }
+    )
+    manifest = manifest.model_copy(
+        update={
+            "stages": [
+                legacy_sweep if record.stage is Stage.SWEEP else record
+                for record in manifest.stages
+            ]
+        }
+    )
+    manifest.save(manifest_path)
+
+    again = _run(tmp_path, root, "--yes")
+    assert again.exit_code == 0, again.output
+    assert len(world_model.tasks) == episodes_after_first
+    assert _says(again.output, "matrix.json is current")
+    assert OutcomeMatrix.load(matrix_path).sweep_identity is None
 
 
 def test_force_from_sweep_redoes_the_sweep_and_everything_after_it(

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -454,6 +454,33 @@ def test_a_legacy_identityless_matrix_stays_usable_when_the_sweep_is_skipped(
     assert len(world_model.tasks) == episodes_after_first
     assert _says(again.output, "matrix.json is current")
     assert OutcomeMatrix.load(matrix_path).sweep_identity is None
+    assert _says(again.output, "recorded current content identity for the legacy matrix")
+    migrated = RunManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+    migrated_sweep = migrated.record_for(Stage.SWEEP)
+    assert migrated_sweep is not None
+    assert {
+        "scenario_content",
+        "tools_hint",
+        "corpus",
+        "world_model",
+        "history_chars",
+    } <= migrated_sweep.fingerprint.keys()
+
+    changed_corpus = [
+        trace.model_copy(
+            update={
+                "steps": [
+                    step.model_copy(update={"task": f"{step.task} revised"}) for step in trace.steps
+                ]
+            }
+        )
+        for trace in _corpus()
+    ]
+    write_traces_jsonl(changed_corpus, root / "models" / "support" / TRACES_FILENAME)
+    changed = _run(tmp_path, root, "--yes")
+    assert changed.exit_code == 0, changed.output
+    assert len(world_model.tasks) > episodes_after_first
+    assert _says(changed.output, "scenario_content changed")
 
 
 def test_force_from_sweep_redoes_the_sweep_and_everything_after_it(

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -406,10 +406,10 @@ def test_a_second_run_skips_every_stage_and_says_why(
     assert "estimatedcandidatespend" not in flat
 
 
-def test_a_legacy_identityless_matrix_stays_usable_when_the_sweep_is_skipped(
+def test_a_legacy_identityless_matrix_is_refreshed_once_with_explicit_consent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An upgrade must not turn a current, downstream-readable matrix into a paid rerun."""
+    """Unknown historical inputs are readable downstream, but never blessed as current."""
     world_model = _patch_seams(monkeypatch, rewards={"cheap-1": 0.4, "pricey-1": 0.9})
     root = _project(tmp_path)
     assert _run(tmp_path, root, "--yes").exit_code == 0
@@ -449,38 +449,26 @@ def test_a_legacy_identityless_matrix_stays_usable_when_the_sweep_is_skipped(
     )
     manifest.save(manifest_path)
 
-    again = _run(tmp_path, root, "--yes")
-    assert again.exit_code == 0, again.output
+    legacy_bytes = matrix_path.read_bytes()
+    unapproved = _run(tmp_path, root)
+    assert unapproved.exit_code == 2, unapproved.output
     assert len(world_model.tasks) == episodes_after_first
-    assert _says(again.output, "matrix.json is current")
+    assert matrix_path.read_bytes() == legacy_bytes
     assert OutcomeMatrix.load(matrix_path).sweep_identity is None
-    assert _says(again.output, "recorded current content identity for the legacy matrix")
-    migrated = RunManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
-    migrated_sweep = migrated.record_for(Stage.SWEEP)
-    assert migrated_sweep is not None
-    assert {
-        "scenario_content",
-        "tools_hint",
-        "corpus",
-        "world_model",
-        "history_chars",
-    } <= migrated_sweep.fingerprint.keys()
+    assert _says(unapproved.output, "has no complete sweep identity")
+    assert _says(unapproved.output, "one measured replacement is required")
 
-    changed_corpus = [
-        trace.model_copy(
-            update={
-                "steps": [
-                    step.model_copy(update={"task": f"{step.task} revised"}) for step in trace.steps
-                ]
-            }
-        )
-        for trace in _corpus()
-    ]
-    write_traces_jsonl(changed_corpus, root / "models" / "support" / TRACES_FILENAME)
-    changed = _run(tmp_path, root, "--yes")
-    assert changed.exit_code == 0, changed.output
-    assert len(world_model.tasks) > episodes_after_first
-    assert _says(changed.output, "scenario_content changed")
+    refreshed = _run(tmp_path, root, "--yes")
+    assert refreshed.exit_code == 0, refreshed.output
+    assert len(world_model.tasks) == episodes_after_first + 6
+    identity = OutcomeMatrix.load(matrix_path).sweep_identity
+    assert identity is not None and identity.complete
+
+    after_refresh = len(world_model.tasks)
+    exact = _run(tmp_path, root, "--yes")
+    assert exact.exit_code == 0, exact.output
+    assert len(world_model.tasks) == after_refresh
+    assert _says(exact.output, "matrix.json is current")
 
 
 def test_force_from_sweep_redoes_the_sweep_and_everything_after_it(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -240,10 +240,11 @@ def sweep(
 
     Nothing measured is lost, and nothing measured is bought twice. Every cell lands in
     `<out>.partial.jsonl` the moment it completes, so a sweep killed at hour five keeps the cells
-    it paid for; re-running the same command measures only what is missing and then writes the
-    matrix and removes the sidecar. Changing what the sweep measures (the pool, the scenario cut,
-    episodes, the step budget, the observation window, the compressor) makes those rows a
-    different arm, and the command says so and stops rather than merging two arms into one matrix.
+    it paid for. The completed matrix records the same plan identity, so re-running the exact
+    command reuses every cell without asking for spend consent. Changing what the sweep measures
+    (the pool, the scenario cut, episodes, the step budget, the observation window, the compressor)
+    makes those rows a different arm, and the command stops rather than overwriting or merging
+    evidence. The partial log is removed only after the completed matrix is safely written.
     `--concurrency N` runs N cells at once, which is the difference between a six-hour grid and a
     one-hour grid; it is not part of what the sweep measures, so a run interrupted at one value
     resumes at another.
@@ -341,15 +342,15 @@ def sweep(
         raise typer.BadParameter(str(exc)) from exc
     print_tiny_corpus_note(_console, plan)
     try:
-        # Before the money question, not after it: a sidecar left by a run of a DIFFERENT plan is
-        # refused here, while refusing still costs nothing.
+        # Before the money question, not after it: a partial or completed artifact from a
+        # DIFFERENT plan is refused here, while refusing still costs nothing.
         already_measured = resumable_cells(plan)
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
     world_model, _serve_provider = load_world_model(model_dir)
 
     print_cost_estimate(_console, plan, already_measured=already_measured)
-    _confirm_cost(plan, yes=yes)
+    _confirm_cost(plan, yes=yes, already_measured=already_measured)
 
     _console.print(
         f"sweeping {len(plan.pool.models)} candidate(s) over {len(plan.scenarios)} held-out "
@@ -611,9 +612,9 @@ def print_cost_estimate(console: Console, plan: SweepPlan, *, already_measured: 
     )
     if already_measured:
         console.print(
-            f"  RESUMING: {already_measured} of those cell(s) are already measured beside the "
-            f"matrix and are NOT bought again, so this run measures {plan.cells - already_measured}"
-            " and spends proportionally less than the total above."
+            f"  RESUMING: {already_measured} of those cell(s) are already measured in the "
+            "completed matrix or its crash log and are NOT bought again, so this run measures "
+            f"{plan.cells - already_measured} and spends proportionally less than the total above."
         )
     if plan.max_concurrency > 1:
         console.print(
@@ -633,7 +634,7 @@ def print_cost_estimate(console: Console, plan: SweepPlan, *, already_measured: 
     )
 
 
-def _confirm_cost(plan: SweepPlan, *, yes: bool) -> None:
+def _confirm_cost(plan: SweepPlan, *, yes: bool, already_measured: int = 0) -> None:
     """Confirm the projected spend before any episode runs.
 
     Consent is said, never inferred: a non-interactive session cannot answer a prompt, so a
@@ -642,14 +643,21 @@ def _confirm_cost(plan: SweepPlan, *, yes: bool) -> None:
     real money it never agreed to; every spend surface now shares one refusal
     (`wmo.cli.consent.require_spend_consent`).
 
+    A completed exact rerun has no cells left to buy, so it needs no spend consent. A partial
+    resume asks only for the remaining cells and their proportional estimate.
+
     Raises:
         typer.Exit: The user declined (exit code 0), or a non-interactive session was not told
             `--yes` (exit code 2).
     """
+    remaining = plan.cells - already_measured
+    if remaining == 0:
+        return
+    remaining_usd = plan.total_usd * remaining / plan.cells
     if not require_spend_consent(
         _console,
         yes=yes,
-        spend=f"~${plan.total_usd:.2f} across {plan.cells} cell(s)",
+        spend=f"~${remaining_usd:.2f} across {remaining} remaining cell(s)",
         command="wmo optimize route sweep",
     ):
         raise typer.Exit(0)

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -1490,6 +1490,50 @@ def test_route_sweep_resumes_the_cells_an_interrupted_run_already_bought(
     assert not sidecar.exists()
 
 
+def test_route_sweep_reuses_a_completed_matrix_without_running_cells_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, first = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert first.exit_code == 0, first.output
+    original = out.read_bytes()
+    scored_before = len(seams.world_model.scored)
+
+    _, second = _sweep(tmp_path, root, "support", "--scenarios", "3")
+    assert second.exit_code == 0, second.output
+    assert _says(second.output, "RESUMING: 6 of those cell(s) are already measured")
+    assert len(seams.world_model.scored) == scored_before
+    assert out.read_bytes() == original
+
+
+def test_route_sweep_refuses_to_overwrite_a_completed_matrix_from_another_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, first = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert first.exit_code == 0, first.output
+    original = out.read_bytes()
+    scored_before = len(seams.world_model.scored)
+
+    _, blocked = _sweep(
+        tmp_path,
+        root,
+        "support",
+        "--scenarios",
+        "3",
+        "--episodes",
+        "2",
+        "--yes",
+    )
+    assert blocked.exit_code != 0
+    assert _says(blocked.output, "completed matrix")
+    assert _says(blocked.output, "episodes per cell changed")
+    assert len(seams.world_model.scored) == scored_before
+    assert out.read_bytes() == original
+
+
 def test_route_sweep_refuses_a_sidecar_that_belongs_to_a_different_plan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmo/engine/world_model.py
+++ b/wmo/engine/world_model.py
@@ -82,6 +82,10 @@ class WorldModel:
         self._grounder = grounder
         self._ground_budget = ground_budget
         self._ground_spent: dict[str, int] = {}  # session id -> live web searches used
+        # Serving persists successful grounding so later sessions can reuse it. Evaluation
+        # freezes this alongside index enrichment: otherwise one cell mutates the knowledge
+        # rendered into later cells and changes the artifact identity during its own sweep.
+        self._persist_grounding_cache = True
         self._verify = verify
         # Online index enrichment (DreamGym-style): serving sessions feed generated steps back
         # into retrieval. Evaluation rollouts must NOT (see `frozen`), or one episode's
@@ -259,19 +263,24 @@ class WorldModel:
 
     @contextmanager
     def frozen(self) -> Iterator[WorldModel]:
-        """Suspend online index enrichment for the duration of the block.
+        """Suspend online artifact mutation for the duration of the block.
 
         Evaluation rollouts (scenario verification, score matrices) step the world model many
         times; if those generated steps were indexed, later episodes would retrieve earlier
-        episodes' predictions instead of only the built trace corpus — results would depend on
-        evaluation order. Serving resumes enrichment when the block exits.
+        episodes' predictions instead of only the built trace corpus. Successful grounding must
+        not enter `grounded.md` either, because later cells would observe an earlier cell's cache
+        and the sweep would mutate the knowledge tree its plan identity hashes. Serving resumes
+        both persistence paths when the block exits.
         """
-        previous = self._enrich_index
+        previous_enrichment = self._enrich_index
+        previous_grounding_cache = self._persist_grounding_cache
         self._enrich_index = False
+        self._persist_grounding_cache = False
         try:
             yield self
         finally:
-            self._enrich_index = previous
+            self._enrich_index = previous_enrichment
+            self._persist_grounding_cache = previous_grounding_cache
 
     def render_step_prompt(self, session_id: str, action: Action) -> str:
         """Assemble the exact (system + user) env prompt `step` would send, without calling the LLM.
@@ -522,7 +531,7 @@ class WorldModel:
         results_text = render_grounding(results)
         # Cache HITS only: persisting "(no results)" would negative-cache a transient failure
         # into the artifact forever (lookup_grounded returns it as a truthy hit).
-        if results and self._knowledge is not None:
+        if results and self._knowledge is not None and self._persist_grounding_cache:
             self._knowledge.append_grounded(query, results_text)
         return results_text
 

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, model_validator
 
 from wmo.core.files import write_text_atomic
 from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.sweep_identity import PlanIdentity
 from wmo.providers.base import TokenUsage
 from wmo.providers.pool import PoolEntry
 
@@ -118,10 +119,15 @@ class OutcomeMatrix(BaseModel):
 
     Carrying the pool snapshot makes the matrix self-describing: a policy fitted from it can
     record exactly which candidates (and at what prices) its assignments were chosen over.
+    Sweep-produced matrices also carry the complete plan identity, which lets an exact rerun
+    reuse the grid and keeps a changed plan from silently replacing different evidence.
     """
 
     pool: list[PoolEntry]
     outcomes: list[ScenarioOutcome]
+    # Present on matrices produced by a sweep. Older and manually assembled matrices remain valid
+    # downstream, but cannot safely be resumed because their complete measurement plan is unknown.
+    sweep_identity: PlanIdentity | None = None
 
     @model_validator(mode="after")
     def _outcomes_name_pool_models(self) -> OutcomeMatrix:

--- a/wmo/optimize/sweep.py
+++ b/wmo/optimize/sweep.py
@@ -49,10 +49,10 @@ from wmo.ingest import get_adapter
 from wmo.optimize.compression import CompressionConfig, compression_signature
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.reward import EpisodeScore
+from wmo.optimize.sweep_identity import PlanIdentity
 from wmo.optimize.sweep_partial import (
     PartialSweepError,
     PartialWriter,
-    PlanIdentity,
     partial_path,
     read_partial,
 )
@@ -417,6 +417,7 @@ def execute_sweep(
     on_outcome: Callable[[ScenarioOutcome], None] | None = None,
     runs_dir: Path | None = None,
     remeasure: frozenset[CellKey] = frozenset(),
+    replace_completed: bool = False,
 ) -> SweepRun:
     """Run every cell of `plan` against a FROZEN world model, write the matrix, meter both sides.
 
@@ -433,9 +434,10 @@ def execute_sweep(
 
     NOTHING IS LOST TO A CRASH. Every cell is appended to `<out>.partial.jsonl` the moment it
     completes, and a later call with the same plan measures only the cells that file does not
-    already hold. A sidecar whose rows were measured under a different plan is refused rather
-    than merged (`SweepPlan.identity`). The sidecar is removed once the matrix is written, so a
-    finished sweep leaves exactly the artifact it always left.
+    already hold. The completed matrix records the same identity and participates in the same
+    resume, so an exact rerun buys no cells. A partial log or completed matrix measured under a
+    different plan is refused rather than merged or overwritten (`SweepPlan.identity`). The
+    partial log is removed once the matrix is written.
 
     The world model opens one metered session per episode and `WorldModelEnv.close` leaves that
     session's final `RunRecord` on the env. Those records used to die with the env: the sweep
@@ -457,11 +459,15 @@ def execute_sweep(
         remeasure: Cells to buy again even though the sidecar already holds them, for a retry
             pass over cells an earlier attempt lost to a transient fault. Their new rows carry
             `remeasured=True` and replace the earlier ones.
+        replace_completed: Ignore a readable completed matrix and start a new attempt. This is
+            explicit replacement authority for callers such as `--force-from sweep`; a matching
+            partial log still resumes so a forced attempt remains crash-safe.
 
     Raises:
-        SweepError: The sidecar beside `out_path` belongs to a different plan, or is damaged.
+        SweepError: A partial or completed artifact belongs to a different plan, has unknown
+            identity, or is damaged.
     """
-    resumed = _resume(plan, remeasure)
+    resumed = _resume(plan, remeasure, replace_completed=replace_completed)
     harvest = _SessionHarvest(env_factory)
     destination = runs_dir or ArtifactPaths(plan.model_dir).runs
     measured: list[ScenarioOutcome] = []
@@ -495,7 +501,11 @@ def execute_sweep(
         # candidate-side rows survive in the sidecar, which is what the next run resumes from.
         usage, usage_path = _persist_harvest(harvest, destination)
         resumed.writer.close()
-    matrix = OutcomeMatrix(pool=plan.pool.models, outcomes=_assemble(plan, resumed.rows, measured))
+    matrix = OutcomeMatrix(
+        pool=plan.pool.models,
+        outcomes=_assemble(plan, resumed.rows, measured),
+        sweep_identity=plan.identity,
+    )
     matrix.save(plan.out_path)
     # Only now: while the matrix was unwritten the sidecar was the only copy of these cells.
     resumed.writer.discard()
@@ -527,13 +537,18 @@ class _Resume:
     writer: PartialWriter
 
 
-def _resume(plan: SweepPlan, remeasure: frozenset[CellKey]) -> _Resume:
-    """Read the sidecar, decide which cells still need buying, and open the log for appending.
+def _resume(
+    plan: SweepPlan,
+    remeasure: frozenset[CellKey],
+    *,
+    replace_completed: bool = False,
+) -> _Resume:
+    """Read prior artifacts, decide which cells still need buying, and open the partial log.
 
-    A row is reused when the sidecar holds it AND the caller did not ask for that cell again.
-    Unscored rows are reused too: the cell ran, the episode was paid for, and its `error` is the
-    diagnosis. Re-running it is a decision the caller makes with `remeasure`, not one a resume
-    makes silently on their behalf and their budget.
+    A row is reused when the completed matrix or partial log holds it AND the caller did not ask
+    for that cell again. Unscored rows are reused too: the cell ran, the episode was paid for,
+    and its `error` is the diagnosis. Re-running it is a decision the caller makes with
+    `remeasure`, not one a resume makes silently on their behalf and their budget.
 
     Raises:
         SweepError: The sidecar belongs to a different plan, or cannot be read.
@@ -541,7 +556,10 @@ def _resume(plan: SweepPlan, remeasure: frozenset[CellKey]) -> _Resume:
     path = partial_path(plan.out_path)
     identity = plan.identity
     try:
-        rows = read_partial(path, identity)
+        rows = [
+            *_read_completed(plan, replace=replace_completed),
+            *read_partial(path, identity),
+        ]
         writer = PartialWriter(path, identity)
     except PartialSweepError as exc:
         raise SweepError(str(exc)) from exc
@@ -591,22 +609,73 @@ def _assemble(
     return ordered
 
 
-def resumable_cells(plan: SweepPlan) -> int:
-    """How many of `plan`'s cells a previous attempt already measured and left in the sidecar.
+def resumable_cells(plan: SweepPlan, *, replace_completed: bool = False) -> int:
+    """How many cells a previous attempt preserved in the completed matrix or partial log.
 
     Called BEFORE the spend confirmation, so a resumed run can say how much of the projected cost
     it is not going to pay again, and so a sidecar that belongs to a different plan is refused
     while refusing is still free. Zero when there is nothing to resume.
 
     Raises:
-        SweepError: The sidecar beside the plan's `out_path` belongs to a different plan, or is
-            damaged. Same message the run itself would raise, delivered before the money question.
+        SweepError: A prior artifact at `out_path` belongs to a different plan, has unknown
+            identity, or is damaged. The run itself would raise the same error, but this check
+            delivers it before the money question.
     """
     try:
-        rows = read_partial(partial_path(plan.out_path), plan.identity)
+        rows = [
+            *_read_completed(plan, replace=replace_completed),
+            *read_partial(partial_path(plan.out_path), plan.identity),
+        ]
     except PartialSweepError as exc:
         raise SweepError(str(exc)) from exc
     return len({CellKey.of(row).model_dump_json() for row in rows})
+
+
+def _read_completed(plan: SweepPlan, *, replace: bool = False) -> list[ScenarioOutcome]:
+    """Read reusable rows from a completed matrix, or honor explicit replacement authority."""
+    path = plan.out_path
+    if not path.is_file():
+        return []
+    try:
+        matrix = OutcomeMatrix.load(path)
+    except (OSError, ValueError) as exc:
+        raise SweepError(
+            f"{path} already exists but is not a readable completed outcome matrix: {exc}. "
+            "Choose a different --out, or move the existing file before re-running"
+        ) from exc
+    if replace:
+        return []
+    identity = matrix.sweep_identity
+    if identity is None:
+        raise SweepError(
+            f"{path} already holds an outcome matrix without a recorded sweep identity. WMO "
+            "cannot prove which plan produced it, so it will not overwrite or reuse it. Choose "
+            "a different --out, or move the existing file before re-running"
+        )
+    difference = plan.identity.mismatch(identity)
+    if difference is not None:
+        raise SweepError(
+            f"{path} holds a completed matrix measured under a DIFFERENT plan: {difference}. "
+            "Re-run with the previous settings to reuse it. To replace it, use the caller's "
+            "explicit replacement option if available, or preserve the matrix at another path "
+            "before re-running this plan"
+        )
+    expected = {
+        cell.key.model_dump_json()
+        for cell in pool_cells(
+            plan.pool,
+            list(plan.scenarios),
+            episodes_per_scenario=plan.episodes,
+        )
+    }
+    actual = [CellKey.of(row).model_dump_json() for row in matrix.outcomes]
+    if len(actual) != len(set(actual)) or set(actual) != expected:
+        raise SweepError(
+            f"{path} records sweep identity {identity.digest} but its cells do not match that "
+            "plan. WMO will not overwrite damaged or edited evidence. Choose a different --out, "
+            "or move the existing file before re-running"
+        )
+    return matrix.outcomes
 
 
 def _pool_digest(pool: ModelPool) -> str:

--- a/wmo/optimize/sweep.py
+++ b/wmo/optimize/sweep.py
@@ -18,6 +18,7 @@ constructed, and so tests can stub both at the CLI module they already patch.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import threading
@@ -35,6 +36,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from wmo.config import ArtifactPaths, HarnessConfig, load_config
 from wmo.core.types import Action, EnvState, Observation
 from wmo.engine import split_holdout
+from wmo.engine.prompts import BASE_ENV_PROMPT
 from wmo.env.closed_loop import (
     CellKey,
     PoolCell,
@@ -150,6 +152,12 @@ class SweepPlan(BaseModel):
     # runs: it decides what the rewards MEAN, so two matrices swept under different compressors
     # are different evidence, and a resumed run whose compressor changed must re-measure.
     compression: CompressionConfig | None = None
+    # Content identities captured while the plan is built. The corpus is an input to scenario
+    # selection and tool hints; the artifact is what the frozen world model will actually load.
+    # Storing both keeps `identity` pure and prevents later filesystem edits from rewriting what
+    # an already-authorized plan says it measures.
+    corpus_identity: str
+    world_model_identity: str
     # How many cells run at once. NOT part of the plan's identity: it changes how long the
     # measurement takes, never what a cell measures, so a run resumed at a different value
     # continues the same cohort rather than re-buying it. 1 is the sequential default.
@@ -183,6 +191,12 @@ class SweepPlan(BaseModel):
         return PlanIdentity(
             pool=_pool_digest(self.pool),
             scenarios=tuple(scenario_id(scenario) for scenario in self.scenarios),
+            scenario_content=_content_digest(
+                [scenario.model_dump(mode="json") for scenario in self.scenarios]
+            ),
+            tools_hint=_content_digest(self.tools_hint),
+            corpus=self.corpus_identity,
+            world_model=self.world_model_identity,
             episodes=self.episodes,
             max_steps=self.max_steps,
             history_chars=self.history_chars,
@@ -320,6 +334,8 @@ def plan_sweep(
         tools_hint=tools_hint_from_traces(train) or None,
         history_chars=history_chars,
         compression=compression,
+        corpus_identity=_content_digest([trace.model_dump(mode="json") for trace in traces]),
+        world_model_identity=_world_model_identity(model_dir, config),
         max_concurrency=max_concurrency,
         trace_count=len(traces),
         tiny_corpus=tiny_corpus,
@@ -687,6 +703,94 @@ def _pool_digest(pool: ModelPool) -> str:
     """
     payload = "\n".join(entry.model_dump_json() for entry in pool.models)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _content_digest(value: object) -> str:
+    """SHA-256 of JSON content with mapping order removed from the identity."""
+    canonical = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _world_model_identity(model_dir: Path, config: HarnessConfig) -> str:
+    """Hash only files a normal frozen `WorldModel.load` consumes during a sweep.
+
+    Run records and optimizer outputs are deliberately absent: a sweep creates them, so including
+    them would make its own completed matrix stale. `auto_fidelity.json` is also absent because
+    route sweeps use the normal load, not `max_fidelity=True`.
+    """
+    paths = ArtifactPaths(model_dir)
+    digest = hashlib.sha256()
+    _hash_part(digest, "config.toml", _canonical_bytes(config.model_dump(mode="json")))
+    if paths.optimized_prompt.exists():
+        _hash_file(digest, paths.root, paths.optimized_prompt)
+    else:
+        _hash_part(
+            digest,
+            "prompts/optimized.txt:fallback",
+            BASE_ENV_PROMPT.encode("utf-8"),
+        )
+    _hash_tree(digest, paths.root, paths.index)
+    if config.knowledge:
+        _hash_tree(digest, paths.root, paths.knowledge)
+    else:
+        _hash_part(digest, "knowledge:disabled", b"")
+    return digest.hexdigest()
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _hash_tree(digest: hashlib._Hash, root: Path, directory: Path) -> None:
+    """Add a sorted tree to `digest`, including paths because loaders assign them meaning."""
+    relative = directory.relative_to(root).as_posix()
+    if not directory.exists():
+        _hash_part(digest, f"{relative}:missing", b"")
+        return
+    if not directory.is_dir():
+        _hash_file(digest, root, directory)
+        return
+    _hash_part(digest, f"{relative}:directory", b"")
+    try:
+        files = sorted(path for path in directory.rglob("*") if path.is_file())
+        for path in files:
+            _hash_file(digest, root, path)
+    except OSError as exc:
+        raise SweepError(
+            f"cannot fingerprint world-model artifact {directory}: {exc}. Fix its permissions "
+            "before sweeping so WMO can identify the frozen model being measured"
+        ) from exc
+
+
+def _hash_file(digest: hashlib._Hash, root: Path, path: Path) -> None:
+    relative = path.relative_to(root).as_posix()
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        raise SweepError(
+            f"cannot fingerprint world-model artifact {path}: {exc}. Fix its permissions before "
+            "sweeping so WMO can identify the frozen model being measured"
+        ) from exc
+    _hash_part(digest, relative, content)
+
+
+def _hash_part(digest: hashlib._Hash, label: str, content: bytes) -> None:
+    """Length-prefix a named blob so neither path nor content boundaries can collide."""
+    name = label.encode("utf-8")
+    digest.update(len(name).to_bytes(8, "big"))
+    digest.update(name)
+    digest.update(len(content).to_bytes(8, "big"))
+    digest.update(content)
 
 
 def _persist_harvest(harvest: _SessionHarvest, runs_dir: Path) -> tuple[RunRecord, Path | None]:

--- a/wmo/optimize/sweep_identity.py
+++ b/wmo/optimize/sweep_identity.py
@@ -1,0 +1,51 @@
+"""Identity of the measurement plan recorded by partial and completed sweep artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, ConfigDict
+
+IDENTITY_DIGEST_CHARS = 16
+"""64 bits, matching the width used for outcome-matrix provenance digests."""
+
+
+class PlanIdentity(BaseModel):
+    """The cohort pins that make measured sweep rows comparable."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pool: str
+    scenarios: tuple[str, ...]
+    episodes: int
+    max_steps: int
+    history_chars: int
+    compression: str
+
+    @property
+    def digest(self) -> str:
+        """Return a short stable hash of the whole identity."""
+        canonical = self.model_dump_json()
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:IDENTITY_DIGEST_CHARS]
+
+    def mismatch(self, other: PlanIdentity) -> str | None:
+        """Describe the first operator-visible difference from an earlier identity."""
+        if self == other:
+            return None
+        if self.pool != other.pool:
+            return "the candidate pool changed (different models, or different prices)"
+        if self.scenarios != other.scenarios:
+            return (
+                f"the scenario cut changed ({len(other.scenarios)} scenario(s) then, "
+                f"{len(self.scenarios)} now)"
+            )
+        if self.episodes != other.episodes:
+            return f"episodes per cell changed ({other.episodes} then, {self.episodes} now)"
+        if self.max_steps != other.max_steps:
+            return f"the step budget changed ({other.max_steps} then, {self.max_steps} now)"
+        if self.history_chars != other.history_chars:
+            return (
+                f"the observation window changed ({other.history_chars} chars then, "
+                f"{self.history_chars} now)"
+            )
+        return f"the compression arm changed ({other.compression} then, {self.compression} now)"

--- a/wmo/optimize/sweep_identity.py
+++ b/wmo/optimize/sweep_identity.py
@@ -17,10 +17,22 @@ class PlanIdentity(BaseModel):
 
     pool: str
     scenarios: tuple[str, ...]
+    # Added with empty defaults so an older partial header or completed matrix remains readable.
+    # Empty means "unknown", never "unchanged": active resume refuses it because those rows
+    # cannot be proven to share the current measurement inputs.
+    scenario_content: str = ""
+    tools_hint: str = ""
+    corpus: str = ""
+    world_model: str = ""
     episodes: int
     max_steps: int
     history_chars: int
     compression: str
+
+    @property
+    def complete(self) -> bool:
+        """Whether every content-bearing measurement input was recorded."""
+        return all((self.scenario_content, self.tools_hint, self.corpus, self.world_model))
 
     @property
     def digest(self) -> str:
@@ -48,4 +60,17 @@ class PlanIdentity(BaseModel):
                 f"the observation window changed ({other.history_chars} chars then, "
                 f"{self.history_chars} now)"
             )
-        return f"the compression arm changed ({other.compression} then, {self.compression} now)"
+        if self.compression != other.compression:
+            return f"the compression arm changed ({other.compression} then, {self.compression} now)"
+        if not self.complete or not other.complete:
+            return (
+                "the earlier artifact predates complete scenario, corpus, and world-model "
+                "identity, so its rows cannot be proven reusable by this build"
+            )
+        if self.scenario_content != other.scenario_content:
+            return "the selected scenario instructions or provenance changed"
+        if self.tools_hint != other.tools_hint:
+            return "the candidate tool hint changed"
+        if self.corpus != other.corpus:
+            return "the trace corpus changed"
+        return "the frozen world-model artifact or config changed"

--- a/wmo/optimize/sweep_partial.py
+++ b/wmo/optimize/sweep_partial.py
@@ -21,7 +21,6 @@ library: before this, nothing on disk recorded WHICH scenario cut a matrix came 
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from pathlib import Path
@@ -30,6 +29,7 @@ from typing import TYPE_CHECKING, Self
 from pydantic import BaseModel, ConfigDict
 
 from wmo.optimize.outcomes import ScenarioOutcome
+from wmo.optimize.sweep_identity import PlanIdentity
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -42,9 +42,6 @@ PARTIAL_SUFFIX = ".partial.jsonl"
 PARTIAL_FORMAT_VERSION = 1
 """Bumped only by a change that makes an older sidecar unreadable, so the refusal can say so."""
 
-IDENTITY_DIGEST_CHARS = 16
-"""64 bits, the same width `OutcomeMatrix`'s provenance digest uses."""
-
 
 class PartialSweepError(ValueError):
     """A sidecar cannot be used, for a reason the operator can fix.
@@ -53,58 +50,6 @@ class PartialSweepError(ValueError):
     mix its rows in) either throws away paid cells or fabricates a matrix whose rows were measured
     under two different plans. `wmo.optimize.sweep` re-raises these as `SweepError`.
     """
-
-
-class PlanIdentity(BaseModel):
-    """What a set of measured rows was measured UNDER: the cohort pins, as data.
-
-    Two matrices are comparable when these agree and are different evidence when they do not, so
-    this is exactly the resume check, and exactly what a sidecar records about itself. Fields are
-    the properties that change what a cell MEASURES; how fast the sweep ran (concurrency) is not
-    one of them, so raising concurrency mid-run resumes cleanly instead of re-buying the grid.
-    """
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    pool: str  # digest of the candidate roster, prices included
-    scenarios: tuple[str, ...]  # the scenario cut, by id, in sweep order
-    episodes: int
-    max_steps: int
-    history_chars: int
-    compression: str  # `wmo.optimize.compression.compression_signature`
-
-    @property
-    def digest(self) -> str:
-        """A short stable hash of the whole identity, for stamping into artifacts and logs."""
-        canonical = self.model_dump_json()
-        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:IDENTITY_DIGEST_CHARS]
-
-    def mismatch(self, other: PlanIdentity) -> str | None:
-        """How `other` differs from this identity in operator terms, or None when it does not.
-
-        Names ONE difference, the first in declaration order: an operator who changed the pool and
-        the episode count fixes them one at a time anyway, and a wall of diffs buries the field
-        that actually explains the refusal.
-        """
-        if self == other:
-            return None
-        if self.pool != other.pool:
-            return "the candidate pool changed (different models, or different prices)"
-        if self.scenarios != other.scenarios:
-            return (
-                f"the scenario cut changed ({len(other.scenarios)} scenario(s) then, "
-                f"{len(self.scenarios)} now)"
-            )
-        if self.episodes != other.episodes:
-            return f"episodes per cell changed ({other.episodes} then, {self.episodes} now)"
-        if self.max_steps != other.max_steps:
-            return f"the step budget changed ({other.max_steps} then, {self.max_steps} now)"
-        if self.history_chars != other.history_chars:
-            return (
-                f"the observation window changed ({other.history_chars} chars then, "
-                f"{self.history_chars} now)"
-            )
-        return f"the compression arm changed ({other.compression} then, {self.compression} now)"
 
 
 class PartialHeader(BaseModel):

--- a/wmo/optimize/sweep_test.py
+++ b/wmo/optimize/sweep_test.py
@@ -562,6 +562,53 @@ def test_a_crash_keeps_its_paid_cells_and_the_resume_buys_only_the_rest(
     assert not partial_path(plan.out_path).exists()
 
 
+def test_a_completed_matrix_is_reused_without_buying_any_cell_again(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    first = _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    assert first.matrix.sweep_identity == plan.identity
+
+    built_before = len(candidates)
+    resumed = _run_plan(
+        _plan(tmp_path, scenarios=3),
+        [],
+        runs_dir=tmp_path / "runs",
+    )
+    assert len(candidates) == built_before
+    assert resumed.resumed_cells == 3
+    assert resumed.matrix == first.matrix
+
+
+def test_a_completed_matrix_from_a_different_plan_is_not_overwritten(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    original = plan.out_path.read_bytes()
+    changed = _plan(tmp_path, scenarios=3, episodes=2)
+
+    with pytest.raises(SweepError, match="episodes per cell changed"):
+        resumable_cells(changed)
+    with pytest.raises(SweepError, match="DIFFERENT plan"):
+        _run_plan(
+            changed,
+            [_StubEnv(0.10) for _ in range(6)],
+            runs_dir=tmp_path / "runs",
+        )
+    assert plan.out_path.read_bytes() == original
+
+    replaced = execute_sweep(
+        changed,
+        world_model=cast("WorldModel", _FrozenWorldModel()),
+        env_factory=_factory([_StubEnv(0.10) for _ in range(6)]),
+        runs_dir=tmp_path / "runs",
+        replace_completed=True,
+    )
+    assert replaced.matrix.sweep_identity == changed.identity
+    assert len(replaced.matrix.outcomes) == 6
+
+
 def test_a_resumed_run_says_its_world_model_figure_is_this_attempt_only(
     tmp_path: Path, candidates: list[str]
 ) -> None:

--- a/wmo/optimize/sweep_test.py
+++ b/wmo/optimize/sweep_test.py
@@ -19,6 +19,9 @@ import pytest
 
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+from wmo.engine.grounding import GroundingResult
+from wmo.engine.knowledge import KnowledgeBase
+from wmo.engine.world_model import WorldModel
 from wmo.env.closed_loop import CellKey
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.compression import CompressionConfig
@@ -47,13 +50,13 @@ from wmo.providers.base import (
     VerifyResult,
 )
 from wmo.providers.pool import PoolEntry, load_pool
+from wmo.retrieval import EmbeddingRetriever, HashingEmbedder
 from wmo.serving.traces_source import TRACES_FILENAME
 from wmo.tracking import Phase, RunRecord, UsageTotals
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from wmo.engine.world_model import WorldModel
     from wmo.env.base import Env
 
 
@@ -459,6 +462,107 @@ def candidates(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
     monkeypatch.setattr("wmo.providers.pool.get_provider", _get_provider)
     return built
+
+
+class _SuccessfulGrounder:
+    """A successful grounding backend whose cache writes would change plan identity."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def ground(self, query: str) -> list[GroundingResult]:
+        self.queries.append(query)
+        return [
+            GroundingResult(
+                title="package fact",
+                url="https://example.test/package",
+                snippet=f"facts about {query}",
+            )
+        ]
+
+
+class _GroundingEnv(_StubEnv):
+    """A scored env that exercises the real frozen world's successful grounding path."""
+
+    def __init__(self, world_model: WorldModel) -> None:
+        super().__init__(0.10)
+        self._world_model = world_model
+        self._session_id: str | None = None
+
+    def reset(self, task: str | None = None, seed_state: object | None = None) -> EnvState:
+        session = self._world_model.new_session(task=task)
+        self._session_id = session.id
+        assert self._world_model._ground(session.id, "package facts") is not None  # noqa: SLF001
+        return session.state
+
+    def close(self) -> None:
+        if self._session_id is not None:
+            self._world_model.end_session(self._session_id)
+            self._session_id = None
+
+
+def test_successful_grounding_cannot_stale_its_own_completed_sweep(
+    tmp_path: Path,
+    candidates: list[str],
+) -> None:
+    model_dir = _model_dir(tmp_path)
+    config = resolve_config(model_dir).model_copy(update={"knowledge": True, "grounder": "brave"})
+    save_config(config, model_dir)
+    knowledge = KnowledgeBase(model_dir / "knowledge")
+    knowledge.write_file("rules.md", "- use package facts when needed")
+    pool = load_pool(_pool_file(tmp_path))
+
+    def build_plan() -> SweepPlan:
+        return plan_sweep(
+            model_dir=model_dir,
+            config=resolve_config(model_dir),
+            pool=pool,
+            out_path=tmp_path / "matrix.json",
+            traces_file=None,
+            scenarios=1,
+            episodes=1,
+            max_steps=1,
+            assume_input_tokens=2000,
+            assume_output_tokens=250,
+        )
+
+    grounder = _SuccessfulGrounder()
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=64))
+    retriever.index([])
+    world_model = WorldModel(
+        _DoneProvider(config.serve_provider_config()),
+        retriever,
+        telemetry_root=tmp_path / "telemetry",
+        knowledge=knowledge,
+        grounder=grounder,
+    )
+    plan = build_plan()
+    first = execute_sweep(
+        plan,
+        world_model=world_model,
+        env_factory=lambda: _GroundingEnv(world_model),
+        runs_dir=tmp_path / "runs",
+    )
+    assert first.matrix.sweep_identity == plan.identity
+    assert grounder.queries == ["package facts"]
+    assert knowledge.lookup_grounded("package facts") is None
+
+    exact_rerun = build_plan()
+    assert exact_rerun.identity == plan.identity
+    built_before = len(candidates)
+
+    def no_new_env() -> Env:
+        raise AssertionError("an exact completed rerun must not execute an environment")
+
+    resumed = execute_sweep(
+        exact_rerun,
+        world_model=world_model,
+        env_factory=no_new_env,
+        runs_dir=tmp_path / "runs",
+    )
+    assert resumed.resumed_cells == 1
+    assert len(candidates) == built_before
+    assert grounder.queries == ["package facts"]
 
 
 class _SlowEnv(_StubEnv):

--- a/wmo/optimize/sweep_test.py
+++ b/wmo/optimize/sweep_test.py
@@ -609,6 +609,136 @@ def test_a_completed_matrix_from_a_different_plan_is_not_overwritten(
     assert len(replaced.matrix.outcomes) == 6
 
 
+def test_completed_rows_are_not_reused_after_a_stable_scenario_id_changes_task(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    first, *rest = plan.scenarios
+    changed = plan.model_copy(
+        update={
+            "scenarios": (
+                first.model_copy(update={"task": f"{first.task} with revised instructions"}),
+                *rest,
+            )
+        }
+    )
+
+    assert changed.identity.scenarios == plan.identity.scenarios
+    with pytest.raises(SweepError, match="scenario instructions or provenance changed"):
+        resumable_cells(changed)
+
+
+def test_completed_rows_are_not_reused_after_the_candidate_tool_hint_changes(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    changed = plan.model_copy(update={"tools_hint": "search(query), fetch(url)"})
+
+    with pytest.raises(SweepError, match="candidate tool hint changed"):
+        resumable_cells(changed)
+
+
+def test_completed_rows_are_not_reused_after_the_trace_corpus_changes(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    changed_traces = [
+        trace.model_copy(
+            update={
+                "steps": [
+                    step.model_copy(
+                        update={"observation": Observation(content="revised corpus observation")}
+                    )
+                    for step in trace.steps
+                ]
+            }
+        )
+        for trace in _traces()
+    ]
+    write_traces_jsonl(changed_traces, plan.model_dir / TRACES_FILENAME)
+    changed = plan_sweep(
+        model_dir=plan.model_dir,
+        config=resolve_config(plan.model_dir),
+        pool=plan.pool,
+        out_path=plan.out_path,
+        traces_file=None,
+        scenarios=len(plan.scenarios),
+        episodes=plan.episodes,
+        max_steps=plan.max_steps,
+        assume_input_tokens=plan.assume_input_tokens,
+        assume_output_tokens=plan.assume_output_tokens,
+    )
+
+    assert changed.identity.scenarios == plan.identity.scenarios
+    assert changed.identity.scenario_content == plan.identity.scenario_content
+    assert changed.identity.tools_hint == plan.identity.tools_hint
+    with pytest.raises(SweepError, match="trace corpus changed"):
+        resumable_cells(changed)
+
+
+@pytest.mark.parametrize("runtime_input", ["config", "prompt", "index", "knowledge"])
+def test_completed_rows_are_not_reused_after_the_frozen_world_model_changes(
+    tmp_path: Path,
+    runtime_input: str,
+) -> None:
+    model_dir = _model_dir(tmp_path)
+    if runtime_input == "prompt":
+        initial_file = model_dir / "prompts" / "optimized.txt"
+    elif runtime_input == "index":
+        initial_file = model_dir / "index" / "steps.jsonl"
+    elif runtime_input == "knowledge":
+        config = resolve_config(model_dir).model_copy(update={"knowledge": True})
+        save_config(config, model_dir)
+        initial_file = model_dir / "knowledge" / "rules.md"
+    else:
+        initial_file = None
+    if initial_file is not None:
+        initial_file.parent.mkdir(parents=True)
+        initial_file.write_text("initial frozen artifact content", encoding="utf-8")
+    plan = _plan(tmp_path, scenarios=3)
+    if runtime_input == "knowledge":
+        # `_plan` refreshes the default test config, so restore the enabled knowledge input.
+        config = resolve_config(model_dir).model_copy(update={"knowledge": True})
+        save_config(config, model_dir)
+        plan = plan_sweep(
+            model_dir=model_dir,
+            config=config,
+            pool=plan.pool,
+            out_path=plan.out_path,
+            traces_file=None,
+            scenarios=len(plan.scenarios),
+            episodes=plan.episodes,
+            max_steps=plan.max_steps,
+            assume_input_tokens=plan.assume_input_tokens,
+            assume_output_tokens=plan.assume_output_tokens,
+        )
+    _run_plan(plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs")
+    if runtime_input == "config":
+        config = resolve_config(plan.model_dir).model_copy(update={"top_k": 9})
+        save_config(config, plan.model_dir)
+    else:
+        assert initial_file is not None
+        initial_file.write_text("revised frozen artifact content", encoding="utf-8")
+    changed = plan_sweep(
+        model_dir=plan.model_dir,
+        config=resolve_config(plan.model_dir),
+        pool=plan.pool,
+        out_path=plan.out_path,
+        traces_file=None,
+        scenarios=len(plan.scenarios),
+        episodes=plan.episodes,
+        max_steps=plan.max_steps,
+        assume_input_tokens=plan.assume_input_tokens,
+        assume_output_tokens=plan.assume_output_tokens,
+    )
+
+    with pytest.raises(SweepError, match="frozen world-model artifact or config changed"):
+        resumable_cells(changed)
+
+
 def test_a_resumed_run_says_its_world_model_figure_is_this_attempt_only(
     tmp_path: Path, candidates: list[str]
 ) -> None:


### PR DESCRIPTION
## What changed

- stamp every sweep-produced `OutcomeMatrix` with the complete measurement identity used by the crash sidecar
- fingerprint the candidate pool, full scenario payload, tool hint, corpus, resolved config, active prompt, recursive index, and enabled knowledge
- reuse matching completed rows on an exact rerun and skip spend consent when zero cells remain
- refuse unreadable, incomplete, damaged, or differently planned artifacts before any paid call can replace them
- keep legacy identity-less matrices readable downstream, while `optimize model` plans one explicit-consent replacement instead of blessing unknown historical inputs
- freeze grounding-cache writes with index and knowledge enrichment so concurrent cells cannot change the artifact or each other's evidence
- keep partial-log crash recovery, explicit stage replacement, and main's atomic durable matrix writer intact

## Why

A successful `wmo optimize route sweep` deleted its partial log and left a final matrix with no plan identity. The next exact command therefore bought every cell again. Changing the plan could also silently overwrite prior evidence.

Stable scenario IDs alone were not enough: task text, tool hints, corpus contents, or the frozen world-model artifact could change under the same IDs. A knowledge-enabled grounded sweep could also write `grounded.md` during measurement, making its saved pre-run identity stale immediately.

## Validation

- rebased onto main's durable-writer change at `31da9251`
- `TERM=xterm-256color COLUMNS=240 uv run pytest -q -p no:cacheprovider`: 4488 passed, 20 skipped
- focused durable-file, world-model, route, sweep, outcome, partial, policy, and optimizer suites: 342 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- successful-grounder regression proves a frozen sweep does not write `grounded.md`, and its exact rerun executes no environment or candidate
- legacy upgrade regression proves no-consent use makes zero calls and preserves the old matrix, authorized use refreshes and stamps full identity once, and the next exact run skips
- local-stub sweep made 4 requests; exact no-`--yes` rerun remained at 4 and preserved the matrix hash; changed episodes refused before calls and preserved the matrix

## Review feedback

Independent cross-PR review found and this branch fixed four additional gaps:

- stable trace IDs can no longer hide changed task, tool, corpus, index, knowledge, prompt, or config inputs
- a legacy matrix remains readable downstream, but the optimizer requires one consented measured replacement rather than stamping current hashes onto unknown evidence
- successful grounding cannot mutate the knowledge tree during a frozen sweep or leak cache state across concurrent cells
- the rebase preserves `OutcomeMatrix.save` through main's atomic durable writer

## Open PR overlap

PR #288 has file-level overlap in route CLI files, but its functional candidate-ordering change is in `wmo/env/closed_loop.py`, which this PR does not touch.
