### PR TITLE
Metering integrity: pipeline spend legs, cache-token splits, and abandoned-stream estimates

### DIFF
--- a/packages/environment-capture/terminal-bench/convert_to_wmo.py
+++ b/packages/environment-capture/terminal-bench/convert_to_wmo.py
@@ -108,9 +108,7 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
     result = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
     if result.get("exception_info") is not None:
         return []
-    trajectory = json.loads(
-        (trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8")
-    )
+    trajectory = json.loads((trial_dir / "agent" / "trajectory.json").read_text(encoding="utf-8"))
     steps = trajectory.get("steps") or []
     rewards = (result.get("verifier_result") or {}).get("rewards") or {}
     model = ((result.get("agent_info") or {}).get("model_info") or {}).get("name", "")
@@ -144,30 +142,34 @@ def spans_for_trial(trial_dir: Path, *, benchmark: str) -> list[dict[str, Any]]:
                 action_attrs.append(_attr("gen_ai.prompt", task_text))
             if ordinal == 0:
                 action_attrs.append(_attr("wmo.trace.metadata", json.dumps(metadata)))
-            spans.append({
-                "traceId": trace_id,
-                "spanId": f"{trace_id[:12]}{ordinal:04x}a",
-                "parentSpanId": "",
-                "name": "chat terminal",
-                "startTimeUnixNano": ordinal * 10,
-                "endTimeUnixNano": ordinal * 10 + 1,
-                "status": {"code": "STATUS_CODE_OK"},
-                "attributes": action_attrs,
-            })
-            spans.append({
-                "traceId": trace_id,
-                "spanId": f"{trace_id[:12]}{ordinal:04x}b",
-                "parentSpanId": "",
-                "name": "execute_tool terminal",
-                "startTimeUnixNano": ordinal * 10 + 2,
-                "endTimeUnixNano": ordinal * 10 + 3,
-                "status": {"code": "STATUS_CODE_OK"},
-                "attributes": [
-                    _attr("gen_ai.operation.name", "execute_tool"),
-                    _attr("gen_ai.tool.name", name),
-                    _attr("gen_ai.tool.message", content),
-                ],
-            })
+            spans.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{trace_id[:12]}{ordinal:04x}a",
+                    "parentSpanId": "",
+                    "name": "chat terminal",
+                    "startTimeUnixNano": ordinal * 10,
+                    "endTimeUnixNano": ordinal * 10 + 1,
+                    "status": {"code": "STATUS_CODE_OK"},
+                    "attributes": action_attrs,
+                }
+            )
+            spans.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{trace_id[:12]}{ordinal:04x}b",
+                    "parentSpanId": "",
+                    "name": "execute_tool terminal",
+                    "startTimeUnixNano": ordinal * 10 + 2,
+                    "endTimeUnixNano": ordinal * 10 + 3,
+                    "status": {"code": "STATUS_CODE_OK"},
+                    "attributes": [
+                        _attr("gen_ai.operation.name", "execute_tool"),
+                        _attr("gen_ai.tool.name", name),
+                        _attr("gen_ai.tool.message", content),
+                    ],
+                }
+            )
             ordinal += 1
     return spans
 

--- a/packages/llm-waterfall/llm_waterfall/adapters/anthropic.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/anthropic.py
@@ -80,9 +80,15 @@ class AnthropicAdapter:
                 temperature=temperature,
             )
         text = "".join(block.text for block in response.content if block.type == "text")
+        # Anthropic's input_tokens EXCLUDES the cache legs; normalize so
+        # input_tokens is the full input and the legs are subsets of it.
+        cache_read = int(getattr(response.usage, "cache_read_input_tokens", 0) or 0)
+        cache_write = int(getattr(response.usage, "cache_creation_input_tokens", 0) or 0)
         usage = TokenUsage(
-            input_tokens=response.usage.input_tokens,
+            input_tokens=response.usage.input_tokens + cache_read + cache_write,
             output_tokens=response.usage.output_tokens,
+            cached_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
         )
         return text, usage
 

--- a/packages/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
@@ -77,4 +77,3 @@ def test_embed_raises_unsupported(fake_anthropic: list[_FakeAnthropic]) -> None:
     adapter = AnthropicAdapter(Backend("anthropic", "claude-opus-4-8"))
     with pytest.raises(EmbeddingsUnsupported):
         adapter.embed(["x"])
-

--- a/packages/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
@@ -26,7 +26,13 @@ class _FakeAnthropic:
         self.calls.append(kwargs)
         return SimpleNamespace(
             content=[SimpleNamespace(type="text", text="claude says hi")],
-            usage=SimpleNamespace(input_tokens=12, output_tokens=6),
+            usage=SimpleNamespace(
+                input_tokens=12,
+                output_tokens=6,
+                # Anthropic reports the cache legs beside (not inside) input_tokens.
+                cache_read_input_tokens=900,
+                cache_creation_input_tokens=50,
+            ),
         )
 
 
@@ -61,10 +67,14 @@ def test_request_shape_and_client_config(fake_anthropic: list[_FakeAnthropic]) -
     assert call["max_tokens"] == 64
     assert "temperature" not in call
     assert text == "claude says hi"
-    assert usage.input_tokens == 12 and usage.output_tokens == 6
+    assert usage.input_tokens == 12 + 900 + 50
+    assert usage.output_tokens == 6
+    assert usage.cached_input_tokens == 900
+    assert usage.cache_write_input_tokens == 50
 
 
 def test_embed_raises_unsupported(fake_anthropic: list[_FakeAnthropic]) -> None:
     adapter = AnthropicAdapter(Backend("anthropic", "claude-opus-4-8"))
     with pytest.raises(EmbeddingsUnsupported):
         adapter.embed(["x"])
+

--- a/packages/llm-waterfall/llm_waterfall/adapters/bedrock.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/bedrock.py
@@ -139,9 +139,16 @@ class BedrockAdapter:
         raw = self._get_client().invoke_model(modelId=self.backend.model, body=json.dumps(body))
         data = cast("_MessagesResponse", json.loads(raw["body"].read()))
         text = "".join(block["text"] for block in data["content"] if block["type"] == "text")
+        # Anthropic-on-Bedrock usage mirrors the direct API: input_tokens
+        # excludes the cache legs, so add them back and keep the split.
+        raw_usage = cast("dict[str, object]", data["usage"])
+        cache_read = int(cast("int", raw_usage.get("cache_read_input_tokens", 0)) or 0)
+        cache_write = int(cast("int", raw_usage.get("cache_creation_input_tokens", 0)) or 0)
         usage = TokenUsage(
-            input_tokens=data["usage"]["input_tokens"],
+            input_tokens=data["usage"]["input_tokens"] + cache_read + cache_write,
             output_tokens=data["usage"]["output_tokens"],
+            cached_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
         )
         return text, usage
 

--- a/packages/llm-waterfall/llm_waterfall/adapters/bedrock.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/bedrock.py
@@ -65,9 +65,12 @@ class _ConverseOutput(TypedDict):
     message: _ConverseMessage
 
 
-class _ConverseUsage(TypedDict):
+class _ConverseUsage(TypedDict, total=False):
     inputTokens: int
     outputTokens: int
+    # Converse reports inputTokens EXCLUDING these two legs.
+    cacheReadInputTokens: int
+    cacheWriteInputTokens: int
 
 
 class _ConverseResponse(TypedDict):
@@ -183,13 +186,23 @@ class BedrockAdapter:
         message: dict[str, object] = {"role": "assistant", "content": text}
         if tool_calls:
             message["tool_calls"] = tool_calls
+        # Converse reports inputTokens EXCLUDING the cache legs; add them back
+        # and keep the split so cached traffic prices at its cache tiers
+        # (mirrors the wmo-side converse mapping and the invoke path above).
+        converse_usage = response["usage"]
+        cache_read = converse_usage.get("cacheReadInputTokens", 0)
+        cache_write = converse_usage.get("cacheWriteInputTokens", 0)
         return ChatResponse.model_validate(
             {
                 "model": self.backend.model,
                 "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
                 "usage": {
-                    "prompt_tokens": response["usage"]["inputTokens"],
-                    "completion_tokens": response["usage"]["outputTokens"],
+                    "prompt_tokens": converse_usage.get("inputTokens", 0)
+                    + cache_read
+                    + cache_write,
+                    "completion_tokens": converse_usage.get("outputTokens", 0),
+                    "prompt_tokens_details": {"cached_tokens": cache_read},
+                    "cache_creation_input_tokens": cache_write,
                 },
             }
         )

--- a/packages/llm-waterfall/llm_waterfall/adapters/openai.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/openai.py
@@ -87,8 +87,15 @@ class OpenAIAdapter:
             raise ValueError(f"{model} returned no choices")
         text = response.choices[0].message.content or ""
         usage = response.usage
