### PR TITLE
Write through a symlinked destination instead of replacing the link

### DIFF
--- a/wmo/core/files.py
+++ b/wmo/core/files.py
@@ -49,20 +49,23 @@ def write_bytes_atomic(path: Path, payload: bytes) -> None:
       about 0.1 s across a 200-step distill run whose steps are minutes of paid rollouts.
     - **The destination's mode is carried over.** `replace` installs a NEW inode, so without this
       a file an operator or an installer had restricted comes back as 0644 on the first write.
+    - **A symlinked destination is written THROUGH, not replaced.** See `_resolve_destination`.
 
     Cleanup is `BaseException`, not `OSError`: a Ctrl-C between the write and the rename would
     otherwise strand a staging file in an artifact directory that serving and the fitter scan.
 
     Args:
-        path: The destination file. Its parent directory is created when missing.
+        path: The destination file, or a symlink to it. Its parent directory is created when
+            missing.
         payload: The complete file contents.
 
     Raises:
-        OSError: The write or the rename failed, which means `path` is untouched and the staging
-            file has been cleaned up. Everything that can fail here fails BEFORE the rename, so a
-            raised error always means the write did not land: see `_fsync_directory` for the one
-            step that is deliberately best effort.
+        OSError: The write or the rename failed, which means the destination is untouched and the
+            staging file has been cleaned up. Everything that can fail here fails BEFORE the
+            rename, so a raised error always means the write did not land: see `_fsync_directory`
+            for the one step that is deliberately best effort.
     """
+    path = _resolve_destination(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
     try:
@@ -79,6 +82,34 @@ def write_bytes_atomic(path: Path, payload: bytes) -> None:
         staging.unlink(missing_ok=True)  # never leave a stray staging file beside the real one
         raise
     _fsync_directory(path.parent)
+
+
+def _resolve_destination(path: Path) -> Path:
+    """The real file to write, following `path` if it is a symlink.
+
+    An in-place `write_text` follows a symlink: an operator who points `.wmo/config.toml` at a
+    shared or version-controlled file gets their writes where they asked for them. `replace` does
+    the opposite, and silently: it swaps the LINK for a regular file and leaves the target holding
+    stale contents, with nothing raised and nothing to notice until something reads the target and
+    gets an old answer.
+
+    Resolving restores the behaviour those writers had before they became atomic, and extends it to
+    the ones that were always atomic (`pool.toml`, `.wmo/config.toml`, `.wmo/settings.toml`), where
+    the clobbering was longstanding rather than new. Following the link is what the operator asked
+    for in every case; nothing wants a symlink quietly turned into a file.
+
+    Resolving is also what keeps the write atomic. The staging file has to sit beside the FINAL
+    target, because `replace` across filesystems fails with EXDEV, and a symlink into another mount
+    is exactly the case where staging beside the link would break.
+
+    A broken symlink resolves to its missing target, which is then created: writing through a
+    dangling link is what an in-place write would have done too.
+
+    Raises:
+        OSError: `path` is a symlink loop, or resolution otherwise fails. Better surfaced than
+            written around.
+    """
+    return path.resolve() if path.is_symlink() else path
 
 
 def _fsync_directory(directory: Path) -> None:

--- a/wmo/core/files.py
+++ b/wmo/core/files.py
@@ -49,7 +49,7 @@ def write_bytes_atomic(path: Path, payload: bytes) -> None:
       about 0.1 s across a 200-step distill run whose steps are minutes of paid rollouts.
     - **The destination's mode is carried over.** `replace` installs a NEW inode, so without this
       a file an operator or an installer had restricted comes back as 0644 on the first write.
-    - **A symlinked destination is written THROUGH, not replaced.** See `_resolve_destination`.
+    - **A symlinked destination is written THROUGH, not replaced.** See `resolve_write_target`.
 
     Cleanup is `BaseException`, not `OSError`: a Ctrl-C between the write and the rename would
     otherwise strand a staging file in an artifact directory that serving and the fitter scan.
@@ -65,7 +65,7 @@ def write_bytes_atomic(path: Path, payload: bytes) -> None:
             rename, so a raised error always means the write did not land: see `_fsync_directory`
             for the one step that is deliberately best effort.
     """
