### PR TITLE
wmo push carries endpoint artifacts and the pipeline run with the bundle

### DIFF
--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -408,13 +408,29 @@ def _push_endpoint_artifacts(
             "(the report is the endpoint's customer-facing evidence)"
         )
         return
-    policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    report = json.loads(report_path.read_text(encoding="utf-8"))
-    if client.get_endpoint(org_id, remote_name) is None:
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise typer.BadParameter(
+            f"the model directory's policy.json/report.json is not valid JSON ({error}); "
+            "refit or regenerate the artifact before pushing"
+        ) from error
+    existing = client.get_endpoint(org_id, remote_name)
+    if existing is None:
         client.create_endpoint(
             org_id, remote_name, world_model_id=world_model_id, model=serve_model
         )
         _console.print(f"{_CHECK} Created endpoint [bold]{remote_name}[/bold]")
+    elif existing.get("world_model_id") != world_model_id:
+        # The platform sets the simulation link at create time and exposes no
+        # update surface for it; installing artifacts below is still correct
+        # (the policy is self-contained), but the link must not silently lie.
+        _console.print(
+            f"[yellow]endpoint {remote_name} is linked to a different simulation "
+            f"(or none); the link is set when an endpoint is created and was left "
+            "untouched[/yellow]"
+        )
     if isinstance(policy, dict) and policy.get("kind") == "knn":
         bank_path = Path(f"{policy_path}.bank.npz")
         client.install_endpoint_policy(
@@ -446,11 +462,17 @@ def _push_pipeline(client: PlatformClient, org_id: str, remote_name: str, model_
         return
     external_id = pipeline_external_id(remote_name)
     events = optimize_events(manifest, model=remote_name, external_id=external_id)
+    recorded = RunsReader(client, org_id).event_count(external_id)
     try:
-        ensure_backfillable(RunsReader(client, org_id).event_count(external_id))
+        ensure_backfillable(recorded)
     except BackfillRefused:
+        # `recorded` cannot distinguish a completed earlier push from one that
+        # died between batches, so the skip names the recovery command instead
+        # of calling the run complete.
         _console.print(
-            f"pipeline run [bold]{external_id}[/bold] is already recorded; skipping the replay"
+            f"pipeline run [bold]{external_id}[/bold] already has {recorded} recorded "
+            f"event(s); skipping the replay. If an earlier push was interrupted, "
+            f"`wmo runs backfill {model_dir} --name {external_id} --force` completes it."
         )
         return
     sink = RunsSink(client, org_id=org_id, emitter_id=default_emitter_id())

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -8,6 +8,7 @@ exists locally (or remotely, for pulls).
 
 from __future__ import annotations
 
+import json
 import socket
 import tempfile
 import webbrowser
@@ -20,6 +21,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from wmo.cli.runs_app import MANIFEST_RELPATH
 from wmo.config.store import WorldModelStore
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
@@ -40,6 +42,10 @@ from wmo.platform.credentials import (
     save_credentials,
 )
 from wmo.platform.transfer import extract_push_meta, pack_model_dir, unpack_model_bundle
+from wmo.runs.backfill import BackfillRefused, ensure_backfillable, optimize_events
+from wmo.runs.client import PushRejected, PushUnavailable, RunsSink, default_emitter_id
+from wmo.runs.reader import RunsReader
+from wmo.runs.schema import pipeline_external_id
 
 _console = Console()
 _CHECK = "[green]✓[/green]"
@@ -71,6 +77,12 @@ _PUSH_REF = typer.Option(
 )
 _PULL_VERSION = typer.Option("--version", help="Harness version to pull (default: latest).")
 _PULL_FORCE = typer.Option("--force", help="Replace an existing local artifact.")
+_PUSH_SERVE_MODEL = typer.Option(
+    "--serve-model",
+    help="Day-one serving model for a newly created endpoint (a platform default "
+    "serves when omitted; deployments without that model's credentials refuse "
+    "and name the serveable set).",
+)
 _ROOT = typer.Option("--root", help="Artifact root directory.")
 
 
@@ -180,9 +192,18 @@ def push(
     kind: Annotated[str | None, _KIND] = None,
     push_as: Annotated[str | None, _PUSH_AS] = None,
     ref: Annotated[str | None, _PUSH_REF] = None,
+    serve_model: Annotated[str | None, _PUSH_SERVE_MODEL] = None,
     root: Annotated[str, _ROOT] = ".wmo",
 ) -> None:
-    """Publish a local world model or harness to the platform registry."""
+    """Publish a local world model or harness to the platform registry.
+
+    A model push carries everything the model directory holds: the simulation
+    (the built bundle), the model (a measured policy.json + report.json become
+    the endpoint's installed artifacts), and the pipeline (the optimize run's
+    manifest replays into the platform's run history). Legs whose artifacts are
+    absent are skipped with a note, so a bundle-only directory pushes exactly
+    as before.
+    """
     model_dir = WorldModelStore(root).dir_for(name)
     harness_exists = HarnessStore(root).exists(name)
     resolved_kind = _resolve_kind(
@@ -193,7 +214,16 @@ def push(
     credentials, org_id = _require_connection(org)
     with _connected(credentials, "Push failed") as client:
         if resolved_kind == "model" and model_dir is not None:
-            _push_model(client, org_id, remote_name, model_dir)
+            pushed_id = _push_model(client, org_id, remote_name, model_dir)
+            _push_endpoint_artifacts(
+                client,
+                org_id,
+                remote_name,
+                model_dir,
+                world_model_id=pushed_id,
+                serve_model=serve_model,
+            )
+            _push_pipeline(client, org_id, remote_name, model_dir)
         else:
             _push_harness(client, org_id, remote_name, name, ref, root)
 
@@ -324,7 +354,7 @@ def _detect_remote_kind(client: PlatformClient, org_id: str, name: str) -> str:
     raise typer.BadParameter(f"the organization has no world model or harness named {name!r}")
 
 
-def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> None:
+def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> str:
     meta = extract_push_meta(model_dir)
     with tempfile.TemporaryDirectory(prefix="wmo-push-") as staging:
         bundle = pack_model_dir(model_dir, Path(staging) / f"{remote_name}.tar.gz")
@@ -346,6 +376,91 @@ def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir
     _console.print(
         f"{_CHECK} Pushed world model [bold]{pushed.name}[/bold] "
         f"({bundle.byte_size:,} bytes, sha256 {bundle.sha256[:12]}…)"
+    )
+    return pushed.id
+
+
+def _push_endpoint_artifacts(
+    client: PlatformClient,
+    org_id: str,
+    remote_name: str,
+    model_dir: Path,
+    *,
+    world_model_id: str,
+    serve_model: str | None,
+) -> None:
+    """Publish the model directory's measured policy and report as the endpoint.
+
+    Creates the endpoint when the org has none by this name (linked to the
+    just-pushed simulation), then installs policy.json + report.json on it. A
+    knn policy carries an evidence bank and goes through the multipart
+    installer; static and rank ride the JSON artifacts route. Skipped with a
+    note when either artifact is absent: a bundle-only push is still a push.
+    """
+    policy_path = model_dir / "policy.json"
+    report_path = model_dir / "report.json"
+    if not policy_path.is_file():
+        _console.print("no policy.json in the model directory; skipping the endpoint leg")
+        return
+    if not report_path.is_file():
+        _console.print(
+            "policy.json has no report.json beside it; skipping the endpoint leg "
+            "(the report is the endpoint's customer-facing evidence)"
+        )
+        return
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if client.get_endpoint(org_id, remote_name) is None:
+        client.create_endpoint(
+            org_id, remote_name, world_model_id=world_model_id, model=serve_model
+        )
+        _console.print(f"{_CHECK} Created endpoint [bold]{remote_name}[/bold]")
+    if isinstance(policy, dict) and policy.get("kind") == "knn":
+        bank_path = Path(f"{policy_path}.bank.npz")
+        client.install_endpoint_policy(
+            org_id,
+            remote_name,
+            policy_path,
+            bank_path if bank_path.is_file() else None,
+            report_path,
+        )
+    else:
+        client.install_endpoint_artifacts(org_id, remote_name, policy=policy, report=report)
+    _console.print(
+        f"{_CHECK} Installed measured policy + report on endpoint [bold]{remote_name}[/bold]"
+    )
+
+
+def _push_pipeline(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> None:
+    """Replay the model's optimize pipeline into the platform's run history.
+
+    The same derivation `wmo runs backfill` performs, riding the push's own
+    client: events come from the manifest's recorded clocks, seqs are
+    deterministic, and the platform discards replays, so re-pushing a model is
+    free. A run that already reported itself live is left alone rather than
+    double-counted.
+    """
+    manifest = model_dir / MANIFEST_RELPATH
+    if not manifest.is_file():
+        _console.print("no optimize manifest in the model directory; skipping the pipeline leg")
+        return
+    external_id = pipeline_external_id(remote_name)
+    events = optimize_events(manifest, model=remote_name, external_id=external_id)
+    try:
+        ensure_backfillable(RunsReader(client, org_id).event_count(external_id))
+    except BackfillRefused:
+        _console.print(
+            f"pipeline run [bold]{external_id}[/bold] is already recorded; skipping the replay"
+        )
+        return
+    sink = RunsSink(client, org_id=org_id, emitter_id=default_emitter_id())
+    try:
+        ack = sink.push(external_id, events)
+    except (PushRejected, PushUnavailable) as error:
+        raise _platform_failure(PlatformError(str(error)), "Pipeline push failed") from error
+    _console.print(
+        f"{_CHECK} Pushed pipeline run [bold]{external_id}[/bold] "
+        f"({ack.accepted} of {len(events)} events newly accepted)"
     )
 
 

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -22,6 +22,8 @@ from wmo.platform.client import (
     WhoAmI,
 )
 from wmo.platform.credentials import ENV_HOME, PlatformCredentials, save_credentials
+from wmo.runs.client import PushAck
+from wmo.runs.schema import pipeline_external_id
 
 if TYPE_CHECKING:
     from wmo.platform.client import PlatformClient
@@ -514,3 +516,162 @@ def test_bare_login_targets_the_hosted_platform(monkeypatch: pytest.MonkeyPatch)
 
     assert result.exit_code == 0, result.output
     assert seen["web_url"] == "https://platform.experientiallabs.ai"
+
+
+def _write_model_dir(root: str, name: str = "demo-model") -> Path:
+    """A minimal local world model: the config file is what makes it one."""
+    model_dir = Path(root) / "models" / name
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.toml").write_text("embed_dim = 64\n", encoding="utf-8")
+    return model_dir
+
+
+_PUSHED = RemoteWorldModel(id="wm-99", name="demo-model", status="ready")
+
+
+class _RecordingPushClient(_StubClient):
+    """Records the push legs; the bundle upload itself is short-circuited."""
+
+    calls: list[tuple[str, object]] = []
+
+    def push_model_bundle(self, *_args: object, **_kwargs: object) -> RemoteWorldModel:
+        type(self).calls.append(("bundle", None))
+        return _PUSHED
+
+    def get_endpoint(self, org_id: str, name: str) -> dict[str, object] | None:
+        del org_id, name
+        return None
+
+    def create_endpoint(self, org_id: str, name: str, **kwargs: object) -> dict[str, object]:
+        del org_id
+        type(self).calls.append(("create", {"name": name, **kwargs}))
+        return {"name": name}
+
+    def install_endpoint_artifacts(
+        self, org_id: str, name: str, *, policy: object, report: object
+    ) -> dict[str, object]:
+        del org_id
+        type(self).calls.append(("artifacts", {"name": name, "policy": policy, "report": report}))
+        return {"name": name, "status": "ready"}
+
+
+def test_push_model_installs_endpoint_artifacts_beside_the_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One push carries the simulation AND the measured endpoint artifacts."""
+    root = str(tmp_path / ".wmo")
+    model_dir = _write_model_dir(root)
+    (model_dir / "policy.json").write_text(
+        '{"kind": "static", "default_model": "m1", "pool": []}', encoding="utf-8"
+    )
+    (model_dir / "report.json").write_text('{"headline": {"accuracy": 1.0}}', encoding="utf-8")
+    _connected()
+    _RecordingPushClient.calls = []
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _RecordingPushClient)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    kinds = [kind for kind, _ in _RecordingPushClient.calls]
+    assert kinds == ["bundle", "create", "artifacts"]
+    _, create = _RecordingPushClient.calls[1]
+    assert create == {"name": "demo-model", "world_model_id": "wm-99", "model": None}
+    _, artifacts = _RecordingPushClient.calls[2]
+    assert isinstance(artifacts, dict)
+    policy = cast("dict[str, object]", artifacts)["policy"]
+    assert isinstance(policy, dict)
+    assert cast("dict[str, object]", policy)["kind"] == "static"
+    # The pipeline leg reports its own absence instead of failing the push.
+    assert "skipping the pipeline leg" in _flatten(result.output)
+
+
+def test_push_model_without_artifacts_still_pushes_the_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bundle-only directory pushes exactly as before, with skip notes."""
+    root = str(tmp_path / ".wmo")
+    _write_model_dir(root)
+    _connected()
+    _RecordingPushClient.calls = []
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _RecordingPushClient)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert [kind for kind, _ in _RecordingPushClient.calls] == ["bundle"]
+    flat = _flatten(result.output)
+    assert "skipping the endpoint leg" in flat
+    assert "skipping the pipeline leg" in flat
+
+
+class _FakeReader:
+    """RunsReader stand-in whose event count is set by the test."""
+
+    count = 0
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def event_count(self, _external_id: str) -> int:
+        return type(self).count
+
+
+class _FakeSink:
+    """RunsSink stand-in recording what was pushed."""
+
+    pushes: list[tuple[str, int]] = []
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def push(self, external_id: str, events: list[object]) -> PushAck:
+        type(self).pushes.append((external_id, len(events)))
+        return PushAck(accepted=len(events), last_seq=len(events))
+
+
+def _pipeline_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    root = str(tmp_path / ".wmo")
+    model_dir = _write_model_dir(root)
+    manifest = model_dir / "optimize" / "optimize-run.json"
+    manifest.parent.mkdir()
+    manifest.write_text("{}", encoding="utf-8")
+    _connected()
+    _RecordingPushClient.calls = []
+    _FakeSink.pushes = []
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _RecordingPushClient)
+    monkeypatch.setattr("wmo.cli.platform_cmds.RunsReader", _FakeReader)
+    monkeypatch.setattr("wmo.cli.platform_cmds.RunsSink", _FakeSink)
+    # The derivation itself is backfill_test.py's contract; here only the
+    # composition is under test.
+    monkeypatch.setattr(
+        "wmo.cli.platform_cmds.optimize_events", lambda *_a, **_k: [object(), object()]
+    )
+    return root
+
+
+def test_push_model_replays_the_pipeline_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The optimize manifest replays into the platform's run history on push."""
+    _FakeReader.count = 0
+    root = _pipeline_fixture(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert _FakeSink.pushes == [(pipeline_external_id("demo-model"), 2)]
+    assert "Pushed pipeline run" in _flatten(result.output)
+
+
+def test_push_model_skips_an_already_recorded_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run the platform already holds is left alone rather than double-counted."""
+    _FakeReader.count = 7
+    root = _pipeline_fixture(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert _FakeSink.pushes == []
+    assert "already recorded" in _flatten(result.output)

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -674,4 +674,66 @@ def test_push_model_skips_an_already_recorded_pipeline(
 
     assert result.exit_code == 0, result.output
     assert _FakeSink.pushes == []
-    assert "already recorded" in _flatten(result.output)
+    assert "already has 7 recorded" in _flatten(result.output)
+
+
+def test_push_reports_malformed_artifact_json_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt policy.json fails through the CLI, not with a raw traceback."""
+    root = str(tmp_path / ".wmo")
+    model_dir = _write_model_dir(root)
+    (model_dir / "policy.json").write_text("{not json", encoding="utf-8")
+    (model_dir / "report.json").write_text("{}", encoding="utf-8")
+    _connected()
+    _RecordingPushClient.calls = []
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _RecordingPushClient)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    _assert_clean_failure(result)
+    assert "not valid JSON" in _flatten(result.output)
+
+
+def test_push_warns_when_the_existing_endpoint_links_elsewhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A same-named endpoint tied to another simulation must not silently lie."""
+    root = str(tmp_path / ".wmo")
+    model_dir = _write_model_dir(root)
+    (model_dir / "policy.json").write_text(
+        '{"kind": "static", "default_model": "m1", "pool": []}', encoding="utf-8"
+    )
+    (model_dir / "report.json").write_text('{"headline": {}}', encoding="utf-8")
+    _connected()
+
+    class _LinkedElsewhereClient(_RecordingPushClient):
+        def get_endpoint(self, org_id: str, name: str) -> dict[str, object] | None:
+            del org_id
+            return {"name": name, "world_model_id": "wm-other"}
+
+    _LinkedElsewhereClient.calls = []
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _LinkedElsewhereClient)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    kinds = [kind for kind, _ in _LinkedElsewhereClient.calls]
+    assert kinds == ["bundle", "artifacts"]
+    assert "linked to a different simulation" in _flatten(result.output)
+
+
+def test_push_skip_message_names_the_partial_replay_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupted earlier push is recoverable from the skip message itself."""
+    _FakeReader.count = 1  # fewer than the derivation's 2: possibly partial
+    root = _pipeline_fixture(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["push", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert _FakeSink.pushes == []
+    flat = _flatten(result.output)
+    assert "wmo runs backfill" in flat
+    assert "--force" in flat

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -573,6 +573,80 @@ class PlatformClient:
         self._raise_for_error(finalize)
         return RemoteWorldModel.model_validate(_decode_json(finalize))
 
+    def get_endpoint(self, org_id: str, name: str) -> JsonObject | None:
+        """One endpoint's detail, or ``None`` when the org has no endpoint by that name.
+
+        A 404 is an answer here, not a failure: the push flow asks this question
+        to decide between creating the endpoint and updating it in place.
+        """
+        response = self._client.get(f"/api/orgs/{org_id}/endpoints/{name}")
+        if response.status_code == 404:
+            return None
+        self._raise_for_error(response)
+        decoded = _decode_json(response)
+        if not isinstance(decoded, dict):
+            msg = f"endpoint detail returned a {type(decoded).__name__}, expected an object"
+            raise PlatformError(msg)
+        return decoded
+
+    def create_endpoint(
+        self,
+        org_id: str,
+        name: str,
+        *,
+        world_model_id: str | None = None,
+        model: str | None = None,
+    ) -> JsonObject:
+        """Create one endpoint, optionally tied to a world model.
+
+        Args:
+            org_id: Organization to create under.
+            name: Endpoint slug.
+            world_model_id: Simulation the endpoint links to, or ``None`` for an
+                endpoint whose evidence comes from a real benchmark.
+            model: Pool entry name for the day-one static policy; the platform
+                default serves when omitted. Deployments differ in which models
+                they hold credentials for, so the platform's refusal names the
+                serveable set when this pick (or its default) cannot serve.
+
+        Returns:
+            The created endpoint summary.
+        """
+        body: dict[str, JsonValue] = {"name": name, "world_model_id": world_model_id}
+        if model is not None:
+            body["model"] = model
+        response = self._client.post(f"/api/orgs/{org_id}/endpoints", json=body)
+        self._raise_for_error(response)
+        decoded = _decode_json(response)
+        if not isinstance(decoded, dict):
+            msg = f"endpoint create returned a {type(decoded).__name__}, expected an object"
+            raise PlatformError(msg)
+        return decoded
+
+    def install_endpoint_artifacts(
+        self, org_id: str, name: str, *, policy: JsonObject, report: JsonObject
+    ) -> JsonObject:
+        """Install a measured policy and its improvement report on an endpoint.
+
+        The JSON body twin of :meth:`install_endpoint_policy`, for policies with
+        no evidence bank (static, rank): the pair replaces the endpoint's day-one
+        policy and null report wholesale. A knn policy is two artifacts and must
+        go through the multipart installer instead; the platform refuses it here.
+
+        Returns:
+            The endpoint detail the platform returns.
+        """
+        response = self._client.put(
+            f"/api/orgs/{org_id}/endpoints/{name}/artifacts",
+            json={"policy": policy, "report": report},
+        )
+        self._raise_for_error(response)
+        decoded = _decode_json(response)
+        if not isinstance(decoded, dict):
+            msg = f"artifacts install returned a {type(decoded).__name__}, expected an object"
+            raise PlatformError(msg)
+        return decoded
+
     def install_endpoint_policy(
         self,
         org_id: str,


### PR DESCRIPTION
## What

`wmo push <model>` now publishes everything the model directory holds, in one command (Silen's directive 2026-07-30):

1. **Simulation** - the built bundle, exactly as before.
2. **Model** - a measured `policy.json` + `report.json` install onto the same-named endpoint via the JSON artifacts route (knn policies ride the multipart installer with their evidence bank). The endpoint is created on first push, linked to the just-pushed simulation. `--serve-model` names the day-one serving model for deployments whose platform default is not serveable (staging has no Anthropic credentials, for example).
3. **Pipeline** - the optimize manifest replays into the platform's run history using the `wmo runs backfill` derivation (artifact clocks, deterministic seqs), riding the push's own client. A run the platform already holds is skipped rather than double-counted, so a re-push is free.

Legs whose artifacts are absent skip with a note - a bundle-only directory pushes exactly as before.

## Verified live

Against staging (api.staging.experientiallabs.ai) with a customer API key:

```
✓ Pushed world model tau-bench (944,880 bytes, sha256 9c4bc3af096d…)
✓ Installed measured policy + report on endpoint tau-bench
✓ Pushed pipeline run tau-bench/optimize (3 of 3 events newly accepted)
```

## Tests

Four new CLI tests: full three-leg composition (bundle -> create -> artifacts), bundle-only skip notes, pipeline replay naming (`pipeline_external_id` of the remote name), and the already-recorded refusal. 892 tests green across cli/platform/runs; ruff + ty clean.