### PR TITLE
Default the GEPA judge to Opus 5 on Anthropic-backed providers

### DIFF
--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -75,22 +75,27 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-opus-4-7",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
+        "claude-opus-5",
     ],
     # Keep this picker curated to inference profiles verified by the normal interactive flow.
     # The full canonical registry remains available to flags and programmatic callers.
-    "bedrock": ["claude-opus-4-8", "claude-opus-4-7", "claude-haiku-4-5"],
+    "bedrock": ["claude-opus-4-8", "claude-opus-4-7", "claude-haiku-4-5", "claude-opus-5"],
     # openai_responses (the Responses API) stays flag-only (`wmo build --provider
     # openai_responses`); the wizard list keeps to the four everyday backends.
     "azure": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 
-# Default GEPA judge model per provider: a cheap, fast model of the same backend. Providers
-# without an entry judge on the serve model itself.
+# Default GEPA judge model per provider. Anthropic-backed providers default to the STRONGEST
+# judge, not the cheapest: the tau sim-to-real probe measured the haiku-4-5 default scoring
+# correct-inaction episodes as failures, which inverted the benchmark's model ranking against
+# reality (DECISIONS 2026-07-28); a judge that cannot follow the domain policy is expensive at
+# any price. Providers without an entry judge on the serve model itself. A judge change is a
+# new fidelity era: never compare rewards across judges.
 _JUDGE_MODEL_DEFAULTS: dict[str, str] = {
-    "anthropic": "claude-haiku-4-5",
+    "anthropic": "claude-opus-5",
     "openai": "gpt-5.4-mini",
-    "bedrock": "claude-haiku-4-5",
+    "bedrock": "claude-opus-5",
 }
 
 

--- a/wmo/cli/ui_test.py
+++ b/wmo/cli/ui_test.py
@@ -266,7 +266,7 @@ def test_build_wizard_collects_all_inputs() -> None:
     assert params.file == "/tmp/traces.jsonl"
     assert params.provider == "bedrock"
     assert params.region == "us-east-1"
-    assert params.judge_model == "claude-haiku-4-5"
+    assert params.judge_model == "claude-opus-5"
     assert params.fidelity == "high"
     assert params.embed_provider == "hashing"
     assert params.train_split == 0.5
@@ -286,7 +286,7 @@ def test_build_wizard_select_by_number() -> None:
     )
     assert params.provider == "anthropic"
     assert params.model == "claude-opus-4-7"  # second anthropic model
-    assert params.judge_model == "claude-haiku-4-5"  # blank accepted the anthropic judge default
+    assert params.judge_model == "claude-opus-5"  # blank accepted the anthropic judge default
     assert params.region is None  # region only prompted for bedrock
     assert params.embed_provider == "hashing"
 

--- a/wmo/providers/models.py
+++ b/wmo/providers/models.py
@@ -99,6 +99,13 @@ _MODELS: tuple[ProviderModel, ...] = (
         model_id="claude-haiku-4-5",
     ),
     ProviderModel(
+        provider=ProviderKind.ANTHROPIC,
+        model_type="claude-opus-5",
+        model_id="claude-opus-5",
+        # Like Opus 4.8, Opus 5 rejects forwarded sampling parameters.
+        forward_temperature=False,
+    ),
+    ProviderModel(
         provider=ProviderKind.BEDROCK,
         model_type="claude-opus-4-8",
         model_id="us.anthropic.claude-opus-4-8",
@@ -120,6 +127,13 @@ _MODELS: tuple[ProviderModel, ...] = (
         provider=ProviderKind.BEDROCK,
         model_type="claude-haiku-4-5",
         model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="claude-opus-5",
+        # Inference-profile id verified live on this account (converse OK, 2026-07-28).
+        model_id="us.anthropic.claude-opus-5",
+        forward_temperature=False,
     ),
     ProviderModel(provider=ProviderKind.BEDROCK, model_type="glm-5", model_id="zai.glm-5"),
     ProviderModel(


### PR DESCRIPTION
## Why

The tau sim-to-real probe (DECISIONS 2026-07-28, cost corner) measured the haiku-4-5 judge default scoring correct-inaction episodes as failures: on tau2's explain-policy-and-do-nothing tasks, transcripts showing correct refusals got critiques of the form "you only retrieved the reservation details and took no action" and rewards of 0.0, while real tau2 scored the same behavior 1.00. That underrated fable-5 by 33 points and inverted the benchmark's top-of-pool ranking against reality. Silen's ruling: Opus 5 is the judge by default; merge immediately.

## What

- `_JUDGE_MODEL_DEFAULTS`: anthropic and bedrock default to `claude-opus-5`. openai keeps `gpt-5.4-mini` (the judge runs on the serve provider's backend; there is no Anthropic route there - flagged, not changed).
- `claude-opus-5` registered in the model catalog for anthropic (`claude-opus-5`) and bedrock (`us.anthropic.claude-opus-5`, inference profile verified live with a converse call on this account). `forward_temperature=False`, matching Opus 4.8's rejected-sampling-params behavior.
- Entries appended at the END of each provider's registry block so first-entry resolution defaults elsewhere (eval grid's pinned judge, `_DEFAULT_WORKER_MODEL` fallback) are byte-identical - those are separate pinned instruments with their own comparability eras, and changing them is their owners' decision (follow-up flagged below).
- Wizard pickers gain `claude-opus-5` as a selectable option (appended, so numbered-selection defaults are unchanged).

## Ledger (justification discipline)

Every addition has a consumer: the registry entries are consumed by `judge_model_default` resolution and the wizard picker; the test updates pin the new default. No removals.

## Consequences callers must know

- A judge change is a NEW FIDELITY ERA: rewards scored under haiku-4-5-judged builds never compare against opus-5-judged builds. Existing artifacts keep their recorded `judge_model` and are unaffected until rebuilt.
- Judge cost rises (~50x haiku per Mtok); the probe evidence says the haiku judge's rankings were wrong enough to invert a benchmark, which is more expensive.
- Follow-ups deliberately NOT taken here: `wmo eval grid`'s pinned judge (`us.anthropic.claude-opus-4-8`) and the rubric's correct-inaction clause (filed in DECISIONS; /improve-judge with the 8 divergent tau scenarios as the labeled regression set).

## Gates

ruff clean, ty clean, 291 tests green across `wmo/cli`, `wmo/providers`, `wmo/config` (two wizard tests updated to the new default; registry-order tests pass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)