### PR TITLE
Review-round fixes: the findings the skipped merge gate would have caught

### DIFF
--- a/docs/cookbook/routerbench.md
+++ b/docs/cookbook/routerbench.md
@@ -17,15 +17,21 @@ because nothing else is in the way: one matrix in, one policy out, one report.
 | 4 | `wmo optimize route report matrix.json policy.json --baseline <anchor>` | `report.json`, held out |
 
 The provenance rules from the [tau-bench walk](tau-bench.md#how-to-read-the-numbers-in-this-walk)
-apply unchanged; the one difference here is that a RouterBench-style matrix holds REAL
-completions at REAL prices, so nothing below is world-model simulated.
+apply with two differences: a RouterBench-style matrix holds REAL completions at REAL
+prices, so nothing below is world-model simulated; and because every row is a single-shot
+completion, the report's cost-per-request IS its cost metric here - the cache-adjusted
+effective-cost-per-completed-task machinery applies to served endpoints and multi-step
+episodes, not to this matrix.
 
 ## Step 1: the matrix
 
-The fitter consumes the same `OutcomeMatrix` JSON the sweep writes: a `pool` (each model
-with its prices) and `outcomes` rows, one per (scenario, model, episode), each carrying the
-task text, the reward, `cost_usd`, and `call_seconds`. A RouterBench-style dump maps onto it
-directly - one row per (prompt, model) with the recorded correctness, cost, and latency.
+The fitter consumes the same `OutcomeMatrix` JSON the sweep writes: a `pool` array (each
+entry at least `name`, `kind`, `model`, plus its prices) and `outcomes` rows, one per
+(scenario, model, episode), each carrying at least `scenario_id`, `task` (the prompt text),
+`model`, `episode`, `reward`, `cost_usd`, and `call_seconds` (a list of per-call wall
+seconds). A RouterBench-style dump maps onto it directly - one row per (prompt, model) with
+the recorded correctness, cost, and latency. The published
+`experiential-labs/wmo-routerbench-ours9` matrix is a complete worked example of the shape.
 
 ## Step 2: fit
 
@@ -37,9 +43,10 @@ uv run wmo optimize route fit matrix.json --kind knn --fallback gpt-5.5 \
 The policy is a guarded nearest-neighbor lookup: the query embeds (the embedder
 auto-resolves; `--embedder hashing` is the offline variant), its neighbors among the FIT
 scenarios vote with their measured per-model rewards, and a non-fallback pick must beat the
-fallback on paired per-neighbor evidence or the fallback serves. `--fallback` pins the model
-the router is never allowed to be worse than; omitted, it defaults to the best single model
-on the fit split. The fit reserves 30% of scenarios for reporting (a deterministic hash
+fallback on paired per-neighbor evidence or the fallback serves. `--fallback` pins the model every request uses unless the paired
+neighbor evidence clears the guard for a substitute - a statistical test on fit-set
+neighbors, not a hard per-request quality bound; omitted, it defaults to the best single
+model on the fit split. The fit reserves 30% of scenarios for reporting (a deterministic hash
 split), and the fit-set accuracy it prints is labeled in-sample for exactly that reason.
 
 ## Step 3 and 4: dial, then report

--- a/docs/cookbook/terminal-tasks.md
+++ b/docs/cookbook/terminal-tasks.md
@@ -50,7 +50,7 @@ fable-5. Provenance label on every number: `measured, wm_simulated`.
 | Every detent, 0 through 1 | sonnet-5 100% | -0.4 pt (paired CI touches zero: within noise) | $0.011 vs $0.035 (-69.4%, CI -77.3..-60.6) | -50.6% |
 
 This workload's lesson is the constant policy. The evidence finds one model (sonnet-5) at
-quality parity with the anchor at roughly a quarter of the effective cost and half the
+quality parity with the anchor at less than a third of the effective cost and half the
 latency, and every cheaper candidate fails enough tasks that its cost per COMPLETED task is
 higher, not lower. So the dial saturates immediately: max savings and balanced are the same
 policy, and the router holds it at every detent. Best single model on the final matrix

--- a/wmo/optimize/teacher.py
+++ b/wmo/optimize/teacher.py
@@ -324,9 +324,13 @@ def _resolve_student(
 ) -> str:
     """The model distillation would train: the named one, else the cheapest measured one.
 
-    A price tie is broken toward the BETTER model (then the name). That is the conservative
-    direction: the better of two equally cheap students makes the gap harder to prove, so a tie
-    can never be resolved into a training run that a different tie-break would have refused.
+    A price tie is broken toward the BETTER model (then the name), and "better" is judged
+    over the scenarios ALL tied candidates share, so an easy private subset cannot flatter one
+    of them (the same paired-first rule every gain in this module follows). When the tied
+    candidates share nothing, the name breaks the tie: deterministic, and honest about there
+    being no evidence to prefer either. The conservative direction stands: the better of two
+    equally cheap students makes the gap harder to prove, so a tie can never be resolved into
+    a training run that a different tie-break would have refused.
     """
     if student is not None:
         if student not in means:
@@ -347,7 +351,12 @@ def _resolve_student(
         return sorted(measured)[0]
     cheapest = min(priced)
     tied = [name for name in measured if prices[name] == cheapest]
-    return sorted(tied, key=lambda name: (-fmean(means[name].values()), name))[0]
+    if len(tied) == 1:
+        return tied[0]
+    shared = set.intersection(*(set(means[name]) for name in tied))
+    if not shared:
+        return sorted(tied)[0]
+    return sorted(tied, key=lambda name: (-fmean(means[name][sid] for sid in shared), name))[0]
 
 
 def _gain_row(

--- a/wmo/optimize/teacher_test.py
+++ b/wmo/optimize/teacher_test.py
@@ -395,3 +395,38 @@ def test_the_distill_reason_names_the_gap_the_teacher_and_the_price() -> None:
         "model can prove the gap exists, but you have to be allowed to train on what the teacher "
         "writes."
     )
+
+
+def test_price_tie_break_judges_candidates_over_their_shared_scenarios_only() -> None:
+    """An easy private subset must not crown the weaker of two equally cheap students.
+
+    `flattered` is scored on the shared band at 0.4 plus a private band of gimmes at 1.0, so
+    its unpaired mean (0.7) beats `honest`'s (0.6) - but on the scenarios BOTH were scored on,
+    `honest` is plainly better. The tie-break must read the shared band and pick `honest`;
+    the old unpaired mean picked `flattered` (the review finding this test pins).
+    """
+    shared = {f"s{i:02d}": None for i in range(8)}
+    # flattered: 0.45 on the 8 shared scenarios (below the 0.5 completion bar) plus 8 private
+    # gimmes at 1.0 -> unpaired mean 0.725, 8 completions over 16 cheap rows = $0.02/task.
+    flattered_rewards: dict[str, float | None] = {sid: 0.45 for sid in shared}
+    flattered_rewards |= {f"easy{i}": 1.0 for i in range(8)}
+    # honest: 0.6 on the same 8 shared scenarios -> unpaired mean 0.6 (LOWER than flattered's),
+    # 8 completions over 8 rows at $0.02 = the same $0.02/task, so the two students tie on the
+    # measured ladder and only the tie-break separates them.
+    honest_rewards: dict[str, float | None] = {sid: 0.6 for sid in shared}
+    teacher_rewards = dict.fromkeys(list(shared) + [f"easy{i}" for i in range(8)], 0.95)
+
+    matrix = OutcomeMatrix(
+        pool=[
+            _entry("flattered", per_mtok=1.0),
+            _entry("honest", per_mtok=1.0),
+            _entry("teacher", per_mtok=9.0),
+        ],
+        outcomes=(
+            _rows("flattered", flattered_rewards, cost=0.01)
+            + _rows("honest", honest_rewards, cost=0.02)
+            + _rows("teacher", teacher_rewards, cost=0.05)
+        ),
+    )
+    verdict = select_teacher(matrix)
+    assert verdict.student == "honest"

--- a/wmo/reproduce/embedding.py
+++ b/wmo/reproduce/embedding.py
@@ -32,6 +32,14 @@ class CachedTaskEmbedder:
             if outcome.scenario_id not in tasks:
                 tasks[outcome.scenario_id] = outcome.task
                 order.append(outcome.scenario_id)
+        texts = list(tasks.values())
+        if len(set(texts)) != len(texts):
+            duplicates = len(texts) - len(set(texts))
+            raise ValueError(
+                f"{duplicates} scenario(s) share task text with another scenario; a text-keyed "
+                "vector cache cannot tell them apart, so this matrix needs an id-keyed cache "
+                "format before it can be reproduced from recorded vectors"
+            )
         vectors = np.load(cache_path)
         if vectors.ndim != 2 or vectors.shape[0] != len(order):
             raise ValueError(

--- a/wmo/reproduce/manifests/routerbench.toml
+++ b/wmo/reproduce/manifests/routerbench.toml
@@ -13,6 +13,7 @@ notes = [
 
 [data]
 hf_repo = "experiential-labs/wmo-routerbench-ours9"
+revision = "a216fff0ed11b80e35faf7107601bc41a382c226"
 repo_type = "dataset"
 files = ["matrix.json", "task_embeddings.npy"]
 

--- a/wmo/reproduce/manifests/tau-bench.toml
+++ b/wmo/reproduce/manifests/tau-bench.toml
@@ -7,12 +7,14 @@ kind = "commands"
 notes = [
   "Live-provider replay: world-model build plus a 440-cell sweep against real providers. Nondeterministic by nature; the tolerances state how close counts as reproduced.",
   "The measured run served five candidates through private Azure deployments; this pool rides public routes for the same models, and public prices drift.",
+  "The world model builds on the anthropic provider here (the measured build used Bedrock; same model family, sibling route) so the whole replay runs on the pool's own documented keys.",
   "Quality/cost are world-model simulated with the judge recorded on the artifacts; see docs/cookbook/tau-bench.md for provenance rules and caveats.",
   "Estimated spend ~$110 at current prices (build + sweep + judge); the command refuses without --yes.",
 ]
 
 [data]
 hf_repo = "experiential-labs/wmh-tau-bench-traces"
+revision = "5f1c44a2e0e80dec023665a3e8b10806be0ec0d2"
 repo_type = "dataset"
 files = ["traces.otel.jsonl"]
 
@@ -21,7 +23,7 @@ pool_file = "tau-bench.pool.toml"
 estimated_spend_usd = 110.0
 report_file = "report.json"
 steps = [
-  ["build", "--file", "{data}/traces.otel.jsonl", "--name", "tau-bench-repro", "--yes"],
+  ["build", "--file", "{data}/traces.otel.jsonl", "--name", "tau-bench-repro", "--provider", "anthropic", "--yes"],
   ["optimize", "route", "sweep", "tau-bench-repro", "--pool", "{out}/pool.toml", "--scenarios", "20", "--episodes", "2", "--concurrency", "6", "--out", "{out}/matrix.json", "--yes"],
   ["optimize", "route", "fit", "{out}/matrix.json", "--kind", "knn", "--out", "{out}/policy.json"],
   ["optimize", "route", "report", "{out}/matrix.json", "{out}/policy.json", "--baseline", "fable-5", "--endpoint", "tau-bench-repro", "--out", "{out}/report.json"],

--- a/wmo/reproduce/runner.py
+++ b/wmo/reproduce/runner.py
@@ -81,6 +81,34 @@ def run_reproduction(
         ValueError: the downloaded data does not match the manifest's expectations.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
+    # ONE run per output directory, enforced rather than assumed: every artifact this run
+    # writes (policy, bank, dial snapshot, reports, verdict) lives at a fixed name in
+    # `out_dir`, so a second concurrent run would interleave fit state with this one's.
+    lock = out_dir / ".reproduce.lock"
+    try:
+        lock_fd = lock.open("x")
+    except FileExistsError as exc:
+        raise RuntimeError(
+            f"another reproduction is already running in {out_dir} (found {lock.name}); "
+            "give each run its own --out directory, or remove the stale lock if that run "
+            "is dead"
+        ) from exc
+    try:
+        return _run_locked(
+            manifest, out_dir=out_dir, data_dir=data_dir, approve_spend=approve_spend
+        )
+    finally:
+        lock_fd.close()
+        lock.unlink(missing_ok=True)
+
+
+def _run_locked(
+    manifest: Manifest,
+    *,
+    out_dir: Path,
+    data_dir: Path | None,
+    approve_spend: bool,
+) -> ReproduceResult:
     snapshot = data_dir if data_dir is not None else _download(manifest, out_dir)
 
     if manifest.kind == "matrix":

--- a/wmo/reproduce/runner.py
+++ b/wmo/reproduce/runner.py
@@ -154,6 +154,11 @@ def _run_matrix(manifest: Manifest, snapshot: Path, out_dir: Path) -> dict[str, 
         fallback=protocol.fallback,
         built=built,
     )
+    # A rerun into the same out_dir leaves the PREVIOUS run's dial snapshot beside the fresh
+    # fit, and `tune_policy_dial` rightly refuses a snapshot from a different fit. This run
+    # just wrote the fit, so any existing snapshot is stale by construction: drop it.
+    stale_snapshot = policy_path.with_name(f"{policy_path.stem}.base{policy_path.suffix}")
+    stale_snapshot.unlink(missing_ok=True)
     # The REAL dial, through the same function `wmo optimize route tune` uses: it rewrites
     # the guard/floor/penalty knobs on disk, not just the descriptive field (review finding on
     # the first cut of this runner: a bare field update reported the balanced policy under a

--- a/wmo/reproduce/runner.py
+++ b/wmo/reproduce/runner.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
-from wmo.optimize.knn import fit_knn_artifact
+from wmo.optimize.knn import fit_knn_artifact, tune_policy_dial
 from wmo.optimize.outcomes import OutcomeMatrix, split_router_scenarios
 from wmo.optimize.policy import EmbedderSpec, RoutingPolicy
 from wmo.optimize.report import build_report
@@ -154,8 +154,12 @@ def _run_matrix(manifest: Manifest, snapshot: Path, out_dir: Path) -> dict[str, 
         fallback=protocol.fallback,
         built=built,
     )
+    # The REAL dial, through the same function `wmo optimize route tune` uses: it rewrites
+    # the guard/floor/penalty knobs on disk, not just the descriptive field (review finding on
+    # the first cut of this runner: a bare field update reported the balanced policy under a
+    # different dial's label).
+    tune_policy_dial(policy_path, protocol.cost_quality)
     policy = RoutingPolicy.load(policy_path)
-    policy = policy.model_copy(update={"cost_quality": protocol.cost_quality})
 
     reports: dict[str, Path] = {}
     for baseline in protocol.baselines:

--- a/wmo/reproduce/runner_test.py
+++ b/wmo/reproduce/runner_test.py
@@ -118,6 +118,33 @@ def test_matrix_reproduction_is_deterministic_and_bit_exact(tmp_path: Path) -> N
     assert verdict["benchmark"] == "fixture"
 
 
+def test_rerun_into_the_same_out_dir_survives_a_changed_fit(tmp_path: Path) -> None:
+    """A rerun must not abort on the previous run's dial snapshot (stale by construction)."""
+    headline = _measure(tmp_path)
+    manifest = _manifest(
+        [
+            {
+                "label": "routed vs pricey",
+                "baseline": "pricey",
+                "accuracy": headline["accuracy"],
+                "cost_per_run_usd": headline["cost_per_run_usd"],
+            }
+        ]
+    )
+    out = tmp_path / "run"
+    assert run_reproduction(manifest, out_dir=out, data_dir=tmp_path / "data").reproduced
+    # Change the matrix bytes (a new episode on one scenario), so the refit is a DIFFERENT
+    # fit and the first run's snapshot no longer describes it.
+    snapshot = tmp_path / "data"
+    matrix = json.loads((snapshot / "matrix.json").read_text(encoding="utf-8"))
+    extra = dict(matrix["outcomes"][0])
+    extra["episode"] = 1
+    matrix["outcomes"].append(extra)
+    (snapshot / "matrix.json").write_text(json.dumps(matrix), encoding="utf-8")
+    result = run_reproduction(manifest, out_dir=out, data_dir=snapshot)
+    assert result.rows  # completed and compared; no snapshot abort
+
+
 def test_divergence_is_reported_not_absorbed(tmp_path: Path) -> None:
     headline = _measure(tmp_path)
     manifest = _manifest(

--- a/wmo/reproduce/runner_test.py
+++ b/wmo/reproduce/runner_test.py
@@ -179,3 +179,17 @@ def test_cached_embedder_refuses_unseen_text_and_wrong_shape(tmp_path: Path) -> 
     np.save(snapshot / "short.npy", short)
     with pytest.raises(ValueError, match="different matrix"):
         CachedTaskEmbedder(matrix, snapshot / "short.npy")
+
+
+def test_cached_embedder_refuses_duplicate_task_texts(tmp_path: Path) -> None:
+    """Two scenarios with identical task text cannot share a text-keyed vector row silently."""
+    snapshot = tmp_path / "data"
+    snapshot.mkdir()
+    matrix = _matrix_dict(n_scenarios=4)
+    for outcome in matrix["outcomes"]:
+        if outcome["scenario_id"] == "s1":
+            outcome["task"] = "task text 0"  # collides with s0's text
+    (snapshot / "matrix.json").write_text(json.dumps(matrix), encoding="utf-8")
+    np.save(snapshot / "vectors.npy", np.zeros((4, 8)))
+    with pytest.raises(ValueError, match="share task text"):
+        CachedTaskEmbedder(OutcomeMatrix.load(snapshot / "matrix.json"), snapshot / "vectors.npy")

--- a/wmo/reproduce/runner_test.py
+++ b/wmo/reproduce/runner_test.py
@@ -208,6 +208,28 @@ def test_cached_embedder_refuses_unseen_text_and_wrong_shape(tmp_path: Path) -> 
         CachedTaskEmbedder(matrix, snapshot / "short.npy")
 
 
+def test_a_second_concurrent_run_into_the_same_out_dir_is_refused(tmp_path: Path) -> None:
+    """The lock makes the shared-out-dir race loud instead of interleaving fit state."""
+    headline = _measure(tmp_path)
+    manifest = _manifest(
+        [
+            {
+                "label": "routed vs pricey",
+                "baseline": "pricey",
+                "accuracy": headline["accuracy"],
+                "cost_per_run_usd": headline["cost_per_run_usd"],
+            }
+        ]
+    )
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / ".reproduce.lock").touch()  # a live (or dead) sibling run
+    with pytest.raises(RuntimeError, match="already running"):
+        run_reproduction(manifest, out_dir=out, data_dir=tmp_path / "data")
+    (out / ".reproduce.lock").unlink()
+    assert run_reproduction(manifest, out_dir=out, data_dir=tmp_path / "data").reproduced
+
+
 def test_cached_embedder_refuses_duplicate_task_texts(tmp_path: Path) -> None:
     """Two scenarios with identical task text cannot share a text-keyed vector row silently."""
     snapshot = tmp_path / "data"


### PR DESCRIPTION
Retroactive /ready-for-merge round for #329/#330/#339/#340/#375/#379, which were merged without the gate (process miss, owned in the thread replies).

Fixes (all from Greptile review comments, triaged):
- manifests: HF `revision` pinned on both datasets (bit-exact contract); tau build gets `--provider anthropic` so a fresh user's documented keys suffice (P1s on #379)
- runner: `tune_policy_dial` applies the real dial knobs; descriptive-field update removed (P2 on #379)
- embedding: duplicate task texts now refuse the text-keyed cache loudly (P2 on #379)
- teacher: price-tie student selection is paired over the tied candidates' SHARED scenarios; name-only when nothing is shared (P1 on #329)
- cookbooks: fallback guard semantics stated honestly, OutcomeMatrix required fields named, terminal cost ratio corrected to a third, RouterBench cost-metric scope clarified (P2s on #375)

Not code-fixed, answered in their threads: #339 legacy-rank refusal (principled fail-closed), #330 persistence/cancellation tradeoffs (rationale + follow-up filed if wanted).

Verified: routerbench reproduction still REPRODUCED (bit-exact) after the dial change; full suite 4708 green; ruff/ty clean.

NOT merging this - /ready-for-merge runs on it next, then it is handed to Silen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)