### PR TITLE
Fix Azure deployment and API routing

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -884,17 +884,6 @@ def build(
             params,
             configured_provider=configured_worker_config,
         )
-        if (
-            configured_worker_config is not None
-            and params.provider != configured_worker_config.kind.value
-        ):
-            params = params.model_copy(
-                update={
-                    "endpoint": None,
-                    "deployment": None,
-                    "api_version": None,
-                }
-            )
     elif params.file is None and not params.pull:
         # This guard also required `name is None`, so `wmo build --name x` (verbatim the
         # empty-state hint `wmo list` prints) fell through to a raw ValueError from the ingest

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -49,7 +49,13 @@ from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
 # mode-inapplicable flags exactly the way `wmo optimize harness` already does.
 from wmo.cli.harness_app import _explicit, harness_app, optimize_app
 from wmo.cli.ingest_cmd import ingest as _ingest_command
-from wmo.cli.model_roles import configured_role_configs, load_settings_or_abort
+from wmo.cli.model_roles import (
+    DEFAULT_AZURE_API_VERSION,
+    configured_role_configs,
+    configured_role_provider_config,
+    inherit_provider_connection,
+    load_settings_or_abort,
+)
 from wmo.cli.platform_cmds import register as register_platform_commands
 from wmo.cli.ui import (
     BuildParams,
@@ -267,7 +273,7 @@ def _worker_provider_config(
         config = config.model_copy(
             update={
                 "deployment": deployment,
-                "api_version": api_version or "2024-05-01-preview",
+                "api_version": api_version or DEFAULT_AZURE_API_VERSION,
             }
         )
     return config
@@ -336,11 +342,17 @@ def providers_set(
         _provider_kind(provider)
     existing = load_settings_or_abort(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
+    config: ProviderConfig | None = None
     if used_picker:
         existing_azure_deployment = (
             existing.deployment if existing is not None and existing.provider == "azure" else None
         )
-        provider, model, region, deployment = select_provider_and_model(
+        existing_provider = (
+            configured_role_provider_config(existing, role="worker")
+            if existing is not None
+            else None
+        )
+        config = select_provider_and_model(
             _console,
             lambda text: _console.input(text),
             lambda text: _console.input(text, password=True),
@@ -351,21 +363,16 @@ def providers_set(
             default_deployment_model=(
                 existing.model if deployment is None and existing_azure_deployment else None
             ),
-            ask_azure_deployment=True,
             interactive=True,
-            check=lambda cfg: verify_all(
-                [
-                    _worker_provider_config(
-                        cfg.kind.value,
-                        cfg.model_type or cfg.model,
-                        cfg.region,
-                        endpoint=endpoint,
-                        deployment=cfg.deployment,
-                        api_version=api_version,
-                    )
-                ]
-            )[0],
+            check=lambda cfg: verify_all([cfg])[0],
+            configured_provider=existing_provider,
+            endpoint=endpoint,
+            api_version=api_version,
         )
+        provider = config.kind.value
+        model = config.model_type or config.model
+        region = config.region
+        deployment = config.deployment
     if provider is None or model is None:
         raise typer.BadParameter(
             "provide --provider and --model, or run `wmo providers set` in a terminal"
@@ -375,14 +382,15 @@ def providers_set(
             "--deployment is required for Azure because deployment names are operator-created "
             "and cannot be inferred from --model"
         )
-    config = _worker_provider_config(
-        provider,
-        model,
-        region,
-        endpoint=endpoint,
-        deployment=deployment,
-        api_version=api_version,
-    )
+    if config is None:
+        config = _worker_provider_config(
+            provider,
+            model,
+            region,
+            endpoint=endpoint,
+            deployment=deployment,
+            api_version=api_version,
+        )
     if not used_picker:
         result = verify_all([config])[0]
         if not result.ok:
@@ -810,6 +818,11 @@ def build(
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider
     )
+    configured_worker_config = (
+        configured_role_provider_config(configured_worker, role="worker")
+        if use_configured_worker and configured_worker is not None
+        else None
+    )
     # Settle the serve provider here so the model default can follow it. A single hard-coded
     # Anthropic default wrote artifacts configured to call e.g. OpenAI with `claude-opus-4-8`.
     resolved_provider = (
@@ -825,6 +838,19 @@ def build(
             f"--provider {resolved_provider} has no default serve model: pass `--model <id>` "
             f"(`wmo build --provider {resolved_provider} --model <id> --file <export>`)"
         )
+    default_provider_config = inherit_provider_connection(
+        _provider_config(
+            resolved_provider,
+            resolved_model or "",
+            region
+            or (
+                configured_worker.region
+                if use_configured_worker and configured_worker is not None
+                else None
+            ),
+        ),
+        configured_worker_config,
+    )
     params = BuildParams(
         name=name or DEFAULT_MODEL_NAME,
         source=source,
@@ -842,6 +868,9 @@ def build(
             region
             or (configured_worker.region if use_configured_worker and configured_worker else None)
         ),
+        endpoint=default_provider_config.endpoint,
+        deployment=default_provider_config.deployment,
+        api_version=default_provider_config.api_version,
         fidelity=fidelity,
         train_split=train_split,
         judge_model=judge_model,
@@ -850,7 +879,22 @@ def build(
         embed_dim=embed_dim,
     )
     if use_wizard:
-        params = run_build_wizard(_console, params)
+        params = run_build_wizard(
+            _console,
+            params,
+            configured_provider=configured_worker_config,
+        )
+        if (
+            configured_worker_config is not None
+            and params.provider != configured_worker_config.kind.value
+        ):
+            params = params.model_copy(
+                update={
+                    "endpoint": None,
+                    "deployment": None,
+                    "api_version": None,
+                }
+            )
     elif params.file is None and not params.pull:
         # This guard also required `name is None`, so `wmo build --name x` (verbatim the
         # empty-state hint `wmo list` prints) fell through to a raw ValueError from the ingest
@@ -867,12 +911,6 @@ def build(
         raise typer.BadParameter(f"--limit must be at least 1, got {params.limit}")
     # The wizard always resolves a provider; the flag path keeps its historical default.
     params.provider = params.provider or _BUILD_PROVIDER
-    # The wizard may replace the configured worker's provider. Re-evaluate the match before
-    # carrying provider-specific connection fields into the build config.
-    use_configured_worker = (
-        configured_worker is not None and params.provider == configured_worker.provider
-    )
-
     # Flag-supplied names get the same whitespace-to-dash normalization as the wizard.
     params.name = normalize_name(params.name)
     try:
@@ -928,14 +966,13 @@ def build(
         judge_model=params.judge_model or judge_model_default(params.provider, params.model),
         trace_adapter=params.source,
     )
-    if use_configured_worker and configured_worker is not None:
-        config.providers[0] = config.providers[0].model_copy(
-            update={
-                "endpoint": configured_worker.endpoint,
-                "deployment": configured_worker.deployment,
-                "api_version": configured_worker.api_version,
-            }
-        )
+    config.providers[0] = config.providers[0].model_copy(
+        update={
+            "endpoint": params.endpoint,
+            "deployment": params.deployment,
+            "api_version": params.api_version,
+        }
+    )
     if grounder not in GROUNDER_KINDS:
         raise typer.BadParameter(
             f"unknown grounder {grounder!r}; choose one of: {', '.join(GROUNDER_KINDS)}"
@@ -2691,7 +2728,7 @@ def demo(
             # failed step — completed steps stay done.
             _console.print(f"\n[red]serve provider is still failing[/red]: {_short_error(exc)}")
             _console.print("[yellow]pick a different provider to continue the demo[/yellow]")
-            provider_name, model_type, region, _deployment = select_provider_and_model(
+            switched = select_provider_and_model(
                 _console,
                 lambda text: _console.input(text),
                 lambda text: _console.input(text, password=True),
@@ -2701,7 +2738,8 @@ def demo(
                 interactive=True,
                 check=lambda cfg: verify_all([cfg])[0],
             )
-            switched = _provider_config(provider_name, model_type, region)
+            provider_name = switched.kind.value
+            model_type = switched.model_type or switched.model
             provider = wrap_provider_with_retries(
                 providers.get_provider(switched), on_retry=_NARRATOR.on_retry, sleep=_NARRATOR.sleep
             )

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -337,6 +337,9 @@ def providers_set(
     existing = load_settings_or_abort(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:
+        existing_azure_deployment = (
+            existing.deployment if existing is not None and existing.provider == "azure" else None
+        )
         provider, model, region, deployment = select_provider_and_model(
             _console,
             lambda text: _console.input(text),
@@ -344,7 +347,10 @@ def providers_set(
             default_provider=provider or (existing.provider if existing else None),
             default_model=model or (existing.model if existing else None),
             default_region=region or (existing.region if existing else None),
-            default_deployment=deployment,
+            default_deployment=deployment or existing_azure_deployment,
+            default_deployment_model=(
+                existing.model if deployment is None and existing_azure_deployment else None
+            ),
             ask_azure_deployment=True,
             interactive=True,
             check=lambda cfg: verify_all(

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -266,7 +266,7 @@ def _worker_provider_config(
     if config.kind is ProviderKind.AZURE_OPENAI:
         config = config.model_copy(
             update={
-                "deployment": deployment or config.model_type or config.model,
+                "deployment": deployment,
                 "api_version": api_version or "2024-05-01-preview",
             }
         )
@@ -337,13 +337,15 @@ def providers_set(
     existing = load_settings_or_abort(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:
-        provider, model, region = select_provider_and_model(
+        provider, model, region, deployment = select_provider_and_model(
             _console,
             lambda text: _console.input(text),
             lambda text: _console.input(text, password=True),
             default_provider=provider or (existing.provider if existing else None),
             default_model=model or (existing.model if existing else None),
             default_region=region or (existing.region if existing else None),
+            default_deployment=deployment,
+            ask_azure_deployment=True,
             interactive=True,
             check=lambda cfg: verify_all(
                 [
@@ -352,7 +354,7 @@ def providers_set(
                         cfg.model_type or cfg.model,
                         cfg.region,
                         endpoint=endpoint,
-                        deployment=deployment,
+                        deployment=cfg.deployment,
                         api_version=api_version,
                     )
                 ]
@@ -361,6 +363,11 @@ def providers_set(
     if provider is None or model is None:
         raise typer.BadParameter(
             "provide --provider and --model, or run `wmo providers set` in a terminal"
+        )
+    if _provider_kind(provider) is ProviderKind.AZURE_OPENAI and deployment is None:
+        raise typer.BadParameter(
+            "--deployment is required for Azure because deployment names are operator-created "
+            "and cannot be inferred from --model"
         )
     config = _worker_provider_config(
         provider,
@@ -398,9 +405,7 @@ def providers_set(
         options=pool_registry.EntryOptions(
             endpoint=config.endpoint,
             region=config.region,
-            # The RAW flags, not the worker config's: `_worker_provider_config` fills an Azure
-            # deployment in from the model id when none was given, and a pool entry must never
-            # inherit a guessed deployment name (nothing can derive an operator's own).
+            # The raw flags, not inferred worker fields. Azure deployment names are operator-owned.
             deployment=deployment,
             api_version=api_version,
             api_key_env=api_key_env,
@@ -2680,7 +2685,7 @@ def demo(
             # failed step — completed steps stay done.
             _console.print(f"\n[red]serve provider is still failing[/red]: {_short_error(exc)}")
             _console.print("[yellow]pick a different provider to continue the demo[/yellow]")
-            provider_name, model_type, region = select_provider_and_model(
+            provider_name, model_type, region, _deployment = select_provider_and_model(
                 _console,
                 lambda text: _console.input(text),
                 lambda text: _console.input(text, password=True),

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1085,6 +1085,47 @@ def test_providers_set_requires_an_operator_named_azure_deployment(
     assert load_settings(root).models.worker is None
 
 
+def test_providers_set_offers_the_saved_azure_deployment_on_interactive_rerun(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A bare rerun carries the configured model's deployment into the picker."""
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(
+        provider="azure",
+        model="kimi-k2.6",
+        deployment="prod-kimi",
+    )
+    save_settings(settings, root)
+    offered: list[tuple[str | None, str | None]] = []
+
+    def select(*_args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        offered.append((kwargs["default_deployment"], kwargs["default_deployment_model"]))
+        return "azure", "kimi-k2.6", None, kwargs["default_deployment"]
+
+    monkeypatch.setattr(
+        cli_app_module,
+        "_console",
+        SimpleNamespace(is_terminal=True, print=lambda *_: None),
+    )
+    monkeypatch.setattr(cli_app_module, "select_provider_and_model", select)
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: [
+            VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs
+        ],
+    )
+    monkeypatch.setattr(cli_app_module, "_register_pool_models", lambda **_kwargs: None)
+
+    result = runner.invoke(app, ["providers", "set", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert offered == [("prod-kimi", "kimi-k2.6")]
+    worker = load_settings(root).models.worker
+    assert worker is not None and worker.deployment == "prod-kimi"
+
+
 def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub both live pings so `providers set` reaches, and gets through, pool registration.
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1052,6 +1052,39 @@ def test_providers_set_verifies_and_saves_local_worker(monkeypatch, tmp_path) ->
     assert worker.endpoint == "https://models.example/v1"
 
 
+def test_providers_set_requires_an_operator_named_azure_deployment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A scripted Azure setup must fail before a guessed deployment is verified or saved."""
+    verified: list[ProviderConfig] = []
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: verified.extend(configs) or [],
+    )
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "azure",
+            "--model",
+            "kimi-k2.6",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--deployment" in result.output
+    assert "operator" in result.output
+    assert verified == []
+    assert load_settings(root).models.worker is None
+
+
 def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub both live pings so `providers set` reaches, and gets through, pool registration.
 
@@ -1250,9 +1283,7 @@ def test_providers_set_rejects_an_unknown_tier(
 def test_providers_set_never_guesses_an_azure_deployment_for_the_pool(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    # The worker config fills an Azure deployment in from the model id when none was given; a
-    # pool entry must not inherit that guess, because Azure sends the deployment as the request
-    # model and a guessed name addresses a route that does not exist.
+    # Neither the worker nor the pool may infer an operator-owned Azure deployment.
     _accept_every_provider(monkeypatch)
     root = tmp_path / ".wmo"
 
@@ -1273,11 +1304,9 @@ def test_providers_set_never_guesses_an_azure_deployment_for_the_pool(
     )
 
     assert result.exit_code != 0
-    assert "azure needs --deployment" in result.output
+    assert "--deployment" in result.output
     assert not (root / "pool.toml").exists()
-    # The worker role is still saved with its derived deployment: only the pool is strict.
-    worker = load_settings(root).models.worker
-    assert worker is not None and worker.deployment == "gpt-5.5"
+    assert load_settings(root).models.worker is None
 
 
 def test_providers_set_registers_a_named_azure_deployment(

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import inspect
+import io
 import json
 import os
 import subprocess
@@ -17,6 +18,7 @@ from typing import cast
 import pytest
 import typer
 from pydantic import ValidationError
+from rich.console import Console
 from typer.testing import CliRunner
 
 from wmo.cli import app, pool_registry
@@ -56,6 +58,7 @@ from wmo.tracking.pricing import ModelPrice
 # `wmo.cli`'s `app` attribute (the Typer object) shadows the `wmo.cli.app` submodule on
 # plain `import wmo.cli.app as ...`; go through importlib to monkeypatch module globals.
 cli_app_module = importlib.import_module("wmo.cli.app")
+ui_module = importlib.import_module("wmo.cli.ui")
 
 runner = CliRunner()
 
@@ -274,7 +277,8 @@ def test_build_wizard_does_not_reuse_connection_for_changed_provider(
     )
     save_settings(settings, root)
 
-    def switch_provider(_console, params):  # noqa: ANN001, ANN202
+    def switch_provider(_console, params, *, configured_provider):  # noqa: ANN001, ANN202
+        assert configured_provider is not None
         return params.model_copy(
             update={
                 "name": "wizard-switch",
@@ -835,6 +839,78 @@ def test_demo_off_a_terminal_calls_an_outage_an_outage(
     assert "wmoprovidersverify" not in flat  # it would only re-report the same outage
 
 
+def test_demo_recovery_uses_the_exact_verified_azure_config(
+    patched_provider: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The capacity picker result must reach the replacement provider unchanged."""
+    import wmo.providers as providers_pkg
+
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    selected = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="kimi-k2.6",
+        model_type="kimi-k2.6",
+        endpoint="https://custom.example",
+        deployment="prod-kimi",
+        api_version="2024-05-01-preview",
+    )
+    verified: list[ProviderConfig] = []
+    constructed: list[ProviderConfig] = []
+    attempts = 0
+
+    def run(*_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("capacity exhausted")
+
+    def select(*_args, **kwargs) -> ProviderConfig:  # noqa: ANN002, ANN003
+        result = kwargs["check"](selected)
+        assert result.ok
+        return selected
+
+    def verify(configs: list[ProviderConfig]) -> list[VerifyResult]:
+        verified.extend(configs)
+        return [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
+
+    def construct(config: ProviderConfig) -> FakeProvider:
+        constructed.append(config)
+        return FakeProvider()
+
+    monkeypatch.setattr(
+        cli_app_module,
+        "_console",
+        Console(force_terminal=True, no_color=True, file=io.StringIO()),
+    )
+    monkeypatch.setattr(cli_app_module, "run_demo", run)
+    monkeypatch.setattr(cli_app_module, "is_capacity_error", lambda _exc: True)
+    monkeypatch.setattr(cli_app_module, "select_provider_and_model", select)
+    monkeypatch.setattr(cli_app_module, "verify_all", verify)
+    monkeypatch.setattr(providers_pkg, "get_provider", construct)
+
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--steps",
+            "1",
+            "--no-prompt",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert attempts == 2
+    assert verified == [selected]
+    assert constructed[-1] == selected
+
+
 def test_demo_keeps_the_traceback_for_a_wmo_bug(patched_provider, tmp_path, monkeypatch) -> None:  # noqa: ANN001
     """Only backend SDK failures are re-rendered; our own bugs must not be dressed up as setup."""
     root = tmp_path / ".wmo"
@@ -1101,7 +1177,13 @@ def test_providers_set_offers_the_saved_azure_deployment_on_interactive_rerun(
 
     def select(*_args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         offered.append((kwargs["default_deployment"], kwargs["default_deployment_model"]))
-        return "azure", "kimi-k2.6", None, kwargs["default_deployment"]
+        return ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="kimi-k2.6",
+            model_type="kimi-k2.6",
+            deployment=kwargs["default_deployment"],
+            api_version="2024-05-01-preview",
+        )
 
     monkeypatch.setattr(
         cli_app_module,
@@ -1124,6 +1206,46 @@ def test_providers_set_offers_the_saved_azure_deployment_on_interactive_rerun(
     assert offered == [("prod-kimi", "kimi-k2.6")]
     worker = load_settings(root).models.worker
     assert worker is not None and worker.deployment == "prod-kimi"
+
+
+def test_providers_set_passes_custom_endpoint_into_the_credential_aware_picker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Interactive setup must classify credentials against the endpoint it will save."""
+    root = tmp_path / ".wmo"
+    endpoint = "https://custom.example"
+    received: list[str | None] = []
+
+    def select(*_args, **kwargs) -> ProviderConfig:  # noqa: ANN002, ANN003
+        received.append(kwargs["endpoint"])
+        return ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="kimi-k2.6",
+            model_type="kimi-k2.6",
+            endpoint=kwargs["endpoint"],
+            deployment="prod-kimi",
+            api_version="2024-05-01-preview",
+        )
+
+    monkeypatch.setattr(
+        cli_app_module,
+        "_console",
+        SimpleNamespace(is_terminal=True, print=lambda *_: None),
+    )
+    monkeypatch.setattr(cli_app_module, "select_provider_and_model", select)
+    monkeypatch.setattr(cli_app_module, "_register_pool_models", lambda **_kwargs: None)
+
+    result = runner.invoke(
+        app,
+        ["providers", "set", "--endpoint", endpoint, "--root", str(root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert received == [endpoint]
+    worker = load_settings(root).models.worker
+    assert worker is not None
+    assert worker.endpoint == endpoint
+    assert worker.deployment == "prod-kimi"
 
 
 def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2078,6 +2200,53 @@ def test_build_interactive_wizard_creates_model(
     )
     assert result.exit_code == 0, result.output
     assert (root / "models" / "wizard-built" / "config.toml").exists()
+
+
+def test_build_interactive_azure_verifies_and_persists_the_entered_deployment(
+    patched_provider: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deployment verified by the wizard must be the one stored in the model."""
+    root = tmp_path / ".wmo"
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    verified: list[ProviderConfig] = []
+
+    def verify(configs: list[ProviderConfig]) -> list[VerifyResult]:
+        verified.extend(configs)
+        return [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
+
+    monkeypatch.setattr(ui_module, "verify_all", verify)
+    answers = "\n".join(
+        [
+            "azure-wizard",
+            "",
+            _traces_file(tmp_path),
+            "4",
+            "4",
+            "prod-kimi",
+            "",
+            "1",
+            "1",
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        ["build", "--interactive", "--root", str(root)],
+        input=answers + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    [pinged] = verified
+    assert pinged.kind is ProviderKind.AZURE_OPENAI
+    assert pinged.deployment == "prod-kimi"
+    assert pinged.api_version == "2024-05-01-preview"
+    persisted = load_config(root / "models" / "azure-wizard").serve_provider_config()
+    assert persisted.kind is ProviderKind.AZURE_OPENAI
+    assert persisted.deployment == "prod-kimi"
+    assert persisted.api_version == "2024-05-01-preview"
 
 
 def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -263,17 +263,15 @@ def test_build_explicit_model_keeps_configured_azure_connection(
     assert provider.api_version == "2026-01-01"
 
 
-def test_build_wizard_does_not_reuse_connection_for_changed_provider(
+def test_build_wizard_preserves_verified_connection_for_changed_provider(
     patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     root = tmp_path / ".wmo"
     settings = load_settings(root)
     settings.models.worker = ModelRole(
-        provider="azure",
-        model="gpt-5.4",
-        endpoint="https://azure.example/v1",
-        deployment="configured-deployment",
-        api_version="2026-01-01",
+        provider="openai",
+        model="gpt-5.4-mini",
+        endpoint="https://old.example/v1",
     )
     save_settings(settings, root)
 
@@ -283,9 +281,12 @@ def test_build_wizard_does_not_reuse_connection_for_changed_provider(
             update={
                 "name": "wizard-switch",
                 "file": _traces_file(tmp_path),
-                "provider": "openai",
-                "model": "gpt-5.4-mini",
+                "provider": "azure",
+                "model": "kimi-k2.6",
                 "region": None,
+                "endpoint": None,
+                "deployment": "prod-kimi",
+                "api_version": "2024-05-01-preview",
             }
         )
 
@@ -296,10 +297,10 @@ def test_build_wizard_does_not_reuse_connection_for_changed_provider(
     assert result.exit_code == 0, result.output
     config = load_config(root / "models" / "wizard-switch")
     provider = config.serve_provider_config()
-    assert provider.kind is ProviderKind.OPENAI
+    assert provider.kind is ProviderKind.AZURE_OPENAI
     assert provider.endpoint is None
-    assert provider.deployment is None
-    assert provider.api_version is None
+    assert provider.deployment == "prod-kimi"
+    assert provider.api_version == "2024-05-01-preview"
 
 
 def test_build_writes_model_card(patched_provider, tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -114,20 +114,57 @@ def configured_role_configs(root: str) -> list[tuple[ModelRoleName, ProviderConf
         configured: ModelRole | None = getattr(models, role)
         if configured is None:
             continue
-        config = _model_config(configured, role=role)
-        spec = resolve_provider_model(config.kind, config.model)
-        resolved.append(
-            (
-                role,
-                config.model_copy(
-                    update={
-                        "model": spec.model_id,
-                        "model_type": config.model_type or spec.model_type,
-                    }
-                ),
-            )
-        )
+        resolved.append((role, configured_role_provider_config(configured, role=role)))
     return resolved
+
+
+def configured_role_provider_config(
+    configured: ModelRole,
+    *,
+    role: ModelRoleName,
+) -> ProviderConfig:
+    """Resolve one stored model role without inspecting unrelated role settings."""
+    config = _model_config(configured, role=role)
+    spec = resolve_provider_model(config.kind, config.model)
+    return config.model_copy(
+        update={
+            "model": spec.model_id,
+            "model_type": config.model_type or spec.model_type,
+        }
+    )
+
+
+def inherit_provider_connection(
+    selected: ProviderConfig,
+    configured: ProviderConfig | None,
+) -> ProviderConfig:
+    """Carry reusable connection settings into a newly selected provider config.
+
+    Endpoints and API versions belong to a provider connection and remain valid across models.
+    Deployment names and request knobs belong to one model and only survive the same canonical
+    model selection.
+    """
+    if configured is None or selected.kind is not configured.kind:
+        return selected
+
+    updates = {
+        field: value
+        for field in ("endpoint", "api_version")
+        if (value := getattr(configured, field)) is not None
+    }
+    selected_model = selected.model_type or selected.model
+    configured_model = configured.model_type or configured.model
+    if selected_model.casefold() == configured_model.casefold():
+        updates.update(
+            {
+                field: value
+                for field in ("deployment", "reasoning_effort")
+                if (value := getattr(configured, field)) is not None
+            }
+        )
+        if "chat_max_tokens_field" in configured.model_fields_set:
+            updates["chat_max_tokens_field"] = configured.chat_max_tokens_field
+    return selected.model_copy(update=updates) if updates else selected
 
 
 def _model_config(configured: ModelRole, *, role: ModelRoleName) -> ProviderConfig:

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -40,6 +40,7 @@ from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
 from wmo.cli.ui import PromptReader, creds_note, ensure_credentials, has_credentials, select_option
 from wmo.config import PROVIDER_ENV_VARS
 from wmo.core.locks import FileLockTimeout
+from wmo.providers.azure_openai import is_untrusted_azure_endpoint
 from wmo.providers.base import ProviderKind, VerifyResult
 from wmo.providers.catalog import CatalogModel, CatalogSource, ProviderCatalog, list_provider_models
 from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
@@ -653,7 +654,7 @@ def _ask_shared_options(
             _ask_text(console, ask, "AWS region (blank = AWS_REGION)", options.region or "") or None
         )
     else:
-        default_env = _default_key_env(kind)
+        default_env = _default_key_env(kind, endpoint=options.endpoint)
         updates["api_key_env"] = (
             _ask_text(
                 console,
@@ -699,8 +700,13 @@ def _ask_per_model_options(
     return options.model_copy(update=updates) if updates else options
 
 
-def _default_key_env(kind: ProviderKind) -> str:
-    """The variable this backend reads by default, named so the blank answer is not a mystery."""
+def _default_key_env(kind: ProviderKind, *, endpoint: str | None = None) -> str:
+    """The variable this exact route reads by default, named so blank is not a mystery."""
+    if kind is ProviderKind.AZURE_OPENAI and is_untrusted_azure_endpoint(endpoint):
+        # Keep the registry on the same trust boundary as AzureOpenAIProvider and the provider
+        # picker: a config-controlled host must never be described as receiving the trusted
+        # resource credential.
+        return "WMO_ENDPOINT_API_KEY"
     env_vars = PROVIDER_ENV_VARS.get(kind, [])
     return env_vars[0] if env_vars else "the backend default"
 

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -189,6 +189,49 @@ def test_a_second_pass_adds_a_second_provider_without_dropping_the_first(tmp_pat
     assert azure.api_version == "2025-01-01-preview"
 
 
+def test_custom_azure_endpoint_pool_prompt_uses_only_endpoint_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The registry must describe the same custom-endpoint credential that dispatch will use."""
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    pool = tmp_path / "pool.toml"
+    verified: list[PoolEntry] = []
+
+    def record(entry: PoolEntry) -> VerifyResult:
+        verified.append(entry)
+        return _ok(entry)
+
+    written, _, script = _drive(
+        pool,
+        [
+            "y",
+            "azure",
+            "gpt-5.4",
+            "",
+            "frontier",
+            "",  # accept the custom endpoint's safe credential default
+            "prod-gpt54",
+            "2025-01-01-preview",
+            "",
+            "n",
+        ],
+        kind=ProviderKind.AZURE_OPENAI,
+        options=EntryOptions(endpoint="https://custom.example"),
+        verify=record,
+    )
+
+    assert written == 1
+    credential_prompt = next(prompt for prompt in script.prompts if "Env var holding" in prompt)
+    assert "WMO_ENDPOINT_API_KEY" in credential_prompt
+    assert "AZURE_OPENAI_API_KEY" not in credential_prompt
+    entry = read_pool_entries(pool)[0]
+    assert len(verified) == 1
+    assert verified[0].endpoint == entry.endpoint
+    assert verified[0].api_key_env == entry.api_key_env
+    assert entry.endpoint == "https://custom.example"
+    assert entry.api_key_env is None
+
+
 def test_re_registering_the_same_model_leaves_the_file_byte_identical(tmp_path: Path) -> None:
     # Idempotence has to be at the FILE level: writing the same entry again would go through
     # upsert's replacement path, which re-renders the roster and drops its comments.

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -42,6 +42,7 @@ from rich.segment import ControlType
 from rich.table import Table
 from rich.text import Text
 
+from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION, inherit_provider_connection
 from wmo.config import (
     PROVIDER_ENV_VARS,
     ModelInfo,
@@ -54,6 +55,7 @@ from wmo.engine.build import DEFAULT_TRAIN_SPLIT
 from wmo.engine.play import PlayTurn, parse_action, play_turn
 from wmo.engine.world_model import WorldModel
 from wmo.providers import verify_all, verify_embedder
+from wmo.providers.azure_openai import is_untrusted_azure_endpoint
 from wmo.providers.base import ProviderConfig, ProviderKind, VerifyResult
 from wmo.providers.models import resolve_provider_model
 
@@ -144,6 +146,9 @@ class BuildParams(BaseModel):
     # Canonical GEPA judge model type; None = pick the cheap per-provider default.
     judge_model: str | None = None
     region: str | None = None
+    endpoint: str | None = None
+    deployment: str | None = None
+    api_version: str | None = None
     fidelity: str = "medium"
     train_split: float = DEFAULT_TRAIN_SPLIT
     embed_provider: str = "hashing"
@@ -240,23 +245,40 @@ def select_provider_and_model(
     default_region: str | None,
     default_deployment: str | None = None,
     default_deployment_model: str | None = None,
-    ask_azure_deployment: bool = False,
     interactive: bool,
     check: Callable[[ProviderConfig], VerifyResult],
-) -> tuple[str, str, str | None, str | None]:
+    configured_provider: ProviderConfig | None = None,
+    endpoint: str | None = None,
+    api_version: str | None = None,
+) -> ProviderConfig:
     """The wizard's serve-provider block: pick provider + model (+ region), creds, live verify.
 
     Providers with credentials present are annotated and the first becomes the suggested default
     (none otherwise); a failed live ping loops back to the picker with the failed pick as the
-    retry default. A caller that owns persistent Azure setup may request the deployment prompt;
-    the exact operator-entered deployment is included in the config passed to `check`. Also reused
-    by `wmo demo`'s switch-provider flow. Returns (provider, model, region, deployment).
+    retry default. Every Azure selection asks for its operator-created deployment. The exact
+    config passed to `check` is returned so build, setup, and demo cannot reconstruct a different
+    endpoint or deployment after verification.
     """
     providers = list(_PROVIDER_MODELS)
-    with_creds = [p for p in providers if has_credentials(p)]
+
+    def connection_endpoint(provider: str) -> str | None:
+        if endpoint is not None:
+            return endpoint
+        if configured_provider is not None and configured_provider.kind.value == provider:
+            return configured_provider.endpoint
+        return None
+
+    with_creds = [
+        provider
+        for provider in providers
+        if has_credentials(provider, endpoint=connection_endpoint(provider))
+    ]
     # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
     # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
-    notes = {p: creds_note(p) for p in with_creds}
+    notes = {
+        provider: creds_note(provider, endpoint=connection_endpoint(provider))
+        for provider in with_creds
+    }
     provider_default = default_provider or (with_creds[0] if with_creds else None)
     retry_deployment: tuple[str, str] | None = None
     while True:
@@ -269,7 +291,12 @@ def select_provider_and_model(
             interactive=interactive,
             notes=notes,
         )
-        ensure_credentials(console, ask_secret, provider)
+        ensure_credentials(
+            console,
+            ask_secret,
+            provider,
+            endpoint=connection_endpoint(provider),
+        )
         model = _select(
             console,
             ask,
@@ -283,17 +310,27 @@ def select_provider_and_model(
         if provider == "bedrock":
             region_default = default_region or _DEFAULT_REGIONS.get(provider)
             region = _prompt_text(console, ask, "AWS region", region_default) or None
-        deployment = None
-        if provider == "azure" and ask_azure_deployment:
+        deployment: str | None = None
+        if provider == "azure":
+            configured_deployment = None
+            if (
+                configured_provider is not None
+                and configured_provider.kind is ProviderKind.AZURE_OPENAI
+            ):
+                configured_model = configured_provider.model_type or configured_provider.model
+                if configured_model.casefold() == model.casefold():
+                    configured_deployment = configured_provider.deployment
             deployment_default = (
                 retry_deployment[1]
                 if retry_deployment is not None and retry_deployment[0] == model
                 else (
                     default_deployment
                     if default_deployment_model is None or default_deployment_model == model
-                    else None
+                    else configured_deployment
                 )
             )
+            if deployment_default is None:
+                deployment_default = configured_deployment
             while not deployment:
                 deployment = (
                     _prompt_text(
@@ -311,19 +348,30 @@ def select_provider_and_model(
         # Live ping now, not at the end: a bad key or model id loops straight back to the
         # picker (the failed pick becomes the suggested retry default).
         console.print(f"verifying {provider}…")
-        model_spec = resolve_provider_model(ProviderKind(provider), model)
-        ping = check(
+        kind = ProviderKind(provider)
+        model_spec = resolve_provider_model(kind, model)
+        selected = inherit_provider_connection(
             ProviderConfig(
-                kind=ProviderKind(provider),
+                kind=kind,
                 model_type=model_spec.model_type,
                 model=model_spec.model_id,
                 region=region,
-                deployment=deployment,
-            )
+            ),
+            configured_provider,
         )
+        updates: dict[str, str | None] = {}
+        if endpoint is not None:
+            updates["endpoint"] = endpoint
+        if kind is ProviderKind.AZURE_OPENAI:
+            updates["deployment"] = deployment
+            updates["api_version"] = (
+                api_version or selected.api_version or DEFAULT_AZURE_API_VERSION
+            )
+        selected = selected.model_copy(update=updates) if updates else selected
+        ping = check(selected)
         if ping.ok:
             console.print(f"  {_CHECK} {provider} ({escape(model)}) reachable")
-            return provider, model, region, deployment
+            return selected
         console.print(
             f"  [red]✗ {provider} ({escape(model)}) failed[/red]: {escape(ping.detail or '')}"
         )
@@ -338,6 +386,7 @@ def run_build_wizard(
     reader: PromptReader | None = None,
     verify: Callable[[ProviderConfig], VerifyResult] | None = None,
     verify_embed: Callable[[ProviderConfig], VerifyResult] | None = None,
+    configured_provider: ProviderConfig | None = None,
 ) -> BuildParams:
     """Guided creation flow: prompt for each build input, pre-filled with `defaults`.
 
@@ -404,16 +453,22 @@ def run_build_wizard(
         console, ask, ask_secret, defaults, interactive
     )
 
-    provider, model, region, _deployment = select_provider_and_model(
+    selected_provider = select_provider_and_model(
         console,
         ask,
         ask_secret,
         default_provider=defaults.provider,
         default_model=defaults.model,
         default_region=defaults.region,
+        default_deployment=defaults.deployment,
+        default_deployment_model=defaults.model if defaults.deployment is not None else None,
         interactive=interactive,
         check=check,
+        configured_provider=configured_provider,
     )
+    provider = selected_provider.kind.value
+    model = selected_provider.model_type or selected_provider.model
+    region = selected_provider.region
 
     # GEPA judge model: defaults to a cheap model of the same provider (haiku / gpt-5.4-mini);
     # picking the serve model itself is always on the list. Same inline verify + retry.
@@ -436,11 +491,11 @@ def run_build_wizard(
         console.print(f"verifying {provider} (judge)…")
         judge_spec = resolve_provider_model(ProviderKind(provider), judge_model)
         ping = check(
-            ProviderConfig(
-                kind=ProviderKind(provider),
-                model_type=judge_spec.model_type,
-                model=judge_spec.model_id,
-                region=region,
+            selected_provider.model_copy(
+                update={
+                    "model_type": judge_spec.model_type,
+                    "model": judge_spec.model_id,
+                }
             )
         )
         if ping.ok:
@@ -510,15 +565,21 @@ def run_build_wizard(
         # Same inline ping for the embed path, with the embeddings model and phi dimension
         # stamped on (mirrors HarnessConfig.embed_provider_config).
         console.print(f"verifying embed:{embed_provider}…")
-        ping = check_embed(
-            ProviderConfig(
-                kind=ProviderKind(embed_provider),
-                model=embed_model,
-                embed_model=embed_model,
-                embed_dim=defaults.embed_dim,
-                region=region if embed_provider == "bedrock" else None,
-            )
+        embed_config = ProviderConfig(
+            kind=ProviderKind(embed_provider),
+            model=embed_model,
+            embed_model=embed_model,
+            embed_dim=defaults.embed_dim,
+            region=region if embed_provider == "bedrock" else None,
         )
+        if embed_config.kind is selected_provider.kind:
+            embed_config = selected_provider.model_copy(
+                update={
+                    "embed_model": embed_model,
+                    "embed_dim": defaults.embed_dim,
+                }
+            )
+        ping = check_embed(embed_config)
         if ping.ok:
             console.print(f"  {_CHECK} embed:{embed_provider} ({escape(embed_model)}) reachable")
             break
@@ -542,6 +603,9 @@ def run_build_wizard(
         model=model,
         judge_model=judge_model,
         region=region,
+        endpoint=selected_provider.endpoint,
+        deployment=selected_provider.deployment,
+        api_version=selected_provider.api_version,
         fidelity=fidelity,
         train_split=defaults.train_split,
         embed_provider=embed_provider,
@@ -727,33 +791,43 @@ def _select(
         console.print(f"[red]pick 1-{len(options)} or an option name[/red]")
 
 
-def _provider_env_vars(provider: str) -> list[str]:
+def _provider_env_vars(provider: str, *, endpoint: str | None = None) -> list[str]:
     """The env vars `provider` reads its credentials from ([] for unknown/offline kinds)."""
+    if provider == ProviderKind.OPENAI.value and endpoint is not None:
+        return ["WMO_ENDPOINT_API_KEY"]
+    if provider == ProviderKind.AZURE_OPENAI.value and is_untrusted_azure_endpoint(endpoint):
+        return ["WMO_ENDPOINT_API_KEY"]
     try:
         return PROVIDER_ENV_VARS[ProviderKind(provider)]
     except (ValueError, KeyError):
         return []
 
 
-def creds_note(provider: str) -> str:
+def creds_note(provider: str, *, endpoint: str | None = None) -> str:
     """Picker annotation for a provider whose credentials are present, naming what was found."""
-    env_vars = _provider_env_vars(provider)
+    env_vars = _provider_env_vars(provider, endpoint=endpoint)
     return f"{env_vars[0]} set" if len(env_vars) == 1 else "creds set"
 
 
-def has_credentials(provider: str) -> bool:
+def has_credentials(provider: str, *, endpoint: str | None = None) -> bool:
     """Offline presence check: every credential env var for `provider` is set (not validated)."""
-    env_vars = _provider_env_vars(provider)
+    env_vars = _provider_env_vars(provider, endpoint=endpoint)
     return bool(env_vars) and all(os.environ.get(var) for var in env_vars)
 
 
-def ensure_credentials(console: Console, ask_secret: PromptReader, provider: str) -> None:
+def ensure_credentials(
+    console: Console,
+    ask_secret: PromptReader,
+    provider: str,
+    *,
+    endpoint: str | None = None,
+) -> None:
     """Prompt for any missing credential env vars and persist entered values to `.env`.
 
     Presence only — the live ping that confirms the creds actually work happens once before
     the build (see `wmo build`). Enter skips a var, leaving it to the shell environment.
     """
-    for var in _provider_env_vars(provider):
+    for var in _provider_env_vars(provider, endpoint=endpoint):
         if os.environ.get(var):
             console.print(f"  {_CHECK} {var} is set")
             continue

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -81,7 +81,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "bedrock": ["claude-opus-4-8", "claude-opus-4-7", "claude-haiku-4-5"],
     # openai_responses (the Responses API) stays flag-only (`wmo build --provider
     # openai_responses`); the wizard list keeps to the four everyday backends.
-    "azure": ["gpt-5.5", "gpt-5.4"],
+    "azure": ["gpt-5.5", "gpt-5.4", "deepseek-v4-pro", "kimi-k2.6"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 
@@ -238,15 +238,18 @@ def select_provider_and_model(
     default_provider: str | None,
     default_model: str | None,
     default_region: str | None,
+    default_deployment: str | None = None,
+    ask_azure_deployment: bool = False,
     interactive: bool,
     check: Callable[[ProviderConfig], VerifyResult],
-) -> tuple[str, str, str | None]:
+) -> tuple[str, str, str | None, str | None]:
     """The wizard's serve-provider block: pick provider + model (+ region), creds, live verify.
 
     Providers with credentials present are annotated and the first becomes the suggested default
     (none otherwise); a failed live ping loops back to the picker with the failed pick as the
-    retry default. Also reused by `wmo demo`'s switch-provider flow. Returns
-    (provider, model, region).
+    retry default. A caller that owns persistent Azure setup may request the deployment prompt;
+    the exact operator-entered deployment is included in the config passed to `check`. Also reused
+    by `wmo demo`'s switch-provider flow. Returns (provider, model, region, deployment).
     """
     providers = list(_PROVIDER_MODELS)
     with_creds = [p for p in providers if has_credentials(p)]
@@ -278,6 +281,22 @@ def select_provider_and_model(
         if provider == "bedrock":
             region_default = default_region or _DEFAULT_REGIONS.get(provider)
             region = _prompt_text(console, ask, "AWS region", region_default) or None
+        deployment = None
+        if provider == "azure" and ask_azure_deployment:
+            while not deployment:
+                deployment = (
+                    _prompt_text(
+                        console,
+                        ask,
+                        f"Azure deployment serving {model}",
+                        default_deployment,
+                    )
+                    or None
+                )
+                if deployment is None:
+                    console.print(
+                        "[red]an operator-created Azure deployment name is required[/red]"
+                    )
         # Live ping now, not at the end: a bad key or model id loops straight back to the
         # picker (the failed pick becomes the suggested retry default).
         console.print(f"verifying {provider}…")
@@ -288,11 +307,12 @@ def select_provider_and_model(
                 model_type=model_spec.model_type,
                 model=model_spec.model_id,
                 region=region,
+                deployment=deployment,
             )
         )
         if ping.ok:
             console.print(f"  {_CHECK} {provider} ({escape(model)}) reachable")
-            return provider, model, region
+            return provider, model, region, deployment
         console.print(
             f"  [red]✗ {provider} ({escape(model)}) failed[/red]: {escape(ping.detail or '')}"
         )
@@ -372,7 +392,7 @@ def run_build_wizard(
         console, ask, ask_secret, defaults, interactive
     )
 
-    provider, model, region = select_provider_and_model(
+    provider, model, region, _deployment = select_provider_and_model(
         console,
         ask,
         ask_secret,

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -239,6 +239,7 @@ def select_provider_and_model(
     default_model: str | None,
     default_region: str | None,
     default_deployment: str | None = None,
+    default_deployment_model: str | None = None,
     ask_azure_deployment: bool = False,
     interactive: bool,
     check: Callable[[ProviderConfig], VerifyResult],
@@ -257,6 +258,7 @@ def select_provider_and_model(
     # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
     notes = {p: creds_note(p) for p in with_creds}
     provider_default = default_provider or (with_creds[0] if with_creds else None)
+    retry_deployment: tuple[str, str] | None = None
     while True:
         provider = _select(
             console,
@@ -283,13 +285,22 @@ def select_provider_and_model(
             region = _prompt_text(console, ask, "AWS region", region_default) or None
         deployment = None
         if provider == "azure" and ask_azure_deployment:
+            deployment_default = (
+                retry_deployment[1]
+                if retry_deployment is not None and retry_deployment[0] == model
+                else (
+                    default_deployment
+                    if default_deployment_model is None or default_deployment_model == model
+                    else None
+                )
+            )
             while not deployment:
                 deployment = (
                     _prompt_text(
                         console,
                         ask,
                         f"Azure deployment serving {model}",
-                        default_deployment,
+                        deployment_default,
                     )
                     or None
                 )
@@ -317,6 +328,7 @@ def select_provider_and_model(
             f"  [red]✗ {provider} ({escape(model)}) failed[/red]: {escape(ping.detail or '')}"
         )
         console.print("  [yellow]fix the credentials or pick a different provider/model[/yellow]")
+        retry_deployment = (model, deployment) if deployment is not None else None
         provider_default = provider
 
 

--- a/wmo/cli/ui_test.py
+++ b/wmo/cli/ui_test.py
@@ -312,6 +312,53 @@ def test_provider_picker_collects_azure_deployment_before_verification() -> None
     assert deployment_prompt == len(prompts) - 1
 
 
+def test_provider_picker_reuses_saved_deployment_and_retains_it_across_retry() -> None:
+    """A project rerun can accept its saved deployment, including after a failed ping."""
+    console = Console(force_terminal=False, no_color=True, width=100)
+    answers = iter(
+        [
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+    verified: list[ProviderConfig] = []
+
+    def verify(config: ProviderConfig) -> VerifyResult:
+        verified.append(config)
+        return VerifyResult(
+            ok=len(verified) == 2,
+            kind=config.kind,
+            model=config.model,
+            detail="temporary failure",
+        )
+
+    provider, model, region, deployment = select_provider_and_model(
+        console,
+        _scripted_reader(list(answers)),
+        _scripted_reader([]),
+        default_provider="azure",
+        default_model="kimi-k2.6",
+        default_region=None,
+        default_deployment="prod-kimi",
+        default_deployment_model="kimi-k2.6",
+        ask_azure_deployment=True,
+        interactive=False,
+        check=verify,
+    )
+
+    assert (provider, model, region, deployment) == (
+        "azure",
+        "kimi-k2.6",
+        None,
+        "prod-kimi",
+    )
+    assert [config.deployment for config in verified] == ["prod-kimi", "prod-kimi"]
+
+
 def test_build_wizard_select_by_number() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # Provider/model/embedder are numbered pickers; choosing by index must work. Pick anthropic (2),

--- a/wmo/cli/ui_test.py
+++ b/wmo/cli/ui_test.py
@@ -288,7 +288,7 @@ def test_provider_picker_collects_azure_deployment_before_verification() -> None
         verified.append(config)
         return VerifyResult(ok=True, kind=config.kind, model=config.model)
 
-    provider, model, region, deployment = select_provider_and_model(
+    selected = select_provider_and_model(
         console,
         read,
         read,
@@ -296,17 +296,14 @@ def test_provider_picker_collects_azure_deployment_before_verification() -> None
         default_model="kimi-k2.6",
         default_region=None,
         default_deployment=None,
-        ask_azure_deployment=True,
         interactive=False,
         check=verify,
     )
 
-    assert (provider, model, region, deployment) == (
-        "azure",
-        "kimi-k2.6",
-        None,
-        "prod-kimi",
-    )
+    assert selected.kind is ProviderKind.AZURE_OPENAI
+    assert selected.model_type == "kimi-k2.6"
+    assert selected.region is None
+    assert selected.deployment == "prod-kimi"
     assert verified[0].deployment == "prod-kimi"
     deployment_prompt = next(i for i, prompt in enumerate(prompts) if "deployment" in prompt)
     assert deployment_prompt == len(prompts) - 1
@@ -336,7 +333,7 @@ def test_provider_picker_reuses_saved_deployment_and_retains_it_across_retry() -
             detail="temporary failure",
         )
 
-    provider, model, region, deployment = select_provider_and_model(
+    selected = select_provider_and_model(
         console,
         _scripted_reader(list(answers)),
         _scripted_reader([]),
@@ -345,18 +342,132 @@ def test_provider_picker_reuses_saved_deployment_and_retains_it_across_retry() -
         default_region=None,
         default_deployment="prod-kimi",
         default_deployment_model="kimi-k2.6",
-        ask_azure_deployment=True,
         interactive=False,
         check=verify,
     )
 
-    assert (provider, model, region, deployment) == (
-        "azure",
-        "kimi-k2.6",
-        None,
-        "prod-kimi",
-    )
+    assert selected.kind is ProviderKind.AZURE_OPENAI
+    assert selected.model_type == "kimi-k2.6"
+    assert selected.region is None
+    assert selected.deployment == "prod-kimi"
     assert [config.deployment for config in verified] == ["prod-kimi", "prod-kimi"]
+
+
+def test_provider_picker_does_not_default_a_saved_deployment_for_another_model() -> None:
+    """Azure deployment names cannot be transferred between canonical models."""
+    console = Console(force_terminal=False, no_color=True, width=100)
+    prompts: list[str] = []
+    answers = iter(["", "", "prod-deepseek"])
+    configured = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="kimi-k2.6",
+        model_type="kimi-k2.6",
+        deployment="prod-kimi",
+        api_version="2024-05-01-preview",
+    )
+
+    def read(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(answers)
+
+    selected = select_provider_and_model(
+        console,
+        read,
+        read,
+        default_provider="azure",
+        default_model="deepseek-v4-pro",
+        default_region=None,
+        configured_provider=configured,
+        interactive=False,
+        check=_ok_verify,
+    )
+
+    deployment_prompt = next(prompt for prompt in prompts if "deployment" in prompt)
+    assert "prod-kimi" not in deployment_prompt
+    assert selected.deployment == "prod-deepseek"
+
+
+def test_provider_picker_custom_azure_endpoint_prompts_only_for_endpoint_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config endpoint must use the same credential boundary as AzureOpenAIProvider."""
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("WMO_ENDPOINT_API_KEY", raising=False)
+    saved: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        ui_module,
+        "upsert_env_var",
+        lambda var, value: (saved.append((var, value)), os.environ.__setitem__(var, value)),
+    )
+    console = Console(force_terminal=False, no_color=True, width=100)
+    prompts: list[str] = []
+    answers = iter(["", "endpoint-secret", "", "prod-kimi"])
+
+    def read(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(answers)
+
+    selected = select_provider_and_model(
+        console,
+        read,
+        read,
+        default_provider="azure",
+        default_model="kimi-k2.6",
+        default_region=None,
+        endpoint="https://custom.example",
+        interactive=False,
+        check=_ok_verify,
+    )
+
+    credential_prompts = [prompt for prompt in prompts if "saved to .env" in prompt]
+    assert len(credential_prompts) == 1
+    assert "WMO_ENDPOINT_API_KEY" in credential_prompts[0]
+    assert "AZURE_OPENAI_API_KEY" not in credential_prompts[0]
+    assert "AZURE_OPENAI_ENDPOINT" not in credential_prompts[0]
+    assert saved == [("WMO_ENDPOINT_API_KEY", "endpoint-secret")]
+    assert selected.endpoint == "https://custom.example"
+    assert selected.deployment == "prod-kimi"
+
+
+def test_build_wizard_verifies_and_returns_effective_azure_config() -> None:
+    """The Azure config verified in the wizard must survive into BuildParams."""
+    console = Console(force_terminal=False, no_color=True, width=100)
+    verified: list[ProviderConfig] = []
+    reader = _scripted_reader(
+        [
+            "azure-build",
+            "",
+            "/tmp/t.jsonl",
+            "azure",
+            "kimi-k2.6",
+            "prod-kimi",
+            "",
+            "low",
+            "hashing",
+        ]
+    )
+
+    def verify(config: ProviderConfig) -> VerifyResult:
+        verified.append(config)
+        return VerifyResult(ok=True, kind=config.kind, model=config.model)
+
+    params = run_build_wizard(
+        console,
+        BuildParams(name="default"),
+        reader=reader,
+        verify=verify,
+        verify_embed=_ok_verify,
+    )
+
+    [selected] = verified
+    assert selected.kind is ProviderKind.AZURE_OPENAI
+    assert selected.deployment == "prod-kimi"
+    assert selected.api_version == "2024-05-01-preview"
+    assert params.provider == "azure"
+    assert params.model == "kimi-k2.6"
+    assert params.deployment == "prod-kimi"
+    assert params.api_version == "2024-05-01-preview"
 
 
 def test_build_wizard_select_by_number() -> None:

--- a/wmo/cli/ui_test.py
+++ b/wmo/cli/ui_test.py
@@ -19,6 +19,7 @@ from wmo.cli.ui import (
     run_build_wizard,
     run_play_repl,
     select_model,
+    select_provider_and_model,
 )
 from wmo.config import PROVIDER_ENV_VARS, ModelInfo
 from wmo.core.types import Action, ActionKind, Observation, Step, Trace
@@ -270,6 +271,45 @@ def test_build_wizard_collects_all_inputs() -> None:
     assert params.fidelity == "high"
     assert params.embed_provider == "hashing"
     assert params.train_split == 0.5
+
+
+def test_provider_picker_collects_azure_deployment_before_verification() -> None:
+    """The providers-set TUI verifies the exact deployment the operator entered."""
+    console = Console(force_terminal=False, no_color=True, width=100)
+    prompts: list[str] = []
+    verified: list[ProviderConfig] = []
+    answers = iter(["", "", "prod-kimi"])
+
+    def read(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(answers)
+
+    def verify(config: ProviderConfig) -> VerifyResult:
+        verified.append(config)
+        return VerifyResult(ok=True, kind=config.kind, model=config.model)
+
+    provider, model, region, deployment = select_provider_and_model(
+        console,
+        read,
+        read,
+        default_provider="azure",
+        default_model="kimi-k2.6",
+        default_region=None,
+        default_deployment=None,
+        ask_azure_deployment=True,
+        interactive=False,
+        check=verify,
+    )
+
+    assert (provider, model, region, deployment) == (
+        "azure",
+        "kimi-k2.6",
+        None,
+        "prod-kimi",
+    )
+    assert verified[0].deployment == "prod-kimi"
+    deployment_prompt = next(i for i, prompt in enumerate(prompts) if "deployment" in prompt)
+    assert deployment_prompt == len(prompts) - 1
 
 
 def test_build_wizard_select_by_number() -> None:

--- a/wmo/providers/azure_openai.py
+++ b/wmo/providers/azure_openai.py
@@ -1,10 +1,10 @@
-"""Azure OpenAI provider (GPT 5.5).
+"""Azure provider for API-versioned Azure OpenAI and Azure Foundry v1 deployments.
 
 The real AZURE_OPENAI_API_KEY is only ever sent to the trusted, operator-supplied
 AZURE_OPENAI_ENDPOINT. A config-controlled endpoint (ProviderConfig.endpoint, which can arrive
 in an untrusted model bundle's config.toml) is treated as an untrusted host: auth for it comes
-from WMO_ENDPOINT_API_KEY, never the real key, mirroring OpenAIProvider. Deployment name and
-api_version come from ProviderConfig.deployment / ProviderConfig.api_version.
+from WMO_ENDPOINT_API_KEY, never the real key, mirroring OpenAIProvider. Deployment name and API
+surface come from ProviderConfig and the canonical model catalog.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ class AzureOpenAIProvider:
         # does not apply. Multi-account pools (several Azure resources, one key each) need this.
         self._api_key = api_key
         self._client: AzureOpenAI | None = None
-        self._responses_client: OpenAI | None = None
+        self._v1_client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
 
     def _resolved_endpoint(self) -> tuple[str, bool]:
@@ -117,9 +117,9 @@ class AzureOpenAIProvider:
                 )
         return self._client
 
-    def _get_responses_client(self) -> OpenAI:
-        """Create the Azure v1 client used by configured structured reasoning calls."""
-        if self._responses_client is None:
+    def _get_v1_client(self) -> OpenAI:
+        """Create the Azure v1 client used by chat and Responses API calls."""
+        if self._v1_client is None:
             endpoint, is_config_endpoint = self._resolved_endpoint()
             if self._api_key is not None:
                 # Same trusted explicit credential as _get_client.
@@ -130,12 +130,12 @@ class AzureOpenAIProvider:
                 api_key = os.environ.get("AZURE_OPENAI_API_KEY")
                 if not api_key:
                     raise ValueError(
-                        "AzureOpenAIProvider needs AZURE_OPENAI_API_KEY for the v1 Responses API."
+                        "AzureOpenAIProvider needs AZURE_OPENAI_API_KEY for the Azure v1 API."
                     )
 
             from openai import OpenAI
 
-            self._responses_client = OpenAI(
+            self._v1_client = OpenAI(
                 api_key=api_key,
                 base_url=_responses_base_url(endpoint),
                 timeout=240.0,
@@ -143,26 +143,32 @@ class AzureOpenAIProvider:
                 # one provider dispatch so usage and the operator's hard budget stay observable.
                 max_retries=0,
             )
-        return self._responses_client
+        return self._v1_client
+
+    def _get_responses_client(self) -> OpenAI:
+        """Return the v1 client used for structured reasoning calls."""
+        return self._get_v1_client()
 
     def prepare(self) -> None:
         """Resolve deployment, api_version, endpoint, and key by building this config's client.
 
-        Satisfies `wmo.providers.base.PreparableProvider`. Branches exactly like `verify`: a
-        `reasoning_effort` config dispatches through the Azure v1 Responses client, everything else
-        through the api-versioned chat client, so the thing that gets prepared is the thing the
-        request will use. All four failures are local, which is what makes this free: `_deployment`
-        rejects a config with no deployment name, `_get_client` rejects a missing api_version and a
-        missing endpoint before it reaches for the SDK, and `AzureOpenAI(...)` itself refuses to
-        construct without a resolvable key. No connection is opened.
+        Satisfies `wmo.providers.base.PreparableProvider`. The model's API-surface capability
+        selects the Azure v1 or API-versioned client independently from reasoning effort. All
+        failures are local, which is what makes this free: `_deployment` rejects a config with no
+        deployment name, each client validates its endpoint and credential before use, and no
+        connection is opened.
 
         Raises:
-            ValueError: The config is missing a deployment, an api_version, or an endpoint.
+            ValueError: The config is missing a deployment or endpoint, or an API-versioned
+                config is missing its api_version.
             openai.OpenAIError: No key resolved for this endpoint.
         """
         self._deployment()
-        if self.config.reasoning_effort is not None:
-            self._get_responses_client()
+        if (
+            self.config.reasoning_effort is not None
+            or self.config.resolved_azure_api_surface() == "v1"
+        ):
+            self._get_v1_client()
             return
         self._get_client()
 
@@ -207,8 +213,13 @@ class AzureOpenAIProvider:
                     input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
                 ),
             )
+        client = (
+            self._get_v1_client()
+            if self.config.resolved_azure_api_surface() == "v1"
+            else self._get_client()
+        )
         return _openai_common.complete(
-            self._get_client().chat.completions,
+            client.chat.completions,
             self._deployment(),
             system,
             messages,
@@ -239,8 +250,13 @@ class AzureOpenAIProvider:
                 "streaming is not yet implemented for reasoning_effort Azure configs; "
                 "unset reasoning_effort or use complete()"
             )
+        client = (
+            self._get_v1_client()
+            if self.config.resolved_azure_api_surface() == "v1"
+            else self._get_client()
+        )
         return _openai_common.stream(
-            self._get_client().chat.completions,
+            client.chat.completions,
             self._deployment(),
             system,
             messages,
@@ -265,8 +281,13 @@ class AzureOpenAIProvider:
                 reasoning_effort=self.config.reasoning_effort,
                 allow_sampling=False,
             )
+        client = (
+            self._get_v1_client()
+            if self.config.resolved_azure_api_surface() == "v1"
+            else self._get_client()
+        )
         return _openai_common.complete_chat(
-            self._get_client().chat.completions,
+            client.chat.completions,
             self._deployment(),
             request,
             max_tokens_field=self.config.resolved_chat_max_tokens_field(),

--- a/wmo/providers/azure_openai.py
+++ b/wmo/providers/azure_openai.py
@@ -72,8 +72,9 @@ class AzureOpenAIProvider:
         # Compare canonically so a trailing slash or host-casing difference between the config
         # value and the trusted env endpoint doesn't misclassify the same Azure resource as an
         # untrusted host (which would strip the real key and break the call).
-        is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
-            self.config.endpoint, env_endpoint
+        is_config_endpoint = is_untrusted_azure_endpoint(
+            self.config.endpoint,
+            trusted_endpoint=env_endpoint,
         )
         return endpoint, is_config_endpoint
 
@@ -308,6 +309,23 @@ class AzureOpenAIProvider:
             # chat-completions ping would prove the wrong endpoint and api surface.
             return verify_via_ping(self, ping=lambda: self.complete_chat(_REASONING_PING))
         return verify_via_ping(self)
+
+
+def is_untrusted_azure_endpoint(
+    endpoint: str | None,
+    *,
+    trusted_endpoint: str | None = None,
+) -> bool:
+    """Whether an explicit Azure endpoint must use the isolated endpoint credential.
+
+    The configured endpoint is trusted only when it canonically matches the operator's
+    ``AZURE_OPENAI_ENDPOINT``. Both provider dispatch and CLI credential prompts call this
+    function so they cannot choose different keys for the same URL.
+    """
+    if endpoint is None:
+        return False
+    trusted = trusted_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
+    return not _same_endpoint(endpoint, trusted)
 
 
 def _same_endpoint(a: str, b: str | None) -> bool:

--- a/wmo/providers/base.py
+++ b/wmo/providers/base.py
@@ -41,6 +41,7 @@ class EmbedderKind(StrEnum):
 
 
 Role = Literal["user", "assistant"]
+AzureAPISurface = Literal["api-versioned", "v1"]
 
 
 class Message(BaseModel):
@@ -105,6 +106,9 @@ class ProviderConfig(BaseModel):
     region: str | None = None  # AWS Bedrock region
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version
+    # Azure has two chat surfaces. Unset resolves through the canonical model catalog, keeping
+    # transport selection independent from optional reasoning configuration.
+    azure_api_surface: AzureAPISurface | None = None
     reasoning_effort: str | None = None  # OpenAI Responses reasoning.effort
     # The serialized default stays stable for persisted configs. When callers do not explicitly
     # set this field, built-in models resolve it from the canonical ProviderModel catalog.
@@ -133,6 +137,15 @@ class ProviderConfig(BaseModel):
             return True
         model = self.model_type or self.model
         return resolve_provider_model(self.kind, model).forward_temperature
+
+    def resolved_azure_api_surface(self) -> AzureAPISurface:
+        """Return the Azure chat API surface selected for this model."""
+        if self.azure_api_surface is not None:
+            return self.azure_api_surface
+        from wmo.providers.models import resolve_provider_model
+
+        model = self.model_type or self.model
+        return resolve_provider_model(self.kind, model).azure_api_surface
 
 
 def normalize_chat_temperature(

--- a/wmo/providers/models.py
+++ b/wmo/providers/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, ConfigDict
 
-from wmo.providers.base import ProviderKind
+from wmo.providers.base import AzureAPISurface, ProviderKind
 
 
 class ProviderModel(BaseModel):
@@ -27,6 +27,7 @@ class ProviderModel(BaseModel):
     model_id: str
     chat_max_tokens_field: ChatMaxTokensField = "max_completion_tokens"
     forward_temperature: bool = True
+    azure_api_surface: AzureAPISurface = "api-versioned"
 
 
 _MODELS: tuple[ProviderModel, ...] = (
@@ -158,12 +159,14 @@ _MODELS: tuple[ProviderModel, ...] = (
         model_type="deepseek-v4-pro",
         model_id="deepseek-v4-pro",
         chat_max_tokens_field="max_tokens",
+        azure_api_surface="v1",
     ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,
         model_type="kimi-k2.6",
         model_id="kimi-k2.6",
         chat_max_tokens_field="max_tokens",
+        azure_api_surface="v1",
     ),
 )
 

--- a/wmo/providers/models_test.py
+++ b/wmo/providers/models_test.py
@@ -73,6 +73,24 @@ def test_azure_models_declare_their_chat_token_parameter() -> None:
     assert actual == expected
 
 
+def test_azure_models_declare_their_api_surface() -> None:
+    """Azure API routing is model capability metadata, not a reasoning side effect."""
+    expected = {
+        "gpt-5.5": "api-versioned",
+        "gpt-5.4": "api-versioned",
+        "gpt-5.4-mini": "api-versioned",
+        "deepseek-v4-pro": "v1",
+        "kimi-k2.6": "v1",
+    }
+
+    actual = {
+        model_type: resolve_provider_model(ProviderKind.AZURE_OPENAI, model_type).azure_api_surface
+        for model_type in expected
+    }
+
+    assert actual == expected
+
+
 def test_unknown_custom_model_round_trips() -> None:
     resolved = resolve_provider_model(ProviderKind.OPENAI, "my-fine-tune")
     assert resolved.model_type == "my-fine-tune"
@@ -102,6 +120,19 @@ def test_provider_config_resolves_model_contract_before_custom_deployment() -> N
     assert config.chat_max_tokens_field == "max_completion_tokens"
     assert "chat_max_tokens_field" not in config.model_fields_set
     assert config.resolved_chat_max_tokens_field() == "max_completion_tokens"
+    assert config.resolved_azure_api_surface() == "api-versioned"
+
+
+def test_provider_config_allows_an_explicit_azure_api_surface_override() -> None:
+    """A custom Foundry deployment can opt into v1 without pretending to be a built-in model."""
+    config = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="my-foundry-model",
+        deployment="prod-model",
+        azure_api_surface="v1",
+    )
+
+    assert config.resolved_azure_api_surface() == "v1"
 
 
 def test_provider_config_allows_an_explicit_custom_endpoint_override() -> None:

--- a/wmo/providers/tests/azure_openai_test.py
+++ b/wmo/providers/tests/azure_openai_test.py
@@ -160,6 +160,51 @@ def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> 
     assert chat.last_kwargs["max_completion_tokens"] == 16
 
 
+@pytest.mark.parametrize("model_type", ["kimi-k2.6", "deepseek-v4-pro"])
+def test_foundry_v1_chat_models_use_v1_without_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch, model_type: str
+) -> None:
+    """A model's Azure API surface, not reasoning configuration, selects its transport."""
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(3, 2)))
+    provider = AzureOpenAIProvider(
+        _config().model_copy(
+            update={
+                "model": model_type,
+                "model_type": model_type,
+                "deployment": f"prod-{model_type}",
+                "reasoning_effort": None,
+            }
+        )
+    )
+    monkeypatch.setattr(provider, "_get_v1_client", lambda: _FakeClient(chat))
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("Foundry v1 must not use AzureOpenAI")),
+    )
+
+    completion = provider.complete("", [Message(role="user", content="ping")], max_tokens=8)
+
+    assert completion.text == "ok"
+    assert chat.last_kwargs["model"] == f"prod-{model_type}"
+    assert chat.last_kwargs["max_tokens"] == 8
+
+
+def test_api_versioned_chat_model_keeps_azure_openai_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(3, 2)))
+    provider = AzureOpenAIProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat))
+    monkeypatch.setattr(
+        provider,
+        "_get_v1_client",
+        lambda: (_ for _ in ()).throw(AssertionError("GPT legacy config must use AzureOpenAI")),
+    )
+
+    assert provider.complete("", [Message(role="user", content="ping")]).text == "ok"
+
+
 @pytest.mark.parametrize(
     ("model_type", "expects_temperature"),
     [("gpt-5.5", False), ("deepseek-v4-pro", True)],
@@ -172,7 +217,10 @@ def test_structured_chat_applies_model_temperature_capability(
     config = _config().model_copy(update={"model_type": model_type, "model": model_type})
     provider = AzureOpenAIProvider(config)
     chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(1, 1)))
-    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat))
+    client_method = (
+        "_get_v1_client" if config.resolved_azure_api_surface() == "v1" else "_get_client"
+    )
+    monkeypatch.setattr(provider, client_method, lambda: _FakeClient(chat))
 
     provider.complete_chat(
         ChatRequest.model_validate(
@@ -442,6 +490,35 @@ def test_embed_uses_embed_model_as_deployment(monkeypatch: pytest.MonkeyPatch) -
     assert vectors == [[0.5, 0.6]]
     # embed_model is sent as the Azure deployment name (the `model` arg).
     assert embeddings.last_kwargs["model"] == "embed-deploy"
+
+
+def test_foundry_v1_chat_selection_does_not_change_embedding_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Azure embeddings remain on the API-versioned deployment route."""
+    embeddings = _FakeEmbeddings(_FakeEmbeddingResponse([[0.5, 0.6]]))
+    provider = AzureOpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="kimi-k2.6",
+            deployment="prod-kimi",
+            api_version="2024-10-21",
+            embed_model="embed-prod",
+        )
+    )
+    legacy = _FakeClient(
+        _FakeChatCompletions(_FakeChatResponse("", _FakeUsage(0, 0))),
+        embeddings,
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: legacy)
+    monkeypatch.setattr(
+        provider,
+        "_get_v1_client",
+        lambda: (_ for _ in ()).throw(AssertionError("embed must not use the v1 chat client")),
+    )
+
+    assert provider.embed(["a"]) == [[0.5, 0.6]]
+    assert embeddings.last_kwargs["model"] == "embed-prod"
 
 
 def test_embed_requires_embed_model() -> None:


### PR DESCRIPTION
## Summary

- require an operator-created Azure deployment before provider verification or persistence
- return the exact verified `ProviderConfig` from the picker and use it in setup, build, and demo recovery
- preserve saved Azure deployments only for the same canonical model and across verification retries
- preserve a newly verified Azure connection when the wizard switches away from a configured provider
- route custom Azure endpoints through `WMO_ENDPOINT_API_KEY` in both picker and routing-pool flows
- model Azure chat API surface explicitly and route Kimi and DeepSeek through Foundry v1 chat completions
- preserve API-versioned GPT chat behavior and Azure embedding behavior

Fixes audit findings QA-017 and QA-012.

## Root cause

The CLI reconstructed provider configuration after verification, which discarded the deployment
that the picker had verified. It also blanked endpoint, deployment, and API version whenever the
selected provider differed from the configured worker, destroying a newly entered Azure
connection. Endpoint-blind credential prompts then advertised the trusted Azure key for custom
hosts even though provider dispatch correctly uses the isolated endpoint key.

Separately, Azure transport selection was coupled to reasoning effort. Non-reasoning Foundry
models were therefore sent through the incompatible API-versioned route.

## Validation

- exact head: `3032859a414b33ff35e363989cedd34ccc453ff3`
- branch merge base: `31da9251`
- branch full suite: 4,492 passed, 20 skipped
- switched-provider, interactive deployment, and exact verified-config regressions: 3 passed
- whole-repo Ruff and ty: passed
- GitHub build and all CodeQL checks: passed
- Greptile exact-head review: 5/5, zero unresolved threads
- local-only combined tree on main `863d29eb` plus PRs #349, #350, #351, and this head:
  4,520 passed, 20 skipped; 662 focused passed, 1 skipped; Ruff and ty passed
- current main `1236ecab` adds only the 0.2.2 version and lockfile bump

## Live controls

Using credentials only in process from the existing `.env.local` path:

- Kimi: provider setup, provider verify, low-fidelity build, and one-step demo passed
- DeepSeek: provider setup, provider verify, low-fidelity build, and one-step demo passed
- real PTY: selected Azure and Kimi, entered deployment before verification, and persisted the
  verified operator value

No credential value was printed, committed, or copied into the repository.

## Review feedback

All review findings are fixed. The final integration audit caught the switched-provider blanking
defect and added a regression proving stale OpenAI endpoint data is excluded while the newly
verified Azure deployment and API version persist.

## Integration order

PR #349 changes the same provider-picker interface. Land #349 first, then rebase this PR while
preserving its exact verified `ProviderConfig` flow and #349's configured-endpoint inheritance.
