### PR TITLE
Cache-aware routing decisions: incumbent cache credit + switch gate (opt-in)

### DIFF
--- a/.agents/scripts/cacheaware_replay.py
+++ b/.agents/scripts/cacheaware_replay.py
@@ -1,0 +1,306 @@
+"""Pre-registered replay gate for cache-aware routing (findings/cacheaware.md, 2026-07-28).
+
+Two replays on routerbench-ours9, blind vs cache-aware arms fitted through the PRODUCTION
+fitter (`fit_knn_policy`, champion defaults), 5 split seeds, deterministic effective billing
+from pool prices + logged token counts:
+
+- R1 repeat-traffic: perturbed repeats of 300 fit items (the duptraffic construction: word
+  dropout / stutter / case flips). The repeat carries the incumbent that served its original
+  and a remembered prefix of the original request + reply.
+- R2 conversation-shaped: 4-turn conversations over test scenarios; turn t's prefix is the
+  concatenated requests + replies of turns < t; each arm chains its OWN incumbent.
+
+EFFECTIVE BILLING per turn, model m serving with prefix_tokens P (chars/4):
+  unswitched (m == incumbent): P x cached_input_per_mtok(m) + fresh_in x input + out x output
+  switched or first turn:      P x input_per_mtok(m)        + fresh_in x input + out x output
+fresh_in / out are the scenario's logged usage for m; a model with no cached rate bills P at
+the full input rate either way (no advantage), matching PoolEntry.cost_usd.
+
+BAR (pre-registered): cache-aware total effective cost reduced vs blind (mean paired saving
+> 0, >= 4/5 seeds) at quality parity (|mean paired quality delta| < 1 combined SE); report
+the switch-rate change alongside. Arms run at pick_lam 0 (champion) and 0.08 (the validated
+frontier point), cache_aware off/on.
+
+Usage: WMO_ROUTING_DATA=... uv run python .agents/scripts/cacheaware_replay.py [--seeds=0..4]
+Appends RunRecords to $WMO_ROUTING_DATA/runs/cacheaware.jsonl (knob params only).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import sys
+import tempfile
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+
+from wmo.optimize.knn import fit_knn_policy
+from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.policy import RoutingPolicy, cache_credit_usd, knn_decision
+from wmo.providers.base import Embedder
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("cacheaware")
+
+DATA = Path(os.environ.get("WMO_ROUTING_DATA", "~/Desktop/Projects/wmh-routing-data")).expanduser()
+RUNS = DATA / "runs" / "cacheaware.jsonl"
+SEEDS = [0, 1, 2, 3, 4]
+REPEATS = 300
+TURNS = 4
+CHARS_PER_TOKEN = 4
+LAMS = [0.0, 0.08]
+
+
+def stratified_split(matrix: OutcomeMatrix, seed: int) -> tuple[list[str], list[str]]:
+    """The routing protocol's 70/30 split (identical to validate_knn_promotion.py)."""
+    by_prefix: dict[str, list[str]] = {}
+    for scenario_id in matrix.scenario_ids():
+        prefix = scenario_id.split(":", 1)[0] if ":" in scenario_id else ""
+        by_prefix.setdefault(prefix, []).append(scenario_id)
+    rng = random.Random(seed)
+    fit: list[str] = []
+    test: list[str] = []
+    for _prefix, ids in sorted(by_prefix.items()):
+        shuffled = ids[:]
+        rng.shuffle(shuffled)
+        cut = max(1, round(len(shuffled) * 0.7)) if len(shuffled) > 1 else 1
+        cut = min(cut, len(shuffled) - 1) if len(shuffled) > 1 else cut
+        fit.extend(shuffled[:cut])
+        test.extend(shuffled[cut:])
+    return sorted(fit), sorted(test)
+
+
+def perturb(text: str, rng: random.Random) -> str:
+    """The duptraffic construction: 10% word dropout, occasional stutter, case flips."""
+    words = text.split()
+    out = []
+    for word in words:
+        roll = rng.random()
+        if roll < 0.10:
+            continue
+        if roll < 0.15:
+            out.append(word)
+        out.append(word.swapcase() if rng.random() < 0.05 else word)
+    return " ".join(out) if out else text
+
+
+class Cells:
+    """Per-(scenario, model) mean reward, usage, and reply/task lengths from the matrix."""
+
+    def __init__(self, matrix: OutcomeMatrix) -> None:
+        self.reward: dict[tuple[str, str], float] = {}
+        self.in_tokens: dict[tuple[str, str], float] = {}
+        self.out_tokens: dict[tuple[str, str], float] = {}
+        self.reply_chars: dict[tuple[str, str], int] = {}
+        self.task: dict[str, str] = {}
+        grouped: dict[tuple[str, str], list] = {}
+        for outcome in matrix.outcomes:
+            self.task.setdefault(outcome.scenario_id, outcome.task)
+            if outcome.reward is not None:
+                grouped.setdefault((outcome.scenario_id, outcome.model), []).append(outcome)
+        for key, outcomes in grouped.items():
+            self.reward[key] = float(np.mean([o.reward for o in outcomes]))
+            self.in_tokens[key] = float(np.mean([o.usage.input_tokens for o in outcomes]))
+            self.out_tokens[key] = float(np.mean([o.usage.output_tokens for o in outcomes]))
+            self.reply_chars[key] = int(
+                np.mean([len("".join(o.replies)) if o.replies else 0 for o in outcomes])
+            )
+
+
+def bill(
+    policy: RoutingPolicy,
+    model: str,
+    prefix_tokens: float,
+    fresh_in: float,
+    out: float,
+    *,
+    cached: bool,
+) -> float:
+    entry = next(e for e in policy.pool if e.name == model)
+    price = entry.price()
+    prefix_rate = (
+        entry.cached_input_per_mtok
+        if cached and entry.cached_input_per_mtok is not None
+        else price.input_per_mtok
+    )
+    return (
+        prefix_tokens * prefix_rate + fresh_in * price.input_per_mtok + out * price.output_per_mtok
+    ) / 1_000_000
+
+
+def scored_or_fallback(cells: Cells, sid: str, model: str, policy: RoutingPolicy) -> str:
+    """The scored model this turn actually serves: pick, else default, else any scored."""
+    if (sid, model) in cells.reward:
+        return model
+    if (sid, policy.default_model) in cells.reward:
+        return policy.default_model
+    return next(m for (s, m) in sorted(cells.reward) if s == sid)
+
+
+def decide(
+    policy: RoutingPolicy, query: np.ndarray, incumbent: str | None, prefix_chars: int
+) -> str:
+    """One arm's routing decision: blind arms stick; aware arms price the incumbent."""
+    if incumbent is not None:
+        if not policy.cache_aware:
+            return incumbent  # sticky, exactly like serving
+        credit = cache_credit_usd(policy, incumbent, prefix_chars)
+        return knn_decision(policy, query, incumbent=incumbent, cache_credit=credit).model
+    return knn_decision(policy, query).model
+
+
+def replay_r1(
+    policy: RoutingPolicy, cells: Cells, fit_ids: list[str], embed: Embedder, seed: int
+) -> tuple[float, float, float]:
+    """(total effective cost, mean quality, switch rate) over perturbed repeats."""
+    rng = random.Random(1000 + seed)
+    items = rng.sample(fit_ids, min(REPEATS, len(fit_ids)))
+    originals = {
+        sid: knn_decision(policy, np.asarray(embed.embed([cells.task[sid]])[0])).model
+        for sid in items
+    }
+    total, quality, switches = 0.0, [], 0
+    for sid in items:
+        incumbent = originals[sid]
+        prefix_chars = len(cells.task[sid]) + cells.reply_chars.get((sid, incumbent), 0)
+        query = np.asarray(embed.embed([perturb(cells.task[sid], rng)])[0])
+        model = scored_or_fallback(
+            cells, sid, decide(policy, query, incumbent, prefix_chars), policy
+        )
+        cached = model == incumbent
+        switches += 0 if cached else 1
+        total += bill(
+            policy,
+            model,
+            prefix_chars / CHARS_PER_TOKEN,
+            cells.in_tokens[(sid, model)],
+            cells.out_tokens[(sid, model)],
+            cached=cached,
+        )
+        quality.append(cells.reward[(sid, model)])
+    return total, float(np.mean(quality)), switches / len(items)
+
+
+def replay_r2(
+    policy: RoutingPolicy, cells: Cells, test_ids: list[str], embed: Embedder, seed: int
+) -> tuple[float, float, float]:
+    """(total effective cost, mean quality, switch rate) over 4-turn conversations."""
+    rng = random.Random(2000 + seed)
+    order = sorted(test_ids)
+    rng.shuffle(order)
+    total, quality, switches, decisions = 0.0, [], 0, 0
+    for start in range(0, len(order) - TURNS + 1, TURNS):
+        convo = order[start : start + TURNS]
+        incumbent: str | None = None
+        prefix_chars = 0
+        for sid in convo:
+            query = np.asarray(embed.embed([cells.task[sid]])[0])
+            model = scored_or_fallback(
+                cells, sid, decide(policy, query, incumbent, prefix_chars), policy
+            )
+            cached = incumbent is not None and model == incumbent
+            if incumbent is not None:
+                decisions += 1
+                switches += 0 if cached else 1
+            total += bill(
+                policy,
+                model,
+                prefix_chars / CHARS_PER_TOKEN,
+                cells.in_tokens[(sid, model)],
+                cells.out_tokens[(sid, model)],
+                cached=cached,
+            )
+            quality.append(cells.reward[(sid, model)])
+            prefix_chars += len(cells.task[sid]) + cells.reply_chars.get((sid, model), 0)
+            incumbent = model
+    return total, float(np.mean(quality)), switches / max(decisions, 1)
+
+
+def main() -> None:
+    seeds = SEEDS
+    for arg in sys.argv[1:]:
+        if arg.startswith("--seeds="):
+            seeds = [int(s) for s in arg.split("=", 1)[1].split(",")]
+    matrix = OutcomeMatrix.load(DATA / "matrices" / "routerbench-ours9_matrix.json")
+    cells = Cells(matrix)
+    ts = datetime.now(tz=UTC).isoformat()
+    results: dict[tuple[str, float, bool, int], tuple[float, float, float]] = {}
+    for seed in seeds:
+        fit_ids, test_ids = stratified_split(matrix, seed)
+        with tempfile.TemporaryDirectory() as tmp:
+            fitted = fit_knn_policy(
+                matrix,
+                bank_path=Path(tmp) / "bank.npz",
+                fit_ids=fit_ids,
+                guard_model="fable-5",
+                fitted_from=f"cacheaware replay s{seed}",
+            )
+            fitted.knn_bank()  # load the sidecar while the tempdir exists
+            embed = fitted.embedder.build()
+            for lam in LAMS:
+                for aware in (False, True):
+                    policy = fitted.model_copy(update={"pick_lam": lam, "cache_aware": aware})
+                    policy.attach_bank(fitted.knn_bank())
+                    for replay_name, fn, ids in (
+                        ("r1", replay_r1, fit_ids),
+                        ("r2", replay_r2, test_ids),
+                    ):
+                        cost, qual, switch = fn(policy, cells, ids, embed, seed)
+                        results[(replay_name, lam, aware, seed)] = (cost, qual, switch)
+                        logger.info(
+                            "s%d %s lam=%.2f aware=%d: cost=$%.4f quality=%.4f switch=%.3f",
+                            seed,
+                            replay_name,
+                            lam,
+                            aware,
+                            cost,
+                            qual,
+                            switch,
+                        )
+    # Paired report + run records.
+    RUNS.parent.mkdir(parents=True, exist_ok=True)
+    with RUNS.open("a", encoding="utf-8") as handle:
+        for replay_name in ("r1", "r2"):
+            for lam in LAMS:
+                rows = [
+                    (results[(replay_name, lam, False, s)], results[(replay_name, lam, True, s)])
+                    for s in seeds
+                ]
+                savings = [(b[0] - a[0]) / b[0] * 100 for b, a in rows]
+                dq = [a[1] - b[1] for b, a in rows]
+                dswitch = [a[2] - b[2] for b, a in rows]
+                record = {
+                    "run_id": f"cacheaware-{replay_name}-lam{lam:g}-{uuid.uuid4().hex[:8]}",
+                    "ts": ts,
+                    "matrix": "routerbench-ours9",
+                    "variant": f"cacheaware-{replay_name}-lam{lam:g}",
+                    "params": {"replay": replay_name, "pick_lam": lam, "turns": TURNS},
+                    "seeds": len(seeds),
+                    "saving_pct_mean": round(float(np.mean(savings)), 3),
+                    "saving_pct_per_seed": [round(s, 3) for s in savings],
+                    "quality_delta_mean": round(float(np.mean(dq)), 5),
+                    "quality_delta_se": round(
+                        float(np.std(dq, ddof=1) / len(dq) ** 0.5) if len(dq) > 1 else 0.0, 5
+                    ),
+                    "switch_delta_mean": round(float(np.mean(dswitch)), 4),
+                }
+                handle.write(json.dumps(record) + "\n")
+                logger.info(
+                    "%s lam=%.2f: saving %+.2f%% (per-seed %s) dQuality %+0.4f+-%.4f dSwitch %+.3f",
+                    replay_name,
+                    lam,
+                    record["saving_pct_mean"],
+                    record["saving_pct_per_seed"],
+                    record["quality_delta_mean"],
+                    record["quality_delta_se"],
+                    record["switch_delta_mean"],
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -376,6 +376,14 @@ class RoutingPolicy(BaseModel):
     # against quality evidence instead of a blunt rule. The quality evidence test itself is
     # unchanged: cache state never buys quality confidence. Off (the default) is bit-identical
     # to today for every policy file, eval, and serving path.
+    #
+    # Safety outranks cache economics: the novelty abstain and the no-scored-candidates
+    # returns still serve the pinned fallback WITHOUT the switch gate. Consequence vs plain
+    # sticky mode (which never reaches the novelty check): a mid-conversation turn that looks
+    # unlike the fit data leaves a cache-warm incumbent for the fallback and pays full
+    # prefill. Ruled deliberate (routing master, 2026-07-28): on novel input the pinned-
+    # fallback contract wins. The switch gate governs evidence-backed decisions only; an
+    # incumbent absent from the fitted bank cannot be tested and sticks.
     cache_aware: bool = False
     # ProxRouter-inspired support tilt (2510.09852, ADAPTED to clusters: their exponential
     # tilt reweights nonparametric scores by a prior; ours multiplies cluster probabilities
@@ -888,8 +896,24 @@ def knn_decision(
         otherwise the decision that keeps the incumbent. Quality thresholds are identical to
         the baseline guard: cache state raises the switch's price bar, never its confidence.
         """
-        if incumbent is None or serve == incumbent or incumbent not in bank.models:
+        if incumbent is None or serve == incumbent:
             return None
+        if incumbent not in bank.models:
+            # The bank predates this pool model, so the incumbent cannot be tested at all;
+            # the amendment's conservative rule applies: an untestable incumbent sticks.
+            return RoutingDecision(
+                model=incumbent,
+                reason=(
+                    f"cache-aware switch gate: kept incumbent {incumbent}, not in the fitted "
+                    f"bank so {serve} cannot be justified against it"
+                ),
+                evidence=RoutingEvidence(
+                    n_pairs=0,
+                    gate="reverted",
+                    propensity="fallback-forced",
+                    cache_credit_usd=credit_applied or None,
+                ),
+            )
         inc_index = bank.models.index(incumbent)
         inc_paired = scored[:, serve_index] & scored[:, inc_index]
         inc_diffs = rewards[inc_paired, serve_index] - rewards[inc_paired, inc_index]

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -809,11 +809,14 @@ def knn_decision(
     the knob reorders candidates, and the guard then re-vetoes whatever it cannot support, so
     turning the knob up can never talk the router into a pick the evidence rejects.
 
-    Cache-aware calls (`incumbent` + `cache_credit` > 0, supplied by `select_model` when the
-    policy has `cache_aware` on) subtract the credit from THE INCUMBENT's mean cost in the two
-    places cost enters the decision: the pick_lam tilt and the guard's pricier test. With
-    credit 0 or no incumbent this function is bit-identical to the cache-blind path; quality
-    evidence (profile, paired diffs, z) never sees the credit.
+    Cache-aware calls (`incumbent` supplied by `select_model` when the policy has
+    `cache_aware` on) do two things. The `cache_credit` is subtracted from THE INCUMBENT's
+    mean cost in the two places cost enters the decision: the pick_lam tilt and the pricier
+    tests. And any decision that would ABANDON the incumbent must additionally clear the
+    switch gate (see `switch_gate` below): the same paired-evidence bar, anchored on the
+    incumbent, at effective prices. With NO incumbent this function is bit-identical to the
+    cache-blind path (the offline-eval invariant); quality evidence (profile, paired diffs,
+    z thresholds) never sees the credit.
     """
     if policy.kind != "knn":
         raise ValueError(f"knn_decision needs a knn policy, got kind='{policy.kind}'")
@@ -874,6 +877,56 @@ def knn_decision(
             effective_cost = mean_cost.copy()
             effective_cost[inc_index] = max(mean_cost[inc_index] - cache_credit, 0.0)
             credit_applied = cache_credit
+
+    def switch_gate(serve_index: int, serve: str) -> RoutingDecision | None:
+        """Cache-aware switch gate (design amendment 1, findings/cacheaware.md).
+
+        Serving `serve` would abandon the cache-warm incumbent, so the challenger must clear
+        the SAME paired-evidence bar against the incumbent that any pick clears against the
+        safety baseline, with the pricier flag on EFFECTIVE costs (incumbent credited,
+        challenger at full prefill). None = switch justified (or gate not applicable);
+        otherwise the decision that keeps the incumbent. Quality thresholds are identical to
+        the baseline guard: cache state raises the switch's price bar, never its confidence.
+        """
+        if incumbent is None or serve == incumbent or incumbent not in bank.models:
+            return None
+        inc_index = bank.models.index(incumbent)
+        inc_paired = scored[:, serve_index] & scored[:, inc_index]
+        inc_diffs = rewards[inc_paired, serve_index] - rewards[inc_paired, inc_index]
+        inc_pairs = int(inc_diffs.size)
+        inc_mean = float(inc_diffs.mean()) if inc_pairs else 0.0
+        inc_error = float(inc_diffs.std(ddof=1)) / inc_pairs**0.5 if inc_pairs > 1 else 0.0
+        if policy.se_floor and 0 < inc_pairs < SE_FLOOR_MAX_PAIRS:
+            inc_error = max(inc_error, (0.25 / inc_pairs) ** 0.5)
+        switch_pricier = bool(effective_cost[serve_index] > effective_cost[inc_index])
+        if policy.guard_mode == "asymmetric":
+            z_switch = policy.knn_z if switch_pricier else -policy.knn_z
+        else:
+            z_switch = 2 * policy.knn_z if switch_pricier else policy.knn_z
+        if inc_pairs >= policy.knn_min_pairs and inc_mean > z_switch * inc_error:
+            return None
+        detail = (
+            f"{inc_pairs} paired neighbors vs incumbent, delta={inc_mean:+.3f}, needs "
+            f"> {z_switch:g}xSE={z_switch * inc_error:.3f} at effective prices"
+        )
+        if inc_pairs < policy.knn_min_pairs:
+            detail = f"{inc_pairs} paired neighbors vs incumbent < {policy.knn_min_pairs}"
+        return RoutingDecision(
+            model=incumbent,
+            reason=(
+                f"cache-aware switch gate: kept incumbent {incumbent}, {serve} not "
+                f"justified against it ({detail})"
+            ),
+            evidence=RoutingEvidence(
+                mean_diff=inc_mean,
+                se=inc_error,
+                n_pairs=inc_pairs,
+                gate="reverted",
+                propensity="fallback-forced",
+                cache_credit_usd=credit_applied or None,
+            ),
+        )
+
     # The cost knob prices each candidate in average-call units before the argmax; at
     # pick_lam=0 the key is the bare profile, bit-identical to the validated champion. A model
     # the bank never priced pays exactly one unit, the reference's default.
@@ -893,6 +946,9 @@ def knn_decision(
             candidates, key=lambda item: (profile[item[0]], -pool_order[item[1]])
         )
         if leader != baseline:
+            gated = switch_gate(pick_index, baseline)
+            if gated is not None:
+                return gated
             return RoutingDecision(
                 model=baseline,
                 reason=(
@@ -906,6 +962,9 @@ def knn_decision(
                     propensity="greedy", cache_credit_usd=credit_applied or None
                 ),
             )
+        gated = switch_gate(pick_index, baseline)
+        if gated is not None:
+            return gated
         return RoutingDecision(
             model=baseline,
             reason=f"knn: baseline {baseline} leads {rows.size} neighbors "
@@ -935,6 +994,10 @@ def knn_decision(
         )
         if pairs < policy.knn_min_pairs:
             detail = f"{pairs} paired neighbors < {policy.knn_min_pairs} required"
+        base_pool_index = bank.models.index(baseline)
+        gated = switch_gate(base_pool_index, baseline)
+        if gated is not None:
+            return gated
         return RoutingDecision(
             model=baseline,
             reason=f"knn guard: reverted to {baseline}, evidence insufficient ({detail})",
@@ -947,6 +1010,10 @@ def knn_decision(
                 cache_credit_usd=credit_applied or None,
             ),
         )
+    gated = switch_gate(pick_index, pick)
+    if gated is not None:
+        return gated
+
     knob = f", cost knob lam={policy.pick_lam:g}" if policy.pick_lam > 0.0 else ""
     # Only the symmetric bar doubles z for a pricier pick; the asymmetric one holds it at z.
     price_note = ""

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -324,6 +324,10 @@ class RoutingEvidence(BaseModel):
     n_pairs: int | None = None  # neighbors scored on BOTH sides, the guard's sample size
     gate: GateOutcome | None = None  # None when no gate was reached
     propensity: Propensity
+    # The incumbent's cache credit that entered this decision's cost arithmetic, in USD
+    # (cache-aware policies only; None whenever no credit was applied). What lets the request
+    # log explain a cache-driven pick: "the incumbent was effectively cheaper by this much".
+    cache_credit_usd: float | None = None
 
 
 class RoutingDecision(BaseModel):
@@ -365,6 +369,14 @@ class RoutingPolicy(BaseModel):
     beta: float = Field(default=DEFAULT_BETA, gt=0.0)
     default_rank: int = Field(default=DEFAULT_RANK, ge=1)
     sticky: bool = True  # keep a conversation's incumbent model (see module docstring)
+    # Cache-aware decisions (Silen directive, 2026-07-28): when on, a knn policy with a
+    # conversation incumbent does NOT take the unconditional sticky return; the decision runs
+    # with the incumbent's cache credit inside its COST arithmetic (the pick_lam tilt and the
+    # guard's pricier test), so stickiness becomes a priced advantage the router can weigh
+    # against quality evidence instead of a blunt rule. The quality evidence test itself is
+    # unchanged: cache state never buys quality confidence. Off (the default) is bit-identical
+    # to today for every policy file, eval, and serving path.
+    cache_aware: bool = False
     # ProxRouter-inspired support tilt (2510.09852, ADAPTED to clusters: their exponential
     # tilt reweights nonparametric scores by a prior; ours multiplies cluster probabilities
     # by support^gamma so thin outlier clusters lose routing weight). 0 = off (reference).
@@ -638,12 +650,39 @@ class RoutingPolicy(BaseModel):
             )
 
 
+CHARS_PER_TOKEN = 4  # the documented, conservative prefix estimate (design: cacheaware.md)
+
+
+def cache_credit_usd(policy: RoutingPolicy, incumbent: str, prefix_chars: int) -> float:
+    """The incumbent's expected cache saving on this request, in USD.
+
+    credit = prefix_tokens x (input rate - cached read rate) at the INCUMBENT's pool prices,
+    with prefix_tokens estimated as prefix_chars / 4 (conservative; errs low). Every other
+    model's credit is zero by definition: a switch pays full prefill. A pool entry with no
+    cached_input_per_mtok earns no credit (its cache reads bill at the full input rate,
+    matching PoolEntry.cost_usd), and an unknown incumbent earns none either.
+
+    The estimate assumes a warm provider cache, which holds inside the provider prefix-cache
+    window (~minutes); the pre-registered replay gate measures under the same assumption.
+    """
+    if prefix_chars <= 0:
+        return 0.0
+    entry = next((e for e in policy.pool if e.name == incumbent), None)
+    if entry is None or entry.cached_input_per_mtok is None:
+        return 0.0
+    saving_per_mtok = entry.price().input_per_mtok - entry.cached_input_per_mtok
+    if saving_per_mtok <= 0.0:
+        return 0.0
+    return (prefix_chars / CHARS_PER_TOKEN) * saving_per_mtok / 1_000_000
+
+
 def select_model(
     policy: RoutingPolicy,
     text: str,
     *,
     incumbent: str | None = None,
     embedder: Embedder | None = None,
+    conversation_chars: int = 0,
 ) -> RoutingDecision:
     """Pick the pool model for one request.
 
@@ -656,15 +695,29 @@ def select_model(
     `policy.embedder` (an azure spec otherwise constructs a fresh HTTP client per call); it must
     be the function this policy's spec describes, or the fitted centroids (rank) and neighbor
     bank (knn) are meaningless. Default None builds it from the spec per call.
+
+    `conversation_chars` is the length of the transcript the affinity fingerprint matched (0
+    when there is none); a cache-aware knn policy turns it into the incumbent's cache credit
+    (`cache_credit_usd`). It is ignored everywhere else, so passing it is always safe.
     """
     names = {entry.name for entry in policy.pool}
-    if incumbent is not None and incumbent in names and policy.sticky:
+    cache_aware_knn = policy.cache_aware and policy.kind == "knn" and incumbent in names
+    if incumbent is not None and incumbent in names and policy.sticky and not cache_aware_knn:
         return RoutingDecision(model=incumbent, reason="sticky: conversation affinity")
     if policy.kind == "static":
         return RoutingDecision(model=policy.default_model, reason="static policy")
 
     query = np.asarray((embedder or policy.embedder.build()).embed([text])[0])
-    decision = knn_decision(policy, query) if policy.kind == "knn" else rank_decision(policy, query)
+    if policy.kind == "knn":
+        credit = cache_credit_usd(policy, incumbent, conversation_chars) if cache_aware_knn else 0.0
+        decision = knn_decision(
+            policy,
+            query,
+            incumbent=incumbent if cache_aware_knn else None,
+            cache_credit=credit,
+        )
+    else:
+        decision = rank_decision(policy, query)
     # Normalized separately rather than by normalizing `query` first: both decision functions do
     # their own normalization in their own precision, and pre-normalizing here would perturb the
     # champion's numerical path for the sake of a logging side effect.
@@ -725,7 +778,13 @@ def rank_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
     )
 
 
-def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
+def knn_decision(
+    policy: RoutingPolicy,
+    query: np.ndarray,
+    *,
+    incumbent: str | None = None,
+    cache_credit: float = 0.0,
+) -> RoutingDecision:
     """The kNN reward-profile core with its paired guard, on an already-embedded query.
 
     Shared by `select_model` (one live request) and batch evaluation, so the served path and the
@@ -749,6 +808,12 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
     It runs on the UNTILTED evidence and after the cost knob, exactly as in the research code:
     the knob reorders candidates, and the guard then re-vetoes whatever it cannot support, so
     turning the knob up can never talk the router into a pick the evidence rejects.
+
+    Cache-aware calls (`incumbent` + `cache_credit` > 0, supplied by `select_model` when the
+    policy has `cache_aware` on) subtract the credit from THE INCUMBENT's mean cost in the two
+    places cost enters the decision: the pick_lam tilt and the guard's pricier test. With
+    credit 0 or no incumbent this function is bit-identical to the cache-blind path; quality
+    evidence (profile, paired diffs, z) never sees the credit.
     """
     if policy.kind != "knn":
         raise ValueError(f"knn_decision needs a knn policy, got kind='{policy.kind}'")
@@ -797,12 +862,24 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
             evidence=RoutingEvidence(propensity="fallback-forced"),
         )
     mean_cost = bank.mean_costs()
+    # Cache-aware: the incumbent's expected cost on THIS request is its sticker price minus
+    # the cache credit (floored at zero); every other model pays full prefill. Effective
+    # costs feed the tilt and the guard's pricier test below; with credit 0 they ARE the
+    # mean costs and the whole path is bit-identical to the cache-blind decision.
+    effective_cost = mean_cost
+    credit_applied = 0.0
+    if cache_credit > 0.0 and incumbent is not None and incumbent in bank.models:
+        inc_index = bank.models.index(incumbent)
+        if not np.isnan(mean_cost[inc_index]):
+            effective_cost = mean_cost.copy()
+            effective_cost[inc_index] = max(mean_cost[inc_index] - cache_credit, 0.0)
+            credit_applied = cache_credit
     # The cost knob prices each candidate in average-call units before the argmax; at
     # pick_lam=0 the key is the bare profile, bit-identical to the validated champion. A model
     # the bank never priced pays exactly one unit, the reference's default.
     tilt = np.zeros(profile.shape)
     if policy.pick_lam > 0.0:
-        priced = np.where(np.isnan(mean_cost), policy.cost_scale, mean_cost)
+        priced = np.where(np.isnan(effective_cost), policy.cost_scale, effective_cost)
         tilt = policy.pick_lam * priced / policy.cost_scale
     pick_index, pick = max(
         candidates, key=lambda item: (profile[item[0]] - tilt[item[0]], -pool_order[item[1]])
@@ -825,13 +902,15 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
                 ),
                 # Greedy: the baseline IS the argmax once the cost knob has priced the
                 # candidates, so nothing overrode the router's own preference.
-                evidence=RoutingEvidence(propensity="greedy"),
+                evidence=RoutingEvidence(
+                    propensity="greedy", cache_credit_usd=credit_applied or None
+                ),
             )
         return RoutingDecision(
             model=baseline,
             reason=f"knn: baseline {baseline} leads {rows.size} neighbors "
             f"(profile {profile[pick_index]:.3f})",
-            evidence=RoutingEvidence(propensity="greedy"),
+            evidence=RoutingEvidence(propensity="greedy", cache_credit_usd=credit_applied or None),
         )
 
     base_index = bank.models.index(baseline)
@@ -842,7 +921,7 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
     error = float(diffs.std(ddof=1)) / pairs**0.5 if pairs > 1 else 0.0
     if policy.se_floor and 0 < pairs < SE_FLOOR_MAX_PAIRS:
         error = max(error, (0.25 / pairs) ** 0.5)
-    pricier = bool(mean_cost[pick_index] > mean_cost[base_index])
+    pricier = bool(effective_cost[pick_index] > effective_cost[base_index])
     if policy.guard_mode == "asymmetric":
         z_effective = policy.knn_z if pricier else -policy.knn_z
     else:
@@ -865,6 +944,7 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
                 n_pairs=pairs,
                 gate="reverted",
                 propensity="fallback-forced",
+                cache_credit_usd=credit_applied or None,
             ),
         )
     knob = f", cost knob lam={policy.pick_lam:g}" if policy.pick_lam > 0.0 else ""
