### PR TITLE
C4: multi-tenant LoRA serving feasibility for the compressor (prototype + measurement instruments)

### DIFF
--- a/.agents/scripts/c4_multilora.py
+++ b/.agents/scripts/c4_multilora.py
@@ -1,0 +1,454 @@
+"""C4 prototype: many per-customer LoRA adapters on one LLMLingua-2 compressor base.
+
+The production compressor endpoint serves ONE checkpoint per process. The product
+direction is per-customer adapted scorers, so this module prototypes the middle rung
+of the C4 feasibility ladder: hold the 177M base resident once, load N PEFT LoRA
+adapters (a few MB each) beside it, and select an adapter per request.
+
+The canonical scorer class is loaded from deploy/compressor-endpoint/server.py by
+path (sha256 recorded), never reimplemented: chunk packing, unscored-words-KEEP,
+fp32, and the serialization lock are all inherited. Three candidate serving modes:
+
+- SWITCH: whole request on one adapter, selected with set_adapter under a selection
+  lock. This runs the canonical compress() end to end (the PeftModel forwards
+  through), so it inherits the production scoring math by construction and serves
+  as the byte-reference for the other two modes.
+- GROUPED: a queue window of requests is batched cross-request, but every forward
+  sub-batch holds exactly one adapter's chunks.
+- MIXED: one forward carries rows from several adapters at once via PEFT's
+  per-row `adapter_names` (peft>=0.20 routes modules_to_save classifier heads
+  per row too).
+
+run_invariance_suite() is the measurement instrument for kill bars KB1-KB4 in the
+track's findings/c4.md: determinism per adapter, residency isolation, base
+passthrough, grouped/mixed byte-equality against SWITCH, merged-vs-unmerged
+equivalence, and threshold-0 losslessness. Adapters are identified by
+(base_fingerprint, adapter_fingerprint); the fingerprint recipe matches the
+server's own (sha256 over sorted state-dict items).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import logging
+import sys
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import torch
+from peft import PeftModel
+from peft.utils import get_peft_model_state_dict
+
+log = logging.getLogger("c4_multilora")
+
+HERE = Path(__file__).resolve().parent
+SERVER_CANDIDATES = (
+    HERE.parents[1] / "deploy/compressor-endpoint/server.py",
+    HERE / "server.py",
+)
+
+# PEFT's reserved name for "no adapter" rows in mixed batches; reused here as the
+# public name for stock (unadapted) compression so one vocabulary covers all modes.
+BASE_ADAPTER = "__base__"
+
+
+def load_server():  # noqa: ANN201 - a module object, typed at runtime
+    """Import the canonical server module by path, recording its sha256."""
+    path = next((p for p in SERVER_CANDIDATES if p.is_file()), None)
+    if path is None:
+        raise SystemExit(f"canonical server.py not found at any of: {SERVER_CANDIDATES}")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    spec = importlib.util.spec_from_file_location("compressor_server", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["compressor_server"] = mod
+    spec.loader.exec_module(mod)
+    mod.LOADED_SERVER_PATH = str(path)
+    mod.LOADED_SERVER_SHA256 = digest
+    return mod
+
+
+SERVER = load_server()
+
+
+def _fingerprint_items(items: Sequence[tuple[str, torch.Tensor]]) -> str:
+    """The server's fingerprint recipe applied to an explicit (name, tensor) list."""
+    digest = hashlib.sha256()
+    for name, tensor in sorted(items):
+        digest.update(name.encode())
+        digest.update(tensor.detach().cpu().contiguous().numpy().tobytes())
+    return digest.hexdigest()[:16]
+
+
+class MultiAdapterCompressor(SERVER.LLMLingua2FixedThreshold):
+    """The canonical fixed-threshold scorer with N resident LoRA adapters.
+
+    `adapter_dirs` maps adapter name -> PEFT checkpoint directory. Names are the
+    serving identity (a request selects by name, never by path); each loaded
+    adapter gets a weight fingerprint so (base_fingerprint, adapter_fingerprint)
+    can be the compressor_version grain.
+    """
+
+    def __init__(self, model_id: str, device: str, adapter_dirs: Mapping[str, Path | str]) -> None:
+        super().__init__(model_id, device)
+        if not adapter_dirs:
+            raise ValueError("adapter_dirs is empty; use the plain server class for no adapters")
+        self.base_fingerprint = self.model_fingerprint
+        self._adapter_dirs = {name: str(path) for name, path in adapter_dirs.items()}
+        names = list(adapter_dirs)
+        peft_model = PeftModel.from_pretrained(
+            self.model, str(adapter_dirs[names[0]]), adapter_name=names[0], is_trainable=False
+        )
+        for name in names[1:]:
+            peft_model.load_adapter(str(adapter_dirs[name]), adapter_name=name)
+        peft_model = peft_model.to(device=device)
+        peft_model.eval()
+        wrong = {str(p.dtype) for p in peft_model.parameters()} - {"torch.float32"}
+        if wrong:
+            raise RuntimeError(f"refusing to serve adapters in {wrong}; fp32 only")
+        self.model = peft_model
+        self.adapter_fingerprints = {
+            name: _fingerprint_items(
+                list(get_peft_model_state_dict(peft_model, adapter_name=name).items())
+            )
+            for name in names
+        }
+        # set_adapter mutates model state, so selection and the GPU pass must be
+        # atomic together; the base class lock only covers the pass itself.
+        self._select_lock = threading.RLock()
+        self._active = names[0]
+        peft_model.set_adapter(self._active)
+
+    @property
+    def adapter_names(self) -> list[str]:
+        return list(self.adapter_fingerprints)
+
+    def compress_as(self, adapter: str, segments: Sequence[str], threshold: float):  # noqa: ANN201
+        """SWITCH mode: the canonical compress() with `adapter` active.
+
+        `BASE_ADAPTER` serves the stock scorer (adapters disabled entirely, LoRA and
+        the saved classifier head both), which is what a customer without an adapted
+        scorer gets; it must be byte-identical to the single-tenant server.
+        """
+        with self._select_lock:
+            if adapter == BASE_ADAPTER:
+                with self.model.disable_adapter():
+                    return self.compress(segments, threshold)
+            if adapter not in self.adapter_fingerprints:
+                raise KeyError(f"unknown adapter {adapter!r}; loaded: {self.adapter_names}")
+            if self._active != adapter:
+                self.model.set_adapter(adapter)
+                self._active = adapter
+            return self.compress(segments, threshold)
+
+    def compress_grouped(
+        self, requests: Sequence[tuple[str, Sequence[str], float]]
+    ) -> list[list[str]]:
+        """GROUPED mode: batch a window of requests, one adapter per forward group.
+
+        Requests sharing (adapter, threshold) have their segments concatenated into
+        one canonical compress() call (chunks never span segments, so concatenation
+        changes batching shape only), then results are split back per request.
+        """
+        grouped: dict[tuple[str, float], list[int]] = defaultdict(list)
+        for index, (adapter, _, threshold) in enumerate(requests):
+            grouped[(adapter, threshold)].append(index)
+        results: list[list[str] | None] = [None] * len(requests)
+        for (adapter, threshold), indices in grouped.items():
+            flat: list[str] = []
+            counts: list[int] = []
+            for index in indices:
+                segments = list(requests[index][1])
+                flat.extend(segments)
+                counts.append(len(segments))
+            outcome = self.compress_as(adapter, flat, threshold)
+            cursor = 0
+            for index, count in zip(indices, counts, strict=True):
+                results[index] = outcome.segments[cursor : cursor + count]
+                cursor += count
+        return [r for r in results if r is not None]
+
+    def compress_mixed(
+        self, requests: Sequence[tuple[str, Sequence[str], float]]
+    ) -> list[list[str]]:
+        """MIXED mode: one forward stream carrying rows from several adapters.
+
+        Reproduces the canonical scoring loop (same packing, same unscored-KEEP
+        rule, same FORWARD_BATCH) but tags every chunk with its request's adapter
+        and passes per-row `adapter_names` to the PEFT model. This is the one mode
+        with its own scoring loop, which is why the invariance suite byte-checks it
+        against SWITCH before any throughput number is allowed to matter.
+        """
+        flat_segments: list[str] = []
+        flat_adapters: list[str] = []
+        thresholds: list[float] = []
+        counts: list[int] = []
+        for adapter, segments, threshold in requests:
+            if adapter != BASE_ADAPTER and adapter not in self.adapter_fingerprints:
+                raise KeyError(f"unknown adapter {adapter!r}; loaded: {self.adapter_names}")
+            segments = list(segments)
+            flat_segments.extend(segments)
+            flat_adapters.extend([adapter] * len(segments))
+            thresholds.extend([threshold] * len(segments))
+            counts.append(len(segments))
+
+        with self._select_lock, self._lock:
+            words_per_segment = [SERVER.WORD_RE.findall(s) for s in flat_segments]
+            leading = [s[: len(s) - len(s.lstrip())] for s in flat_segments]
+            flat_lengths = self._subword_lengths(
+                [word for words in words_per_segment for word in words]
+            )
+            lengths: list[list[int]] = []
+            cursor = 0
+            for words in words_per_segment:
+                lengths.append(flat_lengths[cursor : cursor + len(words)])
+                cursor += len(words)
+
+            chunks: list[tuple[int, int, int]] = []
+            for index, words in enumerate(words_per_segment):
+                chunks.extend(
+                    (index, start, end) for start, end in SERVER._pack_chunks(words, lengths[index])
+                )
+            probabilities = [[1.0] * len(words) for words in words_per_segment]
+            for offset in range(0, len(chunks), SERVER.FORWARD_BATCH):
+                batch = chunks[offset : offset + SERVER.FORWARD_BATCH]
+                encoded = self.tokenizer(
+                    [
+                        [w.strip() for w in words_per_segment[index][start:end]]
+                        for index, start, end in batch
+                    ],
+                    is_split_into_words=True,
+                    truncation=True,
+                    max_length=512,
+                    padding=True,
+                    return_tensors="pt",
+                ).to(self.device)
+                row_adapters = [flat_adapters[index] for index, _, _ in batch]
+                with torch.no_grad():
+                    logits = self.model(**encoded, adapter_names=row_adapters).logits
+                keep = torch.softmax(logits.float(), dim=-1)[:, :, self.keep_index].cpu()
+                for row, (index, start, end) in enumerate(batch):
+                    sums = [0.0] * (end - start)
+                    counts_row = [0] * (end - start)
+                    for position, word_index in enumerate(encoded.word_ids(row)):
+                        if word_index is None:
+                            continue
+                        sums[word_index] += float(keep[row, position])
+                        counts_row[word_index] += 1
+                    for word in range(end - start):
+                        if counts_row[word]:
+                            probabilities[index][start + word] = sums[word] / counts_row[word]
+
+            out: list[str] = []
+            for index, words in enumerate(words_per_segment):
+                out.append(
+                    leading[index]
+                    + "".join(
+                        word
+                        for word, p in zip(words, probabilities[index], strict=True)
+                        if p >= thresholds[index]
+                    )
+                )
+            if self.device.startswith("cuda"):
+                torch.cuda.synchronize()
+
+        results: list[list[str]] = []
+        cursor = 0
+        for count in counts:
+            results.append(out[cursor : cursor + count])
+            cursor += count
+        return results
+
+
+def merged_copy(model_id: str, device: str, adapter_dir: Path | str, out_dir: Path):  # noqa: ANN201
+    """Materialize base+adapter as a single merged checkpoint and load it canonically.
+
+    This is the representation the canonical eval measured (merge_lora.py); live
+    multi-tenant serving keeps adapters unmerged, so KB2's sub-check compares the
+    two byte-for-byte through compress().
+    """
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    base = AutoModelForTokenClassification.from_pretrained(model_id, dtype=torch.float32)
+    merged = PeftModel.from_pretrained(base, str(adapter_dir)).merge_and_unload()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    merged.save_pretrained(out_dir)
+    AutoTokenizer.from_pretrained(model_id).save_pretrained(out_dir)
+    return SERVER.LLMLingua2FixedThreshold(str(out_dir), device)
+
+
+def run_invariance_suite(
+    compressor: MultiAdapterCompressor,
+    segments: Sequence[str],
+    thresholds: Sequence[float] = (0.2, 0.5, 0.8),
+    merged_thresholds: Sequence[float] | None = None,
+    merged_workdir: Path | None = None,
+    single_adapter_reference: bool = True,
+) -> dict:
+    """Run the KB1-KB3 invariance matrix and return JSON-able verdicts.
+
+    SWITCH outputs are the reference everywhere. Verdicts are all-or-nothing byte
+    comparisons; any mismatch is reported with the adapter, threshold, and segment
+    index that produced it (first few only, enough to reproduce).
+    """
+    adapters = [*compressor.adapter_names, BASE_ADAPTER]
+    verdicts: dict = {
+        "server_sha256": SERVER.LOADED_SERVER_SHA256,
+        "device": compressor.device,
+        "base_fingerprint": compressor.base_fingerprint,
+        "adapter_fingerprints": compressor.adapter_fingerprints,
+        "n_segments": len(segments),
+        "thresholds": list(thresholds),
+    }
+    mismatches: list[dict] = []
+
+    def note(kind: str, **detail) -> None:  # noqa: ANN003
+        if len(mismatches) < 20:
+            mismatches.append({"kind": kind, **detail})
+
+    reference: dict[tuple[str, float], list[str]] = {}
+    for adapter in adapters:
+        for threshold in thresholds:
+            reference[(adapter, threshold)] = list(
+                compressor.compress_as(adapter, segments, threshold).segments
+            )
+
+    # KB1: determinism, three passes per (adapter, threshold).
+    determinism = True
+    for adapter in adapters:
+        for threshold in thresholds:
+            for _ in range(2):
+                again = compressor.compress_as(adapter, segments, threshold).segments
+                if list(again) != reference[(adapter, threshold)]:
+                    determinism = False
+                    note("determinism", adapter=adapter, threshold=threshold)
+    verdicts["kb1_determinism"] = determinism
+
+    # KB1b: adapter switch cross-talk, A -> B -> A returns A's bytes.
+    crosstalk_ok = True
+    first, second = adapters[0], adapters[1]
+    for threshold in thresholds:
+        compressor.compress_as(second, segments, threshold)
+        back = compressor.compress_as(first, segments, threshold).segments
+        if list(back) != reference[(first, threshold)]:
+            crosstalk_ok = False
+            note("switch_crosstalk", adapter=first, threshold=threshold)
+    verdicts["kb1_switch_crosstalk_free"] = crosstalk_ok
+
+    # KB2a: base passthrough, stock rows unaffected by resident adapters.
+    plain = SERVER.LLMLingua2FixedThreshold(compressor.model_id, compressor.device)
+    base_ok = plain.model_fingerprint == compressor.base_fingerprint
+    if not base_ok:
+        note("base_fingerprint", plain=plain.model_fingerprint, multi=compressor.base_fingerprint)
+    for threshold in thresholds:
+        expected = plain.compress(segments, threshold).segments
+        if list(expected) != reference[(BASE_ADAPTER, threshold)]:
+            base_ok = False
+            note("base_passthrough", threshold=threshold)
+    verdicts["kb2_base_passthrough"] = base_ok
+
+    # KB2b: residency isolation, adapter A alone vs A with the full roster loaded.
+    residency_ok = True
+    if single_adapter_reference:
+        solo_name = compressor.adapter_names[0]
+        solo = MultiAdapterCompressor(
+            compressor.model_id,
+            compressor.device,
+            {solo_name: _adapter_dir_of(compressor, solo_name)},
+        )
+        for threshold in thresholds:
+            expected = solo.compress_as(solo_name, segments, threshold).segments
+            if list(expected) != reference[(solo_name, threshold)]:
+                residency_ok = False
+                note("residency", adapter=solo_name, threshold=threshold)
+        del solo
+    verdicts["kb2_residency_isolation"] = residency_ok
+
+    # KB2c: grouped and mixed against SWITCH on an interleaved workload.
+    workload: list[tuple[str, list[str], float]] = []
+    for index, segment in enumerate(segments):
+        workload.append((adapters[index % len(adapters)], [segment], 0.5))
+    switch_expected = [
+        list(compressor.compress_as(adapter, segs, threshold).segments)
+        for adapter, segs, threshold in workload
+    ]
+    grouped = compressor.compress_grouped(workload)
+    verdicts["kb2_grouped_vs_switch"] = grouped == switch_expected
+    if grouped != switch_expected:
+        for index, (got, want) in enumerate(zip(grouped, switch_expected, strict=True)):
+            if got != want:
+                note("grouped", request=index, adapter=workload[index][0])
+    try:
+        mixed = compressor.compress_mixed(workload)
+        verdicts["kb2_mixed_vs_switch"] = mixed == switch_expected
+        if mixed != switch_expected:
+            for index, (got, want) in enumerate(zip(mixed, switch_expected, strict=True)):
+                if got != want:
+                    note("mixed", request=index, adapter=workload[index][0])
+    except Exception as error:  # noqa: BLE001 - the verdict IS whether this raises
+        verdicts["kb2_mixed_vs_switch"] = f"UNSUPPORTED: {type(error).__name__}: {error}"
+
+    # KB2d: merged-vs-unmerged representation equivalence, fine threshold sweep.
+    if merged_workdir is not None:
+        sweep = list(merged_thresholds or [round(0.05 * k, 2) for k in range(1, 20)])
+        merged_results: dict[str, dict] = {}
+        for name in compressor.adapter_names:
+            merged = merged_copy(
+                compressor.model_id,
+                compressor.device,
+                _adapter_dir_of(compressor, name),
+                merged_workdir / f"merged-{name}",
+            )
+            flips = [
+                threshold
+                for threshold in sweep
+                if list(merged.compress(segments, threshold).segments)
+                != list(compressor.compress_as(name, segments, threshold).segments)
+            ]
+            merged_results[name] = {
+                "thresholds_swept": len(sweep),
+                "byte_equal_everywhere": not flips,
+                "flip_thresholds": flips,
+                "merged_fingerprint": merged.model_fingerprint,
+            }
+            del merged
+        verdicts["kb2_merged_vs_unmerged"] = merged_results
+
+    # KB3: threshold-0 losslessness per adapter.
+    lossless = True
+    for adapter in adapters:
+        if list(compressor.compress_as(adapter, segments, 0.0).segments) != list(segments):
+            lossless = False
+            note("threshold0", adapter=adapter)
+    verdicts["kb3_threshold0_lossless"] = lossless
+
+    # KB4: the per-adapter startup self-test, timed.
+    self_test_seconds: dict[str, float] = {}
+    for adapter in adapters:
+        started = time.perf_counter()
+        base_output = compressor.compress_as(adapter, SERVER.SELF_TEST_SEGMENTS, 0.5).segments
+        for _ in range(2):
+            repeat = compressor.compress_as(adapter, SERVER.SELF_TEST_SEGMENTS, 0.5).segments
+            if repeat != base_output:
+                note("selftest_determinism", adapter=adapter)
+        isolated = compressor.compress_as(adapter, SERVER.SELF_TEST_SEGMENTS[:1], 0.5).segments
+        if isolated[0] != base_output[0]:
+            note("selftest_batch_invariance", adapter=adapter)
+        if (
+            compressor.compress_as(adapter, SERVER.SELF_TEST_SEGMENTS, 0.0).segments
+            != SERVER.SELF_TEST_SEGMENTS
+        ):
+            note("selftest_threshold0", adapter=adapter)
+        self_test_seconds[adapter] = round(time.perf_counter() - started, 4)
+    verdicts["kb4_self_test_seconds_per_adapter"] = self_test_seconds
+
+    verdicts["mismatches"] = mismatches
+    return verdicts
+
+
+def _adapter_dir_of(compressor: MultiAdapterCompressor, name: str) -> str:
+    """Recover the checkpoint directory an adapter was loaded from."""
+    return compressor._adapter_dirs[name]

