### PR TITLE
Resumed runs read their descending frontier; an unknown status costs only itself

### DIFF
--- a/wmo/runs/hooks.py
+++ b/wmo/runs/hooks.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from threading import Lock
@@ -55,7 +55,7 @@ from wmo.optimize.outcomes import ScenarioOutcome
 from wmo.optimize.pipeline import Stage, StageRecord
 from wmo.runs.backfill import cell_payload
 from wmo.runs.client import ControlCommand, PushAck, PushRejected, RunsSink, runs_sink
-from wmo.runs.reader import RunsReader
+from wmo.runs.reader import EventRow, RunsReader
 from wmo.runs.schema import (
     CELL_BATCH_CAP,
     LEDGER_LINE,
@@ -84,10 +84,14 @@ QUEUE_LIMIT = 2000
 """Events held in memory when the platform is unreachable. Past this the oldest are dropped: a run
 that cannot reach the platform for hours must not convert telemetry into memory pressure."""
 
-FRONTIER_SAMPLE = 50
-"""Descending events read when locating a resumed run's frontier. The newest one carries it (each
-successive descending seq is lower than the last), so a small window is enough; the sample only has
-to survive a few events of another band interleaving."""
+FRONTIER_PAGE = 500
+"""Events per page of the frontier read, matching the route's own default."""
+
+FRONTIER_MAX_PAGES = 40
+"""Pages the frontier scan will walk (20k type-filtered events) before giving up. A scan that has to
+STOP EARLY reports no frontier at all rather than the lowest seq it happened to reach: a partial
+scan's minimum is higher than the true frontier, so using it would re-issue seqs, which is the exact
+failure this read exists to prevent."""
 
 FrontierReader = Callable[[str, int], int | None]
 """Reports a run's DESCENDING frontier in one band, or None when it has none yet (or cannot be
@@ -145,13 +149,82 @@ def _status_value(status: RunStatus | str) -> str | None:
         return None
 
 
-def platform_frontier(external_id: str, band: int) -> int | None:
-    """Read a run's descending frontier in one band from the platform, or None when it has none.
+def frontier_from_reader(reader: RunsReader, external_id: str, band: int) -> int | None:
+    """The LOWEST descending seq one band holds, which is that walk's frontier.
 
-    Two type-filtered tail reads rather than a scan of the log: the descending walk only ever
-    carries heartbeats and a live `run.status`, and the server filters by type in the database, so
-    this stays small on a run with a hundred thousand cells. Returns the LOWEST such seq inside the
-    band, which is the frontier by construction.
+    Two properties make this cheap and exact. Only heartbeats and a live `run.status` ever descend,
+    and the server filters by type in the database, so the scan sees a few thousand rows on a run
+    with a hundred thousand cells. And within a band the descending seqs strictly DECREASE over
+    time, so the most recently arrived one is the lowest: a newest-first window that contains any of
+    this band's events already contains its frontier.
+
+    That is why the tail read is a fast path rather than a heuristic, and why it is not enough on
+    its own. Sibling chunk processes share one run's log under their own bands, so a busy sibling's
+    heartbeats can fill the newest page and leave none of this band's in it. Finding nothing there
+    means "look further", NOT "there is no frontier": treating it as the latter leaves the ceiling
+    spent and re-issues a dead process's terminal status.
+
+    Returns None only when the run genuinely holds no descending event in this band, or when the
+    scan could not be completed (see `FRONTIER_MAX_PAGES`).
+    """
+    floor = band * RUN_SEQ_BAND
+    ceiling = (band + 1) * RUN_SEQ_BAND
+
+    def lowest_of(events: Iterable[EventRow]) -> int | None:
+        mine = [event.seq for event in events if floor < event.seq <= ceiling]
+        return min(mine) if mine else None
+
+    lowest: int | None = None
+    for event_type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS):
+        newest = reader.list_events(
+            external_id, tail=True, limit=FRONTIER_PAGE, event_type=event_type
+        )
+        found = lowest_of(newest.events)
+        if found is None:
+            found = _scan_for_frontier(reader, external_id, event_type, lowest_of)
+        if found is not None and (lowest is None or found < lowest):
+            lowest = found
+    return lowest
+
+
+def _scan_for_frontier(
+    reader: RunsReader,
+    external_id: str,
+    event_type: str,
+    lowest_of: Callable[[Iterable[EventRow]], int | None],
+) -> int | None:
+    """Page one event type from the start of the log, returning the band's lowest seq.
+
+    Only reached when the newest page held nothing for this band, which on a chunked arm means a
+    sibling's traffic pushed it out. Gives up rather than guessing past `FRONTIER_MAX_PAGES`,
+    because a partial answer is worse than none here: it would be too HIGH, and rebasing to a seq
+    above the true frontier re-issues the ones between.
+    """
+    cursor = 0
+    lowest: int | None = None
+    for _page in range(FRONTIER_MAX_PAGES):
+        page = reader.list_events(
+            external_id, after_pos=cursor, limit=FRONTIER_PAGE, event_type=event_type
+        )
+        found = lowest_of(page.events)
+        if found is not None and (lowest is None or found < lowest):
+            lowest = found
+        if not page.events or page.last_pos <= cursor:
+            return lowest
+        cursor = page.last_pos
+    log.warning(
+        "run telemetry for %s: gave up locating the %s frontier after %d pages, so this "
+        "invocation's heartbeats may collide with the previous one's and be discarded. The run "
+        "itself is unaffected.",
+        external_id,
+        event_type,
+        FRONTIER_MAX_PAGES,
+    )
+    return None
+
+
+def platform_frontier(external_id: str, band: int) -> int | None:
+    """`frontier_from_reader` against the saved credential, or None when this machine cannot read.
 
     Never raises: a machine that cannot read simply does not rebase (`_rebase_descending` treats
     None as "leave the ceiling alone"), which costs a resumed run's heartbeats and not the run.
@@ -159,18 +232,8 @@ def platform_frontier(external_id: str, band: int) -> int | None:
     reader = RunsReader.open()
     if reader is None:
         return None
-    floor = band * RUN_SEQ_BAND
-    ceiling = (band + 1) * RUN_SEQ_BAND
-    lowest: int | None = None
     with reader:
-        for event_type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS):
-            page = reader.list_events(
-                external_id, tail=True, limit=FRONTIER_SAMPLE, event_type=event_type
-            )
-            for event in page.events:
-                if floor < event.seq <= ceiling and (lowest is None or event.seq < lowest):
-                    lowest = event.seq
-    return lowest
+        return frontier_from_reader(reader, external_id, band)
 
 
 def _undeclared(refused: PushRejected) -> bool:
@@ -804,16 +867,21 @@ class GridEmitter(_Reporter):
         self._handle(self._flush())
 
     def on_status(self, status: RunStatus, *, error: str | None = None) -> None:
-        """The run's terminal transition. Sends buffered cells first, so none are lost."""
+        """The run's terminal transition. Sends buffered cells first, so none are lost.
+
+        A status this build cannot name is skipped rather than sent (`_status_value`), but the run
+        still ENDED, so everything else here happens anyway. In particular a pending `stop` is acked
+        either way: the command WAS honored, and leaving it pending would show a stop as in-flight
+        forever on a run that has already finished.
+        """
         self.send_cells()
         finished_at = now_iso()
         value = _status_value(status)