+        details = getattr(usage, "prompt_tokens_details", None) if usage is not None else None
+        cached = int(getattr(details, "cached_tokens", 0) or 0)
         token_usage = (
-            TokenUsage(input_tokens=usage.prompt_tokens, output_tokens=usage.completion_tokens)
+            TokenUsage(
+                input_tokens=usage.prompt_tokens,
+                output_tokens=usage.completion_tokens,
+                # OpenAI's prompt_tokens already includes the cached subset.
+                cached_input_tokens=min(cached, max(usage.prompt_tokens, 0)),
+            )
             if usage is not None
             else TokenUsage()
         )

--- a/packages/llm-waterfall/llm_waterfall/pricing.py
+++ b/packages/llm-waterfall/llm_waterfall/pricing.py
@@ -23,35 +23,119 @@ _BEDROCK_SUFFIX = re.compile(r"(-\d{8})?(-v\d+)?(:\d+)?$")
 
 
 class ModelPrice(BaseModel):
-    """USD per 1,000,000 tokens, split by input/output."""
+    """USD per 1,000,000 tokens, split by input/output plus optional cache tiers.
+
+    A missing cache tier bills that leg at the full input rate — an unknown
+    discount must never read as free, and never silently under-charge.
+    """
 
     input_per_mtok: float
     output_per_mtok: float
+    cached_input_per_mtok: float | None = None
+    cache_write_per_mtok: float | None = None
 
 
-# Keyed by normalized model id (see `_normalize`). USD per 1M tokens.
+# Keyed by normalized model id (see `_normalize`). USD per 1M tokens. Cache
+# tiers are the vendors' published multipliers on the row's input rate
+# (Anthropic 5m-TTL: reads 0.1x, writes 1.25x; OpenAI: cached input 0.1x, no
+# write charge); rows without tiers bill cache legs at the full input rate.
 #
 # Completion prices verified 2026-07-01 against the live vendor pricing pages (Claude via
 # platform.claude.com models overview; OpenAI GPT-5.x Standard tier, short context). Embedding
 # prices are long-stable list prices; treat as approximate.
 _PRICES: dict[str, ModelPrice] = {
     # --- Anthropic / Bedrock (Claude) ---
-    "claude-fable-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
-    "claude-mythos-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
-    "claude-opus-4-8": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-7": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-6": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-1": ModelPrice(input_per_mtok=15.0, output_per_mtok=75.0),
-    "claude-sonnet-5": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
-    "claude-sonnet-4-6": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
-    "claude-haiku-4-5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
+    "claude-fable-5": ModelPrice(
+        input_per_mtok=10.0,
+        output_per_mtok=50.0,
+        cached_input_per_mtok=1.0,
+        cache_write_per_mtok=12.5,
+    ),
+    "claude-mythos-5": ModelPrice(
+        input_per_mtok=10.0,
+        output_per_mtok=50.0,
+        cached_input_per_mtok=1.0,
+        cache_write_per_mtok=12.5,
+    ),
+    "claude-opus-4-8": ModelPrice(
+        input_per_mtok=5.0,
+        output_per_mtok=25.0,
+        cached_input_per_mtok=0.5,
+        cache_write_per_mtok=6.25,
+    ),
+    "claude-opus-4-7": ModelPrice(
+        input_per_mtok=5.0,
+        output_per_mtok=25.0,
+        cached_input_per_mtok=0.5,
+        cache_write_per_mtok=6.25,
+    ),
+    "claude-opus-4-6": ModelPrice(
+        input_per_mtok=5.0,
+        output_per_mtok=25.0,
+        cached_input_per_mtok=0.5,
+        cache_write_per_mtok=6.25,
+    ),
+    "claude-opus-4-5": ModelPrice(
+        input_per_mtok=5.0,
+        output_per_mtok=25.0,
+        cached_input_per_mtok=0.5,
+        cache_write_per_mtok=6.25,
+    ),
+    "claude-opus-4-1": ModelPrice(
+        input_per_mtok=15.0,
+        output_per_mtok=75.0,
+        cached_input_per_mtok=1.5,
+        cache_write_per_mtok=18.75,
+    ),
+    "claude-sonnet-5": ModelPrice(
+        input_per_mtok=3.0,
+        output_per_mtok=15.0,
+        cached_input_per_mtok=0.3,
+        cache_write_per_mtok=3.75,
+    ),
+    "claude-sonnet-4-6": ModelPrice(
+        input_per_mtok=3.0,
+        output_per_mtok=15.0,
+        cached_input_per_mtok=0.3,
+        cache_write_per_mtok=3.75,
+    ),
+    "claude-haiku-4-5": ModelPrice(
+        input_per_mtok=1.0,
+        output_per_mtok=5.0,
+        cached_input_per_mtok=0.1,
+        cache_write_per_mtok=1.25,
+    ),
     # --- OpenAI / Azure OpenAI (GPT-5.x; Azure deployments reuse the base model's price) ---
-    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=30.0),
-    "gpt-5.5-pro": ModelPrice(input_per_mtok=30.0, output_per_mtok=180.0),
-    "gpt-5.4": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0),
-    "gpt-5.4-mini": ModelPrice(input_per_mtok=0.75, output_per_mtok=4.5),
-    "gpt-5.4-nano": ModelPrice(input_per_mtok=0.2, output_per_mtok=1.25),
+    "gpt-5.5": ModelPrice(
+        input_per_mtok=5.0,
+        output_per_mtok=30.0,
+        cached_input_per_mtok=0.5,
+        cache_write_per_mtok=0.0,
+    ),
+    "gpt-5.5-pro": ModelPrice(
+        input_per_mtok=30.0,
+        output_per_mtok=180.0,
+        cached_input_per_mtok=3.0,
+        cache_write_per_mtok=0.0,
+    ),
+    "gpt-5.4": ModelPrice(
+        input_per_mtok=2.5,
+        output_per_mtok=15.0,
+        cached_input_per_mtok=0.25,
+        cache_write_per_mtok=0.0,
+    ),
+    "gpt-5.4-mini": ModelPrice(
+        input_per_mtok=0.75,
+        output_per_mtok=4.5,
+        cached_input_per_mtok=0.075,
+        cache_write_per_mtok=0.0,
+    ),
+    "gpt-5.4-nano": ModelPrice(
+        input_per_mtok=0.2,
+        output_per_mtok=1.25,
+        cached_input_per_mtok=0.02,
+        cache_write_per_mtok=0.0,
+    ),
     # Azure-hosted OSS deployments (qwen3-coder, agentworld, ...) are deliberately absent:
     # a $0 placeholder row would defeat the price_for()->None "cost unavailable" contract.
     # Supply their negotiated rates per Waterfall via the `prices` override.
