### PR TITLE
Reformat four files at the repo's line length

### DIFF
--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -502,9 +502,7 @@ def optimize(
         on_proposal=_proposal,
     )
     champion_version = store.aliases(name).get(CHAMPION_ALIAS)
-    current = (
-        store.load(name, str(champion_version)) if champion_version is not None else None
-    )
+    current = store.load(name, str(champion_version)) if champion_version is not None else None
     unchanged = current is not None and current.doc_hash == result.best.doc_hash
     saved = current if unchanged else store.save_version(result.best, alias=CHAMPION_ALIAS)
     selected = len(result.archive.accepted())

--- a/wmo/harness/create.py
+++ b/wmo/harness/create.py
@@ -386,17 +386,13 @@ def gate_delta(
 
 def _is_perfect(report: ClosedLoopReport) -> bool:
     """Return whether every task and every assertion passed."""
-    return (
-        report.success_rate >= 1.0 - _TIE_EPS
-        and report.mean_fraction >= 1.0 - _TIE_EPS
-    )
+    return report.success_rate >= 1.0 - _TIE_EPS and report.mean_fraction >= 1.0 - _TIE_EPS
 
 
 def _strictly_improves_full_objective(verdict: GateRecord) -> bool:
     """Require positive full-split evidence after non-regression gates pass."""
     return verdict.full_delta > _TIE_EPS or (
-        abs(verdict.full_delta) <= _TIE_EPS
-        and verdict.full_fraction_delta > _TIE_EPS
+        abs(verdict.full_delta) <= _TIE_EPS and verdict.full_fraction_delta > _TIE_EPS
     )
 
 
@@ -616,8 +612,7 @@ def create_harness(
             if _is_perfect(parent_report):
                 subject = "seed" if completed_iterations == 0 else "champion"
                 _note(
-                    f"{subject} already passes every task and assertion; "
-                    "stopping before proposals"
+                    f"{subject} already passes every task and assertion; stopping before proposals"
                 )
                 break
             # Eval runners from the previous iteration would otherwise sit idle through the

--- a/wmo/harness/create_test.py
+++ b/wmo/harness/create_test.py
@@ -747,9 +747,7 @@ def test_exact_full_objective_tie_is_audited_but_not_promoted() -> None:
                 target = "target task" in user
                 results = []
                 for assertion in _gold_assertions(user):
-                    passed = (
-                        child and target and assertion == "a target improvement"
-                    ) or (
+                    passed = (child and target and assertion == "a target improvement") or (
                         not child and not target and assertion == "kept partial credit"
                     )
                     results.append({"assertion": assertion, "passed": passed, "why": "x"})
@@ -2168,9 +2166,7 @@ def test_next_iteration_uses_winner_then_stops_when_perfect() -> None:
     """Search advances through an improving parent and buys nothing after perfection."""
     seed = HarnessDoc.baseline("seed")
     provider = _RankedMetaProvider([])
-    proposer = _ParentRecordingProposer(
-        ["You are a weak agent.", "You are a strong agent."]
-    )
+    proposer = _ParentRecordingProposer(["You are a weak agent.", "You are a strong agent."])
     tasks = [
         TaskSpec(task_id="t1", instruction="task one", gold=["the work completed"]),
         TaskSpec(task_id="t2", instruction="task two", gold=["the work completed"]),

--- a/wmo/optimize/pareto.py
+++ b/wmo/optimize/pareto.py
@@ -188,9 +188,7 @@ def held_out_curve(
     on EVERY scenario has no held-out band; the curve then carries the model points alone
     (over all scenarios) rather than in-sample routed points dressed as measurements.
     """
-    held_out = [
-        sid for sid in matrix.scenario_ids() if sid not in set(policy.fit_scenario_ids)
-    ]
+    held_out = [sid for sid in matrix.scenario_ids() if sid not in set(policy.fit_scenario_ids)]
     if not held_out:
         return pareto_curve(matrix, judge=judge, provenance=provenance)
     return pareto_curve(
@@ -235,9 +233,7 @@ def _point(
     per_task_seconds: list[float] = []
     for row in scored:
         by_scenario.setdefault(row.scenario_id, []).append(row.reward)
-        success.setdefault(row.scenario_id, []).append(
-            1.0 if completion.completed(row) else 0.0
-        )
+        success.setdefault(row.scenario_id, []).append(1.0 if completion.completed(row) else 0.0)
         per_task_seconds.append(sum(row.call_seconds))
     scenario_means = [sum(v) / len(v) for v in by_scenario.values()]
     success_means = [sum(v) / len(v) for v in success.values()]
@@ -279,9 +275,7 @@ def _mark_frontier(points: list[ParetoPoint]) -> list[ParetoPoint]:
         )
 
     flagged = {p.id: not dominated(p, cost) for p, cost in placeable}
-    return [
-        p.model_copy(update={"on_frontier": flagged.get(p.id, False)}) for p in points
-    ]
+    return [p.model_copy(update={"on_frontier": flagged.get(p.id, False)}) for p in points]
 
 
 def _recommended(points: list[ParetoPoint], policy: RoutingPolicy | None) -> str | None:
@@ -292,9 +286,7 @@ def _recommended(points: list[ParetoPoint], policy: RoutingPolicy | None) -> str
     and fall back to. None only when nothing is placeable.
     """
     if policy is not None:
-        balanced = next(
-            (p for p in points if p.kind == "routed" and p.dial == 0.25), None
-        )
+        balanced = next((p for p in points if p.kind == "routed" and p.dial == 0.25), None)
         if balanced is not None and balanced.cost_per_completed_task_usd is not None:
             return balanced.id
     frontier = [p for p in points if p.on_frontier]


### PR DESCRIPTION
`uv run ruff format --check .` has been red on main since PR #364 landed: `wmo/cli/harness_app.py`, `wmo/harness/create.py`, `wmo/harness/create_test.py`, `wmo/optimize/pareto.py` are wrapped for ruff's 88-column default instead of the repo's configured `line-length = 100`. That is the signature of running the formatter with pyproject out of scope (from outside the repo root, or on a path with no pyproject above it), so it will keep recurring in those files unless they are normalized.

Formatting only, no logic touched. The gate is clean again (568 files), `ruff check` clean, and the touched packages' suites pass (1202 passed, 3 skipped).

Filed rather than absorbed into the runs hotfix so the fix for another lane's drift stays reviewable on its own.