-        if value is None:
-            return
-        payload: JsonObject = {"status": value, "finished_at": finished_at}
-        if error is not None:
-            payload["error"] = error
-        self._emit_from_top(self._band, RunEventType.RUN_STATUS, finished_at, payload)
+        if value is not None:
+            payload: JsonObject = {"status": value, "finished_at": finished_at}
+            if error is not None:
+                payload["error"] = error
+            self._emit_from_top(self._band, RunEventType.RUN_STATUS, finished_at, payload)
         self._flush()
         for control in self._stop_control:
             self._ack(control, status=ACK_DONE, note=f"run {status}")
@@ -1010,13 +1078,16 @@ class PipelineEmitter(_Reporter):
         self._flush()
 
     def finished(self, status: RunStatus, *, error: str | None = None) -> None:
-        """The run's terminal transition: completed, failed, or stopped by the spend cap."""
+        """The run's terminal transition: completed, failed, or stopped by the spend cap.
+
+        A status this build cannot name is skipped rather than sent (`_status_value`); the flush
+        still happens, so whatever the last stage queued is not stranded behind it.
+        """
         finished_at = now_iso()
         value = _status_value(status)
-        if value is None:
-            return
-        payload: JsonObject = {"status": value, "finished_at": finished_at}
-        if error is not None:
-            payload["error"] = error
-        self._emit(RUN_LEVEL_BAND, RunEventType.RUN_STATUS, finished_at, payload)
+        if value is not None:
+            payload: JsonObject = {"status": value, "finished_at": finished_at}
+            if error is not None:
+                payload["error"] = error
+            self._emit(RUN_LEVEL_BAND, RunEventType.RUN_STATUS, finished_at, payload)
         self._flush()

--- a/wmo/runs/hooks.py
+++ b/wmo/runs/hooks.py
@@ -55,6 +55,7 @@ from wmo.optimize.outcomes import ScenarioOutcome
 from wmo.optimize.pipeline import Stage, StageRecord
 from wmo.runs.backfill import cell_payload
 from wmo.runs.client import ControlCommand, PushAck, PushRejected, RunsSink, runs_sink