@@ -105,6 +189,25 @@ def cost_usd(
     price = price_for(model, prices)
     if price is None:
         return 0.0
+    # The cache legs are subsets of input_tokens (TokenUsage contract); clamp
+    # so a malformed split can never bill more input than there was.
+    total_input = max(usage.input_tokens, 0)
+    read = min(max(usage.cached_input_tokens, 0), total_input)
+    write = min(max(usage.cache_write_input_tokens, 0), total_input - read)
+    uncached = total_input - read - write
+    read_rate = (
+        price.cached_input_per_mtok
+        if price.cached_input_per_mtok is not None
+        else price.input_per_mtok
+    )
+    write_rate = (
+        price.cache_write_per_mtok
+        if price.cache_write_per_mtok is not None
+        else price.input_per_mtok
+    )
     return (
-        usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+        uncached * price.input_per_mtok
+        + read * read_rate
+        + write * write_rate
+        + usage.output_tokens * price.output_per_mtok
     ) / 1_000_000

--- a/packages/llm-waterfall/llm_waterfall/pricing_test.py
+++ b/packages/llm-waterfall/llm_waterfall/pricing_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from llm_waterfall.pricing import ModelPrice, cost_usd, price_for
 from llm_waterfall.types import TokenUsage
 
@@ -58,3 +60,19 @@ def test_no_zero_price_placeholder_rows() -> None:
 
     assert price_for("qwen3-coder") is None
     assert all(p.input_per_mtok > 0 for p in _PRICES.values())
+
+
+def test_cost_prices_cache_legs_at_their_tiers() -> None:
+    """100 fresh + 900 cache-read tokens on fable-5: reads bill at 0.1x."""
+    usage = TokenUsage(input_tokens=1_000, output_tokens=0, cached_input_tokens=900)
+
+    # 100 * 10 + 900 * 1.0 per MTok = 0.0019
+    assert cost_usd("claude-fable-5", usage) == pytest.approx(0.0019)
+
+
+def test_unknown_cache_tier_bills_the_full_input_rate_never_free() -> None:
+    """A row without tiers charges cache legs at the input rate."""
+    prices = {"custom": ModelPrice(input_per_mtok=2.0, output_per_mtok=4.0)}
+    usage = TokenUsage(input_tokens=1_000, cached_input_tokens=600, cache_write_input_tokens=200)
+
+    assert cost_usd("custom", usage, prices) == pytest.approx(1_000 * 2.0 / 1_000_000)

--- a/packages/llm-waterfall/llm_waterfall/types.py
+++ b/packages/llm-waterfall/llm_waterfall/types.py
@@ -225,6 +225,10 @@ class ChatUsage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     prompt_tokens_details: ChatPromptTokensDetails | None = None
+    # Anthropic-style cache-write count (OpenAI has no wire shape for writes;
+    # Anthropic-family backends report it under this name). A SUBSET of
+    # prompt_tokens, like the cached read count.
+    cache_creation_input_tokens: int = 0
 
 
 class ChatChoice(BaseModel):
@@ -252,11 +256,15 @@ class ChatResponse(BaseModel):
             return TokenUsage()
         details = self.usage.prompt_tokens_details
         cached = details.cached_tokens if details is not None else 0
-        # OpenAI semantics: prompt_tokens already includes the cached subset.
+        total = max(self.usage.prompt_tokens, 0)
+        # OpenAI semantics: prompt_tokens already includes both cache subsets.
+        read = min(max(cached, 0), total)
+        write = min(max(self.usage.cache_creation_input_tokens, 0), total - read)
         return TokenUsage(
             input_tokens=self.usage.prompt_tokens,
             output_tokens=self.usage.completion_tokens,
-            cached_input_tokens=min(max(cached, 0), max(self.usage.prompt_tokens, 0)),
+            cached_input_tokens=read,
+            cache_write_input_tokens=write,
         )
 
     def wire_payload(self) -> JsonObject:

--- a/packages/llm-waterfall/llm_waterfall/types.py
+++ b/packages/llm-waterfall/llm_waterfall/types.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 
 Role = Literal["user", "assistant"]
 ChatMaxTokensField = Literal["max_completion_tokens", "max_tokens"]
@@ -210,11 +210,17 @@ class ChatRequest(BaseModel):
 
 
 class ChatPromptTokensDetails(BaseModel):
-    """OpenAI-compatible prompt-token breakdown (`prompt_tokens_details`)."""
+    """OpenAI-compatible prompt-token breakdown (`prompt_tokens_details`).
+
+    ``cached_tokens`` is Optional to match openai-python, whose model_dump
+    emits explicit nulls; a None (or an absent key) reads as "no cached
+    split", never as a validation failure — usage shape must not be able to
+    fail a request.
+    """
 
     model_config = ConfigDict(extra="allow")
 
-    cached_tokens: int = 0
+    cached_tokens: int | None = None
 
 
 class ChatUsage(BaseModel):
@@ -227,8 +233,18 @@ class ChatUsage(BaseModel):
     prompt_tokens_details: ChatPromptTokensDetails | None = None
     # Anthropic-style cache-write count (OpenAI has no wire shape for writes;
     # Anthropic-family backends report it under this name). A SUBSET of
-    # prompt_tokens, like the cached read count.
-    cache_creation_input_tokens: int = 0
+    # prompt_tokens, like the cached read count. Optional so an explicit null
+    # from an SDK dump parses, and so exclude_none keeps it OFF the wire for
+    # the (majority) responses that never had one.
+    cache_creation_input_tokens: int | None = None
+
+    @field_validator("prompt_tokens_details", mode="before")
+    @classmethod
+    def _tolerate_unreadable_details(cls, value: object) -> object:
+        """An unparseable details blob costs the response its cached split, not the request."""
+        if value is None or isinstance(value, dict | ChatPromptTokensDetails):
+            return value
+        return None
 
 
 class ChatChoice(BaseModel):
@@ -255,11 +271,11 @@ class ChatResponse(BaseModel):
         if self.usage is None:
             return TokenUsage()
         details = self.usage.prompt_tokens_details
-        cached = details.cached_tokens if details is not None else 0
+        cached = (details.cached_tokens if details is not None else None) or 0
         total = max(self.usage.prompt_tokens, 0)
         # OpenAI semantics: prompt_tokens already includes both cache subsets.
         read = min(max(cached, 0), total)
-        write = min(max(self.usage.cache_creation_input_tokens, 0), total - read)
+        write = min(max(self.usage.cache_creation_input_tokens or 0, 0), total - read)
         return TokenUsage(
             input_tokens=self.usage.prompt_tokens,
             output_tokens=self.usage.completion_tokens,

--- a/packages/llm-waterfall/llm_waterfall/types.py
+++ b/packages/llm-waterfall/llm_waterfall/types.py
@@ -82,10 +82,18 @@ class RetryPolicy:
 
 
 class TokenUsage(BaseModel):
-    """Raw token counts for one call (pricing converts to USD per 1M tokens)."""
+    """Raw token counts for one call (pricing converts to USD per 1M tokens).
+
+    The cache legs are SUBSETS of `input_tokens` (the total always counts every
+    input token): providers report them separately because reads bill at a
+    discount and writes at a premium, and dropping the split silently re-prices
+    cached traffic at the full input rate.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_write_input_tokens: int = 0
 
 
 AttemptOutcome = Literal["ok", "capacity_error", "client_error", "unsupported"]
@@ -201,6 +209,14 @@ class ChatRequest(BaseModel):
         return payload
 
 
+class ChatPromptTokensDetails(BaseModel):
+    """OpenAI-compatible prompt-token breakdown (`prompt_tokens_details`)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    cached_tokens: int = 0
+
+
 class ChatUsage(BaseModel):
     """OpenAI-compatible structured completion usage."""
 
@@ -208,6 +224,7 @@ class ChatUsage(BaseModel):
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    prompt_tokens_details: ChatPromptTokensDetails | None = None
 
 
 class ChatChoice(BaseModel):
@@ -233,9 +250,13 @@ class ChatResponse(BaseModel):
         """Project provider usage onto the waterfall's canonical counters."""
         if self.usage is None:
             return TokenUsage()
+        details = self.usage.prompt_tokens_details
+        cached = details.cached_tokens if details is not None else 0
+        # OpenAI semantics: prompt_tokens already includes the cached subset.
         return TokenUsage(
             input_tokens=self.usage.prompt_tokens,
             output_tokens=self.usage.completion_tokens,
+            cached_input_tokens=min(max(cached, 0), max(self.usage.prompt_tokens, 0)),
         )
 
     def wire_payload(self) -> JsonObject:

--- a/packages/llm-waterfall/llm_waterfall/types_test.py
+++ b/packages/llm-waterfall/llm_waterfall/types_test.py
@@ -152,3 +152,22 @@ def test_token_usage_projection_keeps_the_cached_subset() -> None:
         }
     )
     assert overclaimed.token_usage().cached_input_tokens == 100
+
+
+def test_token_usage_projection_keeps_the_cache_write_subset() -> None:
+    """Anthropic-style cache_creation_input_tokens prices at the write premium."""
+    response = ChatResponse.model_validate(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 10,
+                "prompt_tokens_details": {"cached_tokens": 900},
+                "cache_creation_input_tokens": 50,
+            },
+        }
+    )
+
+    usage = response.token_usage()
+    assert usage.cached_input_tokens == 900
+    assert usage.cache_write_input_tokens == 50

--- a/packages/llm-waterfall/llm_waterfall/types_test.py
+++ b/packages/llm-waterfall/llm_waterfall/types_test.py
@@ -171,3 +171,43 @@ def test_token_usage_projection_keeps_the_cache_write_subset() -> None:
     usage = response.token_usage()
     assert usage.cached_input_tokens == 900
     assert usage.cache_write_input_tokens == 50
+
+
+def test_null_usage_fields_from_sdk_dumps_never_fail_the_response() -> None:
+    """openai-python model_dump emits explicit nulls; they read as no split."""
+    response = ChatResponse.model_validate(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "prompt_tokens_details": {"audio_tokens": None, "cached_tokens": None},
+                "cache_creation_input_tokens": None,
+            },
+        }
+    )
+
+    usage = response.token_usage()
+    assert usage.input_tokens == 10
+    assert usage.cached_input_tokens == 0
+    assert usage.cache_write_input_tokens == 0
+    # exclude_none keeps the write key OFF the wire when there was no write.
+    wire_usage = response.wire_payload().get("usage")
+    assert isinstance(wire_usage, dict)
+    assert "cache_creation_input_tokens" not in wire_usage
+
+
+def test_an_unreadable_details_blob_costs_the_split_not_the_request() -> None:
+    """A provider emitting a nonsense prompt_tokens_details still parses."""
+    response = ChatResponse.model_validate(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "prompt_tokens_details": "cached",
+            },
+        }
+    )
+
+    assert response.token_usage().cached_input_tokens == 0

