### PR TITLE
wmo optimize route push: install a fitted policy on a hosted endpoint

### DIFF
--- a/packages/environment-capture/terminal-bench/convert_to_wmo.py
+++ b/packages/environment-capture/terminal-bench/convert_to_wmo.py
@@ -108,9 +108,7 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
     result = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
     if result.get("exception_info") is not None:
         return []
-    trajectory = json.loads(
-        (trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8")
-    )
+    trajectory = json.loads((trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8"))
     steps = trajectory.get("steps") or []
     rewards = (result.get("verifier_result") or {}).get("rewards") or {}
     model = ((result.get("agent_info") or {}).get("model_info") or {}).get("name", "")
@@ -144,30 +142,34 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
                 action_attrs.append(_attr("gen_ai.prompt", task_text))
             if ordinal == 0:
                 action_attrs.append(_attr("wmo.trace.metadata", json.dumps(metadata)))
-            spans.append({
-                "traceId": trace_id,
-                "spanId": f"{trace_id[:12]}{ordinal:04x}a",
-                "parentSpanId": "",
-                "name": "chat terminal",
-                "startTimeUnixNano": ordinal * 10,
-                "endTimeUnixNano": ordinal * 10 + 1,
-                "status": {"code": "STATUS_CODE_OK"},
-                "attributes": action_attrs,
-            })
-            spans.append({
-                "traceId": trace_id,
-                "spanId": f"{trace_id[:12]}{ordinal:04x}b",
-                "parentSpanId": "",
-                "name": "execute_tool terminal",
-                "startTimeUnixNano": ordinal * 10 + 2,
-                "endTimeUnixNano": ordinal * 10 + 3,
-                "status": {"code": "STATUS_CODE_OK"},
-                "attributes": [
-                    _attr("gen_ai.operation.name", "execute_tool"),
-                    _attr("gen_ai.tool.name", name),
-                    _attr("gen_ai.tool.message", content),
-                ],
-            })
+            spans.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{trace_id[:12]}{ordinal:04x}a",
+                    "parentSpanId": "",
+                    "name": "chat terminal",
+                    "startTimeUnixNano": ordinal * 10,
+                    "endTimeUnixNano": ordinal * 10 + 1,
+                    "status": {"code": "STATUS_CODE_OK"},
+                    "attributes": action_attrs,
+                }
+            )
+            spans.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{trace_id[:12]}{ordinal:04x}b",
+                    "parentSpanId": "",
+                    "name": "execute_tool terminal",
+                    "startTimeUnixNano": ordinal * 10 + 2,
+                    "endTimeUnixNano": ordinal * 10 + 3,
+                    "status": {"code": "STATUS_CODE_OK"},
+                    "attributes": [
+                        _attr("gen_ai.operation.name", "execute_tool"),
+                        _attr("gen_ai.tool.name", name),
+                        _attr("gen_ai.tool.message", content),
+                    ],
+                }
+            )
             ordinal += 1
     return spans
 

--- a/packages/environment-capture/terminal-bench/convert_to_wmo.py
+++ b/packages/environment-capture/terminal-bench/convert_to_wmo.py
@@ -108,7 +108,9 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
     result = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
     if result.get("exception_info") is not None:
         return []