+from wmo.runs.reader import RunsReader
 from wmo.runs.schema import (
     CELL_BATCH_CAP,
     LEDGER_LINE,
@@ -83,6 +84,15 @@ QUEUE_LIMIT = 2000
 """Events held in memory when the platform is unreachable. Past this the oldest are dropped: a run
 that cannot reach the platform for hours must not convert telemetry into memory pressure."""
 
+FRONTIER_SAMPLE = 50
+"""Descending events read when locating a resumed run's frontier. The newest one carries it (each
+successive descending seq is lower than the last), so a small window is enough; the sample only has
+to survive a few events of another band interleaving."""
+
+FrontierReader = Callable[[str, int], int | None]
+"""Reports a run's DESCENDING frontier in one band, or None when it has none yet (or cannot be
+read). Injected, because locating it needs a read the emitter otherwise never makes."""
+
 SinkFactory = Callable[[], "RunsSink | None"]
 """Opens the transport, or returns None when this machine cannot push. Injected so a test can drive
 the real sink over a fake transport, and so `--no-emit` needs no special case."""
@@ -108,13 +118,19 @@ REJECT_FORCE_FROM_STAGE = (
 )
 
 
-def _status_value(status: RunStatus | str) -> str:
-    """A status as JSON carries it, without ever raising over an unrecognized one.
+def _status_value(status: RunStatus | str) -> str | None:
+    """A status as JSON carries it, or None when this build cannot name it.
 
     `RunStatus(status)` would be the tidy normalization, and it raises on a value outside the enum,
     which is exactly what these hooks may not do: a caller (or a future status this build has not
-    heard of) must not be able to end a paid run through the telemetry path. An unknown status is
-    passed through as text and the platform decides what to make of it.
+    heard of) must not be able to end a paid run through the telemetry path.
+
+    Sending it as text is equally wrong, and less obviously so: the platform's status vocabulary is
+    CLOSED, so an unrecognized value is refused as a permanent 4xx, and a permanent refusal drops
+    the whole batch - including the ledger lines and cells riding with it. One unknown status would
+    cost a chunk's telemetry rather than its own event. So the event is skipped instead: the run
+    stays whatever the platform last heard, which is honest, and the warning names what was
+    dropped.
     """
     if isinstance(status, RunStatus):
         return status.value
@@ -122,9 +138,39 @@ def _status_value(status: RunStatus | str) -> str:
         return RunStatus(status).value
     except ValueError:
         log.warning(
-            "run telemetry: %r is not a status this build knows; sending it as text", status
+            "run telemetry: %r is not a status this build knows; not reporting it "
+            "(the platform refuses unknown statuses, and the refusal would drop the batch)",
+            status,
         )
-        return str(status)
+        return None
+
+
+def platform_frontier(external_id: str, band: int) -> int | None:
+    """Read a run's descending frontier in one band from the platform, or None when it has none.
+
+    Two type-filtered tail reads rather than a scan of the log: the descending walk only ever
+    carries heartbeats and a live `run.status`, and the server filters by type in the database, so
+    this stays small on a run with a hundred thousand cells. Returns the LOWEST such seq inside the
+    band, which is the frontier by construction.
+
+    Never raises: a machine that cannot read simply does not rebase (`_rebase_descending` treats
+    None as "leave the ceiling alone"), which costs a resumed run's heartbeats and not the run.
+    """
+    reader = RunsReader.open()
+    if reader is None:
+        return None
+    floor = band * RUN_SEQ_BAND
+    ceiling = (band + 1) * RUN_SEQ_BAND
+    lowest: int | None = None
+    with reader:
+        for event_type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS):
+            page = reader.list_events(
+                external_id, tail=True, limit=FRONTIER_SAMPLE, event_type=event_type
+            )
+            for event in page.events:
+                if floor < event.seq <= ceiling and (lowest is None or event.seq < lowest):
+                    lowest = event.seq
+    return lowest
 
 
 def _undeclared(refused: PushRejected) -> bool:
@@ -178,6 +224,7 @@ class _Reporter:
         *,
         queue_limit: int = QUEUE_LIMIT,
         top_band: int | None = None,
+        frontier: FrontierReader | None = None,
     ) -> None:
         """Hold the transport for one run, or None when emission is off.
 
