### PR TITLE
Say which routing kind the product uses

### DIFF
--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -989,7 +989,13 @@ def fit(
         "call). Only meaningful with --compressor.",
     ),
 ) -> None:
-    """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
+    """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks).
+
+    `--kind knn` is the product router and what `wmo optimize model` fits. `--kind rank` is a
+    retained research direction (a faithful Avengers replication kept for comparison); the
+    staged pipeline never fits it and no served endpoint carries one, so choose it only to
+    measure against the champion.
+    """
     if kind not in ("rank", "knn"):
         raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
     matrix, source = _load_matrix(matrix_file)

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -8,13 +8,16 @@ WHICH KIND THE PRODUCT USES, because the three below are not peers:
   `kind="knn"`), so every optimized endpoint serves a knn policy.
 - `static` is not an algorithm, it is the pre-optimization state: an endpoint must serve from
   the moment it exists, before any fit has run, and the improvement report needs an honest
-  "before" to measure against. A seeded or freshly created endpoint gets one of these over
-  the strongest available serving model.
+  "before" to measure against. Two producers choose its model differently: the hosted platform
+  seeds one over the strongest serving model available to the org, while `wmo optimize route
+  pin` installs one for whichever `--model` an operator names, which may deliberately be a
+  weaker one.
 - `rank` is a RESEARCH DIRECTION, retained deliberately: a faithful replication kept for
   comparison, reachable only through the manual `wmo optimize route fit --kind rank`. The
-  product pipeline never fits it and no served endpoint carries one. It is also the only kind
-  with clusters, which is why a request log's cluster columns are empty for everything the
-  product serves.
+  staged pipeline never fits one, so nothing serves one today - but the runtime DOES dispatch a
+  manually installed rank artifact through `rank_decision`, so read this as unfitted by the
+  product rather than unservable. It is also the only kind with clusters, which is why a
+  request log's cluster columns are empty for everything the product serves.
 
 The three kinds:
 

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -1,6 +1,22 @@
 """The routing policy artifact: what the routing optimizer emits and the endpoint serves.
 
-An endpoint = {world model, policy, evidence, URL}; this module is the policy leg. Three kinds:
+An endpoint = {world model, policy, evidence, URL}; this module is the policy leg.
+
+WHICH KIND THE PRODUCT USES, because the three below are not peers:
+
+- `knn` is THE learned router. `wmo optimize model` fits nothing else (it pins
+  `kind="knn"`), so every optimized endpoint serves a knn policy.
+- `static` is not an algorithm, it is the pre-optimization state: an endpoint must serve from
+  the moment it exists, before any fit has run, and the improvement report needs an honest
+  "before" to measure against. A seeded or freshly created endpoint gets one of these over
+  the strongest available serving model.
+- `rank` is a RESEARCH DIRECTION, retained deliberately: a faithful replication kept for
+  comparison, reachable only through the manual `wmo optimize route fit --kind rank`. The
+  product pipeline never fits it and no served endpoint carries one. It is also the only kind
+  with clusters, which is why a request log's cluster columns are empty for everything the
+  product serves.
+
+The three kinds:
 
 - `static`: every request goes to `default_model`. Valid without any optimizer run, so an
   endpoint serves from day one and the improvement report has an honest "before" state.


### PR DESCRIPTION
Documentation only, prompted by a real misread: building the per-call routing audit, I described the panel around "which cluster was activated" because `wmo/optimize/policy.py` presents its three policy kinds as peers. They are not, and nothing said so.

What is actually true, verified in the code rather than inferred:

- **`knn` is the product router.** `wmo optimize model` pins `"kind": "knn"` (`optimize_model_app.py:775`), so every optimized endpoint serves a knn policy and the pipeline offers no way to fit anything else.
- **`static` is not an algorithm**, it is the pre-optimization state: an endpoint has to serve from the moment it exists, before any fit has run, and the improvement report needs an honest "before" to measure against. A seeded or freshly created endpoint gets one over the strongest available serving model.
- **`rank` is a retained research direction** — a faithful Avengers replication kept for comparison, reachable only through the manual `wmo optimize route fit --kind rank`. The staged pipeline never fits it and no served endpoint carries one.

And the consequence worth writing down: rank is the *only* kind with clusters, which is why a request log's cluster columns are empty for everything the product serves. That fact now sits both in the artifact's docstring and in the fit command's help, at the point where someone chooses a kind.

No code paths changed and nothing removed; the research direction stays exactly where it is.