### PR TITLE
TEMP DIAGNOSTIC (do not review, will be closed): gate baseline on unmodified main

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -25,8 +25,11 @@ jobs:
       - name: ruff check
         run: uv run ruff check .
       - name: ruff format
+        if: always()
         run: uv run ruff format --check .
       - name: ty check
+        if: always()
         run: uv run ty check
       - name: pytest
+        if: always()
         run: uv run pytest -q

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,32 @@
+name: gate
+
+# The whole-repo gate (AGENTS.md rule 1), run in CI so its promises are real.
+#
+# Deliberately NO `paths:` filter. This job carries the top-level allowlist check
+# (`wmo/repo_layout_test.py`, AGENTS.md rule 5), and that check exists to fail a change which
+# adds an unapproved top-level directory. A path filter would let exactly that change through
+# whenever it touched no Python: the allowlist is closed only if every pull request is checked.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project and its dev extras
+        run: uv sync --extra dev
+      - name: ruff check
+        run: uv run ruff check .
+      - name: ruff format
+        run: uv run ruff format --check .
+      - name: ty check
+        run: uv run ty check
+      - name: pytest
+        run: uv run pytest -q


### PR DESCRIPTION
Throwaway. Adds only `.github/workflows/gate.yml` on top of unmodified main (22b68ea1) to establish whether the CLI pytest failures the new gate surfaces are pre-existing on main or introduced by #343. Will be closed and the branch deleted as soon as the run reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)