### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   🌐 <a href="https://platform.experientiallabs.ai">Platform</a> |
   📚 <a href="https://github.com/experientiallabs/world-model-optimizer/tree/main/docs">Docs</a> |
-  <a href="https://discord.gg/QwjJpEyHd"><img src="https://cdn.simpleicons.org/discord/5865F2" alt="" width="16" height="16"> Discord</a>
+  <a href="https://discord.gg/B6sM8xTVwU"><img src="https://cdn.simpleicons.org/discord/5865F2" alt="" width="16" height="16"> Discord</a>
 </p>
 
 ## Getting started


### PR DESCRIPTION
## Summary

- Replace the README Discord invite with `https://discord.gg/B6sM8xTVwU`.

## Why

The public community link should point to the current Discord invite.

## Impact

The README Discord link now routes visitors to the requested invite. No runtime behavior changes.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `git diff --check`