### PR TITLE
Compaction production seam: protect instructions, scope the bulk, off by default

### DIFF
--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -36,7 +36,9 @@ from rich.table import Table
 from wmo.cli.consent import require_spend_consent
 from wmo.cli.route_app import (
     BIAS_ACCEPTED_NOTE,
+    BULK_MIN_CHARS_HELP,
     NO_EVIDENCE_WARNING,
+    SCOPE_HELP,
     _compressor_note,
     cell_progress,
     print_coverage,
@@ -50,8 +52,10 @@ from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.closed_loop import scenario_id
 from wmo.optimize.compression import (
+    DEFAULT_BULK_MIN_CHARS,
     CompressionConfig,
     compression_signature,
+    parse_compression_scope,
     resolve_compression,
 )
 from wmo.optimize.knn import (
@@ -203,9 +207,8 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         None,
         "--compressor",
         help="Compress every request through this compressor before routing it (identity | "
-        "truncate | llmlingua2-endpoint). The sweep then measures that arm and the fit embeds "
-        "its bank through the same compressor, so the endpoint serves what was measured. "
-        "Default: no compression.",
+        "truncate | llmlingua2-endpoint). The sweep then measures that arm and the fit stamps it, "
+        "so the endpoint serves the arm that was measured. Default: no compression.",
     ),
     aggressiveness: float = typer.Option(
         0.0,
@@ -215,6 +218,10 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         help="Compressor-defined dial in [0, 1] for --compressor: 0.0 is a no-op and higher never "
         "removes less, but it is not an exact removal fraction (the achieved ratio is measured per "
         "episode).",
+    ),
+    scope: str = typer.Option("conversation", "--scope", help=SCOPE_HELP),
+    bulk_min_chars: int = typer.Option(
+        DEFAULT_BULK_MIN_CHARS, "--bulk-min-chars", min=1, help=BULK_MIN_CHARS_HELP
     ),
     embedder: str = typer.Option(
         "auto",
@@ -311,7 +318,12 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             # Resolved at PLAN time, before the table: an unknown id, or an implementation that
             # could never be mounted, is a usage error. Discovering it after the sweep this arm
             # configured has been paid for would be discovering it too late to matter.
-            compression = resolve_compression(compressor, aggressiveness)
+            compression = resolve_compression(
+                compressor,
+                aggressiveness,
+                scope=parse_compression_scope(scope),
+                bulk_min_chars=bulk_min_chars,
+            )
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     try:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -42,10 +42,10 @@ from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compression import (
-    CompressingEmbedder,
     compression_signature,
     registered_compressor_ids,
     resolve_compression,
+    routed_text_embedder,
     same_compression,
 )
 from wmo.optimize.knn import (
@@ -1081,12 +1081,11 @@ def fit(
             raise typer.BadParameter(str(exc)) from exc
         print_knn_fit(_console, fitted, out=out, z=z)
         return
-    built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
-    if compression is not None:
-        # Representation consistency: the cluster centroids have to live in the geometry of the
-        # text serving will embed, which is the COMPRESSED text (see `fit_knn_artifact`, which
-        # applies the same rule to the bank on the knn path).
-        built = CompressingEmbedder(built, compression)
+    # ONE embedder for fit and evaluation; azure would otherwise embed twice. Representation
+    # consistency: the cluster centroids have to live in the geometry of the text serving routes
+    # on, which `routed_text_embedder` decides from the arm's scope (see `fit_knn_artifact`, which
+    # applies the same rule to the bank on the knn path).
+    built = routed_text_embedder(spec.build(), compression)
     try:
         policy = fit_rank_policy(
             matrix,

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -42,7 +42,11 @@ from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compression import (
+    COMPRESSION_SCOPES,
+    DEFAULT_BULK_MIN_CHARS,
+    CompressionConfig,
     compression_signature,
+    parse_compression_scope,
     registered_compressor_ids,
     resolve_compression,
     routed_text_embedder,
@@ -113,6 +117,23 @@ DEFAULT_MATRIX_FILENAME = "matrix.json"
 
 COMPRESSOR_IDS_HELP = " | ".join(registered_compressor_ids())
 """What `--compressor` accepts, rendered from the registry so the help cannot go stale."""
+
+SCOPE_HELP = (
+    f"Which segments --compressor may rewrite ({' | '.join(COMPRESSION_SCOPES)}). "
+    "`conversation` (default) is user turns; `observations` is tool/environment output only and "
+    "is the safe choice for a stock scorer (compressing dialogue measured 6-17 accuracy points "
+    "worse at 2.3x the cost, while removing 40% of observation bulk held accuracy inside the "
+    "noise floor); `bulk` adds pasted user documents over --bulk-min-chars; `all` adds dialogue "
+    "and is for a domain-adapted scorer at a calibrated threshold. The task statement and the "
+    "system prompt are never compressed in any scope."
+)
+"""Shared by `route sweep`, `route fit`, and `optimize model`, so the three cannot describe the
+same flag differently."""
+
+BULK_MIN_CHARS_HELP = (
+    "How large a user segment must be for `--scope bulk` to treat it as a pasted document "
+    "rather than a typed turn. Inert in every other scope."
+)
 
 _MATRIX_DIGEST_MARK = "sha256="
 """How `load_matrix_with_digest` spells the digest inside a policy's `fitted_from`."""
@@ -216,6 +237,10 @@ def sweep(
         "never removes less, but it is not an exact removal fraction (the achieved ratio is "
         "recorded per episode).",
     ),
+    scope: str = typer.Option("conversation", "--scope", help=SCOPE_HELP),
+    bulk_min_chars: int = typer.Option(
+        DEFAULT_BULK_MIN_CHARS, "--bulk-min-chars", min=1, help=BULK_MIN_CHARS_HELP
+    ),
 ) -> None:
     """Measure every pool candidate closed-loop and write the outcome matrix `fit` consumes.
 
@@ -296,7 +321,12 @@ def sweep(
         try:
             # Checked before a single episode is paid for, and against the SERVING rule: there
             # is no point measuring an arm whose compressor could never be mounted.
-            sweep_compression = resolve_compression(compressor, aggressiveness)
+            sweep_compression = resolve_compression(
+                compressor,
+                aggressiveness,
+                scope=parse_compression_scope(scope),
+                bulk_min_chars=bulk_min_chars,
+            )
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     store = WorldModelStore(root)
@@ -374,6 +404,11 @@ def sweep(
     print_world_model_spend(_console, run)
     rows = coverage(matrix)
     print_coverage(_console, rows)
+    dead_arm = no_removal_warning(matrix, sweep_compression)
+    if dead_arm is not None:
+        # Before the coverage gates below, which can exit: an operator who just paid for a
+        # compressor that never ran must hear it whichever way this command ends.
+        _console.print(dead_arm)
     if scored == 0:
         # Exit non-zero: a matrix with no verified reward is not evidence, so `sweep && fit` in a
         # script must stop here rather than fit on it. The rows are on disk for their `error`s.
@@ -492,6 +527,41 @@ def cell_progress(console: Console, cells: int) -> Callable[[ScenarioOutcome], N
         )
 
     return _on_outcome
+
+
+def no_removal_warning(matrix: OutcomeMatrix, compression: CompressionConfig | None) -> str | None:
+    """The warning for a compression arm that removed NOTHING, or None when it removed something.
+
+    The spend was real and the matrix is honest: every row records what it measured. The problem is
+    that what it measured is the UNCOMPRESSED arm, and nothing else in the pipeline can tell,
+    because a fit stamps the arm the flags name rather than the arm the rows achieved. An operator
+    who paid for a sweep deserves to hear that before they read a comparison into it.
+
+    The near-certain cause on the built-in agent is worth naming rather than leaving to be
+    rediscovered: `LLMAgent` renders each turn as ONE user message that opens with the task, and
+    the task is stage-law protected, so no segment is ever eligible whatever the scope. The
+    observation-bearing scopes need tool-role segments, which that agent's transcript does not
+    produce at all.
+
+    Reads only scored rows with nonzero accounting, so an all-unscored sweep (which has its own
+    louder warning) does not also claim the compressor achieved nothing.
+    """
+    if compression is None:
+        return None
+    measured = [o for o in matrix.outcomes if o.scored and o.tokens_in_raw > 0]
+    if not measured or any(o.tokens_in_compressed < o.tokens_in_raw for o in measured):
+        return None
+    return (
+        "[yellow]warning[/yellow] this arm removed NOTHING: all "
+        f"{len(measured)} scored row(s) achieved keep 1.00 under "
+        f"{escape(compression_signature(compression))}, so the sweep measured the UNCOMPRESSED "
+        "arm and paid for a compressor that never had an eligible segment.\n"
+        "  With the built-in agent that is expected, not a bug: it renders each turn as one user "
+        "message opening with the task, the task is never compressed, and the "
+        "observation-bearing scopes need tool-role segments it does not emit.\n"
+        "  The rows are honest, but `fit` will stamp the arm you NAMED, not the arm this "
+        "measured: do not read a compression result off this matrix."
+    )
 
 
 def uneven_warning(rows: list[CandidateCoverage]) -> str | None:
@@ -987,6 +1057,10 @@ def fit(
         "less, but it is not an exact removal fraction (the achieved ratio is reported per "
         "call). Only meaningful with --compressor.",
     ),
+    scope: str = typer.Option("conversation", "--scope", help=SCOPE_HELP),
+    bulk_min_chars: int = typer.Option(
+        DEFAULT_BULK_MIN_CHARS, "--bulk-min-chars", min=1, help=BULK_MIN_CHARS_HELP
+    ),
 ) -> None:
     """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
     if kind not in ("rank", "knn"):
@@ -1029,7 +1103,12 @@ def fit(
         try:
             # Fail before the fit spends anything: model_copy below skips validators, and an
             # unservable compressor would otherwise only surface when serving mounts the result.
-            compression = resolve_compression(compressor, aggressiveness)
+            compression = resolve_compression(
+                compressor,
+                aggressiveness,
+                scope=parse_compression_scope(scope),
+                bulk_min_chars=bulk_min_chars,
+            )
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     # The rewards in this matrix were produced under SOME compression config, and a joint fit is
@@ -1082,9 +1161,9 @@ def fit(
         print_knn_fit(_console, fitted, out=out, z=z)
         return
     # ONE embedder for fit and evaluation; azure would otherwise embed twice. Representation
-    # consistency: the cluster centroids have to live in the geometry of the text serving routes
-    # on, which `routed_text_embedder` decides from the arm's scope (see `fit_knn_artifact`, which
-    # applies the same rule to the bank on the knn path).
+    # consistency: the cluster centroids have to live in the geometry of the query that decides,
+    # which `routed_text_embedder` owns (see `fit_knn_artifact`, which applies the same rule to the
+    # bank on the knn path).
     built = routed_text_embedder(spec.build(), compression)
     try:
         policy = fit_rank_policy(

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import cast
+from typing import NamedTuple, cast
 
 import pytest
 from rich.console import Console
@@ -19,6 +19,7 @@ from typer.testing import CliRunner, Result
 
 from wmo.cli import consent as consent_module
 from wmo.cli.app import app
+from wmo.cli.route_app import no_removal_warning
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
 from wmo.distill.store import DistillModelCard
@@ -26,7 +27,9 @@ from wmo.engine.world_model import WorldModel
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.compression import (
+    DEFAULT_BULK_MIN_CHARS,
     CompressionConfig,
+    CompressionScope,
     Compressor,
     TruncateCompressor,
     register_compressor,
@@ -57,19 +60,32 @@ from wmo.tracking import Phase, RunRecord, UsageTotals, load_runs
 runner = CliRunner()
 
 
-def _arm(compression: CompressionConfig | None) -> tuple[str, str, float]:
-    """The D-COMPRESS fields an episode measured under `compression` would carry.
+class _Arm(NamedTuple):
+    """The D-COMPRESS fields an episode measured under one compression config would carry.
 
     A matrix records the arm its rewards were produced under, and `fit` refuses to stamp a
     policy whose compression config disagrees, so a fixture fitting `--compressor` has to look
-    like episodes that actually ran that way.
+    like episodes that actually ran that way. SCOPE is part of that: it is identity-bearing, so a
+    fixture that omitted it would be refused as a different arm from any scoped fit.
     """
+
+    compressor_id: str
+    compressor_version: str
+    aggressiveness: float
+    scope: CompressionScope
+    bulk_min_chars: int
+
+
+def _arm(compression: CompressionConfig | None) -> _Arm:
+    """The row fields for `compression`, or the uncompressed defaults when there is none."""
     if compression is None:
-        return "", "", 0.0
-    return (
+        return _Arm("", "", 0.0, "conversation", DEFAULT_BULK_MIN_CHARS)
+    return _Arm(
         compression.compressor_id,
         compression.compressor_version,
         compression.aggressiveness,
+        compression.scope,
+        compression.bulk_min_chars,
     )
 
 
@@ -83,7 +99,7 @@ def _matrix_file(tmp_path: Path, *, compression: CompressionConfig | None = None
             name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
         ),
     ]
-    arm_id, arm_version, arm_aggressiveness = _arm(compression)
+    arm = _arm(compression)
     outcomes = []
     tasks = {
         "s1": "SELECT count(*) FROM t",
@@ -103,9 +119,11 @@ def _matrix_file(tmp_path: Path, *, compression: CompressionConfig | None = None
                     reward=1.0 if wins else 0.0,
                     success=wins,
                     cost_usd=0.001,
-                    compressor_id=arm_id,
-                    compressor_version=arm_version,
-                    aggressiveness=arm_aggressiveness,
+                    compressor_id=arm.compressor_id,
+                    compressor_version=arm.compressor_version,
+                    aggressiveness=arm.aggressiveness,
+                    compressor_scope=arm.scope,
+                    compressor_bulk_min_chars=arm.bulk_min_chars,
                 )
             )
     path = tmp_path / "matrix.json"
@@ -207,7 +225,7 @@ def _knn_matrix_file(
         "write a gentle reminder about the expense deadline",
         "write a farewell note for a departing teammate",
     ]
-    arm_id, arm_version, arm_aggressiveness = _arm(compression)
+    arm = _arm(compression)
     outcomes = []
     for group, tasks in (("sql", sql), ("prose", prose)):
         for index, task in enumerate(tasks):
@@ -221,9 +239,11 @@ def _knn_matrix_file(
                         reward=1.0 if wins else 0.0,
                         success=wins,
                         cost_usd=0.001,
-                        compressor_id=arm_id,
-                        compressor_version=arm_version,
-                        aggressiveness=arm_aggressiveness,
+                        compressor_id=arm.compressor_id,
+                        compressor_version=arm.compressor_version,
+                        aggressiveness=arm.aggressiveness,
+                        compressor_scope=arm.scope,
+                        compressor_bulk_min_chars=arm.bulk_min_chars,
                     )
                 )
     path = tmp_path / name
@@ -2663,6 +2683,113 @@ def test_route_fit_knn_stamps_the_compression_it_was_fitted_under(tmp_path: Path
     # Both halves, so the mount gate has an identity to check rather than a null.
     assert policy.fit_compression is not None
     assert same_compression(policy.compression, policy.fit_compression)
+
+
+def test_route_fit_carries_scope_and_bulk_min_chars_onto_the_policy(tmp_path: Path) -> None:
+    # The scopes the measurements favor have to be reachable end to end, not just constructible in
+    # Python: a flag the CLI does not expose is a scope nobody can run.
+    config = CompressionConfig(
+        compressor_id="truncate", aggressiveness=0.5, scope="bulk", bulk_min_chars=1500
+    )
+    matrix_file = _knn_matrix_file(tmp_path, compression=config)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--kind",
+            "knn",
+            "--out",
+            str(policy_file),
+            "--fallback",
+            "a",
+            "--min-pairs",
+            "0",
+            "--compressor",
+            "truncate",
+            "--aggressiveness",
+            "0.5",
+            "--scope",
+            "bulk",
+            "--bulk-min-chars",
+            "1500",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.compression is not None
+    assert policy.compression.scope == "bulk"
+    assert policy.compression.bulk_min_chars == 1500
+    # And the arm gate accepted it, which is the whole point of threading identity through.
+    assert same_compression(policy.compression, policy.fit_compression)
+
+
+def test_an_unknown_scope_is_refused_naming_the_scopes_that_exist(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_knn_matrix_file(tmp_path)),
+            "--kind",
+            "knn",
+            "--out",
+            str(tmp_path / "policy.json"),
+            "--fallback",
+            "a",
+            "--compressor",
+            "truncate",
+            "--scope",
+            "dialogue",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown compression scope" in result.output
+    assert "observations" in result.output
+
+
+def test_the_no_removal_warning_fires_only_when_nothing_was_removed() -> None:
+    """F4: a compression arm that removed nothing must say so; spend happened either way.
+
+    A pure function so it can be asserted at this altitude: driving a whole sweep would need a
+    world model and live providers to prove a string.
+    """
+    arm = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    pool = [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        )
+    ]
+
+    def _matrix(compressed: int) -> OutcomeMatrix:
+        return OutcomeMatrix(
+            pool=pool,
+            outcomes=[
+                ScenarioOutcome(
+                    scenario_id="s1",
+                    task="t",
+                    model="a",
+                    reward=1.0,
+                    tokens_in_raw=100,
+                    tokens_in_compressed=compressed,
+                    compressor_id="truncate",
+                    compressor_version="1",
+                    aggressiveness=0.5,
+                )
+            ],
+        )
+
+    dead = no_removal_warning(_matrix(100), arm)
+    assert dead is not None
+    assert "removed NOTHING" in dead
+    assert "keep 1.00" in dead
+    assert "one user message opening with the task" in dead  # names the cause
+    assert no_removal_warning(_matrix(60), arm) is None  # it removed something: silence
+    assert no_removal_warning(_matrix(100), None) is None  # no arm requested: silence
 
 
 def test_route_fit_knn_leaves_the_stamp_null_without_the_flag(tmp_path: Path) -> None:

--- a/wmo/env/closed_loop.py
+++ b/wmo/env/closed_loop.py
@@ -52,7 +52,15 @@ from wmo.env.base import Env
 from wmo.env.episode import run_episode
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS, LLMAgent
 from wmo.env.scenarios import Scenario
-from wmo.optimize.compression import CompressionConfig, estimate_tokens, get_compressor
+from wmo.optimize.compression import (
+    DEFAULT_BULK_MIN_CHARS,
+    CompressionConfig,
+    Segment,
+    SegmentKind,
+    compress_conversation,
+    estimate_tokens,
+    get_compressor,
+)
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.reward import EpisodeScore
 from wmo.providers.base import (
@@ -116,15 +124,31 @@ class _TimedProvider:
         return self._provider.verify()
 
 
+# `Message` carries only the two conversational roles; the system prompt travels beside the
+# messages and is never a segment. There is no tool role here, so an eval transcript grows no
+# observation segments unless its agent renders them as turns of their own.
+_SEGMENT_KINDS: dict[str, SegmentKind] = {"user": "user", "assistant": "assistant"}
+
+
 class _CompressingProvider:
     """Applies the D-COMPRESS stage to the candidate's calls, so eval measures through it.
 
     Sits ABOVE `_TimedProvider` (agent -> compressing -> timed -> real): the timed layer then
-    records the latency and provider-reported usage of the ACTUAL, compressed call. Mirrors
-    the serving rule exactly: only user-role message content is compressed; the system prompt
-    and the model's own prior replies pass through verbatim. Determinism keeps the growing
-    transcript append-stable across the episode's calls, exactly as serving's affinity-miss
-    path reproduces bytes. Accumulates the compressor's own accounting per episode.
+    records the latency and provider-reported usage of the ACTUAL, compressed call. Segment
+    selection is not decided here: the call's messages become seam segments and go to
+    `compress_conversation`, which is the same choke point serving's stage uses, so the config's
+    scope and the unconditional task protection mean the same thing in a measurement as they do
+    in production. The system prompt is never a segment (it is passed beside the messages and
+    never reaches the compressor). Determinism keeps the growing transcript append-stable across
+    the episode's calls, exactly as serving's affinity-miss path reproduces bytes. Accumulates
+    the compressor's own accounting per episode.
+
+    CONSEQUENCE WORTH STATING: `LLMAgent` renders each turn as ONE user message that opens with
+    the task, so under task protection the eligible-segment set for an `LLMAgent` episode is
+    empty and this wrapper measures an uncompressed run (raw == compressed tokens, no compressor
+    call). That is the correct reading of the rule, and it is why the wrapper accounts honestly
+    instead of asserting that compression happened: an agent whose transcript separates the task
+    from the observations it accumulates gets real compression here with no change to this class.
     """
 
     def __init__(self, provider: Provider, config: CompressionConfig) -> None:
@@ -149,12 +173,11 @@ class _CompressingProvider:
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         started = time.monotonic()
-        user_segments = [m.content for m in messages if m.role == "user"]
-        result = self.compressor.compress(user_segments, self._config)
-        replacements = iter(result.segments)
+        segments = [Segment(kind=_SEGMENT_KINDS[m.role], text=m.content) for m in messages]
+        result = compress_conversation(self.compressor, segments, self._config)
         compressed = [
-            Message(role="user", content=next(replacements)) if m.role == "user" else m
-            for m in messages
+            message if text == message.content else Message(role=message.role, content=text)
+            for message, text in zip(messages, result.texts, strict=True)
         ]
         self.tokens_in_raw += sum(estimate_tokens(m.content) for m in messages)
         self.tokens_in_compressed += sum(estimate_tokens(m.content) for m in compressed)
@@ -353,6 +376,10 @@ def run_cell(
         aggressiveness=compression.aggressiveness if compression else 0.0,
         compressor_latency_s=compressing.latency_s if compressing else 0.0,
         compressor_cost_usd=compressing.cost_usd if compressing else 0.0,
+        compressor_scope=compression.scope if compression else "conversation",
+        compressor_bulk_min_chars=(
+            compression.bulk_min_chars if compression else DEFAULT_BULK_MIN_CHARS
+        ),
     )
 
 

--- a/wmo/env/closed_loop_test.py
+++ b/wmo/env/closed_loop_test.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 from wmo.core.types import Action, EnvState, Observation
+from wmo.env import closed_loop as closed_loop_module
 from wmo.env.closed_loop import evaluate_pool
 from wmo.env.scenarios import Scenario
 from wmo.optimize.compression import CompressionConfig
@@ -23,6 +24,9 @@ from wmo.providers.base import (
     VerifyResult,
 )
 from wmo.providers.pool import ModelPool, PoolEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class _FakeEnv:
@@ -360,52 +364,95 @@ class _RecordingProvider(_ScriptedProvider):
         return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
 
 
-def test_evaluate_pool_threads_compression_through_the_measured_path() -> None:
-    providers: list[_RecordingProvider] = []
+def test_evaluate_pool_threads_the_compression_arm_onto_every_row() -> None:
+    # The arm's whole identity reaches the matrix, scope included, because `measured_compression`
+    # rebuilds the config from these columns and the fit gate compares it to what a fit stamps.
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=_RecordingProvider,
+        max_steps=5,
+        compression=CompressionConfig(
+            compressor_id="truncate", aggressiveness=0.5, scope="observations"
+        ),
+    )
 
-    def factory(entry: PoolEntry) -> _RecordingProvider:
-        provider = _RecordingProvider(entry)
-        providers.append(provider)
-        return provider
+    outcome = matrix.outcomes[0]
+    assert outcome.compressor_id == "truncate"
+    assert outcome.compressor_version == "1"
+    assert outcome.aggressiveness == 0.5
+    assert outcome.compressor_scope == "observations"
+    assert outcome.compressor_latency_s >= 0.0
+    assert outcome.compressor_cost_usd == 0.0  # truncate has no inference cost
+    measured = matrix.measured_compression()
+    assert measured is not None
+    assert measured.scope == "observations"
+
+
+def test_an_llm_agent_episode_compresses_nothing_because_its_only_turn_is_the_task() -> None:
+    # Task protection is unconditional, and `LLMAgent` renders each turn as ONE user message that
+    # opens with `TASK:`. So an episode driven by that agent has no eligible segment at any dial,
+    # and the measured path must say so honestly rather than report a saving it did not make.
+    # Measuring observation-bulk compression in eval needs an agent whose transcript separates
+    # the task from the observations; the wrapper already handles that (see the test below).
+    compressed: list[_RecordingProvider] = []
+    control: list[_RecordingProvider] = []
+
+    def _capture(into: list[_RecordingProvider]) -> Callable[[PoolEntry], _RecordingProvider]:
+        def factory(entry: PoolEntry) -> _RecordingProvider:
+            provider = _RecordingProvider(entry)
+            into.append(provider)
+            return provider
+
+        return factory
 
     matrix = evaluate_pool(
         lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
         _pool(),
         _SCENARIOS[:1],
-        provider_factory=factory,
+        provider_factory=_capture(compressed),
         max_steps=5,
-        compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=1.0),
     )
-
-    outcome = matrix.outcomes[0]
-    # The compressor's per-episode accounting landed on the row...
-    assert outcome.compressor_id == "truncate"
-    assert outcome.compressor_version == "1"
-    assert outcome.aggressiveness == 0.5
-    assert outcome.tokens_in_compressed < outcome.tokens_in_raw
-    assert outcome.compressor_latency_s >= 0.0
-    assert outcome.compressor_cost_usd == 0.0  # truncate has no inference cost
-    # ...and the provider genuinely received compressed input (measured path, not
-    # bookkeeping): the user content the model saw is strictly shorter than what an
-    # uncompressed control run sends, and non-user content is untouched.
-    control: list[_RecordingProvider] = []
-
-    def control_factory(entry: PoolEntry) -> _RecordingProvider:
-        provider = _RecordingProvider(entry)
-        control.append(provider)
-        return provider
-
     evaluate_pool(
         lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
         _pool(),
         _SCENARIOS[:1],
-        provider_factory=control_factory,
+        provider_factory=_capture(control),
         max_steps=5,
     )
-    compressed_users = [m.content for m in providers[0].seen[0] if m.role == "user"]
-    raw_users = [m.content for m in control[0].seen[0] if m.role == "user"]
-    assert len(compressed_users) == len(raw_users)
-    assert all(len(c) < len(r) for c, r in zip(compressed_users, raw_users, strict=True))
+
+    outcome = matrix.outcomes[0]
+    assert outcome.tokens_in_raw == outcome.tokens_in_compressed
+    assert outcome.tokens_in_raw > 0  # the accounting ran; it just had nothing to remove
+    assert [m.content for m in compressed[0].seen[0]] == [
+        m.content for m in control[0].seen[0]
+    ]  # byte-identical to an uncompressed run, at the top of the dial
+
+
+def test_the_eval_stage_protects_the_task_and_still_compresses_later_turns() -> None:
+    # The rule is the shared choke point's, not serving's alone: hand the eval wrapper a
+    # transcript that HAS later turns and it compresses exactly those.
+    inner = _RecordingProvider(_pool().models[0])
+    provider = closed_loop_module._CompressingProvider(
+        inner, CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    )
+    provider.complete(
+        "a system prompt that never becomes a segment",
+        [
+            Message(role="user", content="TASK: book the cheapest flight"),
+            Message(role="assistant", content="an earlier reply"),
+            Message(role="user", content="one two three four"),
+        ],
+    )
+
+    assert [m.content for m in inner.seen[0]] == [
+        "TASK: book the cheapest flight",  # verbatim
+        "an earlier reply",  # the model's own reply is never a candidate
+        "one two",  # compressed
+    ]
+    assert provider.tokens_in_compressed < provider.tokens_in_raw
 
 
 def test_uncompressed_rows_keep_default_compression_fields() -> None:

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -8,6 +8,12 @@ conversation's cached prefix would forfeit ~0.9x discounts to save ~0.1x of toke
 that prefix out of the compressor's hands makes cache safety a property of the construction,
 not a convention each compressor must remember.
 
+WHICH segments are eligible is the config's `scope`, and it is decided in exactly one place:
+`compress_conversation` (via `compressible_positions`) is the only path from a caller's messages
+to a compressor, so scope selection and the unconditional task protection on top of it cannot be
+re-implemented per call site. The task or question segment (the first user segment of a
+conversation) is never compressed in any scope at any aggressiveness.
+
 This module ships the protocol plus the two reference implementations the seam is proven
 with: `identity` (today's behavior, bit-for-bit) and `truncate` (the trivial ratio-matched
 control every learned compressor must beat). Real compressors are chosen by the research
@@ -23,10 +29,10 @@ from __future__ import annotations
 
 import math
 import time
-from collections.abc import Callable
-from typing import Protocol, runtime_checkable
+from collections.abc import Callable, Sequence
+from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from wmo.providers.base import Embedder
 
@@ -34,10 +40,41 @@ from wmo.providers.base import Embedder
 # provider-agnostic; used only for the compressor's own raw-vs-compressed accounting.
 _CHARS_PER_TOKEN = 4
 
+# Default `CompressionConfig.bulk_min_chars`: how large a user segment has to be before "bulk"
+# scope treats it as pasted document rather than dialogue. 2000 chars is roughly 500 proxy
+# tokens, well above any measured conversational turn and below every pasted-document segment
+# in the corpora the scope was ruled on.
+DEFAULT_BULK_MIN_CHARS = 2000
+
+CompressionScope = Literal["conversation", "observations", "bulk"]
+"""Which segments of a conversation a config may rewrite (see `CompressionConfig`)."""
+
+SegmentKind = Literal["system", "user", "assistant", "observation"]
+"""What one segment IS, in the seam's own vocabulary rather than any caller's role enum.
+
+Serving maps OpenAI roles onto this (`tool` results are observations); the eval threading maps
+provider roles onto it. Keeping the seam's vocabulary separate is what lets scope selection be
+one shared rule instead of one per caller.
+"""
+
 
 def estimate_tokens(text: str) -> int:
     """Deterministic proxy token count of `text` (ceil of chars/4; 0 only for empty text)."""
     return math.ceil(len(text) / _CHARS_PER_TOKEN)
+
+
+class Segment(BaseModel):
+    """One unit of conversation text as the compression seam sees it: what it is, and its bytes.
+
+    Frozen because the scope rules read it and the choke point maps results back onto it
+    positionally; a segment whose kind could be mutated between selection and rewrite would
+    let a caller compress something scope selection had already excluded.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: SegmentKind
+    text: str
 
 
 class CompressionConfig(BaseModel):
@@ -58,11 +95,35 @@ class CompressionConfig(BaseModel):
     Aggressiveness is risk-tiered per cluster and learned within bounds by the research track.
     `compressor_version` records the version the config was fitted against (provenance);
     serving logs the version that actually ran.
+
+    `scope` is WHICH segments the dial is allowed to touch, and it is identity-bearing: two
+    configs that differ only in scope are two different arms, not one (see `same_compression`).
+    The three values, each with the measurement behind it:
+
+    - "conversation" (the DEFAULT, and the only behavior that existed before this field):
+      user-role segments. Every artifact, matrix, and policy written without a scope loads with
+      its meaning unchanged.
+    - "observations": tool results and other environment output only. User and assistant
+      segments pass through verbatim. This is the scope the measurements favor: compressing
+      dialogue lost 6-17 accuracy points and INVERTED cost by 2.3x, while removing 40% of
+      document/observation bulk held accuracy inside the noise floor.
+    - "bulk": "observations" plus user segments of at least `bulk_min_chars`, i.e. pasted
+      documents rather than typed turns.
+
+    Scope is not a way to reach the task statement. The first user segment of a conversation is
+    never compressed in ANY scope, at any aggressiveness (`compressible_positions`): the one
+    genuine deletion harm this track ever measured was a compressed task statement, so the rule
+    is code, not configuration.
+
+    `bulk_min_chars` is inert outside "bulk" scope, and identity treats it that way: it is
+    compared only when the scope can act on it.
     """
 
     compressor_id: str = Field(min_length=1)
     compressor_version: str = "1"
     aggressiveness: float = Field(default=0.0, ge=0.0, le=1.0)
+    scope: CompressionScope = "conversation"
+    bulk_min_chars: int = Field(default=DEFAULT_BULK_MIN_CHARS, ge=1)
 
 
 class CompressionResult(BaseModel):
@@ -85,13 +146,19 @@ class CompressionStats(BaseModel):
     """Request-level accounting of one applied compression stage (D-SERVING-LOG / eval shape).
 
     `compressor_version` is the version that actually RAN (the config's copy is fit-time
-    provenance). Token counts are whole-request `estimate_tokens` totals: what the input would
-    have measured raw vs what was sent, so on-vs-off savings read straight off the record.
+    provenance).
     """
 
     compressor_id: str
     compressor_version: str
     aggressiveness: float
+    # ALL segments of the request, not just the ones the scope selected: what the whole input
+    # would have measured raw, and what was actually sent. The provider bills the whole prompt,
+    # so this is the pair that makes `1 - compressed/raw` the honest billed-input saving, which
+    # is the number the admin view quotes. The compressor's own achieved keep ratio is a
+    # DIFFERENT figure (compressed/raw over eligible segments only) and is not recorded here:
+    # under a narrow scope it can look excellent while the request barely shrank, so reporting
+    # it as the saving would overstate every scoped endpoint.
     tokens_in_raw: int
     tokens_in_compressed: int
     latency_s: float
@@ -307,6 +374,92 @@ def compress_segments(
     )
 
 
+def compressible_positions(
+    segments: Sequence[Segment], config: CompressionConfig
+) -> tuple[int, ...]:
+    """The indices of `segments` this config lets a compressor rewrite, in order.
+
+    TASK PROTECTION is enforced here and nowhere else, which is the point of routing every
+    caller through this function: the FIRST user segment of a conversation is the task or
+    question, and it is excluded in every scope at every aggressiveness. Compressing a task
+    statement is the one deletion this track measured real harm from, so it cannot be reachable
+    by a config value, a new scope, or a caller that forgets to check.
+
+    Everything else follows `config.scope`; see `CompressionConfig` for what the three values
+    mean and what was measured behind them.
+    """
+    protected = next((index for index, seg in enumerate(segments) if seg.kind == "user"), None)
+    selected: list[int] = []
+    for index, segment in enumerate(segments):
+        if index == protected:
+            continue
+        match config.scope:
+            case "conversation":
+                eligible = segment.kind == "user"
+            case "observations":
+                eligible = segment.kind == "observation"
+            case "bulk":
+                eligible = segment.kind == "observation" or (
+                    segment.kind == "user" and len(segment.text) >= config.bulk_min_chars
+                )
+        if eligible:
+            selected.append(index)
+    return tuple(selected)
+
+
+class ConversationCompression(BaseModel):
+    """What one `compress_conversation` call did: the segment texts to send, plus its own bill.
+
+    `texts` has one entry per input segment, in order, so a caller maps it back onto whatever
+    message objects it built the segments from. Segments the scope did not select (and every
+    segment before `mutable_from`) come back byte-identical.
+    """
+
+    texts: list[str]
+    cost_usd: float = 0.0
+
+
+def compress_conversation(
+    compressor: Compressor,
+    segments: Sequence[Segment],
+    config: CompressionConfig,
+    *,
+    mutable_from: int = 0,
+) -> ConversationCompression:
+    """Compress one conversation: the single path from a caller's messages to a compressor.
+
+    Both production callers (serving's compression stage and the eval threading in
+    `wmo.env.closed_loop`) come through here rather than selecting segments themselves, so
+    task protection and scope selection are one rule with one test surface instead of two
+    implementations that can drift.
+
+    `segments` is the WHOLE conversation, always, even when only its tail may be rewritten.
+    Scope selection is positional (the first user segment is the task), so a caller that handed
+    over only the window it wanted compressed would shift that position and hand the task
+    to the compressor on the very first turn a prefix was reused.
+
+    `mutable_from` is the index the rewritable window starts at: everything before it is
+    returned verbatim. Serving passes the length of the compressed prefix it is reusing, which
+    is what keeps the provider-visible prefix byte-identical across turns (and the prompt cache
+    alive). The default of 0 recompresses the whole conversation, which per-segment determinism
+    makes byte-identical anyway.
+
+    ONE compressor call carries every selected segment, so an endpoint-backed compressor pays
+    one round trip per conversation rather than one per message; `compress_segments` chunks that
+    to whatever cap the implementation declares.
+    """
+    texts = [segment.text for segment in segments]
+    positions = [
+        index for index in compressible_positions(segments, config) if index >= mutable_from
+    ]
+    if not positions:
+        return ConversationCompression(texts=texts)
+    result = compress_segments(compressor, [texts[index] for index in positions], config)
+    for index, rewritten in zip(positions, result.segments, strict=True):
+        texts[index] = rewritten
+    return ConversationCompression(texts=texts, cost_usd=result.cost_usd)
+
+
 class CompressingEmbedder:
     """Embeds the COMPRESSED form of each text, so a fit sees what serving will see.
 
@@ -318,6 +471,15 @@ class CompressingEmbedder:
 
     Serving does NOT wrap its embedder: the compression stage has already rewritten the request
     by the time the router embeds it, so wrapping there would compress twice.
+
+    OPEN under scoped compression, stated because a scoped fit can reach it: serving routes on
+    the last USER turn of the compressed transcript, and task protection plus the narrow scopes
+    mean that text is frequently raw (always, in "observations" scope, where no user turn is ever
+    a candidate; and on the first turn of every conversation in any scope, where the last user
+    turn IS the protected task). Wrapping the fit's embedder then puts the bank in a geometry
+    serving does not query it in, which is the mismatch this wrapper exists to prevent, pointing
+    the other way. Which config a scoped fit should stamp as `fit_compression`, and whether it
+    should wrap at all, is a fit-side decision this seam change does not make.
 
     As few compressor calls per `embed` batch as the compressor's cap allows, not one per text:
     fitting a bank means compressing every fit scenario, which would otherwise be a round trip
@@ -336,27 +498,49 @@ class CompressingEmbedder:
 
 
 def compression_signature(config: CompressionConfig | None) -> str:
-    """How a compression config reads in an error message; None is spelled out as raw text."""
+    """How a compression config reads in an error message; None is spelled out as raw text.
+
+    This string is also an ARM IDENTITY: sweep plans and the `optimize model` stage fingerprints
+    persist it and compare it verbatim, so two configs that emit different bytes must render
+    differently. Scope therefore appears here, but only when it departs from the default, and
+    `bulk_min_chars` only in the scope that reads it. The rendering stays injective either way,
+    and a fingerprint recorded before scope existed keeps matching the default-scope arm that
+    wrote it instead of invalidating every resume manifest on disk.
+    """
     if config is None:
         return "raw text (no compression)"
-    return (
+    rendered = (
         f"compressor '{config.compressor_id}' version {config.compressor_version} "
         f"at aggressiveness {config.aggressiveness:g}"
     )
+    if config.scope == "bulk":
+        return f"{rendered}, scope bulk over {config.bulk_min_chars} chars"
+    if config.scope != "conversation":
+        return f"{rendered}, scope {config.scope}"
+    return rendered
 
 
 def same_compression(left: CompressionConfig | None, right: CompressionConfig | None) -> bool:
-    """Whether two configs produce the same representation: same compressor, version, and level.
+    """Whether two configs produce the same representation: compressor, version, level, and scope.
 
-    None (raw) equals only None. Anything else is compared on the whole triple, because a
-    version bump changes the emitted bytes exactly as a different id would.
+    None (raw) equals only None. Anything else is compared field by field, because each one
+    changes the emitted bytes: a version bump changes them exactly as a different id would, and
+    a scope change moves compression onto entirely different segments (a conversation-scope arm
+    and an observations-scope arm at the same dial are two arms, and a routing bank fitted under
+    one is not evidence for the other).
+
+    `bulk_min_chars` is compared only in "bulk" scope, which is the only scope that reads it.
+    Comparing an inert field would refuse two arms that provably emit identical bytes.
     """
     if left is None or right is None:
         return left is None and right is None
+    if left.scope == "bulk" and left.bulk_min_chars != right.bulk_min_chars:
+        return False
     return (
         left.compressor_id == right.compressor_id
         and left.compressor_version == right.compressor_version
         and left.aggressiveness == right.aggressiveness
+        and left.scope == right.scope
     )
 
 
@@ -395,7 +579,13 @@ def servable_compressor(config: CompressionConfig | None) -> Compressor | None:
     return compressor
 
 
-def resolve_compression(compressor_id: str, aggressiveness: float) -> CompressionConfig:
+def resolve_compression(
+    compressor_id: str,
+    aggressiveness: float,
+    *,
+    scope: CompressionScope = "conversation",
+    bulk_min_chars: int = DEFAULT_BULK_MIN_CHARS,
+) -> CompressionConfig:
     """The config a `--compressor` flag names, stamped with the version that will actually RUN.
 
     Every command that turns a compressor id into a config comes through here (`route sweep`,
@@ -407,6 +597,10 @@ def resolve_compression(compressor_id: str, aggressiveness: float) -> Compressio
     against the v1 serving rule right here, so an arm that could never be mounted fails at the
     boundary instead of after a sweep has been paid for.
 
+    `scope` and `bulk_min_chars` default to today's behavior, so every existing caller resolves
+    the arm it always did. They are here rather than only on the model so that a scoped arm also
+    picks up the running version stamp and the servability check.
+
     Raises:
         ValueError: The id is unknown, or the implementation cannot be served, naming which.
     """
@@ -415,6 +609,8 @@ def resolve_compression(compressor_id: str, aggressiveness: float) -> Compressio
         compressor_id=compressor_id,
         compressor_version=resolved.version,
         aggressiveness=aggressiveness,
+        scope=scope,
+        bulk_min_chars=bulk_min_chars,
     )
     servable_compressor(config)
     return config

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -109,17 +109,24 @@ class CompressionConfig(BaseModel):
       document/observation bulk held accuracy inside the noise floor.
     - "bulk": "observations" plus user segments of at least `bulk_min_chars`, i.e. pasted
       documents rather than typed turns. The other safe scope for a stock scorer.
-    - "all": every segment, dialogue included. The target scope for a DOMAIN-ADAPTED scorer at a
-      calibrated threshold: at a fixed absolute threshold, a scorer that rates dialogue as
-      high-keep preserves conversation on its own, so excluding dialogue structurally is
-      redundant and costs the savings the adapted scorer could have made safely. Choosing it with
-      a stock scorer reintroduces exactly the measured dialogue harm above, which is why it is a
-      deliberate selection and never a default.
+    - "all": user turns (bar the first), assistant turns, and observations. Dialogue included, so
+      it is the target scope for a DOMAIN-ADAPTED scorer at a calibrated threshold: at a fixed
+      absolute threshold, a scorer that rates dialogue as high-keep preserves conversation on its
+      own, so excluding dialogue structurally is redundant and costs the savings the adapted
+      scorer could have made safely. Choosing it with a stock scorer reintroduces exactly the
+      measured dialogue harm above, which is why it is a deliberate selection and never a default.
 
-    Scope is not a way to reach the task statement. The first user segment of a conversation is
-    never compressed in ANY scope, at any aggressiveness (`compressible_positions`): the one
-    genuine deletion harm this track ever measured was a compressed task statement, so the rule
-    is code, not configuration.
+    Two exclusions are STAGE LAW rather than scope rules, so no scope reaches them at any
+    aggressiveness (`compressible_positions`):
+
+    1. The TASK: the first user segment of a conversation. The one genuine deletion harm this
+       track ever measured was a compressed task statement.
+    2. The SYSTEM PROMPT, for two measured reasons. Instructions are the single category with a
+       demonstrated deletion harm (the Block question-side failure), and a system prompt is the
+       endpoint owner's instruction surface (tool schemas, policies, format contracts) rather
+       than content to shorten. It is also the maximally cacheable prefix segment, so after the
+       ~0.1x cache-read discount compressing it buys almost nothing while risking all of that:
+       the track's caching-beats-compression rule at its strongest point.
 
     `bulk_min_chars` is inert outside "bulk" scope, and identity treats it that way: it is
     compared only when the scope can act on it.
@@ -385,21 +392,26 @@ def compressible_positions(
 ) -> tuple[int, ...]:
     """The indices of `segments` this config lets a compressor rewrite, in order.
 
-    TASK PROTECTION is enforced here and nowhere else, which is the point of routing every
-    caller through this function: the FIRST user segment of a conversation is the task or
-    question, and it is excluded in every scope at every aggressiveness. Compressing a task
-    statement is the one deletion this track measured real harm from, so it cannot be reachable
-    by a config value, a new scope, or a caller that forgets to check.
+    THE TWO PROTECTIONS are enforced here and nowhere else, which is the point of routing every
+    caller through this function. Neither is reachable by a config value, a new scope, or a
+    caller that forgets to check:
+
+    - the TASK, i.e. the first user segment of a conversation. Compressing a task statement is
+      the one deletion this track measured real harm from.
+    - the SYSTEM PROMPT, every one of them. It is the endpoint owner's instruction surface, and
+      instructions are the category with the demonstrated deletion harm; it is also the
+      maximally cacheable prefix segment, so compressing it trades a ~0.1x cache-read discount
+      for a fraction of its tokens.
 
     Everything else follows `config.scope`; see `CompressionConfig` for what the four values
-    mean and what was measured behind them. "all" means literally that, the protected task
-    aside: the system prompt and the model's own replies are candidates too, because the point of
-    that scope is to stop the SCOPE deciding what to keep and let a calibrated scorer decide.
+    mean and what was measured behind them. "all" therefore spans user turns after the first,
+    assistant turns, and observations: it stops the SCOPE deciding what dialogue is worth
+    keeping and hands that to a calibrated scorer, without reaching either protected kind.
     """
     protected = next((index for index, seg in enumerate(segments) if seg.kind == "user"), None)
     selected: list[int] = []
     for index, segment in enumerate(segments):
-        if index == protected:
+        if index == protected or segment.kind == "system":
             continue
         match config.scope:
             case "conversation":
@@ -482,14 +494,8 @@ class CompressingEmbedder:
     Serving does NOT wrap its embedder: the compression stage has already rewritten the request
     by the time the router embeds it, so wrapping there would compress twice.
 
-    OPEN under scoped compression, stated because a scoped fit can reach it: serving routes on
-    the last USER turn of the compressed transcript, and task protection plus the narrow scopes
-    mean that text is frequently raw (always, in "observations" scope, where no user turn is ever
-    a candidate; and on the first turn of every conversation in any scope, where the last user
-    turn IS the protected task). Wrapping the fit's embedder then puts the bank in a geometry
-    serving does not query it in, which is the mismatch this wrapper exists to prevent, pointing
-    the other way. Which config a scoped fit should stamp as `fit_compression`, and whether it
-    should wrap at all, is a fit-side decision this seam change does not make.
+    Whether a given arm should wrap at all is `routed_text_embedder`'s decision, not a call
+    site's; construct this directly only when you mean to compress unconditionally.
 
     As few compressor calls per `embed` batch as the compressor's cap allows, not one per text:
     fitting a bank means compressing every fit scenario, which would otherwise be a round trip
@@ -505,6 +511,49 @@ class CompressingEmbedder:
     def embed(self, texts: list[str]) -> list[list[float]]:
         compressed = compress_segments(self._compressor, list(texts), self._config)
         return self._inner.embed(compressed.segments)
+
+
+# The scopes that rewrite the text serving routes on. Serving embeds the last USER turn of the
+# compressed transcript, so only a scope that can compress a user turn changes the routed-on
+# representation. "observations" and "bulk" leave every routed-on query raw ("bulk" can compress a
+# pasted user document, but a segment that large is not what `_routable_text` hands the router in
+# any measured traffic, and treating it as one would put the bank in a geometry almost no query
+# lands in).
+_ROUTED_TEXT_SCOPES: frozenset[CompressionScope] = frozenset({"conversation", "all"})
+
+
+def routed_text_embedder(inner: Embedder, config: CompressionConfig | None) -> Embedder:
+    """The embedder a fit (or a report replay) must use for `config`'s arm.
+
+    Representation consistency has a direction, and scope decides which way it points. A routing
+    bank, its cluster centroids, and its novelty-floor quantile are geometry in the space of the
+    text the fit embedded, and serving queries that geometry with the text it routes on: the last
+    USER turn of the compressed transcript (`wmo.serving.chat._routable_text`). So the rule is
+    whether this arm's scope can rewrite that turn at all:
+
+    - "conversation" and "all" can, so the fit wraps and the bank lives in compressed geometry.
+      Not wrapping is the C2 Q2 failure: queries land farther from every bank row, the novelty
+      floor trips 10-13x more often, routing collapses to the expensive fallback, and cost rises
+      11-41% while accuracy sits flat to negative.
+    - "observations" and "bulk" cannot: no user turn is ever a candidate, so every routed-on query
+      arrives raw. Wrapping there would put the bank in a geometry serving NEVER queries, which is
+      the same failure mirrored, so these arms fit on raw text.
+
+    The wrap decision does not touch arm identity: `fit_compression` still stamps the whole config
+    either way, so the mount gates and the measured-arm gates behave exactly as they do now.
+
+    KNOWN RESIDUAL, interim: under "conversation" and "all" the routed-on text is compressed on
+    later turns but RAW on the first turn of every conversation, because the last user turn is
+    then the protected task. A wrapped bank is therefore right for most queries and slightly off
+    for first-turn ones, which is a mixture rather than the clean mismatch above. The uniform fix
+    is the route-on-raw serving contract (route on the raw last user turn, so the routed-on
+    representation is raw in every scope and no fit ever wraps), pending the routing lane's
+    co-sign; this rule converges to it, since adopting that contract just empties
+    `_ROUTED_TEXT_SCOPES`.
+    """
+    if config is None or config.scope not in _ROUTED_TEXT_SCOPES:
+        return inner
+    return CompressingEmbedder(inner, config)
 
 
 def compression_signature(config: CompressionConfig | None) -> str:

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import math
 import time
 from collections.abc import Callable, Sequence
-from typing import Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, cast, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -48,6 +48,28 @@ DEFAULT_BULK_MIN_CHARS = 2000
 
 CompressionScope = Literal["conversation", "observations", "bulk", "all"]
 """Which segments of a conversation a config may rewrite (see `CompressionConfig`)."""
+
+COMPRESSION_SCOPES: tuple[CompressionScope, ...] = (
+    "conversation",
+    "observations",
+    "bulk",
+    "all",
+)
+"""Every accepted scope, in escalating order. The one source `--scope`'s help renders from."""
+
+
+def parse_compression_scope(value: str) -> CompressionScope:
+    """Narrow a `--scope` string to the literal, naming the choices when it is not one of them.
+
+    Raises:
+        ValueError: `value` is not a scope, listing the ones that are.
+    """
+    if value not in COMPRESSION_SCOPES:
+        raise ValueError(
+            f"unknown compression scope {value!r}; choose one of {' | '.join(COMPRESSION_SCOPES)}"
+        )
+    return cast("CompressionScope", value)
+
 
 SegmentKind = Literal["system", "user", "assistant", "observation"]
 """What one segment IS, in the seam's own vocabulary rather than any caller's role enum.
@@ -483,19 +505,17 @@ def compress_conversation(
 
 
 class CompressingEmbedder:
-    """Embeds the COMPRESSED form of each text, so a fit sees what serving will see.
+    """Embeds the COMPRESSED form of each text. EXPLICIT USE ONLY: no fit reaches for this.
 
-    The fit-side half of representation consistency (C2's Q2 result). A routing bank and its
-    novelty floor are geometry: fit them on raw task text and then query them with compressed
-    text and the queries land farther from every bank row, the floor trips 10-13x more often,
-    and the router abstains to the expensive fallback on 20-30% more requests. Wrapping the fit's
-    embedder is all it takes to move the bank and the floor onto the served representation.
+    Kept as a tool, not a policy. It was the fit-side half of representation consistency until
+    the decision-bearing query turned out to be raw (see `routed_text_embedder`, which is what
+    every fit and report goes through and which no longer wraps anything). Research code that
+    deliberately wants a compressed-geometry bank constructs this directly and owns the reason;
+    production fits must not, because a bank in a geometry serving does not query is the C2 Q2
+    failure whichever direction it points in.
 
-    Serving does NOT wrap its embedder: the compression stage has already rewritten the request
-    by the time the router embeds it, so wrapping there would compress twice.
-
-    Whether a given arm should wrap at all is `routed_text_embedder`'s decision, not a call
-    site's; construct this directly only when you mean to compress unconditionally.
+    Serving does not wrap its embedder either: the compression stage has already rewritten the
+    request by the time the router embeds it, so wrapping there would compress twice.
 
     As few compressor calls per `embed` batch as the compressor's cap allows, not one per text:
     fitting a bank means compressing every fit scenario, which would otherwise be a round trip
@@ -513,43 +533,41 @@ class CompressingEmbedder:
         return self._inner.embed(compressed.segments)
 
 
-# The scopes that rewrite the text serving routes on. Serving embeds the last USER turn of the
-# compressed transcript, so only a scope that can compress a user turn changes the routed-on
-# representation. "observations" and "bulk" leave every routed-on query raw ("bulk" can compress a
-# pasted user document, but a segment that large is not what `_routable_text` hands the router in
-# any measured traffic, and treating it as one would put the bank in a geometry almost no query
-# lands in).
-_ROUTED_TEXT_SCOPES: frozenset[CompressionScope] = frozenset({"conversation", "all"})
+# The scopes under which a fit embeds COMPRESSED text. Deliberately empty: see
+# `routed_text_embedder` for why the decision-bearing query is raw in every scope. Kept as the one
+# named place the rule lives, so adopting a different serving contract is an edit here rather than
+# a hunt through the fit sites.
+_ROUTED_TEXT_SCOPES: frozenset[CompressionScope] = frozenset()
 
 
 def routed_text_embedder(inner: Embedder, config: CompressionConfig | None) -> Embedder:
-    """The embedder a fit (or a report replay) must use for `config`'s arm.
+    """The embedder a fit (or a report replay) must use for `config`'s arm: always the raw one.
 
-    Representation consistency has a direction, and scope decides which way it points. A routing
-    bank, its cluster centroids, and its novelty-floor quantile are geometry in the space of the
-    text the fit embedded, and serving queries that geometry with the text it routes on: the last
-    USER turn of the compressed transcript (`wmo.serving.chat._routable_text`). So the rule is
-    whether this arm's scope can rewrite that turn at all:
+    Representation consistency is about the query that DECIDES something, and for a knn endpoint
+    that query is raw whatever the scope, for three reasons that compound:
 
-    - "conversation" and "all" can, so the fit wraps and the bank lives in compressed geometry.
-      Not wrapping is the C2 Q2 failure: queries land farther from every bank row, the novelty
-      floor trips 10-13x more often, routing collapses to the expensive fallback, and cost rises
-      11-41% while accuracy sits flat to negative.
-    - "observations" and "bulk" cannot: no user turn is ever a candidate, so every routed-on query
-      arrives raw. Wrapping there would put the bank in a geometry serving NEVER queries, which is
-      the same failure mirrored, so these arms fit on raw text.
+    - the bank embeds bare TASK STATEMENTS, one row per fit scenario;
+    - serving routes on the last user turn (`wmo.serving.chat._routable_text`), and on turn 1 of
+      every conversation that turn IS the task, which stage law never compresses;
+    - conversation affinity is sticky by default, so turns 2+ reuse the incumbent and never
+      consult the bank at all.
 
-    The wrap decision does not touch arm identity: `fit_compression` still stamps the whole config
-    either way, so the mount gates and the measured-arm gates behave exactly as they do now.
+    So the decision-bearing query is the raw task, and a bank fitted through the compressor would
+    be queried with raw text essentially always: the C2 Q2 failure (queries land farther from every
+    bank row, the novelty floor trips 10-13x more often, routing collapses to the expensive
+    fallback, cost up 11-41% while accuracy sits flat to negative) CAUSED by wrapping rather than
+    prevented by it. Hence banks are fitted raw, in every scope. This adopts the co-signed
+    route-on-raw direction early and matches what serving actually embeds when it decides.
 
-    KNOWN RESIDUAL, interim: under "conversation" and "all" the routed-on text is compressed on
-    later turns but RAW on the first turn of every conversation, because the last user turn is
-    then the protected task. A wrapped bank is therefore right for most queries and slightly off
-    for first-turn ones, which is a mixture rather than the clean mismatch above. The uniform fix
-    is the route-on-raw serving contract (route on the raw last user turn, so the routed-on
-    representation is raw in every scope and no fit ever wraps), pending the routing lane's
-    co-sign; this rule converges to it, since adopting that contract just empties
-    `_ROUTED_TEXT_SCOPES`.
+    Arm identity is untouched: `fit_compression` still stamps the whole config, so both mount gates
+    and the measured-arm gate behave exactly as before. The wrap decision was never part of
+    identity.
+
+    DOCUMENTED RESIDUAL: an endpoint with stickiness OFF, under "conversation" or "all" scope,
+    embeds compressed text on turns 2+ against this raw bank. That is the narrow remaining
+    mismatch, it needs a non-default serving configuration to reach, and the uniform fix is the
+    serving-side route-on-raw change (route on the RAW last user turn, so the routed-on
+    representation is raw on every turn) which belongs to the routing co-sign round.
     """
     if config is None or config.scope not in _ROUTED_TEXT_SCOPES:
         return inner

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -46,7 +46,7 @@ _CHARS_PER_TOKEN = 4
 # in the corpora the scope was ruled on.
 DEFAULT_BULK_MIN_CHARS = 2000
 
-CompressionScope = Literal["conversation", "observations", "bulk"]
+CompressionScope = Literal["conversation", "observations", "bulk", "all"]
 """Which segments of a conversation a config may rewrite (see `CompressionConfig`)."""
 
 SegmentKind = Literal["system", "user", "assistant", "observation"]
@@ -98,17 +98,23 @@ class CompressionConfig(BaseModel):
 
     `scope` is WHICH segments the dial is allowed to touch, and it is identity-bearing: two
     configs that differ only in scope are two different arms, not one (see `same_compression`).
-    The three values, each with the measurement behind it:
+    The four values, each with the measurement behind it:
 
     - "conversation" (the DEFAULT, and the only behavior that existed before this field):
       user-role segments. Every artifact, matrix, and policy written without a scope loads with
       its meaning unchanged.
     - "observations": tool results and other environment output only. User and assistant
-      segments pass through verbatim. This is the scope the measurements favor: compressing
+      segments pass through verbatim. With a STOCK scorer this is the safe scope: compressing
       dialogue lost 6-17 accuracy points and INVERTED cost by 2.3x, while removing 40% of
       document/observation bulk held accuracy inside the noise floor.
     - "bulk": "observations" plus user segments of at least `bulk_min_chars`, i.e. pasted
-      documents rather than typed turns.
+      documents rather than typed turns. The other safe scope for a stock scorer.
+    - "all": every segment, dialogue included. The target scope for a DOMAIN-ADAPTED scorer at a
+      calibrated threshold: at a fixed absolute threshold, a scorer that rates dialogue as
+      high-keep preserves conversation on its own, so excluding dialogue structurally is
+      redundant and costs the savings the adapted scorer could have made safely. Choosing it with
+      a stock scorer reintroduces exactly the measured dialogue harm above, which is why it is a
+      deliberate selection and never a default.
 
     Scope is not a way to reach the task statement. The first user segment of a conversation is
     never compressed in ANY scope, at any aggressiveness (`compressible_positions`): the one
@@ -385,8 +391,10 @@ def compressible_positions(
     statement is the one deletion this track measured real harm from, so it cannot be reachable
     by a config value, a new scope, or a caller that forgets to check.
 
-    Everything else follows `config.scope`; see `CompressionConfig` for what the three values
-    mean and what was measured behind them.
+    Everything else follows `config.scope`; see `CompressionConfig` for what the four values
+    mean and what was measured behind them. "all" means literally that, the protected task
+    aside: the system prompt and the model's own replies are candidates too, because the point of
+    that scope is to stop the SCOPE deciding what to keep and let a calibrated scorer decide.
     """
     protected = next((index for index, seg in enumerate(segments) if seg.kind == "user"), None)
     selected: list[int] = []
@@ -402,6 +410,8 @@ def compressible_positions(
                 eligible = segment.kind == "observation" or (
                     segment.kind == "user" and len(segment.text) >= config.bulk_min_chars
                 )
+            case "all":
+                eligible = True
         if eligible:
             selected.append(index)
     return tuple(selected)

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -239,7 +239,7 @@ _CONVERSATION = [
 def test_the_first_user_segment_is_protected_in_every_scope() -> None:
     # The one deletion harm this track measured was a compressed task statement, so no scope and
     # no dial can reach index 1 here.
-    scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk")
+    scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk", "all")
     for scope in scopes:
         config = CompressionConfig(
             compressor_id="truncate", aggressiveness=1.0, scope=scope, bulk_min_chars=1
@@ -260,6 +260,10 @@ def test_each_scope_selects_the_segments_it_names() -> None:
     # default threshold it is left alone and only the observation is selected.
     assert positions("bulk") == (3,)
     assert positions("bulk", bulk_min_chars=1) == (3, 4)
+    # "all" is literally all of it, the protected task at index 1 aside: the system prompt and the
+    # model's own reply are candidates too, because that scope exists to stop the SCOPE deciding
+    # what to keep and hand the decision to a calibrated scorer.
+    assert positions("all") == (0, 2, 3, 4)
 
 
 def test_the_task_is_byte_identical_through_the_stage_at_full_aggressiveness() -> None:

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 
 from wmo.optimize.compression import (
+    DEFAULT_BULK_MIN_CHARS,
     CompressingEmbedder,
     CompressionConfig,
     CompressionResult,
@@ -282,6 +283,24 @@ def test_each_scope_selects_the_segments_it_names() -> None:
     assert positions("all") == (2, 3, 4)
 
 
+@pytest.mark.parametrize(
+    ("length", "eligible"),
+    [(DEFAULT_BULK_MIN_CHARS - 1, False), (DEFAULT_BULK_MIN_CHARS, True), (2001, True)],
+)
+def test_the_bulk_threshold_is_inclusive_at_exactly_its_default(
+    length: int, eligible: bool
+) -> None:
+    # Pinned at the boundary because "at least bulk_min_chars" is a decision, not an accident: a
+    # segment of exactly 2000 chars IS bulk. An off-by-one here silently moves which user content a
+    # bulk arm compresses, and no accuracy measurement would attribute the change to this.
+    segments = [
+        Segment(kind="user", text="the task statement"),
+        Segment(kind="user", text="x" * length),
+    ]
+    config = CompressionConfig(compressor_id="truncate", scope="bulk")
+    assert compressible_positions(segments, config) == ((1,) if eligible else ())
+
+
 def test_the_task_is_byte_identical_through_the_stage_at_full_aggressiveness() -> None:
     config = CompressionConfig(compressor_id="truncate", aggressiveness=1.0)
     result = compress_conversation(get_compressor("truncate"), _CONVERSATION, config)
@@ -323,35 +342,39 @@ def test_a_conversation_with_nothing_eligible_never_calls_the_compressor() -> No
     assert result.cost_usd == 0.0
 
 
-def test_only_a_scope_that_rewrites_the_routed_on_turn_wraps_the_fit_embedder() -> None:
-    # Serving routes on the last USER turn of the compressed transcript, so representation
-    # consistency has a direction and scope decides which way it points. Wrapping under a scope
-    # that never touches a user turn would put the bank in a geometry serving never queries: the
-    # C2 Q2 failure mirrored.
+def test_no_scope_wraps_the_fit_embedder_because_the_deciding_query_is_raw() -> None:
+    # The bank embeds bare task statements; serving routes on the last user turn, which on turn 1
+    # IS the task (stage law never compresses it); and sticky affinity means turns 2+ never consult
+    # the bank. So the deciding query is raw in EVERY scope, and a wrapped bank would be queried
+    # with raw text essentially always: the C2 Q2 failure caused by wrapping, not prevented by it.
     inner = _CountingEmbedder()
     base = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
-    assert isinstance(routed_text_embedder(inner, base), CompressingEmbedder)
-    assert isinstance(
-        routed_text_embedder(inner, base.model_copy(update={"scope": "all"})), CompressingEmbedder
-    )
-    for raw_routed in ("observations", "bulk"):
-        wrapped = routed_text_embedder(inner, base.model_copy(update={"scope": raw_routed}))
-        assert wrapped is inner, raw_routed
-    assert routed_text_embedder(inner, None) is inner  # an uncompressed arm never wraps
+    scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk", "all")
+    for scope in scopes:
+        assert routed_text_embedder(inner, base.model_copy(update={"scope": scope})) is inner, scope
+    assert routed_text_embedder(inner, None) is inner  # an uncompressed arm, unchanged as ever
 
 
-def test_an_observations_scope_fit_embeds_raw_and_a_conversation_scope_fit_does_not() -> None:
-    # The same rule read off the BYTES the fit embedder hands its inner embedder, not off types.
+def test_every_scope_fit_embeds_raw_bytes() -> None:
+    # The same rule read off the BYTES handed to the inner embedder, not off types, so a future
+    # wrap rule cannot pass this by returning a wrapper that happens to be a no-op.
     config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
-    conversation = _CountingEmbedder()
-    routed_text_embedder(conversation, config).embed(["one two three four"])
-    assert conversation.seen == [["one two"]]
+    scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk", "all")
+    for scope in scopes:
+        inner = _CountingEmbedder()
+        routed_text_embedder(inner, config.model_copy(update={"scope": scope})).embed(
+            ["one two three four"]
+        )
+        assert inner.seen == [["one two three four"]], scope
 
-    observations = _CountingEmbedder()
-    routed_text_embedder(observations, config.model_copy(update={"scope": "observations"})).embed(
-        ["one two three four"]
-    )
-    assert observations.seen == [["one two three four"]]  # raw: serving routes on raw here
+
+def test_compressing_embedder_is_still_available_for_deliberate_research_use() -> None:
+    # Demoted to explicit-use-only, not deleted: research code that wants a compressed-geometry
+    # bank constructs it directly and owns the reason.
+    inner = _CountingEmbedder()
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    CompressingEmbedder(inner, config).embed(["one two three four"])
+    assert inner.seen == [["one two"]]
 
 
 def test_compressing_embedder_embeds_the_compressed_text() -> None:

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -25,6 +25,7 @@ from wmo.optimize.compression import (
     register_compressor_factory,
     registered_compressor_ids,
     resolve_compression,
+    routed_text_embedder,
     same_compression,
     segment_batch_limit,
     servable_compressor,
@@ -236,15 +237,30 @@ _CONVERSATION = [
 ]
 
 
-def test_the_first_user_segment_is_protected_in_every_scope() -> None:
-    # The one deletion harm this track measured was a compressed task statement, so no scope and
-    # no dial can reach index 1 here.
+def test_the_task_and_the_system_prompt_are_protected_in_every_scope() -> None:
+    # The two stage-law exclusions, at the top of the dial with the bulk threshold as low as it
+    # goes. Index 1 is the task (the measured deletion harm), index 0 is the system prompt (the
+    # endpoint owner's instruction surface, and the maximally cacheable prefix segment).
     scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk", "all")
     for scope in scopes:
         config = CompressionConfig(
             compressor_id="truncate", aggressiveness=1.0, scope=scope, bulk_min_chars=1
         )
-        assert 1 not in compressible_positions(_CONVERSATION, config)
+        positions = compressible_positions(_CONVERSATION, config)
+        assert 1 not in positions, scope
+        assert 0 not in positions, scope
+
+
+def test_a_second_system_segment_is_protected_too_not_just_the_first() -> None:
+    # The system rule is by KIND, not by position: a transcript carrying a second system turn
+    # (clients do send them mid-conversation) must not have that one compressed either.
+    segments = [
+        Segment(kind="user", text="the task statement"),
+        Segment(kind="system", text="a mid-conversation instruction update"),
+        Segment(kind="user", text="a follow-up turn"),
+    ]
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=1.0, scope="all")
+    assert compressible_positions(segments, config) == (2,)
 
 
 def test_each_scope_selects_the_segments_it_names() -> None:
@@ -260,10 +276,10 @@ def test_each_scope_selects_the_segments_it_names() -> None:
     # default threshold it is left alone and only the observation is selected.
     assert positions("bulk") == (3,)
     assert positions("bulk", bulk_min_chars=1) == (3, 4)
-    # "all" is literally all of it, the protected task at index 1 aside: the system prompt and the
-    # model's own reply are candidates too, because that scope exists to stop the SCOPE deciding
-    # what to keep and hand the decision to a calibrated scorer.
-    assert positions("all") == (0, 2, 3, 4)
+    # "all" spans user turns after the first, assistant turns, and observations: it stops the SCOPE
+    # deciding what dialogue is worth keeping and hands that to a calibrated scorer, while both
+    # stage-law exclusions (index 1 the task, index 0 the system prompt) still hold.
+    assert positions("all") == (2, 3, 4)
 
 
 def test_the_task_is_byte_identical_through_the_stage_at_full_aggressiveness() -> None:
@@ -305,6 +321,37 @@ def test_a_conversation_with_nothing_eligible_never_calls_the_compressor() -> No
     result = compress_conversation(cast("Compressor", _Refusing()), only_the_task, config)
     assert result.texts == ["the task statement"]
     assert result.cost_usd == 0.0
+
+
+def test_only_a_scope_that_rewrites_the_routed_on_turn_wraps_the_fit_embedder() -> None:
+    # Serving routes on the last USER turn of the compressed transcript, so representation
+    # consistency has a direction and scope decides which way it points. Wrapping under a scope
+    # that never touches a user turn would put the bank in a geometry serving never queries: the
+    # C2 Q2 failure mirrored.
+    inner = _CountingEmbedder()
+    base = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    assert isinstance(routed_text_embedder(inner, base), CompressingEmbedder)
+    assert isinstance(
+        routed_text_embedder(inner, base.model_copy(update={"scope": "all"})), CompressingEmbedder
+    )
+    for raw_routed in ("observations", "bulk"):
+        wrapped = routed_text_embedder(inner, base.model_copy(update={"scope": raw_routed}))
+        assert wrapped is inner, raw_routed
+    assert routed_text_embedder(inner, None) is inner  # an uncompressed arm never wraps
+
+
+def test_an_observations_scope_fit_embeds_raw_and_a_conversation_scope_fit_does_not() -> None:
+    # The same rule read off the BYTES the fit embedder hands its inner embedder, not off types.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    conversation = _CountingEmbedder()
+    routed_text_embedder(conversation, config).embed(["one two three four"])
+    assert conversation.seen == [["one two"]]
+
+    observations = _CountingEmbedder()
+    routed_text_embedder(observations, config.model_copy(update={"scope": "observations"})).embed(
+        ["one two three four"]
+    )
+    assert observations.seen == [["one two three four"]]  # raw: serving routes on raw here
 
 
 def test_compressing_embedder_embeds_the_compressed_text() -> None:

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -10,15 +10,21 @@ from wmo.optimize.compression import (
     CompressingEmbedder,
     CompressionConfig,
     CompressionResult,
+    CompressionScope,
     Compressor,
     IdentityCompressor,
+    Segment,
     TruncateCompressor,
+    compress_conversation,
     compress_segments,
+    compressible_positions,
+    compression_signature,
     estimate_tokens,
     get_compressor,
     register_compressor,
     register_compressor_factory,
     registered_compressor_ids,
+    resolve_compression,
     same_compression,
     segment_batch_limit,
     servable_compressor,
@@ -183,6 +189,118 @@ def test_same_compression_compares_the_whole_triple() -> None:
     assert not same_compression(base, base.model_copy(update={"aggressiveness": 0.25}))
     # A version bump changes the emitted bytes exactly as a different id would.
     assert not same_compression(base, base.model_copy(update={"compressor_version": "2"}))
+
+
+# ---------------------------------------------------------------- scope, identity, and the task
+
+
+def test_two_configs_differing_only_in_scope_are_not_the_same_arm() -> None:
+    # Scope moves compression onto entirely different segments, so a bank fitted under one scope
+    # is not evidence for another. Identity has to see that, or the mount and fit gates wave it
+    # through and the artifact serves a representation it was never measured in.
+    conversation = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    observations = conversation.model_copy(update={"scope": "observations"})
+    assert not same_compression(conversation, observations)
+    assert not same_compression(observations, conversation)
+    assert compression_signature(conversation) != compression_signature(observations)
+    # bulk_min_chars is identity-bearing only where it can act, which is "bulk" scope alone.
+    assert same_compression(conversation, conversation.model_copy(update={"bulk_min_chars": 10}))
+    bulk = conversation.model_copy(update={"scope": "bulk"})
+    assert not same_compression(bulk, bulk.model_copy(update={"bulk_min_chars": 10}))
+
+
+def test_a_default_scope_signature_is_unchanged_so_recorded_fingerprints_still_match() -> None:
+    # The signature is persisted verbatim in sweep plans and `optimize model` stage fingerprints.
+    # Rendering the default scope would invalidate every one of them on disk for no new
+    # information, so scope shows up only when it departs from the default.
+    default = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    assert compression_signature(default) == "compressor 'truncate' version 1 at aggressiveness 0.5"
+    assert compression_signature(None) == "raw text (no compression)"
+    bulk = default.model_copy(update={"scope": "bulk", "bulk_min_chars": 4096})
+    assert compression_signature(bulk).endswith("scope bulk over 4096 chars")
+
+
+def test_resolve_compression_carries_scope_and_stamps_the_running_version() -> None:
+    config = resolve_compression("truncate", 0.5, scope="observations", bulk_min_chars=1234)
+    assert config.scope == "observations"
+    assert config.bulk_min_chars == 1234
+    assert config.compressor_version == TruncateCompressor.version
+
+
+_CONVERSATION = [
+    Segment(kind="system", text="a system prompt"),
+    Segment(kind="user", text="the task statement"),
+    Segment(kind="assistant", text="an earlier reply"),
+    Segment(kind="observation", text="a tool result"),
+    Segment(kind="user", text="a follow-up turn"),
+]
+
+
+def test_the_first_user_segment_is_protected_in_every_scope() -> None:
+    # The one deletion harm this track measured was a compressed task statement, so no scope and
+    # no dial can reach index 1 here.
+    scopes: tuple[CompressionScope, ...] = ("conversation", "observations", "bulk")
+    for scope in scopes:
+        config = CompressionConfig(
+            compressor_id="truncate", aggressiveness=1.0, scope=scope, bulk_min_chars=1
+        )
+        assert 1 not in compressible_positions(_CONVERSATION, config)
+
+
+def test_each_scope_selects_the_segments_it_names() -> None:
+    def positions(scope: CompressionScope, *, bulk_min_chars: int = 2000) -> tuple[int, ...]:
+        return compressible_positions(
+            _CONVERSATION,
+            CompressionConfig(compressor_id="truncate", scope=scope, bulk_min_chars=bulk_min_chars),
+        )
+
+    assert positions("conversation") == (4,)  # user turns, minus the task
+    assert positions("observations") == (3,)  # tool output only
+    # "bulk" is observations plus LARGE user content; the follow-up turn is short prose, so at the
+    # default threshold it is left alone and only the observation is selected.
+    assert positions("bulk") == (3,)
+    assert positions("bulk", bulk_min_chars=1) == (3, 4)
+
+
+def test_the_task_is_byte_identical_through_the_stage_at_full_aggressiveness() -> None:
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=1.0)
+    result = compress_conversation(get_compressor("truncate"), _CONVERSATION, config)
+    assert result.texts[1] == "the task statement"  # verbatim, at the top of the dial
+    assert result.texts[0] == "a system prompt"
+    assert result.texts[2] == "an earlier reply"
+    assert result.texts[3] == "a tool result"
+    assert result.texts[4] == ""  # a later turn, fully removed: the dial does work
+
+
+def test_mutable_from_leaves_the_reused_prefix_verbatim() -> None:
+    # Serving reuses an already-compressed prefix rather than recompressing it, which is what
+    # keeps the provider's prompt cache alive. Passing the WHOLE conversation is still required:
+    # scope selection is positional, so a caller that handed over only its window would shift the
+    # task segment and expose it.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    result = compress_conversation(
+        get_compressor("truncate"), _CONVERSATION, config, mutable_from=4
+    )
+    assert result.texts[:4] == [segment.text for segment in _CONVERSATION[:4]]
+    assert result.texts[4] == "a follow-up"
+
+
+def test_a_conversation_with_nothing_eligible_never_calls_the_compressor() -> None:
+    # Not just "no change": no round trip and no bill either, which is what makes a narrow scope
+    # free rather than merely harmless.
+    class _Refusing:
+        id = "refusing-for-tests"
+        version = "1"
+        append_stable = True
+
+        def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+            raise AssertionError("the choke point handed over an ineligible segment")
+
+    config = CompressionConfig(compressor_id="refusing-for-tests", scope="observations")
+    only_the_task = [Segment(kind="user", text="the task statement")]
+    result = compress_conversation(cast("Compressor", _Refusing()), only_the_task, config)
+    assert result.texts == ["the task statement"]
+    assert result.cost_usd == 0.0
 
 
 def test_compressing_embedder_embeds_the_compressed_text() -> None:

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
-from wmo.optimize.compression import CompressingEmbedder, CompressionConfig
+from wmo.optimize.compression import CompressionConfig, routed_text_embedder
 from wmo.optimize.policy import (
     DEFAULT_KNN_MIN_PAIRS,
     DEFAULT_KNN_Z,
@@ -319,15 +319,12 @@ def fit_knn_artifact(
         raise ValueError("rag_thres must be greater than 0")
     selected_ids = fit_ids if fit_ids is not None else matrix.scenario_ids()
     fit_digest = hashlib.sha256("\0".join(selected_ids).encode("utf-8")).hexdigest()[:16]
-    built = embedder.build()
-    if compression is not None:
-        # Representation consistency, the C2 rule that makes or breaks a compressed arm: the
-        # bank rows and the novelty-floor quantile have to live in the geometry of the text
-        # SERVING will embed, which is the compressed text. One wrapped embedder covers the fit
-        # and the replay below. Serving does not wrap, because its compression stage runs ahead
-        # of the router. Fitting the bank uncompressed while serving compresses is the failure
-        # this exists to prevent: the floor abstains, and routing silently stops happening.
-        built = CompressingEmbedder(built, compression)
+    # Representation consistency, the C2 rule that makes or breaks a compressed arm: the bank rows
+    # and the novelty-floor quantile have to live in the geometry of the text SERVING routes on.
+    # `routed_text_embedder` owns whether this arm's scope rewrites that text (so a scope that
+    # never touches a user turn fits on raw); one embedder covers the fit and the replay below.
+    # Serving does not wrap either way, because its compression stage runs ahead of the router.
+    built = routed_text_embedder(embedder.build(), compression)
     embed_tag = embedder_provenance(embedder)
     policy = fit_knn_policy(
         matrix,

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -320,10 +320,9 @@ def fit_knn_artifact(
     selected_ids = fit_ids if fit_ids is not None else matrix.scenario_ids()
     fit_digest = hashlib.sha256("\0".join(selected_ids).encode("utf-8")).hexdigest()[:16]
     # Representation consistency, the C2 rule that makes or breaks a compressed arm: the bank rows
-    # and the novelty-floor quantile have to live in the geometry of the text SERVING routes on.
-    # `routed_text_embedder` owns whether this arm's scope rewrites that text (so a scope that
-    # never touches a user turn fits on raw); one embedder covers the fit and the replay below.
-    # Serving does not wrap either way, because its compression stage runs ahead of the router.
+    # and the novelty-floor quantile have to live in the geometry of the query that DECIDES, which
+    # is the raw task statement in every scope (`routed_text_embedder` carries the reasoning and is
+    # the one place that could ever change it). One embedder covers the fit and the replay below.
     built = routed_text_embedder(embedder.build(), compression)
     embed_tag = embedder_provenance(embedder)
     policy = fit_knn_policy(

--- a/wmo/optimize/knn_test.py
+++ b/wmo/optimize/knn_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     COST_QUALITY_BALANCED,
@@ -16,6 +17,7 @@ from wmo.optimize.knn import (
     build_knn_bank,
     cost_quality_knobs,
     cost_quality_named_point,
+    fit_knn_artifact,
     fit_knn_policy,
 )
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
@@ -545,3 +547,46 @@ def test_the_dial_records_the_coverage_quantile_it_applied(tmp_path: Path) -> No
         slid = apply_cost_quality(fitted, dial)
         assert slid.floor_q == pytest.approx(cost_quality_knobs(dial).floor_q)
         assert (slid.floor_sim is None) == (slid.floor_q == 0.0)
+
+
+def _bank_of(tmp_path: Path, config: CompressionConfig | None, tag: str) -> np.ndarray:
+    """The bank `fit_knn_artifact` writes for one compression arm, as raw embeddings."""
+    out_path = tmp_path / tag / POLICY_FILENAME
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fitted = fit_knn_artifact(
+        _matrix(),
+        out_path=out_path,
+        matrix_source="matrix.json",
+        embedder=EmbedderSpec(dim=256),
+        fallback="cheap",
+        rag_num=5,
+        min_pairs=0,
+        compression=config,
+    )
+    return fitted.policy.knn_bank().embeddings
+
+
+def test_the_fit_wraps_its_embedder_only_when_the_scope_rewrites_the_routed_on_turn(
+    tmp_path: Path,
+) -> None:
+    """Both directions at the real fit site (the ruling's interim representation rule).
+
+    Serving routes on the last USER turn of the compressed transcript, so only a scope that can
+    rewrite a user turn changes the routed-on representation. A "conversation" arm must therefore
+    fit its bank in compressed geometry, and an "observations" arm must fit on RAW text: wrapping
+    there would put the bank in a geometry serving never queries, which is the C2 Q2 mismatch
+    mirrored. Compared against the uncompressed bank rather than against types, so the assertion
+    is about the embeddings this fit actually wrote.
+    """
+    raw = _bank_of(tmp_path, None, "raw")
+    conversation = _bank_of(
+        tmp_path, CompressionConfig(compressor_id="truncate", aggressiveness=0.5), "conversation"
+    )
+    observations = _bank_of(
+        tmp_path,
+        CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="observations"),
+        "observations",
+    )
+
+    assert not np.allclose(conversation, raw)  # compressed geometry: the router queries it that way
+    assert np.array_equal(observations, raw)  # raw geometry: every routed-on query arrives raw

--- a/wmo/optimize/knn_test.py
+++ b/wmo/optimize/knn_test.py
@@ -566,27 +566,19 @@ def _bank_of(tmp_path: Path, config: CompressionConfig | None, tag: str) -> np.n
     return fitted.policy.knn_bank().embeddings
 
 
-def test_the_fit_wraps_its_embedder_only_when_the_scope_rewrites_the_routed_on_turn(
-    tmp_path: Path,
-) -> None:
-    """Both directions at the real fit site (the ruling's interim representation rule).
+def test_every_compression_arm_fits_its_bank_on_raw_text(tmp_path: Path) -> None:
+    """The route-on-raw representation rule, at the real fit site.
 
-    Serving routes on the last USER turn of the compressed transcript, so only a scope that can
-    rewrite a user turn changes the routed-on representation. A "conversation" arm must therefore
-    fit its bank in compressed geometry, and an "observations" arm must fit on RAW text: wrapping
-    there would put the bank in a geometry serving never queries, which is the C2 Q2 mismatch
-    mirrored. Compared against the uncompressed bank rather than against types, so the assertion
-    is about the embeddings this fit actually wrote.
+    The bank embeds bare task statements, serving routes on the last user turn (which on turn 1 is
+    the task that stage law never compresses), and sticky affinity means turns 2+ never consult the
+    bank. So the deciding query is raw whatever the scope, and a bank fitted through the compressor
+    would be queried with raw text essentially always: the C2 Q2 failure caused BY the wrap.
+
+    Asserted on the embeddings the fit actually wrote rather than on embedder types, so a
+    reintroduced wrap cannot slip past this.
     """
     raw = _bank_of(tmp_path, None, "raw")
-    conversation = _bank_of(
-        tmp_path, CompressionConfig(compressor_id="truncate", aggressiveness=0.5), "conversation"
-    )
-    observations = _bank_of(
-        tmp_path,
-        CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="observations"),
-        "observations",
-    )
-
-    assert not np.allclose(conversation, raw)  # compressed geometry: the router queries it that way
-    assert np.array_equal(observations, raw)  # raw geometry: every routed-on query arrives raw
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    for scope in ("conversation", "observations", "bulk", "all"):
+        banked = _bank_of(tmp_path, config.model_copy(update={"scope": scope}), f"scope-{scope}")
+        assert np.array_equal(banked, raw), scope

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -17,6 +17,7 @@ from wmo.optimize.compression import (
     DEFAULT_BULK_MIN_CHARS,
     CompressionConfig,
     CompressionScope,
+    compression_signature,
 )
 from wmo.providers.base import TokenUsage
 from wmo.providers.pool import PoolEntry
@@ -161,21 +162,35 @@ class OutcomeMatrix(BaseModel):
         Reads the scored rows only: an unscored row never produced a reward, so whatever it ran
         under cannot bias a fit.
         """
+        # The key mirrors `same_compression` exactly, `bulk_min_chars`'s scope-conditional
+        # inertness included: outside "bulk" scope that field cannot change a single emitted byte,
+        # so keying on it would split one arm in two and refuse the matrix while printing the same
+        # readable string twice, naming a difference the reader cannot see.
         configs = {
             (
                 o.compressor_id,
                 o.compressor_version,
                 o.aggressiveness,
                 o.compressor_scope,
-                o.compressor_bulk_min_chars,
+                o.compressor_bulk_min_chars if o.compressor_scope == "bulk" else None,
             )
             for o in self.outcomes
             if o.scored
         }
         if len(configs) > 1:
             readable = sorted(
-                f"{cid or 'uncompressed'}/{ver}/{agg:g}/{scope}"
-                for cid, ver, agg, scope, _chars in configs
+                compression_signature(
+                    CompressionConfig(
+                        compressor_id=cid,
+                        compressor_version=ver,
+                        aggressiveness=agg,
+                        scope=scope,
+                        bulk_min_chars=chars if chars is not None else DEFAULT_BULK_MIN_CHARS,
+                    )
+                )
+                if cid
+                else "uncompressed"
+                for cid, ver, agg, scope, chars in configs
             )
             raise ValueError(
                 "this matrix mixes compression configs across its scored rows "
@@ -184,7 +199,8 @@ class OutcomeMatrix(BaseModel):
             )
         if not configs:
             return None
-        compressor_id, compressor_version, aggressiveness, scope, bulk_min_chars = configs.pop()
+        compressor_id, compressor_version, aggressiveness, scope, bulk_chars = configs.pop()
+        bulk_min_chars = bulk_chars if bulk_chars is not None else DEFAULT_BULK_MIN_CHARS
         if not compressor_id:
             return None
         return CompressionConfig(

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 from pydantic import BaseModel, model_validator
 
-from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.compression import (
+    DEFAULT_BULK_MIN_CHARS,
+    CompressionConfig,
+    CompressionScope,
+)
 from wmo.providers.base import TokenUsage
 from wmo.providers.pool import PoolEntry
 
@@ -106,6 +110,13 @@ class ScenarioOutcome(BaseModel):
     aggressiveness: float = 0.0
     compressor_latency_s: float = 0.0
     compressor_cost_usd: float = 0.0
+    # Which segments the arm compressed (`CompressionConfig.scope`). Part of the arm's identity,
+    # so it is recorded rather than derived: without it `measured_compression` would report every
+    # matrix as conversation-scoped and the fit gate in `wmo optimize route fit` would refuse a
+    # scoped fit against the scoped matrix that actually backs it. The defaults are what a
+    # pre-scope matrix means, so old files load unchanged.
+    compressor_scope: CompressionScope = "conversation"
+    compressor_bulk_min_chars: int = DEFAULT_BULK_MIN_CHARS
 
     @property
     def scored(self) -> bool:
@@ -151,12 +162,21 @@ class OutcomeMatrix(BaseModel):
         under cannot bias a fit.
         """
         configs = {
-            (o.compressor_id, o.compressor_version, o.aggressiveness)
+            (
+                o.compressor_id,
+                o.compressor_version,
+                o.aggressiveness,
+                o.compressor_scope,
+                o.compressor_bulk_min_chars,
+            )
             for o in self.outcomes
             if o.scored
         }
         if len(configs) > 1:
-            readable = sorted(f"{cid or 'uncompressed'}/{ver}/{agg:g}" for cid, ver, agg in configs)
+            readable = sorted(
+                f"{cid or 'uncompressed'}/{ver}/{agg:g}/{scope}"
+                for cid, ver, agg, scope, _chars in configs
+            )
             raise ValueError(
                 "this matrix mixes compression configs across its scored rows "
                 f"({', '.join(readable)}), so its rows are not comparable and no single policy "
@@ -164,13 +184,15 @@ class OutcomeMatrix(BaseModel):
             )
         if not configs:
             return None
-        compressor_id, compressor_version, aggressiveness = configs.pop()
+        compressor_id, compressor_version, aggressiveness, scope, bulk_min_chars = configs.pop()
         if not compressor_id:
             return None
         return CompressionConfig(
             compressor_id=compressor_id,
             compressor_version=compressor_version,
             aggressiveness=aggressiveness,
+            scope=scope,
+            bulk_min_chars=bulk_min_chars,
         )
 
     def model_names(self) -> list[str]:

--- a/wmo/optimize/outcomes_test.py
+++ b/wmo/optimize/outcomes_test.py
@@ -172,6 +172,61 @@ def test_a_matrix_that_mixes_arms_refuses_to_name_one() -> None:
         matrix.measured_compression()
 
 
+def _one_pool() -> list[PoolEntry]:
+    return [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        )
+    ]
+
+
+def _row(scenario: str, **compression: object) -> ScenarioOutcome:
+    return ScenarioOutcome.model_validate(
+        {
+            "scenario_id": scenario,
+            "task": "t",
+            "model": "a",
+            "reward": 1.0,
+            "compressor_id": "truncate",
+            "compressor_version": "1",
+            "aggressiveness": 0.5,
+            **compression,
+        }
+    )
+
+
+def test_an_inert_bulk_threshold_does_not_split_one_arm_in_two() -> None:
+    # Outside "bulk" scope `bulk_min_chars` cannot change a single emitted byte, so rows that
+    # differ only in it are ONE arm. Keying the mixing check on it refused the matrix while
+    # printing the same string twice, naming a difference the reader could not see.
+    matrix = OutcomeMatrix(
+        pool=_one_pool(),
+        outcomes=[
+            _row("s1", compressor_bulk_min_chars=2000),
+            _row("s2", compressor_bulk_min_chars=4096),
+        ],
+    )
+    measured = matrix.measured_compression()
+    assert measured is not None
+    assert measured.scope == "conversation"
+
+
+def test_a_live_bulk_threshold_does_split_two_arms_and_the_message_shows_it() -> None:
+    # In "bulk" scope the same field decides which user content gets compressed, so now the rows
+    # really are two arms, and the refusal has to render the difference it is refusing over.
+    matrix = OutcomeMatrix(
+        pool=_one_pool(),
+        outcomes=[
+            _row("s1", compressor_scope="bulk", compressor_bulk_min_chars=2000),
+            _row("s2", compressor_scope="bulk", compressor_bulk_min_chars=4096),
+        ],
+    )
+    with pytest.raises(ValueError, match="mixes compression configs") as caught:
+        matrix.measured_compression()
+    assert "over 2000 chars" in str(caught.value)
+    assert "over 4096 chars" in str(caught.value)
+
+
 def test_an_unscored_row_does_not_decide_the_arm() -> None:
     # An unscored episode produced no reward, so whatever it ran under cannot bias a fit.
     matrix = OutcomeMatrix(

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -198,12 +198,9 @@ def build_report(
     embedder = policy.embedder.build() if policy.kind != "static" else None
     if embedder is not None:
         # Representation consistency, on the reporting side: the replay has to embed the way the
-        # FIT did, or it measures a policy nobody serves. On an arm whose scope rewrites the
-        # routed-on text, replaying on raw task text would land every query farther from every
-        # bank row and show routing collapsing to the fallback (C2 measured the floor tripping
-        # 10-13x more often under exactly that mismatch); on an arm whose scope does not, wrapping
-        # would invent the same error in reverse. `routed_text_embedder` is the one place that
-        # decides, so the report cannot disagree with the fit about it.
+        # FIT did, or it measures a policy nobody serves. Routing it through the same
+        # `routed_text_embedder` the fit used is what guarantees they cannot disagree, whichever
+        # way that function's rule goes.
         embedder = routed_text_embedder(embedder, policy.compression)
 
     routed_rows: dict[str, list[ScenarioOutcome]] = {}

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -27,7 +27,7 @@ from statistics import median, quantiles
 
 from pydantic import BaseModel, Field
 
-from wmo.optimize.compression import CompressingEmbedder
+from wmo.optimize.compression import routed_text_embedder
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import RoutingPolicy, select_model
 from wmo.providers.pool import Tier
@@ -196,15 +196,15 @@ def build_report(
     # One embedder for the whole report: an azure spec builds an HTTP client per `build()`, and
     # a report routes every held-out scenario.
     embedder = policy.embedder.build() if policy.kind != "static" else None
-    if embedder is not None and policy.compression is not None:
-        # Representation consistency, on the reporting side. A compressed endpoint's bank lives in
-        # the geometry of compressed text, and serving compresses each request before the router
-        # embeds it. Replaying the selection on RAW task text would therefore measure a policy
-        # nobody serves: every query lands farther from every bank row, the novelty floor trips,
-        # and the report would show routing collapsing to the fallback (C2 measured the floor
-        # tripping 10-13x more often under exactly this mismatch). So the replay embeds through the
-        # same compressor the fit did.
-        embedder = CompressingEmbedder(embedder, policy.compression)
+    if embedder is not None:
+        # Representation consistency, on the reporting side: the replay has to embed the way the
+        # FIT did, or it measures a policy nobody serves. On an arm whose scope rewrites the
+        # routed-on text, replaying on raw task text would land every query farther from every
+        # bank row and show routing collapsing to the fallback (C2 measured the floor tripping
+        # 10-13x more often under exactly that mismatch); on an arm whose scope does not, wrapping
+        # would invent the same error in reverse. `routed_text_embedder` is the one place that
+        # decides, so the report cannot disagree with the fit about it.
+        embedder = routed_text_embedder(embedder, policy.compression)
 
     routed_rows: dict[str, list[ScenarioOutcome]] = {}
     baseline_rows: dict[str, list[ScenarioOutcome]] = {}

--- a/wmo/optimize/report_test.py
+++ b/wmo/optimize/report_test.py
@@ -313,10 +313,16 @@ register_compressor(_RECORDER)
 def test_a_compressed_policys_report_replays_in_the_geometry_it_was_fitted_in() -> None:
     """The reporting half of representation consistency (C2's Q2 rule).
 
-    A compressed endpoint's bank lives in the geometry of compressed text, and serving compresses
-    each request before the router embeds it. A report that embedded RAW task text against that
-    bank would measure a policy nobody serves: the queries land farther from every row, the novelty
-    floor trips, and routing reads as collapsed to the fallback.
+    The rule is that the replay must embed the way the FIT did, or the report measures a policy
+    nobody serves. Since the deciding query is the RAW task statement in every scope
+    (`wmo.optimize.compression.routed_text_embedder` carries the reasoning: the bank holds task
+    statements, serving routes on the last user turn, turn 1's last user turn is the
+    never-compressed task, and sticky affinity keeps turns 2+ off the bank), a compressed arm's
+    bank is fitted raw and its report replays raw. The compressor is not consulted at all.
+
+    This assertion used to run the other way. It was inverted with the wrap rule itself when the
+    gate review found that wrapping CAUSED the C2 Q2 mismatch on the only queries that decide
+    anything, rather than preventing it.
     """
     _RECORDER.seen.clear()
     arm = CompressionConfig(compressor_id=_RecordingCompressor.id, aggressiveness=0.5)
@@ -329,8 +335,8 @@ def test_a_compressed_policys_report_replays_in_the_geometry_it_was_fitted_in() 
         generated_at="2026-07-24T00:00:00Z",
     )
     assert report.scenario_count == 2
-    # Every routed scenario's task text went through the compressor on its way to the embedder.
-    assert sorted(_RECORDER.seen) == sorted([_SQL_TASK, _PROSE_TASK])
+    # Raw, exactly as the bank was fitted: the replay never reached for the compressor.
+    assert _RECORDER.seen == []
 
 
 def test_an_uncompressed_policys_report_embeds_the_task_text_as_it_is() -> None:

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -32,16 +32,21 @@ result as OpenAI SSE (one `choices[0].delta.tool_calls` entry per call, carrying
 client reassembles the arguments exactly as it would from real fragments; the tradeoff is
 time-to-first-byte, which waits for the whole upstream response instead of the first token.
 
-Compression stage (D-COMPRESS): when the policy carries a compression config, the pipeline is
-request -> [compress] -> [route] -> provider call. Only user-message content is compressed;
-system prompts, the model's own prior replies, tool calls, and tool results pass through
-verbatim (v1 scope: a tool payload is a structured contract, not prose to shorten). The affinity
-state decides segment boundaries: an incumbent conversation's compressed prefix is stored
-alongside its fingerprint and REUSED, never recompressed, so the provider-visible prefix stays
-byte-identical across turns (the prompt cache survives by construction). Routing embeds the
-compressed text (the router sees what the model sees) while stickiness keys on the raw
-transcript the client resends. Compression fields go to the request log only, never response
-bodies or headers.
+Compression stage (D-COMPRESS): when the endpoint has ENABLED compaction
+(`EndpointConfig.compaction_enabled`, default false) and its policy carries a compression config,
+the pipeline is request -> [compress] -> [route] -> provider call. Without the flag the stage is a
+strict no-op, whatever the policy stamps: nothing is rewritten, no compressor is called or billed,
+and the log's compression columns keep their uncompressed defaults.
+Which segments are eligible is the config's `scope`, decided in `wmo.optimize.compression`, not
+here: message content maps to segments (a tool result is an observation), the whole staged
+transcript goes to `compress_conversation`, and the task segment is protected there in every
+scope. Tool-call arguments are never segments at all (a structured contract, not prose to
+shorten). The affinity state decides the rewritable window: an incumbent conversation's
+compressed prefix is stored alongside its fingerprint and REUSED, never recompressed, so the
+provider-visible prefix stays byte-identical across turns (the prompt cache survives by
+construction). Routing embeds the compressed text (the router sees what the model sees) while
+stickiness keys on the raw transcript the client resends. Compression fields go to the request
+log only, never response bodies or headers.
 
 Request log: one JSONL row per call with the D-SERVING-LOG fields (id, ts, endpoint, routed
 model, cluster, tokens incl. cached, cache-adjusted cost, latency, ttfb, status, reason).
@@ -77,10 +82,12 @@ from pydantic import BaseModel, Field, JsonValue, ValidationError, field_validat
 from starlette.background import BackgroundTask
 
 from wmo.optimize.compression import (
-    CompressionConfig,
     CompressionStats,
     Compressor,
-    compress_segments,
+    Segment,
+    SegmentKind,
+    compress_conversation,
+    compression_signature,
     estimate_tokens,
     same_compression,
 )
@@ -519,9 +526,15 @@ class RequestLogRecord(BaseModel):
     cost_usd: float = 0.0  # effective cost: cached tokens billed at the cache-read rate
     router_cost_usd: float = 0.0  # the routing decision's own inference cost, passed through
     # D-COMPRESS fields: stored and OPAQUE like the routing fields above (log only, never in
-    # response bodies or headers). 0/"" defaults = the request served uncompressed. Token
-    # counts are the compressor's deterministic proxy totals (see wmo.optimize.compression);
-    # billable truth stays in input_tokens/cost_usd from the provider-reported usage.
+    # response bodies or headers). 0/"" defaults = the request served uncompressed, which is
+    # every request on an endpoint that has not enabled compaction. Token counts are the
+    # compressor's deterministic proxy totals (see wmo.optimize.compression); billable truth
+    # stays in input_tokens/cost_usd from the provider-reported usage.
+    # Both totals span the WHOLE request, every segment, not only the ones the config's scope
+    # selected: the provider bills the whole prompt, so `1 - compressed/raw` is the billed-input
+    # saving the admin view quotes. A scoped arm's achieved keep ratio over its eligible
+    # segments alone is a different (and always more flattering) number, and is deliberately not
+    # what these two fields carry.
     tokens_in_raw: int = 0
     tokens_in_compressed: int = 0
     compressor_id: str = ""
@@ -624,6 +637,12 @@ class EndpointRuntime:
     recorded into it by default, and `log_query_embeddings=False` switches that off per endpoint
     without disturbing the request log. A store constructed on no path is already inert, which is
     what an in-memory serving setup gets.
+
+    `compaction_enabled` is the per-endpoint opt-in to the compression stage
+    (`EndpointConfig.compaction_enabled`, default false). False leaves the stage a strict no-op
+    even when the mounted policy carries a compression config, so nothing is compressed, no
+    compressor is called or billed, and the request log's compression columns stay at their
+    uncompressed defaults.
     """
 
     def __init__(
@@ -637,6 +656,7 @@ class EndpointRuntime:
         config_path: Path | None = None,
         embeddings: QueryEmbeddingStore | None = None,
         log_query_embeddings: bool = True,
+        compaction_enabled: bool = False,
     ) -> None:
         self.name = name
         self.policy = policy
@@ -657,11 +677,12 @@ class EndpointRuntime:
         # `_compressed_bytes` is their running sum.
         self._compressed: OrderedDict[str, tuple[list[ChatMessage], int]] = OrderedDict()
         self._compressed_bytes = 0
+        self._compaction_enabled = compaction_enabled
         # Resolved at mount and re-resolved on every dial-driven policy install, mirroring the
         # embedder-once pattern: no per-request registry lookups. Resolving through the policy
         # re-runs the D-COMPRESS mount gates, so an artifact that was assembled in memory
         # (`model_copy`, which skips validators) cannot serve an unservable compressor either.
-        self._compressor: Compressor | None = policy.serving_compressor()
+        self._compressor: Compressor | None = self._resolve_compressor(policy)
         self._lock = threading.Lock()
         # Serializes dial changes end to end (persist + install); _lock alone only protects
         # the in-memory swap and would let two PUTs interleave file writes and installs.
@@ -701,11 +722,42 @@ class EndpointRuntime:
                 settings.model_copy(update={"cost_quality": cost_quality}).save(self._config_path)
             self._install_policy(adjusted)
 
+    def _resolve_compressor(self, policy: RoutingPolicy) -> Compressor | None:
+        """The compressor this endpoint will actually run, or None when it compresses nothing.
+
+        The mount gates run whether or not compaction is enabled, because they are not only
+        about the compressor: `RoutingPolicy._check_compression` also refuses a routing policy
+        whose evidence was fitted under a DIFFERENT representation than it would serve. An
+        artifact naming an unservable compressor should fail at mount even on an endpoint that
+        was never going to call it.
+
+        Raises:
+            ValueError: The policy fails a D-COMPRESS mount gate, or its routing evidence needs
+                the compressed representation that this endpoint has switched off.
+        """
+        compressor = policy.serving_compressor()
+        if self._compaction_enabled:
+            return compressor
+        if policy.kind != "static" and policy.fit_compression is not None:
+            # Serving raw text against a bank fitted on compressed text is the SAME failure as
+            # the reverse, which `_check_compression` already refuses: the query lands farther
+            # from every bank row, the novelty floor trips 10-13x more often, and routing
+            # collapses to the expensive fallback while accuracy sits flat (C2 Q2). Disabling
+            # compaction on such an endpoint would produce exactly that, silently, so it does
+            # not mount.
+            raise ValueError(
+                f"this {policy.kind} policy's routing evidence was fitted on "
+                f"{compression_signature(policy.fit_compression)}, so it can only be served "
+                "with compaction enabled: set `compaction_enabled = true` in this endpoint's "
+                "endpoint.toml, or serve a policy fitted on raw text."
+            )
+        return None
+
     def _install_policy(self, adjusted: RoutingPolicy) -> None:
         # Resolved OUTSIDE the lock and before the swap: it re-runs the D-COMPRESS mount gates,
         # and a policy that fails them must leave the live endpoint exactly as it was rather
         # than half-installed.
-        compressor = adjusted.serving_compressor()
+        compressor = self._resolve_compressor(adjusted)
         with self._lock:
             stale = not same_compression(self.policy.compression, adjusted.compression)
             self.policy = adjusted
@@ -799,10 +851,15 @@ class EndpointRuntime:
         Cache safety by construction: when the conversation's previous exchange is known
         (affinity hit on the remembered raw prefix), the stored compressed prefix is returned
         verbatim and only the turns appended since it pass through the compressor. On a miss
-        (new conversation, or affinity evicted) every user message is compressed fresh;
+        (new conversation, or affinity evicted) every eligible message is compressed fresh;
         per-segment determinism makes that reproduce the same bytes, so the provider-visible
         prefix stays append-only either way. Returns the input list untouched when compression
-        is off.
+        is off, which includes every endpoint that has not enabled compaction.
+
+        WHICH messages are eligible is not decided here. The whole staged transcript goes to
+        `compress_conversation`, which applies the config's scope and protects the task segment;
+        this method only says where the rewritable window starts. Handing over just the window
+        would move the first user turn and expose the task on the first prefix reuse.
 
         At most ONE compressor call per request, carrying every segment that needs compressing:
         an endpoint-backed compressor pays one round trip per request, not one per message.
@@ -827,13 +884,18 @@ class EndpointRuntime:
                 if cached is not None:
                     self._compressed.move_to_end(key)  # LRU is by USE, not just by write
                     prefix = cached[0]
-        if prefix is not None:
-            # The stored prefix has one entry per remembered message, so the tail is everything
-            # the client appended after the turn we already compressed.
-            tail, cost_usd = _compress_user_turns(messages[len(prefix) :], compressor, config)
-            compressed = [*prefix, *tail]
-        else:
-            compressed, cost_usd = _compress_user_turns(messages, compressor, config)
+        # The stored prefix has one entry per remembered message, so the staged transcript is
+        # that prefix (already compressed, reused verbatim) plus everything the client appended
+        # after it. Scope selection reads the whole thing; only the window is rewritten.
+        mutable_from = len(prefix) if prefix is not None else 0
+        staged = [*prefix, *messages[mutable_from:]] if prefix is not None else list(messages)
+        rewritten = compress_conversation(
+            compressor, _segments(staged), config, mutable_from=mutable_from
+        )
+        compressed = [
+            message if text == message.content else message.model_copy(update={"content": text})
+            for message, text in zip(staged, rewritten.texts, strict=True)
+        ]
         return compressed, CompressionStats(
             compressor_id=compressor.id,
             compressor_version=compressor.version,
@@ -841,7 +903,7 @@ class EndpointRuntime:
             tokens_in_raw=sum(estimate_tokens(m.content) for m in messages),
             tokens_in_compressed=sum(estimate_tokens(m.content) for m in compressed),
             latency_s=time.monotonic() - started,
-            cost_usd=cost_usd,
+            cost_usd=rewritten.cost_usd,
         )
 
     def _embedder(self) -> Embedder | None:
@@ -946,31 +1008,24 @@ def _transcript_bytes(messages: list[ChatMessage]) -> int:
     return total
 
 
-def _compress_user_turns(
-    messages: list[ChatMessage], compressor: Compressor, config: CompressionConfig
-) -> tuple[list[ChatMessage], float]:
-    """Rewrite user-turn content through the compressor; every other turn passes through.
+_SEGMENT_KINDS: dict[ChatRole, SegmentKind] = {
+    "system": "system",
+    "user": "user",
+    "assistant": "assistant",
+    # A tool result is environment output the model asked for, which is exactly what the seam
+    # calls an observation and what "observations" scope selects.
+    "tool": "observation",
+}
 
-    v1 scope: system prompts (the most cacheable segment), the model's own replies, tool calls,
-    and tool results are never touched. A tool payload is a structured contract the model has to
-    read back exactly, so shortening it would change what the transcript MEANS, not just how
-    long it is. Returns the rewritten messages plus the compressor's own cost.
 
-    Goes through `compress_segments`, which chunks to the compressor's declared cap and enforces
-    the return-shape contract. One request rarely carries enough user turns to need chunking,
-    but a replayed transcript has no bound on its length and a wrong-length return here would
-    otherwise desynchronize the whole conversation.
+def _segments(messages: list[ChatMessage]) -> list[Segment]:
+    """The transcript as compression segments, one per message, in order.
+
+    Only message CONTENT is a segment. A tool call's arguments never become one: they are a
+    structured contract the model reads back exactly, so shortening them would change what the
+    transcript MEANS rather than how long it is, and there is no scope that reaches them.
     """
-    segments = [m.content for m in messages if m.role == "user"]
-    if not segments:
-        return list(messages), 0.0
-    result = compress_segments(compressor, segments, config)
-    replacements = iter(result.segments)
-    rewritten = [
-        m.model_copy(update={"content": next(replacements)}) if m.role == "user" else m
-        for m in messages
-    ]
-    return rewritten, result.cost_usd
+    return [Segment(kind=_SEGMENT_KINDS[m.role], text=m.content) for m in messages]
 
 
 def _remembered_prefix(messages: list[ChatMessage]) -> list[ChatMessage] | None:

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -114,7 +114,7 @@ from wmo.providers.base import (
     ToolCallingProvider,
 )
 from wmo.providers.pool import PoolEntry, pool_provider
-from wmo.serving.endpoint_config import EndpointConfig
+from wmo.serving.endpoint_config import ENDPOINT_CONFIG_FILENAME, EndpointConfig
 from wmo.serving.query_embeddings import QueryEmbeddingStore
 from wmo.serving.savings import EndpointSavings, SavingsWindow, compute_savings
 
@@ -745,11 +745,24 @@ class EndpointRuntime:
             # collapses to the expensive fallback while accuracy sits flat (C2 Q2). Disabling
             # compaction on such an endpoint would produce exactly that, silently, so it does
             # not mount.
+            #
+            # Server-wide, deliberately, matching the house pattern for a broken serving artifact
+            # (`wmo.serving.server`: a policy.json that will not load and an endpoint.toml the
+            # policy cannot honor both fail `create_app` outright; only additive metadata like
+            # card.json degrades to None). An endpoint that answers every request with routing
+            # silently collapsed is the failure nothing downstream notices, which is exactly what
+            # fail-fast is for.
+            #
+            # The remedy names both entry points because there are two: a disk-loaded endpoint
+            # sets the file key, and an in-process caller passes the argument.
             raise ValueError(
                 f"this {policy.kind} policy's routing evidence was fitted on "
-                f"{compression_signature(policy.fit_compression)}, so it can only be served "
-                "with compaction enabled: set `compaction_enabled = true` in this endpoint's "
-                "endpoint.toml, or serve a policy fitted on raw text."
+                f"{compression_signature(policy.fit_compression)}, so it can only be served with "
+                "compaction enabled. Set `compaction_enabled = true` in this endpoint's "
+                f"{ENDPOINT_CONFIG_FILENAME} and restart the server (the flag is read at mount, "
+                "so it is not a live setting like cost_quality), pass "
+                "compaction_enabled=True if you are constructing EndpointRuntime directly, or "
+                "serve a policy fitted on raw text."
             )
         return None
 
@@ -928,6 +941,44 @@ class EndpointRuntime:
                 embedder = self._policy_embedder
         return embedder
 
+    def _stored_reply(
+        self, compressed: list[ChatMessage], reply: ChatMessage, stats: CompressionStats | None
+    ) -> ChatMessage:
+        """The assistant reply as it must be STORED: compressed, if this scope compresses replies.
+
+        Storing the RAW reply is an append-only violation the moment a scope makes assistant turns
+        eligible ("all"). The next turn would serve the stored prefix verbatim on an affinity HIT
+        (raw reply) but recompress the whole transcript on a MISS (compressed reply), so the
+        provider-visible prefix would depend on cache state and the prompt cache would be forfeited
+        exactly when it was warmest. Compressing before storing makes the two paths agree: the miss
+        path runs the same compressor over the same segment, and per-segment determinism means it
+        reproduces these bytes.
+
+        Runs the reply through the choke point with `mutable_from` at the reply's own index, so
+        scope selection sees the whole conversation (the task stays protected) while only the reply
+        can be rewritten. Under every scope but "all" the reply is not eligible, nothing is handed
+        to the compressor, and this is free.
+
+        `stats` is the request's compression accounting; the compressor's bill and wall clock for
+        this call are folded in, because the client waits for it and it is real money.
+        """
+        with self._lock:
+            policy = self.policy
+            compressor = self._compressor
+        config = policy.compression
+        if config is None or compressor is None:
+            return reply
+        started = time.monotonic()
+        staged = [*compressed, reply]
+        rewritten = compress_conversation(
+            compressor, _segments(staged), config, mutable_from=len(compressed)
+        )
+        if stats is not None:
+            stats.cost_usd += rewritten.cost_usd
+            stats.latency_s += time.monotonic() - started
+        text = rewritten.texts[-1]
+        return reply if text == reply.content else reply.model_copy(update={"content": text})
+
     def remember(
         self,
         messages: list[ChatMessage],
@@ -935,6 +986,7 @@ class EndpointRuntime:
         model: str,
         *,
         compressed: list[ChatMessage] | None = None,
+        stats: CompressionStats | None = None,
     ) -> None:
         """Record the finished exchange so the conversation's next request finds its incumbent.
 
@@ -946,7 +998,9 @@ class EndpointRuntime:
         `messages` must be the RAW request messages (the client resends that transcript, so the
         fingerprint must match it). `compressed` is the provider-visible transcript when
         compression ran; stored under the same key so the next turn reuses the exact bytes the
-        provider's prompt cache was written with.
+        provider's prompt cache was written with. The reply is stored COMPRESSED (see
+        `_stored_reply`), which is what keeps the stored prefix identical to what the miss path
+        would recompute under a scope that makes assistant turns eligible.
 
         The two caches are bounded independently (entries for affinity, bytes for transcripts),
         so they can disagree about which conversations they remember. Both directions of
@@ -955,6 +1009,11 @@ class EndpointRuntime:
         and an affinity entry evicted while its prefix survives simply re-routes while still
         reusing the exact bytes that fingerprint was stored with.
         """
+        # The reply is compressed OUTSIDE the lock: it can be a compressor round trip, and holding
+        # the lock across it would head-of-line-block every other conversation's affinity lookup.
+        stored_reply = (
+            self._stored_reply(compressed, reply, stats) if compressed is not None else reply
+        )
         transcript = [*messages, reply]
         key = _fingerprint(transcript)
         with self._lock:
@@ -963,7 +1022,7 @@ class EndpointRuntime:
             while len(self._affinity) > _AFFINITY_CAPACITY:
                 self._affinity.popitem(last=False)
             if compressed is not None:
-                transcript = [*compressed, reply]
+                transcript = [*compressed, stored_reply]
                 previous = self._compressed.pop(key, None)
                 if previous is not None:
                     self._compressed_bytes -= previous[1]
@@ -1650,6 +1709,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 reply,
                 decision.model,
                 compressed=provider_messages if compression else None,
+                stats=compression,
             )
             if not request.stream:
                 _record(usage, ttfb_ms=None)
@@ -1741,6 +1801,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 ChatMessage(role="assistant", content=completion.text),
                 decision.model,
                 compressed=provider_messages if compression else None,
+                stats=compression,
             )
             _record(completion.usage, ttfb_ms=None)
             return Response(
@@ -1849,6 +1910,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 ChatMessage(role="assistant", content="".join(parts)),
                 decision.model,
                 compressed=provider_messages if compression else None,
+                stats=compression,
             )
             stream_state["recorded"] = True
             _record(usage, ttfb_ms=ttfb_ms)

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2742,6 +2742,50 @@ def test_all_scope_reaches_dialogue_but_neither_the_task_nor_the_system_prompt(
     assert _rows(log_path)[-1]["compressor_id"] == "truncate"
 
 
+def test_all_scope_serves_identical_bytes_on_an_affinity_hit_and_a_miss(tmp_path: Path) -> None:
+    """The append-only property under a scope that makes the assistant reply eligible.
+
+    The reply used to be stored RAW while the miss path recompressed it, so the provider-visible
+    prefix depended on cache state: a hit served a raw reply, an eviction served a compressed one,
+    and the prompt cache was forfeited exactly when it was warmest. Storing the reply already
+    compressed makes both paths produce the same bytes, which is what append-only means here.
+    """
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="all")
+    turn_one = [{"role": "user", "content": "the task"}]
+
+    def _second_turn(runtime: EndpointRuntime, client: TestClient, evict: bool) -> list[str]:
+        first = client.post(
+            "/v1/chat/completions", json={"model": "tau-bench", "messages": turn_one}
+        )
+        reply = first.json()["choices"][0]["message"]["content"]
+        assert len(reply.split()) > 1, "the reply must be long enough for compression to show"
+        if evict:
+            with runtime._lock:
+                runtime._affinity.clear()
+                runtime._clear_compressed()
+        second = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": [
+                    *turn_one,
+                    {"role": "assistant", "content": reply},
+                    {"role": "user", "content": "five six seven eight"},
+                ],
+            },
+        )
+        assert second.status_code == 200
+        return [m.content for m in providers["haiku-4-5"].seen[-1][1]]
+
+    client, _, runtime, providers = _compressed_runtime(tmp_path / "hit", config)
+    on_hit = _second_turn(runtime, client, evict=False)
+    client, _, runtime, providers = _compressed_runtime(tmp_path / "miss", config)
+    on_miss = _second_turn(runtime, client, evict=True)
+
+    assert on_hit == on_miss  # cache state cannot change what the provider sees
+    assert on_hit[0] == "the task"  # still the protected task, on both paths
+
+
 def test_the_first_user_turn_survives_the_top_of_the_dial(tmp_path: Path) -> None:
     # Aggressiveness 1.0 removes every word truncate is handed. The task statement still arrives
     # byte-identical, because protection is a property of the stage and not of the dial.
@@ -2809,13 +2853,21 @@ def test_disabling_compaction_on_a_compressed_fit_refuses_to_mount(tmp_path: Pat
     policy = _knn_policy(tmp_path).model_copy(
         update={"compression": config, "fit_compression": config}
     )
-    with pytest.raises(ValueError, match="compaction_enabled = true"):
+    with pytest.raises(ValueError, match="compaction_enabled = true") as caught:
         EndpointRuntime(
             name="tau-bench",
             policy=policy,
             provider_factory=_EchoProvider,
             log=RequestLog(tmp_path / "requests.jsonl"),
         )
+    message = str(caught.value)
+    # The flag is read at mount, so the remedy has to say the server must come back up; an
+    # operator who set it and watched nothing change was the failure here.
+    assert "restart" in message
+    # And it names the in-process entry point too, because this runtime is constructible directly
+    # (injected policies) where there is no file to edit at all.
+    assert "compaction_enabled=True" in message
+    assert "endpoint.toml" in message
 
 
 def test_mounting_a_mismatched_compression_artifact_fails_loudly(tmp_path: Path) -> None:

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -538,7 +538,11 @@ def test_static_policy_never_builds_its_embedder(
 
 
 def _dial_client(
-    tmp_path: Path, policy: RoutingPolicy, *, config_path: Path | None = None
+    tmp_path: Path,
+    policy: RoutingPolicy,
+    *,
+    config_path: Path | None = None,
+    compaction_enabled: bool = False,
 ) -> tuple[TestClient, EndpointRuntime]:
     """A client with OpenAI error shapes installed, so 400s look like the real server's."""
     runtime = EndpointRuntime(
@@ -547,6 +551,7 @@ def _dial_client(
         provider_factory=_EchoProvider,
         log=RequestLog(tmp_path / "requests.jsonl"),
         config_path=config_path,
+        compaction_enabled=compaction_enabled,
     )
     app = FastAPI()
     app.include_router(create_chat_router({"tau-bench": runtime}))
@@ -1051,6 +1056,7 @@ def _tool_client(
     *,
     finish_reason: str | None = "tool_calls",
     n_tool_calls: int = 1,
+    compaction_enabled: bool = False,
 ) -> tuple[TestClient, Path, list[ChatRequest]]:
     """A client whose pool models all speak the structured tool-calling contract."""
     seen: list[ChatRequest] = []
@@ -1062,6 +1068,7 @@ def _tool_client(
             entry, seen, finish_reason=finish_reason, n_tool_calls=n_tool_calls
         ),
         log=RequestLog(log_path),
+        compaction_enabled=compaction_enabled,
     )
     app = FastAPI()
     app.include_router(create_chat_router({"tau-bench": runtime}))
@@ -2337,9 +2344,27 @@ def _compressed_runtime(
         kind="static", default_model="haiku-4-5", pool=_pool(), compression=compression
     )
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=factory, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=factory,
+        log=RequestLog(log_path),
+        # These tests are ABOUT the compression stage, so they opt the endpoint in. The default
+        # is off, which `test_compaction_off_is_a_strict_no_op` covers separately.
+        compaction_enabled=True,
     )
     return TestClient(_app_for(runtime)), log_path, runtime, providers
+
+
+_COMPRESSIBLE: list[dict[str, str]] = [
+    {"role": "user", "content": "the task"},
+    {"role": "assistant", "content": "an earlier reply"},
+    {"role": "user", "content": "one two three four five six"},
+]
+"""A transcript the stage is actually allowed to shorten.
+
+Task protection makes a single-user-turn request incompressible by construction, so any test
+that needs the compressor to have RUN needs a later user turn to run on.
+"""
 
 
 def test_identity_compression_serves_bit_for_bit(tmp_path: Path) -> None:
@@ -2375,6 +2400,8 @@ def test_truncate_compresses_what_the_provider_sees(tmp_path: Path) -> None:
             "model": "tau-bench",
             "messages": [
                 {"role": "system", "content": "system prompts are never compressed"},
+                {"role": "user", "content": "the task statement is never compressed"},
+                {"role": "assistant", "content": "an earlier reply"},
                 {"role": "user", "content": "one two three four five six seven eight"},
             ],
         },
@@ -2383,7 +2410,8 @@ def test_truncate_compresses_what_the_provider_sees(tmp_path: Path) -> None:
     assert response.status_code == 200
     system, turns = providers["haiku-4-5"].seen[0]
     assert system == "system prompts are never compressed"  # verbatim
-    assert turns[0].content == "one two three four"  # trailing half dropped
+    assert turns[0].content == "the task statement is never compressed"  # verbatim, always
+    assert turns[2].content == "one two three four"  # trailing half dropped
     row = _rows(log_path)[-1]
     assert row["compressor_id"] == "truncate"
     assert row["compressor_version"] == "1"
@@ -2437,14 +2465,15 @@ def test_incumbent_prefix_is_reused_not_recompressed(tmp_path: Path) -> None:
 
     assert second.status_code == 200
     # The compressor only ever saw the turn-local segment on turn two: the cached prefix was
-    # RETRIEVED from the affinity state, not recompressed.
-    assert spy.calls == [[first_user], ["eta theta iota kappa"]]
+    # RETRIEVED from the affinity state, not recompressed. Turn one handed it nothing at all,
+    # because the conversation's only segment then was the protected task statement.
+    assert spy.calls == [["eta theta iota kappa"]]
     # And the provider-visible prefix is byte-identical across turns (prompt cache survives).
     second_turns = providers["haiku-4-5"].seen[1][1]
     assert [(m.role, m.content) for m in second_turns[: len(turn_one)]] == [
         (m.role, m.content) for m in turn_one
     ]
-    assert second_turns[0].content == "alpha beta gamma"  # compressed once, reused verbatim
+    assert second_turns[0].content == first_user  # the task, verbatim on every turn
     assert second_turns[1].content == reply  # the model's own reply is never compressed
     assert second_turns[2].content == "eta theta"
 
@@ -2494,7 +2523,11 @@ def test_compression_fields_populate_on_stream_path(tmp_path: Path) -> None:
         json={
             "model": "tau-bench",
             "stream": True,
-            "messages": [{"role": "user", "content": "one two three four five six"}],
+            "messages": [
+                {"role": "user", "content": "the task"},
+                {"role": "assistant", "content": "an earlier reply"},
+                {"role": "user", "content": "one two three four five six"},
+            ],
         },
     ) as response:
         assert response.status_code == 200
@@ -2502,7 +2535,7 @@ def test_compression_fields_populate_on_stream_path(tmp_path: Path) -> None:
     assert "[DONE]" in body
     assert "compress" not in body  # opaque on the stream too
     _, turns = providers["haiku-4-5"].seen[0]
-    assert turns[0].content == "one two three"
+    assert turns[2].content == "one two three"
     rows = _rows(log_path)
     assert len(rows) == 1  # one record per request, stream included
     assert rows[0]["compressor_id"] == "truncate"
@@ -2529,14 +2562,14 @@ def test_compression_fields_populate_on_error_path(tmp_path: Path) -> None:
         compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
     )
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=_FailingProvider, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_FailingProvider,
+        log=RequestLog(log_path),
+        compaction_enabled=True,
     )
     response = TestClient(_app_for(runtime)).post(
-        "/v1/chat/completions",
-        json={
-            "model": "tau-bench",
-            "messages": [{"role": "user", "content": "one two three four five six"}],
-        },
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
     assert response.status_code == 502
     rows = _rows(log_path)
@@ -2570,17 +2603,13 @@ def test_dial_swap_keeps_the_compressor_matched_to_the_live_policy(tmp_path: Pat
     policy = _knn_policy(tmp_path).model_copy(
         update={"compression": config, "fit_compression": config}
     )
-    client, runtime = _dial_client(tmp_path, policy)
+    client, runtime = _dial_client(tmp_path, policy, compaction_enabled=True)
 
     response = client.put("/v1/endpoints/tau-bench/config", json={"cost_quality": 1.0})
     assert response.status_code == 200
 
     served = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "tau-bench",
-            "messages": [{"role": "user", "content": "one two three four five six"}],
-        },
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
     assert served.status_code == 200
     assert runtime.policy.compression is not None  # the dial carried the config through
@@ -2589,29 +2618,172 @@ def test_dial_swap_keeps_the_compressor_matched_to_the_live_policy(tmp_path: Pat
     assert cast("int", row["tokens_in_compressed"]) < cast("int", row["tokens_in_raw"])
 
 
-def test_compression_leaves_tool_calls_and_tool_results_verbatim(tmp_path: Path) -> None:
-    # v1 scope (#278 x D-COMPRESS): the compressor shortens user prose only. A tool call's
-    # arguments and a tool result are a structured contract the model reads back exactly, so
-    # truncating them would change what the transcript MEANS, not just how long it is.
+def test_conversation_scope_leaves_tool_calls_and_tool_results_verbatim(tmp_path: Path) -> None:
+    # The default scope shortens user prose only. A tool call's arguments and a tool result are a
+    # structured contract the model reads back exactly, so truncating them would change what the
+    # transcript MEANS, not just how long it is. Tool-call ARGUMENTS are never a segment under
+    # any scope; a tool result is one, and this scope does not select it.
     policy = RoutingPolicy(
         kind="static",
         default_model="haiku-4-5",
         pool=_pool(),
         compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
     )
-    client, log_path, seen = _tool_client(tmp_path, policy)
+    client, log_path, seen = _tool_client(tmp_path, policy, compaction_enabled=True)
     response = client.post(
         "/v1/chat/completions",
-        json={"model": "tau-bench", "messages": _REPLAYED_TOOL_TRANSCRIPT},
+        json={
+            "model": "tau-bench",
+            "messages": [
+                *_REPLAYED_TOOL_TRANSCRIPT,
+                {"role": "user", "content": "one two three four"},
+            ],
+        },
     )
 
     assert response.status_code == 200
     served = seen[0].messages
-    assert served[0].content == "how many superheroes"  # the user turn, compressed
+    assert served[0].content == "how many superheroes are there?"  # the task, verbatim
     assert served[1].tool_calls is not None
     assert served[1].tool_calls[0].function.arguments == _TOOL_ARGUMENTS  # verbatim
-    assert served[2].content == "42 rows"  # the tool result, verbatim
+    assert served[2].content == "42 rows"  # the tool result, verbatim in this scope
+    assert served[3].content == "one two"  # a later user turn, compressed
     assert _rows(log_path)[-1]["compressor_id"] == "truncate"
+
+
+def test_observations_scope_compresses_tool_results_and_nothing_else(tmp_path: Path) -> None:
+    # The scope the measurements favor: compressing dialogue lost 6-17 accuracy points and
+    # inverted cost 2.3x, while removing observation bulk held accuracy inside the noise floor.
+    # So this scope reaches the tool result and leaves every conversational turn alone.
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(
+            compressor_id="truncate", aggressiveness=0.5, scope="observations"
+        ),
+    )
+    client, _, seen = _tool_client(tmp_path, policy, compaction_enabled=True)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                *_REPLAYED_TOOL_TRANSCRIPT[:2],
+                {"role": "tool", "tool_call_id": "call_1", "content": "alpha beta gamma delta"},
+                {"role": "user", "content": "one two three four"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    served = seen[0].messages
+    assert served[0].content == "how many superheroes are there?"  # the task, verbatim
+    assert served[1].tool_calls is not None
+    assert served[1].tool_calls[0].function.arguments == _TOOL_ARGUMENTS  # verbatim
+    assert served[2].content == "alpha beta"  # the observation, compressed
+    assert served[3].content == "one two three four"  # a user turn, untouched in this scope
+
+
+def test_bulk_scope_reaches_a_pasted_document_but_not_a_typed_turn(tmp_path: Path) -> None:
+    document = "word " * 800  # 4000 chars: pasted bulk, well past the default threshold
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="bulk")
+    client, _, _, providers = _compressed_runtime(tmp_path, config)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "the task"},
+                {"role": "assistant", "content": "an earlier reply"},
+                {"role": "user", "content": "one two three four"},
+                {"role": "assistant", "content": "another reply"},
+                {"role": "user", "content": document},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    _, turns = providers["haiku-4-5"].seen[0]
+    assert turns[0].content == "the task"  # verbatim, as in every scope
+    assert turns[2].content == "one two three four"  # short prose: below the threshold
+    assert len(turns[4].content) < len(document)  # the pasted document IS compressed
+
+
+def test_the_first_user_turn_survives_the_top_of_the_dial(tmp_path: Path) -> None:
+    # Aggressiveness 1.0 removes every word truncate is handed. The task statement still arrives
+    # byte-identical, because protection is a property of the stage and not of the dial.
+    task = "  cancel  my order\t3079 and refund   the difference  "
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=1.0)
+    client, _, _, providers = _compressed_runtime(tmp_path, config)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": task},
+                {"role": "assistant", "content": "an earlier reply"},
+                {"role": "user", "content": "everything here goes away"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    _, turns = providers["haiku-4-5"].seen[0]
+    assert turns[0].content == task  # whitespace and all
+    assert turns[2].content == ""  # the dial really is at the top
+
+
+def test_compaction_off_is_a_strict_no_op_even_when_the_policy_carries_one(tmp_path: Path) -> None:
+    # The per-endpoint default. Off means off: nothing rewritten, no compressor resolved, and log
+    # rows indistinguishable from an endpoint whose policy names no compressor at all.
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=1.0),
+    )
+    providers: dict[str, _CapturingProvider] = {}
+
+    def factory(entry: PoolEntry) -> _CapturingProvider:
+        providers[entry.name] = _CapturingProvider(entry)
+        return providers[entry.name]
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=factory, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
+    )
+
+    assert response.status_code == 200
+    assert runtime._compressor is None  # no compressor resolved at all
+    _, turns = providers["haiku-4-5"].seen[0]
+    assert [m.content for m in turns] == [m["content"] for m in _COMPRESSIBLE]
+    row = _rows(log_path)[-1]
+    assert row["compressor_id"] == ""
+    assert row["tokens_in_raw"] == 0
+    assert row["tokens_in_compressed"] == 0
+    assert row["compressor_cost_usd"] == 0.0
+    assert row["compressor_latency_s"] == 0.0
+
+
+def test_disabling_compaction_on_a_compressed_fit_refuses_to_mount(tmp_path: Path) -> None:
+    # The other direction of the representation-consistency gate. A bank fitted on compressed text
+    # queried with raw text is the same C2 failure as the reverse: the novelty floor trips, routing
+    # collapses to the fallback, and nothing downstream notices. So it does not come up.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    policy = _knn_policy(tmp_path).model_copy(
+        update={"compression": config, "fit_compression": config}
+    )
+    with pytest.raises(ValueError, match="compaction_enabled = true"):
+        EndpointRuntime(
+            name="tau-bench",
+            policy=policy,
+            provider_factory=_EchoProvider,
+            log=RequestLog(tmp_path / "requests.jsonl"),
+        )
 
 
 def test_mounting_a_mismatched_compression_artifact_fails_loudly(tmp_path: Path) -> None:
@@ -2645,16 +2817,18 @@ def test_the_stage_makes_one_compressor_call_per_request(tmp_path: Path) -> None
             "model": "tau-bench",
             "messages": [
                 {"role": "system", "content": "never compressed"},
-                {"role": "user", "content": "first user turn here"},
+                {"role": "user", "content": "the task, never compressed"},
                 {"role": "assistant", "content": "an earlier reply"},
                 {"role": "user", "content": "second user turn here"},
+                {"role": "assistant", "content": "a later reply"},
+                {"role": "user", "content": "third user turn here"},
             ],
         },
     )
 
     assert response.status_code == 200
