### PR TITLE
wmo pull fetches current endpoint state, endpoint-only names included

### DIFF
--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -229,21 +229,41 @@ def push(
 
 
 def pull(
-    name: Annotated[str, typer.Argument(help="Remote world model or harness name.")],
+    name: Annotated[str, typer.Argument(help="Remote world model, endpoint, or harness name.")],
     org: Annotated[str | None, _ORG] = None,
     kind: Annotated[str | None, _KIND] = None,
     version: Annotated[int | None, _PULL_VERSION] = None,
     force: Annotated[bool, _PULL_FORCE] = False,
     root: Annotated[str, _ROOT] = ".wmo",
 ) -> None:
-    """Fetch a world model or harness from the platform registry."""
+    """Fetch the CURRENT platform state of a model, endpoint, or harness.
+
+    A model pull restores the bundle as pushed, then overwrites policy.json,
+    report.json, and the knn bank with what the same-named endpoint serves NOW,
+    so a hosted optimizer's fit comes home with the pull. A name that is only
+    an endpoint (platform-created, never pushed) pulls those artifacts into the
+    model directory by themselves. The artifact overwrite is the point of the
+    command and does not need --force; --force still governs replacing an
+    existing local bundle.
+    """
     if kind is not None and kind not in ("model", "harness"):
         raise typer.BadParameter("--kind must be 'model' or 'harness'")
     credentials, org_id = _require_connection(org)
     with _connected(credentials, "Pull failed") as client:
-        resolved_kind = kind or _detect_remote_kind(client, org_id, name)
+        resolved_kind = kind or _detect_pullable_kind(client, org_id, name)
         if resolved_kind == "model":
             _pull_model(client, org_id, name, root, force=force)
+            _pull_endpoint_artifacts(client, org_id, name, WorldModelStore(root).model_dir(name))
+        elif resolved_kind == "endpoint":
+            dest_dir = WorldModelStore(root).model_dir(name)
+            if not _pull_endpoint_artifacts(client, org_id, name, dest_dir):
+                raise typer.BadParameter(
+                    f"the organization has no world model, endpoint, or harness named {name!r}"
+                )
+            _console.print(
+                "no simulation to pull: the endpoint's evidence came from a real benchmark "
+                "or a hosted fit, so only its measured artifacts live locally"
+            )
         else:
             _pull_harness(client, org_id, name, root, version=version)
 
@@ -352,6 +372,23 @@ def _detect_remote_kind(client: PlatformClient, org_id: str, name: str) -> str:
     if name in harness_names:
         return "harness"
     raise typer.BadParameter(f"the organization has no world model or harness named {name!r}")
+
+
+def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str:
+    """`_detect_remote_kind` plus the endpoint-only fallback for pulls.
+
+    An endpoint with no same-named simulation (platform-created, or its
+    evidence is a real benchmark) is still pullable: its measured artifacts
+    are the whole point of fetching current state.
+    """
+    try:
+        return _detect_remote_kind(client, org_id, name)
+    except typer.BadParameter:
+        if client.get_endpoint(org_id, name) is not None:
+            return "endpoint"
+        raise typer.BadParameter(
+            f"the organization has no world model, endpoint, or harness named {name!r}"
+        ) from None
 
 
 def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> str:
@@ -528,6 +565,48 @@ def _pull_model(client: PlatformClient, org_id: str, name: str, root: str, *, fo
         except FileExistsError as error:
             raise typer.BadParameter(str(error)) from error
     _console.print(f"{_CHECK} Pulled world model [bold]{name}[/bold] into {dest_dir}")
+
+
+def _pull_endpoint_artifacts(
+    client: PlatformClient, org_id: str, name: str, dest_dir: Path
+) -> bool:
+    """Overwrite the local dir's measured artifacts with the endpoint's CURRENT state.
+
+    The pull half of D-LOCAL-PUSH: policy.json, report.json, and the knn bank
+    reflect what the endpoint serves NOW (a hosted optimizer's fit included),
+    not what was last pushed. Overwriting is the point, so no --force gate.
+
+    Returns:
+        Whether the org had an endpoint by this name at all.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    payload = client.download_endpoint_policy(
+        org_id, name, bank_dest=dest_dir / "policy.json.bank.npz"
+    )
+    if payload is None:
+        _console.print(f"no endpoint named {name!r}; the bundle is all there is to pull")
+        return False
+    (dest_dir / "policy.json").write_text(
+        json.dumps(payload["policy"], indent=2) + "\n", encoding="utf-8"
+    )
+    wrote = ["policy.json"]
+    report = payload.get("report")
+    if report is not None:
+        (dest_dir / "report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        wrote.append("report.json")
+    bank_path = dest_dir / "policy.json.bank.npz"
+    if isinstance(payload.get("bank"), dict):
+        wrote.append("policy.json.bank.npz")
+    elif bank_path.is_file():
+        # A bankless current policy must not leave an older fit's sidecar
+        # beside it; the pair would disagree the next time anything reads them.
+        bank_path.unlink()
+        _console.print("removed a stale policy.json.bank.npz from an earlier fit")
+    _console.print(
+        f"{_CHECK} Pulled endpoint [bold]{name}[/bold]'s current {' + '.join(wrote)} "
+        f"into {dest_dir}"
+    )
+    return True
 
 
 def _pull_harness(

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -362,7 +362,16 @@ def _nothing_local(name: str, root: str, *, kind: str | None) -> str:
     return f"no local {label} named {name!r} under {root} ({found}); {hint}, or pass --root <dir>"
 
 
-def _detect_remote_kind(client: PlatformClient, org_id: str, name: str) -> str:
+def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str:
+    """What a pull by this name reaches: model, harness, or endpoint-only.
+
+    The endpoint probe runs only after the model and harness reads both come
+    up empty, so a genuine model/harness ambiguity still refuses with the
+    pass-`--kind` message instead of silently selecting a same-named endpoint.
+    An endpoint with no same-named simulation (platform-created, or its
+    evidence is a real benchmark) is still pullable: its measured artifacts
+    are the whole point of fetching current state.
+    """
     model_names = {model.name for model in client.list_world_models(org_id)}
     harness_names = {harness.name for harness in client.list_harnesses(org_id)}
     if name in model_names and name in harness_names:
@@ -371,24 +380,11 @@ def _detect_remote_kind(client: PlatformClient, org_id: str, name: str) -> str:
         return "model"
     if name in harness_names:
         return "harness"
-    raise typer.BadParameter(f"the organization has no world model or harness named {name!r}")
-
-
-def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str:
-    """`_detect_remote_kind` plus the endpoint-only fallback for pulls.
-
-    An endpoint with no same-named simulation (platform-created, or its
-    evidence is a real benchmark) is still pullable: its measured artifacts
-    are the whole point of fetching current state.
-    """
-    try:
-        return _detect_remote_kind(client, org_id, name)
-    except typer.BadParameter:
-        if client.get_endpoint(org_id, name) is not None:
-            return "endpoint"
-        raise typer.BadParameter(
-            f"the organization has no world model, endpoint, or harness named {name!r}"
-        ) from None
+    if client.get_endpoint(org_id, name) is not None:
+        return "endpoint"
+    raise typer.BadParameter(
+        f"the organization has no world model, endpoint, or harness named {name!r}"
+    )
 
 
 def _push_model(client: PlatformClient, org_id: str, remote_name: str, model_dir: Path) -> str:
@@ -591,9 +587,15 @@ def _pull_endpoint_artifacts(
     )
     wrote = ["policy.json"]
     report = payload.get("report")
+    report_path = dest_dir / "report.json"
     if report is not None:
-        (dest_dir / "report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
         wrote.append("report.json")
+    elif report_path.is_file():
+        # Same rule as the bank below: a reportless current endpoint must not
+        # keep an as-pushed or earlier-pull report reading as current evidence.
+        report_path.unlink()
+        _console.print("removed a stale report.json from an earlier state")
     bank_path = dest_dir / "policy.json.bank.npz"
     if isinstance(payload.get("bank"), dict):
         wrote.append("policy.json.bank.npz")

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -372,8 +372,21 @@ def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str
     evidence is a real benchmark) is still pullable: its measured artifacts
     are the whole point of fetching current state.
     """
+    # The model list goes first ON PURPOSE: a dead credential fails here with
+    # the platform's own sentence, so the tolerant harness probe below never
+    # masks a real auth problem.
     model_names = {model.name for model in client.list_world_models(org_id)}
-    harness_names = {harness.name for harness in client.list_harnesses(org_id)}
+    try:
+        harness_names = {harness.name for harness in client.list_harnesses(org_id)}
+    except PlatformError as error:
+        if error.status_code in (401, 403, 404):
+            # This platform exposes no harness registry to this credential
+            # (the hosted platform serves none at all, and the customer-key
+            # allowlist ends before it); a name cannot collide with what
+            # cannot be read.
+            harness_names = set()
+        else:
+            raise
     if name in model_names and name in harness_names:
         raise typer.BadParameter("both a model and a harness have this name remotely; pass --kind")
     if name in model_names:

--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -382,9 +382,15 @@ def _detect_pullable_kind(client: PlatformClient, org_id: str, name: str) -> str
         if error.status_code in (401, 403, 404):
             # This platform exposes no harness registry to this credential
             # (the hosted platform serves none at all, and the customer-key
-            # allowlist ends before it); a name cannot collide with what
-            # cannot be read.
+            # allowlist ends before it). The credential could not pull a
+            # harness either way, so the model proceeds - but never silently,
+            # in case a registry this credential cannot see does hold the name.
             harness_names = set()
+            if error.status_code != 404:
+                _console.print(
+                    "harness registry not readable with this credential; "
+                    "assuming the name is not also a harness"
+                )
         else:
             raise
     if name in model_names and name in harness_names:

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -737,3 +738,142 @@ def test_push_skip_message_names_the_partial_replay_recovery(
     flat = _flatten(result.output)
     assert "wmo runs backfill" in flat
     assert "--force" in flat
+
+
+class _PullStateClient(_StubClient):
+    """Client double for the current-state pull: canned registry and policy reads."""
+
+    model_names: tuple[str, ...] = ()
+    endpoint_names: tuple[str, ...] = ()
+    policy_payload: dict[str, object] = {}
+    bank_bytes: bytes | None = None
+
+    def list_world_models(self, _org_id: str) -> list[RemoteWorldModel]:
+        return [
+            RemoteWorldModel(id=f"wm-{name}", name=name, status="ready")
+            for name in type(self).model_names
+        ]
+
+    def list_harnesses(self, _org_id: str) -> list[object]:
+        return []
+
+    def get_endpoint(self, _org_id: str, name: str) -> dict[str, object] | None:
+        return {"name": name} if name in type(self).endpoint_names else None
+
+    def download_endpoint_policy(
+        self, _org_id: str, name: str, *, bank_dest: Path | None = None
+    ) -> dict[str, object] | None:
+        if name not in type(self).endpoint_names:
+            return None
+        payload = dict(type(self).policy_payload)
+        bank_bytes = type(self).bank_bytes
+        if bank_dest is not None and bank_bytes is not None:
+            bank_dest.write_bytes(bank_bytes)
+        return payload
+
+
+def test_pull_model_overwrites_artifacts_with_the_endpoint_current_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pull hands back what the endpoint serves NOW, not what was pushed."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+    _PullStateClient.model_names = ("demo-model",)
+    _PullStateClient.endpoint_names = ("demo-model",)
+    _PullStateClient.policy_payload = {
+        "policy": {"kind": "static", "default_model": "current-pick", "pool": []},
+        "report": {"headline": {"accuracy": 0.9}},
+        "bank": None,
+    }
+    _PullStateClient.bank_bytes = None
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _PullStateClient)
+
+    def fake_pull_model(
+        _client: object, _org_id: str, name: str, root_dir: str, *, force: bool
+    ) -> None:
+        del force
+        model_dir = Path(root_dir) / "models" / name
+        model_dir.mkdir(parents=True)
+        # The bundle carries the AS-PUSHED policy; the artifacts leg must replace it.
+        (model_dir / "policy.json").write_text(
+            '{"kind": "static", "default_model": "as-pushed"}', encoding="utf-8"
+        )
+    monkeypatch.setattr("wmo.cli.platform_cmds._pull_model", fake_pull_model)
+
+    result = runner.invoke(app, ["pull", "demo-model", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    model_dir = Path(root) / "models" / "demo-model"
+    policy = json.loads((model_dir / "policy.json").read_text(encoding="utf-8"))
+    assert policy["default_model"] == "current-pick"
+    report = json.loads((model_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["headline"] == {"accuracy": 0.9}
+    assert "current" in _flatten(result.output)
+
+
+def test_pull_reaches_an_endpoint_that_was_never_pushed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A platform-created endpoint with no simulation still pulls its artifacts."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+    _PullStateClient.model_names = ()
+    _PullStateClient.endpoint_names = ("hosted-only",)
+    _PullStateClient.policy_payload = {
+        "policy": {"kind": "knn", "default_model": "m1", "pool": []},
+        "report": {"headline": {"accuracy": 0.7}},
+        "bank": {"sha256": "abc", "byte_size": 3},
+    }
+    _PullStateClient.bank_bytes = b"npz"
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _PullStateClient)
+
+    result = runner.invoke(app, ["pull", "hosted-only", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    model_dir = Path(root) / "models" / "hosted-only"
+    assert json.loads((model_dir / "policy.json").read_text(encoding="utf-8"))["kind"] == "knn"
+    assert (model_dir / "policy.json.bank.npz").read_bytes() == b"npz"
+    assert (model_dir / "report.json").is_file()
+    assert "no simulation to pull" in _flatten(result.output)
+
+
+def test_pull_removes_a_stale_bank_when_the_current_policy_has_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bankless current policy must not keep an older fit's sidecar beside it."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+    _PullStateClient.model_names = ()
+    _PullStateClient.endpoint_names = ("hosted-only",)
+    _PullStateClient.policy_payload = {
+        "policy": {"kind": "static", "default_model": "m1", "pool": []},
+        "report": None,
+        "bank": None,
+    }
+    _PullStateClient.bank_bytes = None
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _PullStateClient)
+    stale = Path(root) / "models" / "hosted-only" / "policy.json.bank.npz"
+    stale.parent.mkdir(parents=True)
+    stale.write_bytes(b"old fit")
+
+    result = runner.invoke(app, ["pull", "hosted-only", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert not stale.exists()
+    assert "stale policy.json.bank.npz" in _flatten(result.output)
+
+
+def test_pull_names_endpoints_in_the_nothing_found_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The not-found message covers everything a pull can now reach."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+    _PullStateClient.model_names = ()
+    _PullStateClient.endpoint_names = ()
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _PullStateClient)
+
+    result = runner.invoke(app, ["pull", "ghost", "--root", root])
+
+    _assert_clean_failure(result)
+    assert "no world model, endpoint, or harness" in _flatten(result.output)

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -926,3 +926,30 @@ def test_pull_removes_a_stale_report_when_the_endpoint_has_none(
     assert result.exit_code == 0, result.output
     assert not stale.exists()
     assert "stale report.json" in _flatten(result.output)
+
+
+def test_pull_tolerates_a_platform_with_no_harness_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hosted platform serves no harness routes; detection must not die there."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+
+    class _NoHarnessRegistryClient(_PullStateClient):
+        def list_harnesses(self, _org_id: str) -> list[RemoteHarness]:
+            raise PlatformError("Unauthorized", status_code=401)
+
+    _NoHarnessRegistryClient.model_names = ()
+    _NoHarnessRegistryClient.endpoint_names = ("hosted-only",)
+    _NoHarnessRegistryClient.policy_payload = {
+        "policy": {"kind": "static", "default_model": "m1", "pool": []},
+        "report": None,
+        "bank": None,
+    }
+    _NoHarnessRegistryClient.bank_bytes = None
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _NoHarnessRegistryClient)
+
+    result = runner.invoke(app, ["pull", "hosted-only", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert (Path(root) / "models" / "hosted-only" / "policy.json").is_file()

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -19,6 +19,7 @@ from wmo.platform.client import (
     HarnessVersionDoc,
     PlatformError,
     PlatformUnreachable,
+    RemoteHarness,
     RemoteWorldModel,
     WhoAmI,
 )
@@ -754,7 +755,7 @@ class _PullStateClient(_StubClient):
             for name in type(self).model_names
         ]
 
-    def list_harnesses(self, _org_id: str) -> list[object]:
+    def list_harnesses(self, _org_id: str) -> list[RemoteHarness]:
         return []
 
     def get_endpoint(self, _org_id: str, name: str) -> dict[str, object] | None:
@@ -798,6 +799,7 @@ def test_pull_model_overwrites_artifacts_with_the_endpoint_current_state(
         (model_dir / "policy.json").write_text(
             '{"kind": "static", "default_model": "as-pushed"}', encoding="utf-8"
         )
+
     monkeypatch.setattr("wmo.cli.platform_cmds._pull_model", fake_pull_model)
 
     result = runner.invoke(app, ["pull", "demo-model", "--root", root])
@@ -877,3 +879,50 @@ def test_pull_names_endpoints_in_the_nothing_found_error(
 
     _assert_clean_failure(result)
     assert "no world model, endpoint, or harness" in _flatten(result.output)
+
+
+def test_pull_still_refuses_a_model_harness_ambiguity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A same-named endpoint must not swallow the deliberate ambiguity refusal."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+
+    class _AmbiguousClient(_PullStateClient):
+        def list_harnesses(self, _org_id: str) -> list[RemoteHarness]:
+            return [RemoteHarness(id="h-1", name="demo-model", latest_version=1)]
+
+    _AmbiguousClient.model_names = ("demo-model",)
+    _AmbiguousClient.endpoint_names = ("demo-model",)
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _AmbiguousClient)
+
+    result = runner.invoke(app, ["pull", "demo-model", "--root", root])
+
+    _assert_clean_failure(result)
+    assert "pass --kind" in _flatten(result.output)
+
+
+def test_pull_removes_a_stale_report_when_the_endpoint_has_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reportless current endpoint must not keep old evidence reading as current."""
+    root = str(tmp_path / ".wmo")
+    _connected()
+    _PullStateClient.model_names = ()
+    _PullStateClient.endpoint_names = ("hosted-only",)
+    _PullStateClient.policy_payload = {
+        "policy": {"kind": "static", "default_model": "m1", "pool": []},
+        "report": None,
+        "bank": None,
+    }
+    _PullStateClient.bank_bytes = None
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _PullStateClient)
+    stale = Path(root) / "models" / "hosted-only" / "report.json"
+    stale.parent.mkdir(parents=True)
+    stale.write_text('{"headline": {"accuracy": 0.99}}', encoding="utf-8")
+
+    result = runner.invoke(app, ["pull", "hosted-only", "--root", root])
+
+    assert result.exit_code == 0, result.output
+    assert not stale.exists()
+    assert "stale report.json" in _flatten(result.output)

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -953,3 +953,6 @@ def test_pull_tolerates_a_platform_with_no_harness_registry(
 
     assert result.exit_code == 0, result.output
     assert (Path(root) / "models" / "hosted-only" / "policy.json").is_file()
+    # An auth-denied registry (as opposed to one the platform does not serve)
+    # is worked around AUDIBLY: the collision assumption is stated.
+    assert "assuming the name is not also a harness" in _flatten(result.output)

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -698,6 +698,50 @@ class PlatformClient:
         self._raise_for_error(response)
         return _decode_json(response)
 
+    def download_endpoint_policy(
+        self, org_id: str, name: str, *, bank_dest: Path | None = None
+    ) -> JsonObject | None:
+        """The endpoint's CURRENT policy and report, streaming its knn bank when asked.
+
+        The pull half of the publish surface (D-LOCAL-PULL): the platform
+        returns the policy the endpoint serves NOW - a hosted optimizer's fit
+        included - beside its improvement report. ``None`` when the org has no
+        endpoint by that name (a 404 is an answer here, exactly like
+        :meth:`get_endpoint`). When the policy carries an evidence bank and
+        ``bank_dest`` is given, the bank bytes stream from the signed URL to
+        that path and are digest-verified; a policy with no bank leaves the
+        path unwritten.
+
+        Returns:
+            The response payload (``policy``, ``report``, ``bank`` metadata),
+            or ``None`` for an absent endpoint.
+        """
+        response = self._client.get(f"/api/orgs/{org_id}/endpoints/{name}/policy")
+        if response.status_code == 404:
+            return None
+        self._raise_for_error(response)
+        payload = _decode_json(response)
+        bank = payload.get("bank")
+        if bank_dest is not None and isinstance(bank, dict):
+            declared = str(bank["sha256"])
+            digest = hashlib.sha256()
+            part_path = bank_dest.with_name(f"{bank_dest.name}.part")
+            with self._transfer.stream("GET", str(bank["url"])) as stream:
+                if not stream.is_success:
+                    msg = f"policy bank download failed with HTTP {stream.status_code}"
+                    raise PlatformError(msg, status_code=stream.status_code)
+                with part_path.open("wb") as fh:
+                    for chunk in stream.iter_bytes():
+                        digest.update(chunk)
+                        fh.write(chunk)
+            actual = digest.hexdigest()
+            if actual != declared:
+                part_path.unlink(missing_ok=True)
+                msg = f"policy bank digest mismatch for {name}: expected {declared}, got {actual}"
+                raise PlatformError(msg)
+            part_path.replace(bank_dest)
+        return payload
+
     def download_model_bundle(self, org_id: str, name: str, dest: Path) -> str:
         """Stream a model's bundle from storage to ``dest``, verifying its digest.
 

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -721,7 +721,15 @@ class PlatformClient:
             return None
         self._raise_for_error(response)
         payload = _decode_json(response)
+        if not isinstance(payload.get("policy"), dict):
+            msg = f"policy download for {name} returned no policy object"
+            raise PlatformError(msg)
         bank = payload.get("bank")
+        if bank is not None and not (
+            isinstance(bank, dict) and isinstance(bank.get("url"), str) and "sha256" in bank
+        ):
+            msg = f"policy download for {name} returned an unusable bank reference"
+            raise PlatformError(msg)
         if bank_dest is not None and isinstance(bank, dict):
             declared = str(bank["sha256"])
             digest = hashlib.sha256()


### PR DESCRIPTION
## What

Silen's directive (2026-07-30): pull gets the MOST RECENT data, not just what was pushed - and works when nothing was ever pushed.

- A **model pull** restores the bundle as before, then overwrites `policy.json`, `report.json`, and the knn bank with what the same-named endpoint serves NOW (a hosted optimizer's fit included). The overwrite is the point of the command, so it does not sit behind `--force` (`--force` still governs replacing an existing local bundle).
- An **endpoint-only name** (platform-created endpoint, no simulation, no push ever) now resolves in kind detection and pulls its measured artifacts into the model directory by themselves, with a note explaining why there is no bundle.
- A **bankless current policy removes a stale bank sidecar** from an earlier fit instead of leaving a disagreeing pair on disk.
- Client: `download_endpoint_policy` (404 = None like `get_endpoint`; knn bank streams from the signed URL and is digest-verified, mirroring the bundle download).

Rides platform PR #410 (GET /orgs/{org}/endpoints/{name}/policy). Live verification against staging follows that merge.

## Tests

Current-state overwrite beats the as-pushed bundle contents; endpoint-only pull lands policy+bank+report with the no-simulation note; stale-bank removal; the not-found error names endpoints. 799 tests green across cli/platform; ruff + ty clean.