### PR TITLE
Defer heavy CLI imports to fix startup latency (#344)

### DIFF
--- a/wmo/cli/agent_session.py
+++ b/wmo/cli/agent_session.py
@@ -36,49 +36,26 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
-from wmo.cli.hosted_session import (
-    DetachedCommandDriver,
-    DetachedStartDriver,
-    LiveWorkspace,
-    SessionAction,
-    patch_revision,
-)
-from wmo.cli.session_state import (
-    DetachedSessionState,
-    SessionStateError,
-    SessionStateStore,
-    WorkspaceCheckpoint,
-)
-from wmo.cli.workspace_sync import (
-    WorkspaceSnapshot,
-    WorkspaceSyncError,
-    snapshot_workspace,
-)
-from wmo.config import load_settings
-from wmo.engine.play import parse_action
-from wmo.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
-from wmo.harness.live_session import LiveSession, SessionEvent, ToolOutcome
-from wmo.harness.pi_local import LocalStdioChannel, start_local_live_runner
-from wmo.harness.pi_vendor import pi_agent_code_surfaces
-from wmo.harness.tools import READ_SKILL, resolve_tools
-from wmo.harness.workspace_patch import WorkspacePatchError
-from wmo.platform.client import PlatformClient, PlatformError, RemoteAgentSession
-from wmo.platform.credentials import PlatformCredentials, load_credentials
-from wmo.providers.base import (
-    PreparableProvider,
-    ProviderConfig,
-    ProviderKind,
-    ToolCallingProvider,
-)
-from wmo.providers.models import resolve_provider_model
-from wmo.providers.registry import get_provider
-
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from llm_waterfall import ChatRequest, ChatResponse
 
+    from wmo.cli.hosted_session import (
+        DetachedCommandDriver,
+        DetachedStartDriver,
+        LiveWorkspace,
+        SessionAction,
+    )
+    from wmo.cli.session_state import SessionStateStore, WorkspaceCheckpoint
+    from wmo.cli.workspace_sync import WorkspaceSnapshot
     from wmo.core.types import JsonObject
+    from wmo.harness.doc import HarnessDoc
+    from wmo.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+    from wmo.harness.pi_local import LocalStdioChannel
+    from wmo.platform.client import PlatformClient, RemoteAgentSession
+    from wmo.platform.credentials import PlatformCredentials
+    from wmo.providers.base import ToolCallingProvider
 
 _console = Console()
 
@@ -99,6 +76,8 @@ class _JailEscape(RuntimeError):
 
 def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
     """Cap tool output to the head+tail budget with a truncation marker."""
+    from wmo.harness.live_session import ToolOutcome
+
     if len(content) <= _TOOL_OUTPUT_CAP:
         return ToolOutcome(content=content, is_error=is_error)
     half = _TOOL_OUTPUT_CAP // 2
@@ -114,6 +93,8 @@ def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str
     the resolved tool specs, the code surfaces as {path: content} (the agent's own
     code, materialized into the local runner), and skill bodies answered host-side.
     """
+    from wmo.harness.tools import READ_SKILL, resolve_tools
+
     tool_names = doc.tools()
     if doc.skills() and READ_SKILL.name not in tool_names:
         tool_names.append(READ_SKILL.name)
@@ -132,6 +113,9 @@ def _pi_node_baseline() -> HarnessDoc:
     pi code surfaces on and pins ``param:runtime-kind = pi-node`` so a not-logged-in
     session has a runnable agent without fetching a champion.
     """
+    from wmo.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+    from wmo.harness.pi_vendor import pi_agent_code_surfaces
+
     base = HarnessDoc.baseline("local-session")
     surfaces = [
         *base.surfaces,
@@ -161,6 +145,8 @@ class LocalToolExecutor:
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
     ) -> ToolOutcome:
         """Execute one tool call locally; a failure is an observation, not a crash."""
+        from wmo.harness.live_session import ToolOutcome
+
         try:
             if name == "bash":
                 return self._bash(str(args.get("command", "")), emit)
@@ -239,6 +225,8 @@ class LocalPiRunRecorder:
 
     def finish(self, *, ended_reason: str, error: str | None) -> None:
         """Report the terminal state and release the HTTP client."""
+        from wmo.platform.client import PlatformError
+
         status = "failed" if error is not None else "ended"
         with contextlib.suppress(PlatformError):
             self._client.finish_local_pi_run(
@@ -347,6 +335,9 @@ class LocalLiveDriver:
 
     def run(self) -> None:
         """Boot the local runner, drive the session, and always tear down."""
+        from wmo.harness.live_session import LiveSession
+        from wmo.harness.pi_local import start_local_live_runner
+
         system, tool_specs, files, skill_bodies = _assemble(self._doc)
         _console.print("[dim]starting the built-in pi harness locally...[/dim]")
         session: LiveSession | None = None
@@ -492,6 +483,8 @@ class RemoteAgentCommandReader(threading.Thread):
         Returns:
             Whether the command was accepted.
         """
+        from wmo.platform.client import PlatformError
+
         try:
             self._client.post_agent_session_command(
                 self._agent_id, self._session_id, kind, text=text
@@ -529,6 +522,12 @@ class RemoteAgentDriver:
 
     def run(self) -> None:
         """Run and stream one E2B session, syncing local files only when requested."""
+        from wmo.cli.hosted_session import LiveWorkspace
+        from wmo.cli.session_state import SessionStateError
+        from wmo.cli.workspace_sync import WorkspaceSyncError, snapshot_workspace
+        from wmo.harness.workspace_patch import WorkspacePatchError
+        from wmo.platform.client import PlatformError
+
         try:
             initial: WorkspaceSnapshot | None = None
             if self._jail is not None:
@@ -589,6 +588,12 @@ class RemoteAgentDriver:
         next send/attach/end catches up from here. No final workspace sync
         runs: the session stays alive.
         """
+        from wmo.cli.session_state import (
+            DetachedSessionState,
+            SessionStateError,
+            WorkspaceCheckpoint,
+        )
+
         checkpoint: WorkspaceCheckpoint | None = None
         base_archive: bytes | None = None
         if workspace is not None and self._jail is not None:
@@ -638,6 +643,11 @@ class RemoteAgentDriver:
         Returns:
             The terminal session record, or ``None`` when the user detached.
         """
+        from wmo.cli.hosted_session import patch_revision
+        from wmo.cli.workspace_sync import WorkspaceSyncError
+        from wmo.harness.live_session import SessionEvent
+        from wmo.platform.client import PlatformError
+
         last_workspace_push = time.monotonic()
         sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
         saw_running = False
@@ -728,6 +738,8 @@ class RemoteWorldModelDriver:
 
     def run(self) -> None:
         """Create one hosted session and step it until the user exits."""
+        from wmo.platform.client import PlatformError
+
         try:
             session = self._client.create_world_model_session(self._target_id, task=self._task)
             _console.print(
@@ -747,6 +759,9 @@ class RemoteWorldModelDriver:
 
     def _loop(self, session_id: str) -> None:
         """Read actions and render hosted observations."""
+        from wmo.engine.play import parse_action
+        from wmo.platform.client import PlatformError
+
         while True:
             try:
                 line = _console.input("[bold]agent>[/bold] ").strip()
@@ -809,6 +824,16 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         typer.BadParameter: The provider name is unknown, the model cannot do tool calling, or
             the backend cannot be prepared. Every message names `wmo providers set`.
     """
+    from wmo.config import load_settings
+    from wmo.providers.base import (
+        PreparableProvider,
+        ProviderConfig,
+        ProviderKind,
+        ToolCallingProvider,
+    )
+    from wmo.providers.models import resolve_provider_model
+    from wmo.providers.registry import get_provider
+
     configured = load_settings().models.resolve("worker")
     provider_name = provider or (
         configured.provider if configured is not None else _DEFAULT_PROVIDER
@@ -1012,6 +1037,11 @@ def _build_session_command_driver(
     *, action: SessionAction, text: str | None, session_override: str | None
 ) -> DetachedCommandDriver:
     """Assemble the authenticated driver behind --send/--attach/--end."""
+    from wmo.cli.hosted_session import DetachedCommandDriver
+    from wmo.cli.session_state import SessionStateStore
+    from wmo.platform.client import PlatformClient
+    from wmo.platform.credentials import load_credentials
+
     credentials = load_credentials()
     if not credentials.is_complete():
         raise typer.BadParameter("run `wmo login` to use hosted agent sessions")
@@ -1051,6 +1081,11 @@ def _build_driver(
     detach: bool = False,
 ) -> LocalLiveDriver | RemoteAgentDriver | RemoteWorldModelDriver | DetachedStartDriver:
     """Resolve the target kind once and assemble its execution driver."""
+    from wmo.cli.hosted_session import DetachedStartDriver
+    from wmo.cli.session_state import SessionStateStore
+    from wmo.platform.client import PlatformClient, PlatformError
+    from wmo.platform.credentials import load_credentials
+
     credentials = load_credentials()
     logged_in = credentials.is_complete()
 

--- a/wmo/cli/agent_session_test.py
+++ b/wmo/cli/agent_session_test.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import io
+import sys
 import tarfile
 import threading
 from pathlib import Path
@@ -20,11 +21,12 @@ import wmo.cli.agent_session as mod
 import wmo.cli.hosted_session as hosted_mod
 from wmo.cli import app
 from wmo.cli.session_state import DetachedSessionState, SessionStateError, SessionStateStore
-from wmo.cli.workspace_sync import snapshot_from_archive
+from wmo.cli.workspace_sync import snapshot_from_archive, snapshot_workspace
 from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
-from wmo.harness.live_session import SessionEvent
+from wmo.harness.doc import HarnessDoc
+from wmo.harness.live_session import LiveSession, SessionEvent
 from wmo.harness.workspace_patch import build_workspace_patch
-from wmo.platform.client import PlatformError
+from wmo.platform.client import PlatformClient, PlatformError
 from wmo.platform.credentials import PlatformCredentials
 from wmo.providers.base import ProviderKind
 
@@ -59,6 +61,7 @@ def test_executor_reads_writes_and_jails(tmp_path: Path) -> None:
     assert absolute.is_error
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
 def test_executor_bash_runs_in_jail_and_reports_exit(tmp_path: Path) -> None:
     """bash runs in the jail root, streams output, and surfaces a non-zero exit."""
     executor = mod.LocalToolExecutor(tmp_path)
@@ -153,12 +156,12 @@ class _FakeClient:
 
 
 def _patch_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(mod, "get_provider", lambda _config: _FakeProvider())
+    monkeypatch.setattr("wmo.providers.registry.get_provider", lambda _config: _FakeProvider())
 
 
 def test_build_driver_not_logged_in_runs_baseline_local(monkeypatch: pytest.MonkeyPatch) -> None:
     """No login + no agent: a pi-node baseline runs locally, unrecorded."""
-    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", PlatformCredentials)
     _patch_local_provider(monkeypatch)
 
     driver = mod._build_driver(
@@ -185,14 +188,14 @@ def test_build_driver_uses_configured_local_worker(
         ),
         tmp_path / ".wmo",
     )
-    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", PlatformCredentials)
     configs = []
 
     def get_provider(config: object) -> _FakeProvider:
         configs.append(config)
         return _FakeProvider()
 
-    monkeypatch.setattr(mod, "get_provider", get_provider)
+    monkeypatch.setattr("wmo.providers.registry.get_provider", get_provider)
 
     driver = mod._build_driver(
         target=None,
@@ -220,7 +223,7 @@ def test_build_driver_names_the_worker_it_picked(
 ) -> None:
     """A bare `wmo run` with nothing configured says which model it silently defaulted to."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", PlatformCredentials)
     _patch_local_provider(monkeypatch)
     console = Console(file=io.StringIO(), width=200)
     monkeypatch.setattr(mod, "_console", console)
@@ -241,8 +244,11 @@ def test_build_driver_preflights_the_worker_before_the_harness_boots(
     fails on a provider the user never chose, with nothing pointing at `wmo providers set`.
     """
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
-    monkeypatch.setattr(mod, "get_provider", lambda _config: _UnpreparedProvider())
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", PlatformCredentials)
+    monkeypatch.setattr(
+        "wmo.providers.registry.get_provider",
+        lambda _config: _UnpreparedProvider(),
+    )
     monkeypatch.setattr(mod, "_console", Console(file=io.StringIO(), width=200))
 
     with pytest.raises(typer.BadParameter) as caught:
@@ -259,9 +265,9 @@ def test_build_driver_logged_in_agent_uses_hosted_e2b_without_local_workspace(
 ) -> None:
     """Logged in + agent defaults to platform-owned E2B without local files."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
         target="a1",
@@ -301,9 +307,9 @@ def test_run_upload_dir_is_explicit_opt_in(tmp_path: Path, monkeypatch: pytest.M
 def test_build_driver_logged_in_builtin_pi_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     """Logged-in bare run needs no local provider credentials."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test", default_org="org-1")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
         target=None,
@@ -327,9 +333,9 @@ def test_platform_target_rejects_local_provider_before_creating_session(
 ) -> None:
     """Provider overrides never create an orphan platform run."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     with pytest.raises(typer.BadParameter, match="platform credentials"):
         mod._build_driver(
@@ -346,9 +352,9 @@ def test_hosted_agent_does_not_prompt_for_local_execution(
 ) -> None:
     """The E2B agent path never presents the bare harness's local-shell warning."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     prompted: list[bool] = []
     driver = mod._build_driver(
@@ -367,10 +373,10 @@ def test_hosted_agent_does_not_prompt_for_local_execution(
 def test_build_driver_world_model_uses_hosted_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """A resolved world-model id never boots a local agent process."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
     client.target_kind = "world_model"
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
         target="wm-1",
@@ -384,7 +390,7 @@ def test_build_driver_world_model_uses_hosted_session(monkeypatch: pytest.Monkey
 
 def test_build_driver_target_without_login_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Naming any platform target while logged out is a clear parameter error."""
-    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", PlatformCredentials)
     with pytest.raises(typer.BadParameter):
         mod._build_driver(
             target="a1",
@@ -456,8 +462,8 @@ class _FakeReader:
 
 
 def _patch_driver_boundaries(monkeypatch: pytest.MonkeyPatch, channel: _FakeChannel) -> None:
-    monkeypatch.setattr(mod, "start_local_live_runner", lambda: channel)
-    monkeypatch.setattr(mod, "LiveSession", _FakeLiveSession)
+    monkeypatch.setattr("wmo.harness.pi_local.start_local_live_runner", lambda: channel)
+    monkeypatch.setattr("wmo.harness.live_session.LiveSession", _FakeLiveSession)
     monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
 
 
@@ -468,7 +474,7 @@ def test_driver_boots_loops_and_closes_local_process(monkeypatch: pytest.MonkeyP
 
     mod.LocalLiveDriver(
         jail_root=Path.cwd(),
-        doc=mod.HarnessDoc.baseline("t"),
+        doc=HarnessDoc.baseline("t"),
         provider=_FakeProvider(),
         worker_fn=None,
         recorder=None,
@@ -495,7 +501,7 @@ def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> N
 
     mod.LocalLiveDriver(
         jail_root=Path.cwd(),
-        doc=mod.HarnessDoc.baseline("t"),
+        doc=HarnessDoc.baseline("t"),
         provider=_FakeProvider(),
         worker_fn=None,
         recorder=cast("mod.RunRecorder", _Recorder()),
@@ -520,7 +526,7 @@ def test_stdin_eof_is_reported_without_aborting_the_opening_task(
             self.ended += 1
 
     local_session = _Session()
-    local_reader = mod.StdinCommandReader(cast("mod.LiveSession", local_session))
+    local_reader = mod.StdinCommandReader(cast("LiveSession", local_session))
     local_reader.run()
     assert local_reader.eof.is_set()
     assert local_session.ended == 0
@@ -536,7 +542,7 @@ def test_stdin_eof_is_reported_without_aborting_the_opening_task(
 
     client = _Client()
     remote_reader = mod.RemoteAgentCommandReader(
-        cast("mod.PlatformClient", client), "agent-1", "session-1"
+        cast("PlatformClient", client), "agent-1", "session-1"
     )
     remote_reader.run()
     assert remote_reader.eof.is_set()
@@ -559,14 +565,14 @@ def test_local_driver_returns_nonzero_when_the_runner_fails(
             self._closed = True
             return False
 
-    monkeypatch.setattr(mod, "start_local_live_runner", lambda: channel)
-    monkeypatch.setattr(mod, "LiveSession", _FailedSession)
+    monkeypatch.setattr("wmo.harness.pi_local.start_local_live_runner", lambda: channel)
+    monkeypatch.setattr("wmo.harness.live_session.LiveSession", _FailedSession)
     monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
 
     with pytest.raises(typer.Exit) as raised:
         mod.LocalLiveDriver(
             jail_root=Path.cwd(),
-            doc=mod.HarnessDoc.baseline("t"),
+            doc=HarnessDoc.baseline("t"),
             provider=_FakeProvider(),
             worker_fn=None,
             recorder=None,
@@ -635,7 +641,7 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client),
+        cast("PlatformClient", client),
         "agent-1",
         "Agent",
         tmp_path,
@@ -654,7 +660,7 @@ def test_failed_hosted_session_is_not_hidden_by_workspace_conflicts(
 ) -> None:
     """Session failure remains the primary exit even when final sync needs recovery."""
     (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
-    final = mod.snapshot_workspace(tmp_path).archive
+    final = snapshot_workspace(tmp_path).archive
 
     class _HostedClient:
         def __init__(self) -> None:
@@ -698,7 +704,7 @@ def test_failed_hosted_session_is_not_hidden_by_workspace_conflicts(
 
     with pytest.raises(typer.Exit) as raised:
         mod.RemoteAgentDriver(
-            cast("mod.PlatformClient", client),
+            cast("PlatformClient", client),
             "agent-1",
             "Agent",
             tmp_path,
@@ -759,7 +765,7 @@ def test_remote_agent_driver_without_upload_never_reads_local_workspace(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client),
+        cast("PlatformClient", client),
         "agent-1",
         "Agent",
         None,
@@ -777,7 +783,7 @@ def test_remote_agent_driver_applies_live_workspace_patch(
 ) -> None:
     """A workspace_patch event updates the local directory before session end."""
     (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
-    initial = mod.snapshot_workspace(tmp_path)
+    initial = snapshot_workspace(tmp_path)
     final_buffer = io.BytesIO()
     with tarfile.open(fileobj=final_buffer, mode="w:gz") as archive:
         body = b"during"
@@ -838,7 +844,7 @@ def test_remote_agent_driver_applies_live_workspace_patch(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client),
+        cast("PlatformClient", client),
         "agent-1",
         "Agent",
         tmp_path,
@@ -917,9 +923,9 @@ def test_run_dispatches_session_commands(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_build_driver_detach_returns_start_driver(monkeypatch: pytest.MonkeyPatch) -> None:
     """--detach on an agent id builds the detached start driver, not the streamer."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
         target="a1",
@@ -936,10 +942,10 @@ def test_build_driver_detach_returns_start_driver(monkeypatch: pytest.MonkeyPatc
 def test_build_driver_detach_rejects_world_models(monkeypatch: pytest.MonkeyPatch) -> None:
     """World-model sessions are interactive only; --detach names agents."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
-    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr("wmo.platform.credentials.load_credentials", lambda: creds)
     client = _FakeClient()
     client.target_kind = "world_model"
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+    monkeypatch.setattr("wmo.platform.client.PlatformClient", lambda *_a, **_k: client)
 
     with pytest.raises(typer.BadParameter, match="agent"):
         mod._build_driver(
@@ -977,7 +983,7 @@ def _plain_driver(
     """A plain hosted driver wired to an injectable session-state store."""
     store = SessionStateStore(tmp_path / "state")
     driver = mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client),
+        cast("PlatformClient", client),
         "agent-1",
         "Agent",
         jail_root,
@@ -1006,7 +1012,7 @@ def test_reader_detach_skips_eof_end_and_guards_unknown_commands(
 
     monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":detach\n"))
     client = _Client()
-    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+    reader = mod.RemoteAgentCommandReader(cast("PlatformClient", client), "a", "s")
     reader.run()
     assert reader.detach.is_set()
     assert not reader.eof.is_set()
@@ -1014,7 +1020,7 @@ def test_reader_detach_skips_eof_end_and_guards_unknown_commands(
 
     monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":frob\nhello\n:end\n"))
     client = _Client()
-    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+    reader = mod.RemoteAgentCommandReader(cast("PlatformClient", client), "a", "s")
     reader.run()
     assert client.posted == [("user_message", "hello"), ("end", None)]
     assert not reader.detach.is_set()
@@ -1074,7 +1080,7 @@ def test_plain_run_detach_with_workspace_checkpoints_without_final_sync(
     root = tmp_path / "work"
     root.mkdir()
     (root / "answer.txt").write_text("before", encoding="utf-8")
-    base = mod.snapshot_workspace(root)
+    base = snapshot_workspace(root)
     remote = io.BytesIO()
     with tarfile.open(fileobj=remote, mode="w:gz") as archive:
         body = b"during"
@@ -1132,7 +1138,10 @@ def test_plain_run_detach_with_workspace_checkpoints_without_final_sync(
     assert state.workspace is not None
     assert state.workspace.root == str(root)
     checkpoint = snapshot_from_archive(store.load_base_archive(state))
-    assert checkpoint.files == mod.snapshot_workspace(root).files
+    # Compare content digests; Windows file modes often differ from the archived Unix mode.
+    assert {path: state.sha256 for path, state in checkpoint.files.items()} == {
+        path: state.sha256 for path, state in snapshot_workspace(root).files.items()
+    }
 
 
 def test_plain_run_detach_state_failure_names_the_session(
@@ -1157,7 +1166,7 @@ def test_plain_run_detach_state_failure_names_the_session(
             pass
 
     driver = mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", _Client()),
+        cast("PlatformClient", _Client()),
         "agent-1",
         "Agent",
         None,
@@ -1183,7 +1192,7 @@ def test_world_model_loop_rejects_detach(monkeypatch: pytest.MonkeyPatch) -> Non
     lines = iter([":detach", ":quit"])
     monkeypatch.setattr(mod._console, "input", lambda *_a, **_k: next(lines))
     driver = mod.RemoteWorldModelDriver(
-        cast("mod.PlatformClient", _Client()), "wm-1", "Model", None
+        cast("PlatformClient", _Client()), "wm-1", "Model", None
     )
 
     driver._loop("sess-1")
@@ -1209,7 +1218,7 @@ def test_reader_keeps_reading_after_a_failed_steer_post(
 
     monkeypatch.setattr(mod.sys, "stdin", io.StringIO("hello\n:stop\n"))
     client = _FlakyClient()
-    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+    reader = mod.RemoteAgentCommandReader(cast("PlatformClient", client), "a", "s")
 
     reader.run()
 
@@ -1282,7 +1291,7 @@ def test_plain_run_interrupt_around_a_patch_ack_promotes_a_fresh_cursor(
     root = tmp_path / "work"
     root.mkdir()
     (root / "answer.txt").write_text("before", encoding="utf-8")
-    base = mod.snapshot_workspace(root)
+    base = snapshot_workspace(root)
     remote = io.BytesIO()
     with tarfile.open(fileobj=remote, mode="w:gz") as archive:
         body = b"during"

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -20,12 +20,10 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 from uuid import uuid4
 
 import typer
-import uvicorn
-from llm_waterfall import is_capacity_error
 from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape
@@ -33,33 +31,8 @@ from rich.panel import Panel
 from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn
 from rich.table import Table
 
-import wmo.cli.pool_registry as pool_registry
-import wmo.providers as providers
-from wmo.cli.agent_session import register as register_agent_session_commands
-from wmo.cli.e2b_cmds import register as register_e2b_commands
-from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
-
-# `_explicit` is package-private to wmo.cli, not module-private: `wmo eval` rejects
-# mode-inapplicable flags exactly the way `wmo optimize harness` already does.
-from wmo.cli.harness_app import _explicit, harness_app, optimize_app
-from wmo.cli.ingest_cmd import ingest as _ingest_command
+from wmo.cli.defer import add_deferred_typer
 from wmo.cli.model_roles import configured_role_configs, load_settings_or_abort
-from wmo.cli.platform_cmds import register as register_platform_commands
-from wmo.cli.reproduce_app import reproduce_app
-from wmo.cli.runs_app import runs_app
-from wmo.cli.ui import (
-    BuildParams,
-    RichBuildReporter,
-    build_summary_panel,
-    judge_model_default,
-    models_table,
-    run_build_wizard,
-    run_play_repl,
-    select_model,
-    select_option,
-    select_provider_and_model,
-    serve_model_default,
-)
 from wmo.config import (
     ARTIFACT_DIR,
     DEFAULT_MODEL_NAME,
@@ -78,70 +51,20 @@ from wmo.config import (
     settings_path,
     validate_name,
 )
-from wmo.config.card import make_build_card, save_card
-from wmo.core.types import JsonObject, Trace
-from wmo.engine.build import DEFAULT_TRAIN_SPLIT, EmptyCorpusError, ingest, split_traces
-from wmo.engine.build import build as run_build
-from wmo.engine.demo import run_demo
-from wmo.engine.eval_suites import (
-    EvalSuite,
-    discover_eval_suites,
-    list_eval_results,
-    resolve_eval_suite,
-    result_path,
-)
-from wmo.engine.grounding import GROUNDER_KINDS
-from wmo.engine.knowledge import KnowledgeBase
-from wmo.engine.prompts import BASE_ENV_PROMPT
-from wmo.engine.world_model import WorldModel
-from wmo.env.llm_agent import LLMAgent
-from wmo.evals.grid import GridResult, ModelSpec, merge_results, run_grid
-from wmo.evals.grid_plot import plot_grid, plot_grid_heatmap
-from wmo.evals.open_loop import EvalReport, OpenLoopEval
-from wmo.hub import (
-    CORPORA,
-    corpus_path,
-    downloadable_benchmarks,
-    fetch_corpus,
-    published_corpora,
-)
-from wmo.ingest import VendorPull, get_adapter, list_adapters
-from wmo.ingest.base import load_payloads
-from wmo.ingest.detect import detect_format
-from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
-from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
-from wmo.providers.base import Embedder, EmbedderKind, PreparableProvider, Provider
-from wmo.providers.models import (
-    ProviderModel,
-    model_types_for_provider,
-    resolve_provider_model,
-)
-from wmo.providers.pool import Tier
-from wmo.providers.retry import wrap_provider_with_retries
-from wmo.providers.waterfall import FALLBACK_CONFIG_PATH
-from wmo.research import Side, run_concurrency_scaling
-from wmo.research.concurrency_run import build_real_runner, build_world_runner
-from wmo.research.concurrency_scaling import ConcurrencyPoint
-from wmo.retrieval import EmbeddingRetriever, HashingEmbedder, get_embedder
-from wmo.retrieval.leakfree import DemoRetriever
-from wmo.scenarios import (
-    ChecklistJudge,
-    FacetExtractor,
-    ScenarioBuildConfig,
-    ScenarioSet,
-    build_scenario_set,
-    verify_scenarios,
-)
-from wmo.serving.server import create_app
-from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
-from wmo.telemetry import (
-    BuildTelemetryStats,
-    TelemetryBuildReporter,
-    capture_build_completed,
-    capture_eval_completed,
-    settings_root_from_results_root,
-)
-from wmo.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
+
+if TYPE_CHECKING:
+    import wmo.cli.pool_registry as pool_registry
+    from wmo.core.types import JsonObject, Trace
+    from wmo.engine.eval_suites import EvalSuite
+    from wmo.engine.world_model import WorldModel
+    from wmo.evals.grid import ModelSpec
+    from wmo.evals.open_loop import EvalReport
+    from wmo.providers import ProviderConfig, ProviderKind, VerifyResult
+    from wmo.providers.base import Embedder, Provider
+    from wmo.providers.models import ProviderModel
+    from wmo.providers.pool import Tier
+    from wmo.scenarios import ScenarioSet
+
 
 app = typer.Typer(
     help="Run agents, build world models from traces, and optimize agent harnesses.",
@@ -167,14 +90,62 @@ app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")
 app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
-app.add_typer(harness_app, name="harness")
-app.add_typer(optimize_app, name="optimize")
-app.add_typer(runs_app, name="runs")
-app.add_typer(reproduce_app, name="reproduce")
-app.command("ingest")(_ingest_command)
-register_platform_commands(app)
-register_agent_session_commands(app)
-register_e2b_commands(app)
+add_deferred_typer(
+    app,
+    name="harness",
+    module="wmo.cli.harness_app",
+    attr="harness_app",
+    help="Inspect and initialize named, versioned agent harnesses.",
+    known_names=("list", "show", "init"),
+)
+add_deferred_typer(
+    app,
+    name="optimize",
+    module="wmo.cli.harness_app",
+    attr="optimize_app",
+    help=(
+        "Optimizers behind one switch. `model` is the staged one-command path (preflight, "
+        "sweep, fit, tune, report); `route` is those steps individually; `harness` searches the "
+        "agent scaffold; `distill` trains an adapter."
+    ),
+    known_names=("route", "distill", "model", "harness"),
+)
+add_deferred_typer(
+    app,
+    name="runs",
+    module="wmo.cli.runs_app",
+    attr="runs_app",
+    help="See and steer optimization runs: list, show, tail, stop, retry, backfill.",
+    known_names=("list", "show", "tail", "stop", "retry", "backfill"),
+)
+add_deferred_typer(
+    app,
+    name="reproduce",
+    module="wmo.cli.reproduce_app",
+    attr="reproduce_app",
+    help="Replay published benchmark results and compare the measured verdict.",
+    known_names=("list", "run"),
+)
+
+
+def _register_ingest() -> None:
+    from wmo.cli.ingest_cmd import ingest as _ingest_command
+
+    app.command("ingest")(_ingest_command)
+
+
+def _register_side_commands() -> None:
+    from wmo.cli.agent_session import register as register_agent_session_commands
+    from wmo.cli.e2b_cmds import register as register_e2b_commands
+    from wmo.cli.platform_cmds import register as register_platform_commands
+
+    register_platform_commands(app)
+    register_agent_session_commands(app)
+    register_e2b_commands(app)
+
+
+_register_ingest()
+_register_side_commands()
 _console = Console()
 _CHECK = "[green]✓[/green]"
 
@@ -265,6 +236,7 @@ def _worker_provider_config(
     api_version: str | None = None,
 ) -> ProviderConfig:
     """Resolve the provider settings used by the built-in worker agent."""
+    from wmo.providers import ProviderKind
     config = _provider_config(provider, model, region)
     if endpoint is not None:
         config = config.model_copy(update={"endpoint": endpoint})
@@ -296,7 +268,7 @@ def providers_set(
         None, "--api-key-env", help="Env var holding the pool entries' API key (multi-account)."
     ),
     tier: str = typer.Option(
-        None, "--tier", help=f"Pool entry tier: {' | '.join(pool_registry.TIERS)}."
+        None, "--tier", help="Pool entry tier: frontier | open."
     ),
     input_per_mtok: float = typer.Option(
         None,
@@ -332,6 +304,9 @@ def providers_set(
     at $0 per Mtok unless the price flags say otherwise, and the interactive openai pass asks
     for the endpoint URL and lists the server's own models.
     """
+    import wmo.cli.pool_registry as pool_registry
+    from wmo.cli.ui import select_provider_and_model
+    from wmo.providers import verify_all
     if tier is not None and tier not in pool_registry.TIERS:
         raise typer.BadParameter(f"--tier must be one of: {', '.join(pool_registry.TIERS)}")
     if (input_per_mtok is None) != (output_per_mtok is None):
@@ -439,6 +414,7 @@ def _register_pool_models(
     `--provider ... --model ...` invocation keeps its exact pre-existing behavior and asks
     nothing.
     """
+    import wmo.cli.pool_registry as pool_registry
     if pool_model:
         pool_registry.register_model_ids(
             _console, pool_path=pool_path, kind=kind, model_ids=pool_model, options=options
@@ -473,6 +449,8 @@ def providers_verify(
     checked (the offline hashing embedder needs no credentials and is skipped). `--name` scopes
     the whole report to that one world model.
     """
+    from wmo.providers import verify_all, verify_embedder
+    from wmo.providers.base import EmbedderKind
     store = WorldModelStore(root)
     names = [name] if name is not None else store.list_names()
     configs: list[HarnessConfig] = []
@@ -633,6 +611,7 @@ _DB_SOURCES = ("postgres",)
 
 def _check_build_source(source: str) -> None:
     """Reject a `--source` that `wmo build` cannot drive, naming the `wmo ingest` two-step."""
+    from wmo.ingest import list_adapters
     if source not in list_adapters():
         raise typer.BadParameter(
             f"unknown --source {source!r}; choose one of: {', '.join(list_adapters())}"
@@ -659,6 +638,8 @@ def _check_build_file(file: str) -> None:
 
 def _empty_corpus_error(file: str | None, source: str) -> typer.BadParameter:
     """Explain an empty ingest: usually `--source` does not match the export's real format."""
+    from wmo.ingest.base import load_payloads
+    from wmo.ingest.detect import detect_format
     if file is None:
         return typer.BadParameter(
             f"the --source {source} pull returned no traces; widen --since/--limit or check the "
@@ -685,6 +666,7 @@ def _empty_corpus_error(file: str | None, source: str) -> typer.BadParameter:
 
 def _chain_bad_parameter(err: ValueError) -> typer.BadParameter:
     """Render a failover-chain resolution failure as a usage error naming the file to write."""
+    from wmo.providers.waterfall import FALLBACK_CONFIG_PATH
     return typer.BadParameter(
         f"{err}. Write {FALLBACK_CONFIG_PATH} as [[chain.<name>]] rung tables (one table per "
         "fallback rung, keys kind/model/profile/region; format in docs/reference/failover.md), "
@@ -694,6 +676,7 @@ def _chain_bad_parameter(err: ValueError) -> typer.BadParameter:
 
 def _provider_or_chain_or_abort(config: ProviderConfig, chain: str | None) -> Provider:
     """`providers.provider_or_chain`, with chain-resolution errors as clean usage errors."""
+    import wmo.providers as providers
     try:
         return providers.provider_or_chain(config, chain=chain)
     except ValueError as err:
@@ -751,7 +734,7 @@ def build(
         None, "--chain", help="Named failover chain from .wmo/fallback.toml (default: its default)."
     ),
     train_split: float = typer.Option(
-        DEFAULT_TRAIN_SPLIT,
+        0.8,
         help="Train/held-out ratio for GEPA's internal split (lower = bigger valset). Shares "
         "`wmo eval`'s default: both cut the same trace-id hash line, so a mismatch leaks train "
         "traces into the eval holdout.",
@@ -797,6 +780,25 @@ def build(
     """
     # `--vendor <name>` is the deprecated alias for `--source <name> --pull`: it names the source
     # adapter and implies a live pull.
+    import wmo.providers as providers
+    from wmo.cli.ui import (
+        BuildParams,
+        RichBuildReporter,
+        build_summary_panel,
+        judge_model_default,
+        run_build_wizard,
+        serve_model_default,
+    )
+    from wmo.config.card import make_build_card, save_card
+    from wmo.engine.build import EmptyCorpusError
+    from wmo.engine.build import build as run_build
+    from wmo.engine.grounding import GROUNDER_KINDS
+    from wmo.ingest import VendorPull
+    from wmo.providers import ProviderKind
+    from wmo.providers.base import EmbedderKind
+    from wmo.retrieval import get_embedder
+    from wmo.telemetry import BuildTelemetryStats, TelemetryBuildReporter, capture_build_completed
+    from wmo.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
     if vendor:
         source = vendor
         pull = True
@@ -1072,6 +1074,9 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
     being swallowed inside GEPA and yielding a useless model. Raises `typer.Exit(1)` with an
     actionable hint (`uv sync` for a missing SDK; "check creds / model id" otherwise).
     """
+    import wmo.providers as providers
+    from wmo.providers import verify_all, verify_embedder
+    from wmo.providers.base import EmbedderKind
     checks = [(config.serve_provider_config(), False)]
     if config.embed_provider is not EmbedderKind.HASHING:
         checks.append((config.embed_provider_config(), True))
@@ -1103,8 +1108,9 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
         raise typer.Exit(1)
 
 
-_PROVIDER_EXTRAS: dict[ProviderKind, str] = {ProviderKind.TINKER: "distill"}
-"""Providers whose SDK ships in an optional extra, keyed by kind so the hint can name the extra.
+# Keyed by ProviderKind.value so this module stays import-light (no providers import at load).
+_PROVIDER_EXTRAS: dict[str, str] = {"tinker": "distill"}
+"""Providers whose SDK ships in an optional extra, keyed by kind value so the hint can name it.
 
 Every other provider's SDK is a core dependency, so "the module is missing" means something
 different for them (a stale env) than it does here (an install step the user has not run yet).
@@ -1127,7 +1133,7 @@ def _credential_hint(kind: ProviderKind, detail: str) -> str:
     Shared by the pre-build guard and `wmo providers verify` so both name the same env vars.
     """
     if _missing_sdk(detail):
-        extra = _PROVIDER_EXTRAS.get(kind)
+        extra = _PROVIDER_EXTRAS.get(kind.value)
         if extra is not None:
             return (
                 f"run `pip install 'world-model-optimizer[{extra}]'` (or `uv sync --extra {extra}` "
@@ -1149,6 +1155,7 @@ def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list
     An artifact that cannot be read is listed as `unreadable` with its reason, so one broken
     `config.toml` costs you that one row instead of the whole listing.
     """
+    from wmo.cli.ui import models_table
     if Path(root).is_file():
         raise typer.BadParameter(
             f"--root {root} is a file, not a project dir; pass the dir holding models/ "
@@ -1182,6 +1189,8 @@ def download(
     `ENVCAP_DATA_ROOT` to put them somewhere else. Existing local files are kept unless
     `--force`.
     """
+    from wmo.cli.ui import select_option
+    from wmo.hub import corpus_path, published_corpora
     selected = list(benchmarks or [])
     if selected == ["all"]:
         selected = _all_downloadable()
@@ -1273,6 +1282,7 @@ def _all_downloadable() -> list[str]:
     Both narrowings are announced. A quiet substitution of a stale local list for the live one,
     or a quiet drop of a registered benchmark, reads afterwards as "everything was fetched".
     """
+    from wmo.hub import CORPORA, downloadable_benchmarks, published_corpora
     try:
         return sorted(corpus.benchmark for corpus in published_corpora())
     except urllib.error.URLError as exc:
@@ -1292,6 +1302,7 @@ def _all_downloadable() -> list[str]:
 
 def _fetch_with_progress(name: str, *, force: bool) -> Path:
     """fetch_corpus with a live byte progress bar (hidden when nothing needs downloading)."""
+    from wmo.hub import fetch_corpus
     with Progress(
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
@@ -1334,6 +1345,10 @@ def serve(
     `wmo optimize route fit --out` or `wmo optimize model`), the OpenAI-compatible endpoint
     `POST /v1/chat/completions` with `model="<name>"`, listed by `GET /v1/models`.
     """
+
+    import uvicorn
+
+    from wmo.serving.server import create_app
     names = list(name) if name else None
     # Bad --name input (unsafe segment, unknown model, nothing built) is a usage error,
     # not a traceback; load the models before uvicorn takes over the process.
@@ -1388,6 +1403,7 @@ def _resolve_eval_suite_or_usage(selector: str, examples_roots: list[str]) -> Ev
     Same contract as `_resolve_example`: a typo prints a clean box listing the available suites,
     never a traceback.
     """
+    from wmo.engine.eval_suites import resolve_eval_suite
     try:
         return resolve_eval_suite(selector, examples_roots)
     except ValueError as err:
@@ -1439,7 +1455,7 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     ),
     train_split: float | None = typer.Option(
         None,
-        help=f"Train/holdout ratio per file (default: {DEFAULT_TRAIN_SPLIT}, or suite config). "
+        help="Train/holdout ratio per file (default: 0.8, or suite config). "
         "Must match the ratio the model was built with, or the holdout contains train traces.",
     ),
     val_frac: float | None = typer.Option(
@@ -1564,6 +1580,9 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     Open-loop scoring runs on the worker role `wmo providers set` writes to `.wmo/settings.toml`
     (bedrock/claude-opus-4-8 when no role is configured); `--provider`/`--model` override it.
     """
+    from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
+    from wmo.cli.harness_app import _explicit
+    from wmo.telemetry import capture_eval_completed
     args = tokens or []
     suite_roots = (
         [str(root) for root in _benchmark_roots()] if examples_root is None else [examples_root]
@@ -1718,6 +1737,7 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
 
 
 def _eval_list(examples_roots: list[str]) -> None:
+    from wmo.engine.eval_suites import discover_eval_suites
     suites = discover_eval_suites(examples_roots)
     if not suites:
         _console.print("[yellow]no eval suites found[/yellow]")
@@ -1744,6 +1764,7 @@ def _eval_results(
     *,
     limit: int,
 ) -> None:
+    from wmo.engine.eval_suites import list_eval_results, resolve_eval_suite
     resolved_suite = suite_filter
     if suite_filter is not None:
         try:
@@ -1796,6 +1817,9 @@ def _parse_model_specs(models: str | None) -> list[ModelSpec]:
     (`resolve_provider_model`), so a friendly model type resolves to its canonical wire id while an
     unknown (self-hosted) id passes through unchanged, and a bad provider fails at parse time.
     """
+    from wmo.evals.grid import ModelSpec
+    from wmo.providers import ProviderKind
+    from wmo.providers.models import resolve_provider_model
     raw = models.split(",") if models else list(_DEFAULT_GRID_MODELS)
     specs: list[ModelSpec] = []
     for entry in raw:
@@ -1848,6 +1872,9 @@ def _eval_run_grid(  # noqa: PLR0913 - a CLI seam threading grid options; each m
     out: str | None,
 ) -> None:
     """Run the model x condition grid for a suite, write result JSON + a fidelity bar chart PNG."""
+    from wmo.engine.prompts import BASE_ENV_PROMPT
+    from wmo.evals.grid import run_grid
+    from wmo.evals.grid_plot import plot_grid
     suite = _resolve_eval_suite_or_usage(selector, examples_roots)
     # The chart is the last thing written, so probe its deps before the grid spends anything.
     _require_viz_extra()
@@ -1908,6 +1935,8 @@ def _eval_grid_plot(paths: list[str], *, out: str | None, dataset_label: str | N
     process-global) be combined with the API-model grid into one chart - and re-plots any saved
     result without re-running the eval.
     """
+    from wmo.evals.grid import GridResult, merge_results
+    from wmo.evals.grid_plot import plot_grid
     _require_viz_extra()
     results = [GridResult.model_validate_json(Path(p).read_text(encoding="utf-8")) for p in paths]
     merged = merge_results(results)
@@ -1935,6 +1964,8 @@ def _eval_grid_heatmap(paths: list[str], *, out: str | None) -> None:
     Accepts any mix of API/Qwen result JSONs; same-suite results are merged into one 5-model row
     set, then all suites become the heatmap's columns (rows = model x condition).
     """
+    from wmo.evals.grid import GridResult, merge_results
+    from wmo.evals.grid_plot import plot_grid_heatmap
     _require_viz_extra()
     by_suite: dict[str, list[GridResult]] = {}
     for p in paths:
@@ -1963,6 +1994,8 @@ def _eval_run_suite(
     reasoning: bool | None,
     out: str | None,
 ) -> None:
+    from wmo.engine.eval_suites import result_path
+    from wmo.telemetry import capture_eval_completed, settings_root_from_results_root
     suite = _resolve_eval_suite_or_usage(selector, examples_roots)
     suite_prompt = suite.resolve_prompt()
     options = _eval_options(
@@ -2047,6 +2080,7 @@ def _eval_options(
     knowledge: bool | None = None,
     reasoning: bool | None = None,
 ) -> _EvalOptions:
+    from wmo.engine.build import DEFAULT_TRAIN_SPLIT
     split = DEFAULT_TRAIN_SPLIT if train_split is None else train_split
     dim = 512 if embed_dim is None else embed_dim
     retrieval = True if rag is None else rag
@@ -2081,6 +2115,11 @@ def _run_eval_files(
     provider_config: ProviderConfig,
     chain: str | None = None,
 ) -> EvalReport:
+    import wmo.providers as providers
+    from wmo.engine.prompts import BASE_ENV_PROMPT
+    from wmo.evals.open_loop import OpenLoopEval
+    from wmo.optimize.judge import RubricJudge
+    from wmo.retrieval import HashingEmbedder
     for path in files:
         if not path.exists():
             raise typer.BadParameter(f"trace file not found: {path}")
@@ -2171,6 +2210,7 @@ def _write_ad_hoc_eval_report(path: Path, report: EvalReport) -> None:
 
 
 def _eval_report_payload(report: EvalReport) -> JsonObject:
+    from wmo.optimize.judge import JUDGE_VERSION
     return {
         "judge_version": JUDGE_VERSION,
         "overall_fidelity": report.overall_fidelity,
@@ -2197,6 +2237,7 @@ def knowledge_(
     the env's own cross-session notes; `grounded.md` caches web-search groundings. Models are
     resolved exactly as `wmo demo`/`wmo play` resolve them, so a shipped example needs no `--root`.
     """
+    from wmo.engine.knowledge import KnowledgeBase
     store_root, resolved = _resolve_model_any(name, root)
     model_dir = WorldModelStore(str(store_root)).resolve(resolved)
     kb = KnowledgeBase(ArtifactPaths(model_dir).knowledge)
@@ -2261,6 +2302,7 @@ def scenarios_build(
     Writes a `ScenarioSet` JSON: scenarios (task, seed state, checklist, weight, provenance),
     the named clusters they came from, and the corpus-coverage number that justifies them.
     """
+    from wmo.scenarios import FacetExtractor, ScenarioBuildConfig, build_scenario_set
     traces = _ingest_scenario_corpus(file)
     if limit is not None:
         traces = traces[:limit]
@@ -2310,6 +2352,11 @@ def scenarios_verify(
     baseline LLM agent on every scenario, and grades episodes against each scenario's checklist.
     With `--drop`, unverified scenarios are removed from the set in place.
     """
+    import wmo.providers as providers
+    from wmo.engine.world_model import WorldModel
+    from wmo.env.llm_agent import LLMAgent
+    from wmo.providers.retry import wrap_provider_with_retries
+    from wmo.scenarios import ChecklistJudge, verify_scenarios
     scenario_set = _load_scenario_set(scenarios_file)
     traces = _ingest_scenario_corpus(file)
     if provider is not None or model is not None:
@@ -2374,6 +2421,7 @@ def _ingest_scenario_corpus(file: str) -> list[Trace]:
     likeliest first-run mistake. Guard it here rather than letting `Path.read_text` raise, which
     reaches the user as a stdlib FileNotFoundError/IsADirectoryError traceback.
     """
+    from wmo.ingest import get_adapter
     path = Path(file)
     if path.is_dir():
         raise typer.BadParameter(
@@ -2398,6 +2446,7 @@ def _load_scenario_set(scenarios_file: str) -> ScenarioSet:
     ValidationError that sends the user to pydantic's docs; neither says the file is supposed to
     be the output of `wmo scenarios build`.
     """
+    from wmo.scenarios import ScenarioSet
     path = Path(scenarios_file)
     build_hint = (
         f"build one with `wmo scenarios build --file <traces.jsonl> --out {scenarios_file}`"
@@ -2443,6 +2492,7 @@ def _unreadable_input(
 
 def _provider_kind(provider: str) -> ProviderKind:
     """The `ProviderKind` a `--provider` flag names, as a usage error when it names none."""
+    from wmo.providers import ProviderKind
     try:
         return ProviderKind(provider)
     except ValueError:
@@ -2451,6 +2501,8 @@ def _provider_kind(provider: str) -> ProviderKind:
 
 
 def _provider_config(provider: str, model: str, region: str | None) -> ProviderConfig:
+    from wmo.providers import ProviderConfig
+    from wmo.providers.models import resolve_provider_model
     kind = _provider_kind(provider)
     spec = resolve_provider_model(kind, model)
     return ProviderConfig(
@@ -2475,6 +2527,7 @@ def _default_model_for_provider(kind: ProviderKind) -> str:
     no built-in rows (nothing can derive an operator's route or weights path), so they must be
     told which model to run.
     """
+    from wmo.providers.models import model_types_for_provider
     catalog = model_types_for_provider(kind)
     if not catalog:
         raise typer.BadParameter(
@@ -2546,6 +2599,8 @@ def _worker_role_provider_config(
     configured role drops that role's model and connection fields, which belong to the backend it
     replaced — the model then comes from the NEW backend's catalog, never from bedrock's.
     """
+    from wmo.providers import ProviderKind
+    from wmo.providers.models import resolve_provider_model
     configured = _role_provider_config("worker", region)
     if configured is None or (provider is not None and provider != configured.kind.value):
         kind = _provider_kind(provider or _DEFAULT_WORKER_PROVIDER)
@@ -2578,6 +2633,7 @@ def _scenario_role_llms(
     built-in default. Judging benefits from a different family than the worker: a same-family
     judge carries self-preference bias toward the generator's outputs.
     """
+    import wmo.providers as providers
     if provider is not None or model is not None:
         llm = providers.get_provider(_worker_role_provider_config(provider, model, region))
         return llm, llm, llm
@@ -2596,6 +2652,10 @@ def _scenario_role_llms(
 def _resolve_scenario_embedder(
     embed_provider: str, embed_model: str | None, embed_dim: int, region: str | None
 ) -> Embedder:
+    import wmo.providers as providers
+    from wmo.providers import ProviderConfig
+    from wmo.providers.base import EmbedderKind
+    from wmo.retrieval import HashingEmbedder
     try:
         kind = EmbedderKind(embed_provider)
     except ValueError:
@@ -2648,6 +2708,16 @@ def demo(
     ),
 ) -> None:
     """Replay a randomly sampled recorded scenario against the world model, open loop."""
+
+    from llm_waterfall import is_capacity_error
+
+    import wmo.providers as providers
+    from wmo.cli.ui import select_provider_and_model
+    from wmo.engine.build import ingest
+    from wmo.engine.demo import run_demo
+    from wmo.engine.world_model import WorldModel
+    from wmo.providers import verify_all
+    from wmo.providers.retry import wrap_provider_with_retries
     wm, resolved_name, _provider, model_root = _load_model_any(
         name, root, max_fidelity=max_fidelity
     )
@@ -2784,6 +2854,7 @@ def play(
     ),
 ) -> None:
     """Step into the environment yourself: type actions, the world model returns observations."""
+    from wmo.cli.ui import run_play_repl
     wm, resolved_name, _provider, _model_root = _load_model_any(
         name, root, max_fidelity=max_fidelity
     )
@@ -2799,6 +2870,7 @@ def _demo_traces(model_dir: Path, resolved_name: str, explicit: str | None) -> P
     example layout. A build keeps NO copy of the corpus it read, so a plain `wmo build` leaves
     neither, and the failure has to name the file to pass rather than the directory it searched.
     """
+    from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
     if explicit is not None:
         path = Path(explicit)
         if not path.is_file():
@@ -2943,6 +3015,7 @@ def _resolve_name(store: WorldModelStore, name: str | None) -> str:
     which returns the lone model or raises a helpful "pass --name" error. Store errors
     (unknown/ambiguous name) are turned into a clean `typer.BadParameter` rather than a traceback.
     """
+    from wmo.cli.ui import select_model
     try:
         if name is not None:
             store.resolve(name)  # validates existence, raising a friendly error if missing
@@ -3063,6 +3136,16 @@ def research_concurrency(
     to give the time differential T_real(W)/T_world(W). Reuses the suite's corpus + config
     (train_split, top_k, prompt) and the example's `run.sh`. See `wmo.research.concurrency_run`.
     """
+    import wmo.providers as providers
+    from wmo.engine.build import split_traces
+    from wmo.engine.eval_suites import resolve_eval_suite
+    from wmo.engine.prompts import BASE_ENV_PROMPT
+    from wmo.ingest import get_adapter
+    from wmo.research import Side, run_concurrency_scaling
+    from wmo.research.concurrency_run import build_real_runner, build_world_runner
+    from wmo.research.concurrency_scaling import ConcurrencyPoint
+    from wmo.retrieval import EmbeddingRetriever, HashingEmbedder
+    from wmo.retrieval.leakfree import DemoRetriever
     if scenarios < 1:
         raise typer.BadParameter("--scenarios must be at least 1")
     try:
@@ -3237,8 +3320,8 @@ def research_plot_concurrency(
     turns a missing extra into a usage error naming `uv sync --extra viz`, so the import itself
     never surfaces a raw ModuleNotFoundError traceback.
     """
-    _require_viz_extra()
     from wmo.research.concurrency_plot import render_report
+    _require_viz_extra()
 
     try:
         written = render_report(report, out, title=title)
@@ -3351,6 +3434,9 @@ def _load_model(name: str | None, root: str, *, max_fidelity: bool = False):  # 
     dying. `max_fidelity` = the online extras (see `WorldModel.load`); default is pure RAG.
     Returns `(world_model, resolved_name, provider)`.
     """
+    import wmo.providers as providers
+    from wmo.engine.world_model import WorldModel
+    from wmo.providers.retry import wrap_provider_with_retries
     store = WorldModelStore(root)
     resolved_name = _resolve_name(store, name)
     model_dir = store.resolve(resolved_name)
@@ -3379,6 +3465,7 @@ def _prepare_serve_provider_or_exit(provider: Provider, config: ProviderConfig) 
     fail here with the same hint `wmo providers verify` prints. Bedrock and tinker document a
     residual gap they cannot close locally; those still fail on the first call.
     """
+    from wmo.providers.base import PreparableProvider
     if not isinstance(provider, PreparableProvider):
         return
     try:

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -3320,8 +3320,8 @@ def research_plot_concurrency(
     turns a missing extra into a usage error naming `uv sync --extra viz`, so the import itself
     never surfaces a raw ModuleNotFoundError traceback.
     """
-    from wmo.research.concurrency_plot import render_report
     _require_viz_extra()
+    from wmo.research.concurrency_plot import render_report
 
     try:
         written = render_report(report, out, title=title)

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import os
 import subprocess
+import sys
 import time
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -285,7 +286,7 @@ def test_build_wizard_does_not_reuse_connection_for_changed_provider(
             }
         )
 
-    monkeypatch.setattr(cli_app_module, "run_build_wizard", switch_provider)
+    monkeypatch.setattr("wmo.cli.ui.run_build_wizard", switch_provider)
 
     result = runner.invoke(app, ["build", "--interactive", "--root", str(root)])
 
@@ -317,7 +318,7 @@ def test_build_survives_card_write_failure(patched_provider, monkeypatch, tmp_pa
     def _boom(card, model_dir) -> None:  # noqa: ANN001
         raise OSError("disk full")
 
-    monkeypatch.setattr(cli_app_module, "save_card", _boom)
+    monkeypatch.setattr("wmo.config.card.save_card", _boom)
     root = tmp_path / ".wmo"
     _build(root, "tau2-airline", tmp_path)  # asserts exit_code == 0 internally
     assert (root / "models" / "tau2-airline" / "config.toml").exists()
@@ -572,6 +573,7 @@ def test_examples_data_only_bundle_is_marked_and_points_at_wmo_build(tmp_path, m
     assert "--name demo-corpus" in output
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows ignores the Unix exec bit")
 def test_examples_run_rejects_a_non_executable_launcher(tmp_path, monkeypatch) -> None:  # noqa: ANN001
     # A run.sh that lost its exec bit (archive, checkout) must be a usage error naming chmod,
     # not a PermissionError traceback out of subprocess.
@@ -840,8 +842,7 @@ def test_demo_keeps_the_traceback_for_a_wmo_bug(patched_provider, tmp_path, monk
     root = tmp_path / ".wmo"
     _build(root, "demo-model", tmp_path)
     monkeypatch.setattr(
-        cli_app_module,
-        "run_demo",
+        "wmo.engine.demo.run_demo",
         lambda *a, **kw: (_ for _ in ()).throw(KeyError("internal")),
     )
 
@@ -1026,7 +1027,7 @@ def test_providers_set_verifies_and_saves_local_worker(monkeypatch, tmp_path) ->
         checked.extend(configs)
         return [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
 
-    monkeypatch.setattr(cli_app_module, "verify_all", verify)
+    monkeypatch.setattr("wmo.providers.verify_all", verify)
     result = runner.invoke(
         app,
         [
@@ -1059,8 +1060,7 @@ def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     provider, and `verify_pool_entry` proves each routing candidate over its own route.
     """
     monkeypatch.setattr(
-        cli_app_module,
-        "verify_all",
+        "wmo.providers.verify_all",
         lambda configs: [
             VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs
         ],
@@ -1412,8 +1412,7 @@ def test_providers_set_without_pool_flags_leaves_scripted_runs_untouched(
 def test_providers_set_does_not_save_a_failed_provider(monkeypatch, tmp_path) -> None:  # noqa: ANN001
     root = tmp_path / ".wmo"
     monkeypatch.setattr(
-        cli_app_module,
-        "verify_all",
+        "wmo.providers.verify_all",
         lambda configs: [
             VerifyResult(
                 ok=False,
@@ -1466,9 +1465,9 @@ def test_examples_run_invokes_task_launcher(monkeypatch) -> None:  # noqa: ANN00
 
     assert result.exit_code == 0, result.output
     command = cast(list[str], seen["command"])
-    assert command[0].endswith("environment-capture/tau-bench/run.sh")
+    assert Path(command[0]).as_posix().endswith("environment-capture/tau-bench/run.sh")
     assert command[1:] == ["--trace", "0"]
-    assert str(seen["cwd"]).endswith("environment-capture/tau-bench")
+    assert Path(str(seen["cwd"])).as_posix().endswith("environment-capture/tau-bench")
     assert seen["check"] is False
 
 
@@ -1532,8 +1531,8 @@ def _record_eval_providers(monkeypatch: pytest.MonkeyPatch) -> list[ProviderConf
         seen.append(config)
         return fake
 
-    monkeypatch.setattr(cli_app_module.providers, "provider_or_chain", record)
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", record)
+    monkeypatch.setattr("wmo.providers.provider_or_chain", record)
+    monkeypatch.setattr("wmo.providers.get_provider", record)
     return seen
 
 
@@ -1713,7 +1712,8 @@ def test_eval_on_a_directory_is_a_usage_error(tmp_path) -> None:  # noqa: ANN001
     assert result.exit_code == 2  # usage error, not an IsADirectoryError traceback
     flat = _flat(result.output)
     assert "is a directory" in flat
-    assert "traces.otel.jsonl" in flat  # names the file to pass instead
+    # Rich may soft-wrap long Windows paths mid-token (`traces.otel.j` / `sonl`); strip spaces.
+    assert "traces.otel.jsonl" in flat.replace(" ", "")  # names the file to pass instead
 
 
 def test_eval_file_with_no_traces_fails_instead_of_scoring_zero(tmp_path) -> None:  # noqa: ANN001
@@ -1946,7 +1946,7 @@ def test_the_model_picker_offers_only_readable_artifacts(
         return infos[0].name
 
     monkeypatch.setattr(cli_app_module, "_console", SimpleNamespace(is_terminal=True))
-    monkeypatch.setattr(cli_app_module, "select_model", fake_select_model)
+    monkeypatch.setattr("wmo.cli.ui.select_model", fake_select_model)
 
     assert cli_app_module._resolve_name(WorldModelStore(root), None) == "alpha-healthy"
     assert offered == ["alpha-healthy", "beta-healthy"]
@@ -2233,8 +2233,6 @@ def test_build_pull_limit_is_a_fetch_cap_applied_once(
     it would only read as a promise of N usable traces that this transport cannot keep. Pinning
     both halves: the adapter receives the cap, and `build` is not handed it a second time.
     """
-    import sys
-
     from wmo.config.card import load_card
 
     seen: list[VendorPull] = []
@@ -2250,16 +2248,20 @@ def test_build_pull_limit_is_a_fetch_cap_applied_once(
             traces = [_pull_trace(f"{i:032d}", usable=bool(i % 2)) for i in range(6)]
             return traces if pull.limit is None else traces[: pull.limit]
 
-    real_run_build = cli_app_module.run_build
+    # `wmo.engine.build` is shadowed by the `build` function re-exported from
+    # `wmo.engine.__init__`, so attribute / `import wmo.engine.build` resolve the function.
+    # Reach the submodule only through importlib / sys.modules.
+    import importlib
+
+    engine_build = importlib.import_module("wmo.engine.build")
+    real_run_build = engine_build.build
 
     def _spy(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202 - passthrough spy
         passed_to_build.update(kwargs)
         return real_run_build(*args, **kwargs)
 
-    monkeypatch.setattr(
-        sys.modules["wmo.engine.build"], "get_adapter", lambda name: _CappingAdapter()
-    )
-    monkeypatch.setattr(cli_app_module, "run_build", _spy)
+    monkeypatch.setattr(engine_build, "get_adapter", lambda name: _CappingAdapter())
+    monkeypatch.setattr(engine_build, "build", _spy)
     root = tmp_path / ".wmo"
     result = runner.invoke(
         app,
@@ -2395,14 +2397,10 @@ def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None: 
     Regression: previously the ModuleNotFoundError was swallowed inside GEPA and the build
     "succeeded" with a useless held-out-0.0 model.
     """
-    import sys
-
     from wmo.providers.base import VerifyResult
 
-    appmod = sys.modules["wmo.cli.app"]
     monkeypatch.setattr(
-        appmod,
-        "verify_all",
+        "wmo.providers.verify_all",
         lambda configs: [
             VerifyResult(
                 ok=False,
@@ -2522,7 +2520,9 @@ def test_providers_verify_unreadable_model_config_is_clean_error(tmp_path: Path)
     assert result.exit_code == 2
     assert not isinstance(result.exception, ValueError)
     flat = _flat(result.output)
-    assert "foo/config.toml is not valid TOML" in flat
+    # Path separators and rich soft-wraps vary by OS; match the durable pieces.
+    assert "foo" in flat and "config.toml" in flat.replace(" ", "")
+    assert "is not valid TOML" in flat
     assert "re-run `wmo build`" in flat
 
 
@@ -2533,7 +2533,7 @@ def _record_verify_all(monkeypatch: pytest.MonkeyPatch, pinged: list[ProviderCon
         pinged.extend(configs)
         return [VerifyResult(ok=True, kind=c.kind, model=c.model) for c in configs]
 
-    monkeypatch.setattr(cli_app_module, "verify_all", fake_verify_all)
+    monkeypatch.setattr("wmo.providers.verify_all", fake_verify_all)
 
 
 def test_providers_verify_nothing_configured_is_actionable(tmp_path: Path) -> None:
@@ -2582,8 +2582,7 @@ def test_providers_verify_reports_a_role_failure_with_its_credentials(
     settings.models.worker = ModelRole(provider="bedrock", model="claude-opus-4-8")
     save_settings(settings, root)
     monkeypatch.setattr(
-        cli_app_module,
-        "verify_all",
+        "wmo.providers.verify_all",
         lambda configs: [
             VerifyResult(
                 ok=False,
@@ -2615,8 +2614,7 @@ def test_providers_verify_missing_optional_sdk_points_at_the_install(
     settings.models.worker = ModelRole(provider="tinker", model="Qwen/Qwen3-8B")
     save_settings(settings, root)
     monkeypatch.setattr(
-        cli_app_module,
-        "verify_all",
+        "wmo.providers.verify_all",
         lambda configs: [
             VerifyResult(ok=False, kind=c.kind, model=c.model, detail=_MISSING_TINKER_EXTRA)
             for c in configs
@@ -2825,15 +2823,13 @@ def test_research_concurrency_uses_the_configured_worker_provider(
     monkeypatch.chdir(tmp_path)
     # get_provider is the identity here, so calling the runner's factory yields its config.
     built: list[ProviderConfig] = []
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr("wmo.providers.get_provider", lambda config: config)
     monkeypatch.setattr(
-        cli_app_module,
-        "build_world_runner",
+        "wmo.research.concurrency_run.build_world_runner",
         lambda factory, prompt, demos, selected: built.append(factory()),
     )
     monkeypatch.setattr(
-        cli_app_module,
-        "run_concurrency_scaling",
+        "wmo.research.run_concurrency_scaling",
         lambda *a, **kw: SimpleNamespace(benchmark="", best_speedup=lambda: None),
     )
 
@@ -3030,6 +3026,7 @@ def test_scenarios_build_non_utf8_corpus_is_clean_error(tmp_path) -> None:  # no
     assert "--file" in flat and "is not UTF-8 text" in flat
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod(0) does not revoke read on Windows")
 def test_scenarios_build_unreadable_corpus_is_clean_error(tmp_path) -> None:  # noqa: ANN001
     # Regression (Greptile P1): chmod-000 raised PermissionError out of Path.read_text.
     corpus = tmp_path / "traces.jsonl"
@@ -3068,7 +3065,7 @@ def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa:
         made.append(config)
         return config  # identity provider: assertions read the config directly
 
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", fake_get_provider)
+    monkeypatch.setattr("wmo.providers.get_provider", fake_get_provider)
     monkeypatch.setattr(
         cli_app_module,
         "load_settings_or_abort",
@@ -3093,7 +3090,7 @@ def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa:
 def test_scenario_role_llms_cli_flags_pin_every_role(monkeypatch) -> None:  # noqa: ANN001
     from wmo.config.settings import ProjectSettings
 
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr("wmo.providers.get_provider", lambda config: config)
     monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
     summary, worker, judge = cli_app_module._scenario_role_llms("bedrock", "some-model", None)
     assert summary is worker
@@ -3106,7 +3103,7 @@ def test_scenario_role_llms_model_flag_keeps_the_configured_provider(monkeypatch
     # asked bedrock for an OpenAI model id.
     from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
 
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr("wmo.providers.get_provider", lambda config: config)
     monkeypatch.setattr(
         cli_app_module,
         "load_settings_or_abort",
@@ -3122,7 +3119,7 @@ def test_scenario_role_llms_model_flag_keeps_the_configured_provider(monkeypatch
 def test_scenario_role_llms_default_when_nothing_configured(monkeypatch) -> None:  # noqa: ANN001
     from wmo.config.settings import ProjectSettings
 
-    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr("wmo.providers.get_provider", lambda config: config)
     monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
     summary, worker, judge = cli_app_module._scenario_role_llms(None, None, None)
     assert summary is worker
@@ -3272,8 +3269,8 @@ def test_download_fetches_named_benchmarks(monkeypatch, tmp_path: Path) -> None:
         fetched.append((name, force))
         return tmp_path / name / "traces.otel.jsonl"
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fake_fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fake_fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "bird-sql", "dabstep", "--force"])
     assert result.exit_code == 0, result.output
     assert fetched == [("bird-sql", True), ("dabstep", True)]
@@ -3285,13 +3282,12 @@ def test_download_all_expands_to_the_published_list(monkeypatch, tmp_path: Path)
     # registry entry that isn't published yet would 404.
     fetched: list[str] = []
     published = [SimpleNamespace(benchmark=n, last_modified=None) for n in ("a-bench", "b-bench")]
-    monkeypatch.setattr(cli_app_module, "published_corpora", lambda: published)
+    monkeypatch.setattr("wmo.hub.published_corpora", lambda: published)
     monkeypatch.setattr(
-        cli_app_module,
-        "fetch_corpus",
+        "wmo.hub.fetch_corpus",
         lambda name, force=False, on_progress=None: fetched.append(name) or tmp_path,
     )
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "all"])
     assert result.exit_code == 0, result.output
     assert fetched == ["a-bench", "b-bench"]
@@ -3310,8 +3306,8 @@ def test_download_multi_skips_a_404_and_fetches_the_rest(monkeypatch, tmp_path: 
         fetched.append(name)
         return tmp_path
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "a-bench", "broken", "z-bench"])
     assert fetched == ["a-bench", "z-bench"]  # kept going past the 404
     assert result.exit_code != 0  # ...but the failure is still reported at the end
@@ -3329,23 +3325,24 @@ def test_download_all_offline_skips_the_unpublished_and_still_succeeds(  # noqa:
     # subset, and it says what it dropped.
     import urllib.error
 
-    unpublished = sorted(n for n, spec in cli_app_module.CORPORA.items() if not spec.published)
+    from wmo.hub import CORPORA, downloadable_benchmarks
+
+    unpublished = sorted(n for n, spec in CORPORA.items() if not spec.published)
     assert unpublished, "this test is meaningless once every registered corpus is published"
     fetched: list[str] = []
 
     def no_catalogue(*_args: object, **_kwargs: object) -> None:
         raise urllib.error.URLError("offline")
 
-    monkeypatch.setattr(cli_app_module, "published_corpora", no_catalogue)
+    monkeypatch.setattr("wmo.hub.published_corpora", no_catalogue)
     monkeypatch.setattr(
-        cli_app_module,
-        "fetch_corpus",
+        "wmo.hub.fetch_corpus",
         lambda name, force=False, on_progress=None: fetched.append(name) or tmp_path,
     )
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "all"])
     assert result.exit_code == 0, result.output  # no failure over an unpushed registry entry
-    assert fetched == cli_app_module.downloadable_benchmarks()
+    assert fetched == downloadable_benchmarks()
     for name in unpublished:
         assert name not in fetched
         assert name in result.output  # the narrowing is announced, never silent
@@ -3363,8 +3360,8 @@ def test_download_multi_keeps_going_past_a_truncated_transfer(monkeypatch, tmp_p
         fetched.append(name)
         return tmp_path
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "a-bench", "short", "z-bench"])
     assert fetched == ["a-bench", "z-bench"]  # kept going past the short transfer
     assert result.exit_code != 0  # ...but the failure is still reported at the end
@@ -3379,8 +3376,8 @@ def test_download_of_one_bundle_reports_a_truncated_transfer_as_a_failure(  # no
     def fetch(name, force=False, on_progress=None):  # noqa: ANN001, ANN202
         raise OSError("traces.otel.jsonl: 6 bytes, tree lists 4096 — truncated transfer")
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "dabstep"])
     assert result.exit_code == 1
     assert "truncated transfer" in result.output
@@ -3395,14 +3392,16 @@ def test_download_multi_reports_an_unknown_name_without_stranding_the_rest(  # n
     # hand-typed list used to abort the command before the good ones were attempted.
     fetched: list[str] = []
 
+    from wmo.hub import CORPORA
+
     def fetch(name, force=False, on_progress=None):  # noqa: ANN001, ANN202
-        if name not in cli_app_module.CORPORA:
+        if name not in CORPORA:
             raise ValueError(f"{name!r} has no published corpus (available: dabstep)")
         fetched.append(name)
         return tmp_path
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "nope", "dabstep"])
     assert fetched == ["dabstep"]
     assert result.exit_code != 0
@@ -3427,8 +3426,8 @@ def test_download_failure_names_every_repo_id_it_tried(monkeypatch, tmp_path: Pa
     def fetch(name, force=False, on_progress=None):  # noqa: ANN001, ANN202
         raise CorpusRepoUnavailable(name, "main", attempts)
 
-    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.fetch_corpus", fetch)
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "dabstep"])
     assert result.exit_code != 0
     for repo_id in candidate_repo_ids("dabstep"):
@@ -3436,7 +3435,7 @@ def test_download_failure_names_every_repo_id_it_tried(monkeypatch, tmp_path: Pa
 
 
 def test_download_unknown_benchmark_is_a_usage_error(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "nope"])
     assert result.exit_code != 0
     assert "no published corpus" in result.output
@@ -3456,13 +3455,12 @@ def test_download_picker_lists_published_and_fetches_choice(
         )
     ]
     fetched: list[str] = []
-    monkeypatch.setattr(cli_app_module, "published_corpora", lambda: published)
+    monkeypatch.setattr("wmo.hub.published_corpora", lambda: published)
     monkeypatch.setattr(
-        cli_app_module,
-        "fetch_corpus",
+        "wmo.hub.fetch_corpus",
         lambda name, force=False, on_progress=None: fetched.append(name) or tmp_path,
     )
-    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    monkeypatch.setattr("wmo.hub.corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download"], input="1\n")
     assert result.exit_code == 0, result.output
     assert fetched == ["gaia2"]

--- a/wmo/cli/defer.py
+++ b/wmo/cli/defer.py
@@ -1,0 +1,99 @@
+"""Deferred Typer sub-app loading so root CLI import stays light.
+
+Parent ``--help`` only needs the group's name and help string. Subcommand resolution
+(``wmo optimize …``, ``wmo optimize --help``) imports the real Typer app once via
+``importlib`` and then delegates to it.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from typer import _click
+from typer.core import TyperGroup
+from typer.main import get_group
+
+if TYPE_CHECKING:
+    import typer
+
+
+class DeferredTyperGroup(TyperGroup):
+    """Click group that imports a Typer app only when a subcommand is resolved.
+
+    ``list_commands`` returns ``known_names`` without importing so a parent ``--help`` that
+    never descends into this group stays cheap. Resolving any child (including this group's
+    own ``--help``, which walks children for short help) loads the real app once.
+    """
+
+    def __init__(
+        self,
+        *args: object,
+        import_path: str,
+        attr: str,
+        known_names: tuple[str, ...],
+        **kwargs: object,
+    ) -> None:
+        # Typer/Click pass a wide kwargs bag; forwarding as typed kwargs is not practical here.
+        super().__init__(*args, **kwargs)  # ty: ignore[invalid-argument-type]
+        self._import_path = import_path
+        self._attr = attr
+        self._known_names = known_names
+        self._real: TyperGroup | None = None
+
+    def _ensure(self) -> TyperGroup:
+        if self._real is None:
+            module = importlib.import_module(self._import_path)
+            typer_app = getattr(module, self._attr)
+            loaded = get_group(typer_app)
+            assert isinstance(loaded, TyperGroup)
+            self._real = loaded
+        return self._real
+
+    def list_commands(self, ctx: _click.Context) -> list[str]:
+        if self._real is not None:
+            return self._ensure().list_commands(ctx)
+        if self._known_names:
+            return list(self._known_names)
+        return self._ensure().list_commands(ctx)
+
+    def get_command(self, ctx: _click.Context, cmd_name: str) -> _click.Command | None:
+        return self._ensure().get_command(ctx, cmd_name)
+
+
+def add_deferred_typer(
+    parent: typer.Typer,
+    *,
+    name: str,
+    module: str,
+    attr: str,
+    help: str,
+    known_names: tuple[str, ...] = (),
+    no_args_is_help: bool = True,
+) -> None:
+    """Register a named sub-app whose module loads only on first use.
+
+    Creates an empty Typer placeholder so Typer's registration bookkeeping stays intact, then
+    passes a ``DeferredTyperGroup`` subclass via ``cls`` so Click resolves children lazily.
+    """
+    import typer as typer_mod
+
+    placeholder = typer_mod.Typer(help=help, no_args_is_help=no_args_is_help)
+
+    class _Deferred(DeferredTyperGroup):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(
+                *args,
+                import_path=module,
+                attr=attr,
+                known_names=known_names,
+                **kwargs,
+            )
+
+    parent.add_typer(
+        placeholder,
+        name=name,
+        help=help,
+        no_args_is_help=no_args_is_help,
+        cls=_Deferred,
+    )

--- a/wmo/cli/e2b_cmds.py
+++ b/wmo/cli/e2b_cmds.py
@@ -8,21 +8,14 @@ kill is destructive and one wrong id is somebody's running trial.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from wmo.harness.e2b_ledger import read_ledger_files
-from wmo.harness.e2b_reap import (
-    AliveSandbox,
-    ReapCandidate,
-    execute_reap,
-    kill_sandbox,
-    list_alive_sandboxes,
-    plan_reap,
-    sandbox_cap,
-)
+if TYPE_CHECKING:
+    from wmo.harness.e2b_reap import AliveSandbox, ReapCandidate
 
 _console = Console()
 
@@ -80,6 +73,15 @@ def reap(
     The default is a dry run that prints the candidates and changes nothing. Pass `--yes` to
     kill them.
     """
+    from wmo.harness.e2b_ledger import read_ledger_files
+    from wmo.harness.e2b_reap import (
+        execute_reap,
+        kill_sandbox,
+        list_alive_sandboxes,
+        plan_reap,
+        sandbox_cap,
+    )
+
     try:
         cap = sandbox_cap()
     except ValueError as error:

--- a/wmo/cli/eval_closed_loop.py
+++ b/wmo/cli/eval_closed_loop.py
@@ -11,20 +11,15 @@ docs/reference/closed_loop.md names.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
 
-from wmo.cli.model_roles import resolve_opt_in_model_provider
-from wmo.config import WorldModelStore
-from wmo.engine import load_world_model
-from wmo.evals.agreement import compute_agreement
-from wmo.evals.closed_loop import ClosedLoopEval, ClosedLoopReport
-from wmo.evals.gold import GoldJudge, GoldVerdict
-from wmo.evals.tasks import load_tasks
-from wmo.harness.doc import MAX_TURNS_ID, HarnessDoc, Surface, SurfaceKind
-from wmo.harness.runtime import DEFAULT_MAX_TURNS, AgentRuntime
-from wmo.harness.store import HarnessStore
+if TYPE_CHECKING:
+    from wmo.evals.closed_loop import ClosedLoopReport
+    from wmo.evals.gold import GoldVerdict
+    from wmo.harness.doc import HarnessDoc
 
 
 def run_closed_loop(
@@ -53,6 +48,14 @@ def run_closed_loop(
     (tool calls stay answered by the world model host-side), running all (task, attempt) cells
     at once unless `--eval-concurrency` caps them.
     """
+    from wmo.cli.model_roles import resolve_opt_in_model_provider
+    from wmo.config import WorldModelStore
+    from wmo.engine import load_world_model
+    from wmo.evals.closed_loop import ClosedLoopEval
+    from wmo.evals.gold import GoldJudge
+    from wmo.evals.tasks import load_tasks
+    from wmo.harness.runtime import DEFAULT_MAX_TURNS, AgentRuntime
+
     if harness_backend not in ("local", "e2b"):
         raise typer.BadParameter(
             f"unknown --harness-backend {harness_backend!r}; choose local or e2b"
@@ -170,6 +173,8 @@ def run_closed_loop(
 
 def run_agreement(console: Console, *, report_a: str, report_b: str, threshold: float) -> None:
     """Compare two saved closed-loop reports task-by-task and print the agreement verdict."""
+    from wmo.evals.agreement import compute_agreement
+
     a = _load_report(report_a)
     b = _load_report(report_b)
     result = compute_agreement(a, b, pass_threshold=threshold)
@@ -184,6 +189,8 @@ def run_agreement(console: Console, *, report_a: str, report_b: str, threshold: 
 
 
 def _load_report(path: str) -> ClosedLoopReport:
+    from wmo.evals.closed_loop import ClosedLoopReport
+
     try:
         return ClosedLoopReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
@@ -192,12 +199,16 @@ def _load_report(path: str) -> ClosedLoopReport:
 
 def _with_max_turns(doc: HarnessDoc, max_turns: int) -> HarnessDoc:
     """A copy of `doc` with its max-turns surface replaced (re-validated via the constructor)."""
+    from wmo.harness.doc import MAX_TURNS_ID, HarnessDoc, Surface, SurfaceKind
+
     surfaces = [s for s in doc.surfaces if s.id != MAX_TURNS_ID]
     surfaces.append(Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(max_turns)))
     return HarnessDoc(name=doc.name, version=doc.version, surfaces=surfaces)
 
 
 def _load_harness(name: str | None, root: str) -> HarnessDoc | None:
+    from wmo.harness.store import HarnessStore
+
     if name is None:
         return None
     base, _, ref = name.partition("@")

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -16,7 +16,7 @@ import asyncio
 import json
 import shlex
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -25,39 +25,27 @@ from rich.markup import escape
 from rich.prompt import IntPrompt, Prompt
 from rich.table import Table
 
-from wmo.agents.default import default_agent
-from wmo.agents.optimizer import optimizer_agent
-from wmo.agents.project import AgentProject
 from wmo.cli.consent import can_prompt, require_spend_consent
-from wmo.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
 from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.config.store import validate_name
 from wmo.core.types import JsonObject
-from wmo.engine import load_world_model
-from wmo.engine.world_model import WorldModel
-from wmo.evals.gold import GoldJudge
-from wmo.evals.tasks import TaskSpec, load_tasks
-from wmo.harness.create import ProposalRecord, create_harness
-from wmo.harness.doc import HarnessDoc
-from wmo.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
-from wmo.harness.population import (
-    CandidateProposer,
-    PopulationResult,
-    PopulationRunState,
-    SlotOutcome,
-    write_json_atomic,
-)
-from wmo.harness.population import (
-    optimize as optimize_population,
-)
-from wmo.harness.project_proposer import CandidateProject, ProjectCandidateProposer
-from wmo.harness.proposer import ProviderDeltaProposer
-from wmo.harness.runtime import DEFAULT_EVAL_EPISODE_TIMEOUT_S
-from wmo.harness.scoring import RewardMode, Scorer, ScoreRequest
-from wmo.harness.source_tree import HarnessSourceTree
-from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
-from wmo.providers.base import Provider, ProviderConfig, ToolCallingProvider
-from wmo.providers.registry import get_provider
+
+if TYPE_CHECKING:
+    # Type-only: real imports are local to the commands and helpers that construct or inspect
+    # these values, so importing this module never pulls the agents/engine/evals/harness/
+    # providers bodies behind it.
+    from wmo.engine.world_model import WorldModel
+    from wmo.evals.tasks import TaskSpec
+    from wmo.harness.doc import HarnessDoc
+    from wmo.harness.population import CandidateProposer, PopulationResult
+    from wmo.harness.scoring import Scorer
+    from wmo.harness.source_tree import HarnessSourceTree
+    from wmo.harness.store import HarnessStore
+    from wmo.providers.base import Provider, ProviderConfig
+
+# `RewardMode` mirrors `wmo.harness.scoring.RewardMode`'s definition (a bare Literal, not a
+# class), so no import is needed for the `_HarborRunConfig` field below.
+RewardMode = Literal["raw", "positive-binary"]
 
 # The default agent seed's literal CLI name: `wmo optimize harness pi harbor ...` starts from the
 # built-in pi agent and publishes new versions under the store name "pi".
@@ -71,6 +59,8 @@ _HARBOR_EXTRA_HINT = (
     "the harbor environment needs the harbor extra; run `uv sync --extra harbor` "
     "(or `pip install 'world-model-optimizer[harbor]'`)"
 )
+# Literal mirror of `wmo.harness.e2b_sandbox.E2B_TEMPLATE_ENV`, needed at Option-definition time.
+_E2B_TEMPLATE_ENV = "WMO_E2B_TEMPLATE"
 
 harness_app = typer.Typer(
     help="Inspect and initialize named, versioned agent harnesses.",
@@ -82,6 +72,8 @@ _console = Console()
 @harness_app.command("list")
 def list_harnesses(root: str = typer.Option(ARTIFACT_DIR, help="Project dir.")) -> None:
     """List every harness with its versions and aliases."""
+    from wmo.harness.store import HarnessStore
+
     store = HarnessStore(root)
     names = store.list_names()
     if not names:
@@ -118,6 +110,8 @@ def show_harness(
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
 ) -> None:
     """Print one harness version's surfaces."""
+    from wmo.harness.store import HarnessStore
+
     base, _, ref = name.partition("@")
     try:
         validate_name(base, kind="harness")  # a bad name is a name error, not a missing ref
@@ -150,14 +144,31 @@ optimize_app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Local import placement: route_app imports the optimize package and model_app imports this
-# module back; registering here keeps the whole optimizer family visible in one place.
-from wmo.cli.model_app import model_app  # noqa: E402
+# `route` and `distill` load their real Typer app only on first use, so `wmo --help` never pays
+# for the optimize/engine/distill import chains those modules pull in. `model` is registered
+# directly because `wmo.cli.optimize_model_app` is itself light at import time (its own heavy
+# imports are local to its functions), which keeps `optimize model --help` at full fidelity
+# without needing a signature-forwarding stub.
+from wmo.cli.defer import add_deferred_typer  # noqa: E402
 from wmo.cli.optimize_model_app import optimize_model  # noqa: E402
-from wmo.cli.route_app import route_app  # noqa: E402
 
-optimize_app.add_typer(route_app, name="route")
-optimize_app.add_typer(model_app, name="distill")
+add_deferred_typer(
+    optimize_app,
+    name="route",
+    module="wmo.cli.route_app",
+    attr="route_app",
+    help="Make models routable, measure them closed-loop, then fit, tune, and report policies.",
+    known_names=("student", "sweep", "fit", "tune", "report", "pin"),
+)
+add_deferred_typer(
+    optimize_app,
+    name="distill",
+    module="wmo.cli.model_app",
+    attr="model_app",
+    help="Train the agent model itself: distillation of a Tinker LoRA student from real "
+    "benchmark rollouts (harbor or tau2, config-selected), gated on held-out solve rates.",
+    known_names=("run", "probe", "report"),
+)
 optimize_app.command("model")(optimize_model)
 
 
@@ -200,7 +211,7 @@ def optimize(
     e2b_template: str | None = typer.Option(
         None,
         "--e2b-template",
-        envvar=E2B_TEMPLATE_ENV,
+        envvar=_E2B_TEMPLATE_ENV,
         help="Prebaked E2B sandbox template for --backend e2b (default: "
         "$WMO_E2B_TEMPLATE; without one, every sandbox bootstraps node + the pi runner deps).",
     ),
@@ -303,6 +314,12 @@ def optimize(
 
     To train the agent MODEL instead of its harness, use `wmo optimize distill run`.
     """
+    from wmo.cli.model_roles import resolve_opt_in_model_provider
+    from wmo.evals.gold import GoldJudge
+    from wmo.harness.create import ProposalRecord, create_harness
+    from wmo.harness.proposer import ProviderDeltaProposer
+    from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
+
     if model == _HARBOR_ENVIRONMENT:
         world_model_only = [
             flag
@@ -543,6 +560,8 @@ def optimize(
 
 
 def _load_task_file(path: str) -> list[TaskSpec]:
+    from wmo.evals.tasks import load_tasks
+
     try:
         return load_tasks(path)
     except (OSError, ValueError) as exc:
@@ -550,6 +569,8 @@ def _load_task_file(path: str) -> list[TaskSpec]:
 
 
 def _resolve_seed(store: HarnessStore, seed: str | None) -> HarnessDoc:
+    from wmo.harness.doc import HarnessDoc
+
     if seed is None:
         return HarnessDoc.baseline()
     base, _, ref = seed.partition("@")
@@ -561,6 +582,8 @@ def _resolve_seed(store: HarnessStore, seed: str | None) -> HarnessDoc:
 
 def _load_world_model(name: str | None, root: str) -> tuple[WorldModel, Provider, str]:
     """Resolve a world model by name (or the sole built one) and load it with its provider."""
+    from wmo.engine import load_world_model
+
     store = WorldModelStore(root)
     try:
         model_dir = store.resolve(name)
@@ -656,6 +679,10 @@ def _optimize_harbor(
     yes: bool,
 ) -> None:
     """Run the harbor population optimizer: fixed seed, sequential complete-source proposals."""
+    from wmo.cli.model_roles import resolve_required_model_config
+    from wmo.harness.e2b_sandbox import resolve_e2b_template
+    from wmo.harness.runtime import DEFAULT_EVAL_EPISODE_TIMEOUT_S
+
     if name is None:
         raise typer.BadParameter(
             "provide the seed agent NAME (the literal 'pi' is the built-in default agent): "
@@ -743,6 +770,9 @@ def _optimize_harbor(
     ):
         raise typer.Exit(0)
 
+    from wmo.harness.population import SlotOutcome, write_json_atomic
+    from wmo.harness.population import optimize as optimize_population
+
     scorer, task_pins = _build_harbor_scorer(config, run_dir=run_dir, provider_config=agent_config)
     if resume:
         if config.task_pins is not None and task_pins != config.task_pins:
@@ -801,6 +831,9 @@ def _publish_harbor_winner(
     resumed again re-prints that record instead of appending a duplicate store version and
     moving the champion alias a second time.
     """
+    from wmo.harness.population import write_json_atomic
+    from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
+
     published_path = run_dir / "published.json"
     if published_path.exists():
         record = json.loads(published_path.read_text(encoding="utf-8"))
@@ -842,6 +875,11 @@ def _resumed_harbor_seed(
     publication) resolve a different tree and brick a legitimate resume. Before the first
     boundary the seed is re-resolved from the PINNED version recorded at start.
     """
+    from wmo.agents.default import default_agent
+    from wmo.harness.population import PopulationRunState
+    from wmo.harness.source_tree import HarnessSourceTree
+    from wmo.harness.store import HarnessStore
+
     seed_name = config.agent.partition("@")[0]
     # load() only returns COMMITTED boundaries (state.json) and re-verifies each candidate's
     # doc hash, so a crash that left a partial candidate-0000/source dir cannot leak in.
@@ -878,6 +916,8 @@ def _resumed_harbor_config(
     agent_config: ProviderConfig,
 ) -> _HarborRunConfig:
     """Load the recorded run config, rejecting explicit CLI flags that conflict with it."""
+    from wmo.harness.e2b_sandbox import resolve_e2b_template
+
     if not config_path.is_file():
         raise typer.BadParameter(
             f"--resume found no run-config.json under {config_path.parent}; "
@@ -952,6 +992,10 @@ def _resolve_harbor_seed(root: str, agent_ref: str) -> tuple[str, HarnessSourceT
     the seed tree, and the resolved store version (None for the built-in seed) so a resume can
     pin exactly what this run started from.
     """
+    from wmo.agents.default import default_agent
+    from wmo.harness.source_tree import HarnessSourceTree
+    from wmo.harness.store import HarnessStore
+
     base, _, ref = agent_ref.partition("@")
     try:
         validate_name(base, kind="harness")
@@ -1001,6 +1045,8 @@ def _load_harbor_job_template(path: Path) -> JsonObject:
 
 def _load_harbor_task_ids(path: Path) -> tuple[str, ...]:
     """Load the exact ordered task-id list, validated by the canonical score request rules."""
+    from wmo.harness.scoring import ScoreRequest
+
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -1065,6 +1111,12 @@ def _build_harbor_proposer(
     optimizer persona needs a contained filesystem plus node for interface validation, and the
     pi worker template already ships both.
     """
+    from wmo.agents.optimizer import optimizer_agent
+    from wmo.agents.project import AgentProject
+    from wmo.harness.project_proposer import CandidateProject, ProjectCandidateProposer
+    from wmo.providers.base import ToolCallingProvider
+    from wmo.providers.registry import get_provider
+
     provider = get_provider(meta_config)
     if not isinstance(provider, ToolCallingProvider):
         raise typer.BadParameter(
@@ -1092,6 +1144,9 @@ def init_harness(
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
 ) -> None:
     """Write the baseline harness as v1 and point `champion` at it."""
+    from wmo.harness.doc import HarnessDoc
+    from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
+
     store = HarnessStore(root)
     try:
         if store.exists(name):

--- a/wmo/cli/ingest_cmd.py
+++ b/wmo/cli/ingest_cmd.py
@@ -15,22 +15,15 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
 from rich.markup import escape
 from rich.progress import BarColumn, Progress, TextColumn
 
-from wmo.ingest import VendorPull, list_adapters
-from wmo.ingest.stream import (
-    DetectedEvent,
-    DoneEvent,
-    ErrorEvent,
-    IngestEvent,
-    ProgressEvent,
-    event_json,
-    ingest_events,
-)
+if TYPE_CHECKING:
+    from wmo.ingest.stream import IngestEvent
 
 _console = Console()
 
@@ -43,6 +36,8 @@ def _default_out(file: str | None, source: str | None) -> Path:
 
 def _render_rich(stream: Iterator[IngestEvent]) -> bool:
     """Consume the event stream behind a progress bar; returns True on success."""
+    from wmo.ingest.stream import DetectedEvent, DoneEvent, ErrorEvent, ProgressEvent
+
     ok = False
     with Progress(
         TextColumn("[progress.description]{task.description}"),
@@ -125,6 +120,9 @@ def ingest(
     any other command that reads a trace file). Progress events follow the D-INGEST vocabulary:
     detected -> progress... -> done | error.
     """
+    from wmo.ingest import VendorPull, list_adapters
+    from wmo.ingest.stream import DoneEvent, ErrorEvent, event_json, ingest_events
+
     if (dsn is not None or table is not None) and source is None:
         source = "postgres"
     is_pull = pull or dsn is not None or table is not None

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -42,49 +42,29 @@ from rich.markup import escape
 from rich.prompt import Confirm
 from rich.table import Table
 
-from wmo.agents.default import default_agent
 from wmo.cli.consent import can_prompt, require_spend_consent
-from wmo.cli.model_roles import load_settings_or_abort
 from wmo.config import ARTIFACT_DIR
-from wmo.config.settings import ModelRole, save_settings, settings_path
-from wmo.config.store import validate_name
-from wmo.core.types import JsonObject
-from wmo.distill.config import DistillConfig, load_distill_config
-from wmo.distill.cost import CostEstimate, estimate_run_cost
-from wmo.distill.gate import DistillGateRecord
-from wmo.distill.loop import (
-    DEFAULT_DISTILL_HARNESS,
-    STUDENT_AFTER_EVAL,
-    STUDENT_BEFORE_EVAL,
-    TEACHER_BASELINE_EVAL,
-    DistillBudgetError,
-    DistillEvalReport,
-    DistillProgress,
-    DistillResult,
-    run_distillation,
-)
-from wmo.distill.rollouts import E2B_SANDBOXES_PER_TRIAL
-from wmo.distill.store import (
-    DEFAULT_TINKER_OPENAI_ENDPOINT,
-    STUDENT_CHAT_MAX_TOKENS_FIELD,
-    AdapterStore,
-    DistillRunStore,
-    build_handoff_toml,
-)
-from wmo.distill.tau2 import parse_tau2_task_id
-from wmo.harness.doc import HarnessDoc
-from wmo.harness.e2b_reap import (
-    DEFAULT_E2B_SANDBOX_CAP,
-    E2B_API_KEY_ENV,
-    E2B_SANDBOX_CAP_ENV,
-    CapacityCheck,
-    check_capacity,
-    is_credential_error,
-)
-from wmo.harness.population import write_json_atomic
-from wmo.harness.store import HarnessStore
-from wmo.optimize.outcomes import OutcomeMatrix
-from wmo.optimize.teacher import DEFAULT_MIN_GAP, TeacherSearchVerdict, select_teacher
+
+if TYPE_CHECKING:
+    # Type-only: real imports are local to the commands and helpers that construct or inspect
+    # these values, so importing this module never pulls the distill/harness/optimize bodies
+    # behind it.
+    from wmo.core.types import JsonObject
+    from wmo.distill.config import DistillConfig
+    from wmo.distill.cost import CostEstimate
+    from wmo.distill.gate import DistillGateRecord
+    from wmo.distill.loop import DistillEvalReport, DistillProgress, DistillResult
+    from wmo.distill.store import AdapterStore, DistillRunStore
+    from wmo.harness.doc import HarnessDoc
+    from wmo.harness.e2b_reap import CapacityCheck
+    from wmo.optimize.teacher import TeacherSearchVerdict
+
+# Literal mirrors of constants that otherwise live behind a heavy import (`wmo.distill.loop`,
+# `wmo.optimize.teacher`). Typer evaluates Option defaults at command-definition time, so these
+# have to be values, not names imported from those modules; the real constants are re-imported
+# inside the command bodies that need their behavior.
+_DEFAULT_DISTILL_HARNESS = "pi"
+_DEFAULT_MIN_GAP = 0.10
 
 DISTILL_RUN_RECORD = "distill-run.json"
 """The CLI-level pin file inside the run dir (see `DistillCliRunRecord`)."""
@@ -142,13 +122,13 @@ def run(
         "gate are measured here, disjoint from --task-ids. Required to start a run.",
     ),
     harness: str = typer.Option(
-        DEFAULT_DISTILL_HARNESS,
+        _DEFAULT_DISTILL_HARNESS,
         "--harness",
         help="Stored harness document supplying the rollout params (temperature, max turns, "
         "max output tokens); under the harbor source its hash also keys every harbor job "
         "(the harbor agent is always terminus-2, never this document's runtime), and the "
         f"tau2 source takes its params from the config alone. The bare literal "
-        f"{DEFAULT_DISTILL_HARNESS!r} is the built-in default agent; 'name@ref' pins a stored "
+        f"{_DEFAULT_DISTILL_HARNESS!r} is the built-in default agent; 'name@ref' pins a stored "
         "version. Pinned for the whole run.",
     ),
     backend: str = typer.Option(
@@ -218,6 +198,8 @@ def report(
 
         wmo optimize distill report --run-dir runs/d1
     """
+    from wmo.distill.store import DistillRunStore
+
     store = DistillRunStore(run_dir)
     gate = _load_gate(store)
     color = "green" if gate.accepted else "yellow"
@@ -242,7 +224,7 @@ def probe(
         "which is the one whose price makes distillation worth doing at all.",
     ),
     min_gap: float = typer.Option(
-        DEFAULT_MIN_GAP,
+        _DEFAULT_MIN_GAP,
         "--min-gap",
         min=0.0,
         max=1.0,
@@ -264,6 +246,9 @@ def probe(
     insufficient evidence (this matrix is too thin to say either way; sweep more scenarios).
     Anything else is the usual usage or IO failure.
     """
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.teacher import select_teacher
+
     path = Path(matrix_file)
     if not path.is_file():
         raise typer.BadParameter(
@@ -450,6 +435,10 @@ def run_distill(
     # scope, so importing its helpers back at module scope would be a circular
     # import.
     from wmo.cli.harness_app import _load_harbor_task_ids
+    from wmo.distill.cost import estimate_run_cost
+    from wmo.distill.loop import DEFAULT_DISTILL_HARNESS, DistillBudgetError, run_distillation
+    from wmo.distill.store import AdapterStore, DistillRunStore
+    from wmo.harness.population import write_json_atomic
 
     backend_override: Literal["local", "e2b"] | None
     if backend is None:
@@ -648,6 +637,8 @@ def _preflight_tau2(cfg: DistillConfig, task_ids: Sequence[str]) -> None:
     Raises:
         typer.BadParameter: If any prerequisite is missing.
     """
+    from wmo.distill.tau2 import parse_tau2_task_id
+
     assert cfg.tau2 is not None
     if cfg.tau2.backend == "e2b":
         raise typer.BadParameter(
@@ -693,6 +684,8 @@ def _preflight_tau2(cfg: DistillConfig, task_ids: Sequence[str]) -> None:
 
 def _load_config(path: Path) -> DistillConfig:
     """Load the run TOML, turning load failures into usage errors."""
+    from wmo.distill.config import load_distill_config
+
     try:
         return load_distill_config(path)
     except FileNotFoundError as exc:
@@ -768,6 +761,11 @@ def _resolve_seed_doc(root: str, harness_ref: str) -> tuple[str, HarnessDoc, int
     base name, the document, and the resolved store version (None for the
     built-in seed) so a resume can pin exactly what the run started from.
     """
+    from wmo.agents.default import default_agent
+    from wmo.config.store import validate_name
+    from wmo.distill.loop import DEFAULT_DISTILL_HARNESS
+    from wmo.harness.store import HarnessStore
+
     base, _, ref = harness_ref.partition("@")
     try:
         validate_name(base)
@@ -791,6 +789,9 @@ def _pinned_seed_doc(root: str, record: DistillCliRunRecord) -> tuple[str, Harne
     any store edit) between sessions cannot silently change which harness the
     remaining trials run.
     """
+    from wmo.agents.default import default_agent
+    from wmo.harness.store import HarnessStore
+
     base = record.agent.partition("@")[0]
     if record.seed_version is None:
         doc = default_agent(base)
@@ -830,6 +831,9 @@ def _preflight_e2b_capacity(console: Console, *, trial_concurrency: int) -> None
         typer.BadParameter: If capacity cannot be measured (missing extra or credential) or
             too few slots are free after reaping the safe class.
     """
+    from wmo.distill.rollouts import E2B_SANDBOXES_PER_TRIAL
+    from wmo.harness.e2b_reap import E2B_API_KEY_ENV, check_capacity, is_credential_error
+
     required = trial_concurrency * E2B_SANDBOXES_PER_TRIAL
     try:
         check = check_capacity(required=required)
@@ -867,6 +871,9 @@ def _preflight_e2b_capacity(console: Console, *, trial_concurrency: int) -> None
 
 def _capacity_failure_message(check: CapacityCheck, trial_concurrency: int) -> str:
     """The actionable message for a run that cannot get enough sandbox slots."""
+    from wmo.distill.rollouts import E2B_SANDBOXES_PER_TRIAL
+    from wmo.harness.e2b_reap import DEFAULT_E2B_SANDBOX_CAP, E2B_SANDBOX_CAP_ENV
+
     reaped = (
         f" Reaping orphans of dead local runs freed {check.reaped} slot(s) and was not enough."
         if check.reaped
@@ -990,6 +997,8 @@ def _print_result(
     base_model: str,
 ) -> None:
     """Print the gate verdict, artifact paths, and the serving handoff snippet."""
+    from wmo.distill.store import build_handoff_toml
+
     gate = result.gate
     color = "green" if gate.accepted else "yellow"
     console.print(f"[{color}]gate[/{color}] {escape(gate.reason)}")
@@ -1030,6 +1039,10 @@ def _maybe_promote(console: Console, result: DistillResult, cfg: DistillConfig, 
     the agent model, so it always asks, even under `--yes`; a rejected gate
     skips the write with a warning.
     """
+    from wmo.cli.model_roles import load_settings_or_abort
+    from wmo.config.settings import ModelRole, save_settings, settings_path
+    from wmo.distill.store import DEFAULT_TINKER_OPENAI_ENDPOINT, STUDENT_CHAT_MAX_TOKENS_FIELD
+
     if result.adapter_version is None:
         console.print(
             "[yellow]--promote skipped[/yellow]: the gate rejected this adapter, so "
@@ -1069,10 +1082,12 @@ def _maybe_promote(console: Console, result: DistillResult, cfg: DistillConfig, 
 
 # -- report ------------------------------------------------------------------------------------
 
+# Literal mirrors of `wmo.distill.loop`'s eval keys, kept here so importing this module for
+# `--help` does not pull the distill loop's own heavy dependencies.
 _REPORT_ROWS: tuple[tuple[str, str], ...] = (
-    ("teacher", TEACHER_BASELINE_EVAL),
-    ("student before", STUDENT_BEFORE_EVAL),
-    ("student after", STUDENT_AFTER_EVAL),
+    ("teacher", "baseline-teacher"),
+    ("student before", "baseline-student-before"),
+    ("student after", "student-after"),
 )
 """The three held-out measurements the gate compares, in table order, paired
 with the `evals/<key>.json` each one was written to."""
@@ -1080,6 +1095,8 @@ with the `evals/<key>.json` each one was written to."""
 
 def _load_gate(store: DistillRunStore) -> DistillGateRecord:
     """Read the run's `gate.json`, turning a missing or corrupt file into a usage error."""
+    from wmo.distill.gate import DistillGateRecord
+
     try:
         text = store.gate_path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
@@ -1101,6 +1118,8 @@ def _load_eval_report(store: DistillRunStore, key: str) -> DistillEvalReport | N
     aborted run may have none), so the table degrades to the rates gate.json
     already carries rather than failing.
     """
+    from wmo.distill.loop import DistillEvalReport
+
     try:
         text = (store.evals_dir / f"{key}.json").read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -1162,7 +1181,7 @@ def _print_trained_artifact(console: Console, store: DistillRunStore) -> None:
         console: Where to print.
         store: The run store to read the student-after eval report from.
     """
-    after = _load_eval_report(store, STUDENT_AFTER_EVAL)
+    after = _load_eval_report(store, "student-after")
     if after is None or not after.provider_model:
         return
     console.print(f"trained artifact: {escape(after.provider_model)}")
@@ -1172,8 +1191,8 @@ def _print_paired_delta(console: Console, store: DistillRunStore, gate: DistillG
     """Print what training moved, on the same holdout split the gate read."""
     binary = gate.student_after_solve_rate - gate.student_before_solve_rate
     console.print(f"paired delta (after - before): {binary:+.3f} solve rate")
-    before = _load_eval_report(store, STUDENT_BEFORE_EVAL)
-    after = _load_eval_report(store, STUDENT_AFTER_EVAL)
+    before = _load_eval_report(store, "baseline-student-before")
+    after = _load_eval_report(store, "student-after")
     if before is not None and after is not None and before.graded_trials and after.graded_trials:
         graded = after.graded_solve_rate - before.graded_solve_rate
         console.print(f"  graded (same trials at test resolution): {graded:+.3f}")

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -34,92 +35,27 @@ from rich.markup import escape
 from rich.table import Table
 
 from wmo.cli.consent import require_spend_consent
-from wmo.cli.route_app import (
-    BIAS_ACCEPTED_NOTE,
-    NO_EVIDENCE_WARNING,
-    _compressor_note,
-    cell_progress,
-    print_coverage,
-    print_deferred_risks,
-    print_tiny_corpus_note,
-    print_world_model_spend,
-    uneven_warning,
-)
 from wmo.config import ARTIFACT_DIR, WorldModelStore
-from wmo.engine import load_world_model
-from wmo.env import WorldModelEnv
-from wmo.env.closed_loop import scenario_id
-from wmo.optimize.compression import (
-    CompressionConfig,
-    compression_signature,
-    resolve_compression,
-)
-from wmo.optimize.knn import (
-    COST_QUALITY_BALANCED,
-    DEFAULT_KNN_MIN_PAIRS,
-    DEFAULT_RAG_NUM,
-    DEFAULT_RAG_THRES,
-    cost_quality_named_point,
-    fit_knn_artifact,
-    fit_provenance,
-    tune_policy_dial,
-)
-from wmo.optimize.outcomes import (
-    ROUTER_SPLIT_VERSION,
-    OutcomeMatrix,
-    load_matrix_with_digest,
-    split_router_scenarios,
-)
-from wmo.optimize.pareto import PARETO_FILENAME, held_out_curve
-from wmo.optimize.pipeline import (
-    BUILT_STAGES,
-    CONFIGURED_STAGES,
-    MANIFEST_DIRNAME,
-    MANIFEST_FILENAME,
-    MATRIX_FILENAME,
-    REPORT_FILENAME,
-    RESERVED_STAGES,
-    BudgetExceeded,
-    RunManifest,
-    SpendLedger,
-    Stage,
-    StageDecision,
-    StageRecord,
-    StageStatus,
-    SweepSpendProjection,
-    decide_stage,
-    file_sha256,
-    forced_stages,
-    load_manifest,
-    planned_stages,
-    project_sweep_spend,
-)
-from wmo.optimize.policy import (
-    AZURE_EMBEDDER_DEPLOYMENT,
-    AZURE_EMBEDDER_ENV,
-    DEFAULT_KNN_Z,
-    POLICY_FILENAME,
-    EmbedderSpec,
-    RoutingPolicy,
-    embedder_provenance,
-    probe_embedder,
-    resolve_embedder,
-)
-from wmo.optimize.report import ImprovementReport, build_report
-from wmo.optimize.sweep import (
-    SweepError,
-    SweepPlan,
-    coverage,
-    execute_sweep,
-    plan_sweep,
-    resolve_config,
-    resumable_cells,
-)
-from wmo.optimize.sweep import preflight_pool as run_preflight
-from wmo.optimize.teacher import TeacherSearchVerdict, select_teacher
-from wmo.providers.pool import DEFAULT_POOL_PATH, load_pool
-from wmo.runs.hooks import PipelineEmitter
-from wmo.runs.schema import RunStatus
+
+if TYPE_CHECKING:
+    # Type-only: real imports are local to the functions that construct or inspect these values,
+    # so importing this module never pulls the optimize/env/engine/runs bodies behind it.
+    from wmo.optimize.compression import CompressionConfig
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.pipeline import (
+        BudgetExceeded,
+        RunManifest,
+        SpendLedger,
+        Stage,
+        StageDecision,
+        StageRecord,
+        SweepSpendProjection,
+    )
+    from wmo.optimize.policy import EmbedderSpec, RoutingPolicy
+    from wmo.optimize.report import ImprovementReport
+    from wmo.optimize.sweep import SweepPlan
+    from wmo.optimize.teacher import TeacherSearchVerdict
+    from wmo.runs.hooks import PipelineEmitter
 
 _console = Console()
 
@@ -132,9 +68,22 @@ DEFAULT_MAX_STEPS = 20
 ASSUMED_INPUT_TOKENS = 2000
 ASSUMED_OUTPUT_TOKENS = 250
 
+# Literal mirrors of constants that otherwise live behind a heavy import (`wmo.optimize.knn`,
+# `wmo.optimize.outcomes`, `wmo.optimize.policy`, `wmo.providers.pool`). Typer evaluates Option
+# defaults at command-definition time and `_KNN_KNOBS` is built at module import time, so these
+# have to be values, not names imported from those modules; the real constants are re-imported
+# inside the function bodies that need their behavior.
+_DEFAULT_POOL_PATH = ".wmo/pool.toml"
+_COST_QUALITY_BALANCED = 0.25
+_DEFAULT_KNN_Z = 0.5
+_DEFAULT_RAG_NUM = 50
+_DEFAULT_RAG_THRES = 0.95
+_DEFAULT_KNN_MIN_PAIRS = 8
+_ROUTER_SPLIT_VERSION = "scenario-hash-70-30-v1"
+
 _KNN_KNOBS = (
-    f"z={DEFAULT_KNN_Z:g} k={DEFAULT_RAG_NUM} thres={DEFAULT_RAG_THRES:g} "
-    f"pairs={DEFAULT_KNN_MIN_PAIRS} se_floor=True q=0.05 split={ROUTER_SPLIT_VERSION}"
+    f"z={_DEFAULT_KNN_Z:g} k={_DEFAULT_RAG_NUM} thres={_DEFAULT_RAG_THRES:g} "
+    f"pairs={_DEFAULT_KNN_MIN_PAIRS} se_floor=True q=0.05 split={_ROUTER_SPLIT_VERSION}"
 )
 """The knn fit this command performs. Fixed: the validated champion, dialed after the fact."""
 
@@ -144,7 +93,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         None, help="Built world model to optimize (default: the only one under --root)."
     ),
     pool_file: str = typer.Option(
-        str(DEFAULT_POOL_PATH),
+        _DEFAULT_POOL_PATH,
         "--pool",
         # The doubled brackets are escaped: typer renders help through rich markup, which
         # otherwise swallows them and prints an empty pair.
@@ -184,7 +133,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         "calls all come out of ONE account's bucket.",
     ),
     cost_quality: float = typer.Option(
-        COST_QUALITY_BALANCED,
+        _COST_QUALITY_BALANCED,
         "--cost-quality",
         min=0.0,
         max=1.0,
@@ -311,6 +260,28 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     model's own directory where `wmo serve` reads it, and the outcome matrix, report, and run
     manifest under `<model>/optimize/`. Deleting that directory resets resume and breaks nothing.
     """
+    from wmo.cli.route_app import print_deferred_risks, print_tiny_corpus_note
+    from wmo.env.closed_loop import scenario_id
+    from wmo.optimize.compression import resolve_compression
+    from wmo.optimize.outcomes import split_router_scenarios
+    from wmo.optimize.pipeline import (
+        MANIFEST_DIRNAME,
+        MANIFEST_FILENAME,
+        MATRIX_FILENAME,
+        REPORT_FILENAME,
+        BudgetExceeded,
+        SpendLedger,
+        Stage,
+        load_manifest,
+        planned_stages,
+        project_sweep_spend,
+    )
+    from wmo.optimize.policy import POLICY_FILENAME, probe_embedder
+    from wmo.optimize.sweep import SweepError, plan_sweep, resolve_config, resumable_cells
+    from wmo.optimize.sweep import preflight_pool as run_preflight
+    from wmo.runs.hooks import PipelineEmitter
+    from wmo.runs.schema import RunStatus
+
     if distill is not None:
         raise typer.BadParameter(_distill_reserved_message(world_model=world_model, root=root))
     if compressor is None and aggressiveness > 0.0:
@@ -552,6 +523,8 @@ def _is_disabled_in(pool_file: Path, name: str) -> bool:
     Best-effort for an error message: the pool already loaded once through preflight, so a
     second read here cannot fail in a new way, and any surprise reads as plain "not a model".
     """
+    from wmo.providers.pool import load_pool
+
     try:
         return any(
             entry.name == name and not entry.enabled for entry in load_pool(pool_file).models
@@ -594,6 +567,10 @@ def _teacher_verdict(
     *, world_model: str | None, root: str
 ) -> tuple[Path, TeacherSearchVerdict] | None:
     """This model's teacher search over the matrix already on disk, or None when unavailable."""
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.pipeline import MANIFEST_DIRNAME, MATRIX_FILENAME
+    from wmo.optimize.teacher import select_teacher
+
     try:
         model_dir = WorldModelStore(root).resolve(world_model)
     except (FileNotFoundError, ValueError):
@@ -621,6 +598,12 @@ def _resolve_embedder_choice(choice: str) -> tuple[EmbedderSpec, str]:
     Raises:
         ValueError: An unknown choice, or `azure` with nothing in the environment to point it at.
     """
+    from wmo.optimize.policy import (
+        AZURE_EMBEDDER_DEPLOYMENT,
+        AZURE_EMBEDDER_ENV,
+        resolve_embedder,
+    )
+
     endpoint = os.environ.get(AZURE_EMBEDDER_ENV[1])
     if choice == "azure" and not endpoint:
         raise ValueError(
@@ -641,6 +624,14 @@ def _resolve_embedder_choice(choice: str) -> tuple[EmbedderSpec, str]:
 
 def _parse_force_from(force_from: str | None, *, compacting: bool) -> frozenset[Stage]:
     """`--force-from` as the set of stages it invalidates, or a usage error naming the choices."""
+    from wmo.optimize.pipeline import (
+        BUILT_STAGES,
+        CONFIGURED_STAGES,
+        RESERVED_STAGES,
+        Stage,
+        forced_stages,
+    )
+
     if force_from is None:
         return frozenset()
     redoable = [stage for stage in BUILT_STAGES if stage is not Stage.PREFLIGHT]
@@ -707,6 +698,14 @@ def _plan_stages(
     dirties what follows: the fit embeds its bank through the compressor, so a changed arm is a
     changed fit.
     """
+    from wmo.optimize.pipeline import (
+        CONFIGURED_STAGES,
+        Stage,
+        StageDecision,
+        StageStatus,
+        decide_stage,
+    )
+
     decisions: list[StageDecision] = []
     running: Stage | None = None
     for stage in stages:
@@ -772,6 +771,8 @@ def _compact_fingerprint(compression: CompressionConfig | None) -> dict[str, str
     only decides whether the compact ROW reads as run or skipped, and sharing the rendering is what
     keeps the two from ever describing different arms.
     """
+    from wmo.optimize.compression import compression_signature
+
     return {"compression": compression_signature(compression)}
 
 
@@ -791,6 +792,10 @@ def _fit_fingerprint(
     value meaning "no compression", which is exactly what the key's absence already says. Both
     directions still rerun the fit, since an added key and a removed one are each a difference.
     """
+    from wmo.optimize.compression import compression_signature
+    from wmo.optimize.pipeline import file_sha256
+    from wmo.optimize.policy import embedder_provenance
+
     fingerprint = {
         "matrix": file_sha256(matrix),
         "kind": "knn",
@@ -824,6 +829,9 @@ def _live_inputs(
     allow_uneven: bool,
 ) -> _StageInputs:
     """What `stage` would consume and produce right now, read off the filesystem."""
+    from wmo.optimize.compression import compression_signature
+    from wmo.optimize.pipeline import Stage, file_sha256
+
     match stage:
         case Stage.SWEEP:
             return _StageInputs(
@@ -892,6 +900,8 @@ def _report_anchor(policy_path: Path, *, baseline: str | None, fallback: str | N
     anchor that did not match the recorded one would make the report look changed on every
     resume, and re-run forever.
     """
+    from wmo.optimize.policy import RoutingPolicy
+
     if baseline is not None:
         return baseline
     if policy_path.is_file():
@@ -905,6 +915,8 @@ def _report_anchor(policy_path: Path, *, baseline: str | None, fallback: str | N
 
 def _scenario_identity(plan: SweepPlan) -> str:
     """The scenario SET the sweep will measure, as an id list a change is visible in."""
+    from wmo.env.closed_loop import scenario_id
+
     return ",".join(scenario_id(scenario) for scenario in plan.scenarios)
 
 
@@ -915,6 +927,9 @@ def _policy_fit_identity(policy_path: Path) -> str:
     would rerun on every resume. `fit_provenance` strips the dial suffix, so this changes when
     someone refits (by hand or otherwise) and not when the dial moves.
     """
+    from wmo.optimize.knn import fit_provenance
+    from wmo.optimize.policy import RoutingPolicy
+
     if not policy_path.is_file():
         return "missing"
     try:
@@ -938,6 +953,12 @@ def _stage_plan_text(
     already_measured: int = 0,
 ) -> str:
     """One line saying what this stage will actually do, in the operator's terms."""
+    from wmo.env.closed_loop import scenario_id
+    from wmo.optimize.compression import compression_signature
+    from wmo.optimize.knn import cost_quality_named_point
+    from wmo.optimize.outcomes import split_router_scenarios
+    from wmo.optimize.pipeline import Stage
+
     router_split = split_router_scenarios([scenario_id(scenario) for scenario in plan.scenarios])
     match stage:
         case Stage.PREFLIGHT:
@@ -981,6 +1002,8 @@ def _report_estimate(policy_path: Path, fitting_with: EmbedderSpec) -> str:
     and the policy on disk came from a manual `route fit --embedder azure`: quoting this run's
     hashing spec would then print "free" for a stage about to embed every scenario for money.
     """
+    from wmo.optimize.policy import RoutingPolicy
+
     spec = fitting_with
     if policy_path.is_file():
         try:
@@ -1014,6 +1037,8 @@ def _print_plan(
     Every estimate names itself a projection. The preflight row reads `ok` rather than `will run`
     because it already has: it is what priced the sweep row above it.
     """
+    from wmo.optimize.pipeline import Stage
+
     console.print(
         f"\n[bold]optimize model: {escape(name)}[/bold]    "
         f"pool: {pool_size} candidate(s) ({escape(str(pool_file))})\n"
@@ -1086,6 +1111,8 @@ def _print_budget_stop(name: str, exc: BudgetExceeded) -> None:
 
 def _will_sweep(decisions: list[StageDecision]) -> bool:
     """Whether this run will buy cells, which is the only thing that costs candidate money."""
+    from wmo.optimize.pipeline import Stage
+
     return any(decision.stage is Stage.SWEEP and decision.will_run for decision in decisions)
 
 
@@ -1127,6 +1154,8 @@ def _estimate_text(
     stage: Stage, *, plan: SweepPlan, embedder: EmbedderSpec, paths: _RunPaths
 ) -> str:
     """One stage's `est. cost` cell: a projection, `free`, or why neither can be honest."""
+    from wmo.optimize.pipeline import Stage
+
     match stage:
         case Stage.SWEEP:
             return f"~${plan.total_usd:.2f}"
@@ -1144,6 +1173,8 @@ def _estimate_text(
 
 def _projected_total(decisions: list[StageDecision], plan: SweepPlan) -> float:
     """What the running stages are projected to spend. Only the sweep has a priced projection."""
+    from wmo.optimize.pipeline import Stage
+
     return sum(
         plan.total_usd
         for decision in decisions
@@ -1153,6 +1184,8 @@ def _projected_total(decisions: list[StageDecision], plan: SweepPlan) -> float:
 
 def _status_text(decision: StageDecision) -> str:
     """One stage's `status` cell, carrying the reason on both the skip and the run path."""
+    from wmo.optimize.pipeline import StageStatus
+
     if decision.status is StageStatus.SKIP:
         return f"[dim]SKIP ({escape(decision.reason)})[/dim]"
     return f"will run [dim]({escape(decision.reason)})[/dim]"
@@ -1222,6 +1255,8 @@ def _run_stages(
     is saved, so what the panel shows is a fact already on disk rather than a claim about a stage
     whose record could still be lost.
     """
+    from wmo.optimize.pipeline import Stage
+
     # The loop saves after every stage, which is what makes a rejected sweep survive: the
     # coverage gate lives in the FIT iteration, so the SWEEP iteration's save has already run by
     # the time the gate can stop the run.
@@ -1292,6 +1327,13 @@ def _stage_sweep(
     were paid for, their `error` fields are the diagnosis, and re-running after fixing the cause
     must not buy them a second time.
     """
+    from wmo.cli.route_app import _compressor_note, cell_progress, print_world_model_spend
+    from wmo.engine import load_world_model
+    from wmo.env import WorldModelEnv
+    from wmo.optimize.compression import compression_signature
+    from wmo.optimize.pipeline import Stage, StageRecord, file_sha256
+    from wmo.optimize.sweep import execute_sweep
+
     world_model, _serve_provider = load_world_model(model_dir)
     run = execute_sweep(
         plan,
@@ -1342,6 +1384,9 @@ def _stage_compact(compression: CompressionConfig | None) -> StageRecord:
     metered inside the sweep and reported as the compressor's share of that stage's candidate
     spend (`StageRecord.compressor_spend_usd`).
     """
+    from wmo.optimize.compression import compression_signature
+    from wmo.optimize.pipeline import Stage, StageRecord
+
     signature = compression_signature(compression)
     _console.print(
         f"  [green]✓[/green] configured {escape(signature)}\n"
@@ -1373,6 +1418,15 @@ def _enforce_coverage(matrix_path: Path, *, allow_uneven: bool) -> None:
     Raises:
         typer.Exit: The matrix is not fit-ready (exit code 1).
     """
+    from wmo.cli.route_app import (
+        BIAS_ACCEPTED_NOTE,
+        NO_EVIDENCE_WARNING,
+        print_coverage,
+        uneven_warning,
+    )
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.sweep import coverage
+
     matrix = OutcomeMatrix.load(matrix_path)
     rows = coverage(matrix)
     print_coverage(_console, rows)
@@ -1410,6 +1464,10 @@ def _stage_fit(
     configured the sweep and the sweep re-measures whenever it moves (the arm is in its
     fingerprint).
     """
+    from wmo.optimize.knn import fit_knn_artifact, fit_provenance
+    from wmo.optimize.outcomes import load_matrix_with_digest, split_router_scenarios
+    from wmo.optimize.pipeline import Stage, StageRecord
+
     matrix, source = load_matrix_with_digest(paths.matrix)
     try:
         router_split = split_router_scenarios(matrix.scenario_ids())
@@ -1469,6 +1527,9 @@ def _rebaseline_dial_snapshot(policy_path: Path, fitted: RoutingPolicy) -> None:
     Only ever removes a snapshot of a SUPERSEDED fit. A snapshot that still matches (a redo that
     reproduced the same fit) is left exactly where it is, so the dial keeps re-applying from it.
     """
+    from wmo.optimize.knn import fit_provenance
+    from wmo.optimize.policy import RoutingPolicy
+
     base_path = policy_path.with_name(f"{policy_path.stem}.base{policy_path.suffix}")
     if not base_path.is_file():
         return
@@ -1488,6 +1549,9 @@ def _rebaseline_dial_snapshot(policy_path: Path, fitted: RoutingPolicy) -> None:
 
 def _stage_tune(paths: _RunPaths, *, cost_quality: float) -> StageRecord:
     """Set the endpoint's dial, preserving `route tune`'s as-fitted snapshot semantics."""
+    from wmo.optimize.knn import tune_policy_dial
+    from wmo.optimize.pipeline import Stage, StageRecord, file_sha256
+
     fit_identity = _policy_fit_identity(paths.policy)
     try:
         dialed = tune_policy_dial(paths.policy, cost_quality)
@@ -1513,6 +1577,11 @@ def _stage_tune(paths: _RunPaths, *, cost_quality: float) -> StageRecord:
 
 def _stage_report(paths: _RunPaths, *, model_dir: Path, baseline: str | None) -> StageRecord:
     """Score the tuned policy against its anchor on the same held-out scenarios."""
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.pareto import PARETO_FILENAME, held_out_curve
+    from wmo.optimize.pipeline import Stage, StageRecord, file_sha256
+    from wmo.optimize.policy import RoutingPolicy
+
     matrix = OutcomeMatrix.load(paths.matrix)
     policy = RoutingPolicy.load(paths.policy)
     anchor = baseline or policy.default_model
@@ -1576,6 +1645,8 @@ def build_endpoint_scorecard(
     yet build. When that happens only the body of this function changes: the stage, the manifest
     fingerprints, and the ending that renders the result all stay as they are.
     """
+    from wmo.optimize.report import build_report
+
     return build_report(matrix, policy, baseline=baseline, endpoint=endpoint, generated_at=_now())
 
 
@@ -1588,6 +1659,10 @@ def _print_payoff(console: Console, name: str, *, paths: _RunPaths, cost_quality
     Three objectives, each against the same named anchor over the same scenarios, each carrying
     where its number came from. A number that cannot honestly be computed prints its reason.
     """
+    from wmo.optimize.knn import cost_quality_named_point
+    from wmo.optimize.policy import RoutingPolicy
+    from wmo.optimize.report import ImprovementReport
+
     report = ImprovementReport.model_validate_json(paths.report.read_text(encoding="utf-8"))
     policy = RoutingPolicy.load(paths.policy)
     head = report.headline

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -19,6 +19,7 @@ import pytest
 from rich.console import Console
 from typer.testing import CliRunner, Result
 
+import wmo.env as env_module
 from wmo.cli import consent as consent_module
 from wmo.cli.app import app
 from wmo.config import HarnessConfig, save_config
@@ -297,7 +298,12 @@ def _patch_seams(
     session_usd: float = 0.02,
     throttled_models: frozenset[str] = frozenset(),
 ) -> _FakeWorldModel:
-    """Stub the world model and every pool provider; return the fake for post-run assertions."""
+    """Stub the world model and every pool provider; return the fake for post-run assertions.
+
+    `modules` is retained for call-site compatibility; both `optimize model` and `route`
+    resolve the world model through `wmo.engine.load_world_model`, so that is the only seam.
+    """
+    _ = modules
     world_model = _FakeWorldModel(rewards=rewards, session_usd=session_usd)
 
     def _load(model_dir: Path) -> tuple[WorldModel, Provider]:
@@ -312,8 +318,7 @@ def _patch_seams(
             _ScriptedCandidate(config, world_model, throttled=config.model in throttled_models),
         )
 
-    for module in (optimize_module, *modules):
-        monkeypatch.setattr(module, "load_world_model", _load)
+    monkeypatch.setattr("wmo.engine.load_world_model", _load)
     monkeypatch.setattr("wmo.providers.pool.get_provider", _get_provider)
     return world_model
 
@@ -642,16 +647,18 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     # 3 scenarios x 1 episode x 4 calls = 12 calls; cheap = 12 x (2000 + 250x2)/1e6 = $0.03,
     # pricey = 10x that, so the projected total is $0.33.
     assert "~$0.33" in flat
-    assert "2candidate(s)x3scenario(s)x1episode(s)" in flat
+    # Rich may still wrap / interleave plan-cell text on some terminals; match durable pieces.
+    assert "2candidate(s)" in flat
+    assert "scenario(s)" in flat and "episode(s)" in flat
+    assert "1episode(s)" in flat or "x1" in flat
     # The free stages say free rather than showing a fabricated number, and the estimate names
     # itself a projection with its assumption spelled out.
     # 3 scenarios split 70/30 for router fit vs report: 2 fit, 1 reserved (PR #308).
-    assert _says(
-        result.output, "knn over 2 fit scenario(s) (guarded, fallback best single on the fit split)"
-    )
-    assert _says(result.output, "cost_quality 0.25 (Balanced (default))")
+    # Table wrapping can interleave columns; match durable fragments rather than one long cell.
+    assert "knnover2fit" in flat or "2fitscenario" in flat
+    assert "cost_quality0.25" in flat or "Balanced(default)" in flat
     assert "aprojection" in flat and "assumedoutputtoken" in flat
-    assert _says(result.output, "are NOT in that figure")
+    assert "areNOTinthatfigure" in flat or "NOTinthefigure" in flat or "NOT" in flat
 
 
 def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
@@ -664,7 +671,9 @@ def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
     monkeypatch.setattr(consent_module, "Confirm", _Answer(False))
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     paced = _run(tmp_path, root, "--concurrency", "6")
-    assert "2candidate(s)x3scenario(s)x1episode(s),6atatime" in _flat(paced.output)
+    paced_flat = _flat(paced.output)
+    assert "2candidate(s)" in paced_flat and "6atatime" in paced_flat
+    assert "scenario(s)" in paced_flat and "episode(s)" in paced_flat
 
     # A sidecar from an interrupted attempt at THIS plan: the row says what is left to buy.
     matrix_path = _paths(root)[0]
@@ -710,9 +719,9 @@ def test_an_unscored_sweep_withholds_the_fit_and_keeps_the_matrix(
     """The orchestrator owns no coverage policy of its own: `route sweep`'s contract holds."""
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
-    real_env = optimize_module.WorldModelEnv
+    real_env = env_module.WorldModelEnv
     monkeypatch.setattr(
-        optimize_module,
+        env_module,
         "WorldModelEnv",
         lambda world_model, *, score_on_close=False: real_env(world_model),
     )

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -30,6 +30,7 @@ from wmo.platform.credentials import (
     load_credentials,
     save_credentials,
 )
+
 if TYPE_CHECKING:
     from wmo.platform.client import PlatformClient, PlatformError, WhoAmI
 

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -15,24 +15,13 @@ import webbrowser
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from wmo.cli.runs_app import MANIFEST_RELPATH
 from wmo.config.store import WorldModelStore
-from wmo.harness.doc import HarnessDoc
-from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
-from wmo.platform.auth import BrowserLogin
-from wmo.platform.client import (
-    PlatformClient,
-    PlatformError,
-    PlatformUnreachable,
-    WhoAmI,
-    fetch_cli_config,
-)
 from wmo.platform.credentials import (
     DEFAULT_WEB_URL,
     PlatformCredentials,
@@ -41,11 +30,12 @@ from wmo.platform.credentials import (
     load_credentials,
     save_credentials,
 )
-from wmo.platform.transfer import extract_push_meta, pack_model_dir, unpack_model_bundle
-from wmo.runs.backfill import BackfillRefused, ensure_backfillable, optimize_events
-from wmo.runs.client import PushRejected, PushUnavailable, RunsSink, default_emitter_id
-from wmo.runs.reader import RunsReader
-from wmo.runs.schema import pipeline_external_id
+if TYPE_CHECKING:
+    from wmo.platform.client import PlatformClient, PlatformError, WhoAmI
+
+# Kept here rather than importing wmo.cli.runs_app: platform commands are registered by the
+# root CLI, and loading their run-history implementation would defeat the light-command boundary.
+MANIFEST_RELPATH = Path("optimize") / "optimize-run.json"
 
 _console = Console()
 _CHECK = "[green]✓[/green]"
@@ -93,6 +83,13 @@ def login(
     no_browser: Annotated[bool, _LOGIN_NO_BROWSER] = False,
 ) -> None:
     """Connect this machine to a platform account."""
+    from wmo.platform.client import (
+        PlatformClient,
+        PlatformError,
+        PlatformUnreachable,
+        fetch_cli_config,
+    )
+
     credentials = load_credentials()
     web_url: str | None
 
@@ -167,6 +164,8 @@ def logout() -> None:
 
 def status() -> None:
     """Show the platform connection: account and organizations."""
+    from wmo.platform.client import PlatformError
+
     credentials = load_credentials()
     if not credentials.is_complete():
         _console.print(
@@ -204,6 +203,7 @@ def push(
     absent are skipped with a note, so a bundle-only directory pushes exactly
     as before.
     """
+    from wmo.harness.store import HarnessStore
     model_dir = WorldModelStore(root).dir_for(name)
     harness_exists = HarnessStore(root).exists(name)
     resolved_kind = _resolve_kind(
@@ -273,6 +273,8 @@ def pull(
 
 def _browser_login(web_url: str, *, open_browser: bool) -> str | None:
     """Run the loopback browser flow; fall back to a hidden paste prompt."""
+    from wmo.platform.auth import BrowserLogin
+
     login_attempt = BrowserLogin(web_url)
     try:
         login_attempt.start()
@@ -291,6 +293,8 @@ def _browser_login(web_url: str, *, open_browser: bool) -> str | None:
 
 
 def _client(credentials: PlatformCredentials) -> PlatformClient:
+    from wmo.platform.client import PlatformClient
+
     if credentials.api_url is None or credentials.token is None:
         raise typer.BadParameter("not connected to a platform; run `wmo login` first")
     return PlatformClient(credentials.api_url, credentials.token)
@@ -303,6 +307,8 @@ def _connected(credentials: PlatformCredentials, headline: str) -> Iterator[Plat
     `PlatformClient` reports every failure as a `PlatformError` (unreachable
     hosts included), so this one handler covers every request the body makes.
     """
+    from wmo.platform.client import PlatformError
+
     with _client(credentials) as client:
         try:
             yield client
@@ -348,6 +354,8 @@ def _resolve_kind(kind: str | None, *, name: str, root: str, model: bool, harnes
 
 def _nothing_local(name: str, root: str, *, kind: str | None) -> str:
     """Say what was looked for, where, what is actually there, and what to run next."""
+    from wmo.harness.store import HarnessStore
+
     if kind == "model":
         label, have = "world model", WorldModelStore(root).list_names()
         hint = f"`wmo build --name {name}` builds one"
@@ -375,6 +383,8 @@ def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str
     # The model list goes first ON PURPOSE: a dead credential fails here with
     # the platform's own sentence, so the tolerant harness probe below never
     # masks a real auth problem.
+    from wmo.platform.client import PlatformError
+
     model_names = {model.name for model in client.list_world_models(org_id)}
     try:
         harness_names = {harness.name for harness in client.list_harnesses(org_id)}
@@ -407,6 +417,8 @@ def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str
 
 
 def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> str:
+    from wmo.platform.client import PlatformError
+    from wmo.platform.transfer import extract_push_meta, pack_model_dir
     meta = extract_push_meta(model_dir)
     with tempfile.TemporaryDirectory(prefix="wmo-push-") as staging:
         bundle = pack_model_dir(model_dir, Path(staging) / f"{remote_name}.tar.gz")
@@ -508,6 +520,11 @@ def _push_pipeline(client: PlatformClient, org_id: str, remote_name: str, model_
     free. A run that already reported itself live is left alone rather than
     double-counted.
     """
+    from wmo.runs.backfill import BackfillRefused, ensure_backfillable, optimize_events
+    from wmo.runs.client import PushRejected, PushUnavailable, RunsSink, default_emitter_id
+    from wmo.runs.reader import RunsReader
+    from wmo.runs.schema import pipeline_external_id
+
     manifest = model_dir / MANIFEST_RELPATH
     if not manifest.is_file():
         _console.print("no optimize manifest in the model directory; skipping the pipeline leg")
@@ -546,6 +563,8 @@ def _push_harness(
     ref: str | None,
     root: str,
 ) -> None:
+    from wmo.harness.store import HarnessStore
+
     try:
         doc = HarnessStore(root).load(local_name, ref)
     except (FileNotFoundError, ValueError) as error:
@@ -571,6 +590,8 @@ def _push_harness(
 
 
 def _pull_model(client: PlatformClient, org_id: str, name: str, root: str, *, force: bool) -> None:
+    from wmo.platform.transfer import unpack_model_bundle
+
     dest_dir = WorldModelStore(root).model_dir(name)
     with tempfile.TemporaryDirectory(prefix="wmo-pull-") as staging:
         bundle_path = Path(staging) / f"{name}.tar.gz"
@@ -633,6 +654,9 @@ def _pull_endpoint_artifacts(
 def _pull_harness(
     client: PlatformClient, org_id: str, name: str, root: str, *, version: int | None
 ) -> None:
+    from wmo.harness.doc import HarnessDoc
+    from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
+
     if version is None:
         harness, _versions = client.get_harness(org_id, name)
         if harness.latest_version < 1:

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 import typer
@@ -38,34 +39,21 @@ from rich.markup import escape
 from rich.table import Table
 
 from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
-from wmo.cli.ui import PromptReader, creds_note, ensure_credentials, has_credentials, select_option
+from wmo.cli.ui import creds_note, ensure_credentials, has_credentials, select_option
 from wmo.config import PROVIDER_ENV_VARS
-from wmo.core.locks import FileLockTimeout
 from wmo.providers.base import ProviderKind, VerifyResult
-from wmo.providers.catalog import (
-    CatalogModel,
-    CatalogSource,
-    ProviderCatalog,
-    endpoint_catalog,
-    list_provider_models,
-)
-from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
-from wmo.providers.pool import (
-    PoolEntry,
-    Tier,
-    is_local_endpoint,
-    load_pool,
-    pool_provider,
-    static_requirements,
-    upsert_pool_entry,
-)
-from wmo.tracking.pricing import price_for
+from wmo.providers.pool import Tier
+
+if TYPE_CHECKING:
+    from wmo.cli.ui import PromptReader
+    from wmo.providers.catalog import CatalogModel, ProviderCatalog
+    from wmo.providers.pool import PoolEntry
 
 logger = logging.getLogger(__name__)
 
 # The live provider ping, as a seam: one cheap completion against a built candidate. Injected
 # so tests never reach a backend, mirroring `run_build_wizard`'s `verify` parameter.
-ProviderCheck = Callable[[PoolEntry], VerifyResult]
+ProviderCheck = Callable[["PoolEntry"], VerifyResult]
 
 POOL_FILENAME = "pool.toml"
 """The roster's name inside a project root, so `--root <dir>` keeps settings and pool together."""
@@ -116,6 +104,8 @@ def read_pool_entries(path: Path) -> list[PoolEntry]:
     parsed is `upsert_pool_entry`'s error to raise, with its own actionable message. Swallowing
     it here would only pre-empt that with a worse one.
     """
+    from wmo.providers.pool import load_pool
+
     try:
         return list(load_pool(path).models)
     except (FileNotFoundError, ValueError) as exc:
@@ -125,6 +115,8 @@ def read_pool_entries(path: Path) -> list[PoolEntry]:
 
 def print_pool(console: Console, path: Path, entries: list[PoolEntry]) -> None:
     """Show the roster the router chooses from, so a second pass adds to a visible starting set."""
+    from wmo.providers.pool import is_local_endpoint
+
     if not entries:
         console.print(f"[dim]routing pool[/dim] {path} [dim]is empty[/dim]")
         return
@@ -227,6 +219,8 @@ def register_from_provider(
     operator-chosen deployment, so a first deployment that answers proves nothing about the
     second. `wmo providers verify` bills a call per model for the same reason.
     """
+    from wmo.providers.catalog import endpoint_catalog, list_provider_models
+
     if kind is ProviderKind.OPENAI:
         # The one kind that can point at a self-hosted server (Ollama, vLLM, llama.cpp), so the
         # endpoint question comes BEFORE the catalog: a set URL swaps the built-in registry for
@@ -265,6 +259,8 @@ def _ask_endpoint(console: Console, ask: PromptReader, options: EntryOptions) ->
     with `-` as the explicit way back to the hosted API. Without that escape a session started
     with `--endpoint` could never register a hosted candidate at all.
     """
+    from wmo.providers.pool import is_local_endpoint
+
     if options.endpoint:
         hint = f"blank = keep {escape(options.endpoint)}; '-' = OpenAI's own API"
     else:
@@ -318,6 +314,8 @@ def verify_pool_entry(entry: PoolEntry) -> VerifyResult:
     Never raises: a backend that refuses to be built at all (an unset `api_key_env`, Bedrock
     handed a key) comes back as a failure with its own message, like any other.
     """
+    from wmo.providers.pool import pool_provider
+
     try:
         return pool_provider(entry).verify()
     except ValueError as exc:
@@ -358,6 +356,9 @@ def register_model_ids(
             models for one. Non-interactively there is nobody to ask, so this fails loudly rather
             than writing a candidate that does not work.
     """
+    from wmo.providers.catalog import CatalogModel, endpoint_catalog, list_provider_models
+    from wmo.providers.pool import is_local_endpoint, static_requirements
+
     _check_azure_deployment(kind, model_ids, options)
     if _self_hosted(kind, options) and (options.input_per_mtok is None) != (
         options.output_per_mtok is None
@@ -473,6 +474,8 @@ def choose_models(
     Returns:
         The chosen models, in selection order.
     """
+    from wmo.providers.catalog import CatalogModel
+
     by_target = {
         _target(entry.kind, entry.model, entry.deployment, entry.endpoint): entry
         for entry in existing
@@ -530,6 +533,8 @@ def build_pool_entry(
         pydantic.ValidationError: The entry is not a valid candidate, most often a model with no
             built-in price and no declared one.
     """
+    from wmo.providers.pool import PoolEntry
+
     azure = kind is ProviderKind.AZURE_OPENAI
     bedrock = kind is ProviderKind.BEDROCK
     return PoolEntry(
@@ -560,6 +565,9 @@ def needs_price(kind: ProviderKind, model: CatalogModel) -> bool:
     The OpenRouter lookup reads the same cached table the picker listed from, so it costs no
     second fetch.
     """
+    from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
+    from wmo.tracking.pricing import price_for
+
     if price_for(model.id) is not None:
         return False
     if kind is ProviderKind.OPENROUTER:
@@ -586,6 +594,8 @@ def _register_one(
     Returns:
         True when the roster gained or changed this entry, False when it was skipped.
     """
+    from wmo.providers.pool import static_requirements
+
     per_model = _ask_per_model_options(console, ask, kind, model, options)
     try:
         probe = build_pool_entry(name="probe", kind=kind, model=model, options=per_model)
@@ -628,6 +638,9 @@ def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
     Returns:
         True when the roster changed, False when it was already right or the write was refused.
     """
+    from wmo.core.locks import FileLockTimeout
+    from wmo.providers.pool import upsert_pool_entry
+
     existing = {row.name: row for row in read_pool_entries(pool_path)}.get(entry.name)
     if existing is not None and not existing.enabled:
         # `enabled = false` is an explicit operator edit; a re-run of a registration script
@@ -670,6 +683,8 @@ def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
 
 def _describe_catalog(console: Console, catalog: ProviderCatalog) -> None:
     """One line saying where this backend's model list came from, before the picker opens."""
+    from wmo.providers.catalog import CatalogSource
+
     match catalog.source:
         case CatalogSource.PUBLISHED:
             origin = "published catalog"
@@ -774,6 +789,8 @@ def _ask_per_model_options(
     options: EntryOptions,
 ) -> EntryOptions:
     """Ask what THIS model needs and nothing else: an Azure deployment, or a missing price."""
+    from wmo.providers.pool import is_local_endpoint
+
     updates: dict[str, str | float | None] = {}
     if kind is ProviderKind.AZURE_OPENAI:
         # On the wire Azure's model IS the deployment name, and every deployment is named by the

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -1384,7 +1384,6 @@ def report(
 ) -> None:
     """Build the improvement report for a fitted policy over a matrix."""
     from wmo.optimize.pareto import (
-        DEFAULT_WM_JUDGE,
         PARETO_FILENAME,
         REAL_EPISODE,
         WM_SIMULATED,
@@ -1500,7 +1499,7 @@ def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
 
 @route_app.command("push")
 def push(
-    policy_file: str = typer.Argument(POLICY_FILENAME, help="Fitted policy JSON to install."),
+    policy_file: str = typer.Argument(_POLICY_FILENAME, help="Fitted policy JSON to install."),
     endpoint: str = typer.Option(
         ...,
         "--endpoint",
@@ -1533,6 +1532,8 @@ def push(
     The endpoint keeps its id, name, and URL, so a customer's client is unaffected by
     the swap, and live pods pick the new policy up on their own.
     """
+    from wmo.optimize.policy import RoutingPolicy
+
     policy_path = Path(policy_file)
     if not policy_path.is_file():
         raise typer.BadParameter(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -26,10 +26,9 @@ from collections import Counter
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import typer
-from llm_waterfall import ChatMaxTokensField
 from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape
@@ -38,73 +37,18 @@ from rich.table import Table
 
 from wmo.cli.consent import require_spend_consent
 from wmo.config import ARTIFACT_DIR, WorldModelStore
-from wmo.core.locks import FileLockTimeout
-from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_entry
-from wmo.engine import load_world_model
-from wmo.env import WorldModelEnv
-from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
-from wmo.optimize.compression import (
-    CompressingEmbedder,
-    compression_signature,
-    registered_compressor_ids,
-    resolve_compression,
-    same_compression,
-)
-from wmo.optimize.knn import (
-    COST_QUALITY_ANCHORS,
-    DialResult,
-    KnnFitOutcome,
-    fit_knn_artifact,
-    tune_policy_dial,
-)
-from wmo.optimize.outcomes import (
-    ROUTER_SPLIT_VERSION,
-    OutcomeMatrix,
-    ScenarioOutcome,
-    load_matrix_with_digest,
-    split_router_scenarios,
-)
-from wmo.optimize.pareto import (
-    DEFAULT_WM_JUDGE,
-    PARETO_FILENAME,
-    REAL_EPISODE,
-    WM_SIMULATED,
-    held_out_curve,
-)
-from wmo.optimize.policy import (
-    AZURE_EMBEDDER_DIM,
-    AZURE_EMBEDDER_ENV,
-    HASHING_EMBEDDER_DIM,
-    POLICY_FILENAME,
-    RoutingPolicy,
-    embedder_provenance,
-    probe_embedder,
-    resolve_embedder,
-    write_artifact_atomically,
-)
-from wmo.optimize.report import build_report
-from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
-from wmo.optimize.sweep import (
-    CandidateCoverage,
-    DeferredRisk,
-    SweepError,
-    SweepPlan,
-    SweepRun,
-    Unevenness,
-    coverage,
-    execute_sweep,
-    plan_sweep,
-    preflight_pool,
-    resolve_config,
-    resumable_cells,
-    unevenness,
-)
-from wmo.providers.pool import (
-    DEFAULT_POOL_PATH,
-    PoolEntry,
-    load_pool,
-    upsert_pool_entry,
-)
+
+if TYPE_CHECKING:
+    # Type-only: real imports are local to the commands and helpers that construct or inspect
+    # these values, so importing this module never pulls the optimize/engine/env/distill/pool
+    # bodies behind it.
+    from llm_waterfall import ChatMaxTokensField
+
+    from wmo.optimize.knn import DialResult, KnnFitOutcome
+    from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+    from wmo.optimize.policy import RoutingPolicy
+    from wmo.optimize.sweep import CandidateCoverage, DeferredRisk, SweepPlan, SweepRun
+    from wmo.providers.pool import PoolEntry
 
 # The two output-budget parameter names any OpenAI-compatible backend accepts.
 _MAX_TOKENS_FIELDS: tuple[ChatMaxTokensField, ...] = ("max_tokens", "max_completion_tokens")
@@ -119,8 +63,23 @@ _console = Console()
 DEFAULT_MATRIX_FILENAME = "matrix.json"
 """Default `sweep --out`: the outcome matrix `fit` takes as its argument."""
 
-COMPRESSOR_IDS_HELP = " | ".join(registered_compressor_ids())
-"""What `--compressor` accepts, rendered from the registry so the help cannot go stale."""
+# Literal mirrors of constants that otherwise live behind a heavy import
+# (`wmo.optimize.compression`, `wmo.optimize.policy`, `wmo.env.llm_agent`, `wmo.providers.pool`).
+# Typer evaluates Option defaults and f-string help text at command-definition time, so these
+# have to be values, not names imported from those modules; the real constants are re-imported
+# inside the command bodies that need their behavior.
+_DEFAULT_HISTORY_CHARS = 2000
+_DEFAULT_POOL_PATH = ".wmo/pool.toml"
+_POLICY_FILENAME = "policy.json"
+_HASHING_EMBEDDER_DIM = 512
+_AZURE_EMBEDDER_DIM = 3072
+_AZURE_EMBEDDER_ENV = ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")
+_WM_SIMULATED = "wm_simulated"
+_REAL_EPISODE = "real_episode"
+_DEFAULT_WM_JUDGE = "world-model verifier"
+
+COMPRESSOR_IDS_HELP = "identity | llmlingua2-endpoint | truncate"
+"""What `--compressor` accepts. Mirrors `wmo.optimize.compression.registered_compressor_ids()`."""
 
 _MATRIX_DIGEST_MARK = "sha256="
 """How `load_matrix_with_digest` spells the digest inside a policy's `fitted_from`."""
@@ -132,7 +91,7 @@ def sweep(
         None, help="World model to measure against (default: the only one built under --root)."
     ),
     pool_file: str = typer.Option(
-        str(DEFAULT_POOL_PATH),
+        _DEFAULT_POOL_PATH,
         "--pool",
         # The doubled brackets are escaped: typer renders help through rich markup, which
         # otherwise swallows them and prints an empty pair.
@@ -169,7 +128,7 @@ def sweep(
         "into throttling errors instead of results.",
     ),
     history_chars: int = typer.Option(
-        DEFAULT_HISTORY_CHARS,
+        _DEFAULT_HISTORY_CHARS,
         "--history-chars",
         min=1,
         help="Characters of each observation the agent sees on later turns. Raise it for an "
@@ -296,6 +255,19 @@ def sweep(
     without `--allow-uneven-coverage`. `sweep && fit` in a script then stops instead of fitting on
     it, and the matrix is written either way.
     """
+    from wmo.engine import load_world_model
+    from wmo.env import WorldModelEnv
+    from wmo.optimize.compression import resolve_compression
+    from wmo.optimize.sweep import (
+        SweepError,
+        coverage,
+        execute_sweep,
+        plan_sweep,
+        preflight_pool,
+        resolve_config,
+        resumable_cells,
+    )
+
     out_path = Path(out)
     if compressor is None and aggressiveness > 0.0:
         raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
@@ -509,6 +481,8 @@ def uneven_warning(rows: list[CandidateCoverage]) -> str | None:
     SETS, and candidates ranked on the same scenarios with different numbers of surviving EPISODES.
     Both bias a fit; naming which one happened is what makes the message actionable.
     """
+    from wmo.optimize.sweep import Unevenness, unevenness
+
     counts = ", ".join(f"{escape(row.candidate)} {row.scored}" for row in rows)
     match unevenness(rows):
         case Unevenness.EVEN:
@@ -687,7 +661,7 @@ def student(
         "student", "--name", help="Pool handle: what policy artifacts and request logs call it."
     ),
     pool: str = typer.Option(
-        str(DEFAULT_POOL_PATH), "--pool", help="Candidate pool TOML to add the entry to."
+        _DEFAULT_POOL_PATH, "--pool", help="Candidate pool TOML to add the entry to."
     ),
     endpoint: str = typer.Option(
         None,
@@ -729,6 +703,10 @@ def student(
     `wmo optimize route pin <world-model> --model student`; to have the router CHOOSE between the
     student and the rest of the roster, run `wmo optimize route fit` on a matrix that covers both.
     """
+    from wmo.core.locks import FileLockTimeout
+    from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_entry
+    from wmo.providers.pool import upsert_pool_entry
+
     card_path = Path(card_dir) / MODEL_CARD_FILE
     if not card_path.is_file():
         raise typer.BadParameter(
@@ -821,6 +799,8 @@ def _credential_note(entry: PoolEntry) -> str:
 
 def _pool_has(path: Path, name: str) -> bool:
     """Whether `path` already carries an entry called `name` (False when there is no pool yet)."""
+    from wmo.providers.pool import load_pool
+
     if not path.is_file():
         return False
     try:
@@ -833,6 +813,8 @@ def _pool_has(path: Path, name: str) -> bool:
 
 def _pool_disabled(path: Path, name: str) -> bool:
     """Whether `path` carries an entry called `name` with `enabled = false` (else False)."""
+    from wmo.providers.pool import load_pool
+
     if not path.is_file():
         return False
     try:
@@ -867,6 +849,8 @@ def _reads_as(model: type[OutcomeMatrix] | type[RoutingPolicy], path: Path) -> b
 
 def _load_matrix(matrix_file: str) -> tuple[OutcomeMatrix, str]:
     """The outcome matrix at `matrix_file`, with the digest provenance a fit stamps."""
+    from wmo.optimize.outcomes import load_matrix_with_digest
+
     path = Path(matrix_file)
     try:
         return load_matrix_with_digest(path)
@@ -878,6 +862,8 @@ def _load_matrix(matrix_file: str) -> tuple[OutcomeMatrix, str]:
     except OSError as exc:
         raise typer.BadParameter(f"cannot read the outcome matrix at {path}: {exc}") from exc
     except ValidationError as exc:
+        from wmo.optimize.policy import RoutingPolicy
+
         if _reads_as(RoutingPolicy, path):
             raise typer.BadParameter(
                 f"{path} holds a fitted policy, not an outcome matrix. The matrix is what "
@@ -889,6 +875,8 @@ def _load_matrix(matrix_file: str) -> tuple[OutcomeMatrix, str]:
 
 def _load_policy(policy_file: str) -> RoutingPolicy:
     """The fitted policy at `policy_file`."""
+    from wmo.optimize.policy import RoutingPolicy
+
     path = Path(policy_file)
     try:
         return RoutingPolicy.load(path)
@@ -905,6 +893,8 @@ def _load_policy(policy_file: str) -> RoutingPolicy:
         # as a ValidationError.
         raise typer.BadParameter(f"cannot read the policy at {path}: {exc}") from exc
     except ValidationError as exc:
+        from wmo.optimize.outcomes import OutcomeMatrix
+
         if _reads_as(OutcomeMatrix, path):
             raise typer.BadParameter(
                 f"{path} holds an outcome matrix, not a fitted policy. The policy is what "
@@ -924,7 +914,7 @@ def fit(
         "`sweep`'s handoff and the docs all assume) | rank (Avengers cluster ranks).",
     ),
     out: str = typer.Option(
-        POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
+        _POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
     ),
     fallback: str = typer.Option(
         None,
@@ -980,7 +970,7 @@ def fit(
         "auto",
         "--embedder",
         help="auto | hashing | azure. auto uses the Azure text-embedding-3-large deployment when "
-        f"{' and '.join(AZURE_EMBEDDER_ENV)} are set, and hashing otherwise; either way it says "
+        f"{' and '.join(_AZURE_EMBEDDER_ENV)} are set, and hashing otherwise; either way it says "
         "which one it picked. Resolving to azure means this fit CALLS A PAID EMBEDDING API "
         "(billed to that resource); --embedder hashing keeps it offline and free.",
     ),
@@ -989,7 +979,7 @@ def fit(
         "--dim",
         min=1,
         help="Embedding dimension, sent as the request's `dimensions`. Default: the resolved "
-        f"model's native width ({HASHING_EMBEDDER_DIM} hashing, {AZURE_EMBEDDER_DIM} "
+        f"model's native width ({_HASHING_EMBEDDER_DIM} hashing, {_AZURE_EMBEDDER_DIM} "
         "text-embedding-3-large). Set it only to reduce a model's output deliberately.",
     ),
     deployment: str = typer.Option(None, "--deployment", help="(azure) embedding deployment."),
@@ -1020,6 +1010,17 @@ def fit(
     staged pipeline never fits it and no served endpoint carries one, so choose it only to
     measure against the champion.
     """
+    from wmo.optimize.compression import (
+        CompressingEmbedder,
+        compression_signature,
+        resolve_compression,
+        same_compression,
+    )
+    from wmo.optimize.knn import fit_knn_artifact
+    from wmo.optimize.outcomes import ROUTER_SPLIT_VERSION, split_router_scenarios
+    from wmo.optimize.policy import embedder_provenance, probe_embedder, resolve_embedder
+    from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+
     if kind not in ("rank", "knn"):
         raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
     matrix, source = _load_matrix(matrix_file)
@@ -1177,7 +1178,7 @@ def pin(
         help="Pool entry every request goes to (a `wmo optimize route student` name).",
     ),
     pool: str = typer.Option(
-        str(DEFAULT_POOL_PATH), "--pool", help="Candidate pool TOML to snapshot into the policy."
+        _DEFAULT_POOL_PATH, "--pool", help="Candidate pool TOML to snapshot into the policy."
     ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir holding the built models."),
     out: str = typer.Option(
@@ -1202,6 +1203,9 @@ def pin(
     say so. Replace it with `wmo optimize route fit` on a real outcome matrix to let the router
     choose per request.
     """
+    from wmo.optimize.policy import RoutingPolicy
+    from wmo.providers.pool import load_pool
+
     store = WorldModelStore(root)
     try:
         model_dir = store.resolve(world_model)
@@ -1233,8 +1237,8 @@ def pin(
         raise typer.BadParameter(
             f"no pool model named '{model}' in {pool_path}; available: {available}"
         )
-    out_path = Path(out) if out else model_dir / POLICY_FILENAME
-    if out and out_path.resolve() != (model_dir / POLICY_FILENAME).resolve():
+    out_path = Path(out) if out else model_dir / _POLICY_FILENAME
+    if out and out_path.resolve() != (model_dir / _POLICY_FILENAME).resolve():
         # The foot-gun that bit both bench-defaults lanes (2026-07-29): an --out
         # anywhere but <model dir>/policy.json succeeds, prints the same cheerful
         # line, and leaves the file serving actually reads holding whatever policy
@@ -1243,7 +1247,7 @@ def pin(
         # see it.
         _console.print(
             f"[yellow]![/yellow] --out is outside {model_dir}; `wmo serve --name "
-            f"{model_dir.name}` and GET /config read {model_dir / POLICY_FILENAME}, "
+            f"{model_dir.name}` and GET /config read {model_dir / _POLICY_FILENAME}, "
             "which this pin does NOT update"
         )
     if out_path.is_file() and not yes and not _confirm_overwrite(out_path):
@@ -1284,7 +1288,7 @@ def _confirm_overwrite(path: Path) -> bool:
 
 @route_app.command("tune")
 def tune(
-    policy_file: str = typer.Argument(POLICY_FILENAME, help="Fitted knn policy JSON to re-tune."),
+    policy_file: str = typer.Argument(_POLICY_FILENAME, help="Fitted knn policy JSON to re-tune."),
     cost_quality: float = typer.Option(
         ...,
         "--cost-quality",
@@ -1311,6 +1315,8 @@ def tune(
     The evidence bank is untouched, so this is instant. A served endpoint can be dialed without
     touching files at all: `PUT /v1/endpoints/{name}/config`.
     """
+    from wmo.optimize.knn import tune_policy_dial
+
     try:
         dialed = tune_policy_dial(Path(policy_file), cost_quality)
     except ValueError as exc:
@@ -1320,6 +1326,8 @@ def tune(
 
 def print_dial(console: Console, dialed: DialResult) -> None:
     """Report an applied dial position against the frontier that was actually measured."""
+    from wmo.optimize.knn import COST_QUALITY_ANCHORS
+
     knobs = dialed.knobs
     console.print(
         f"[green]✓[/green] cost_quality={dialed.cost_quality:g} "
@@ -1353,14 +1361,14 @@ def report(
     endpoint: str = typer.Option("endpoint", "--endpoint", help="Endpoint id for the report."),
     out: str = typer.Option("report.json", "--out", help="Where to write the report JSON."),
     provenance: str = typer.Option(
-        WM_SIMULATED,
+        _WM_SIMULATED,
         "--provenance",
-        help=f"How this matrix's rewards were produced: {WM_SIMULATED} (closed-loop against a "
-        f"world model, the default) or {REAL_EPISODE} (episodes of the real benchmark). It rides "
+        help=f"How this matrix's rewards were produced: {_WM_SIMULATED} (closed-loop against a "
+        f"world model, the default) or {_REAL_EPISODE} (episodes of the real benchmark). It rides "
         "on the pareto curve and must never be wrong: consumers refuse to blend the two.",
     ),
     judge: str = typer.Option(
-        DEFAULT_WM_JUDGE,
+        _DEFAULT_WM_JUDGE,
         "--judge",
         help="What scored the episodes, printed beside every rendering of the curve. Pass the "
         "real scorer for a real-benchmark matrix (for example \\[tau2 reward]).",
@@ -1375,6 +1383,16 @@ def report(
     ),
 ) -> None:
     """Build the improvement report for a fitted policy over a matrix."""
+    from wmo.optimize.pareto import (
+        DEFAULT_WM_JUDGE,
+        PARETO_FILENAME,
+        REAL_EPISODE,
+        WM_SIMULATED,
+        held_out_curve,
+    )
+    from wmo.optimize.policy import write_artifact_atomically
+    from wmo.optimize.report import build_report
+
     if provenance not in {WM_SIMULATED, REAL_EPISODE}:
         # A typo here would silently label real measurements as simulated, which is the one
         # mistake the curve's provenance field exists to prevent.

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import itertools
 import json
+import sys
 from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -16,6 +17,7 @@ from filelock import FileLock
 from rich.console import Console
 from typer.testing import CliRunner, Result
 
+import wmo.env as env_module
 from wmo.cli import consent as consent_module
 from wmo.cli.app import app
 from wmo.config import HarnessConfig, save_config
@@ -608,6 +610,10 @@ def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
     assert RoutingPolicy.load(policy_file).cost_quality is None  # the refit is untouched
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows rejects '|' in path components used by this regression fixture",
+)
 def test_route_tune_survives_a_matrix_path_that_looks_like_a_dial_suffix(tmp_path: Path) -> None:
     """An operator-supplied path must not be able to truncate the fit identity it opens.
 
@@ -1418,12 +1424,12 @@ def _patch_seams(
             _ScriptedCandidate(config, seams.systems, throttled=throttled),
         )
 
-    monkeypatch.setattr(route_module, "load_world_model", _load)
+    monkeypatch.setattr("wmo.engine.load_world_model", _load)
     monkeypatch.setattr("wmo.providers.pool.get_provider", _get_provider)
     if no_scoring:
-        real = route_module.WorldModelEnv
+        real = env_module.WorldModelEnv
         monkeypatch.setattr(
-            route_module,
+            env_module,
             "WorldModelEnv",
             lambda world_model, *, score_on_close=False: real(world_model),
         )
@@ -1570,7 +1576,7 @@ def test_route_sweep_resumes_the_cells_an_interrupted_run_already_bought(
     """
     seams = _patch_seams(monkeypatch)
     root = _project(tmp_path, traces=_corpus())
-    real_env = route_module.WorldModelEnv
+    real_env = env_module.WorldModelEnv
     cells = itertools.count(1)
 
     class _DiesOnTheFourthCell:
@@ -1586,14 +1592,14 @@ def test_route_sweep_resumes_the_cells_an_interrupted_run_already_bought(
         def __getattr__(self, name: str) -> object:
             return getattr(self._inner, name)
 
-    monkeypatch.setattr(route_module, "WorldModelEnv", _DiesOnTheFourthCell)
+    monkeypatch.setattr(env_module, "WorldModelEnv", _DiesOnTheFourthCell)
     out, first = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
     assert first.exit_code != 0
     assert not out.exists()  # no matrix: the sweep never finished
     sidecar = out.with_name(out.name + ".partial.jsonl")
     assert len(sidecar.read_text(encoding="utf-8").splitlines()) == 4  # header + 3 paid cells
 
-    monkeypatch.setattr(route_module, "WorldModelEnv", real_env)
+    monkeypatch.setattr(env_module, "WorldModelEnv", real_env)
     scored_before = len(seams.world_model.scored)
     _, second = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
     assert second.exit_code == 0, second.output
@@ -2653,7 +2659,8 @@ def test_route_fit_refuses_compressed_rewards_under_a_raw_fit(tmp_path: Path) ->
         ],
     )
     assert result.exit_code != 0
-    assert "would stamp raw text" in result.output
+    flat = "".join(ch for ch in result.output if not ch.isspace() and ch not in "│┌┐└┘─╔╗╚╝║═")
+    assert "wouldstamprawtext" in flat
 
 
 def test_route_sweep_rejects_an_unservable_compressor_before_spending(tmp_path: Path) -> None:

--- a/wmo/cli/runs_app.py
+++ b/wmo/cli/runs_app.py
@@ -21,7 +21,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from pydantic import ValidationError
@@ -30,17 +30,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from wmo.config import ARTIFACT_DIR
-from wmo.core.types import JsonObject
-from wmo.platform.client import PlatformError
 from wmo.platform.credentials import credentials_path
-from wmo.runs.backfill import BackfillRefused, ensure_backfillable, grid_arm_events, optimize_events
-from wmo.runs.client import (
-    PushRejected,
-    PushUnavailable,
-    RunsSink,
-    default_emitter_id,
-)
-from wmo.runs.reader import CellStats, EventRow, RunDetail, RunsReader, RunSummary
 from wmo.runs.schema import (
     LEDGER_LINE,
     LOG_LINE,
@@ -53,6 +43,12 @@ from wmo.runs.schema import (
     is_terminal_status,
     pipeline_external_id,
 )
+
+if TYPE_CHECKING:
+    from wmo.core.types import JsonObject
+    from wmo.platform.client import PlatformError
+    from wmo.runs.reader import CellStats, EventRow, RunDetail, RunsReader, RunSummary
+    from wmo.runs.schema import RunEvent
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +95,9 @@ _ORG = typer.Option(
 
 def _reader(org: str | None = None) -> RunsReader:
     """The org-scoped reader, or a clean usage error naming the fix."""
+    from wmo.platform.client import PlatformError
+    from wmo.runs.reader import RunsReader
+
     try:
         reader = RunsReader.open(org=org)
     except PlatformError as error:
@@ -144,6 +143,8 @@ def list_runs(
     org: Annotated[str | None, _ORG] = None,
 ) -> None:
     """List this organization's runs, newest first."""
+    from wmo.platform.client import PlatformError
+
     with _reader(org) as reader:
         try:
             page = reader.list_runs(status=status, kind=kind, limit=limit)
@@ -183,6 +184,8 @@ def show_run(
     org: Annotated[str | None, _ORG] = None,
 ) -> None:
     """Show one run: where it is, what it spent, its stages and its cells."""
+    from wmo.platform.client import PlatformError
+
     with _reader(org) as reader:
         try:
             detail = reader.get_run(external_id)
@@ -291,6 +294,8 @@ def tail_run(
     positions nothing can arrive behind), and a finished run's tail ends on its own rather than
     hanging. Ctrl-C stops following and changes nothing about the run.
     """
+    from wmo.platform.client import PlatformError
+
     with _reader() as reader:
         try:
             cursor = _print_backlog(
@@ -440,6 +445,8 @@ def retry_run(
 
 def _command(external_id: str, command: str, args: JsonObject | None, label: str) -> None:
     """Queue one control command and report what the platform recorded."""
+    from wmo.platform.client import PlatformError
+
     with _reader() as reader:
         try:
             control = reader.request_control(external_id, command, args)
@@ -529,6 +536,8 @@ def _plan_backfill(
         typer.BadParameter: The path is neither a grid directory nor an optimize manifest, which is
             almost always a mistyped path rather than an empty directory.
     """
+    from wmo.runs.backfill import optimize_events
+
     if path.is_dir() and (path / COHORT_FILE).is_file():
         return _grid_plans(path, arm, name)
     manifest = path if path.is_file() else path / MANIFEST_RELPATH
@@ -576,6 +585,8 @@ def _grid_plans(
     directory holds several arms and each is its own run: a `--name` that named the whole run would
     collapse three arms into one.
     """
+    from wmo.runs.backfill import grid_arm_events
+
     relpath = (name or grid_relpath(grid_dir)).strip("/")
     arms = [arm] if arm is not None else _arms(grid_dir)
     if not arms:
@@ -662,6 +673,10 @@ def _push(external_id: str, events: list[RunEvent], *, force: bool) -> None:
     wrote under different seqs, which is why an already-reported run is refused rather than merged:
     its ledger lines would land twice and the spend curve would double.
     """
+    from wmo.platform.client import PlatformError
+    from wmo.runs.backfill import BackfillRefused, ensure_backfillable
+    from wmo.runs.client import PushRejected, PushUnavailable, RunsSink, default_emitter_id
+
     # ONE client for both halves of this command, closed when it is done: the guard reads the run
     # and the push writes it, and opening a second connection pool to do that leaked one per arm.
     with _reader() as reader:

--- a/wmo/cli/startup_test.py
+++ b/wmo/cli/startup_test.py
@@ -1,0 +1,107 @@
+"""Startup / import-isolation tests for the light CLI shell (#344).
+
+Each probe runs in a fresh subprocess so pytest collection of other CLI tests cannot pollute
+``sys.modules``. Light paths must stay free of FastAPI, sklearn, scipy, uvicorn, and the heavy
+serving / distill / route bodies.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(code: str) -> None:
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=120)
+
+
+
+
+def test_cli_import_stays_free_of_heavy_third_parties() -> None:
+    _run(
+        """
+import sys
+import wmo.cli
+banned = ("fastapi", "sklearn", "scipy", "uvicorn")
+roots = {k.split(".")[0] for k in sys.modules}
+bad = sorted(b for b in banned if b in roots)
+assert not bad, f"heavy packages loaded on import wmo.cli: {bad}"
+"""
+    )
+
+
+def test_cli_help_stays_free_of_heavy_product_modules() -> None:
+    _run(
+        """
+import sys
+from typer.testing import CliRunner
+from wmo.cli.app import app
+
+result = CliRunner().invoke(app, ["--help"])
+assert result.exit_code == 0, result.output
+banned = (
+    "fastapi",
+    "sklearn",
+    "scipy",
+    "uvicorn",
+    "wmo.serving.server",
+    "wmo.distill",
+    "wmo.cli.route_app",
+    "wmo.evals.open_loop",
+)
+roots = {k.split(".")[0] for k in sys.modules}
+bad = []
+for name in banned:
+    if name in sys.modules:
+        bad.append(name)
+    elif "." not in name and name in roots:
+        bad.append(name)
+assert not bad, f"heavy modules loaded for wmo --help: {bad}"
+"""
+    )
+
+
+def test_list_and_config_do_not_load_serve_or_distill() -> None:
+    _run(
+        """
+import sys
+from typer.testing import CliRunner
+from wmo.cli.app import app
+
+runner = CliRunner()
+assert runner.invoke(app, ["list"]).exit_code == 0
+assert runner.invoke(app, ["config", "telemetry", "status"]).exit_code == 0
+banned = (
+    "wmo.serving.server",
+    "wmo.distill",
+    "wmo.cli.route_app",
+    "fastapi",
+    "sklearn",
+    "uvicorn",
+)
+roots = {k.split(".")[0] for k in sys.modules}
+bad = []
+for name in banned:
+    if name in sys.modules:
+        bad.append(name)
+    elif "." not in name and name in roots:
+        bad.append(name)
+assert not bad, f"light commands pulled: {bad}"
+"""
+    )
+
+
+def test_serve_help_loads_uvicorn_path_when_handler_imports() -> None:
+    """Invoking the serve command body must be able to import the serve stack.
+
+    ``serve --help`` only needs the signature (still light). Importing the serve handler's
+    dependencies on demand is checked by importing create_app the same way ``serve`` does.
+    """
+    _run(
+        """
+import sys
+from wmo.serving.server import create_app
+assert callable(create_app)
+assert "fastapi" in {m.split(".")[0] for m in sys.modules}
+"""
+    )

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -20,6 +20,7 @@ import os
 import sys
 from collections import deque
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import click
 import typer
@@ -49,13 +50,12 @@ from wmo.config import (
     upsert_env_var,
     validate_name,
 )
-from wmo.core.types import Action, ActionKind, Session
-from wmo.engine.build import DEFAULT_TRAIN_SPLIT
-from wmo.engine.play import PlayTurn, parse_action, play_turn
-from wmo.engine.world_model import WorldModel
-from wmo.providers import verify_all, verify_embedder
 from wmo.providers.base import ProviderConfig, ProviderKind, VerifyResult
-from wmo.providers.models import resolve_provider_model
+
+if TYPE_CHECKING:
+    from wmo.core.types import Action, Session
+    from wmo.engine.play import PlayTurn
+    from wmo.engine.world_model import WorldModel
 
 # A reader takes a fully-rendered prompt string and returns the user's typed line.
 PromptReader = Callable[[str], str]
@@ -150,7 +150,9 @@ class BuildParams(BaseModel):
     judge_model: str | None = None
     region: str | None = None
     fidelity: str = "medium"
-    train_split: float = DEFAULT_TRAIN_SPLIT
+    # Mirrors wmo.engine.build.DEFAULT_TRAIN_SPLIT (0.8): kept as a literal here so this light,
+    # importable-without-the-engine module never has to pull in wmo.engine.build.
+    train_split: float = 0.8
     embed_provider: str = "hashing"
     embed_model: str | None = None
     embed_dim: int = 512
@@ -253,6 +255,8 @@ def select_provider_and_model(
     retry default. Also reused by `wmo demo`'s switch-provider flow. Returns
     (provider, model, region).
     """
+    from wmo.providers.models import resolve_provider_model
+
     providers = list(_PROVIDER_MODELS)
     with_creds = [p for p in providers if has_credentials(p)]
     # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
@@ -320,6 +324,9 @@ def run_build_wizard(
     to the picker instead of surfacing after the wizard. `verify`/`verify_embed` exist so tests
     can stub the pings. Raises `ValueError` if no trace source (file or vendor) is provided.
     """
+    from wmo.providers import verify_all, verify_embedder
+    from wmo.providers.models import resolve_provider_model
+
     interactive = reader is None
     check = verify if verify is not None else (lambda cfg: verify_all([cfg])[0])
     check_embed = verify_embed if verify_embed is not None else verify_embedder
@@ -1095,6 +1102,8 @@ def _handle_action(console: Console, world_model: WorldModel, session_id: str, l
     A failed step (e.g. a provider/network error) is reported and swallowed so the REPL keeps the
     session alive instead of crashing the whole interactive run.
     """
+    from wmo.engine.play import parse_action, play_turn
+
     try:
         action = parse_action(line)
     except ValueError as exc:
@@ -1131,6 +1140,8 @@ def _render_state(console: Console, session: Session) -> None:
 
 
 def _action_text(action: Action) -> str:
+    from wmo.core.types import ActionKind
+
     if action.kind == ActionKind.TOOL_CALL:
         return f"{action.name}({action.arguments})"
     return f'message: "{action.content}"'

--- a/wmo/providers/__init__.py
+++ b/wmo/providers/__init__.py
@@ -4,7 +4,14 @@ One interface (`Provider`), multiple backends, one entry point (`get_provider` â
 `provider_or_chain`, which upgrades to the local `.wmo/fallback.toml` failover chain when present).
 All can be verified on startup with a cheap ping. Built fresh for this repo; no external client
 framework.
+
+Waterfall exports load on first access so a caller that only needs `get_provider` never pays for
+the failover chain (or the Bedrock helper it uses for region resolution).
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from wmo.providers.base import (
     DEFAULT_MAX_TOKENS,
@@ -18,7 +25,10 @@ from wmo.providers.base import (
 )
 from wmo.providers.models import ProviderModel, model_types_for_provider, resolve_provider_model
 from wmo.providers.registry import get_provider, verify_all, verify_embedder
-from wmo.providers.waterfall import WaterfallProvider, provider_or_chain
+
+if TYPE_CHECKING:
+    from wmo.providers.waterfall import WaterfallProvider as WaterfallProvider
+    from wmo.providers.waterfall import provider_or_chain as provider_or_chain
 
 __all__ = [
     "Provider",
@@ -38,3 +48,13 @@ __all__ = [
     "model_types_for_provider",
     "resolve_provider_model",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name in ("WaterfallProvider", "provider_or_chain"):
+        from wmo.providers.waterfall import WaterfallProvider, provider_or_chain
+
+        globals()["WaterfallProvider"] = WaterfallProvider
+        globals()["provider_or_chain"] = provider_or_chain
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/wmo/providers/registry.py
+++ b/wmo/providers/registry.py
@@ -2,28 +2,49 @@
 
 `get_provider` is the single constructor the rest of the harness uses; nothing imports a concrete
 backend directly. `verify_all` powers `wmo providers verify`.
+
+Backends are imported only when their `ProviderKind` is requested, so a CLI that never talks to
+Tinker (or Anthropic, …) never pays for those modules.
 """
 
 from __future__ import annotations
 
-from wmo.providers.anthropic import AnthropicProvider
-from wmo.providers.azure_openai import AzureOpenAIProvider
-from wmo.providers.base import Provider, ProviderConfig, ProviderKind, VerifyResult
-from wmo.providers.bedrock import BedrockProvider
-from wmo.providers.openai import OpenAIProvider
-from wmo.providers.openai_responses import OpenAIResponsesProvider
-from wmo.providers.openrouter import OpenRouterProvider
-from wmo.providers.tinker import TinkerChatProvider
+import importlib
+from typing import TYPE_CHECKING
 
-_BACKENDS = {
-    ProviderKind.ANTHROPIC: AnthropicProvider,
-    ProviderKind.BEDROCK: BedrockProvider,
-    ProviderKind.AZURE_OPENAI: AzureOpenAIProvider,
-    ProviderKind.OPENAI: OpenAIProvider,
-    ProviderKind.OPENAI_RESPONSES: OpenAIResponsesProvider,
-    ProviderKind.OPENROUTER: OpenRouterProvider,
-    ProviderKind.TINKER: TinkerChatProvider,
+from wmo.providers.base import Provider, ProviderConfig, ProviderKind, VerifyResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# kind -> "module.path:ClassName". Resolved on first get_provider call for that kind only.
+_BACKEND_PATHS: dict[ProviderKind, str] = {
+    ProviderKind.ANTHROPIC: "wmo.providers.anthropic:AnthropicProvider",
+    ProviderKind.BEDROCK: "wmo.providers.bedrock:BedrockProvider",
+    ProviderKind.AZURE_OPENAI: "wmo.providers.azure_openai:AzureOpenAIProvider",
+    ProviderKind.OPENAI: "wmo.providers.openai:OpenAIProvider",
+    ProviderKind.OPENAI_RESPONSES: "wmo.providers.openai_responses:OpenAIResponsesProvider",
+    ProviderKind.OPENROUTER: "wmo.providers.openrouter:OpenRouterProvider",
+    ProviderKind.TINKER: "wmo.providers.tinker:TinkerChatProvider",
 }
+
+_backend_cache: dict[ProviderKind, Callable[..., Provider]] = {}
+
+
+def _load_backend(kind: ProviderKind) -> Callable[..., Provider]:
+    """Import and cache the constructor for `kind`."""
+    cached = _backend_cache.get(kind)
+    if cached is not None:
+        return cached
+    try:
+        path = _BACKEND_PATHS[kind]
+    except KeyError:  # pragma: no cover - exhaustive over the enum
+        raise ValueError(f"unknown provider kind: {kind}") from None
+    module_path, _, class_name = path.partition(":")
+    module = importlib.import_module(module_path)
+    backend = getattr(module, class_name)
+    _backend_cache[kind] = backend
+    return backend
 
 
 def get_provider(config: ProviderConfig, *, api_key: str | None = None) -> Provider:
@@ -33,10 +54,7 @@ def get_provider(config: ProviderConfig, *, api_key: str | None = None) -> Provi
     model pool, tests) can pass it, so untrusted bundle config can never choose a credential.
     When set, the backend authenticates with exactly this key instead of its default env vars.
     """
-    try:
-        backend = _BACKENDS[config.kind]
-    except KeyError:  # pragma: no cover - exhaustive over the enum
-        raise ValueError(f"unknown provider kind: {config.kind}") from None
+    backend = _load_backend(config.kind)
     if api_key is None:
         return backend(config)
     return backend(config, api_key=api_key)

--- a/wmo/providers/tests/registry_test.py
+++ b/wmo/providers/tests/registry_test.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
 
 from wmo.providers import ProviderConfig, ProviderKind, get_provider, verify_embedder
@@ -21,6 +24,24 @@ def test_tinker_kind_constructs_tinker_provider() -> None:
         kind=ProviderKind.TINKER, model_type="Qwen/Qwen3-8B", model="tinker://run/weights/0"
     )
     assert isinstance(get_provider(config), TinkerChatProvider)
+
+
+def test_get_provider_loads_only_the_selected_backend() -> None:
+    """OpenAI construction must not import Anthropic or Tinker backend modules."""
+    code = """
+import sys
+from wmo.providers.base import ProviderConfig, ProviderKind
+from wmo.providers.registry import get_provider
+
+get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5"))
+assert "wmo.providers.openai" in sys.modules
+bad = [
+    m for m in ("wmo.providers.anthropic", "wmo.providers.tinker", "wmo.providers.bedrock")
+    if m in sys.modules
+]
+assert not bad, f"unrelated backends loaded: {bad}"
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=120)
 
 
 def test_verify_never_raises_and_reports_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmo/providers/waterfall.py
+++ b/wmo/providers/waterfall.py
@@ -48,7 +48,6 @@ from wmo.providers.base import (
     TokenUsage,
     VerifyResult,
 )
-from wmo.providers.bedrock import resolve_region
 from wmo.providers.registry import get_provider
 
 # ProviderKinds with a REAL llm-waterfall adapter, mapped to the package's provider names
@@ -83,6 +82,8 @@ def to_backend(config: ProviderConfig, *, profile: str | None = None) -> Backend
         )
     region = config.region
     if config.kind is ProviderKind.BEDROCK:
+        from wmo.providers.bedrock import resolve_region
+
         region = resolve_region(region)
     return Backend(
         provider,


### PR DESCRIPTION
## Summary

Fixes #344: `wmo` paid nearly the full product import cost before Typer dispatched even light commands (`--help`, `list`, `config telemetry status`).

- Lazy provider registry: backends load by `kind → module:Class` inside `get_provider`, not at import
- Deferred Typer sub-apps via `DeferredTyperGroup` / `add_deferred_typer` (harness, optimize, route, distill, runs, etc.)
- Move heavy imports in CLI modules into command/helper bodies (engine, serve, evals, optimize, research)
- Startup isolation tests in `wmo/cli/startup_test.py` plus provider registry isolation coverage
- No intentional UX change to command names, flags, help, or behavior

Approach note: same load-cut as the proposal (light definitions, heavy code on demand), implemented with in-module deferral rather than a full handlers/ package split.

## Timing (warm `uv run`, this machine)

| Command | Before | After |
|---|---|---|
| `wmo --help` | ~4.2 s | ~1.1–1.2 s |
| `wmo list` | ~4.1 s | ~1.1–1.2 s |
| `wmo config telemetry status` | ~4.0 s | ~1.1–1.2 s |
| `wmo optimize --help` | ~4.1 s | ~1.1–1.2 s |
| `import wmo.cli` | ~3.4 s (fastapi/sklearn/uvicorn present) | ~0.8–0.9 s (those modules absent) |

Absolute seconds vary by machine; the hard gate is the import-boundary tests.

## Test plan

- [x] `uv run pytest -q wmo/cli/startup_test.py wmo/providers/tests/registry_test.py`
- [x] `uv run pytest -q wmo/cli/app_test.py wmo/cli/agent_session_test.py wmo/cli/optimize_model_app_test.py wmo/cli/route_app_test.py`
- [x] `uv run ruff check` / `uv run ty check` on touched CLI/provider areas
- [ ] Remeasure warm timings on a second machine and paste into a PR comment
- [ ] Spot-check: `wmo --help`, `wmo list`, `wmo build --help`, `wmo optimize --help`, then one heavy path (`serve` or `optimize model --help` after descent)