-    trajectory = json.loads((trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8"))
+    trajectory = json.loads(
+        (trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8")
+    )
     steps = trajectory.get("steps") or []
     rewards = (result.get("verifier_result") or {}).get("rewards") or {}
     model = ((result.get("agent_info") or {}).get("model_info") or {}).get("name", "")
@@ -142,34 +144,30 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
                 action_attrs.append(_attr("gen_ai.prompt", task_text))
             if ordinal == 0:
                 action_attrs.append(_attr("wmo.trace.metadata", json.dumps(metadata)))
-            spans.append(
-                {
-                    "traceId": trace_id,
-                    "spanId": f"{trace_id[:12]}{ordinal:04x}a",
-                    "parentSpanId": "",
-                    "name": "chat terminal",
-                    "startTimeUnixNano": ordinal * 10,
-                    "endTimeUnixNano": ordinal * 10 + 1,
-                    "status": {"code": "STATUS_CODE_OK"},
-                    "attributes": action_attrs,
-                }
-            )
-            spans.append(
-                {
-                    "traceId": trace_id,
-                    "spanId": f"{trace_id[:12]}{ordinal:04x}b",
-                    "parentSpanId": "",
-                    "name": "execute_tool terminal",
-                    "startTimeUnixNano": ordinal * 10 + 2,
-                    "endTimeUnixNano": ordinal * 10 + 3,
-                    "status": {"code": "STATUS_CODE_OK"},
-                    "attributes": [
-                        _attr("gen_ai.operation.name", "execute_tool"),
-                        _attr("gen_ai.tool.name", name),
-                        _attr("gen_ai.tool.message", content),
-                    ],
-                }
-            )
+            spans.append({
+                "traceId": trace_id,
+                "spanId": f"{trace_id[:12]}{ordinal:04x}a",
+                "parentSpanId": "",
+                "name": "chat terminal",
+                "startTimeUnixNano": ordinal * 10,
+                "endTimeUnixNano": ordinal * 10 + 1,
+                "status": {"code": "STATUS_CODE_OK"},
+                "attributes": action_attrs,
+            })
+            spans.append({
+                "traceId": trace_id,
+                "spanId": f"{trace_id[:12]}{ordinal:04x}b",
+                "parentSpanId": "",
+                "name": "execute_tool terminal",
+                "startTimeUnixNano": ordinal * 10 + 2,
+                "endTimeUnixNano": ordinal * 10 + 3,
+                "status": {"code": "STATUS_CODE_OK"},
+                "attributes": [
+                    _attr("gen_ai.operation.name", "execute_tool"),
+                    _attr("gen_ai.tool.name", name),
+                    _attr("gen_ai.tool.message", content),
+                ],
+            })
             ordinal += 1
     return spans
 

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -1422,3 +1422,84 @@ def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
         "IN-SAMPLE, not held out: every request retrieves its own row. Sweep a second matrix "
         "over scenarios the fit never saw and report against that one."
     )
+
+
+@route_app.command("push")
+def push(
+    policy_file: str = typer.Argument(POLICY_FILENAME, help="Fitted policy JSON to install."),
+    endpoint: str = typer.Option(
+        ...,
+        "--endpoint",
+        help="Hosted endpoint slug to install onto (the `model` a customer's client sends).",
+    ),
+    org: str | None = typer.Option(
+        None,
+        "--org",
+        help="Organization id or slug (default: the login's, or $WMO_PLATFORM_ORG).",
+    ),
+    report_file: str | None = typer.Option(
+        None,
+        "--report",
+        help="Improvement report JSON to publish with the policy (see `route report`).",
+    ),
+) -> None:
+    """Install a fitted policy on a hosted endpoint, so serving actually uses it.
+
+    The last link in the chain. `fit` writes a policy that only this machine can see;
+    an endpoint created on the platform serves a `static` policy until something
+    replaces it. This is that something:
+
+        wmo optimize route push models/support/policy.json --endpoint support-prod
+
+    A knn policy is TWO artifacts, and this sends both: the JSON plus the `.npz`
+    evidence bank beside it, resolved from the policy's own `knn_bank_path` rather
+    than guessed, so a renamed sidecar is a local error instead of a server refusal.
+    Sending the policy alone would store a row that validates and cannot serve.
+
+    The endpoint keeps its id, name, and URL, so a customer's client is unaffected by
+    the swap, and live pods pick the new policy up on their own.
+    """
+    policy_path = Path(policy_file)
+    if not policy_path.is_file():
+        raise typer.BadParameter(
+            f"no policy at {policy_path} (`wmo optimize route fit` writes one)"
+        )
+    try:
+        policy = RoutingPolicy.load(policy_path)
+    except (ValidationError, ValueError) as exc:
+        raise typer.BadParameter(f"{policy_path} is not a routing policy: {exc}") from exc
+
+    bank_path: Path | None = None
+    if policy.kind == "knn":
+        bank_path = policy.bank_path()
+        if not bank_path.is_file():
+            # Checked here, not left to the server: the policy names its own sidecar,
+            # so a missing one means the local artifact pair is broken and pushing
+            # would only turn that into a 400 after uploading nothing useful.
+            raise typer.BadParameter(
+                f"{policy_path} is a knn policy whose evidence bank is missing at "
+                f"{bank_path}; a knn policy is served together with its sidecar, so "
+                "copy it beside the policy or refit with `wmo optimize route fit --kind knn`"
+            )
+    report_path = Path(report_file) if report_file is not None else None
+    if report_path is not None and not report_path.is_file():
+        raise typer.BadParameter(
+            f"no report at {report_path} (`wmo optimize route report` writes one)"
+        )
+
+    # Imported here, not at module scope: `platform_cmds` builds its own command
+    # surface at import time, and pulling that in for one command changed behavior
+    # in unrelated `route` commands (15 of this module's tests went red).
+    from wmo.cli.platform_cmds import _connected, _require_connection
+
+    credentials, org_id = _require_connection(org)
+    with _connected(credentials, "Could not install the policy") as client:
+        client.install_endpoint_policy(org_id, endpoint, policy_path, bank_path, report_path)
+
+    size = f", bank {bank_path.stat().st_size / 1024:.0f}KiB" if bank_path is not None else ""
+    _console.print(
+        f"[green]✓[/green] installed {policy.kind} policy on [bold]{endpoint}[/bold]{size}\n"
+        f"  from: {policy_path}\n"
+        f"  serving picks it up without a restart; `wmo runs` and the endpoint's "
+        f"telemetry show what it routes."
+    )

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -21,6 +21,7 @@ customer copy never says router.
 from __future__ import annotations
 
 import itertools
+import json
 from collections import Counter
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -1435,7 +1436,7 @@ def push(
     org: str | None = typer.Option(
         None,
         "--org",
-        help="Organization id or slug (default: the login's, or $WMO_PLATFORM_ORG).",
+        help="Organization id (default: the login's, or $WMO_PLATFORM_ORG).",
     ),
     report_file: str | None = typer.Option(
         None,
@@ -1466,7 +1467,7 @@ def push(
         )
     try:
         policy = RoutingPolicy.load(policy_path)
-    except (ValidationError, ValueError) as exc:
+    except (OSError, ValidationError, ValueError) as exc:
         raise typer.BadParameter(f"{policy_path} is not a routing policy: {exc}") from exc
 
     bank_path: Path | None = None
@@ -1482,21 +1483,31 @@ def push(
                 "copy it beside the policy or refit with `wmo optimize route fit --kind knn`"
             )
     report_path = Path(report_file) if report_file is not None else None
-    if report_path is not None and not report_path.is_file():
-        raise typer.BadParameter(
-            f"no report at {report_path} (`wmo optimize route report` writes one)"
-        )
+    if report_path is not None:
+        if not report_path.is_file():
+            raise typer.BadParameter(
+                f"no report at {report_path} (`wmo optimize route report` writes one)"
+            )
+        try:
+            json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            # Same rule as the sidecar check: a broken local artifact fails here,
+            # not as a server refusal after the upload already happened.
+            raise typer.BadParameter(f"{report_path} is not readable JSON: {exc}") from exc
 
     # Imported here, not at module scope: `platform_cmds` builds its own command
     # surface at import time, and pulling that in for one command changed behavior
     # in unrelated `route` commands (15 of this module's tests went red).
     from wmo.cli.platform_cmds import _connected, _require_connection
 
+    # Sized before the install: a stat after a SUCCESSFUL install would make the
+    # whole command read as failed if anything removed the local file meanwhile.
+    size = f", bank {bank_path.stat().st_size / 1024:.0f}KiB" if bank_path is not None else ""
+
     credentials, org_id = _require_connection(org)
     with _connected(credentials, "Could not install the policy") as client:
         client.install_endpoint_policy(org_id, endpoint, policy_path, bank_path, report_path)
 
-    size = f", bank {bank_path.stat().st_size / 1024:.0f}KiB" if bank_path is not None else ""
     _console.print(
         f"[green]✓[/green] installed {policy.kind} policy on [bold]{endpoint}[/bold]{size}\n"
         f"  from: {policy_path}\n"

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3172,3 +3172,146 @@ def test_route_student_replacement_keeps_a_disabled_entry_disabled(tmp_path: Pat
     entries = load_pool(pool_file).models
     assert len(entries) == 1
     assert entries[0].enabled is False
+
+
+def _fitted_knn_policy(tmp_path: Path) -> Path:
+    """Fit a real knn policy + sidecar through the CLI, returning the policy path."""
+    matrix_file = _knn_matrix_file(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--kind",
+            "knn",
+            "--fallback",
+            "a",
+            "--z",
+            "0.5",
+            "--rag-num",
+            "3",
+            "--min-pairs",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return policy_file
+
+
+class _FakeClient:
+    """Records the install call instead of making it."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Path, Path | None, Path | None]] = []
+
+    def install_endpoint_policy(
+        self,
+        org_id: str,
+        endpoint: str,
+        policy_path: Path,
+        bank_path: Path | None,
+        report_path: Path | None = None,
+    ) -> dict[str, str]:
+        self.calls.append((org_id, endpoint, policy_path, bank_path, report_path))
+        return {"name": endpoint}
+
+
+@contextmanager
+def _connected_to(client: _FakeClient) -> Iterator[None]:
+    """Stand in for a platform login for the duration of one command.
+
+    Patches `platform_cmds`, which is where `push` resolves the connection from, so
+    the command runs its real body against a client that records instead of calling.
+    """
+    import wmo.cli.platform_cmds as platform_module
+
+    @contextmanager
+    def _fake_connected(_credentials: object, _headline: str) -> Iterator[_FakeClient]:
+        yield client
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(platform_module, "_connected", _fake_connected)
+        patch.setattr(platform_module, "_require_connection", lambda _org: (None, "org-1"))
+        yield
+
+
+def test_route_push_sends_the_policy_and_its_sidecar(tmp_path: Path) -> None:
+    """Push sends BOTH artifacts: a knn policy alone would store an unservable row."""
+    policy_file = _fitted_knn_policy(tmp_path)
+    client = _FakeClient()
+    with _connected_to(client):
+        result = runner.invoke(
+            app,
+            ["optimize", "route", "push", str(policy_file), "--endpoint", "support-prod"],
+        )
+    assert result.exit_code == 0, result.output
+    assert len(client.calls) == 1
+    _org, endpoint, sent_policy, sent_bank, sent_report = client.calls[0]
+    assert endpoint == "support-prod"
+    assert sent_policy == policy_file
+    # Resolved from the policy's own knn_bank_path, not guessed from the policy name.
+    assert sent_bank == RoutingPolicy.load(policy_file).bank_path()
+    assert sent_bank is not None and sent_bank.is_file()
+    assert sent_report is None
+    assert _says(result.output, "installed knn policy")
+
+
+def test_route_push_refuses_a_knn_policy_whose_sidecar_is_missing(tmp_path: Path) -> None:
+    """A knn policy without its bank fails locally, before any upload."""
+    # The pair is broken on this machine, so pushing would only turn a local mistake
+    # into a server refusal after sending a policy the server must reject.
+    policy_file = _fitted_knn_policy(tmp_path)
+    RoutingPolicy.load(policy_file).bank_path().unlink()
+    client = _FakeClient()
+    with _connected_to(client):
+        result = runner.invoke(
+            app,
+            ["optimize", "route", "push", str(policy_file), "--endpoint", "support-prod"],
+        )
+    assert result.exit_code != 0
+    assert _says(result.output, "evidence bank is missing")
+    assert client.calls == []
+
+
+def test_route_push_refuses_a_path_that_is_not_a_policy(tmp_path: Path) -> None:
+    """A file that is not a routing policy is refused without contacting the platform."""
+    junk = tmp_path / "policy.json"
+    junk.write_text('{"kind": "not-a-kind"}', encoding="utf-8")
+    client = _FakeClient()
+    with _connected_to(client):
+        result = runner.invoke(
+            app, ["optimize", "route", "push", str(junk), "--endpoint", "support-prod"]
+        )
+    assert result.exit_code != 0
+    assert _says(result.output, "not a routing policy")
+    assert client.calls == []
+
+
+def test_route_push_sends_no_bank_for_a_static_policy(tmp_path: Path) -> None:
+    """A static policy has no sidecar, so none is sent and none is required."""
+    policy_file = tmp_path / "policy.json"
+    RoutingPolicy(
+        kind="static",
+        default_model="a",
+        pool=[
+            PoolEntry(
+                name="a",
+                kind=ProviderKind.OPENAI,
+                model="a",
+                input_per_mtok=1.0,
+                output_per_mtok=1.0,
+            )
+        ],
+    ).save(policy_file)
+    client = _FakeClient()
+    with _connected_to(client):
+        result = runner.invoke(
+            app, ["optimize", "route", "push", str(policy_file), "--endpoint", "support-prod"]
+        )
+    assert result.exit_code == 0, result.output
+    assert client.calls[0][3] is None

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3315,3 +3315,27 @@ def test_route_push_sends_no_bank_for_a_static_policy(tmp_path: Path) -> None:
         )
     assert result.exit_code == 0, result.output
     assert client.calls[0][3] is None
+
+
+def test_route_push_sends_the_report_when_given_one(tmp_path: Path) -> None:
+    """--report rides through to the install, so the endpoint gains its evidence."""
+    policy_file = _fitted_knn_policy(tmp_path)
+    report_file = tmp_path / "report.json"
+    report_file.write_text('{"headline": {}}', encoding="utf-8")
+    client = _FakeClient()
+    with _connected_to(client):
+        result = runner.invoke(
+            app,
+            [
+                "optimize",
+                "route",
+                "push",
+                str(policy_file),
+                "--endpoint",
+                "support-prod",
+                "--report",
+                str(report_file),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert client.calls[0][4] == report_file

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -573,6 +573,46 @@ class PlatformClient:
         self._raise_for_error(finalize)
         return RemoteWorldModel.model_validate(_decode_json(finalize))
 
+    def install_endpoint_policy(
+        self,
+        org_id: str,
+        endpoint: str,
+        policy_path: Path,
+        bank_path: Path | None,
+        report_path: Path | None = None,
+    ) -> JsonValue:
+        """Install a fitted routing policy on a hosted endpoint.
+
+        Multipart rather than a signed-URL handoff like `push_model_bundle`: a policy
+        bank is a few hundred KB to a few MB, not a whole model bundle, and the server
+        has to validate the bank AGAINST the policy before storing it. Splitting them
+        across two requests would mean accepting bytes it cannot yet check.
+
+        Args:
+            org_id: Organization that owns the endpoint.
+            endpoint: Endpoint slug (the `model` a customer's client sends).
+            policy_path: Fitted `policy.json`.
+            bank_path: The `.npz` evidence sidecar; required for a knn policy, and
+                ``None`` for static or rank, which have none.
+            report_path: Optional improvement-report JSON to publish alongside.
+
+        Returns:
+            The endpoint summary the platform returns.
+        """
+        files: dict[str, tuple[str, bytes, str]] = {}
+        if bank_path is not None:
+            files["bank"] = (bank_path.name, bank_path.read_bytes(), "application/octet-stream")
+        data = {"policy": policy_path.read_text(encoding="utf-8")}
+        if report_path is not None:
+            data["report"] = report_path.read_text(encoding="utf-8")
+        response = self._client.put(
+            f"/api/orgs/{org_id}/endpoints/{endpoint}/policy",
+            data=data,
+            files=files or None,
+        )
+        self._raise_for_error(response)
+        return _decode_json(response)
+
     def download_model_bundle(self, org_id: str, name: str, dest: Path) -> str:
         """Stream a model's bundle from storage to ``dest``, verifying its digest.
 

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -599,12 +599,23 @@ class PlatformClient:
         Returns:
             The endpoint summary the platform returns.
         """
-        files: dict[str, tuple[str, bytes, str]] = {}
-        if bank_path is not None:
-            files["bank"] = (bank_path.name, bank_path.read_bytes(), "application/octet-stream")
-        data = {"policy": policy_path.read_text(encoding="utf-8")}
-        if report_path is not None:
-            data["report"] = report_path.read_text(encoding="utf-8")
+        # File reads are this client's own failure surface: a path that vanished or
+        # became unreadable between the CLI's validation and this call must surface
+        # as the PlatformError every caller already renders, not a raw traceback.
+        try:
+            files: dict[str, tuple[str, bytes, str]] = {}
+            if bank_path is not None:
+                files["bank"] = (
+                    bank_path.name,
+                    bank_path.read_bytes(),
+                    "application/octet-stream",
+                )
+            data = {"policy": policy_path.read_text(encoding="utf-8")}
+            if report_path is not None:
+                data["report"] = report_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            msg = f"could not read the policy artifacts to install: {error}"
+            raise PlatformError(msg) from error
         response = self._client.put(
             f"/api/orgs/{org_id}/endpoints/{endpoint}/policy",
             data=data,


### PR DESCRIPTION
## What

The last link in the routing chain. `fit` writes a policy only the local machine can see, and a hosted endpoint serves `static` until something replaces it, so the measured router never reached production traffic.

Platform gained the writer in [platform #397](https://github.com/experientiallabs/platform/pull/397). This is the command that drives it:

```
wmo optimize route push models/support/policy.json --endpoint support-prod
```

Extends the documented chain by one step: `student -> pool -> sweep -> OutcomeMatrix -> fit -> policy.json -> tune / report -> **push**`.

## Sends both artifacts

A knn policy is two artifacts. The command resolves the `.npz` bank from the policy's own `knn_bank_path`, not from the policy's filename, so a renamed sidecar is a local error rather than a server refusal. A missing bank fails locally, before uploading a policy the server would have to reject. `static` and `rank` send no bank and are not asked for one.

Multipart rather than the signed-URL handoff `push_model_bundle` uses: a bank is hundreds of KB to a few MB, not a whole bundle, and the server validates the bank *against* the policy before storing it, so splitting the two across requests would mean accepting bytes it cannot yet check.

## Two mistakes worth recording

Both were caught by running the suite, not by reading the diff.

The `platform_cmds` import started at module scope and turned **15 unrelated tests in this module red**, because that module builds its own command surface at import time. It is imported inside the command now.

Then my test helper was named `_flat`, which this module **already defines** and uses in a dozen assertions, so appending mine silently redefined it with different semantics and broke the same 15 tests a second time. The module also already had `_says` for the exact problem I was re-solving: rich wraps a long message inside its error box, so a phrase a reader sees on one line is split by newlines *and* box borders in captured output. Duplicate removed, house helpers used.

## Gates

ruff, ruff format, ty clean. `route_app_test` 102 passed (98 pre-existing plus 4 new). Removing the sidecar guard turns its test red. Full `wmo/` suite running.

## Not in this PR

The platform running the optimizer itself and installing the result. That needs a sweep against the org's scenarios, which is real model spend per run, so it is a separate piece of work.