### PR TITLE
Anthropic text and streaming paths forward the effort dial instead of refusing it

### DIFF
--- a/wmo/providers/_anthropic_chat.py
+++ b/wmo/providers/_anthropic_chat.py
@@ -27,6 +27,18 @@ CACHE_CONTROL_EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
 """The 5-minute-TTL breakpoint. The only TTL the Messages API bills at the documented rates."""
 
 
+def effort_fields(reasoning_effort: str) -> dict[str, object]:
+    """The cross-vendor effort dial as Messages-API fields; the ONE owner of this wire shape.
+
+    Claude 5 refuses budget-token thinking ("use thinking.type.adaptive and
+    output_config.effort"), so the dial is adaptive thinking plus an effort level
+    (low|medium|high|max, probed live 2026-07-29). Every Anthropic call path - the
+    structured chat contract, plain completion, and streaming - sends exactly these
+    fields, so two pool arms differing only in effort stay two arms on every path.
+    """
+    return {"thinking": {"type": "adaptive"}, "output_config": {"effort": reasoning_effort}}
+
+
 def messages_request(
     request: ChatRequest,
     model: str,
@@ -114,8 +126,7 @@ def messages_request(
         "max_tokens": request.max_tokens or request.max_completion_tokens or default_max_tokens,
     }
     if reasoning_effort is not None:
-        payload["thinking"] = {"type": "adaptive"}
-        payload["output_config"] = {"effort": reasoning_effort}
+        payload.update(effort_fields(reasoning_effort))
 
     tools = _tools(request)
     if tools is not None:

--- a/wmo/providers/anthropic.py
+++ b/wmo/providers/anthropic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from wmo.providers._anthropic_chat import messages_request, messages_response
+from wmo.providers._anthropic_chat import effort_fields, messages_request, messages_response
 from wmo.providers.base import (
     DEFAULT_MAX_TOKENS,
     Completion,
@@ -65,22 +65,18 @@ class AnthropicProvider:
                 "variable holding it explicitly (a pool entry's `api_key_env` field)"
             )
 
-    def _refuse_dropped_effort(self, path: str) -> None:
-        """Refuse a config whose effort dial this path would silently drop.
+    def _effort_kwargs(self) -> dict[str, object]:
+        """The config's effort dial as extra Messages-API kwargs; empty when undialed.
 
         `PoolEntry.reasoning_effort` exists so two entries differing only in
-        effort are two ARMS. Only `complete_chat` forwards the dial; a text or
-        streaming call would send byte-identical requests for both arms, so a
-        grid comparing them would measure sampling noise and report an effort
-        effect. Refusing loudly is the same posture Azure's streaming path
-        takes for the same gap.
+        effort are two ARMS, and every call path must keep them two arms:
+        `complete_chat` forwards the dial through `messages_request`, and the
+        text and streaming paths splat exactly the same fields here. One wire
+        shape, one owner (`effort_fields`).
         """
-        if self.config.reasoning_effort is not None:
-            raise ValueError(
-                f"AnthropicProvider.{path} does not forward reasoning_effort="
-                f"{self.config.reasoning_effort!r}; only complete_chat does. Two pool arms "
-                "differing only in effort would silently collapse into one on this path."
-            )
+        if self.config.reasoning_effort is None:
+            return {}
+        return effort_fields(self.config.reasoning_effort)
 
     def complete(
         self,
@@ -92,7 +88,6 @@ class AnthropicProvider:
     ) -> Completion:
         # Opus 4.8 takes `system` as a top-level arg and rejects sampling params, so temperature
         # is intentionally not forwarded; adaptive thinking is the default.
-        self._refuse_dropped_effort("complete")
         api_messages = [
             cast("MessageParam", {"role": m.role, "content": m.content}) for m in messages
         ]
@@ -101,6 +96,7 @@ class AnthropicProvider:
             system=system,
             messages=api_messages,
             max_tokens=max_tokens,
+            **cast("Any", self._effort_kwargs()),
         )
         text = "".join(block.text for block in response.content if block.type == "text")
         # Anthropic reports cache reads and writes BESIDE input_tokens (input_tokens excludes
@@ -146,7 +142,6 @@ class AnthropicProvider:
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Iterator[StreamChunk]:
         """Stream a completion natively (raw SSE events; temperature not forwarded, as complete)."""
-        self._refuse_dropped_effort("stream")
         del temperature  # Claude 4.8+/5 reject sampling params; mirror complete()
         api_messages = [
             cast("MessageParam", {"role": m.role, "content": m.content}) for m in messages
@@ -161,6 +156,7 @@ class AnthropicProvider:
                 messages=api_messages,
                 max_tokens=max_tokens,
                 stream=True,
+                **cast("Any", self._effort_kwargs()),
             ),
         )
         usage = TokenUsage()

--- a/wmo/providers/tests/anthropic_test.py
+++ b/wmo/providers/tests/anthropic_test.py
@@ -152,13 +152,69 @@ def test_complete_chat_wires_the_configs_reasoning_effort_to_the_wire(
     assert response.choices[0].message.content == "ok"
 
 
-def test_text_paths_refuse_a_config_whose_effort_they_would_drop() -> None:
-    """Two arms differing only in effort must never silently collapse into one."""
+def test_complete_forwards_the_configs_effort_dial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two arms differing only in effort must stay two arms on the text path.
+
+    The sweep's agent measures candidates through `complete`, so this is the
+    line that lets an effort-dialed Claude arm be MEASURED at all; before it,
+    the path refused the dial and Claude arms could not sweep.
+    """
+    fake = _FakeClient(_FakeResponse([_FakeTextBlock("ok")], _FakeUsage(3, 2)))
+    provider = AnthropicProvider(
+        ProviderConfig(kind=ProviderKind.ANTHROPIC, model="claude-fable-5", reasoning_effort="high")
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("system", [Message(role="user", content="hi")])
+
+    assert fake.messages.last_kwargs["thinking"] == {"type": "adaptive"}
+    assert fake.messages.last_kwargs["output_config"] == {"effort": "high"}
+
+
+def test_complete_sends_no_thinking_fields_when_undialed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An undialed config keeps the request byte-identical to before the dial existed."""
+    fake = _FakeClient(_FakeResponse([_FakeTextBlock("ok")], _FakeUsage(3, 2)))
+    provider = AnthropicProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("system", [Message(role="user", content="hi")])
+
+    assert "thinking" not in fake.messages.last_kwargs
+    assert "output_config" not in fake.messages.last_kwargs
+
+
+def test_stream_forwards_the_configs_effort_dial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The streaming path sends the same wire fields as complete and complete_chat."""
+
+    class _FakeStream:
+        def __iter__(self) -> object:
+            return iter(())
+
+        def close(self) -> None:
+            return None
+
+    class _FakeStreamMessages:
+        def __init__(self) -> None:
+            self.last_kwargs: dict[str, object] = {}
+
+        def create(self, **kwargs: object) -> _FakeStream:
+            self.last_kwargs = kwargs
+            return _FakeStream()
+
+    class _FakeStreamClient:
+        def __init__(self) -> None:
+            self.messages = _FakeStreamMessages()
+
+    fake = _FakeStreamClient()
     provider = AnthropicProvider(
         ProviderConfig(kind=ProviderKind.ANTHROPIC, model="claude-fable-5", reasoning_effort="max")
     )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
 
-    with pytest.raises(ValueError, match="does not forward reasoning_effort"):
-        provider.complete("system", [Message(role="user", content="hi")])
-    with pytest.raises(ValueError, match="does not forward reasoning_effort"):
-        next(provider.stream("system", [Message(role="user", content="hi")]))
+    list(provider.stream("system", [Message(role="user", content="hi")]))
+
+    assert fake.messages.last_kwargs["stream"] is True
+    assert fake.messages.last_kwargs["thinking"] == {"type": "adaptive"}
+    assert fake.messages.last_kwargs["output_config"] == {"effort": "max"}


### PR DESCRIPTION
Claude reasoning arms could not be swept: a routing sweep's agent measures candidates through `complete()`, which refused any effort-dialed config, and a hosted endpoint serving an effort arm refused every streaming client the same way.

`effort_fields()` is now the one owner of the wire shape (adaptive thinking + `output_config.effort`, the Claude 5 dial probed live 2026-07-29), and `complete_chat`, `complete`, and `stream` all send it. Undialed configs stay byte-identical to before.

Follows from the platform's reasoning-arms work: Silen's ruling 2026-08-01 that OpenAI AND Anthropic models participate in effort routing. Provider tests cover both dialed paths and the undialed no-op. The 120 pre-existing `wmo/cli/*` test failures on main (lazy-import monkeypatch breakage from #373) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)