### PR TITLE
Read OpenInference tool calls from Arize's nested output-messages export

### DIFF
--- a/wmo/ingest/normalize.py
+++ b/wmo/ingest/normalize.py
@@ -457,16 +457,54 @@ def _tool_args(attrs: JsonObject) -> JsonObject:
 _OI_TOOL_NAME_SUFFIX = ".tool_call.function.name"
 _OI_TOOL_ARGS_SUFFIX = ".tool_call.function.arguments"
 
+# Arize's `export_model_to_df` flattens the SAME tool call differently: `llm.output_messages` stays
+# a nested list whose inner keys are dotted, so NO top-level key ends in the suffixes above, e.g.
+#   llm.output_messages = [{"message.role": "assistant",
+#                           "message.tool_calls": [{"tool_call.function.name": "read_file",
+#                                                   "tool_call.function.arguments": "{...}"}]}]
+# Every level is shape-checked rather than assumed: the dataframe path fills an absent column with
+# a float NaN, and a raw OTLP export carries the same field as a JSON string. Neither is a list, so
+# both fall through to the caller's existing behavior instead of being guessed at.
+_OI_MESSAGES_KEY = "llm.output_messages"
+_OI_TOOL_CALLS_KEY = "message.tool_calls"
+_OI_CALL_NAME_KEY = "tool_call.function.name"
+_OI_CALL_ARGS_KEY = "tool_call.function.arguments"
+
+
+def _nested_openinference_tool_call(attrs: JsonObject) -> tuple[str, JsonValue] | None:
+    """The first tool call inside a nested `llm.output_messages` list, if any."""
+    messages = attrs.get(_OI_MESSAGES_KEY)
+    if not isinstance(messages, list):
+        return None
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        calls = message.get(_OI_TOOL_CALLS_KEY)
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get(_OI_CALL_NAME_KEY)
+            if isinstance(name, str) and name:
+                return name, call.get(_OI_CALL_ARGS_KEY)
+    return None
+
 
 def _openinference_tool_call(attrs: JsonObject) -> tuple[str, JsonValue] | None:
-    """The lowest-indexed OpenInference tool call `(name, raw_args)` on an LLM span, if any."""
+    """The first OpenInference tool call `(name, raw_args)` on an LLM span, if any.
+
+    Reads either flattening of the same span: Phoenix's indexed top-level keys first, then Arize's
+    nested `llm.output_messages` list. A turn with parallel calls yields only its first here, the
+    one paired with this span; the rest arrive as their own steps from their tool spans.
+    """
     name_keys = sorted(k for k in attrs if k.endswith(_OI_TOOL_NAME_SUFFIX))
     for name_key in name_keys:
         name = attrs.get(name_key)
         if isinstance(name, str) and name:
             args_key = name_key[: -len(_OI_TOOL_NAME_SUFFIX)] + _OI_TOOL_ARGS_SUFFIX
             return name, attrs.get(args_key)
-    return None
+    return _nested_openinference_tool_call(attrs)
 
 
 def action_from_llm_span(span: SpanRecord) -> Action:

--- a/wmo/ingest/normalize_test.py
+++ b/wmo/ingest/normalize_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from wmo.core.types import ErrorClass, StepAttribution
+from wmo.core.types import ActionKind, ErrorClass, StepAttribution
 from wmo.ingest.normalize import (
     SpanEmitter,
     SpanRecord,
@@ -266,3 +266,67 @@ def test_span_emitter_keeps_a_span_own_value_and_needs_no_trace_attributes() -> 
     bare = SpanEmitter("t2")
     bare.emit({"gen_ai.completion": "hi"}, tool=False)
     assert bare.spans[0].attributes == {"gen_ai.operation.name": "chat", "gen_ai.completion": "hi"}
+
+
+def test_openinference_tool_call_is_read_from_a_nested_output_messages_list() -> None:
+    """Arize keeps `llm.output_messages` a nested list; the tool call must still be found.
+
+    Regression: the flat scan only matched top-level keys ending in `.tool_call.function.name`,
+    which an `export_model_to_df` export has none of, so a tool call fell through to the message
+    branch and `output.value` (the whole provider envelope: system instructions, usage, sampling
+    config) became the action content. On a real export that misread 739 of 876 LLM spans. The
+    envelope is in this fixture on purpose: it is what the span would have fallen back to.
+    """
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            attributes={
+                "openinference.span.kind": "LLM",
+                "llm.output_messages": [
+                    {
+                        "message.role": "assistant",
+                        "message.tool_calls": [
+                            {
+                                "tool_call.function.name": "read_file",
+                                "tool_call.function.arguments": '{"path": "migrations/007.sql"}',
+                                "tool_call.id": "call_abc123",
+                            }
+                        ],
+                    }
+                ],
+                "output.value": (
+                    '{"id": "resp_1", "instructions": "You are a migration reviewer.",'
+                    ' "usage": {"total_tokens": 4158}, "temperature": 1.0}'
+                ),
+            },
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    action = trace.steps[0].action
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "read_file"
+    assert action.arguments == {"path": "migrations/007.sql"}
+    # The envelope must not survive anywhere on the action.
+    assert action.content is None
+
+
+def test_openinference_tool_call_still_reads_the_flat_indexed_keys() -> None:
+    """Phoenix's `get_spans_dataframe` flattening keeps working alongside Arize's nested one."""
+    prefix = "llm.output_messages.0.message.tool_calls.0.tool_call.function"
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            attributes={
+                "openinference.span.kind": "LLM",
+                f"{prefix}.name": "get_user",
+                f"{prefix}.arguments": '{"id": "u1"}',
+            },
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    action = trace.steps[0].action
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "get_user"
+    assert action.arguments == {"id": "u1"}


### PR DESCRIPTION
## Overview

This PR makes it so wmo ingest takes in nested tool calls from Arize traces and ignores the full system prompt, usage, and sampling config, repeated on every span(there is still at least one per trace) effectively increasing the amount of information in an ingest while decreasing the bytes. 

## What breaks

`_openinference_tool_call` finds an LLM-emitted tool call by scanning for flat top-level attribute keys ending in `.tool_call.function.name`. That is the shape Phoenix's `get_spans_dataframe()` produces, and the one `wmo/ingest/phoenix.py` documents.

Arize's `export_model_to_df` flattens the same span differently. `llm.output_messages` stays a nested list whose inner keys are dotted:

```json
[{"message.role": "assistant",
  "message.tool_calls": [{"tool_call.function.name": "read_file",
                          "tool_call.function.arguments": "{\"path\": \"migrations/007.sql\"}",
                          "tool_call.id": "call_abc123"}]}]
```

Such an export contains zero matching top-level keys, so the scan never fires. The span falls through to the message branch, where `output.value` supplies the content: the entire raw provider envelope, carrying the full system prompt in `instructions` plus usage and sampling config.

A tool call therefore normalizes into a `MESSAGE` action wrapping an 11KB API envelope. The byte count is the visible symptom; the real damage is that `Action.kind` is wrong and the tool name and arguments are discarded, so a world model built from the corpus learns to predict API envelopes instead of agent behavior.

## The fix

The flat scan runs first and is unchanged, then falls back to reading the nested list. Extending the existing helper rather than adding a parallel one keeps a single owner for "did this LLM span emit a tool call", since the answer is the same regardless of which export flattened it.

Every level is shape-checked rather than assumed. The dataframe path fills an absent column with a float NaN, and a raw OTLP export carries the same field as a JSON string. Neither is a list, so both keep today's behavior rather than being guessed at. Unrecognized shapes are left alone, never made worse.

## Measured

Real 91MB Arize export, 3,000-span slice (141 traces, 2,262 steps), through `wmo ingest --source phoenix`:

| | before | after |
|---|---|---|
| steps | 2,262 | 2,262 |
| `TOOL_CALL` actions | 97 | 836 |
| `MESSAGE` actions | 2,165 | 1,426 |
| with name and arguments | 97 | 836 |
| total `action.content` | 11,774,100 bytes | 2,961,435 bytes |

739 of 876 LLM spans recover their tool call, and action content drops 75%. The step count is unchanged, so span pairing is unaffected.

## Parallel tool calls

23 spans in that corpus emit between 2 and 13 calls in one message, and only the first pairs with the LLM span, matching the flat reader's existing behavior. Nothing is lost: the remaining calls already arrive as their own steps from their own tool spans, via the existing branch in `_build_steps` that builds an action from a tool span when none is pending. The slice holds exactly 836 tool calls across all messages and yields exactly 836 `TOOL_CALL` steps.

## Tests

Two, in `wmo/ingest/normalize_test.py`, both built from inline `SpanRecord` literals:

- `test_openinference_tool_call_is_read_from_a_nested_output_messages_list` captures the repro and fails before the change. The fixture carries the `output.value` envelope on purpose, since that is what the span previously fell back to.
- `test_openinference_tool_call_still_reads_the_flat_indexed_keys` guards Phoenix's existing flattening, which must keep working.

## Scope

Only OpenInference spans reaching the normalizer through `phoenix.py` or the OTLP default change behavior. The row-shaped adapters (langfuse, langsmith, braintrust, mastra, posthog) build spans in a fixed `gen_ai.*` vocabulary and cannot produce `llm.output_messages`, so they are untouched. No existing test asserted the old behavior.

Normalization happens at ingest, so there is no stored-artifact migration. Re-ingesting an Arize corpus now yields structured tool calls, which is the point, and benefiting from it means rebuilding from the re-ingested corpus.

Deliberately left for follow-ups: spans whose messages carry `message.contents` (multi-part text) rather than a tool call, and the `output.value` versus `llm.output_messages` ordering in `_COMPLETION_KEYS`.