--- a/packages/llm-waterfall/llm_waterfall/types_test.py
+++ b/packages/llm-waterfall/llm_waterfall/types_test.py
@@ -121,3 +121,34 @@ def test_structured_response_preserves_tool_calls_and_usage() -> None:
     assert response.choices[0].message.tool_calls is not None
     assert response.choices[0].message.tool_calls[0].function.name == "bash"
     assert response.token_usage().input_tokens == 10
+
+
+def test_token_usage_projection_keeps_the_cached_subset() -> None:
+    """`prompt_tokens_details.cached_tokens` survives into TokenUsage, clamped to the total."""
+    response = ChatResponse.model_validate(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 10,
+                "prompt_tokens_details": {"cached_tokens": 900},
+            },
+        }
+    )
+
+    usage = response.token_usage()
+    assert usage.input_tokens == 1000
+    assert usage.cached_input_tokens == 900
+    assert usage.cache_write_input_tokens == 0
+
+    overclaimed = ChatResponse.model_validate(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "prompt_tokens_details": {"cached_tokens": 900},
+            },
+        }
+    )
+    assert overclaimed.token_usage().cached_input_tokens == 100

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -1263,7 +1263,12 @@ def _run_stages(
                 record = _stage_report(paths, model_dir=model_dir, baseline=baseline)
         manifest = manifest.with_record(record)
         manifest.save(paths.manifest)
-        emitter.stage_completed(record, lifetime_spend_usd=manifest.lifetime_spend_usd)
+        lifetime_candidate_usd, lifetime_wm_usd = manifest.lifetime_split
+        emitter.stage_completed(
+            record,
+            lifetime_candidate_usd=lifetime_candidate_usd,
+            lifetime_wm_usd=lifetime_wm_usd,
+        )
     return manifest
 
 

--- a/wmo/optimize/pipeline.py
+++ b/wmo/optimize/pipeline.py
@@ -159,6 +159,19 @@ class RunManifest(BaseModel):
     # predecessor and the stage rows alone cannot answer "what has this cost so far". A spend cap
     # asks exactly that, so the total accumulates here and is never rewritten downward.
     lifetime_spend_usd: float = 0.0
+    # The same lifetime, kept as the two legs the run telemetry reports separately
+    # (candidate side vs world-model side). Manifests written before these fields carry
+    # only the combined total; `lifetime_split` attributes that untracked remainder to
+    # the candidate leg, which is exactly what the emitter used to report.
+    lifetime_candidate_usd: float = 0.0
+    lifetime_wm_usd: float = 0.0
+
+    @property
+    def lifetime_split(self) -> tuple[float, float]:
+        """Lifetime spend as (candidate_usd, wm_usd), summing to `lifetime_spend_usd`."""
+        tracked = self.lifetime_candidate_usd + self.lifetime_wm_usd
+        remainder = max(0.0, self.lifetime_spend_usd - tracked)
+        return self.lifetime_candidate_usd + remainder, self.lifetime_wm_usd
 
     def record_for(self, stage: Stage) -> StageRecord | None:
         """The recorded run of `stage`, or None when it has never completed."""
@@ -177,6 +190,8 @@ class RunManifest(BaseModel):
             update={
                 "stages": sorted(kept, key=lambda item: STAGE_ORDER.index(item.stage)),
                 "lifetime_spend_usd": self.lifetime_spend_usd + record.total_spend_usd,
+                "lifetime_candidate_usd": self.lifetime_candidate_usd + record.spend_usd,
+                "lifetime_wm_usd": self.lifetime_wm_usd + record.world_model_spend_usd,
             }
         )
 

--- a/wmo/optimize/pipeline_test.py
+++ b/wmo/optimize/pipeline_test.py
@@ -349,3 +349,43 @@ def test_a_prior_that_was_all_compressor_supplies_no_ratio() -> None:
         1.0, _sweep_record(candidate=0.5, world_model=9.0, compressor=0.5)
     )
     assert projection.basis is None and projection.world_model_usd == 0.0
+
+
+def test_lifetime_split_attributes_presplit_remainder_to_the_candidate_leg() -> None:
+    """Manifests written before the split fields reported the combined total as
+    the candidate figure; the split keeps doing that for the untracked
+    remainder so a resumed run's platform row never jumps."""
+    legacy = RunManifest(world_model="tau-bench", lifetime_spend_usd=12.5)
+
+    assert legacy.lifetime_split == (12.5, 0.0)
+
+    tracked = RunManifest(
+        world_model="tau-bench",
+        lifetime_spend_usd=12.5,
+        lifetime_candidate_usd=9.25,
+        lifetime_wm_usd=3.25,
+    )
+    assert tracked.lifetime_split == (9.25, 3.25)
+
+
+def test_with_record_accumulates_both_lifetime_legs() -> None:
+    """Each stage's spend lands on its own lifetime leg, and re-swept stages
+    keep their replaced spend counted (money left the account either way)."""
+    record = StageRecord(
+        stage=Stage.SWEEP,
+        fingerprint={},
+        artifact_path="matrix.json",
+        artifact_identity="a",
+        completed_at="2026-07-29T00:00:00+00:00",
+        spend_usd=2.0,
+        compressor_spend_usd=0.5,
+        world_model_spend_usd=7.0,
+    )
+    manifest = RunManifest(world_model="tau-bench").with_record(record)
+    twice = manifest.with_record(record)
+
+    assert manifest.lifetime_candidate_usd == 2.0
+    assert manifest.lifetime_wm_usd == 7.0
+    assert manifest.lifetime_split == (2.0, 7.0)
+    assert twice.lifetime_split == (4.0, 14.0)
+    assert twice.lifetime_spend_usd == 18.0

--- a/wmo/providers/_bedrock_chat.py
+++ b/wmo/providers/_bedrock_chat.py
@@ -130,13 +130,26 @@ def converse_response(raw: object, model: str) -> ChatResponse:
         message["tool_calls"] = tool_calls
     usage = response.get("usage")
     usage_data = usage if isinstance(usage, dict) else {}
+    # Converse reports `inputTokens` EXCLUDING the cached prefix, so the two
+    # cache legs must be added back or every cached call under-reports its
+    # input by the whole prefix (the `complete` path in bedrock.py does the
+    # same normalization). The read leg rides the OpenAI-compatible
+    # `prompt_tokens_details.cached_tokens` shape the serving log already
+    # prices at the cache-read rate; the write leg has no OpenAI-compatible
+    # field, so it bills at the full input rate — slightly under the write
+    # premium, never silently free.
+    cache_read = int(usage_data.get("cacheReadInputTokens", 0) or 0)
+    cache_write = int(usage_data.get("cacheWriteInputTokens", 0) or 0)
     return ChatResponse.model_validate(
         {
             "model": model,
             "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
             "usage": {
-                "prompt_tokens": usage_data.get("inputTokens", 0),
+                "prompt_tokens": int(usage_data.get("inputTokens", 0) or 0)
+                + cache_read
+                + cache_write,
                 "completion_tokens": usage_data.get("outputTokens", 0),
+                "prompt_tokens_details": {"cached_tokens": cache_read},
             },
         }
     )

--- a/wmo/providers/_bedrock_chat.py
+++ b/wmo/providers/_bedrock_chat.py
@@ -134,10 +134,9 @@ def converse_response(raw: object, model: str) -> ChatResponse:
     # cache legs must be added back or every cached call under-reports its
     # input by the whole prefix (the `complete` path in bedrock.py does the
     # same normalization). The read leg rides the OpenAI-compatible
-    # `prompt_tokens_details.cached_tokens` shape the serving log already
-    # prices at the cache-read rate; the write leg has no OpenAI-compatible
-    # field, so it bills at the full input rate — slightly under the write
-    # premium, never silently free.
+    # `prompt_tokens_details.cached_tokens` shape; the write leg rides the
+    # Anthropic-style `cache_creation_input_tokens` field, so both price at
+    # their cache tiers.
     cache_read = _token_count(usage_data.get("cacheReadInputTokens"))
     cache_write = _token_count(usage_data.get("cacheWriteInputTokens"))
     return ChatResponse.model_validate(
@@ -150,6 +149,7 @@ def converse_response(raw: object, model: str) -> ChatResponse:
                 + cache_write,
                 "completion_tokens": usage_data.get("outputTokens", 0),
                 "prompt_tokens_details": {"cached_tokens": cache_read},
+                "cache_creation_input_tokens": cache_write,
             },
         }
     )

--- a/wmo/providers/_bedrock_chat.py
+++ b/wmo/providers/_bedrock_chat.py
@@ -147,7 +147,7 @@ def converse_response(raw: object, model: str) -> ChatResponse:
                 "prompt_tokens": _token_count(usage_data.get("inputTokens"))
                 + cache_read
                 + cache_write,
