### PR TITLE
Release 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "world-model-optimizer"
-version = "0.2.1"
+version = "0.2.2"
 description = "Run agents, build world models from traces, and optimize agent harnesses."
 readme = "README.md"
 # harbor 0.20.0 requires Python >=3.12; the harbor evaluator is a first-class optimize

--- a/uv.lock
+++ b/uv.lock
@@ -3913,7 +3913,7 @@ wheels = [
 
 [[package]]
 name = "world-model-optimizer"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
28 commits since v0.2.1. Root `pyproject.toml` version + `uv.lock` only, mirroring #276 and #327.

## Headline: two money-safety fixes

**`wmo build` is free by default (#326).** `--fidelity` defaulted to `medium`, which runs a light GEPA pass plus a config search. In one measured end-to-end build that was **$1.47 of $2.02 — 73% of spend**. An audit of the repo's own data found no controlled comparison where GEPA beats `--fidelity low`; the two-seed budget sweep is +0.003 / −0.012 / −0.012 at the budget `medium` ships. GEPA is unchanged and one flag away.

**Nothing spends in a non-TTY without consent (#321).** `optimize harness`, `optimize distill run` and `optimize route sweep` skipped their cost confirmation entirely under CI, cron or a pipe. Worse, the gate checked `stdout` while the prompt read `stdin`, so at a terminal with redirected input a blank line counted as approval — `wmo optimize distill run --yes < /dev/null` could start an uncapped training run.

## Data integrity

- **#341** — registering a second model with `wmo providers set` wrote an unparseable `pool.toml`; every later command that read the pool died. One model worked, two corrupted it, and two is the minimum for routing to mean anything.
- **#345 / #354** — the atomic-write-under-lock discipline `pool.py` documented now applies to every durable-file writer, including through symlinked destinations.

## CLI robustness (11 PRs, #313-#325)

Raw Python tracebacks replaced with errors that name the next command: malformed TOML, unreachable platform host, missing files, directories passed where files were expected, bad `--chain`, invalid route/eval/scenario inputs. Plus Rich markup escaping so bracketed text in help and error codes stops vanishing, and worker-role defaults resolving from settings instead of hardcoded Bedrock.

## Also

**#332** records GEPA's base-vs-winner delta on selection-disjoint data, so a build can finally answer from its own artifacts whether GEPA earned its cost.

## Verified against the built wheel

```
uv build --package world-model-optimizer --no-sources
```
`import llm_waterfall, wmo` OK. `wmo/cli/consent.py` ships. `--fidelity` help reads `low (default; free ...)`. Providers: `anthropic, bedrock, azure, openai, openai_responses, openrouter, tinker`.

## Known gap

`wmo download` still resolves `environment-capture` from PyPI at 0.1.0, which hardcodes the pre-rename `wmh-` repo id — so the dataset-name fix never reaches wheel users. **#322** fixes this by vendoring the fetch core and is at Greptile 5/5, ready but unmerged. If it lands before this is tagged it ships automatically; otherwise the workaround stays:

```bash
curl -sL https://huggingface.co/datasets/experiential-labs/wmh-tau-bench-traces/resolve/main/traces.otel.jsonl -o traces.otel.jsonl
wmo build --file traces.otel.jsonl --name tau
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)