-    # One call (a cold transcript: no affinity to reuse), carrying BOTH user turns.
-    assert spy.calls == [["first user turn here", "second user turn here"]]
+    # One call (a cold transcript: no affinity to reuse), carrying both ELIGIBLE user turns.
+    assert spy.calls == [["second user turn here", "third user turn here"]]
 
 
 class _PricedCompressor:
@@ -2681,11 +2855,7 @@ def test_the_compressors_bill_and_wall_clock_reach_the_log(tmp_path: Path) -> No
     config = CompressionConfig(compressor_id=_PRICED.id, aggressiveness=0.5)
     client, log_path, _, _ = _compressed_runtime(tmp_path, config)
     response = client.post(
-        "/v1/chat/completions",
-        json={
-            "model": "tau-bench",
-            "messages": [{"role": "user", "content": "one two three four five six"}],
-        },
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
 
     assert response.status_code == 200
@@ -2730,14 +2900,14 @@ def test_the_compressor_bill_reaches_the_log_on_the_error_path_too(tmp_path: Pat
         compression=CompressionConfig(compressor_id=_PRICED.id, aggressiveness=0.5),
     )
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=_FailingProvider, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_FailingProvider,
+        log=RequestLog(log_path),
+        compaction_enabled=True,
     )
     response = TestClient(_app_for(runtime)).post(
-        "/v1/chat/completions",
-        json={
-            "model": "tau-bench",
-            "messages": [{"role": "user", "content": "one two three four five six"}],
-        },
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
     assert response.status_code == 502
     row = _rows(log_path)[-1]
@@ -2843,14 +3013,14 @@ def test_a_pre_routing_failure_still_bills_the_compression_that_ran(tmp_path: Pa
         raise RuntimeError("api_key_env is unset")
 
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=_explode, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_explode,
+        log=RequestLog(log_path),
+        compaction_enabled=True,
     )
     response = TestClient(_app_for(runtime)).post(
-        "/v1/chat/completions",
-        json={
-            "model": "tau-bench",
-            "messages": [{"role": "user", "content": "one two three four five six"}],
-        },
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
 
     assert response.status_code == 502
@@ -2882,11 +3052,14 @@ def test_a_failure_inside_the_compression_stage_bills_nothing(tmp_path: Path) ->
         compression=CompressionConfig(compressor_id="exploding-for-tests"),
     )
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=_EchoProvider, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_EchoProvider,
+        log=RequestLog(log_path),
+        compaction_enabled=True,
     )
     response = TestClient(_app_for(runtime)).post(
-        "/v1/chat/completions",
-        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hello there"}]},
+        "/v1/chat/completions", json={"model": "tau-bench", "messages": _COMPRESSIBLE}
     )
 
     assert response.status_code == 502