-                "completion_tokens": usage_data.get("outputTokens", 0),
+                "completion_tokens": _token_count(usage_data.get("outputTokens")),
                 "prompt_tokens_details": {"cached_tokens": cache_read},
                 "cache_creation_input_tokens": cache_write,
             },

--- a/wmo/providers/_bedrock_chat.py
+++ b/wmo/providers/_bedrock_chat.py
@@ -138,14 +138,14 @@ def converse_response(raw: object, model: str) -> ChatResponse:
     # prices at the cache-read rate; the write leg has no OpenAI-compatible
     # field, so it bills at the full input rate — slightly under the write
     # premium, never silently free.
-    cache_read = int(usage_data.get("cacheReadInputTokens", 0) or 0)
-    cache_write = int(usage_data.get("cacheWriteInputTokens", 0) or 0)
+    cache_read = _token_count(usage_data.get("cacheReadInputTokens"))
+    cache_write = _token_count(usage_data.get("cacheWriteInputTokens"))
     return ChatResponse.model_validate(
         {
             "model": model,
             "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
             "usage": {
-                "prompt_tokens": int(usage_data.get("inputTokens", 0) or 0)
+                "prompt_tokens": _token_count(usage_data.get("inputTokens"))
                 + cache_read
                 + cache_write,
                 "completion_tokens": usage_data.get("outputTokens", 0),
@@ -153,6 +153,11 @@ def converse_response(raw: object, model: str) -> ChatResponse:
             },
         }
     )
+
+
+def _token_count(value: object) -> int:
+    """A Converse usage counter, or 0 for an absent/malformed one."""
+    return value if isinstance(value, int) else 0
 
 
 def _chat_text(content: JsonValue) -> str:

--- a/wmo/providers/_bedrock_chat_test.py
+++ b/wmo/providers/_bedrock_chat_test.py
@@ -93,3 +93,34 @@ def test_converse_response_preserves_filtered_stops(stop_reason: str) -> None:
     )
 
     assert response.choices[0].finish_reason == "content_filter"
+
+
+def test_converse_response_normalizes_cached_prompt_tokens() -> None:
+    """Converse excludes the cache legs from inputTokens; the mapping adds them back.
+
+    Without the normalization a cached tool-calling call under-reports its input
+    by the entire cached prefix — under-billing, not just a lost discount. The
+    read leg rides `prompt_tokens_details.cached_tokens`, the shape the serving
+    log prices at the cache-read rate.
+    """
+    response = converse_response(
+        {
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 5,
+                "cacheReadInputTokens": 900,
+                "cacheWriteInputTokens": 50,
+            },
+        },
+        "model-id",
+    )
+
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 1050
+    assert response.usage.prompt_tokens_details is not None
+    assert response.usage.prompt_tokens_details.cached_tokens == 900
+    usage = response.token_usage()
+    assert usage.input_tokens == 1050
+    assert usage.cached_input_tokens == 900

--- a/wmo/providers/_bedrock_chat_test.py
+++ b/wmo/providers/_bedrock_chat_test.py
@@ -124,3 +124,4 @@ def test_converse_response_normalizes_cached_prompt_tokens() -> None:
     usage = response.token_usage()
     assert usage.input_tokens == 1050
     assert usage.cached_input_tokens == 900
+    assert usage.cache_write_input_tokens == 50

--- a/wmo/providers/waterfall.py
+++ b/wmo/providers/waterfall.py
@@ -166,6 +166,10 @@ class WaterfallProvider:
             usage=TokenUsage(
                 input_tokens=result.usage.input_tokens,
                 output_tokens=result.usage.output_tokens,
+                # The cache split rides through so cached traffic prices at the
+                # cache tiers instead of the full input rate.
+                cached_input_tokens=result.usage.cached_input_tokens,
+                cache_write_input_tokens=result.usage.cache_write_input_tokens,
             ),
             model=result.model_used,  # true attribution even when a fallback served
         )

--- a/wmo/runs/hooks.py
+++ b/wmo/runs/hooks.py
@@ -1027,11 +1027,14 @@ class PipelineEmitter(_Reporter):
         )
         self._flush()
 
-    def stage_completed(self, record: StageRecord, *, lifetime_spend_usd: float) -> None:
+    def stage_completed(
+        self, record: StageRecord, *, lifetime_candidate_usd: float, lifetime_wm_usd: float
+    ) -> None:
         """A stage finished, with the fingerprint and artifact identity it recorded.
 
         Takes the `StageRecord` the manifest just persisted, so the event and the manifest cannot
-        disagree about what the stage produced or what it cost.
+        disagree about what the stage produced or what it cost. The lifetime figures are the
+        manifest's `lifetime_split` legs.
         """
         self._stages_done += 1
         self._emit(
@@ -1054,13 +1057,23 @@ class PipelineEmitter(_Reporter):
                 },
             },
         )
-        self.heartbeat(stage=record.stage, lifetime_spend_usd=lifetime_spend_usd)
+        self.heartbeat(
+            stage=record.stage,
+            lifetime_candidate_usd=lifetime_candidate_usd,
+            lifetime_wm_usd=lifetime_wm_usd,
+        )
 
-    def heartbeat(self, *, stage: Stage | None, lifetime_spend_usd: float) -> None:
+    def heartbeat(
+        self, *, stage: Stage | None, lifetime_candidate_usd: float, lifetime_wm_usd: float
+    ) -> None:
         """Where the pipeline is and what it has spent, at a stage boundary.
 
-        The spend is the manifest's LIFETIME total, both sides together, which is the number the
-        run's own cap is checked against (`SpendLedger`).
+        The spend is the manifest's LIFETIME total — the number the run's own cap is checked
+        against (`SpendLedger`) — reported as its two legs. The platform's run row stores the
+        legs exactly as reported and totals them (`candidate_usd + wm_usd`), so folding both
+        sides into `candidate_usd` (as an earlier version did) inflated the candidate leg,
+        rendered the world-model leg as unreported, and made the panel's cells-vs-ledger
+        reconciliation fire on every pipeline run.
         """
         self._emit(
             RUN_LEVEL_BAND,
@@ -1072,7 +1085,10 @@ class PipelineEmitter(_Reporter):
                     "total": None,
                     "stage": stage.value if stage is not None else None,
                 },
-                "spend": {"candidate_usd": lifetime_spend_usd},
+                "spend": {
+                    "candidate_usd": lifetime_candidate_usd,
+                    "wm_usd": lifetime_wm_usd,
+                },
             },
         )
         self._flush()

--- a/wmo/runs/hooks_test.py
+++ b/wmo/runs/hooks_test.py
@@ -593,7 +593,8 @@ def test_pipeline_reports_stages_in_the_run_level_band() -> None:
             compressor_spend_usd=0.5,
             world_model_spend_usd=7.0,
         ),
-        lifetime_spend_usd=9.0,
+        lifetime_candidate_usd=2.0,
+        lifetime_wm_usd=7.0,
     )
     emitter.stage_skipped(Stage.FIT, reason="policy.json is current")
     emitter.finished(RunStatus.COMPLETED)
@@ -617,16 +618,21 @@ def test_pipeline_reports_stages_in_the_run_level_band() -> None:
 
 
 def test_pipeline_heartbeat_carries_lifetime_spend() -> None:
-    """The panel's spend for a staged run is the manifest's lifetime total, both sides."""
+    """The panel's spend for a staged run is the manifest's lifetime total, split by leg.
+
+    Both legs are reported separately: the platform totals `candidate_usd + wm_usd`, so a
+    combined figure under `candidate_usd` (the old behavior) inflated the candidate leg and
+    read the world-model leg as unreported.
+    """
     transport = FakeTransport()
     emitter = PipelineEmitter.create(world_model="tau-bench", factory=lambda: _sink(transport))
     emitter.start(world_model="tau-bench", config={})
 
-    emitter.heartbeat(stage=Stage.TUNE, lifetime_spend_usd=12.5)
+    emitter.heartbeat(stage=Stage.TUNE, lifetime_candidate_usd=9.25, lifetime_wm_usd=3.25)
 
     beat = transport.of_type("heartbeat")[0].payload
     assert obj(beat["progress"])["stage"] == "tune"
-    assert obj(beat["spend"])["candidate_usd"] == 12.5
+    assert obj(beat["spend"]) == {"candidate_usd": 9.25, "wm_usd": 3.25}
 
 
 def test_the_emitter_names_its_arm_so_a_caller_can_scope_ledger_lines() -> None:
@@ -780,7 +786,7 @@ def test_an_unreachable_probe_is_not_read_as_a_fresh_run() -> None:
     emitter = PipelineEmitter.create(world_model="tau-bench", factory=lambda: _sink(transport))
 
     emitter.start(world_model="tau-bench", config={})