--- a/.agents/scripts/c4_multilora.py
+++ b/.agents/scripts/c4_multilora.py
@@ -51,8 +51,14 @@ SERVER_CANDIDATES = (
     HERE / "server.py",
 )
 
-# PEFT's reserved name for "no adapter" rows in mixed batches; reused here as the
-# public name for stock (unadapted) compression so one vocabulary covers all modes.
+# PEFT's reserved name for "no adapter" rows in mixed batches, recognized by BOTH
+# adapter code paths: the LoRA layers skip the delta for "__base__" rows
+# (tuners/lora/model.py filters it from unique_adapters) and the saved classifier
+# head routes them to original_module (utils/other.py,
+# AuxiliaryTrainingWrapper._mixed_batch_forward's `active_adapter == "__base__"`
+# branch). Reused here as the public name for stock compression so one vocabulary
+# covers all serving modes; the invariance suite byte-checks base passthrough in
+# every mode against a plain single-tenant server instance.
 BASE_ADAPTER = "__base__"
 
 

--- a/.agents/scripts/c4_multilora_bench.py
+++ b/.agents/scripts/c4_multilora_bench.py
@@ -157,6 +157,8 @@ def run_windowed(
 
 def switch_overhead(compressor: MultiAdapterCompressor, threshold: float) -> dict:
     """Sticky vs alternating tenants on identical payloads, plus bare set_adapter."""
+    if len(compressor.adapter_names) < 2:
+        return {"skipped": "needs 2+ resident adapters to alternate"}
     names = compressor.adapter_names[:2]
     payload = [SERVER.SELF_TEST_SEGMENTS[0]]
     for adapter in (*names, names[0]):
@@ -210,8 +212,14 @@ def main() -> None:
     residency = [int(part) for part in args.residency.split(",")]
     concurrency = [int(part) for part in args.concurrency.split(",")]
     requests = load_requests(args.requests_per_corpus, args.max_segment_chars)
+    if not requests:
+        raise SystemExit(
+            f"no live-segment episodes found under {DATA_ROOT}/cache/; every timing below "
+            "would divide by zero. Point C4_DATA_ROOT at the compression data root."
+        )
     log.info("%d requests (episodes) loaded", len(requests))
     results: dict = {
+        "owner": "c4",
         "device": args.device,
         "gpu": torch.cuda.get_device_name(),
         "server_sha256": SERVER.LOADED_SERVER_SHA256,
@@ -322,15 +330,24 @@ def main() -> None:
                 deltas.append(round(gpu_mem_mb() - before, 1))
         except torch.cuda.OutOfMemoryError:
             log.info("OOM at %d resident full models", len(instances))
-        per_model = statistics.mean(deltas[1:]) if len(deltas) > 1 else deltas[0]
         total_gb = torch.cuda.get_device_properties(args.device).total_memory / 1e9
-        results["memory_rung_c"] = {
-            "resident_loaded": len(instances),
-            "mem_mb_per_model": round(per_model, 1),
-            "deltas_mb": deltas,
-            "gpu_total_gb": round(total_gb, 1),
-            "implied_ceiling_models": int((total_gb * 1000 * 0.9 - base_mem) / per_model),
-        }
+        if not deltas:
+            # Even the first full model OOMed (tenant holding the GPU): report the fact
+            # instead of crashing past the already-collected curve results.
+            results["memory_rung_c"] = {
+                "resident_loaded": 0,
+                "gpu_total_gb": round(total_gb, 1),
+                "error": "first full-model load OOMed; GPU not idle enough for rung (c)",
+            }
+        else:
+            per_model = statistics.mean(deltas[1:]) if len(deltas) > 1 else deltas[0]
+            results["memory_rung_c"] = {
+                "resident_loaded": len(instances),
+                "mem_mb_per_model": round(per_model, 1),
+                "deltas_mb": deltas,
+                "gpu_total_gb": round(total_gb, 1),
+                "implied_ceiling_models": int((total_gb * 1000 * 0.9 - base_mem) / per_model),
+            }
         log.info("rung c memory: %s", results["memory_rung_c"])
         del instances
         torch.cuda.empty_cache()
@@ -341,6 +358,7 @@ def main() -> None:
     log.info("results -> %s", out_path)
     run_row = {
         "run_id": f"c4-bench-{device_slug}",
+        "owner": "c4",
         "ts": datetime.datetime.now(tz=datetime.UTC).isoformat(),
         "matrix": "c4-multilora-bench",
         "variant": args.device,

--- a/.agents/scripts/c4_multilora_bench.py
+++ b/.agents/scripts/c4_multilora_bench.py
@@ -1,0 +1,365 @@
+"""C4 throughput/latency/memory curves for multi-tenant compressor serving.
+
+Answers the product question "what does adapter #40 cost us" with measured curves
+on a verified-idle GPU:
+
+- single-model baseline re-anchored in this harness (the comparison anchor for
+  kill bar KB5; C1's round 1a number is a different harness and is not reused),
+- s/10k tokens and request-latency p50/p95 at concurrency {1,4,16} x resident
+  adapters {1,4,16,40} under uniform round-robin tenant traffic, for SWITCH /
+  GROUPED / MIXED serving modes,
+- adapter-switch overhead (sticky vs alternating tenants, plus bare set_adapter),
+- GPU memory per resident adapter (rung b) and per resident full checkpoint
+  (rung c), with the ceiling each implies against the 40-tenant bar.
+
+Payload: live user-segment episodes captured by C1 (one request = one episode's
+segments, the shape production requests have). Results: cache/c4-bench-<device>.json
+in the compression data root plus a RunRecord row in runs/c4.jsonl.
+
+Usage (GPU box, after verifying the GPU is idle):
+    python c4_multilora_bench.py --device cuda:1 --full-max 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import queue
+import statistics
+import threading
+import time
+from pathlib import Path
+
+import torch
+from c4_multilora import BASE_ADAPTER, SERVER, MultiAdapterCompressor
+
+log = logging.getLogger("c4_bench")
+
+DATA_ROOT = Path(
+    os.environ.get("C4_DATA_ROOT", "~/Desktop/Projects/wmh-compression-data")
+).expanduser()
+ADAPTER_ROOT = DATA_ROOT / "cache/c4-adapters"
+CORPORA = ("financebench", "swe-bench", "tau-bench", "terminal-tasks")
+
+
+def load_requests(per_corpus: int, max_segment_chars: int) -> list[list[str]]:
+    """One request per captured episode: its non-empty segments, char-capped."""
+    requests: list[list[str]] = []
+    for corpus in CORPORA:
+        path = DATA_ROOT / f"cache/live-segments-{corpus}.jsonl"
+        taken = 0
+        for line in path.open():
+            if taken >= per_corpus:
+                break
+            record = json.loads(line)
+            segments = [s[:max_segment_chars] for s in record.get("segments", []) if s.strip()]
+            if segments:
+                requests.append(segments)
+                taken += 1
+    return requests
+
+
+def _percentiles(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    return {
+        "p50_ms": round(1000 * ordered[len(ordered) // 2], 2),
+        "p95_ms": round(1000 * ordered[int(len(ordered) * 0.95)], 2),
+        "mean_ms": round(1000 * statistics.mean(ordered), 2),
+    }
+
+
+def run_switch(
+    compressor: MultiAdapterCompressor,
+    workload: list[tuple[str, list[str]]],
+    concurrency: int,
+    threshold: float,
+) -> dict:
+    """Concurrent per-request serving with per-request adapter switching."""
+    tasks: queue.SimpleQueue = queue.SimpleQueue()
+    for item in workload:
+        tasks.put(item)
+    latencies: list[float] = []
+    tokens = [0]
+    lock = threading.Lock()
+
+    def worker() -> None:
+        while True:
+            try:
+                adapter, segments = tasks.get_nowait()
+            except queue.Empty:
+                return
+            started = time.perf_counter()
+            outcome = compressor.compress_as(adapter, segments, threshold)
+            elapsed = time.perf_counter() - started
+            with lock:
+                latencies.append(elapsed)
+                tokens[0] += outcome.tokens_in
+
+    started = time.perf_counter()
+    threads = [threading.Thread(target=worker) for _ in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    wall = time.perf_counter() - started
+    return {
+        "mode": "switch",
+        "wall_s": round(wall, 3),
+        "tokens_in": tokens[0],
+        "s_per_10k_wall": round(wall / (tokens[0] / 10_000), 4),
+        "request_latency": _percentiles(latencies),
+        "n_requests": len(workload),
+    }
+
+
+def run_windowed(
+    compressor: MultiAdapterCompressor,
+    workload: list[tuple[str, list[str]]],
+    window: int,
+    threshold: float,
+    mode: str,
+    total_tokens: int,
+) -> dict:
+    """Queue-window batching: GROUPED or MIXED cross-request forwards.
+
+    Single dispatcher thread because the GPU lock serializes anyway; the window is
+    what stands in for "requests that arrived together". Latency is per window
+    (every request in a window completes when the window does). `total_tokens` is
+    the workload's precomputed token count, so nothing but serving sits inside the
+    timed region.
+    """
+    call = compressor.compress_grouped if mode == "grouped" else compressor.compress_mixed
+    latencies: list[float] = []
+    started_all = time.perf_counter()
+    for offset in range(0, len(workload), window):
+        chunk = [
+            (adapter, segments, threshold)
+            for adapter, segments in workload[offset : offset + window]
+        ]
+        started = time.perf_counter()
+        call(chunk)
+        elapsed = time.perf_counter() - started
+        latencies.extend([elapsed] * len(chunk))
+    wall = time.perf_counter() - started_all
+    return {
+        "mode": mode,
+        "window": window,
+        "wall_s": round(wall, 3),
+        "tokens_in": total_tokens,
+        "s_per_10k_wall": round(wall / (total_tokens / 10_000), 4),
+        "request_latency": _percentiles(latencies),
+        "n_requests": len(workload),
+    }
+
+
+def switch_overhead(compressor: MultiAdapterCompressor, threshold: float) -> dict:
+    """Sticky vs alternating tenants on identical payloads, plus bare set_adapter."""
+    names = compressor.adapter_names[:2]
+    payload = [SERVER.SELF_TEST_SEGMENTS[0]]
+    for adapter in (*names, names[0]):
+        compressor.compress_as(adapter, payload, threshold)
+
+    def timed(sequence: list[str]) -> float:
+        started = time.perf_counter()
+        for adapter in sequence:
+            compressor.compress_as(adapter, payload, threshold)
+        return (time.perf_counter() - started) / len(sequence)
+
+    sticky = timed([names[0]] * 40)
+    alternating = timed([names[0], names[1]] * 20)
+    bare: list[float] = []
+    for index in range(100):
+        target = names[index % 2]
+        started = time.perf_counter()
+        compressor.model.set_adapter(target)
+        bare.append(time.perf_counter() - started)
+    compressor._active = names[1]
+    compressor.model.set_adapter(names[1])
+    return {
+        "sticky_ms_per_request": round(sticky * 1000, 3),
+        "alternating_ms_per_request": round(alternating * 1000, 3),
+        "overhead_ms_per_switch": round((alternating - sticky) * 1000, 3),
+        "bare_set_adapter_ms_p50": round(1000 * sorted(bare)[50], 3),
+    }
+
+
+def gpu_mem_mb() -> float:
+    torch.cuda.synchronize()
+    return torch.cuda.memory_allocated() / 1e6
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", required=True)
+    parser.add_argument("--residency", default="1,4,16,40")
+    parser.add_argument("--concurrency", default="1,4,16")
+    parser.add_argument("--requests-per-corpus", type=int, default=15)
+    parser.add_argument("--max-segment-chars", type=int, default=8000)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--full-max", type=int, default=12, help="rung (c) resident full models")
+    parser.add_argument("--skip-full", action="store_true")
+    args = parser.parse_args()
+    if not args.device.startswith("cuda"):
+        raise SystemExit("curves are a GPU deliverable; run on a verified-idle CUDA device")
+    torch.cuda.set_device(args.device)
+
+    residency = [int(part) for part in args.residency.split(",")]
+    concurrency = [int(part) for part in args.concurrency.split(",")]
+    requests = load_requests(args.requests_per_corpus, args.max_segment_chars)
+    log.info("%d requests (episodes) loaded", len(requests))
+    results: dict = {
+        "device": args.device,
+        "gpu": torch.cuda.get_device_name(),
+        "server_sha256": SERVER.LOADED_SERVER_SHA256,
+        "threshold": args.threshold,
+        "n_requests": len(requests),
+    }
+
+    # Baseline anchor: the plain single-tenant server class in this same harness.
+    torch.cuda.empty_cache()
+    mem_before = gpu_mem_mb()
+    plain = SERVER.LLMLingua2FixedThreshold(SERVER.DEFAULT_MODEL_ID, args.device)
+    results["base_model_mem_mb"] = round(gpu_mem_mb() - mem_before, 1)
+    plain.compress(SERVER.SELF_TEST_SEGMENTS, args.threshold)
+    anchor_workload = [(None, segments) for segments in requests]
+    latencies: list[float] = []
+    tokens = 0
+    started = time.perf_counter()
+    for _, segments in anchor_workload:
+        call_start = time.perf_counter()
+        outcome = plain.compress(segments, args.threshold)
+        latencies.append(time.perf_counter() - call_start)
+        tokens += outcome.tokens_in
+    wall = time.perf_counter() - started
+    results["baseline_single_model"] = {
+        "wall_s": round(wall, 3),
+        "tokens_in": tokens,
+        "s_per_10k_wall": round(wall / (tokens / 10_000), 4),
+        "request_latency": _percentiles(latencies),
+    }
+    log.info("baseline: %s", results["baseline_single_model"])
+    del plain
+    torch.cuda.empty_cache()
+
+    # Rung (b): adapters resident on one base.
+    real_dirs = {c: ADAPTER_ROOT / f"adapted-{c}-lora" for c in CORPORA}
+    curves: list[dict] = []
+    mem_curve: list[dict] = []
+    total_tokens = tokens
+    for n_resident in residency:
+        adapter_dirs = {
+            f"tenant-{index:02d}": real_dirs[CORPORA[index % len(CORPORA)]]
+            for index in range(n_resident)
+        }
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        mem_before = gpu_mem_mb()
+        compressor = MultiAdapterCompressor(SERVER.DEFAULT_MODEL_ID, args.device, adapter_dirs)
+        mem_after_load = gpu_mem_mb()
+        names = compressor.adapter_names
+        workload = [
+            (names[index % len(names)], segments) for index, segments in enumerate(requests)
+        ]
+        for level in concurrency:
+            row = run_switch(compressor, workload, level, args.threshold)
+            row.update({"resident_adapters": n_resident, "concurrency": level})
+            curves.append(row)
+            log.info("%s", row)
+        for mode in ("grouped", "mixed"):
+            for window in concurrency:
+                if window == 1 and mode == "grouped":
+                    continue
+                try:
+                    row = run_windowed(
+                        compressor, workload, window, args.threshold, mode, total_tokens
+                    )
+                except Exception as error:  # noqa: BLE001 - a mode may be unsupported
+                    row = {
+                        "mode": mode,
+                        "window": window,
+                        "error": f"{type(error).__name__}: {error}",
+                    }
+                row.update({"resident_adapters": n_resident, "concurrency": window})
+                curves.append(row)
+                log.info("%s", row)
+        peak = torch.cuda.max_memory_allocated() / 1e6
+        mem_curve.append(
+            {
+                "resident_adapters": n_resident,
+                "mem_after_load_mb": round(mem_after_load - mem_before, 1),
+                "adapter_mem_mb_each": round(
+                    (mem_after_load - mem_before - results["base_model_mem_mb"]) / n_resident, 2
+                ),
+                "peak_serving_mb": round(peak / 1, 1),
+            }
+        )
+        if n_resident == max(residency):
+            results["switch_overhead"] = switch_overhead(compressor, args.threshold)
+            log.info("switch overhead: %s", results["switch_overhead"])
+        del compressor
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+    results["curves"] = curves
+    results["memory_rung_b"] = mem_curve
+
+    # Rung (c): N resident FULL checkpoints (each its own scorer instance).
+    if not args.skip_full:
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        instances = []
+        deltas = []
+        base_mem = gpu_mem_mb()
+        try:
+            for _ in range(args.full_max):
+                before = gpu_mem_mb()
+                instances.append(
+                    SERVER.LLMLingua2FixedThreshold(SERVER.DEFAULT_MODEL_ID, args.device)
+                )
+                deltas.append(round(gpu_mem_mb() - before, 1))
+        except torch.cuda.OutOfMemoryError:
+            log.info("OOM at %d resident full models", len(instances))
+        per_model = statistics.mean(deltas[1:]) if len(deltas) > 1 else deltas[0]
+        total_gb = torch.cuda.get_device_properties(args.device).total_memory / 1e9
+        results["memory_rung_c"] = {
+            "resident_loaded": len(instances),
+            "mem_mb_per_model": round(per_model, 1),
+            "deltas_mb": deltas,
+            "gpu_total_gb": round(total_gb, 1),
+            "implied_ceiling_models": int((total_gb * 1000 * 0.9 - base_mem) / per_model),
+        }
+        log.info("rung c memory: %s", results["memory_rung_c"])
+        del instances
+        torch.cuda.empty_cache()
+
+    device_slug = args.device.replace(":", "")
+    out_path = DATA_ROOT / f"cache/c4-bench-{device_slug}.json"
+    out_path.write_text(json.dumps(results, indent=2))
+    log.info("results -> %s", out_path)
+    run_row = {
+        "run_id": f"c4-bench-{device_slug}",
+        "ts": datetime.datetime.now(tz=datetime.UTC).isoformat(),
+        "matrix": "c4-multilora-bench",
+        "variant": args.device,
+        "params": {
+            "residency": residency,
+            "concurrency": concurrency,
+            "requests_per_corpus": args.requests_per_corpus,
+            "threshold": args.threshold,
+            "base_adapter_name": BASE_ADAPTER,
+        },
+        "result": {
+            "baseline_s_per_10k": results["baseline_single_model"]["s_per_10k_wall"],
+            "n_curve_rows": len(curves),
+        },
+        "notes": f"full results in {out_path.name}",
+    }
+    with (DATA_ROOT / "runs/c4.jsonl").open("a") as handle:
+        handle.write(json.dumps(run_row) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c4_multilora_invariance.py
+++ b/.agents/scripts/c4_multilora_invariance.py
@@ -1,0 +1,133 @@
+"""Run the C4 multi-adapter invariance suite (kill bars KB1-KB4) on real segments.
+
+Payload: live user-segments captured by C1 (task + tool observations, the text the
+production compressor actually sees), a sample per corpus, plus the server's own
+self-test segments. Adapters: C1's four per-corpus LoRA r16 checkpoints.
+
+Writes cache/c4-invariance-<device>.json in the compression data root and appends a
+RunRecord-shaped row to runs/c4.jsonl.
+
+Usage:
+    python c4_multilora_invariance.py --device cpu --segments-per-corpus 3 --max-chars 2000
+    python c4_multilora_invariance.py --device cuda:1
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from c4_multilora import BASE_ADAPTER, SERVER, MultiAdapterCompressor, run_invariance_suite
+
+log = logging.getLogger("c4_invariance")
+
+DATA_ROOT = Path(
+    os.environ.get("C4_DATA_ROOT", "~/Desktop/Projects/wmh-compression-data")
+).expanduser()
+ADAPTER_ROOT = DATA_ROOT / "cache/c4-adapters"
+CORPORA = ("financebench", "swe-bench", "tau-bench", "terminal-tasks")
+
+
+def load_segments(per_corpus: int, max_chars: int) -> list[str]:
+    """A deterministic sample of live segments across the four corpora."""
+    segments: list[str] = []
+    for corpus in CORPORA:
+        path = DATA_ROOT / f"cache/live-segments-{corpus}.jsonl"
+        taken = 0
+        for line in path.open():
+            if taken >= per_corpus:
+                break
+            record = json.loads(line)
+            for segment in record.get("segments", []):
+                if taken >= per_corpus:
+                    break
+                if not segment.strip():
+                    continue
+                segments.append(segment[:max_chars])
+                taken += 1
+    return segments
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--segments-per-corpus", type=int, default=6)
+    parser.add_argument("--max-chars", type=int, default=6000)
+    parser.add_argument("--skip-merged", action="store_true")
+    parser.add_argument(
+        "--merged-thresholds",
+        default=None,
+        help="comma-separated threshold sweep for the merged-vs-unmerged check "
+        "(default: 0.05..0.95 step 0.05)",
+    )
+    args = parser.parse_args()
+    merged_thresholds = (
+        [float(part) for part in args.merged_thresholds.split(",")]
+        if args.merged_thresholds
+        else None
+    )
+
+    adapter_dirs = {
+        corpus: ADAPTER_ROOT / f"adapted-{corpus}-lora"
+        for corpus in CORPORA
+        if (ADAPTER_ROOT / f"adapted-{corpus}-lora").is_dir()
+    }
+    log.info("adapters: %s", sorted(adapter_dirs))
+    segments = load_segments(args.segments_per_corpus, args.max_chars)
+    log.info(
+        "payload: %d segments (server sha %s)", len(segments), SERVER.LOADED_SERVER_SHA256[:12]
+    )
+
+    compressor = MultiAdapterCompressor(SERVER.DEFAULT_MODEL_ID, args.device, adapter_dirs)
+    log.info("base %s adapters %s", compressor.base_fingerprint, compressor.adapter_fingerprints)
+    with tempfile.TemporaryDirectory(prefix="c4-merged-") as workdir:
+        verdicts = run_invariance_suite(
+            compressor,
+            segments,
+            merged_thresholds=merged_thresholds,
+            merged_workdir=None if args.skip_merged else Path(workdir),
+        )
+
+    verdicts["segments_per_corpus"] = args.segments_per_corpus
+    verdicts["max_chars"] = args.max_chars
+    device_slug = args.device.replace(":", "")
+    out_path = DATA_ROOT / f"cache/c4-invariance-{device_slug}.json"
+    out_path.write_text(json.dumps(verdicts, indent=2))
+    log.info("verdicts -> %s", out_path)
+
+    booleans = {
+        key: value
+        for key, value in verdicts.items()
+        if key.startswith("kb") and isinstance(value, (bool, str))
+    }
+    log.info("verdict summary: %s", booleans)
+
+    run_row = {
+        "run_id": f"c4-invariance-{device_slug}",
+        "ts": datetime.datetime.now(tz=datetime.UTC).isoformat(),
+        "matrix": "c4-multilora-invariance",
+        "variant": args.device,
+        "params": {
+            "segments_per_corpus": args.segments_per_corpus,
+            "max_chars": args.max_chars,
+            "adapters": sorted(adapter_dirs),
+            "base_adapter_name": BASE_ADAPTER,
+            "server_sha256": SERVER.LOADED_SERVER_SHA256,
+        },
+        "result": booleans,
+        "notes": f"full verdicts in {out_path.name}",
+    }
+    runs_path = DATA_ROOT / "runs/c4.jsonl"
+    with runs_path.open("a") as handle:
+        handle.write(json.dumps(run_row) + "\n")
+    log.info("run row -> %s", runs_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c4_multilora_invariance.py
+++ b/.agents/scripts/c4_multilora_invariance.py
@@ -94,6 +94,7 @@ def main() -> None:
             merged_workdir=None if args.skip_merged else Path(workdir),
         )
 
+    verdicts["owner"] = "c4"
     verdicts["segments_per_corpus"] = args.segments_per_corpus
     verdicts["max_chars"] = args.max_chars
     device_slug = args.device.replace(":", "")
@@ -110,6 +111,7 @@ def main() -> None:
 
     run_row = {
         "run_id": f"c4-invariance-{device_slug}",
+        "owner": "c4",
         "ts": datetime.datetime.now(tz=datetime.UTC).isoformat(),
         "matrix": "c4-multilora-invariance",
         "variant": args.device,

--- a/.agents/scripts/c4_multilora_test.py
+++ b/.agents/scripts/c4_multilora_test.py
@@ -1,0 +1,98 @@
+"""Regression tests for the C4 multi-adapter prototype (CPU, real weights, tiny payloads).
+
+Run explicitly (not discovered by the root pytest config, .agents is workspace):
+    <venv>/bin/python -m pytest .agents/scripts/c4_multilora_test.py -q
+
+Requires the LLMLingua-2 base in the HF cache and C1's LoRA checkpoints in the
+compression data root; skips cleanly when either is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DATA_ROOT = Path("~/Desktop/Projects/wmh-compression-data").expanduser()
+ADAPTER_ROOT = DATA_ROOT / "cache/c4-adapters"
+
+if not ADAPTER_ROOT.is_dir():  # pragma: no cover - environment guard
+    pytest.skip("C1 LoRA checkpoints not present", allow_module_level=True)
+
+from c4_multilora import (  # noqa: E402 - after the env guard
+    BASE_ADAPTER,
+    SERVER,
+    MultiAdapterCompressor,
+)
+
+SEGMENTS = [
+    "The quarterly revenue report shows total revenue increased by 12 percent year over "
+    "year, driven primarily by strong performance in the enterprise segment.",
+    '{"tool": "search_flights", "args": {"origin": "SFO", "destination": "JFK"}}',
+    "Traceback (most recent call last): File main.py line 42 in run KeyError: 'user_id'",
+]
+
+
+@pytest.fixture(scope="module")
+def compressor() -> MultiAdapterCompressor:
+    return MultiAdapterCompressor(
+        SERVER.DEFAULT_MODEL_ID,
+        "cpu",
+        {
+            "financebench": ADAPTER_ROOT / "adapted-financebench-lora",
+            "tau-bench": ADAPTER_ROOT / "adapted-tau-bench-lora",
+        },
+    )
+
+
+def test_fingerprints_distinct_and_shaped(compressor: MultiAdapterCompressor) -> None:
+    prints = compressor.adapter_fingerprints
+    assert set(prints) == {"financebench", "tau-bench"}
+    assert prints["financebench"] != prints["tau-bench"]
+    assert all(len(value) == 16 for value in prints.values())
+    assert compressor.base_fingerprint != prints["financebench"]
+
+
+def test_adapters_change_output_and_are_deterministic(compressor: MultiAdapterCompressor) -> None:
+    fin = compressor.compress_as("financebench", SEGMENTS, 0.5).segments
+    tau = compressor.compress_as("tau-bench", SEGMENTS, 0.5).segments
+    again = compressor.compress_as("financebench", SEGMENTS, 0.5).segments
+    assert fin == again, "same adapter twice must be byte-identical"
+    assert fin != tau, "different adapters should score differently on mixed text"
+
+
+def test_base_passthrough_matches_plain_server(compressor: MultiAdapterCompressor) -> None:
+    plain = SERVER.LLMLingua2FixedThreshold(SERVER.DEFAULT_MODEL_ID, "cpu")
+    assert plain.model_fingerprint == compressor.base_fingerprint
+    for threshold in (0.2, 0.5, 0.8):
+        assert (
+            compressor.compress_as(BASE_ADAPTER, SEGMENTS, threshold).segments
+            == plain.compress(SEGMENTS, threshold).segments
+        )
+
+
+def test_grouped_and_mixed_match_switch(compressor: MultiAdapterCompressor) -> None:
+    workload = [
+        ("financebench", [SEGMENTS[0]], 0.5),
+        ("tau-bench", [SEGMENTS[1]], 0.5),
+        (BASE_ADAPTER, [SEGMENTS[2]], 0.5),
+        ("tau-bench", [SEGMENTS[0]], 0.5),
+    ]
+    expected = [
+        list(compressor.compress_as(adapter, segments, threshold).segments)
+        for adapter, segments, threshold in workload
+    ]
+    assert compressor.compress_grouped(workload) == expected
+    assert compressor.compress_mixed(workload) == expected
+
+
+def test_threshold_zero_lossless_per_adapter(compressor: MultiAdapterCompressor) -> None:
+    for adapter in (*compressor.adapter_names, BASE_ADAPTER):
+        assert compressor.compress_as(adapter, SEGMENTS, 0.0).segments == SEGMENTS
+
+
+def test_unknown_adapter_refused(compressor: MultiAdapterCompressor) -> None:
+    with pytest.raises(KeyError, match="unknown adapter"):
+        compressor.compress_as("someone-elses-tenant", SEGMENTS, 0.5)
+    with pytest.raises(KeyError, match="unknown adapter"):
+        compressor.compress_mixed([("someone-elses-tenant", SEGMENTS, 0.5)])


### PR DESCRIPTION
Compression child C4 (Silen directive, DECISIONS 2026-07-28 round 3): can many per-customer adapted scorers serve on ONE compressor base instead of one process per checkpoint? Full findings ledger with pre-registered kill bars: `~/Desktop/Projects/wmh-compression-data/findings/c4.md`.

**Status per master's ruling (2026-07-28): ARCHITECTURE READY, ACTIVATION PARKED.** The feasibility evidence below is the durable deliverable. Activation of per-customer adapters is gated on an adapted scorer beating stock against truth (C1's scaled leg reversed the adaptation program; no current adapted scorer clears that bar). The (base_fp, adapter_fp) version grain and adapter-by-name API are adopted into D-COMPRESS regardless. If the program un-parks, the invariance suite here is the regression gate it restarts from.

## What this adds (all under `.agents/scripts/`, workspace research code)

- `c4_multilora.py`: `MultiAdapterCompressor` subclassing the CANONICAL `deploy/compressor-endpoint/server.py` scorer (loaded by path, sha256 recorded, zero reimplementation of scoring), plus the KB1-KB4 invariance suite. Three serving modes: SWITCH (per-request `set_adapter`, canonical path end to end), GROUPED (cross-request batching, one adapter per forward group), MIXED (per-row PEFT `adapter_names`).
- `c4_multilora_invariance.py`: runs the suite on real live segments, writes verdict JSONs + run rows (owner-stamped) to the compression data root.
- `c4_multilora_bench.py`: residency x concurrency throughput/latency curves, adapter-switch overhead, memory per resident adapter (rung b) and per resident full checkpoint (rung c).
- `c4_multilora_test.py`: regression tests against C1's real LoRA checkpoints (6 pass locally, CPU).

## Justification ledger

- Every file has a named consumer: the C4 feasibility report (findings/c4.md) cites the two runners' outputs; the module is the seam C3 would productionize on an un-park; the tests pin the invariance contract.
- No production changes: `deploy/` untouched; the live endpoint was never touched (all GPU work on box-6 GPU1 / h100_azure under the verify-idle rule).
- Nothing imports from `.agents/`; scripts load the canonical server by explicit path.
- Runner outputs carry `owner: c4` (DECISIONS attribution rule).

## Measured results (evidence in the data root; headline)

- vLLM multi-LoRA CANNOT serve this model (3 independent blockers, cited from vLLM 0.25.1 source; architecture gate + half-precision-only adapter kernels vs our fp32 law + continuous batching vs composition invariance).
- Torch-native multi-adapter passes EVERY serving law byte-for-byte on CPU and H100 fp32: determinism, residency isolation, base passthrough, grouped/mixed == switch (including `__base__` rows), merged == unmerged (19-threshold sweep), threshold-0 losslessness; per-adapter self-test 0.05s.
- Curves (box-6 GPU1, verified idle): baseline re-anchored 0.218 s/10k; 16 resident adapters @ concurrency 4 = 1.16x baseline (KB5 bar was 2x); adapter #40 costs 2.37MB GPU + ~10ms per switch (worst-case round-robin 1.32x). Full checkpoints: 710MB each, ~126/GPU ceiling.
- Quality: LoRA r16 passes the offline canonical bar 4/4; the truth leg is a half-pass (beats stock, does not reproduce full-FT's hold-at-floor) and is superseded by C1's scaled-leg reversal for activation purposes.

## How Silen tests

    cd <worktree> && uv run ruff check .agents/scripts/c4_multilora*.py   # clean
    <venv-with-torch+peft>/bin/python -m pytest .agents/scripts/c4_multilora_test.py -q   # 6 pass
    open ~/Desktop/Projects/wmh-compression-data/findings/c4.md   # the ledger; every number names its evidence file

🤖 Generated with [Claude Code](https://claude.com/claude-code)