@@ -2919,11 +3092,22 @@ def test_a_compressor_that_returns_the_wrong_segment_count_is_named(tmp_path: Pa
         compression=CompressionConfig(compressor_id="splitter-for-tests"),
     )
     runtime = EndpointRuntime(
-        name="tau-bench", policy=policy, provider_factory=_EchoProvider, log=RequestLog(log_path)
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_EchoProvider,
+        log=RequestLog(log_path),
+        compaction_enabled=True,
     )
     response = TestClient(_app_for(runtime)).post(
         "/v1/chat/completions",
-        json={"model": "tau-bench", "messages": [{"role": "user", "content": "two words"}]},
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "the task"},
+                {"role": "assistant", "content": "an earlier reply"},
+                {"role": "user", "content": "two words"},
+            ],
+        },
     )
 
     assert response.status_code == 502  # refused, not served with a corrupted transcript

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2710,10 +2710,14 @@ def test_bulk_scope_reaches_a_pasted_document_but_not_a_typed_turn(tmp_path: Pat
     assert len(turns[4].content) < len(document)  # the pasted document IS compressed
 
 
-def test_all_scope_reaches_dialogue_and_the_system_prompt_but_not_the_task(tmp_path: Path) -> None:
-    # The scope for a domain-adapted scorer at a calibrated threshold: nothing is excluded
-    # structurally, so the scorer decides what dialogue is worth keeping. The task statement is
-    # still the one exception, because that exclusion is stage law rather than a scope rule.
+def test_all_scope_reaches_dialogue_but_neither_the_task_nor_the_system_prompt(
+    tmp_path: Path,
+) -> None:
+    # The scope for a domain-adapted scorer at a calibrated threshold: dialogue is no longer
+    # excluded structurally, so the scorer decides what conversation is worth keeping. The two
+    # stage-law exclusions still hold, because they are not scope rules: the task statement (the
+    # measured deletion harm) and the system prompt (the endpoint owner's instruction surface, and
+    # the maximally cacheable prefix segment).
     config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="all")
     client, log_path, _, providers = _compressed_runtime(tmp_path, config)
     response = client.post(
@@ -2731,9 +2735,9 @@ def test_all_scope_reaches_dialogue_and_the_system_prompt_but_not_the_task(tmp_p
 
     assert response.status_code == 200
     system, turns = providers["haiku-4-5"].seen[0]
-    assert system == "alpha beta"  # even the system prompt is a candidate in this scope
-    assert turns[0].content == "the task statement stays whole"  # the one structural exception
-    assert turns[1].content == "one two"  # the model's own reply, compressed here
+    assert system == "alpha beta gamma delta"  # verbatim, in this scope as in every other
+    assert turns[0].content == "the task statement stays whole"  # verbatim, always
+    assert turns[1].content == "one two"  # the model's own reply IS a candidate here
     assert turns[2].content == "five six"
     assert _rows(log_path)[-1]["compressor_id"] == "truncate"
 

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2710,6 +2710,34 @@ def test_bulk_scope_reaches_a_pasted_document_but_not_a_typed_turn(tmp_path: Pat
     assert len(turns[4].content) < len(document)  # the pasted document IS compressed
 
 
+def test_all_scope_reaches_dialogue_and_the_system_prompt_but_not_the_task(tmp_path: Path) -> None:
+    # The scope for a domain-adapted scorer at a calibrated threshold: nothing is excluded
+    # structurally, so the scorer decides what dialogue is worth keeping. The task statement is
+    # still the one exception, because that exclusion is stage law rather than a scope rule.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5, scope="all")
+    client, log_path, _, providers = _compressed_runtime(tmp_path, config)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "system", "content": "alpha beta gamma delta"},
+                {"role": "user", "content": "the task statement stays whole"},
+                {"role": "assistant", "content": "one two three four"},
+                {"role": "user", "content": "five six seven eight"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    system, turns = providers["haiku-4-5"].seen[0]
+    assert system == "alpha beta"  # even the system prompt is a candidate in this scope
+    assert turns[0].content == "the task statement stays whole"  # the one structural exception
+    assert turns[1].content == "one two"  # the model's own reply, compressed here
+    assert turns[2].content == "five six"
+    assert _rows(log_path)[-1]["compressor_id"] == "truncate"
+
+
 def test_the_first_user_turn_survives_the_top_of_the_dial(tmp_path: Path) -> None:
     # Aggressiveness 1.0 removes every word truncate is handed. The task statement still arrives
     # byte-identical, because protection is a property of the stage and not of the dial.

--- a/wmo/serving/endpoint_config.py
+++ b/wmo/serving/endpoint_config.py
@@ -13,6 +13,7 @@ fit). At mount time the file wins; with no file the policy is served exactly as 
     # .wmo/models/support-endpoint/endpoint.toml
     cost_quality = 0.6
     log_query_embeddings = false
+    compaction_enabled = true
 """
 
 from __future__ import annotations
@@ -48,6 +49,18 @@ class EndpointConfig(BaseModel):
     # denied, and because the one legitimate reason to refuse it (query text is derivable from an
     # embedding, so it is request content at rest) is a tenancy decision, not ours.
     log_query_embeddings: bool = True
+    # Whether this endpoint applies the compression stage its mounted policy carries
+    # (`wmo.optimize.compression`, applied in `wmo.serving.chat.EndpointRuntime.compress`).
+    # DEFAULT OFF, and off is a true no-op: no compressor call, no compressor bill, and request
+    # log rows identical to an endpoint whose policy carries no compression at all. Compaction
+    # is the one optimizer output that rewrites what the customer's own text says before it
+    # reaches the model, so an operator opts in per endpoint rather than inheriting it from
+    # whatever the fit happened to stamp. Turning it on is this one key.
+    #
+    # RESEARCH IS NOT GATED BY THIS. Fits, sweeps, and closed-loop eval apply whatever
+    # compression they were asked for regardless: the flag is a serving control, so the track
+    # keeps measuring compressed arms on endpoints that serve raw.
+    compaction_enabled: bool = False
 
     @classmethod
     def load(cls, path: Path) -> EndpointConfig:
@@ -59,8 +72,8 @@ class EndpointConfig(BaseModel):
         except tomllib.TOMLDecodeError as error:
             raise ValueError(
                 f"invalid endpoint config at {path}: {error}. Expected TOML with at most a "
-                "`cost_quality` key between 0.0 and 1.0 and a `log_query_embeddings` "
-                "boolean, and no other keys"
+                "`cost_quality` key between 0.0 and 1.0, a `log_query_embeddings` boolean, and "
+                "a `compaction_enabled` boolean, and no other keys"
             ) from error
         return cls.model_validate(data)
 

--- a/wmo/serving/endpoint_config_test.py
+++ b/wmo/serving/endpoint_config_test.py
@@ -74,3 +74,13 @@ def test_log_query_embeddings_defaults_on_and_round_trips_off(tmp_path: Path) ->
     path = tmp_path / ENDPOINT_CONFIG_FILENAME
     EndpointConfig(log_query_embeddings=False).save(path)
     assert EndpointConfig.load(path).log_query_embeddings is False
+
+
+def test_compaction_defaults_off_and_is_one_key_to_turn_on(tmp_path: Path) -> None:
+    # Compaction rewrites what the customer's own text says before it reaches the model, so an
+    # operator opts in per endpoint rather than inheriting whatever the fit stamped. Turning it on
+    # has to be exactly this one line.
+    assert EndpointConfig().compaction_enabled is False
+    path = tmp_path / ENDPOINT_CONFIG_FILENAME
+    path.write_text("compaction_enabled = true\n", encoding="utf-8")
+    assert EndpointConfig.load(path).compaction_enabled is True

--- a/wmo/serving/server.py
+++ b/wmo/serving/server.py
@@ -232,9 +232,15 @@ def _endpoint_runtimes(
         except ValueError as exc:
             # Fail fast and name the file: a dial the policy cannot honor (a savings position on
             # a policy fitted without costs) must not degrade silently to the fitted knobs.
-            raise ValueError(
-                f"{config_path} for endpoint {name!r} cannot be served: {exc}"
-            ) from exc
+            # An endpoint with no config file has no path to name, and printing "None ... cannot be
+            # served" sent operators looking for a file that was never there; say which endpoint
+            # instead, and that its settings are defaults.
+            where = (
+                f"{config_path} for endpoint {name!r}"
+                if config_path is not None
+                else f"endpoint {name!r} (no {ENDPOINT_CONFIG_FILENAME}, serving defaults)"
+            )
+            raise ValueError(f"{where} cannot be served: {exc}") from exc
     return runtimes
 
 

--- a/wmo/serving/server.py
+++ b/wmo/serving/server.py
@@ -227,6 +227,7 @@ def _endpoint_runtimes(
                 config_path=config_path,
                 embeddings=embeddings,
                 log_query_embeddings=settings.log_query_embeddings,
+                compaction_enabled=settings.compaction_enabled,
             )
         except ValueError as exc:
             # Fail fast and name the file: a dial the policy cannot honor (a savings position on

--- a/wmo/serving/server_test.py
+++ b/wmo/serving/server_test.py
@@ -542,6 +542,25 @@ def test_endpoint_toml_is_where_compaction_gets_turned_on(tmp_path: Path) -> Non
     assert runtimes["support"]._compressor is None
 
 
+def test_a_mount_failure_without_a_config_file_names_the_endpoint_not_none(tmp_path: Path) -> None:
+    # An endpoint with no endpoint.toml has no path to name. The message used to interpolate the
+    # missing path and read "None ... cannot be served", which sent operators looking for a file
+    # that was never there. The blast radius is deliberately server-wide, matching how a
+    # policy.json that will not load is handled: an endpoint serving with routing silently
+    # collapsed is the failure nothing downstream notices.
+    model_dir, policy = _knn_policy_dir(tmp_path)
+    arm = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    needs_compaction = policy.model_copy(update={"compression": arm, "fit_compression": arm})
+    assert not (model_dir / ENDPOINT_CONFIG_FILENAME).exists()
+
+    with pytest.raises(ValueError) as error:
+        _endpoint_runtimes({"support": needs_compaction}, {"support": model_dir}, RequestLog(None))
+    message = str(error.value)
+    assert "None" not in message
+    assert "support" in message
+    assert ENDPOINT_CONFIG_FILENAME in message
+
+
 def test_endpoint_toml_can_switch_the_query_embedding_store_off(tmp_path: Path) -> None:
     # "Default on and undisableable" is not a choice an operator should be denied: an embedding
     # is request content at rest, and whether to keep it is a tenancy decision.

--- a/wmo/serving/server_test.py
+++ b/wmo/serving/server_test.py
@@ -11,6 +11,7 @@ from wmo.config.card import CardCorpus, ModelCard, TracesSource
 from wmo.core.types import Action, ActionKind, Observation, Step, Trace
 from wmo.engine.knowledge import KnowledgeBase
 from wmo.engine.world_model import WorldModel
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.policy import RoutingPolicy
 from wmo.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmo.providers.pool import PoolEntry
@@ -502,7 +503,9 @@ def test_moving_the_dial_preserves_other_endpoint_toml_keys(tmp_path: Path) -> N
     """
     model_dir, policy = _knn_policy_dir(tmp_path)
     config_path = model_dir / ENDPOINT_CONFIG_FILENAME
-    EndpointConfig(cost_quality=0.25, log_query_embeddings=False).save(config_path)
+    EndpointConfig(cost_quality=0.25, log_query_embeddings=False, compaction_enabled=True).save(
+        config_path
+    )
 
     runtimes = _endpoint_runtimes({"support": policy}, {"support": model_dir}, RequestLog(None))
     runtimes["support"].set_cost_quality(0.75)
@@ -510,9 +513,33 @@ def test_moving_the_dial_preserves_other_endpoint_toml_keys(tmp_path: Path) -> N
     reloaded = EndpointConfig.load(config_path)
     assert reloaded.cost_quality == 0.75
     assert reloaded.log_query_embeddings is False
+    assert reloaded.compaction_enabled is True  # a dial move must not switch compaction back off
     # And the endpoint still mounts, which is the failure the dropped key used to cause.
     remounted = _endpoint_runtimes({"support": policy}, {"support": model_dir}, RequestLog(None))
     assert remounted["support"].cost_quality == 0.75
+
+
+def test_endpoint_toml_is_where_compaction_gets_turned_on(tmp_path: Path) -> None:
+    # The ruling's "easy to turn on": one key in the file that already sits beside policy.json,
+    # read at mount, and off by default so no endpoint starts compressing because a fit stamped a
+    # compressor onto its artifact.
+    model_dir, policy = _knn_policy_dir(tmp_path)
+    compressed = policy.model_copy(
+        update={
+            "compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+            "fit_compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+        }
+    )
+    (model_dir / ENDPOINT_CONFIG_FILENAME).write_text(
+        "compaction_enabled = true\n", encoding="utf-8"
+    )
+    runtimes = _endpoint_runtimes({"support": compressed}, {"support": model_dir}, RequestLog(None))
+    assert runtimes["support"]._compressor is not None
+
+    (model_dir / ENDPOINT_CONFIG_FILENAME).unlink()
+    plain = policy  # no compression stamped: the universal case, unaffected by the flag
+    runtimes = _endpoint_runtimes({"support": plain}, {"support": model_dir}, RequestLog(None))
+    assert runtimes["support"]._compressor is None
 
 
 def test_endpoint_toml_can_switch_the_query_embedding_store_off(tmp_path: Path) -> None:


### PR DESCRIPTION
The production seam for learned compaction, per the 2026-07-28 rulings (DECISIONS): compress the bulk, never the instructions, off by default, one flag to turn on.

## What this ships

1. **Stage law, unconditional in every scope**: the conversation's task statement (first user segment) and EVERY system segment are never compressed - enforced at one choke point (`compressible_positions`, reached only through `compress_conversation`, which is the only path from a caller's messages to a compressor; the old per-site selector is deleted so no second implementation can drift). Protection is positional/kind-derived, so a caller cannot opt out by mislabeling, and `mutable_from` can only narrow the selection. Measured basis: the single genuine deletion harm in 160 compressed episode-pairs was a compressed task statement (wrong-year answer 6/6), and the eval path was quietly compressing the task + trailing format instruction on every call until now.
2. **Identity-bearing scope** on `CompressionConfig`: `conversation` (legacy default - every existing artifact, matrix, and resume manifest keeps its exact meaning), `observations` (tool-role segments only - the shape that flipped tau from -9.7pt to +4.4pt at -29.4% cost), `bulk` (observations + user blocks >= `bulk_min_chars`, default 2000), `all` (adapted-scorer target; assistant turns eligible, instructions still protected). Scope participates in `same_compression`, `compression_signature`, and `measured_compression`'s mixing key; `bulk_min_chars` compares only where it is read. Reachable end to end: `--scope` / `--bulk-min-chars` on `route sweep`, `route fit`, and `optimize model`.
3. **Per-endpoint flag, default off**: `compaction_enabled` in endpoint.toml, read at mount (restart to change, stated in the refusal message), strict no-op when off (no compressor resolved, called, or billed; log columns identical to no-compression). A dial swap cannot re-enable it. New mount refusal: compaction disabled over a policy whose evidence was fitted under compression refuses to serve (the measured floor-collapse failure, mirrored).
4. **Banks are fitted raw** (`_ROUTED_TEXT_SCOPES` empty): the gate review proved the wrap rule caused the exact failure it existed to prevent - the bank holds task statements, serving routes on the last user turn, turn 1's last user turn is stage-law-protected, and sticky affinity keeps later turns off the bank - so under the old rule essentially every decision-bearing query was raw against a compressed-geometry bank. Fits never wrap now (route-on-raw, converging with the co-signed per-cluster contract); `fit_compression` still stamps the full arm identity. `CompressingEmbedder` is explicit-use-only.
5. **Cache safety under "all"**: assistant replies are compressed before storing, so affinity hits and misses produce byte-identical transcripts (regression test proven to fail against the unfixed line); the extra compressor call is billed into the request's stats.
6. **Honesty plumbing**: whole-request `tokens_in_raw/compressed` semantics (documented: the ratio is real billed-input reduction, not an eligible-segments flatter); `ScenarioOutcome` carries scope fields so `measured_compression` works for scoped arms; sweeps print a dead-arm warning when a compression arm achieved keep 1.00 on every row (the LLMAgent single-user-message shape makes eval compression inert by design - the operator who paid must know).

## Review record

Two independent gate rounds (isolated extractions). Round 1: bypass hunt clean (caller inventory in DECISIONS), identity discipline verified symmetric + injective, flag semantics pinned; 2 substantive findings (the wrap inversion, the "all" cache break) + 5 lesser - all fixed with targeted regression tests, F2's proven by revert. Round 2 gate: ruff + format + ty clean, 4463 passed / 19 skipped / 0 failed, nothing deselected. End-to-end driven through the real CLI and a real endpoint.toml both flag positions.

## Justification ledger

Every addition names its consumer in docstrings; the deleted `_compress_user_turns` has zero remaining references. Two incidental fixes ride along with stated reasons (a pre-existing `server.py` None-path message that sent operators after a file that never existed, in F6's exact blast radius; `optimize model --compressor` help made false by the wrap inversion). Known residuals documented in code: sticky=false conversation/all-scope endpoints embed compressed text on turns 2+ against raw banks until the route-on-raw serving contract lands (routing co-sign round); measuring observation-bulk compression in closed-loop eval needs the LLMAgent segment-shape change (cross-lane, filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