-    emitter.heartbeat(stage=Stage.SWEEP, lifetime_spend_usd=1.0)
+    emitter.heartbeat(stage=Stage.SWEEP, lifetime_candidate_usd=1.0, lifetime_wm_usd=0.0)
 
     # The failed probe did not stand as "fresh run": it was retried, the mark was learned, and
     # numbering continued past it. Events numbered DURING the outage may still be discarded (they

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -73,7 +73,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from llm_waterfall.types import ChatChoice, ChatRequest, ChatResponse, ChatTool, ChatToolCall
 from llm_waterfall.types import ChatMessage as ProviderChatMessage
-from pydantic import BaseModel, Field, JsonValue, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, Field, JsonValue, field_validator, model_validator
 from starlette.background import BackgroundTask
 
 from wmo.optimize.compression import (
@@ -1118,31 +1118,21 @@ def _provider_request(request: ChatCompletionRequest, messages: list[ChatMessage
     return provider_request
 
 
-class _PromptTokensDetails(BaseModel):
-    """The cached-prompt split an OpenAI-shaped `usage` object carries beside its totals."""
-
-    cached_tokens: int = 0
-
-
 def _structured_usage(response: ChatResponse) -> TokenUsage:
     """Real token usage from a structured response, cached-prompt split included.
 
-    `ChatResponse.token_usage()` keeps only the two totals, but cache reads bill at a discount
-    and the request log prices each row with them (`PoolEntry.cost_usd`), so the split is read
-    off the provider's own `prompt_tokens_details`. A shape this build cannot parse costs the
-    row its cached split (priced at the full input rate, never silently free), not the request.
+    `ChatResponse.token_usage()` parses the provider's own `prompt_tokens_details` (cache
+    reads bill at a discount and the request log prices each row with the split via
+    `PoolEntry.cost_usd`); this projects it onto wmo's counters. A shape the parse cannot
+    read costs the row its cached split (priced at the full input rate, never silently
+    free), not the request.
     """
     counts = response.token_usage()
-    cached = 0
-    if response.usage is not None:
-        raw = (response.usage.model_extra or {}).get("prompt_tokens_details")
-        if isinstance(raw, dict):
-            with contextlib.suppress(ValidationError):
-                cached = _PromptTokensDetails.model_validate(raw).cached_tokens
     return TokenUsage(
         input_tokens=counts.input_tokens,
         output_tokens=counts.output_tokens,
-        cached_input_tokens=cached,
+        cached_input_tokens=counts.cached_input_tokens,
+        cache_write_input_tokens=counts.cache_write_input_tokens,
     )
 
 
@@ -1765,9 +1755,16 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
         # Shared with _finalize: a disconnecting client makes starlette CANCEL the stream
         # without ever closing the sync generator, so cleanup inside the generator (finally,
         # GeneratorExit) never runs on that path. The BackgroundTask below is the only hook
-        # that fires on both normal completion and disconnect.
+        # that fires on both normal completion and disconnect. The generator appends every
+        # delta it emitted to `streamed_parts` so the disconnect path can estimate the
+        # partial generation it never got a usage chunk for.
         stream_state = {"recorded": False}
-        partial_usage = TokenUsage()
+        streamed_parts: list[str] = []
+        # The probe chunk was already pulled off the upstream before the response body
+        # exists, so it is generated (and billed) even when the client disconnects before
+        # the generator ever runs; seed it so the estimate counts it exactly once.
+        if first is not None and first.delta:
+            streamed_parts.append(first.delta)
 
         def _events() -> Iterator[str]:
             yield _sse(
@@ -1775,8 +1772,8 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     completion_id, created, runtime.name, {"role": "assistant", "content": ""}
                 )
             )
-            parts: list[str] = []
-            usage = partial_usage
+            parts = streamed_parts
+            usage = TokenUsage()
             try:
                 chunk = first
                 while chunk is not None:
@@ -1784,7 +1781,8 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                         if chunk.usage is not None:
                             usage = chunk.usage
                     elif chunk.delta:
-                        parts.append(chunk.delta)
+                        if chunk is not first:  # the probe chunk is pre-seeded above
+                            parts.append(chunk.delta)
                         yield _sse(
                             _chunk_payload(
                                 completion_id,
@@ -1830,8 +1828,13 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             """Runs after the response ends, HOWEVER it ends (starlette BackgroundTask).
 
             An abandoned stream still consumed upstream tokens: leaving it unrecorded would
-            be silent usage loss (D-METERING). Also closes the upstream iterator, which the
-            cancelled threadpool iteration otherwise leaks.
+            be silent usage loss (D-METERING). The provider's usage arrives only in the
+            terminal chunk the client never waited for, so the row carries a chars/4
+            estimate of what actually went out and came back — the same documented,
+            conservative proxy the cache-credit estimate uses — and names itself as one.
+            An estimate that errs low still beats the zero-token row an earlier version
+            wrote here, which billed the whole partial generation at $0. Also closes the
+            upstream iterator, which the cancelled threadpool iteration otherwise leaks.
             """
             close = getattr(upstream, "close", None)
             if callable(close):
@@ -1839,11 +1842,22 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     close()
             if not stream_state["recorded"]:
                 stream_state["recorded"] = True
+                sent_chars = sum(
+                    len(message.content) for message in provider_messages if message.content
+                )
+                streamed_chars = sum(len(part) for part in streamed_parts)
                 _record(
-                    partial_usage,
+                    TokenUsage(
+                        input_tokens=sent_chars // 4,
+                        output_tokens=streamed_chars // 4,
+                    ),
                     ttfb_ms=ttfb_ms,
                     status="error",
-                    error_message="client disconnected mid-stream",
+                    error_message=(
+                        "client disconnected mid-stream; usage is a chars/4 estimate of the "
+                        "partial generation (the provider reports exact counts only in the "
+                        "terminal chunk, which never arrived)"
+                    ),
                 )
 
         return StreamingResponse(

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -517,6 +517,11 @@ class RequestLogRecord(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
     cached_tokens: int = 0  # cache-read prompt tokens (subset of input_tokens)
+    # Cache-WRITE prompt tokens (subset of input_tokens, disjoint from
+    # cached_tokens). Priced at the write premium by the entry's cost model;
+    # persisted so a post-hoc reconstruction (savings counterfactuals)
+    # decomposes the same tokens the price did.
+    cache_write_tokens: int = 0
     cost_usd: float = 0.0  # effective cost: cached tokens billed at the cache-read rate
     router_cost_usd: float = 0.0  # the routing decision's own inference cost, passed through
     # D-COMPRESS fields: stored and OPAQUE like the routing fields above (log only, never in
@@ -1221,6 +1226,14 @@ def _usage_dict(usage: TokenUsage) -> dict[str, object]:
         "total_tokens": usage.input_tokens + usage.output_tokens,
         # OpenAI's cached-prompt reporting shape; 0 when the upstream provider reported none.
         "prompt_tokens_details": {"cached_tokens": usage.cached_input_tokens},
+        # Anthropic's cache-write shape, only when one happened: a chained wmo
+        # endpoint keeps pricing writes at the premium, while plain responses
+        # stay free of nonstandard keys.
+        **(
+            {"cache_creation_input_tokens": usage.cache_write_input_tokens}
+            if usage.cache_write_input_tokens > 0
+            else {}
+        ),
     }
 
 
@@ -1550,6 +1563,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     input_tokens=usage.input_tokens,
                     output_tokens=usage.output_tokens,
                     cached_tokens=usage.cached_input_tokens,
+                    cache_write_tokens=usage.cache_write_input_tokens,
                     cost_usd=entry.cost_usd(usage),
                     tokens_in_raw=compression.tokens_in_raw if compression else 0,
                     tokens_in_compressed=compression.tokens_in_compressed if compression else 0,
@@ -1758,7 +1772,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
         # that fires on both normal completion and disconnect. The generator appends every
         # delta it emitted to `streamed_parts` so the disconnect path can estimate the
         # partial generation it never got a usage chunk for.
-        stream_state = {"recorded": False}
+        stream_state: dict[str, object] = {"recorded": False, "usage": None}
         streamed_parts: list[str] = []
         # The probe chunk was already pulled off the upstream before the response body
         # exists, so it is generated (and billed) even when the client disconnects before
@@ -1776,12 +1790,17 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             usage = TokenUsage()
             try:
                 chunk = first
+                is_probe = True  # the probe chunk's delta is pre-seeded above
                 while chunk is not None:
                     if chunk.done:
                         if chunk.usage is not None:
                             usage = chunk.usage
+                            # Stash for _finalize: a client that closes on
+                            # [DONE] without reading EOF must still get its
+                            # EXACT usage recorded, never an estimate.
+                            stream_state["usage"] = usage
                     elif chunk.delta:
-                        if chunk is not first:  # the probe chunk is pre-seeded above
+                        if not is_probe:
                             parts.append(chunk.delta)
                         yield _sse(
                             _chunk_payload(
@@ -1791,6 +1810,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                                 {"content": chunk.delta},
                             )
                         )
+                    is_probe = False
                     chunk = next(upstream, None)
             except Exception as exc:  # noqa: BLE001 - response already started; log and end
                 stream_state["recorded"] = True
@@ -1798,6 +1818,20 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 logger.error("stream from %s failed mid-response: %s", entry.name, exc)
                 yield "data: [DONE]\n\n"
                 return
+            # Record BEFORE the closing yields: openai-python clients stop
+            # reading at [DONE], so starlette can cancel this generator
+            # anywhere in the tail — metering must already be done by then.
+            stream_state["recorded"] = True
+            _record(usage, ttfb_ms=ttfb_ms)
+            try:
+                runtime.remember(
+                    request.messages,
+                    ChatMessage(role="assistant", content="".join(parts)),
+                    decision.model,
+                    compressed=provider_messages if compression else None,
+                )
+            except Exception:  # noqa: BLE001 - affinity is best-effort; the response is not
+                logger.exception("conversation affinity update failed for %s", runtime.name)
             yield _sse(
                 _chunk_payload(completion_id, created, runtime.name, {}, finish_reason="stop")
             )
@@ -1815,14 +1849,6 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     }
                 )
             yield "data: [DONE]\n\n"
-            runtime.remember(
-                request.messages,
-                ChatMessage(role="assistant", content="".join(parts)),
-                decision.model,
-                compressed=provider_messages if compression else None,
-            )
-            stream_state["recorded"] = True
-            _record(usage, ttfb_ms=ttfb_ms)
 
         def _finalize() -> None:
             """Runs after the response ends, HOWEVER it ends (starlette BackgroundTask).
@@ -1842,6 +1868,17 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     close()
             if not stream_state["recorded"]:
                 stream_state["recorded"] = True
+                exact = stream_state["usage"]
+                if isinstance(exact, TokenUsage):
+                    # The terminal chunk DID arrive before the disconnect; the
+                    # estimate is for when it did not.
+                    _record(
+                        exact,
+                        ttfb_ms=ttfb_ms,
+                        status="error",
+                        error_message="client disconnected before [DONE]; exact usage recorded",
+                    )
+                    return
                 sent_chars = sum(
                     len(message.content) for message in provider_messages if message.content
                 )

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -360,7 +360,7 @@ def test_abandoned_stream_still_records_metering(tmp_path: Path) -> None:
             max_tokens: int = 8192,
         ) -> Iterator[StreamChunk]:
             for _ in range(1_000_000):  # far more than any client buffer; never finishes
-                yield StreamChunk(delta="x")
+                yield StreamChunk(delta="xxxxxxxx")
 
     log_path = tmp_path / "requests.jsonl"
     runtime = EndpointRuntime(
@@ -376,7 +376,12 @@ def test_abandoned_stream_still_records_metering(tmp_path: Path) -> None:
     # http.disconnect, which is what starlette listens for to cancel a StreamingResponse
     # and close its body iterator (GeneratorExit in the generator).
     body = json.dumps(
-        {"model": "tau-bench", "stream": True, "messages": [{"role": "user", "content": "hi"}]}
+        {
+            "model": "tau-bench",
+            "stream": True,
+            # Long enough that the disconnect path's chars/4 input estimate is nonzero.
+            "messages": [{"role": "user", "content": "summarize this for me " * 8}],
+        }
     ).encode()
     state = {"request_sent": False}
 
@@ -409,6 +414,12 @@ def test_abandoned_stream_still_records_metering(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0]["status"] == "error"
     assert "disconnected" in rows[0]["error_message"]
+    # The provider's exact usage rides only the terminal chunk the client never took, so
+    # the row carries a chars/4 estimate of the partial generation and says so. Zero here
+    # was the old behavior: the whole abandoned generation billed as free.
+    assert rows[0]["input_tokens"] > 0
+    assert rows[0]["output_tokens"] > 0
+    assert "estimate" in rows[0]["error_message"]
 
 
 def test_create_app_with_injected_policies_and_no_artifact_dirs(tmp_path: Path) -> None:

--- a/wmo/serving/savings.py
+++ b/wmo/serving/savings.py
@@ -227,6 +227,7 @@ def compute_savings(
                     input_tokens=record.input_tokens,
                     output_tokens=record.output_tokens,
                     cached_input_tokens=record.cached_tokens,
+                    cache_write_input_tokens=record.cache_write_tokens,
                 )
             )
             for record in served

--- a/wmo/tracking/metered.py
+++ b/wmo/tracking/metered.py
@@ -95,8 +95,10 @@ class MeteredProvider:
     ) -> Iterator[StreamChunk]:
         """Forward a native stream, recording usage from the terminal chunk.
 
-        A stream abandoned before its terminal chunk records nothing even though the provider
-        billed the partial generation; serving owns closing streams it starts.
+        A stream abandoned before its terminal chunk still consumed provider tokens; the
+        provider reports exact counts only in the chunk the consumer never took, so the
+        abandonment path records a chars/4 estimate of what was sent and what streamed
+        (the documented, conservative proxy) instead of the zero an earlier version wrote.
         """
         if not isinstance(self._provider, StreamingProvider):
             raise TypeError(
@@ -104,13 +106,32 @@ class MeteredProvider:
                 "stream() is only available for native backends"
             )
         phase = self._classify(system) if self._classify is not None else self._base_phase
-        for chunk in self._provider.stream(
-            system, messages, temperature=temperature, max_tokens=max_tokens
-        ):
-            if chunk.done and chunk.usage is not None:
-                model = chunk.model or self._provider.config.model
-                self._tracker.record(phase, model, chunk.usage)
-            yield chunk
+        recorded = False
+        streamed_chars = 0
+        try:
+            for chunk in self._provider.stream(
+                system, messages, temperature=temperature, max_tokens=max_tokens
+            ):
+                if chunk.delta:
+                    streamed_chars += len(chunk.delta)
+                if chunk.done and chunk.usage is not None:
+                    model = chunk.model or self._provider.config.model
+                    self._tracker.record(phase, model, chunk.usage)
+                    recorded = True
+                yield chunk
+        finally:
+            # Runs on GeneratorExit (consumer closed or dropped the iterator) and on
+            # upstream exceptions alike; a normally finished stream was already recorded.
+            if not recorded:
+                sent_chars = len(system) + sum(len(m.content) for m in messages if m.content)
+                self._tracker.record(
+                    phase,
+                    self._provider.config.model,
+                    TokenUsage(
+                        input_tokens=sent_chars // 4,
+                        output_tokens=streamed_chars // 4,
+                    ),
+                )
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         # Embeddings carry no token usage from our providers; record a zero-usage event for the

--- a/wmo/tracking/metered.py
+++ b/wmo/tracking/metered.py
@@ -95,10 +95,13 @@ class MeteredProvider:
     ) -> Iterator[StreamChunk]:
         """Forward a native stream, recording usage from the terminal chunk.
 
-        A stream abandoned before its terminal chunk still consumed provider tokens; the
-        provider reports exact counts only in the chunk the consumer never took, so the
-        abandonment path records a chars/4 estimate of what was sent and what streamed
-        (the documented, conservative proxy) instead of the zero an earlier version wrote.
+        A stream ABANDONED by its consumer (generator closed / dropped) still consumed
+        provider tokens; the provider reports exact counts only in the chunk the consumer
+        never took, so that one path records a chars/4 estimate of what was sent and what
+        streamed (the documented, conservative proxy) instead of the zero an earlier
+        version wrote. Upstream failures and terminal chunks without usage still record
+        nothing: a throttled attempt that generated nothing must not book a full-prompt
+        phantom into the tracker (whose total feeds spend caps).
         """
         if not isinstance(self._provider, StreamingProvider):
             raise TypeError(
@@ -119,9 +122,9 @@ class MeteredProvider:
                     self._tracker.record(phase, model, chunk.usage)
                     recorded = True
                 yield chunk
-        finally:
-            # Runs on GeneratorExit (consumer closed or dropped the iterator) and on
-            # upstream exceptions alike; a normally finished stream was already recorded.
+        except GeneratorExit:
+            # The consumer closed (or dropped) the iterator mid-stream: the partial
+            # generation was billed, so estimate it. This is the ONLY estimating path.
             if not recorded:
                 sent_chars = len(system) + sum(len(m.content) for m in messages if m.content)
                 self._tracker.record(
@@ -132,6 +135,7 @@ class MeteredProvider:
                         output_tokens=streamed_chars // 4,
                     ),
                 )
+            raise
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         # Embeddings carry no token usage from our providers; record a zero-usage event for the

--- a/wmo/tracking/metered_test.py
+++ b/wmo/tracking/metered_test.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from wmo.providers.base import Completion, Message, ProviderConfig, ProviderKind, TokenUsage
+from collections.abc import Generator, Iterator
+
+from wmo.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    StreamChunk,
+    TokenUsage,
+)
 from wmo.tracking.metered import MeteredProvider, classify_build_call
 from wmo.tracking.tracker import Phase, RunTracker
 
@@ -128,3 +137,57 @@ def test_cost_attributed_to_serving_model_not_primary() -> None:
     (event,) = tracker._events
     assert event.model == "claude-haiku-4-5"
     assert event.cost_usd == (100 * 1.0 + 20 * 5.0) / 1_000_000
+
+
+class FakeStreamingProvider(FakeProvider):
+    """Streams three deltas, then a terminal chunk carrying exact usage."""
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Iterator[StreamChunk]:
+        yield StreamChunk(delta="aaaa")
+        yield StreamChunk(delta="bbbb")
+        yield StreamChunk(delta="cccc")
+        yield StreamChunk(done=True, usage=TokenUsage(input_tokens=100, output_tokens=3))
+
+
+def test_stream_records_the_terminal_usage_once() -> None:
+    """A stream consumed to the end records exactly the provider's own counts."""
+    tracker = RunTracker(run_id="r", kind="test")
+    provider = MeteredProvider(FakeStreamingProvider(), tracker, base_phase=Phase.SERVE)
+
+    chunks = list(provider.stream("sys", [Message(role="user", content="hi")]))
+
+    assert chunks[-1].done
+    assert len(tracker.events) == 1
+    assert tracker.events[0].usage.input_tokens == 100
+    assert tracker.events[0].usage.output_tokens == 3
+
+
+def test_abandoned_stream_records_a_chars_over_four_estimate() -> None:
+    """Closing the stream before its terminal chunk records the documented estimate.
+
+    The provider reports exact counts only in the chunk the consumer never took; the old
+    behavior recorded nothing, billing the whole partial generation as free.
+    """
+    tracker = RunTracker(run_id="r", kind="test")
+    provider = MeteredProvider(FakeStreamingProvider(), tracker, base_phase=Phase.SERVE)
+
+    stream = provider.stream("sysprompt", [Message(role="user", content="x" * 39)])
+    assert next(stream).delta == "aaaa"
+    assert next(stream).delta == "bbbb"
+    # The metered wrapper is a generator; closing it is how an abandoning
+    # consumer (or GC) ends it, which is the path under test.
+    assert isinstance(stream, Generator)
+    stream.close()
+
+    assert len(tracker.events) == 1
+    event = tracker.events[0]
+    # input: (9 system chars + 39 message chars) // 4; output: 8 streamed chars // 4.
+    assert event.usage.input_tokens == 12
+    assert event.usage.output_tokens == 2

--- a/wmo/tracking/metered_test.py
+++ b/wmo/tracking/metered_test.py
@@ -191,3 +191,66 @@ def test_abandoned_stream_records_a_chars_over_four_estimate() -> None:
     # input: (9 system chars + 39 message chars) // 4; output: 8 streamed chars // 4.
     assert event.usage.input_tokens == 12
     assert event.usage.output_tokens == 2
+
+
+class FailingStreamProvider(FakeProvider):
+    """Streams one delta then raises, like a throttled upstream."""
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Iterator[StreamChunk]:
+        yield StreamChunk(delta="partial")
+        msg = "ThrottlingException"
+        raise RuntimeError(msg)
+
+
+def test_upstream_stream_failure_records_nothing() -> None:
+    """An upstream failure must not book a full-prompt phantom estimate.
+
+    The tracker's total feeds spend caps; a throttled retry loop estimating
+    the whole prompt each attempt would trip a cap on money never spent.
+    Only consumer abandonment (GeneratorExit) estimates.
+    """
+    tracker = RunTracker(run_id="r", kind="test")
+    provider = MeteredProvider(FailingStreamProvider(), tracker, base_phase=Phase.SERVE)
+
+    stream = provider.stream("s" * 400_000, [Message(role="user", content="hi")])
+    assert next(stream).delta == "partial"
+    try:
+        next(stream)
+        raise AssertionError("expected the upstream failure to propagate")
+    except RuntimeError:
+        pass
+
+    assert tracker.events == []
+
+
+class UsagelessStreamProvider(FakeProvider):
+    """Finishes normally but its terminal chunk carries no usage."""
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Iterator[StreamChunk]:
+        yield StreamChunk(delta="hello")
+        yield StreamChunk(done=True)
+
+
+def test_fully_consumed_stream_without_usage_records_nothing() -> None:
+    """Normal exhaustion without a usage chunk stays unrecorded, not estimated."""
+    tracker = RunTracker(run_id="r", kind="test")
+    provider = MeteredProvider(UsagelessStreamProvider(), tracker, base_phase=Phase.SERVE)
+
+    chunks = list(provider.stream("sys", [Message(role="user", content="hi")]))
+
+    assert chunks[-1].done
+    assert tracker.events == []


### PR DESCRIPTION
## What

Three accounting bugs from the 2026-07-29 billing audit, each of which corrupts a number the platform now bills or displays from.

### 1. Pipeline heartbeat mislabeled its spend legs
`PipelineEmitter.heartbeat` sent the manifest's combined lifetime total under `candidate_usd` and never reported `wm_usd` — inflating the candidate leg, rendering the WM leg "not reported", tripping the false "partial spend" warning, and firing the panel's cells-vs-ledger alarm on every pipeline run. The manifest now accumulates `lifetime_candidate_usd`/`lifetime_wm_usd` and the heartbeat reports both legs (matching `GridEmitter`). Pre-split manifests attribute their untracked remainder to the candidate leg — exactly what the old emitter reported, so resumed runs don't jump (tested).

### 2. Cache-token splits were dropped on three paths
- **Bedrock Converse (wmo `_bedrock_chat.py` AND `llm_waterfall`'s own adapter)**: Converse reports `inputTokens` *excluding* the cache legs and both mappers discarded them — cached tool-calling traffic under-reported input by the whole cached prefix. Both now normalize like the `complete` path always did; reads ride `prompt_tokens_details.cached_tokens`, writes ride Anthropic-style `cache_creation_input_tokens`, and **both legs price at their cache tiers** end to end (the write premium included).
- **Failover chain**: `llm_waterfall.TokenUsage/ChatUsage` gain the cache split, adapters parse it (with each provider's real semantics: Anthropic/Bedrock exclude the legs from input, OpenAI includes the cached subset), the wmo provider passes it through, and **the package's own `cost_usd` learned the cache tiers** — normalizing input without that would have made its attempt costs 4–5x on cached traffic (caught in review, reproduced, fixed with vendor multipliers + never-free fallback).
- The serving log persists the write leg (`RequestLogRecord.cache_write_tokens`), emits it on the wire only when nonzero, and the savings counterfactual decomposes tokens identically to the price.

### 3. Abandoned streams recorded zero tokens
Both stream paths claimed D-METERING's no-silent-loss rule while writing 0-token rows. Now: serving records the **exact** usage *before* the `[DONE]` tail (openai clients stop reading there, so the tail is cancellable), `_finalize` prefers stashed exact usage and only estimates (chars/4, labeled as such in `error_message`) when the terminal chunk truly never arrived, and `MeteredProvider.stream` estimates **only on consumer abandonment** (`GeneratorExit`) — an upstream throttle or a usage-less terminal chunk records nothing, so failed attempts can't book full-prompt phantoms into the spend-cap tracker (caught in review, reproduced, tested).

## Review rounds
Greptile (2 P1s) + adversarial review (3 HIGHs, proven by executed probes) all addressed: null-tolerant typed usage fields (openai-python dumps explicit nulls — a local OpenAI-compatible backend would have 502'd every request), abandonment-only estimates, cache-aware package pricing, exact-over-estimate finalizer, positional probe-chunk guard, hardened Converse output counter.

## Disclosures
- **Convention change**: `RequestLogRecord.input_tokens` for Bedrock Converse serving traffic becomes cache-inclusive at this deploy. Pre-deploy rows weren't a different convention — they were under-counted (the bug); a savings window straddling the deploy blends the two. Not versioned: the old rows can't be retroactively fixed either way.
- **Rollback hazard**: `RunManifest` is `extra="forbid"`, so a manifest written by this build is unreadable by older builds — `load_manifest` resets loudly (never corrupts) but a reset re-plans stages. Relevant for mixed-checkout worktrees sharing `.wmo` artifacts.
- Prior pipeline runs' inflated `candidate_usd` rows on the platform are not rewritten; only new events carry the split.
- `router_cost_usd` still has no producer — deferred to the hosted-kNN lane (the embed interface has no usage channel).

## Proof
4704 passed, 19 skipped; ruff + ty clean. Two deselected tests are live-Bedrock calls failing identically on clean main ("Bedrock is unable to process your request").