@@ -882,6 +962,7 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
             n_pairs=pairs,
             gate="passed",
             propensity="greedy",
+            cache_credit_usd=credit_applied or None,
         ),
     )
 

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -1405,3 +1405,16 @@ def test_cache_aware_switch_gate_allows_justified_switches() -> None:
     policy = _knn_policy(_knn_bank(rewards), knn_z=0.5, knn_min_pairs=8)
     switched = knn_decision(policy, _QUERY, incumbent="haiku-4-5", cache_credit=0.001)
     assert switched.model == "fable-5"
+
+
+def test_cache_aware_incumbent_absent_from_the_bank_sticks() -> None:
+    """An incumbent the bank was never fitted on cannot be tested, so the conversation
+    sticks with it (the amendment's conservative rule) instead of switching unjudged."""
+    rewards = [[1.0, 0.0]] * 12  # unanimous for fable, but the incumbent is not a bank column
+    policy = _knn_policy(_knn_bank(rewards), knn_z=0.5, knn_min_pairs=8)
+    kept = knn_decision(policy, _QUERY, incumbent="opus-4-8", cache_credit=0.001)
+    assert kept.model == "opus-4-8"
+    assert "not in the fitted bank" in kept.reason
+    assert kept.evidence is not None
+    assert kept.evidence.gate == "reverted"
+    assert kept.evidence.n_pairs == 0

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -29,6 +29,7 @@ from wmo.optimize.policy import (
     EmbedderSpec,
     KnnBank,
     RoutingPolicy,
+    cache_credit_usd,
     embedder_provenance,
     knn_decision,
     probe_embedder,
@@ -1270,3 +1271,111 @@ def test_a_per_cluster_override_is_version_checked_too(tmp_path: Path) -> None:
     policy.model_copy(update={"clusters": clusters}).save(path)
     with pytest.raises(ValidationError, match="fitted against version 99"):
         RoutingPolicy.load(path)
+
+
+# --- cache-aware decisions (Silen directive 2026-07-28; design in findings/cacheaware.md) ---
+
+
+def _cached_pool() -> list[PoolEntry]:
+    """The test pool with explicit prices and cache-read rates (fable pricey, haiku cheap)."""
+    return [
+        PoolEntry(
+            name="fable-5",
+            kind=ProviderKind.ANTHROPIC,
+            model="claude-fable-5",
+            input_per_mtok=10.0,
+            output_per_mtok=40.0,
+            cached_input_per_mtok=1.0,
+        ),
+        PoolEntry(
+            name="haiku-4-5",
+            kind=ProviderKind.ANTHROPIC,
+            model="claude-haiku-4-5",
+            input_per_mtok=1.0,
+            output_per_mtok=4.0,
+            cached_input_per_mtok=0.1,
+        ),
+    ]
+
+
+def test_cache_credit_formula_and_its_zero_cases() -> None:
+    policy = _knn_policy(_knn_bank([[0.0, 1.0]] * 12))
+    policy = policy.model_copy(update={"pool": _cached_pool()})
+    # 4000 chars ~= 1000 tokens; fable saves (10 - 1) per Mtok => 1000 * 9 / 1e6.
+    assert cache_credit_usd(policy, "fable-5", 4000) == pytest.approx(0.009)
+    assert cache_credit_usd(policy, "fable-5", 0) == 0.0
+    assert cache_credit_usd(policy, "a-stranger", 4000) == 0.0
+    # No cached rate on the entry: cache reads bill at the full rate, so no credit.
+    no_cache = policy.model_copy(update={"pool": _pool()})
+    assert cache_credit_usd(no_cache, "fable-5", 4000) == 0.0
+
+
+def test_cache_blind_paths_are_bit_identical_with_zero_credit() -> None:
+    """The hard invariant: no incumbent, or credit 0, must not change the decision at all."""
+    for rewards, pick_lam in ([[0.0, 1.0]] * 12, 0.0), ([[1.0, 1.0]] * 12, 0.5):
+        policy = _knn_policy(_knn_bank(rewards), pick_lam=pick_lam)
+        plain = knn_decision(policy, _QUERY)
+        with_args = knn_decision(policy, _QUERY, incumbent="fable-5", cache_credit=0.0)
+        no_incumbent = knn_decision(policy, _QUERY, incumbent=None, cache_credit=0.5)
+        assert plain.model_dump() == with_args.model_dump()
+        assert plain.model_dump() == no_incumbent.model_dump()
+
+
+def test_cache_credit_flips_the_guards_pricier_test() -> None:
+    """A cache-warm pricey incumbent is effectively cheaper, so the challenger doubles z.
+
+    7 wins / 5 losses: delta 0.167 clears z=0.5 (needs > 0.149) but not the doubled bar
+    (needs > 0.297). Cache-blind, haiku is the cheaper pick and routes; with the incumbent
+    fable credited below haiku's price, haiku becomes the effectively-pricier pick and the
+    guard reverts it. Quality evidence identical in both runs: only the billing view moved.
+    """
+    rewards = [[0.0, 1.0]] * 7 + [[1.0, 0.0]] * 5
+    policy = _knn_policy(_knn_bank(rewards), knn_z=0.5, knn_min_pairs=8)
+    blind = knn_decision(policy, _QUERY)
+    assert blind.model == "haiku-4-5"
+    assert blind.evidence is not None
+    credited = knn_decision(
+        policy,
+        _QUERY,
+        incumbent="fable-5",
+        cache_credit=_PRICEY,  # floors fable to $0
+    )
+    assert credited.model == "fable-5"
+    assert credited.evidence is not None
+    assert credited.evidence.cache_credit_usd == pytest.approx(_PRICEY)
+    # The evidence numbers the guard tested are the SAME: cache state bought no confidence.
+    assert credited.evidence.mean_diff == pytest.approx(blind.evidence.mean_diff)
+    assert credited.evidence.se == pytest.approx(blind.evidence.se)
+
+
+def test_cache_credit_reprices_the_cost_knob_tilt() -> None:
+    """Equal quality, pick_lam on: blind tilt prefers cheap haiku (then the guard reverts a
+    zero-delta pick); credited, the incumbent fable is effectively free and IS the argmax."""
+    policy = _knn_policy(_knn_bank([[1.0, 1.0]] * 12), pick_lam=0.5)
+    blind = knn_decision(policy, _QUERY)
+    assert blind.model == "fable-5"
+    assert blind.evidence is not None and blind.evidence.gate == "reverted"
+    credited = knn_decision(policy, _QUERY, incumbent="fable-5", cache_credit=_PRICEY)
+    assert credited.model == "fable-5"
+    assert credited.evidence is not None
+    assert credited.evidence.gate is None  # baseline led the priced argmax outright
+    assert credited.evidence.cache_credit_usd == pytest.approx(_PRICEY)
+
+
+def test_select_model_cache_aware_prices_the_incumbent_instead_of_sticking() -> None:
+    rewards = [[0.0, 1.0]] * 12  # haiku dominates on evidence
+    bank = _knn_bank(rewards)
+    sticky = _knn_policy(bank)
+    aware = _knn_policy(bank).model_copy(update={"cache_aware": True, "pool": _cached_pool()})
+    aware.attach_bank(bank)
+    kwargs = {"incumbent": "fable-5", "embedder": _UnitEmbedder(), "conversation_chars": 4000}
+    stuck = select_model(sticky, "anything", **kwargs)
+    assert stuck.reason == "sticky: conversation affinity"
+    routed = select_model(aware, "anything", **kwargs)
+    # The evidence overwhelms the credit: cache-aware routing may still switch.
+    assert routed.model == "haiku-4-5"
+    assert routed.evidence is not None and routed.evidence.gate == "passed"
+    # And with no incumbent the cache-aware policy behaves exactly like today.
+    fresh_aware = select_model(aware, "anything", embedder=_UnitEmbedder())
+    fresh_sticky = select_model(sticky, "anything", embedder=_UnitEmbedder())
+    assert fresh_aware.model_dump() == fresh_sticky.model_dump()

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -1379,3 +1379,29 @@ def test_select_model_cache_aware_prices_the_incumbent_instead_of_sticking() -> 
     fresh_aware = select_model(aware, "anything", embedder=_UnitEmbedder())
     fresh_sticky = select_model(sticky, "anything", embedder=_UnitEmbedder())
     assert fresh_aware.model_dump() == fresh_sticky.model_dump()
+
+
+def test_cache_aware_switch_gate_blocks_unjustified_switches() -> None:
+    """7/5 mixed evidence clears the baseline guard for haiku but NOT the switch gate when
+    the incumbent is haiku itself... exercised the other way: incumbent haiku, evidence says
+    baseline fable leads -> switching back to fable must be justified AGAINST haiku."""
+    # Fable wins 7, haiku wins 5: fable leads the profile, blind decision serves fable.
+    rewards = [[1.0, 0.0]] * 7 + [[0.0, 1.0]] * 5
+    policy = _knn_policy(_knn_bank(rewards), knn_z=0.5, knn_min_pairs=8)
+    blind = knn_decision(policy, _QUERY)
+    assert blind.model == "fable-5"
+    # Cache-aware with incumbent haiku: fable's edge over haiku (delta +0.167) does not clear
+    # the doubled bar (fable is pricier, effectively too: no credit can rescue a switch TO a
+    # pricier model), so the conversation stays on haiku.
+    kept = knn_decision(policy, _QUERY, incumbent="haiku-4-5", cache_credit=0.001)
+    assert kept.model == "haiku-4-5"
+    assert "switch gate" in kept.reason
+    assert kept.evidence is not None and kept.evidence.gate == "reverted"
+
+
+def test_cache_aware_switch_gate_allows_justified_switches() -> None:
+    """Unanimous evidence against the incumbent clears the switch gate."""
+    rewards = [[1.0, 0.0]] * 12  # fable always wins, haiku always loses
+    policy = _knn_policy(_knn_bank(rewards), knn_z=0.5, knn_min_pairs=8)
+    switched = knn_decision(policy, _QUERY, incumbent="haiku-4-5", cache_credit=0.001)
+    assert switched.model == "fable-5"

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -771,12 +771,25 @@ class EndpointRuntime:
         exactly what the model will see.
         """
         incumbent = None
+        conversation_chars = 0
         remembered = _remembered_prefix(messages)
         if remembered is not None:
             with self._lock:
                 incumbent = self._affinity.get(_fingerprint(remembered))
+            if incumbent is not None:
+                # The transcript the fingerprint matched IS the shared prefix a warm cache
+                # would cover; its length feeds the cache-aware credit (chars/4 tokens,
+                # documented in `cache_credit_usd`). Content only: tool payloads are part of
+                # the prefix too, so this errs conservative, which is the designed direction.
+                conversation_chars = sum(len(m.content or "") for m in remembered)
         text = route_text if route_text is not None else _routable_text(messages)
-        return select_model(self.policy, text, incumbent=incumbent, embedder=self._embedder())
+        return select_model(
+            self.policy,
+            text,
+            incumbent=incumbent,
+            embedder=self._embedder(),
+            conversation_chars=conversation_chars,
+        )
 
     def record_query_embedding(self, record_id: str, decision: RoutingDecision) -> str | None:
         """Persist the vector `decision` was routed on, returning the log row's ref (or None).


### PR DESCRIPTION
Implements Silen's directive: the routing decision's cost arithmetic now includes cached tokens. Design, pre-registered gate, amendment, and scoring in `wmh-routing-data/findings/cacheaware.md`; vocabulary registered in DECISIONS 2026-07-28. For the routing master's co-sign (routing-serving delta).

## Mechanism (additive; default OFF is bit-identical everywhere)

- `RoutingPolicy.cache_aware: bool = False`. When ON with a conversation incumbent, a knn policy prices stickiness instead of applying it blindly:
  - `cache_credit_usd()` = remembered-prefix chars/4 tokens x (input - cached rate) at the incumbent's pool prices (0 for every other model: a switch pays full prefill; 0 without a cached rate, matching `PoolEntry.cost_usd`).
  - The credit enters the `pick_lam` tilt and every pricier test. Quality evidence (profile, paired diffs, z, min_pairs, se_floor) never sees it.
  - **Switch gate** (design amendment 1): any decision that would abandon the incumbent must clear the same paired-evidence bar AGAINST the incumbent at effective prices. Baseline safety guard unchanged and runs first.
- `RoutingEvidence.cache_credit_usd` explains cache-driven picks in the request log; serving's `decide()` passes the remembered-prefix length through `select_model(conversation_chars=...)`.

## Invariant and proofs

- No incumbent (offline eval, first turn) or knob off: `knn_decision` byte-identical (tests both directions). All 4,123 tests green; ruff/ty clean.
- #259 promotion gate re-run on the branch: reproduces the champion exactly. `validate_cost_quality.py`: VALIDATION PASSED.

## Pre-registered gate (5 seeds paired, deterministic billing from pool prices + logged tokens)

| replay | pick_lam | effective-cost saving | quality delta | verdict |
|---|---|---|---|---|
| repeat traffic | 0.08 (dial savings point) | **+2.08%, 5/5 seeds** | -0.0007 +- 0.0013 (parity) | **PASS** |
| repeat traffic | 0.00 | +0.33%, 3/5 | +0.0000 | tie |
| conversations (heterogeneous stress) | 0.00 / 0.08 | -4.2% / -5.3% | **+1.7 / +2.6 pt (significant)** | fails cost bar; guarded quality-buy |

Honest notes: the conversation stress case chains RANDOM scenarios (maximally heterogeneous turns, worst case for stickiness; real traffic is topically coherent). Predictions scored in findings, including the miss on saving magnitude (ours9 prefixes are short).

## Proposed disposition

Ship as opt-in, default OFF, recommended with `pick_lam > 0` (the dial's savings leg); the R2 quality-buy profile is documented on the knob. The switch gate also fixes blunt stickiness: a conversation can now escape a bad incumbent with statistical justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)