-    path = _resolve_destination(path)
+    path = resolve_write_target(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
     try:
@@ -84,7 +84,7 @@ def write_bytes_atomic(path: Path, payload: bytes) -> None:
     _fsync_directory(path.parent)
 
 
-def _resolve_destination(path: Path) -> Path:
+def resolve_write_target(path: Path) -> Path:
     """The real file to write, following `path` if it is a symlink.
 
     An in-place `write_text` follows a symlink: an operator who points `.wmo/config.toml` at a
@@ -98,9 +98,12 @@ def _resolve_destination(path: Path) -> Path:
     the clobbering was longstanding rather than new. Following the link is what the operator asked
     for in every case; nothing wants a symlink quietly turned into a file.
 
-    Resolving is also what keeps the write atomic. The staging file has to sit beside the FINAL
-    target, because `replace` across filesystems fails with EXDEV, and a symlink into another mount
-    is exactly the case where staging beside the link would break.
+    Resolving is also what keeps the write atomic, and what keeps the LOCK correct.
+    `wmo.core.locks.file_write_lock` derives its lock file from this same answer, so two callers
+    reaching one target through different symlinks contend on one lock rather than taking a lock
+    each and both proceeding. And the staging file has to sit beside the FINAL target, because
+    `replace` across filesystems fails with EXDEV, and a symlink into another mount is exactly the
+    case where staging beside the link would break the rename.
 
     A broken symlink resolves to its missing target, which is then created: writing through a
     dangling link is what an in-place write would have done too.

--- a/wmo/core/files_test.py
+++ b/wmo/core/files_test.py
@@ -254,3 +254,79 @@ def test_a_directory_close_failure_does_not_fail_a_write_that_landed(
     assert path.read_text(encoding="utf-8") == "payload"
     assert "could not close the directory handle" in caplog.text
     assert list(tmp_path.glob("*.partial")) == []
+
+
+def test_write_text_atomic_writes_through_a_symlinked_destination(tmp_path: Path) -> None:
+    """An operator who points a config at a shared file must get their writes there.
+
+    `replace` swaps the LINK for a regular file and leaves the target stale, with nothing raised.
+    An in-place `write_text` followed the link, so the three writers converted to atomic writes
+    (`HarnessStore.set_alias`, `wmo/config/card.py`, `OutcomeMatrix.save`) silently changed
+    meaning; the ones that were always atomic had been clobbering links all along.
+    """
+    target = tmp_path / "shared.toml"
+    target.write_text("original", encoding="utf-8")
+    link = tmp_path / "config.toml"
+    link.symlink_to(target)
+
+    write_text_atomic(link, "new")
+
+    assert link.is_symlink(), "the symlink was replaced by a regular file"
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_write_text_atomic_stages_beside_the_symlink_target_not_the_link(tmp_path: Path) -> None:
+    """Atomicity depends on this: `replace` across filesystems fails with EXDEV.
+
+    A symlink pointing into another mount is exactly the case where staging next to the LINK would
+    make the final rename cross a filesystem boundary and fail. Staging beside the resolved target
+    keeps the rename local. A separate directory stands in for a separate mount here, which pins
+    the staging location even though it cannot pin EXDEV itself.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    target = elsewhere / "shared.toml"
+    target.write_text("original", encoding="utf-8")
+    link = tmp_path / "config.toml"
+    link.symlink_to(target)
+    staged: list[Path] = []
+    real_replace = Path.replace
+
+    def _record(self: Path, destination: object) -> Path:
+        staged.append(self)
+        return real_replace(self, destination)  # ty: ignore[invalid-argument-type]
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(Path, "replace", _record)
+        write_text_atomic(link, "new")
+
+    assert [item.parent for item in staged] == [elsewhere], "staged beside the link, not the target"
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_write_text_atomic_keeps_the_symlink_targets_mode(tmp_path: Path) -> None:
+    """The mode that matters is the target's, since that is the inode being replaced."""
+    target = tmp_path / "shared.toml"
+    target.write_text("original", encoding="utf-8")
+    target.chmod(0o600)
+    link = tmp_path / "config.toml"
+    link.symlink_to(target)
+
+    write_text_atomic(link, "new")
+
+    # Both halves matter: without the content assertion this passes on the broken behaviour,
+    # because a target that was never written trivially keeps its mode.
+    assert target.read_text(encoding="utf-8") == "new"
+    assert target.stat().st_mode & 0o777 == 0o600
+
+
+def test_write_text_atomic_creates_the_target_of_a_dangling_symlink(tmp_path: Path) -> None:
+    """Writing through a broken link creates its target, as an in-place write would have."""
+    missing = tmp_path / "not-there-yet.toml"
+    link = tmp_path / "config.toml"
+    link.symlink_to(missing)
+
+    write_text_atomic(link, "created")
+
+    assert missing.read_text(encoding="utf-8") == "created"
+    assert link.is_symlink()

--- a/wmo/core/locks.py
+++ b/wmo/core/locks.py
@@ -26,6 +26,8 @@ from pathlib import Path
 
 from filelock import FileLock, Timeout
 
+from wmo.core.files import resolve_write_target
+
 # How long a writer waits for another process to finish. These writes are a few file operations,
 # so real contention never comes close; the bound exists so a hung holder is REPORTED instead of
 # hanging the terminal forever.
@@ -51,6 +53,12 @@ def file_write_lock(
     atomic rename, which swaps the inode, so a lock taken on the file would stop protecting
     anything the moment the first writer landed.
 
+    The sibling is chosen beside the file the write will actually LAND on, via
+    `resolve_write_target`, not beside `path` as given. A symlinked roster is written through to its
+    target, so two callers reaching one target through different links (a shared pool symlinked from
+    two project directories) would otherwise take one lock each, both succeed, and lose an update
+    apiece: exactly what this exists to prevent.
+
     The lock is released by the OS when the holder exits, crashes, or is killed, so a leftover
     `.lock` FILE is never a held lock and can never wedge a later run. That is also why it is left
     in place: unlinking it would let a waiter block on an inode nobody else can reach. A live
@@ -74,7 +82,8 @@ def file_write_lock(
     Raises:
         FileLockTimeout: The lock was still held after `timeout_s`.
     """
-    lock_path = path.with_name(f"{path.name}.lock")
+    target = resolve_write_target(path)
+    lock_path = target.with_name(f"{target.name}.lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock = FileLock(lock_path, timeout=timeout_s, mode=0o600)
     try:

--- a/wmo/core/locks_test.py
+++ b/wmo/core/locks_test.py
@@ -102,3 +102,29 @@ def test_file_write_lock_is_not_reentrant_and_says_so_within_the_bound(tmp_path:
         with pytest.raises(FileLockTimeout):
             with file_write_lock(path, what="the roster", timeout_s=0.05):
                 pass  # pragma: no cover - the outer lock is held
+
+
+def test_two_symlinks_to_one_target_contend_on_a_single_lock(tmp_path: Path) -> None:
+    """A shared roster symlinked from two project directories is ONE file to be serialized.
+
+    The lock file is derived from the resolved write target, not from the path as given. Keyed off
+    the link instead, each caller takes its own lock, both proceed, and each loses the other's
+    update: precisely the failure the lock exists to prevent, and reachable only once writes follow
+    symlinks through to their target.
+    """
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    target = shared / "pool.toml"
+    target.write_text("roster", encoding="utf-8")
+    first = tmp_path / "project-a.toml"
+    first.symlink_to(target)
+    second = tmp_path / "project-b.toml"
+    second.symlink_to(target)
+
+    with file_write_lock(first, what="the model pool", timeout_s=0.05):
+        with pytest.raises(FileLockTimeout):
+            with file_write_lock(second, what="the model pool", timeout_s=0.05):
+                pass  # pragma: no cover - the first lock is held
+
+    assert [item.name for item in shared.glob("*.lock")] == ["pool.toml.lock"]
+    assert list(tmp_path.glob("*.lock")) == [], "a lock was keyed off the symlink, not the target"


### PR DESCRIPTION
## The defect

`write_bytes_atomic` replaced a symlinked destination with a regular file and left the target
holding stale contents. Nothing raised; nothing surfaced it until something read the target and got
an old answer.

```
$ ls -l .wmo/config.toml
.wmo/config.toml -> ~/shared/wmo-config.toml

# after any wmo write:
$ ls -l .wmo/config.toml
.wmo/config.toml           # a regular file now
$ cat ~/shared/wmo-config.toml
# ...still the old contents
```

## Why it exists

This shipped as an accident of #345, not a decision. That PR converted three writers from an
in-place `write_text`, which **follows** a symlink, to atomic `replace`, which does not:

| writer | before #345 | after #345 |
|---|---|---|
| `HarnessStore.set_alias` | `write_text` (follows) | `replace` (clobbers) |
| `wmo/config/card.py` | `write_text` (follows) | `replace` (clobbers) |
| `OutcomeMatrix.save` | `write_text` (follows) | `replace` (clobbers) |
| `pool.toml`, `.wmo/config.toml`, `.wmo/settings.toml` | `replace` (clobbers) | unchanged |

So three writers silently changed meaning, and three had been clobbering links all along. This
fixes all six rather than just restoring what #345 changed: following the link is what the operator
asked for in every case, and nothing wants a symlink quietly turned into a file.

## Resolving is also what keeps the write atomic

The part worth knowing beyond the symlink semantics: the staging file has to sit beside the **final
target**, because `replace` across filesystems fails with `EXDEV`. A symlink pointing into another
mount is exactly the case where staging next to the link would make the rename cross a boundary and
fail. `_resolve_destination` runs first, so staging, the mode carry-over and the directory fsync are
all relative to the real file.

## Behaviour, stated

- A dangling symlink resolves to its missing target and creates it, as an in-place write would have.
- A symlink loop raises `OSError` rather than being written around.
- A plain path is untouched: `resolve()` is called only when `is_symlink()` says to, so the common
  case is unchanged.
- The mode carried over is the **target's**, since that is the inode being replaced.

## Tests

Four new, all failing on the parent commit. The mode test asserts contents as well as mode, because
a target that was never written trivially keeps its mode and the assertion passed on the broken
behaviour without it.

Also driven end to end, not just unit tested: a `HarnessStore` whose `aliases.toml` is a symlink to
a shared file now promotes through the link, and `resolve_version` reads the new champion back.

## Provenance

Found while answering a question about how confident I was in #345, not by any of the review passes
on it, including three Greptile rounds that ended 5/5. Worth noting as a gap in what those passes
cover: every reviewer looked at whether the write was atomic, none at what it was atomic *to*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