@@ -186,6 +233,7 @@ class _Reporter:
         """
         self._sink = sink
         self._top_band = top_band
+        self._frontier = frontier
         # The run's declaration. Kept out of the queue's eviction path and re-sendable: the platform
         # refuses every batch of an undeclared run, so losing this one event would end the run's
         # telemetry permanently rather than costing one event.
@@ -259,18 +307,36 @@ class _Reporter:
         # walk expects it, or every ledger line would be renumbered off its artifact position.
         if 0 < ack.last_seq <= RUN_SEQ_BAND:
             self._bands.resume_at(RUN_LEVEL_BAND, ack.last_seq + 1)
-        # And the descending walk, which nothing else rebases: a heartbeat and a terminal status
-        # have no artifact position, so a re-invocation that restarts at the ceiling re-issues
-        # exactly the seqs it used last time.
-        band = self._top_band
-        if band is not None and self._bands.band_start(
-            band
-        ) <= ack.last_seq <= self._bands.band_end(band):
-            self._bands.resume_from_top(band, ack.last_seq - 1)
+        # And the descending walk, which nothing else rebases and which `last_seq` cannot locate
+        # (see `_rebase_descending`).
+        self._rebase_descending()
         self._resumed_from = ack.last_seq
         self._resumed = ack.last_seq > 0
         self._pulled_at_resume = ack.control
         return ack.last_seq
+
+    def _rebase_descending(self) -> None:
+        """Continue the descending walk below where the previous invocation left it.
+
+        This needs a READ, and `last_seq` cannot substitute for it: a descending walk's frontier is
+        the MINIMUM of the seqs it issued, `last_seq` is the maximum over the whole run, and a
+        maximum cannot locate a minimum. Rebasing from `last_seq - 1` re-issues every descending seq
+        but the first, which costs the terminal status and leaves a finished run reading `running`.
+
+        Reading it is cheap because the newest descending event IS the frontier: each successive one
+        is lower than the last. A run with no descending events yet has no frontier, and the ceiling
+        is already correct, so None means "leave it alone".
+        """
+        band = self._top_band
+        if band is None or self._frontier is None:
+            return
+        frontier: int | None = None
+        with self._quiet("could not locate the run's heartbeat frontier"):
+            frontier = self._frontier(self._external_id, band)
+        if frontier is None:
+            return
+        with self._quiet("could not rebase the heartbeat walk"):
+            self._bands.resume_from_top(band, frontier - 1)
 
     def _emit(self, band: int, event_type: str, ts: str, payload: JsonObject) -> None:
         """Number one event from its band's ascending walk and hold it for the next flush.
@@ -569,11 +635,14 @@ class GridEmitter(_Reporter):
         flush_cells: int = CELL_BATCH_CAP,
         flush_seconds: float = HEARTBEAT_INTERVAL_S,
         queue_limit: int = QUEUE_LIMIT,
+        frontier: FrontierReader | None = None,
     ) -> None:
         """Build the emitter directly. Most callers want `create`, which resolves the sink."""
         # `top_band` is this writer's own band: its heartbeats and terminal status descend from that
         # ceiling, so a resume has to rebase that walk too or it re-issues the same seqs.
-        super().__init__(sink, external_id, queue_limit=queue_limit, top_band=band)
+        super().__init__(
+            sink, external_id, queue_limit=queue_limit, top_band=band, frontier=frontier
+        )
         self._band = band
         self._arm = arm
         self._snapshot = snapshot
@@ -599,6 +668,7 @@ class GridEmitter(_Reporter):
         requested: bool = True,
         flush_cells: int = CELL_BATCH_CAP,
         flush_seconds: float = HEARTBEAT_INTERVAL_S,
+        frontier: FrontierReader | None = None,
     ) -> GridEmitter:
         """Build the emitter for one arm, off unless a credential and an organization resolve.
 
@@ -614,6 +684,8 @@ class GridEmitter(_Reporter):
                 credentials at all.
             flush_cells: Cells buffered before a send.
             flush_seconds: Age at which a partial buffer is sent anyway.
+            frontier: Locates a resumed run's descending frontier; defaults to reading it from the
+                platform. Only consulted when emission is on.
         """
         external_id = grid_arm_external_id(grid_relpath, arm)
         return cls(
@@ -624,6 +696,7 @@ class GridEmitter(_Reporter):
             snapshot=snapshot,
             flush_cells=flush_cells,
             flush_seconds=flush_seconds,
+            frontier=frontier if frontier is not None else platform_frontier,
         )
 
     @property
@@ -734,7 +807,10 @@ class GridEmitter(_Reporter):
         """The run's terminal transition. Sends buffered cells first, so none are lost."""
         self.send_cells()
         finished_at = now_iso()
-        payload: JsonObject = {"status": _status_value(status), "finished_at": finished_at}
+        value = _status_value(status)
+        if value is None:
+            return
+        payload: JsonObject = {"status": value, "finished_at": finished_at}
         if error is not None:
             payload["error"] = error
         self._emit_from_top(self._band, RunEventType.RUN_STATUS, finished_at, payload)
@@ -936,7 +1012,10 @@ class PipelineEmitter(_Reporter):
     def finished(self, status: RunStatus, *, error: str | None = None) -> None:
         """The run's terminal transition: completed, failed, or stopped by the spend cap."""
         finished_at = now_iso()
-        payload: JsonObject = {"status": _status_value(status), "finished_at": finished_at}
+        value = _status_value(status)
+        if value is None:
+            return
+        payload: JsonObject = {"status": value, "finished_at": finished_at}
         if error is not None:
             payload["error"] = error
         self._emit(RUN_LEVEL_BAND, RunEventType.RUN_STATUS, finished_at, payload)

--- a/wmo/runs/hooks_test.py
+++ b/wmo/runs/hooks_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import cast
 
 import pytest
 from pydantic import BaseModel, ConfigDict
