### PR TITLE
Serve the measured Pareto curve: pareto module, pareto.json, GET /config

### DIFF
--- a/packages/environment-capture/tau-bench/rl/real_episodes.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes.py
@@ -531,11 +531,18 @@ def batch_command(
     pins: ProtocolPins,
 ) -> list[str]:
     """The exact tau2 CLI invocation for one (candidate, domain) batch, pins included."""
+    # The pinned telecom scenarios were captured from telecom's 2285-task "full" split;
+    # tau2's default task set for the domain does not contain them, so every telecom batch
+    # died with "Not all tasks were found" until this forwarded the same override the
+    # training lane pins (wmo/distill/tau2.py TASK_SPLIT_OVERRIDES). A property of the
+    # corpus, not a knob.
+    split_override = ["--task-split-name", "full"] if domain == "telecom" else []
     return [
         str(capture_dir / ".venv" / "bin" / "tau2"),
         "run",
         "--domain",
         domain,
+        *split_override,
         "--agent-llm",
         litellm_route(entry),
         "--agent-llm-args",

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -70,6 +70,7 @@ from wmo.optimize.outcomes import (
     load_matrix_with_digest,
     split_router_scenarios,
 )
+from wmo.optimize.pareto import PARETO_FILENAME, held_out_curve
 from wmo.optimize.pipeline import (
     BUILT_STAGES,
     CONFIGURED_STAGES,
@@ -1457,6 +1458,24 @@ def _stage_report(paths: _RunPaths, *, model_dir: Path, baseline: str | None) ->
         f"scenario(s) -> {escape(str(paths.report))}",
         soft_wrap=True,
     )
+    # The measured cost/quality curve. It goes in MODEL_DIR (a serving artifact, mounted by
+    # GET /config beside policy.json), not the disposable optimize manifest dir, so the
+    # platform's Pareto graph renders this workload's real frontier (D-PARETO). Additive: a
+    # curve failure warns rather than failing a report that already succeeded.
+    try:
+        curve = held_out_curve(matrix, policy, judge="world-model verifier")
+        pareto_path = model_dir / PARETO_FILENAME
+        pareto_path.write_text(curve.model_dump_json(indent=2), encoding="utf-8")
+        _console.print(
+            f"  [green]✓[/green] pareto curve ({sum(1 for p in curve.points if p.on_frontier)} "
+            f"frontier point(s), recommended {curve.recommended}) -> "
+            f"{escape(str(pareto_path))}",
+            soft_wrap=True,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        _console.print(
+            f"  [yellow]![/yellow] pareto curve skipped: {escape(str(exc))}", soft_wrap=True
+        )
     return StageRecord(
         stage=Stage.REPORT,
         fingerprint={

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -63,6 +63,7 @@ from wmo.optimize.outcomes import (
     load_matrix_with_digest,
     split_router_scenarios,
 )
+from wmo.optimize.pareto import PARETO_FILENAME, held_out_curve
 from wmo.optimize.policy import (
     AZURE_EMBEDDER_DIM,
     AZURE_EMBEDDER_ENV,
@@ -1328,6 +1329,15 @@ def report(
     # mkdir + atomic, exactly as `fit --out` and `pin --out` write their policies: a report whose
     # parent directory does not exist must not throw away the work that produced it.
     write_artifact_atomically(Path(out), improvement.model_dump_json(indent=2).encode("utf-8"))
+    # The measured cost/quality curve rides beside every report (D-PARETO): GET /config
+    # serves it from the model dir so the platform's graph renders this workload's frontier.
+    try:
+        curve = held_out_curve(matrix, policy, judge="world-model verifier")
+        pareto_out = Path(out).parent / PARETO_FILENAME
+        write_artifact_atomically(pareto_out, curve.model_dump_json(indent=2).encode("utf-8"))
+        _console.print(f"[green]✓[/green] pareto curve -> {pareto_out}")
+    except (ValueError, FileNotFoundError) as exc:
+        _console.print(f"[yellow]![/yellow] pareto curve skipped: {exc}")
     headline = improvement.headline
     _console.print(
         f"[green]✓[/green] report -> {out}\n"

--- a/wmo/optimize/pareto.py
+++ b/wmo/optimize/pareto.py
@@ -1,0 +1,303 @@
+"""The cost/quality Pareto curve over an outcome matrix: the product's central artifact.
+
+The pipeline's promise is not one number, it is a CURVE: every measured way to serve the
+workload, placed on (effective cost per completed task, quality), with the non-dominated
+points marked so an operator can pick any point and mount it. This module computes that
+curve ONE way for every surface that shows it: the endpoint report, the admin frontend's
+graph, the live estimate a run emits while a sweep is still landing cells (D-RUNS stage
+artifacts), and the research analyses. Two surfaces disagreeing about the same curve is the
+two-truths bug this module exists to prevent.
+
+Costs come from `wmo.optimize.scorecard.effective_cost_per_completed_task` (the D-COMPRESS
+accounting rule: cache-adjusted, per COMPLETED task, unscored spend excluded and counted)
+and nowhere else. Quality is the scenario-mean reward, matching the scorecard's averaging.
+A point computed from a partial matrix says so: `n_scenarios`/`n_scored` travel on every
+point and `ParetoCurve.complete` is False whenever any candidate has unscored cells, so a
+mid-sweep estimate can never be mistaken for the final curve.
+
+The routed points are POLICY REPLAYS (`rows_for_policy`), measured on the scenarios the
+caller passes (a report passes the fit's held-out band; a live estimate passes everything
+scored so far). `recommended` is the point the product would mount today: the routed point
+at the balanced dial when a policy is given, else the guarded fit's own answer (the best
+single model on the matrix). It is a default, not a verdict; the curve exists so an
+operator can choose differently.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.scorecard import (
+    DEFAULT_COMPLETION,
+    CompletionRule,
+    effective_cost_per_completed_task,
+    rows_for_model,
+    rows_for_policy,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from wmo.optimize.policy import RoutingPolicy
+    from wmo.providers.base import Embedder
+
+PointKind = Literal["model", "routed"]
+
+# The curve's artifact name, written beside `report.json` by the report writers and loaded
+# from the model directory at serving mount (GET /config carries it to the platform).
+PARETO_FILENAME = "pareto.json"
+
+
+class ParetoPoint(BaseModel):
+    """One measured way to serve the workload, on all three objectives."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str  # pool model name, or "routed@<dial>"
+    kind: PointKind
+    label: str
+    cost_per_completed_task_usd: float | None  # None: nothing completed, unplottable
+    mean_reward: float
+    task_success_rate: float
+    latency_p50_s: float
+    n_scenarios: int
+    n_scored: int
+    n_excluded: int  # unscored episodes behind this point (infrastructure, not zeros)
+    on_frontier: bool = False
+    dial: float | None = None  # routed points: the cost_quality position replayed
+    mix: dict[str, int] = Field(default_factory=dict)  # routed points: scenarios per model
+
+
+class ParetoCurve(BaseModel):
+    """The measured curve plus the honesty fields no rendering may drop.
+
+    `complete` is False while any candidate still has unscored cells: early cells are not a
+    random sample of the workload, so an incomplete curve is an ESTIMATE and every consumer
+    must label it as one. `recommended` names a point id from `points`.
+    """
+
+    points: list[ParetoPoint]
+    recommended: str | None
+    complete: bool
+    n_scenarios: int
+    provenance: str  # e.g. "wm_simulated"; consumers print it next to every rendering
+    judge: str
+
+
+def pareto_curve(
+    matrix: OutcomeMatrix,
+    *,
+    judge: str,
+    provenance: str = "wm_simulated",
+    policy: RoutingPolicy | None = None,
+    dials: Sequence[float] = (0.0, 0.25, 0.5, 0.75, 1.0),
+    scenario_ids: Sequence[str] | None = None,
+    embedder: Embedder | None = None,
+    completion: CompletionRule = DEFAULT_COMPLETION,
+) -> ParetoCurve:
+    """Compute the cost/quality curve over `matrix`, optionally with a policy's dial points.
+
+    Args:
+        matrix: the measured pool x scenario grid, complete or mid-sweep.
+        judge: the verifier that produced the rewards; printed on every rendering.
+        provenance: wm_simulated or real_episode; never blended by consumers.
+        policy: a fitted routing policy whose dial detents become routed points. The caller
+            owns split discipline: pass `scenario_ids` the fit never saw (a report's
+            held-out band) or accept in-sample routed points labeled by its own context.
+        dials: the cost_quality detents to replay when `policy` is given.
+        scenario_ids: restrict the curve to these scenarios (default: every scenario with
+            any scored row). Model points and routed points share the restriction so the
+            curve is one comparison.
+        embedder: one embedder for the whole replay (see `rows_for_policy`).
+        completion: what counts as a completed task.
+
+    Raises:
+        ValueError: when no scenario has a scored row, or `scenario_ids` names scenarios
+            the matrix never measured.
+    """
+    from wmo.optimize.knn import apply_cost_quality
+
+    ids = list(scenario_ids) if scenario_ids is not None else matrix.scenario_ids()
+    known = set(matrix.scenario_ids())
+    ghosts = [sid for sid in ids if sid not in known]
+    if ghosts:
+        raise ValueError(
+            f"scenario_ids name {len(ghosts)} scenario(s) this matrix never measured "
+            f"(first: {ghosts[0]!r}); a curve over unmeasured scenarios would be invented"
+        )
+    wanted = set(ids)
+
+    points: list[ParetoPoint] = []
+    any_unscored = False
+    for model in matrix.model_names():
+        rows = [o for o in rows_for_model(matrix, model) if o.scenario_id in wanted]
+        point = _point(model, "model", model, rows, completion)
+        if point is None:
+            any_unscored = True  # a candidate with no scored row yet is missing, not absent
+            continue
+        any_unscored = any_unscored or point.n_excluded > 0
+        points.append(point)
+    if not points:
+        raise ValueError(
+            "no pool model has a scored row on the requested scenarios; there is no curve "
+            "to compute yet"
+        )
+
+    if policy is not None:
+        shared = embedder or _replay_embedder(policy)
+        for dial in dials:
+            rows = rows_for_policy(
+                matrix, apply_cost_quality(policy, dial), ids=ids, embedder=shared
+            )
+            mix: dict[str, int] = {}
+            for sid in ids:
+                for chosen in {row.model for row in rows if row.scenario_id == sid}:
+                    mix[chosen] = mix.get(chosen, 0) + 1
+            point = _point(
+                f"routed@{dial:g}", "routed", f"routed (dial {dial:g})", rows, completion
+            )
+            if point is not None:
+                points.append(point.model_copy(update={"dial": dial, "mix": mix}))
+
+    flagged = _mark_frontier(points)
+    return ParetoCurve(
+        points=flagged,
+        recommended=_recommended(flagged, policy),
+        complete=not any_unscored,
+        n_scenarios=len(ids),
+        provenance=provenance,
+        judge=judge,
+    )
+
+
+def held_out_curve(
+    matrix: OutcomeMatrix,
+    policy: RoutingPolicy,
+    *,
+    judge: str,
+    provenance: str = "wm_simulated",
+    embedder: Embedder | None = None,
+) -> ParetoCurve:
+    """The curve a report ships: routed points on the fit's held-out band only.
+
+    Mirrors `wmo.optimize.report.build_report`'s split discipline: `fit_scenario_ids` are
+    excluded so no routed point is graded on the fit's own training data. A policy fitted
+    on EVERY scenario has no held-out band; the curve then carries the model points alone
+    (over all scenarios) rather than in-sample routed points dressed as measurements.
+    """
+    held_out = [
+        sid for sid in matrix.scenario_ids() if sid not in set(policy.fit_scenario_ids)
+    ]
+    if not held_out:
+        return pareto_curve(matrix, judge=judge, provenance=provenance)
+    return pareto_curve(
+        matrix,
+        judge=judge,
+        provenance=provenance,
+        policy=policy,
+        scenario_ids=held_out,
+        embedder=embedder,
+    )
+
+
+def _replay_embedder(policy: RoutingPolicy) -> Embedder:
+    """The function the policy's bank geometry was fitted with.
+
+    A compressed-fit policy embeds COMPRESSED text (C2's representation-consistency rule,
+    exactly as `build_report` replays); querying its bank with raw vectors trips the
+    novelty floor and mismeasures the routed points.
+    """
+    from wmo.optimize.compression import CompressingEmbedder
+
+    built = policy.embedder.build()
+    if policy.fit_compression is not None:
+        return CompressingEmbedder(built, policy.fit_compression)
+    return built
+
+
+def _point(
+    point_id: str,
+    kind: PointKind,
+    label: str,
+    rows: list,
+    completion: CompletionRule,
+) -> ParetoPoint | None:
+    """Aggregate one config's rows into a point; None when nothing is scored yet."""
+    scored = [row for row in rows if row.reward is not None]
+    if not scored:
+        return None
+    cost = effective_cost_per_completed_task(rows, completion=completion)
+    by_scenario: dict[str, list[float]] = {}
+    success: dict[str, list[float]] = {}
+    per_task_seconds: list[float] = []
+    for row in scored:
+        by_scenario.setdefault(row.scenario_id, []).append(row.reward)
+        success.setdefault(row.scenario_id, []).append(
+            1.0 if completion.completed(row) else 0.0
+        )
+        per_task_seconds.append(sum(row.call_seconds))
+    scenario_means = [sum(v) / len(v) for v in by_scenario.values()]
+    success_means = [sum(v) / len(v) for v in success.values()]
+    per_task_seconds.sort()
+    return ParetoPoint(
+        id=point_id,
+        kind=kind,
+        label=label,
+        cost_per_completed_task_usd=cost.cost_per_completed_task_usd,
+        mean_reward=sum(scenario_means) / len(scenario_means),
+        task_success_rate=sum(success_means) / len(success_means),
+        latency_p50_s=per_task_seconds[len(per_task_seconds) // 2],
+        n_scenarios=len(by_scenario),
+        n_scored=len(scored),
+        n_excluded=cost.n_excluded,
+    )
+
+
+def _mark_frontier(points: list[ParetoPoint]) -> list[ParetoPoint]:
+    """Flag the non-dominated points on (cost down, reward up); ties stay on the frontier.
+
+    A point with no defined cost cannot be placed on the cost axis and is never on the
+    frontier (it stays in `points` so a renderer can show it as unplaced rather than
+    dropping it silently).
+    """
+    placeable = [
+        (p, p.cost_per_completed_task_usd)
+        for p in points
+        if p.cost_per_completed_task_usd is not None
+    ]
+
+    def dominated(p: ParetoPoint, cost: float) -> bool:
+        return any(
+            other_cost <= cost
+            and o.mean_reward >= p.mean_reward
+            and (other_cost < cost or o.mean_reward > p.mean_reward)
+            for o, other_cost in placeable
+            if o is not p
+        )
+
+    flagged = {p.id: not dominated(p, cost) for p, cost in placeable}
+    return [
+        p.model_copy(update={"on_frontier": flagged.get(p.id, False)}) for p in points
+    ]
+
+
+def _recommended(points: list[ParetoPoint], policy: RoutingPolicy | None) -> str | None:
+    """The point the product would mount today.
+
+    With a policy: its balanced-dial routed point (the shipped default detent). Without
+    one: the frontier's best-quality point, which is what the guarded fit would discover
+    and fall back to. None only when nothing is placeable.
+    """
+    if policy is not None:
+        balanced = next(
+            (p for p in points if p.kind == "routed" and p.dial == 0.25), None
+        )
+        if balanced is not None and balanced.cost_per_completed_task_usd is not None:
+            return balanced.id
+    frontier = [p for p in points if p.on_frontier]
+    if not frontier:
+        return None
+    return max(frontier, key=lambda p: p.mean_reward).id

--- a/wmo/optimize/pareto_test.py
+++ b/wmo/optimize/pareto_test.py
@@ -1,0 +1,141 @@
+"""Tests for the cost/quality Pareto curve: pure offline aggregation, no spend."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.pareto import ParetoCurve, pareto_curve
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry
+
+
+def _row(
+    sid: str,
+    model: str,
+    *,
+    reward: float | None,
+    cost: float = 0.01,
+    episode: int = 0,
+) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=sid,
+        task=f"task for {sid}",
+        model=model,
+        episode=episode,
+        reward=reward,
+        success=reward is not None and reward >= 0.5,
+        usage=TokenUsage(input_tokens=100, output_tokens=50),
+        cost_usd=cost,
+        call_seconds=[0.5, 0.5],
+        error=None if reward is not None else "sandbox timeout",
+    )
+
+
+def _matrix(outcomes: list[ScenarioOutcome]) -> OutcomeMatrix:
+    return OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="cheap",
+                kind=ProviderKind.OPENAI,
+                model="cheap-model",
+                input_per_mtok=0.1,
+                output_per_mtok=0.2,
+            ),
+            PoolEntry(
+                name="mid",
+                kind=ProviderKind.OPENAI,
+                model="mid-model",
+                input_per_mtok=1.0,
+                output_per_mtok=2.0,
+            ),
+            PoolEntry(name="strong", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        ],
+        outcomes=outcomes,
+    )
+
+
+def _three_model_matrix() -> OutcomeMatrix:
+    # cheap: $0.01/completed at reward 0.5; mid: dominated (dearer than strong, worse);
+    # strong: $0.06/completed at reward 1.0.
+    return _matrix(
+        [
+            _row("s1", "cheap", reward=1.0, cost=0.01),
+            _row("s2", "cheap", reward=0.0, cost=0.01),
+            _row("s1", "mid", reward=0.5, cost=0.08),
+            _row("s2", "mid", reward=0.5, cost=0.08),
+            _row("s1", "strong", reward=1.0, cost=0.03),
+            _row("s2", "strong", reward=1.0, cost=0.03),
+        ]
+    )
+
+
+def test_frontier_marks_non_dominated_points_and_keeps_dominated_ones() -> None:
+    curve = pareto_curve(_three_model_matrix(), judge="test-judge")
+
+    by_id = {p.id: p for p in curve.points}
+    assert by_id["cheap"].on_frontier  # cheapest per completed task
+    assert by_id["strong"].on_frontier  # best reward
+    assert not by_id["mid"].on_frontier  # dearer than strong AND worse: dominated
+    assert len(curve.points) == 3  # dominated points stay visible, never dropped
+
+
+def test_recommended_without_policy_is_the_frontiers_best_quality_point() -> None:
+    curve = pareto_curve(_three_model_matrix(), judge="test-judge")
+
+    assert curve.recommended == "strong"
+
+
+def test_complete_flag_is_false_while_any_candidate_has_unscored_cells() -> None:
+    outcomes = _three_model_matrix().outcomes + [_row("s3", "cheap", reward=None)]
+    curve = pareto_curve(_matrix(outcomes), judge="test-judge")
+
+    assert curve.complete is False
+
+
+def test_full_matrix_reports_complete() -> None:
+    curve = pareto_curve(_three_model_matrix(), judge="test-judge")
+
+    assert curve.complete is True
+    assert curve.n_scenarios == 2
+    assert curve.judge == "test-judge"
+    assert curve.provenance == "wm_simulated"
+
+
+def test_scenario_restriction_applies_to_every_point() -> None:
+    curve = pareto_curve(_three_model_matrix(), judge="test-judge", scenario_ids=["s1"])
+
+    assert curve.n_scenarios == 1
+    assert all(p.n_scenarios == 1 for p in curve.points)
+    # On s1 alone, cheap completes 1 task at $0.01 and reward 1.0: it dominates strong.
+    by_id = {p.id: p for p in curve.points}
+    assert by_id["cheap"].on_frontier
+    assert not by_id["strong"].on_frontier
+
+
+def test_unmeasured_scenario_ids_are_refused() -> None:
+    with pytest.raises(ValueError, match="never measured"):
+        pareto_curve(_three_model_matrix(), judge="test-judge", scenario_ids=["ghost"])
+
+
+def test_nothing_completed_point_is_unplaced_but_visible() -> None:
+    outcomes = _three_model_matrix().outcomes + [
+        _row("s1", "mid", reward=0.0, cost=0.05, episode=1),
+    ]
+    # Rebuild mid as all-failures: replace its rows with reward-0 episodes.
+    outcomes = [o for o in outcomes if o.model != "mid"] + [
+        _row("s1", "mid", reward=0.0, cost=0.05),
+        _row("s2", "mid", reward=0.0, cost=0.05),
+    ]
+    curve = pareto_curve(_matrix(outcomes), judge="test-judge")
+
+    mid = next(p for p in curve.points if p.id == "mid")
+    assert mid.cost_per_completed_task_usd is None
+    assert not mid.on_frontier
+
+
+def test_serializes_for_the_wire() -> None:
+    curve = pareto_curve(_three_model_matrix(), judge="test-judge")
+
+    restored = ParetoCurve.model_validate_json(curve.model_dump_json())
+    assert restored == curve

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -90,6 +90,7 @@ from wmo.optimize.knn import (
     apply_cost_quality,
     cost_quality_named_point,
 )
+from wmo.optimize.pareto import ParetoCurve
 from wmo.optimize.policy import (
     Embedder,
     GateOutcome,
@@ -637,9 +638,13 @@ class EndpointRuntime:
         config_path: Path | None = None,
         embeddings: QueryEmbeddingStore | None = None,
         log_query_embeddings: bool = True,
+        pareto: ParetoCurve | None = None,
     ) -> None:
         self.name = name
         self.policy = policy
+        # The measured curve written at optimize time (pareto.json); served verbatim on
+        # GET /config. None for artifacts that predate it: absence, never an empty curve.
+        self.pareto = pareto
         self.log = log
         self._embeddings = embeddings if log_query_embeddings else None
         self._base_policy = policy
@@ -1293,6 +1298,14 @@ class EndpointConfigResponse(BaseModel):
 
     `dialable` is false for policy kinds with no dial (static and rank endpoints), and then the
     dial fields are null and PUT returns 409.
+
+    `pareto` is the MEASURED cost/quality curve for THIS endpoint's workload
+    (`wmo.optimize.pareto`, written as `pareto.json` beside the report at optimize time):
+    every candidate and the routed dial detents on (effective cost per completed task,
+    reward), frontier-flagged, with a recommended point. None for endpoints optimized before
+    the artifact existed; a renderer shows nothing then, never an empty chart. Unlike
+    `anchors` (a global table measured on routerbench-ours9), the curve is per-workload; the
+    two must never be blended into one figure.
     """
 
     endpoint: str
@@ -1301,6 +1314,7 @@ class EndpointConfigResponse(BaseModel):
     named_point: str
     knobs: ServedKnobs | None
     anchors: list[CostQualityAnchor]
+    pareto: ParetoCurve | None = None
 
 
 class EndpointConfigUpdate(BaseModel):
@@ -1336,6 +1350,7 @@ def _config_response(runtime: EndpointRuntime) -> EndpointConfigResponse:
             else None
         ),
         anchors=list(COST_QUALITY_ANCHORS),
+        pareto=runtime.pareto,
     )
 
 

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2928,3 +2928,54 @@ def test_a_compressor_that_returns_the_wrong_segment_count_is_named(tmp_path: Pa
 
     assert response.status_code == 502  # refused, not served with a corrupted transcript
     assert "splitter-for-tests" in _error_message(_rows(log_path)[-1])
+
+
+def test_config_carries_the_pareto_curve_when_the_runtime_has_one(tmp_path: Path) -> None:
+    from wmo.optimize.pareto import ParetoCurve, ParetoPoint
+
+    curve = ParetoCurve(
+        points=[
+            ParetoPoint(
+                id="cheap",
+                kind="model",
+                label="cheap",
+                cost_per_completed_task_usd=0.01,
+                mean_reward=0.5,
+                task_success_rate=0.5,
+                latency_p50_s=1.0,
+                n_scenarios=2,
+                n_scored=4,
+                n_excluded=0,
+                on_frontier=True,
+            )
+        ],
+        recommended="cheap",
+        complete=True,
+        n_scenarios=2,
+        provenance="wm_simulated",
+        judge="test-judge",
+    )
+    policy = _knn_policy(tmp_path)
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=policy,
+        provider_factory=_EchoProvider,
+        log=RequestLog(tmp_path / "requests.jsonl"),
+        pareto=curve,
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    body = TestClient(app).get("/v1/endpoints/tau-bench/config").json()
+
+    assert body["pareto"]["recommended"] == "cheap"
+    assert body["pareto"]["complete"] is True
+    assert body["pareto"]["points"][0]["on_frontier"] is True
+    # The per-workload curve and the global ours9 anchors travel side by side, distinct.
+    assert [anchor["s"] for anchor in body["anchors"]] == [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
+def test_config_omits_pareto_for_artifacts_that_predate_it(tmp_path: Path) -> None:
+    client, _ = _dial_client(tmp_path, _knn_policy(tmp_path))
+    body = client.get("/v1/endpoints/tau-bench/config").json()
+
+    assert body["pareto"] is None

--- a/wmo/serving/server.py
+++ b/wmo/serving/server.py
@@ -31,6 +31,7 @@ from wmo.config.card import ModelCard, load_card
 from wmo.core.types import Action, EnvState, Observation, Session
 from wmo.engine.loader import load_world_model
 from wmo.engine.world_model import WorldModel
+from wmo.optimize.pareto import PARETO_FILENAME, ParetoCurve
 from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy
 from wmo.optimize.reward import EpisodeScore
 from wmo.serving.builds import BuildManager, BuildRouteRequest, BuildSnapshot
@@ -189,6 +190,23 @@ def _load_models(
     return models, cards, dirs
 
 
+def _load_pareto_or_none(model_dir: Path | None) -> ParetoCurve | None:
+    """The measured curve written at optimize time, or None when it never was.
+
+    A malformed file fails the mount loudly (same posture as an invalid policy): serving a
+    stale or truncated curve as "the measured frontier" is worse than refusing to start.
+    """
+    if model_dir is None:
+        return None
+    path = model_dir / PARETO_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        return ParetoCurve.model_validate_json(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise ValueError(f"invalid pareto curve at {path}: {exc}") from exc
+
+
 def _endpoint_runtimes(
     policies: Mapping[str, RoutingPolicy],
     model_dirs: Mapping[str, Path],
@@ -227,6 +245,7 @@ def _endpoint_runtimes(
                 config_path=config_path,
                 embeddings=embeddings,
                 log_query_embeddings=settings.log_query_embeddings,
+                pareto=_load_pareto_or_none(model_dir),
             )
         except ValueError as exc:
             # Fail fast and name the file: a dial the policy cannot honor (a savings position on


### PR DESCRIPTION
Split of the product code from jt/corners (#311) so platform #388 can verify against main: wmo.optimize.pareto (one Pareto computation for every surface, scorecard-only costs, complete-flag honesty on partial matrices), report writers emit pareto.json, GET /config serves it, plus the real-episodes full-task-split fix. Pure additions; applied as hunks onto current main (the corners branch carries an older pool API that was NOT brought along). Gates on this branch: pytest 4522 green, ty clean, ruff clean.