@@ -21,6 +22,7 @@ from wmo.runs.hooks import (
     CONTROL_FORCE_FROM_STAGE,
     CONTROL_RETRY_UNSCORED,
     CONTROL_STOP,
+    FrontierReader,
     GridEmitter,
     GridSnapshot,
     PipelineEmitter,
@@ -93,6 +95,9 @@ class FakeTransport:
         # here is what lets a test fail on a collision at all: a double that accepts everything
         # cannot distinguish the band design working from the band design being broken.
         self.held: set[int] = set(range(1, held_last_seq + 1)) if held_last_seq else set()
+        # Type per held seq, so the double can answer the frontier read the way the platform's
+        # type-filtered tail does.
+        self.held_types: dict[int, str] = {}
 
     def push_run_events(
         self,
@@ -126,6 +131,8 @@ class FakeTransport:
         seqs = [int(str(event["seq"])) for event in events]
         fresh = [seq for seq in seqs if seq not in self.held]
         self.held.update(seqs)
+        for event in events:
+            self.held_types.setdefault(int(str(event["seq"])), str(event["type"]))
         return {
             "accepted": len(fresh) if self._accepted is None else self._accepted,
             "last_seq": max(self.held),
@@ -174,6 +181,26 @@ def _no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("wmo.runs.client.PUSH_BACKOFF_SECONDS", 0.0)
 
 
+def _frontier_of(transport: FakeTransport) -> FrontierReader:
+    """The frontier read, answered from what the double holds.
+
+    Same rule as `platform_frontier`: the LOWEST heartbeat or `run.status` seq inside the band,
+    which is where the previous invocation's descending walk stopped.
+    """
+
+    def read(external_id: str, band: int) -> int | None:
+        floor, ceiling = band * RUN_SEQ_BAND, (band + 1) * RUN_SEQ_BAND
+        descending = [
+            seq
+            for seq, event_type in transport.held_types.items()
+            if floor < seq <= ceiling
+            and event_type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS)
+        ]
+        return min(descending) if descending else None
+
+    return read
+
+
 def _sink(transport: FakeTransport) -> RunsSink:
     return RunsSink(transport, org_id=ORG, emitter_id="test")
 
@@ -186,6 +213,7 @@ def _grid(
         arm=ARM,
         band=band,
         factory=lambda: _sink(transport),
+        frontier=_frontier_of(transport),
         snapshot=lambda: GridSnapshot(done=4, scored=3, total=10, candidate_usd=1.5, wm_usd=3.0),
         flush_cells=flush_cells,
     )
@@ -724,11 +752,89 @@ def test_an_unreachable_probe_is_not_read_as_a_fresh_run() -> None:
     assert transport.of_type("heartbeat")[0].seq > 7
 
 
-def test_an_unknown_status_is_reported_rather_than_raised() -> None:
-    """Telemetry may not end a paid run, not even over a status this build has not heard of."""
+def test_an_unknown_status_is_skipped_rather_than_raised_or_sent() -> None:
+    """Telemetry may not end a paid run, and may not cost a batch, over an unknown status.
+
+    Two wrong answers are available here. Raising ends a paid run through the telemetry path.
+    Sending the value as text is refused by the platform's closed vocabulary as a permanent 4xx,
+    and a permanent refusal drops the whole batch, so one unknown status would take the ledger
+    lines and cells riding with it. Skipping the event costs only the event.
+    """
     transport = FakeTransport()
     emitter = _declared(transport)
+    ledger_before = len(transport.of_type("ledger.line"))
 
-    emitter.on_status("canceled")  # type: ignore[arg-type]
+    # Cast rather than ignore: the point is a value OUTSIDE the vocabulary, which a correct caller
+    # cannot produce but a future platform status could.
+    emitter.on_status(cast("RunStatus", "canceled"))
+    emitter.on_ledger_line({"event": "merge", "arm": ARM}, ts=_ts(9), position=9)
 
-    assert transport.of_type("run.status")[0].payload["status"] == "canceled"
+    assert transport.of_type("run.status") == []
+    # The batch behind it is untouched: skipping the event is not skipping the run.
+    assert len(transport.of_type("ledger.line")) == ledger_before + 1
+
+
+def test_a_resumed_arm_with_several_descending_events_does_not_re_use_any() -> None:
+    """The frontier of a descending walk is its MINIMUM, and `last_seq` is a maximum.
+
+    A maximum cannot locate a minimum, so rebasing from `last_seq - 1` re-issues every descending
+    seq the previous invocation used except its first: two heartbeats and a terminal status become
+    two heartbeats and a terminal status the platform discards. The terminal one is the expensive
+    loss, because a finished run then reads `running` forever.
+    """
+    transport = FakeTransport()
+    first = _declared(transport, band=cell_band(0))
+    first.on_ledger_line({"event": "chunk", "arm": ARM}, ts=_ts(1), position=1)
+    first.on_ledger_line({"event": "chunk", "arm": ARM}, ts=_ts(2), position=2)
+    first.on_status(RunStatus.STOPPED)
+    spent = {event.seq for event in transport.events if event.seq > RUN_SEQ_BAND}
+    assert len(spent) >= 3, "the first invocation must spend several descending seqs"
+
+    resumed = _declared(transport, band=cell_band(0))
+    resumed.on_ledger_line({"event": "merge", "arm": ARM}, ts=_ts(3), position=3)
+    resumed.on_status(RunStatus.COMPLETED)
+
+    issued = [
+        event.seq
+        for push in transport.pushes
+        for event in push
+        if event.seq > RUN_SEQ_BAND and event.type in ("heartbeat", "run.status")
+    ]
+    assert len(issued) == len(set(issued)), f"a descending seq was re-issued: {sorted(issued)}"
+    terminal = [event for event in transport.of_type("run.status") if event.seq > RUN_SEQ_BAND]
+    assert terminal[-1].payload["status"] == RunStatus.COMPLETED.value
+
+
+def test_three_invocations_never_re_use_a_descending_seq() -> None:
+    """Resume has to hold for the THIRD invocation, not just the second.
+
+    This is what rules out every scheme derived from a fixed point. `last_seq` stays pinned at the
+    first invocation's ceiling (the highest seq the run ever held), so any constant offset below it
+    hands the second and third invocations the same answer and the third collides with the second.
+    Only reading the descending walk's own frontier survives repetition, which is why the fix costs
+    a read.
+    """
+    transport = FakeTransport()
+    issued: list[int] = []
+    for invocation in range(3):
+        emitter = _declared(transport, band=cell_band(0))
+        emitter.on_ledger_line(
+            {"event": "chunk", "arm": ARM, "chunk": invocation},
+            ts=_ts(invocation + 1),
+            position=invocation + 1,
+        )
+        emitter.on_status(RunStatus.STOPPED if invocation < 2 else RunStatus.COMPLETED)
+        issued.extend(
+            event.seq
+            for push in transport.pushes
+            for event in push
+            if event.seq > RUN_SEQ_BAND
+            and event.type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS)
+        )
+        transport.pushes.clear()
+
+    assert len(issued) >= 6, "each invocation spends at least one heartbeat and one status"
+    assert len(issued) == len(set(issued)), f"a descending seq was re-issued: {sorted(issued)}"
+    # Each invocation's terminal status landed, which is the fact the whole exercise protects: a
+    # discarded one leaves a finished run reading `running` on the panel forever.
+    assert sum(1 for kind in transport.held_types.values() if kind == RunEventType.RUN_STATUS) == 3

--- a/wmo/runs/hooks_test.py
+++ b/wmo/runs/hooks_test.py
@@ -22,11 +22,14 @@ from wmo.runs.hooks import (
     CONTROL_FORCE_FROM_STAGE,
     CONTROL_RETRY_UNSCORED,
     CONTROL_STOP,
+    FRONTIER_PAGE,
     FrontierReader,
     GridEmitter,
     GridSnapshot,
     PipelineEmitter,
+    frontier_from_reader,
 )
+from wmo.runs.reader import EventPage, EventRow, RunsReader
 from wmo.runs.schema import (
     CELL_BATCH_CAP,
     RUN_LEVEL_BAND,
@@ -98,6 +101,10 @@ class FakeTransport:
         # Type per held seq, so the double can answer the frontier read the way the platform's
         # type-filtered tail does.
         self.held_types: dict[int, str] = {}
+        # Arrival order, which is what `pos` orders by. Kept so a reader over this double can page
+        # and TRUNCATE exactly like the route: a double that answers the whole log at once hides
+        # every bug that only appears when a window is too small to reach back far enough.
+        self.arrivals: list[tuple[int, str]] = []
 
     def push_run_events(
         self,
@@ -130,9 +137,13 @@ class FakeTransport:
         self.pushes.append([Pushed.model_validate(event) for event in events])
         seqs = [int(str(event["seq"])) for event in events]
         fresh = [seq for seq in seqs if seq not in self.held]
+        fresh_set = set(fresh)
         self.held.update(seqs)
         for event in events:
-            self.held_types.setdefault(int(str(event["seq"])), str(event["type"]))
+            seq, kind = int(str(event["seq"])), str(event["type"])
+            self.held_types.setdefault(seq, kind)
+            if seq in fresh_set:
+                self.arrivals.append((seq, kind))
         return {
             "accepted": len(fresh) if self._accepted is None else self._accepted,
             "last_seq": max(self.held),
@@ -181,6 +192,38 @@ def _no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("wmo.runs.client.PUSH_BACKOFF_SECONDS", 0.0)
 
 
+class _EventReader:
+    """The events route over a `FakeTransport`, with the semantics that matter here.
+
+    Honest about the three things the production read depends on: `pos` orders by ARRIVAL (so a
+    sibling band's traffic really does sit between this band's events), `tail=True` returns the
+    NEWEST `limit` of that type (so a window can be too small to reach this band at all), and
+    `after_pos`/`last_pos` page forward.
+    """
+
+    def __init__(self, transport: FakeTransport) -> None:
+        self._transport = transport
+        self.reads = 0
+
+    def list_events(
+        self,
+        external_id: str,
+        *,
+        after_pos: int = 0,
+        limit: int = 500,
+        tail: bool = False,
+        event_type: str | None = None,
+    ) -> EventPage:
+        self.reads += 1
+        rows = [
+            EventRow(pos=pos, seq=seq, type=kind, payload={}, ts=_ts(0))
+            for pos, (seq, kind) in enumerate(self._transport.arrivals, start=1)
+            if event_type is None or kind == event_type
+        ]
+        window = rows[-limit:] if tail else [row for row in rows if row.pos > after_pos][:limit]
+        return EventPage(events=tuple(window), last_pos=window[-1].pos if window else after_pos)
+
+
 def _frontier_of(transport: FakeTransport) -> FrontierReader:
     """The frontier read, answered from what the double holds.
 
@@ -189,14 +232,9 @@ def _frontier_of(transport: FakeTransport) -> FrontierReader:
     """
 
     def read(external_id: str, band: int) -> int | None:
-        floor, ceiling = band * RUN_SEQ_BAND, (band + 1) * RUN_SEQ_BAND
-        descending = [
-            seq
-            for seq, event_type in transport.held_types.items()
-            if floor < seq <= ceiling
-            and event_type in (RunEventType.HEARTBEAT, RunEventType.RUN_STATUS)
-        ]
-        return min(descending) if descending else None
+        # The real function over a faithful reader, not a re-implementation of its answer: a double
+        # that computes the frontier its own way cannot catch the frontier being computed wrongly.
+        return frontier_from_reader(cast("RunsReader", _EventReader(transport)), external_id, band)
 
     return read
 
@@ -838,3 +876,58 @@ def test_three_invocations_never_re_use_a_descending_seq() -> None:
     # Each invocation's terminal status landed, which is the fact the whole exercise protects: a
     # discarded one leaves a finished run reading `running` on the panel forever.
     assert sum(1 for kind in transport.held_types.values() if kind == RunEventType.RUN_STATUS) == 3
+
+
+def test_a_busy_sibling_cannot_hide_a_dead_processs_frontier() -> None:
+    """A chunked arm's siblings share one log, and their traffic must not hide this band's frontier.
+
+    The frontier read's newest-page fast path returns the newest events of a type across EVERY band.
+    A live sibling emitting heartbeats under its own band can fill that page completely, and reading
+    "nothing for my band" as "no frontier" leaves the ceiling spent: the restarted process then
+    re-issues its predecessor's seqs and the platform discards them, terminal status included. So
+    finding nothing in the newest page has to mean "look further", not "there is none".
+    """
+    transport = FakeTransport()
+    # A crashed process on band 1: it spent descending seqs and never reported a terminal status.
+    dead = _declared(transport, band=cell_band(0))
+    dead.on_ledger_line({"event": "chunk", "arm": ARM, "chunk": 0}, ts=_ts(1), position=1)
+    spent = sorted(seq for seq in transport.held if seq > RUN_SEQ_BAND)
+    assert spent, "the crashed process must have spent descending seqs"
+
+    # A sibling on band 6 (chunks 5+) then floods the log with more than one page of heartbeats.
+    sibling = _declared(transport, band=cell_band(5))
+    for beat in range(FRONTIER_PAGE + 10):
+        sibling.on_ledger_line(
+            {"event": "retry", "arm": ARM, "chunk": 5}, ts=_ts(beat % 60), position=beat + 2
+        )
+
+    # The crashed process restarts on its own band and reports its terminal status.
+    resumed = _declared(transport, band=cell_band(0))
+    resumed.on_status(RunStatus.COMPLETED)
+
+    landed = [
+        seq
+        for seq, kind in transport.held_types.items()
+        if kind == RunEventType.RUN_STATUS and seq > RUN_SEQ_BAND
+    ]
+    assert landed, "the resumed arm's terminal status was discarded as a replay"
+    assert not set(landed) & set(spent), "it re-used a seq the crashed process had already spent"
+
+
+def test_a_pending_stop_is_acked_even_when_the_status_cannot_be_named() -> None:
+    """The stop was honored whether or not this build can name the status the run ended with.
+
+    Leaving it unacked shows the operator a stop still in flight on a run that has already finished,
+    and the row stays pending forever because only the runner that owns the run ever acks it.
+    """
+    transport = FakeTransport(control=[{"id": "c5", "command": CONTROL_STOP, "args": {}}])
+    emitter = _declared(transport)
+    assert emitter.stop_requested is True
+
+    emitter.on_status(cast("RunStatus", "canceled"))
+
+    assert transport.of_type("run.status") == [], "an unnameable status is still not sent"
+    assert [(control, status) for control, status, _note in transport.acks] == [
+        ("c5", ACK_ACKED),
+        ("c5", ACK_DONE),
+    ]


### PR DESCRIPTION
Post-merge follow-up to #362. Both defects landed in the merge window and main is red without this (one `ty` diagnostic plus a failing resume test).

## The frontier could not be inferred

`_resume` rebased the descending walk with `resume_from_top(band, last_seq - 1)`. That is a type mismatch in the numbers, not a coding slip: a descending walk's frontier is the **minimum** seq it issued, `last_seq` is the **maximum** over the whole run, and a maximum cannot locate a minimum. An invocation that emitted heartbeats at 200000/199999 and a status at 199998 reports `last_seq` 200000, so the resume restarted at 199999 and re-issued everything after it. The platform discarded the re-issues as replays, and the one that mattered was the terminal `run.status`: a finished run read `running` on the panel forever.

It now **reads** the frontier: two type-filtered tail reads, minimum seq inside the writer's own band. Correct from any box, cheap on a run with a hundred thousand cells because the server filters by type in the database, and inside the never-raise guard so a machine that cannot read simply does not rebase. An arm with no descending events yet has no frontier, and None leaves the ceiling alone, which also retires the case where the old arithmetic pointed into the ascending region.

## An unknown status was about to cost a batch

The unknown-status guard passed the value through as text. The platform's status vocabulary is closed, so that is a permanent 4xx, and a permanent refusal drops the whole batch: one unrecognized status would have taken the ledger lines and cells riding with it. Skipping the event costs only the event, and the run stays whatever the platform last heard, which is honest.

## The lesson both halves of this seam learned

The original resume test passed **for the wrong reason** — its first invocation emitted a single descending event, the one case where `last_seq - 1` is accidentally correct. The same shape appeared three other times this round: a sink's internal retry swallowing a single injected failure, a probe counter not counting failed probes, twelve tests pushing into runs they never declared, and three tests built on ledger lines the real runner would have skipped. A test double more permissive than production turns a suite into decoration. The double now answers the frontier read the way the server does, and the fix was written against a failing test first.

Verified through the real runner: two invocations of one arm produce `200000, 199999, 199998` then `199997, 199996, 199995`, all distinct, and both terminal statuses land. Gates: 4637 passed, ruff + format + ty clean.

## Two more defects in the same path (c3c1687f)

**A busy sibling could hide the frontier.** Sibling chunk processes share one arm's event log under their own bands, so a live sibling's heartbeats fill a newest-N window and evict a dead process's events from it. The read found nothing for its band and treated that as "no frontier" — the one wrong default, since the run has one and the ceiling is spent. Within a band the descending seqs strictly decrease, so a newest-first window holding any of this band's events already holds its frontier; finding none means look further. The tail read is now a fast path with a forward paging fallback (500 per page, type-filtered), and a scan that hits the page cap reports no frontier rather than a partial minimum, which would be too high and would re-issue the seqs between.

**An unnameable status could strand a stop.** The early return sat above the stop-control ack, so a run ending in a status this build cannot name never acked its pending stop, and an operator saw a stop in flight on a finished run forever. The status event is now conditional and nothing after it is: the stop was honored whether or not we can name the state the run ended in.

## The transferable rule this seam produced

> A test double more permissive than production turns a whole suite into decoration. Three bugs here hid behind exactly that shape. Three of the backfill's ledger tests fed lines the runner itself would have skipped, so they asserted on positions no real ledger produces. Twelve of the emitter's tests pushed into runs the platform would have refused as undeclared, so they exercised a server that accepts anything. And the frontier read's double answered from its entire event set where the server answers with the newest fifty, so the read looked exact and was not. Each suite was green, and each was green about a world the server does not implement. A double may be SMALLER than production, never more permissive: where production refuses, discards, truncates, or paginates, the double must too, or the tests standing on it prove only that the double agrees with itself.

Companion rule, from four green-for-the-wrong-reason tests in one round: a green test proves nothing until you have checked that it goes red for the reason you think it does.

## Known limits, deliberately not fixed here

- The frontier scan's cap bounds a run's **lifetime** descending-event count (40 pages x 500 rows; a four-process arm at a 15s heartbeat crosses it after roughly 21 hours), not the distance back to the frontier, because the events read cannot walk backward — `tail` is clamped server-side. A multi-day arm that then resumes stops rebasing and warns. Deferred rather than papered over because the degradation is **visible and true**: `wedgedFor` already flags any run claiming `running` with a heartbeat older than 120s, across the runs table, the run detail and the model card, so such a run shows a wedged badge instead of a healthy-looking stale `running`. The same mechanism is the only thing that can ever cover a `kill -9`, which reports nothing at all. Closing it properly is a server-side seq-range filter on the events read (one row, `ORDER BY seq ASC LIMIT 1` within the band), filed as a follow-up.
- A process restarting within 2s of its own last heartbeat loses one event to a replay discard, because the safe frontier will not serve past it. Unfixable client-side.
- That same read-side honesty is the positive case for the unknown-status ruling: skipping leaves an operator a true badge rather than a confident `stopped` that may be false.
