### PR TITLE
Restore wmo run for local agents and hosted world models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,21 +51,17 @@ uv run pytest -q
   evaluation adapters. Optimization may depend on this package; runtime code must not depend on
   optimization algorithms.
 - Keep `wmo run` as the primary supported execution surface. Bare runs use the built-in local pi
-  harness; platform ids resolve to hosted world-model or agent sessions. Add another public entry
-  point only for a distinct user need, with consistent lifecycle and safety behavior.
+  harness; platform world-model ids resolve to hosted sessions. Agent ids must fail clearly until
+  the platform exposes a hosted agent-session API again. Add another public entry point only for a
+  distinct user need, with consistent lifecycle and safety behavior.
 - `wmo providers set` owns the project-local worker model in `.wmo/settings.toml`. Local runs and
   builds use that role unless explicit flags override it; credentials remain in the environment
   or gitignored `.env`, never in settings.
 - Only bare runs execute harness code and bash on the user's machine. Preserve the explicit local
   execution consent boundary and the `--dir` file-tool jail.
-- Hosted agent ids run their champion harness in platform-managed E2B. Do not require local model
-  or E2B credentials for this path, and keep worker LLM calls, provider secrets, and world-model
-  state host-side.
-- Workspace upload is explicit through `-u` or `--upload-dir`. Preserve bounded regular-file
-  snapshots, incremental bidirectional patches, final three-way reconciliation, concurrent local
-  edits, and the complete remote recovery archive on conflict.
-- Detached sessions must survive without a local process. Persist the transcript cursor and sync
-  checkpoint under WMO user state, then catch up before send, attach, or end.
+- Do not reintroduce hosted-agent CLI flags against endpoints that do not exist. If hosted agent
+  sessions return, keep worker LLM calls, provider secrets, and world-model state host-side, and
+  require no local model or E2B credentials for that path.
 - For optimizer and eval E2B runs, sandbox the real pi process while the environment remains the
   world-model simulation. Reuse warm sandboxes within score waves, isolate concurrent cells,
   meter sandbox lifetime, retry uncertain transport only in a fresh sandbox, and fail closed when

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Distill your own small model into the pool with [`wmo optimize distill`](wmo/opt
 serve a single model with no routing via `wmo optimize route pin`, or build an optimized harness
 for your agent with `wmo optimize harness`.
 
+### Run the built-in agent
+
+A bare `wmo run` launches the built-in pi harness on this machine. File tools stay under the
+selected directory, but bash is not OS-sandboxed, so the CLI asks for explicit consent. Logged-out
+runs use the configured local worker provider; logged-in runs proxy worker calls through the
+platform.
+
+```bash
+wmo providers set
+wmo run --dir . --task "fix the failing tests"
+```
+
 ### Hosted platform
 
 Create an account at [platform.experientiallabs.ai](https://platform.experientiallabs.ai), then
@@ -64,10 +76,10 @@ authenticate the CLI:
 wmo login
 ```
 
-Copy an agent ID from the platform and run its current champion harness:
+Copy a world-model ID from the platform and open an interactive session:
 
 ```bash
-wmo run <agent-id>
+wmo run <world-model-id>
 ```
 
 ### E2B backend
@@ -103,27 +115,20 @@ print(obs.content)
 Or over HTTP (same code path), namespaced by model name: `GET /world_models`, then `POST
 /world_models/{name}/sessions` and `POST /world_models/{name}/sessions/{id}/step`.
 
-## Run after platform login
+## Run a world model from the platform
 
-After `wmo login`, the same `wmo run` command can open a hosted world model or run an agent's
-current champion harness in E2B. The platform manages model and sandbox credentials, so hosted
-runs do not need local API keys.
+After `wmo login`, `wmo run` resolves a platform target ID and opens a hosted world-model session.
+The platform manages model credentials, so this path needs no local API key.
 
 ```bash
 wmo login
-wmo run <world-model-or-agent-id>
-wmo run <agent-id> -u . --task "fix the failing tests"
+wmo run <world-model-id> --task "check out the cart"
 ```
 
-Workspace upload is opt-in with `-u`: WMO live-syncs changes and preserves concurrent local edits.
-Long-running agents can detach, continue in the platform, and be messaged or reattached later.
-
-```bash
-wmo run <agent-id> -u . --detach
-wmo run --send "Now run the full test suite"
-wmo run --attach
-wmo run --end
-```
+The target resolver still distinguishes agent IDs from world-model IDs. Hosted agent sessions are
+currently unavailable because the platform no longer exposes their session API; an agent ID fails
+with an actionable message instead of falling through to the world-model endpoint. Omit the ID to
+run the built-in pi harness locally.
 
 ## Runtime agents and optimizers in E2B sandboxes
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,6 @@ Distill your own small model into the pool with [`wmo optimize distill`](wmo/opt
 serve a single model with no routing via `wmo optimize route pin`, or build an optimized harness
 for your agent with `wmo optimize harness`.
 
-### Run the built-in agent
-
-A bare `wmo run` launches the built-in pi harness on this machine. File tools stay under the
-selected directory, but bash is not OS-sandboxed, so the CLI asks for explicit consent. Logged-out
-runs use the configured local worker provider; logged-in runs proxy worker calls through the
-platform.
-
-```bash
-wmo providers set
-wmo run --dir . --task "fix the failing tests"
-```
-
 ### Hosted platform
 
 Create an account at [platform.experientiallabs.ai](https://platform.experientiallabs.ai), then
@@ -124,11 +112,6 @@ The platform manages model credentials, so this path needs no local API key.
 wmo login
 wmo run <world-model-id> --task "check out the cart"
 ```
-
-The target resolver still distinguishes agent IDs from world-model IDs. Hosted agent sessions are
-currently unavailable because the platform no longer exposes their session API; an agent ID fails
-with an actionable message instead of falling through to the world-model endpoint. Omit the ID to
-run the built-in pi harness locally.
 
 ## Runtime agents and optimizers in E2B sandboxes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,7 @@ JSONL. The two formats are not interchangeable.
 
 | Command | Purpose | Artifact |
 |---|---|---|
+| `wmo run [world-model-id]` | With no target, run the built-in pi agent against a selected local directory. With a hosted world-model ID, open its interactive simulation session. Hosted agent IDs are currently unsupported. | nothing locally; logged-in local runs leave a platform usage record |
 | `wmo login` / `logout` / `status` | Connect this machine to a platform account, disconnect, or show the current account and organizations. | a saved credential |
 | `wmo push` / `pull` | Publish a local world model to the platform registry, or fetch a model or endpoint state from it. | a registry entry, or a local artifact dir |
 | `reproduce list` / `run <benchmark>` (moved to the [research repo](https://github.com/experientiallabs/research)) | Reproduce a published benchmark result from its shipped manifest: download the pinned data, replay the pinned protocol, and compare every published number field by field. `matrix` manifests run offline and bit-exact; `commands` manifests replay live CLI steps, state their estimated spend, and refuse without `--yes`. Exit 0 is REPRODUCED, 4 is DIVERGED. | `verdict.json` plus the run's own artifacts |

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -32,6 +32,7 @@ from rich.table import Table
 
 from wmo.cli.defer import add_deferred_typer
 from wmo.cli.model_roles import configured_role_configs, load_settings_or_abort
+from wmo.cli.run_cmd import register as register_run_command
 from wmo.common.config import (
     ARTIFACT_DIR,
     DEFAULT_MODEL_NAME,
@@ -115,7 +116,6 @@ def _register_ingest() -> None:
 
 def _register_side_commands() -> None:
     from wmo.cli.platform_cmds import register as register_platform_commands
-    from wmo.cli.run_cmd import register as register_run_command
 
     register_platform_commands(app)
     register_run_command(app)

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -115,8 +115,10 @@ def _register_ingest() -> None:
 
 def _register_side_commands() -> None:
     from wmo.cli.platform_cmds import register as register_platform_commands
+    from wmo.cli.run_cmd import register as register_run_command
 
     register_platform_commands(app)
+    register_run_command(app)
 
 
 _register_ingest()

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -338,10 +338,9 @@ def test_cli_exposes_the_small_command_set() -> None:
         "download",
         "knowledge",
     }
-    # `run` (the hosted agent-session runner) moved to the agent-optimization repo
-    # with the rest of the agent surfaces; the platform commands that remain are
-    # the model registry round-trip and the login lifecycle.
-    platform = {"login", "logout", "status", "push", "pull"}
+    # `run` owns local pi execution and hosted world-model sessions. Platform
+    # commands also cover the model registry round-trip and login lifecycle.
+    platform = {"login", "logout", "status", "push", "pull", "run"}
     assert names == core | platform
     # `optimize` is a GROUP (route, model, and distill; harness search moved out).
     groups = {group.name for group in app.registered_groups}

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -643,7 +643,7 @@ class LocalLiveDriver:
 
     def _handle_sigint(self, session: live_session.LiveSession) -> None:
         """First Ctrl-C interrupts the current turn; a second ends the session."""
-        if session.status != "running":
+        if not session.turn_active:
             self._interrupts = 0
             _console.print("\n[yellow]no active turn (:quit to end)[/yellow]")
             return
@@ -991,10 +991,16 @@ def register(app: typer.Typer) -> None:
 def _confirm_local_execution(jail_root: Path, *, yes: bool) -> None:
     """Warn that harness code and bash run with local user permissions."""
     _console.print(
-        "[bold yellow]The built-in pi harness and its shell commands run on THIS machine"
-        "[/bold yellow].\n"
-        f"File tools stay under {jail_root}, and bash starts there, but bash is not "
-        "OS-sandboxed and can access anything your user can."
+        Text.assemble(
+            (
+                "The built-in pi harness and its shell commands run on THIS machine",
+                "bold yellow",
+            ),
+            ".\nFile tools stay under ",
+            str(jail_root),
+            ", and bash starts there, but bash is not OS-sandboxed and can access anything your "
+            "user can.",
+        )
     )
     if not yes and not typer.confirm("continue?"):
         raise typer.Exit(code=1)

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -519,20 +519,34 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         ProviderKind,
         ToolCallingProvider,
     )
-    from wmo.common.providers.models import resolve_provider_model
+    from wmo.common.providers.models import model_types_for_provider, resolve_provider_model
     from wmo.common.providers.registry import get_provider
 
     configured = load_settings().models.resolve("worker")
     provider_name = provider or (
         configured.provider if configured is not None else _DEFAULT_PROVIDER
     )
-    model_name = model or (configured.model if configured is not None else _DEFAULT_MODEL)
     try:
         kind = ProviderKind(provider_name)
     except ValueError:
         kinds = ", ".join(k.value for k in ProviderKind)
         msg = f"unknown provider {provider_name!r}; choose one of: {kinds}"
         raise typer.BadParameter(msg) from None
+    if model is not None:
+        model_name = model
+    elif configured is not None and configured.provider == kind.value:
+        model_name = configured.model
+    elif provider is None:
+        model_name = _DEFAULT_MODEL
+    else:
+        catalog = model_types_for_provider(kind)
+        if not catalog:
+            raise typer.BadParameter(
+                f"provider {kind.value!r} has no default model; pass --model <model>, or run "
+                f"`wmo providers set --provider {kind.value} --model <model>` to configure the "
+                "worker role"
+            )
+        model_name = catalog[0]
     spec = resolve_provider_model(kind, model_name)
     use_configured_knobs = configured is not None and configured.provider == kind.value
     built = get_provider(

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -476,7 +476,6 @@ class StdinCommandReader(threading.Thread):
         """Read stdin on a daemon thread; the session's intents are thread-safe."""
         super().__init__(daemon=True)
         self._session = session
-        self.submitted = threading.Event()
         self.eof = threading.Event()
 
     def run(self) -> None:
@@ -492,7 +491,6 @@ class StdinCommandReader(threading.Thread):
                 self._session.interrupt()
             elif line:
                 self._session.send_user_message(line)
-                self.submitted.set()
         # The driver owns EOF handling. It must wait until any submitted turn
         # returns to idle before ending the session.
         self.eof.set()
@@ -560,8 +558,7 @@ class LocalLiveDriver:
             reader = StdinCommandReader(session)
             reader.start()
             stdin_eof = getattr(reader, "eof", threading.Event())
-            stdin_submitted = getattr(reader, "submitted", threading.Event())
-            self._loop(session, stdin_eof, stdin_submitted)
+            self._loop(session, stdin_eof)
             if session.status == "failed":
                 error = "local live session runner failed"
                 reason = "error"
@@ -581,33 +578,22 @@ class LocalLiveDriver:
         """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
-    def _loop(
-        self,
-        session: live_session.LiveSession,
-        stdin_eof: threading.Event,
-        stdin_submitted: threading.Event | None = None,
-    ) -> None:
+    def _loop(self, session: live_session.LiveSession, stdin_eof: threading.Event) -> None:
         """Pump until closed, treating closed stdin as one-shot after the final turn."""
-        stdin_submitted = stdin_submitted or threading.Event()
         last_tick = 0.0
-        saw_running = False
         end_sent = False
         while not session.closed:
             try:
                 session.pump(timeout=0.5)
             except KeyboardInterrupt:
                 self._handle_sigint(session)
-            saw_running = saw_running or session.status == "running"
-            if (
-                stdin_eof.is_set()
-                and not end_sent
-                and (
-                    (self._instruction is None and not stdin_submitted.is_set())
-                    or (saw_running and session.status == "idle")
-                )
-            ):
-                session.end()
-                end_sent = True
+            if stdin_eof.is_set() and not end_sent:
+                # EOF is published only after the reader queues its final message. Drain any
+                # message that raced with the frame just received, then wait for its idle boundary.
+                session.flush_pending_intents()
+                if session.status == "idle" and not session.turn_active:
+                    session.end()
+                    end_sent = True
             now = time.monotonic()
             if now - last_tick >= _TICK_S:
                 last_tick = now

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -51,6 +51,7 @@ from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
 from wmo.runtime.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
 from wmo.runtime.harness.live_session import SessionEvent, ToolOutcome
 from wmo.runtime.harness.pi_vendor import pi_agent_code_surfaces
+from wmo.runtime.harness.runner_link import provider_context_window
 from wmo.runtime.harness.tools import READ_SKILL, resolve_tools
 from wmo.simulation.model.play import parse_action
 
@@ -507,6 +508,7 @@ class LocalLiveDriver:
         worker_fn: Callable[[ChatRequest], ChatResponse] | None,
         recorder: RunRecorder | None,
         instruction: str | None,
+        context_window: int | None = None,
     ) -> None:
         """Configure the driver; ``run`` performs boot, loop, and teardown."""
         self._jail = jail_root
@@ -514,7 +516,8 @@ class LocalLiveDriver:
         self._provider = provider
         self._worker_fn = worker_fn
         self._recorder = recorder
-        self._instruction = instruction
+        self._instruction = instruction or None
+        self._context_window = context_window
         self._executor = LocalToolExecutor(jail_root)
         self._channel: pi_local.LocalStdioChannel | None = None
         self._interrupts = 0
@@ -541,6 +544,7 @@ class LocalLiveDriver:
                 worker_fn=self._worker_fn,
                 max_output_tokens=self._doc.max_output_tokens(),
                 temperature=self._doc.temperature(),
+                context_window=self._context_window,
                 cancel_active=self._executor.cancel,
                 reset_cancel=self._executor.reset_cancel,
             )
@@ -845,6 +849,40 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
     return built
 
 
+def _platform_worker_context_window(run: platform_client.LocalPiRunInfo) -> int | None:
+    """Resolve the context guard for the platform-selected worker without using its credentials.
+
+    A current platform may return the deployment-owned value directly. For older deployments,
+    Tinker catalog identities can carry their served tier as the final numeric suffix; otherwise
+    use the same provider capability probe as local pi execution. That probe is best-effort and
+    degrades to the runner fallback when the local machine cannot inspect a platform-owned backend.
+    """
+    if run.context_window is not None:
+        return run.context_window if run.context_window >= 1024 else None
+    try:
+        kind = ProviderKind(run.worker_provider)
+    except ValueError:
+        return None
+    if kind is ProviderKind.TINKER:
+        raw_tier = run.worker_model.rsplit(":", 1)[-1]
+        with contextlib.suppress(ValueError):
+            declared = int(raw_tier)
+            if declared >= 1024:
+                return declared
+    spec = resolve_provider_model(kind, run.worker_model)
+    try:
+        worker = provider_registry.get_provider(
+            ProviderConfig(
+                kind=kind,
+                model_type=spec.model_type,
+                model=spec.model_id,
+            )
+        )
+    except Exception:  # noqa: BLE001 - capability discovery must not block a proxied run
+        return None
+    return provider_context_window(worker)
+
+
 _TARGET_ARG = typer.Argument(
     help="Platform run-target id. Omit it to run the built-in pi harness locally."
 )
@@ -983,6 +1021,7 @@ def _build_driver(
             worker_fn=built_in_worker,
             recorder=recorder,
             instruction=task,
+            context_window=_platform_worker_context_window(run),
         )
 
     if not logged_in:

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -763,12 +763,26 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         model_name = catalog[0]
     spec = resolve_provider_model(kind, model_name)
     use_configured_knobs = configured is not None and configured.provider == kind.value
+    configured_spec = (
+        resolve_provider_model(kind, configured.model) if use_configured_knobs else None
+    )
+    same_configured_model = (
+        configured_spec is not None and configured_spec.model_id == spec.model_id
+    )
+    model_type = spec.model_type
+    if (
+        use_configured_knobs
+        and configured is not None
+        and configured.model_type is not None
+        and (model is None or same_configured_model)
+    ):
+        # A tinker:// runtime ID does not encode the base model that selects its renderer,
+        # tokenizer, and served context tier. Preserve that explicit identity unless this call
+        # actually swapped to a different model.
+        model_type = configured.model_type
     deployment = configured.deployment if use_configured_knobs else None
     api_version = configured.api_version if use_configured_knobs else None
     if kind is ProviderKind.AZURE_OPENAI:
-        configured_spec = (
-            resolve_provider_model(kind, configured.model) if use_configured_knobs else None
-        )
         model_changed = (
             model is not None
             and configured_spec is not None
@@ -789,17 +803,25 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
             )
         deployment = deployment or spec.model_type
         api_version = api_version or DEFAULT_AZURE_API_VERSION
-    built = provider_registry.get_provider(
-        ProviderConfig(
-            kind=kind,
-            model_type=spec.model_type,
-            model=spec.model_id,
-            region=configured.region if use_configured_knobs else None,
-            endpoint=configured.endpoint if use_configured_knobs else None,
-            deployment=deployment,
-            api_version=api_version,
-        )
+    config = ProviderConfig(
+        kind=kind,
+        model_type=model_type,
+        model=spec.model_id,
+        region=configured.region if use_configured_knobs else None,
+        endpoint=configured.endpoint if use_configured_knobs else None,
+        deployment=deployment,
+        api_version=api_version,
+        reasoning_effort=configured.reasoning_effort if use_configured_knobs else None,
     )
+    if (
+        use_configured_knobs
+        and configured is not None
+        and configured.chat_max_tokens_field is not None
+    ):
+        config = config.model_copy(
+            update={"chat_max_tokens_field": configured.chat_max_tokens_field}
+        )
+    built = provider_registry.get_provider(config)
     if not isinstance(built, ToolCallingProvider):
         msg = (
             f"provider {kind.value}/{spec.model_id} does not support structured tool calling; "

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -120,20 +120,21 @@ class LocalToolExecutor:
         """Confine every tool path under ``jail_root`` (its resolved real path)."""
         self._jail = jail_root.resolve()
         self._cancelled = threading.Event()
-        self._process_lock = threading.Lock()
+        self._operation_lock = threading.Lock()
         self._active_process: subprocess.Popen[bytes] | None = None
 
     def cancel(self) -> None:
         """Cancel the current command and reject racing tools until the turn reaches idle."""
-        self._cancelled.set()
-        with self._process_lock:
+        with self._operation_lock:
+            self._cancelled.set()
             process = self._active_process
         if process is not None and process.poll() is None:
             _kill_process_group(process)
 
     def reset_cancel(self) -> None:
         """Allow tools for the next turn after the runner reports the idle boundary."""
-        self._cancelled.clear()
+        with self._operation_lock:
+            self._cancelled.clear()
 
     def _resolve(self, path: str) -> Path:
         """Resolve a tool path under the jail, rejecting any escape."""
@@ -159,8 +160,13 @@ class LocalToolExecutor:
             if name == "write_file":
                 path = str(args.get("path", ""))
                 target = self._resolve(path)
-                target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text(str(args.get("content", "")), encoding="utf-8")
+                # Cancellation and filesystem mutation share one linearization point. If cancel
+                # acquires the lock first, no directory or file from the stale turn is created.
+                with self._operation_lock:
+                    if self._cancelled.is_set():
+                        return ToolOutcome(content="interrupted", is_error=True)
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(str(args.get("content", "")), encoding="utf-8")
                 return ToolOutcome(content=f"wrote {path}")
         except _JailEscape as error:
             return ToolOutcome(content=f"path {error} escapes the session directory", is_error=True)
@@ -184,7 +190,7 @@ class LocalToolExecutor:
         if process.stdout is None or process.stderr is None:  # pragma: no cover
             process.kill()
             raise RuntimeError("bash process did not expose stdout and stderr")
-        with self._process_lock:
+        with self._operation_lock:
             self._active_process = process
         if self._cancelled.is_set():
             _kill_process_group(process)
@@ -243,7 +249,7 @@ class LocalToolExecutor:
             if readers_stopped:
                 process.stdout.close()
                 process.stderr.close()
-            with self._process_lock:
+            with self._operation_lock:
                 if self._active_process is process:
                     self._active_process = None
 

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -1,0 +1,746 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Run the built-in local pi harness or a hosted world model.
+
+A bare run starts WMO's retained pi runtime as a local Node child. The host
+answers worker-model requests and executes bash and file tools inside the
+explicit working-directory boundary. Logged-in bare runs proxy worker calls
+through the platform; logged-out runs use local provider credentials.
+
+A platform target is resolved before execution. Hosted world models use their
+interactive session API. Agent targets fail with an actionable message because
+the platform no longer exposes the hosted agent-session API that the deleted
+command used.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Protocol
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from wmo.common.core.types import JsonObject
+    from wmo.common.providers.base import ToolCallingProvider
+    from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
+    from wmo.runtime.harness.doc import HarnessDoc
+    from wmo.runtime.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+    from wmo.runtime.harness.pi_local import LocalStdioChannel
+    from wmo.runtime.platform.client import PlatformClient
+
+_console = Console()
+
+_TOOL_OUTPUT_CAP = 16_000
+_BASH_TIMEOUT_S = 300.0
+_TICK_S = 5.0
+_DEFAULT_PROVIDER = "bedrock"
+_DEFAULT_MODEL = "claude-opus-4-8"
+
+
+class _JailEscape(RuntimeError):
+    """A tool path resolved outside the session's working directory."""
+
+
+def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
+    """Cap tool output to the head+tail budget with a truncation marker."""
+    from wmo.runtime.harness.live_session import ToolOutcome
+
+    if len(content) <= _TOOL_OUTPUT_CAP:
+        return ToolOutcome(content=content, is_error=is_error)
+    half = _TOOL_OUTPUT_CAP // 2
+    dropped = len(content) - _TOOL_OUTPUT_CAP
+    capped = f"{content[:half]}\n... [{dropped} chars truncated] ...\n{content[-half:]}"
+    return ToolOutcome(content=capped, is_error=is_error, truncated=True)
+
+
+def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str]]:
+    """Derive the LiveSession inputs from a HarnessDoc (mirrors the hosted driver).
+
+    Returns the assembled system prompt (prompt + rendered tools + skills index),
+    the resolved tool specs, the code surfaces as {path: content} (the agent's own
+    code, materialized into the local runner), and skill bodies answered host-side.
+    """
+    from wmo.runtime.harness.tools import READ_SKILL, resolve_tools
+
+    tool_names = doc.tools()
+    if doc.skills() and READ_SKILL.name not in tool_names:
+        tool_names.append(READ_SKILL.name)
+    tool_specs = resolve_tools(tool_names)
+    system = doc.assembled_prompt()
+    files = {surface.path: surface.content for surface in doc.code_files() if surface.path}
+    skill_bodies = {skill.name: skill.body for skill in doc.skills()}
+    return system, tool_specs, files, skill_bodies
+
+
+def _pi_node_baseline() -> HarnessDoc:
+    """A pi-node baseline: the default prompt/tools plus the vendored pi agent code.
+
+    ``HarnessDoc.baseline`` is the in-process loop, which the live pi runner
+    cannot host (it needs the pi agent's src/agent.ts). This grafts the vendored
+    pi code surfaces on and pins ``param:runtime-kind = pi-node`` so a not-logged-in
+    session has a runnable agent without fetching a champion.
+    """
+    from wmo.runtime.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+    from wmo.runtime.harness.pi_vendor import pi_agent_code_surfaces
+
+    base = HarnessDoc.baseline("local-session")
+    surfaces = [
+        *base.surfaces,
+        *pi_agent_code_surfaces(),
+        Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+    ]
+    return HarnessDoc(name="local-session", surfaces=surfaces)
+
+
+class LocalToolExecutor:
+    """Jail file tools to one directory and start bash there without OS isolation."""
+
+    def __init__(self, jail_root: Path) -> None:
+        """Confine every tool path under ``jail_root`` (its resolved real path)."""
+        self._jail = jail_root.resolve()
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve a tool path under the jail, rejecting any escape."""
+        target = (self._jail / path).resolve()
+        try:
+            target.relative_to(self._jail)
+        except ValueError as error:
+            raise _JailEscape(path) from error
+        return target
+
+    def __call__(
+        self, name: str, args: JsonObject, emit: Callable[[str, str], None]
+    ) -> ToolOutcome:
+        """Execute one tool call locally; a failure is an observation, not a crash."""
+        from wmo.runtime.harness.live_session import ToolOutcome
+
+        try:
+            if name == "bash":
+                return self._bash(str(args.get("command", "")), emit)
+            if name == "read_file":
+                target = self._resolve(str(args.get("path", "")))
+                return _capped(target.read_text(encoding="utf-8", errors="replace"))
+            if name == "write_file":
+                path = str(args.get("path", ""))
+                target = self._resolve(path)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(str(args.get("content", "")), encoding="utf-8")
+                return ToolOutcome(content=f"wrote {path}")
+        except _JailEscape as error:
+            return ToolOutcome(content=f"path {error} escapes the session directory", is_error=True)
+        except OSError as error:
+            return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
+        return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+
+    def _bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
+        """Run a fresh ``bash -lc`` in the jail root, streaming output to ``emit``."""
+        try:
+            result = subprocess.run(  # noqa: S603 - the agent's tool is meant to run shell commands
+                ["bash", "-lc", command],  # noqa: S607 - bash on PATH is the documented contract
+                cwd=self._jail,
+                capture_output=True,
+                text=True,
+                timeout=_BASH_TIMEOUT_S,
+                check=False,
+            )
+            stdout, stderr, exit_code = result.stdout, result.stderr, result.returncode
+        except subprocess.TimeoutExpired as error:
+            stdout = _as_text(error.stdout)
+            stderr = _as_text(error.stderr) + f"\n[timed out after {int(_BASH_TIMEOUT_S)}s]"
+            exit_code = 124
+        if stdout:
+            emit("stdout", stdout)
+        if stderr:
+            emit("stderr", stderr)
+        body = stdout + stderr
+        if exit_code != 0:
+            body = f"{body}\n[exit {exit_code}]"
+        return _capped(body, is_error=exit_code != 0)
+
+
+def _as_text(value: object) -> str:
+    """Coerce subprocess stdout/stderr (str | bytes | None) to text."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else ""
+
+
+class RunRecorder(Protocol):
+    """Recording slice consumed by the local driver and terminal event sink."""
+
+    def record(self, event: SessionEvent) -> None: ...
+
+    def flush(self) -> None: ...
+
+    def finish(self, *, ended_reason: str, error: str | None) -> None: ...
+
+
+class LocalPiRunRecorder:
+    """Finish and close an org-scoped built-in pi run; it has no transcript."""
+
+    def __init__(self, client: PlatformClient, org_id: str, run_id: str) -> None:
+        self._client = client
+        self._org_id = org_id
+        self._run_id = run_id
+
+    def record(self, event: SessionEvent) -> None:
+        """Ignore transcript events; this row exists only for usage accounting."""
+        _ = event
+
+    def flush(self) -> None:
+        """There is no transcript buffer for a built-in run."""
+
+    def finish(self, *, ended_reason: str, error: str | None) -> None:
+        """Report the terminal state and release the HTTP client."""
+        from wmo.runtime.platform.client import PlatformError
+
+        status = "failed" if error is not None else "ended"
+        with contextlib.suppress(PlatformError):
+            self._client.finish_local_pi_run(
+                self._org_id,
+                self._run_id,
+                status=status,
+                ended_reason=ended_reason,
+                error=error,
+            )
+        self._client.close()
+
+
+class TerminalEventSink:
+    """Render the SessionEvent stream to the terminal and mirror it to a recorder."""
+
+    def __init__(
+        self,
+        *,
+        recorder: RunRecorder | None,
+        on_running: Callable[[bool], None],
+    ) -> None:
+        """Render to the console; ``on_running`` tracks turn state for keepalive."""
+        self._recorder = recorder
+        self._on_running = on_running
+
+    def __call__(self, event: SessionEvent) -> None:
+        """Render one event and mirror it (never raises: a sink must not stop the loop)."""
+        with contextlib.suppress(Exception):
+            self._render(event)
+        if self._recorder is not None:
+            self._recorder.record(event)
+
+    def _render(self, event: SessionEvent) -> None:
+        payload = event.payload
+        if event.kind == "assistant_message":
+            text = str(payload.get("text", ""))
+            if text:
+                _console.print(f"\n[bold cyan]agent[/bold cyan] {text}")
+        elif event.kind == "tool_call":
+            _console.print(f"[dim]$ {payload.get('name', '')} {payload.get('arguments', '')}[/dim]")
+        elif event.kind == "tool_output":
+            _console.print(str(payload.get("text", "")), end="", markup=False, highlight=False)
+        elif event.kind == "tool_result":
+            if payload.get("is_error"):
+                _console.print(f"[red]{payload.get('content', '')}[/red]")
+        elif event.kind == "submit":
+            _console.print(f"\n[bold green]submitted[/bold green] {payload.get('answer', '')}")
+        elif event.kind == "state":
+            status = str(payload.get("status", ""))
+            self._on_running(status == "running")
+            _console.print(f"[dim]({status})[/dim]")
+        elif event.kind == "error":
+            _console.print(f"[red]error: {payload.get('message', '')}[/red]")
+
+
+class StdinCommandReader(threading.Thread):
+    """Feed typed stdin lines as steer/interrupt/end intents to the session."""
+
+    def __init__(self, session: LiveSession) -> None:
+        """Read stdin on a daemon thread; the session's intents are thread-safe."""
+        super().__init__(daemon=True)
+        self._session = session
+        self.eof = threading.Event()
+
+    def run(self) -> None:
+        """Map each line to an intent until end-of-input or the session closes."""
+        for raw in sys.stdin:
+            if self._session.closed:
+                return
+            line = raw.strip()
+            if line in {":quit", ":q", ":exit"}:
+                self._session.end()
+                return
+            if line == ":stop":
+                self._session.interrupt()
+            elif line:
+                self._session.send_user_message(line)
+        # The driver owns EOF handling. For a one-shot ``--task`` it must wait
+        # until the opening turn returns to idle before ending the session.
+        self.eof.set()
+
+
+class LocalLiveDriver:
+    """Own one local pi process + LiveSession and drive it against the local directory."""
+
+    def __init__(
+        self,
+        *,
+        jail_root: Path,
+        doc: HarnessDoc,
+        provider: ToolCallingProvider | None,
+        worker_fn: Callable[[ChatRequest], ChatResponse] | None,
+        recorder: RunRecorder | None,
+        instruction: str | None,
+    ) -> None:
+        """Configure the driver; ``run`` performs boot, loop, and teardown."""
+        self._jail = jail_root
+        self._doc = doc
+        self._provider = provider
+        self._worker_fn = worker_fn
+        self._recorder = recorder
+        self._instruction = instruction
+        self._executor = LocalToolExecutor(jail_root)
+        self._channel: LocalStdioChannel | None = None
+        self._interrupts = 0
+
+    def run(self) -> None:
+        """Boot the local runner, drive the session, and always tear down."""
+        from wmo.runtime.harness.live_session import LiveSession
+        from wmo.runtime.harness.pi_local import start_local_live_runner
+
+        system, tool_specs, files, skill_bodies = _assemble(self._doc)
+        _console.print("[dim]starting the built-in pi harness locally...[/dim]")
+        session: LiveSession | None = None
+        reason = "user_ended"
+        error: str | None = None
+        try:
+            channel = start_local_live_runner()
+            self._channel = channel
+            session = LiveSession(
+                channel,
+                tools=tool_specs,
+                execute_tool=self._execute,
+                on_event=TerminalEventSink(
+                    recorder=self._recorder, on_running=lambda _running: None
+                ),
+                files=files,
+                system_prompt=system,
+                skill_bodies=skill_bodies,
+                provider=self._provider,
+                worker_fn=self._worker_fn,
+                max_output_tokens=self._doc.max_output_tokens(),
+                temperature=self._doc.temperature(),
+            )
+            session.start()
+            _console.print(
+                "[green]session ready[/green] - type to steer, [bold]:stop[/bold] to interrupt, "
+                "[bold]:quit[/bold] to end."
+            )
+            if self._instruction:
+                session.send_user_message(self._instruction)
+            reader = StdinCommandReader(session)
+            reader.start()
+            stdin_eof = getattr(reader, "eof", threading.Event())
+            self._loop(session, stdin_eof)
+            if session.status == "failed":
+                error = "local live session runner failed"
+                reason = "error"
+                _console.print(f"[red]session failed: {error}[/red]")
+        except Exception as exc:  # noqa: BLE001 - report any driver failure, then tear down
+            error = str(exc)
+            reason = "error"
+            _console.print(f"[red]session failed: {exc}[/red]")
+        finally:
+            self._teardown(session, reason=reason, error=error)
+        if error is not None:
+            raise typer.Exit(code=1)
+
+    def _execute(
+        self, name: str, args: JsonObject, emit: Callable[[str, str], None]
+    ) -> ToolOutcome:
+        """Run one tool locally (each tool blocks the session pump)."""
+        return self._executor(name, args, emit)
+
+    def _loop(self, session: LiveSession, stdin_eof: threading.Event) -> None:
+        """Pump until closed, treating closed stdin as one-shot after ``--task``."""
+        last_tick = 0.0
+        saw_running = False
+        end_sent = False
+        while not session.closed:
+            try:
+                session.pump(timeout=0.5)
+            except KeyboardInterrupt:
+                self._handle_sigint(session)
+            saw_running = saw_running or session.status == "running"
+            if (
+                stdin_eof.is_set()
+                and not end_sent
+                and (self._instruction is None or (saw_running and session.status == "idle"))
+            ):
+                session.end()
+                end_sent = True
+            now = time.monotonic()
+            if now - last_tick >= _TICK_S:
+                last_tick = now
+                if self._recorder is not None:
+                    self._recorder.flush()
+
+    def _handle_sigint(self, session: LiveSession) -> None:
+        """First Ctrl-C interrupts the current turn; a second ends the session."""
+        self._interrupts += 1
+        if self._interrupts == 1:
+            _console.print("\n[yellow]interrupting (press Ctrl-C again to quit)[/yellow]")
+            session.interrupt()
+        else:
+            _console.print("\n[yellow]ending session[/yellow]")
+            session.end()
+
+    def _teardown(self, session: LiveSession | None, *, reason: str, error: str | None) -> None:
+        if session is not None and not session.closed:
+            with contextlib.suppress(Exception):
+                session.end()
+        if self._recorder is not None:
+            self._recorder.finish(ended_reason=reason, error=error)
+        if self._channel is not None:
+            with contextlib.suppress(Exception):
+                self._channel.close()
+        _console.print(f"[dim]session ended ({reason})[/dim]")
+
+
+class RemoteWorldModelDriver:
+    """Interactive terminal loop over the platform's world-model session API."""
+
+    def __init__(self, client: PlatformClient, target_id: str, name: str, task: str | None) -> None:
+        """Store the resolved target and opening task."""
+        self._client = client
+        self._target_id = target_id
+        self._name = name
+        self._task = task
+
+    def run(self) -> None:
+        """Create one hosted session and step it until the user exits."""
+        from wmo.runtime.platform.client import PlatformError
+
+        try:
+            session = self._client.create_world_model_session(self._target_id, task=self._task)
+            _console.print(
+                Panel(
+                    'Type an action such as [cyan]search {"q": "SFO"}[/cyan], '
+                    "or a free-text message. Commands: [cyan]:help[/cyan], [cyan]:quit[/cyan].",
+                    title=f"[bold]running world model[/bold] {self._name}",
+                    subtitle=f"task: {self._task}" if self._task else "no task set",
+                    border_style="cyan",
+                )
+            )
+            self._loop(session.id)
+        except PlatformError as error:
+            raise typer.BadParameter(str(error)) from error
+        finally:
+            self._client.close()
+
+    def _loop(self, session_id: str) -> None:
+        """Read actions and render hosted observations."""
+        from wmo.runtime.platform.client import PlatformError
+        from wmo.simulation.model.play import parse_action
+
+        while True:
+            try:
+                line = _console.input("[bold]agent>[/bold] ").strip()
+            except (EOFError, KeyboardInterrupt):
+                _console.print("\n[dim]bye[/dim]")
+                return
+            if not line:
+                continue
+            if line in {":quit", ":q", ":exit"}:
+                _console.print("[dim]bye[/dim]")
+                return
+            if line == ":detach":
+                _console.print(
+                    "[yellow]world-model sessions are interactive only; "
+                    ":detach is unavailable. Use :quit to leave.[/yellow]"
+                )
+                continue
+            if line in {":help", ":h"}:
+                _console.print(
+                    'Tool call: [cyan]name {"arg": "value"}[/cyan]. '
+                    "Any other text is sent as a message."
+                )
+                continue
+            try:
+                action = parse_action(line)
+            except ValueError as error:
+                _console.print(f"[red]parse error[/red]: {error}")
+                continue
+            try:
+                with _console.status("[dim]world model thinking...[/dim]", spinner="dots"):
+                    observation = self._client.step_world_model_session(session_id, action)
+            except PlatformError as error:
+                _console.print(f"[red]step failed[/red]: {error}")
+                continue
+            style = "red" if observation.is_error else "green"
+            title = "error" if observation.is_error else "observation"
+            _console.print(
+                Panel(
+                    observation.content or "[dim](empty)[/dim]",
+                    title=title,
+                    border_style=style,
+                )
+            )
+
+
+def _local_worker_provider(provider: str | None, model: str | None) -> ToolCallingProvider:
+    """Build the logged-out worker provider from local environment credentials, and pre-flight it.
+
+    The pre-flight is the point. Constructing a provider proves almost nothing (every backend
+    builds its SDK client lazily), so a bare `wmo run` with nothing configured used to say
+    nothing about the model it picked, download the ~130MB pi Node runtime, reach "session
+    ready", and only THEN fail mid-session on a Bedrock configuration the user never chose. The
+    chosen provider/model is now named up front and `PreparableProvider.prepare` runs before the
+    harness boots, the same free, request-free check `wmo optimize route sweep` does over its
+    roster (`wmo.common.providers.pool.prepare_pool_provider`). Backends keep their documented
+    residual gaps: bedrock's AWS credentials and tinker's reachability are not locally knowable
+    and stay first-call failures.
+
+    Raises:
+        typer.BadParameter: The provider name is unknown, the model cannot do tool calling, or
+            the backend cannot be prepared. Every message names `wmo providers set`.
+    """
+    from wmo.common.config import load_settings
+    from wmo.common.providers.base import (
+        PreparableProvider,
+        ProviderConfig,
+        ProviderKind,
+        ToolCallingProvider,
+    )
+    from wmo.common.providers.models import resolve_provider_model
+    from wmo.common.providers.registry import get_provider
+
+    configured = load_settings().models.resolve("worker")
+    provider_name = provider or (
+        configured.provider if configured is not None else _DEFAULT_PROVIDER
+    )
+    model_name = model or (configured.model if configured is not None else _DEFAULT_MODEL)
+    try:
+        kind = ProviderKind(provider_name)
+    except ValueError:
+        kinds = ", ".join(k.value for k in ProviderKind)
+        msg = f"unknown provider {provider_name!r}; choose one of: {kinds}"
+        raise typer.BadParameter(msg) from None
+    spec = resolve_provider_model(kind, model_name)
+    use_configured_knobs = configured is not None and configured.provider == kind.value
+    built = get_provider(
+        ProviderConfig(
+            kind=kind,
+            model_type=spec.model_type,
+            model=spec.model_id,
+            region=configured.region if use_configured_knobs else None,
+            endpoint=configured.endpoint if use_configured_knobs else None,
+            deployment=configured.deployment if use_configured_knobs else None,
+            api_version=configured.api_version if use_configured_knobs else None,
+        )
+    )
+    if not isinstance(built, ToolCallingProvider):
+        msg = (
+            f"provider {kind.value}/{spec.model_id} does not support structured tool calling; "
+            "pick a tool-calling model with "
+            f"`wmo providers set --provider {kind.value} --model <model>`"
+        )
+        raise typer.BadParameter(msg)
+    source = "settings models.worker" if configured is not None else "built-in default"
+    if provider is not None or model is not None:
+        source = "--provider/--model"
+    _console.print(f"[dim]worker: {kind.value}/{spec.model_id} ({source})[/dim]")
+    if isinstance(built, PreparableProvider):
+        try:
+            built.prepare()
+        except Exception as exc:  # noqa: BLE001 - every backend raises its own SDK's type here
+            raise typer.BadParameter(
+                f"worker provider {kind.value}/{spec.model_id} ({source}) cannot be used: {exc}\n"
+                f"Fix that, or choose another worker with "
+                f"`wmo providers set --provider <provider> --model <model>`"
+            ) from exc
+    return built
+
+
+_TARGET_ARG = typer.Argument(
+    help="Platform run-target id. Omit it to run the built-in pi harness locally."
+)
+_DIR_OPT = typer.Option(
+    "--dir",
+    help="Working directory and file-tool jail for the built-in local pi harness.",
+)
+_PROVIDER_OPT = typer.Option(
+    "--provider",
+    help="Worker provider for a logged-out built-in local pi run.",
+)
+_MODEL_OPT = typer.Option(
+    "--model",
+    help="Worker model for a logged-out built-in local pi run.",
+)
+_TASK_OPT = typer.Option(
+    "--task",
+    "--instruction",
+    help="Opening task for either execution kind.",
+)
+_YES_OPT = typer.Option(
+    "--yes",
+    help="Skip the local-execution consent prompt.",
+)
+
+
+def register(app: typer.Typer) -> None:
+    """Register the root-level wmo run command."""
+
+    @app.command("run")
+    def run(
+        target: Annotated[str | None, _TARGET_ARG] = None,
+        directory: Annotated[str | None, _DIR_OPT] = None,
+        provider: Annotated[str | None, _PROVIDER_OPT] = None,
+        model: Annotated[str | None, _MODEL_OPT] = None,
+        task: Annotated[str | None, _TASK_OPT] = None,
+        yes: Annotated[bool, _YES_OPT] = False,
+    ) -> None:
+        """Run a hosted world model by id, or the built-in pi harness locally."""
+        if target is not None and directory is not None:
+            raise typer.BadParameter("--dir is only supported for a bare wmo run")
+
+        jail_root = Path(directory or ".").resolve() if target is None else None
+        if jail_root is not None and not jail_root.is_dir():
+            raise typer.BadParameter(f"working directory does not exist: {jail_root}")
+
+        confirm_local: Callable[[], None] | None = None
+        if jail_root is not None:
+            local_root = jail_root
+
+            def confirm_execution() -> None:
+                _confirm_local_execution(local_root, yes=yes)
+
+            confirm_local = confirm_execution
+
+        driver = _build_driver(
+            target=target,
+            jail_root=jail_root,
+            provider=provider,
+            model=model,
+            task=task,
+            confirm_local=confirm_local,
+        )
+        driver.run()
+
+
+def _confirm_local_execution(jail_root: Path, *, yes: bool) -> None:
+    """Warn that harness code and bash run with local user permissions."""
+    _console.print(
+        "[bold yellow]The built-in pi harness and its shell commands run on THIS machine"
+        "[/bold yellow].\n"
+        f"File tools stay under {jail_root}, and bash starts there, but bash is not "
+        "OS-sandboxed and can access anything your user can."
+    )
+    if not yes and not typer.confirm("continue?"):
+        raise typer.Exit(code=1)
+
+
+def _build_driver(
+    *,
+    target: str | None,
+    jail_root: Path | None,
+    provider: str | None,
+    model: str | None,
+    task: str | None,
+    confirm_local: Callable[[], None] | None = None,
+) -> LocalLiveDriver | RemoteWorldModelDriver:
+    """Resolve the execution kind once and assemble its driver."""
+    from wmo.runtime.platform.client import PlatformClient, PlatformError
+    from wmo.runtime.platform.credentials import load_credentials
+
+    credentials = load_credentials()
+    logged_in = credentials.is_complete()
+
+    if target is None:
+        if jail_root is None:
+            raise typer.BadParameter("a working directory is required for the built-in pi harness")
+        if confirm_local is not None:
+            confirm_local()
+        if not logged_in:
+            _console.print(
+                "[dim]not logged in: running the built-in baseline agent with local "
+                "credentials[/dim]"
+            )
+            return LocalLiveDriver(
+                jail_root=jail_root,
+                doc=_pi_node_baseline(),
+                provider=_local_worker_provider(provider, model),
+                worker_fn=None,
+                recorder=None,
+                instruction=task,
+            )
+        if provider is not None or model is not None:
+            raise typer.BadParameter(
+                "logged-in runs use platform credentials; omit --provider/--model, "
+                "or run wmo logout to use local credentials"
+            )
+        client = PlatformClient(str(credentials.api_url), str(credentials.token))
+        try:
+            org_id = _default_org(client, credentials.default_org)
+            run = client.create_local_pi_run(org_id)
+        except typer.BadParameter:
+            client.close()
+            raise
+        except PlatformError as error:
+            client.close()
+            raise typer.BadParameter(str(error)) from error
+        recorder = LocalPiRunRecorder(client, org_id, run.id)
+
+        def built_in_worker(request: ChatRequest) -> ChatResponse:
+            return client.complete_local_pi_worker(org_id, run.id, request)
+
+        return LocalLiveDriver(
+            jail_root=jail_root,
+            doc=_pi_node_baseline(),
+            provider=None,
+            worker_fn=built_in_worker,
+            recorder=recorder,
+            instruction=task,
+        )
+
+    if not logged_in:
+        raise typer.BadParameter(
+            "run wmo login to use a platform id, or omit the id to run the built-in pi harness"
+        )
+    if provider is not None or model is not None:
+        raise typer.BadParameter(
+            "platform target runs use platform credentials; --provider/--model are not accepted"
+        )
+
+    client = PlatformClient(str(credentials.api_url), str(credentials.token))
+    try:
+        resolved = client.resolve_run_target(target)
+        if resolved.kind == "world_model":
+            return RemoteWorldModelDriver(client, resolved.id, resolved.name, task)
+        client.close()
+        raise typer.BadParameter(
+            "hosted agent sessions are unavailable because the platform no longer exposes "
+            "their session API; omit the id to run the built-in pi harness locally"
+        )
+    except PlatformError as error:
+        client.close()
+        raise typer.BadParameter(str(error)) from error
+
+
+def _default_org(client: PlatformClient, configured: str | None) -> str:
+    """Resolve the login's organization, auto-picking only an unambiguous sole org."""
+    if configured is not None:
+        return configured
+    identity = client.whoami()
+    if len(identity.orgs) == 1:
+        return identity.orgs[0].id
+    raise typer.BadParameter(
+        "no default organization selected; run `wmo login` again and choose an organization"
+    )

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -19,6 +19,7 @@ import codecs
 import contextlib
 import os
 import signal
+import stat
 import subprocess
 import sys
 import threading
@@ -156,7 +157,7 @@ class LocalToolExecutor:
                 return self._bash(str(args.get("command", "")), emit)
             if name == "read_file":
                 target = self._resolve(str(args.get("path", "")))
-                return _capped(target.read_text(encoding="utf-8", errors="replace"))
+                return self._read_file(target)
             if name == "write_file":
                 path = str(args.get("path", ""))
                 target = self._resolve(path)
@@ -173,6 +174,28 @@ class LocalToolExecutor:
         except OSError as error:
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
         return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+
+    def _read_file(self, target: Path) -> ToolOutcome:
+        """Read one regular file incrementally without retaining its full contents."""
+        descriptor = os.open(target, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                return ToolOutcome(
+                    content="read_file failed: path is not a regular file", is_error=True
+                )
+            output = _BoundedTextBuffer(_TOOL_OUTPUT_CAP)
+            decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+            while not self._cancelled.is_set():
+                chunk = os.read(descriptor, 4096)
+                if not chunk:
+                    break
+                output.append(decoder.decode(chunk))
+            if self._cancelled.is_set():
+                return ToolOutcome(content="interrupted", is_error=True)
+            output.append(decoder.decode(b"", final=True))
+            return ToolOutcome(content=output.render(), truncated=output.truncated)
+        finally:
+            os.close(descriptor)
 
     def _bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
         """Run a fresh ``bash -lc`` in the jail root, streaming output to ``emit``."""

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -37,6 +37,7 @@ import wmo.runtime.harness.live_session as live_session
 import wmo.runtime.harness.pi_local as pi_local
 import wmo.runtime.platform.client as platform_client
 import wmo.runtime.platform.credentials as platform_credentials
+from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
 from wmo.common.config import load_settings
 from wmo.common.core.types import JsonObject
 from wmo.common.providers.base import (
@@ -116,6 +117,21 @@ class LocalToolExecutor:
     def __init__(self, jail_root: Path) -> None:
         """Confine every tool path under ``jail_root`` (its resolved real path)."""
         self._jail = jail_root.resolve()
+        self._cancelled = threading.Event()
+        self._process_lock = threading.Lock()
+        self._active_process: subprocess.Popen[bytes] | None = None
+
+    def cancel(self) -> None:
+        """Cancel the current command and reject racing tools until the turn reaches idle."""
+        self._cancelled.set()
+        with self._process_lock:
+            process = self._active_process
+        if process is not None and process.poll() is None:
+            _kill_process_group(process)
+
+    def reset_cancel(self) -> None:
+        """Allow tools for the next turn after the runner reports the idle boundary."""
+        self._cancelled.clear()
 
     def _resolve(self, path: str) -> Path:
         """Resolve a tool path under the jail, rejecting any escape."""
@@ -130,6 +146,8 @@ class LocalToolExecutor:
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
     ) -> ToolOutcome:
         """Execute one tool call locally; a failure is an observation, not a crash."""
+        if self._cancelled.is_set():
+            return ToolOutcome(content="interrupted", is_error=True)
         try:
             if name == "bash":
                 return self._bash(str(args.get("command", "")), emit)
@@ -164,6 +182,10 @@ class LocalToolExecutor:
         if process.stdout is None or process.stderr is None:  # pragma: no cover
             process.kill()
             raise RuntimeError("bash process did not expose stdout and stderr")
+        with self._process_lock:
+            self._active_process = process
+        if self._cancelled.is_set():
+            _kill_process_group(process)
         readers = (
             threading.Thread(
                 target=_drain_process_stream,
@@ -189,11 +211,20 @@ class LocalToolExecutor:
             if process.poll() is None:
                 _kill_process_group(process)
             process.wait()
+            # A child can fork into the new group while the first signal is being delivered.
+            # Re-signal after the leader exits so no just-forked descendant retains the pipes.
+            if timed_out or self._cancelled.is_set():
+                _kill_process_group(process)
             for reader in readers:
                 reader.join()
             process.stdout.close()
             process.stderr.close()
+            with self._process_lock:
+                if self._active_process is process:
+                    self._active_process = None
 
+        if self._cancelled.is_set():
+            return ToolOutcome(content="interrupted", is_error=True)
         if timed_out:
             note = f"\n[timed out after {_BASH_TIMEOUT_S:g}s]"
             stderr_buffer.append(note)
@@ -258,7 +289,8 @@ def _drain_process_stream(
 ) -> None:
     """Drain a byte pipe in small chunks while retaining only bounded decoded text."""
     decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
-    while chunk := stream.read(4096):
+    read: Callable[[int], bytes] = getattr(stream, "read1", stream.read)
+    while chunk := read(4096):
         text = decoder.decode(chunk)
         output.append(text)
         _emit_safely(emit, emit_lock, stream_name, text)
@@ -287,10 +319,27 @@ def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
     except ProcessLookupError:
         pass
     except PermissionError:
-        # Some app sandboxes allow setsid but deny killpg. Killing the group leader still
-        # terminates the ordinary single-command path and keeps timeout handling functional.
-        with contextlib.suppress(ProcessLookupError):
-            process.kill()
+        # Some app sandboxes allow setsid but deny killpg. Enumerate this exact process group so
+        # foreground children are still terminated even after their leader exits.
+        _kill_process_group_members(process.pid)
+
+
+def _kill_process_group_members(group_id: int) -> None:
+    """Kill one owned process group member-by-member when killpg is unavailable."""
+    try:
+        members = subprocess.run(  # noqa: S603, S607 - fixed pgrep with a numeric group ID
+            ["pgrep", "-g", str(group_id)],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            check=False,
+        ).stdout.splitlines() or [str(group_id)]
+    except (OSError, subprocess.SubprocessError):
+        members = [str(group_id)]
+    for raw_pid in members:
+        with contextlib.suppress(ValueError):
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.kill(int(raw_pid), signal.SIGKILL)
 
 
 class RunRecorder(Protocol):
@@ -443,9 +492,7 @@ class LocalLiveDriver:
                 channel,
                 tools=tool_specs,
                 execute_tool=self._execute,
-                on_event=TerminalEventSink(
-                    recorder=self._recorder, on_running=lambda _running: None
-                ),
+                on_event=TerminalEventSink(recorder=self._recorder, on_running=self._on_running),
                 files=files,
                 system_prompt=system,
                 skill_bodies=skill_bodies,
@@ -453,6 +500,8 @@ class LocalLiveDriver:
                 worker_fn=self._worker_fn,
                 max_output_tokens=self._doc.max_output_tokens(),
                 temperature=self._doc.temperature(),
+                cancel_active=self._executor.cancel,
+                reset_cancel=self._executor.reset_cancel,
             )
             session.start()
             _console.print(
@@ -510,6 +559,10 @@ class LocalLiveDriver:
 
     def _handle_sigint(self, session: live_session.LiveSession) -> None:
         """First Ctrl-C interrupts the current turn; a second ends the session."""
+        if session.status != "running":
+            self._interrupts = 0
+            _console.print("\n[yellow]no active turn (:quit to end)[/yellow]")
+            return
         self._interrupts += 1
         if self._interrupts == 1:
             _console.print("\n[yellow]interrupting (press Ctrl-C again to quit)[/yellow]")
@@ -517,6 +570,11 @@ class LocalLiveDriver:
         else:
             _console.print("\n[yellow]ending session[/yellow]")
             session.end()
+
+    def _on_running(self, running: bool) -> None:
+        """Reset Ctrl-C escalation once the interrupted turn reaches a non-running state."""
+        if not running:
+            self._interrupts = 0
 
     def _teardown(
         self,
@@ -664,6 +722,11 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         model_name = catalog[0]
     spec = resolve_provider_model(kind, model_name)
     use_configured_knobs = configured is not None and configured.provider == kind.value
+    deployment = configured.deployment if use_configured_knobs else None
+    api_version = configured.api_version if use_configured_knobs else None
+    if kind is ProviderKind.AZURE_OPENAI:
+        deployment = deployment or spec.model_type
+        api_version = api_version or DEFAULT_AZURE_API_VERSION
     built = provider_registry.get_provider(
         ProviderConfig(
             kind=kind,
@@ -671,8 +734,8 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
             model=spec.model_id,
             region=configured.region if use_configured_knobs else None,
             endpoint=configured.endpoint if use_configured_knobs else None,
-            deployment=configured.deployment if use_configured_knobs else None,
-            api_version=configured.api_version if use_configured_knobs else None,
+            deployment=deployment,
+            api_version=api_version,
         )
     )
     if not isinstance(built, ToolCallingProvider):

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -15,28 +15,43 @@ command used.
 
 from __future__ import annotations
 
+import codecs
 import contextlib
+import os
+import signal
 import subprocess
 import sys
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Protocol
+from typing import Annotated, BinaryIO, Protocol
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
+from rich.text import Text
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from wmo.common.core.types import JsonObject
-    from wmo.common.providers.base import ToolCallingProvider
-    from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
-    from wmo.runtime.harness.doc import HarnessDoc
-    from wmo.runtime.harness.live_session import LiveSession, SessionEvent, ToolOutcome
-    from wmo.runtime.harness.pi_local import LocalStdioChannel
-    from wmo.runtime.platform.client import PlatformClient
+import wmo.common.providers.registry as provider_registry
+import wmo.runtime.harness.live_session as live_session
+import wmo.runtime.harness.pi_local as pi_local
+import wmo.runtime.platform.client as platform_client
+import wmo.runtime.platform.credentials as platform_credentials
+from wmo.common.config import load_settings
+from wmo.common.core.types import JsonObject
+from wmo.common.providers.base import (
+    PreparableProvider,
+    ProviderConfig,
+    ProviderKind,
+    ToolCallingProvider,
+)
+from wmo.common.providers.models import model_types_for_provider, resolve_provider_model
+from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
+from wmo.runtime.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+from wmo.runtime.harness.live_session import SessionEvent, ToolOutcome
+from wmo.runtime.harness.pi_vendor import pi_agent_code_surfaces
+from wmo.runtime.harness.tools import READ_SKILL, resolve_tools
+from wmo.simulation.model.play import parse_action
 
 _console = Console()
 
@@ -51,12 +66,10 @@ class _JailEscape(RuntimeError):
     """A tool path resolved outside the session's working directory."""
 
 
-def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
+def _capped(content: str, *, is_error: bool = False, truncated: bool = False) -> ToolOutcome:
     """Cap tool output to the head+tail budget with a truncation marker."""
-    from wmo.runtime.harness.live_session import ToolOutcome
-
     if len(content) <= _TOOL_OUTPUT_CAP:
-        return ToolOutcome(content=content, is_error=is_error)
+        return ToolOutcome(content=content, is_error=is_error, truncated=truncated)
     half = _TOOL_OUTPUT_CAP // 2
     dropped = len(content) - _TOOL_OUTPUT_CAP
     capped = f"{content[:half]}\n... [{dropped} chars truncated] ...\n{content[-half:]}"
@@ -70,8 +83,6 @@ def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str
     the resolved tool specs, the code surfaces as {path: content} (the agent's own
     code, materialized into the local runner), and skill bodies answered host-side.
     """
-    from wmo.runtime.harness.tools import READ_SKILL, resolve_tools
-
     tool_names = doc.tools()
     if doc.skills() and READ_SKILL.name not in tool_names:
         tool_names.append(READ_SKILL.name)
@@ -90,9 +101,6 @@ def _pi_node_baseline() -> HarnessDoc:
     pi code surfaces on and pins ``param:runtime-kind = pi-node`` so a not-logged-in
     session has a runnable agent without fetching a champion.
     """
-    from wmo.runtime.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
-    from wmo.runtime.harness.pi_vendor import pi_agent_code_surfaces
-
     base = HarnessDoc.baseline("local-session")
     surfaces = [
         *base.surfaces,
@@ -122,8 +130,6 @@ class LocalToolExecutor:
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
     ) -> ToolOutcome:
         """Execute one tool call locally; a failure is an observation, not a crash."""
-        from wmo.runtime.harness.live_session import ToolOutcome
-
         try:
             if name == "bash":
                 return self._bash(str(args.get("command", "")), emit)
@@ -144,35 +150,147 @@ class LocalToolExecutor:
 
     def _bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
         """Run a fresh ``bash -lc`` in the jail root, streaming output to ``emit``."""
+        stdout_buffer = _BoundedTextBuffer(_TOOL_OUTPUT_CAP)
+        stderr_buffer = _BoundedTextBuffer(_TOOL_OUTPUT_CAP)
+        emit_lock = threading.Lock()
+        process = subprocess.Popen(  # noqa: S603 - the agent's tool intentionally runs commands
+            ["bash", "-lc", command],  # noqa: S607 - bash on PATH is the documented contract
+            cwd=self._jail,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        # PIPE guarantees both handles. Keep the guard for type narrowing and defensive failure.
+        if process.stdout is None or process.stderr is None:  # pragma: no cover
+            process.kill()
+            raise RuntimeError("bash process did not expose stdout and stderr")
+        readers = (
+            threading.Thread(
+                target=_drain_process_stream,
+                args=(process.stdout, "stdout", stdout_buffer, emit, emit_lock),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_drain_process_stream,
+                args=(process.stderr, "stderr", stderr_buffer, emit, emit_lock),
+                daemon=True,
+            ),
+        )
+        for reader in readers:
+            reader.start()
+        timed_out = False
         try:
-            result = subprocess.run(  # noqa: S603 - the agent's tool is meant to run shell commands
-                ["bash", "-lc", command],  # noqa: S607 - bash on PATH is the documented contract
-                cwd=self._jail,
-                capture_output=True,
-                text=True,
-                timeout=_BASH_TIMEOUT_S,
-                check=False,
-            )
-            stdout, stderr, exit_code = result.stdout, result.stderr, result.returncode
-        except subprocess.TimeoutExpired as error:
-            stdout = _as_text(error.stdout)
-            stderr = _as_text(error.stderr) + f"\n[timed out after {int(_BASH_TIMEOUT_S)}s]"
+            exit_code = process.wait(timeout=_BASH_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill_process_group(process)
             exit_code = 124
-        if stdout:
-            emit("stdout", stdout)
-        if stderr:
-            emit("stderr", stderr)
+        finally:
+            if process.poll() is None:
+                _kill_process_group(process)
+            process.wait()
+            for reader in readers:
+                reader.join()
+            process.stdout.close()
+            process.stderr.close()
+
+        if timed_out:
+            note = f"\n[timed out after {_BASH_TIMEOUT_S:g}s]"
+            stderr_buffer.append(note)
+            _emit_safely(emit, emit_lock, "stderr", note)
+        stdout = stdout_buffer.render()
+        stderr = stderr_buffer.render()
         body = stdout + stderr
         if exit_code != 0:
             body = f"{body}\n[exit {exit_code}]"
-        return _capped(body, is_error=exit_code != 0)
+        return _capped(
+            body,
+            is_error=exit_code != 0,
+            truncated=stdout_buffer.truncated or stderr_buffer.truncated,
+        )
 
 
-def _as_text(value: object) -> str:
-    """Coerce subprocess stdout/stderr (str | bytes | None) to text."""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return value if isinstance(value, str) else ""
+class _BoundedTextBuffer:
+    """Keep only the head and tail of one process stream in bounded memory."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._head_limit = limit // 2
+        self._tail_limit = limit - self._head_limit
+        self._head = ""
+        self._tail = ""
+        self._total = 0
+
+    @property
+    def truncated(self) -> bool:
+        return self._total > self._limit
+
+    def append(self, chunk: str) -> None:
+        """Record a chunk without retaining more than ``limit`` characters."""
+        if not chunk:
+            return
+        self._total += len(chunk)
+        head_room = self._head_limit - len(self._head)
+        if head_room > 0:
+            self._head += chunk[:head_room]
+            chunk = chunk[head_room:]
+        if chunk and self._tail_limit:
+            self._tail = (self._tail + chunk)[-self._tail_limit :]
+
+    def render(self) -> str:
+        """Return the complete stream or a fixed-size head/tail rendering."""
+        if not self.truncated:
+            return self._head + self._tail
+        dropped = self._total - self._limit
+        marker = f"\n... [{dropped} chars truncated] ...\n"
+        payload = max(0, self._limit - len(marker))
+        head_size = payload // 2
+        tail_size = payload - head_size
+        return self._head[:head_size] + marker + self._tail[-tail_size:]
+
+
+def _drain_process_stream(
+    stream: BinaryIO,
+    stream_name: str,
+    output: _BoundedTextBuffer,
+    emit: Callable[[str, str], None],
+    emit_lock: threading.Lock,
+) -> None:
+    """Drain a byte pipe in small chunks while retaining only bounded decoded text."""
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    while chunk := stream.read(4096):
+        text = decoder.decode(chunk)
+        output.append(text)
+        _emit_safely(emit, emit_lock, stream_name, text)
+    tail = decoder.decode(b"", final=True)
+    output.append(tail)
+    _emit_safely(emit, emit_lock, stream_name, tail)
+
+
+def _emit_safely(
+    emit: Callable[[str, str], None],
+    lock: threading.Lock,
+    stream: str,
+    chunk: str,
+) -> None:
+    """Serialize the two pipe-reader callbacks and keep draining if a sink fails."""
+    if not chunk:
+        return
+    with lock, contextlib.suppress(Exception):
+        emit(stream, chunk)
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+    """Kill bash and its descendants so a timed-out pipeline cannot retain the pipes."""
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        # Some app sandboxes allow setsid but deny killpg. Killing the group leader still
+        # terminates the ordinary single-command path and keeps timeout handling functional.
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
 
 
 class RunRecorder(Protocol):
@@ -188,7 +306,7 @@ class RunRecorder(Protocol):
 class LocalPiRunRecorder:
     """Finish and close an org-scoped built-in pi run; it has no transcript."""
 
-    def __init__(self, client: PlatformClient, org_id: str, run_id: str) -> None:
+    def __init__(self, client: platform_client.PlatformClient, org_id: str, run_id: str) -> None:
         self._client = client
         self._org_id = org_id
         self._run_id = run_id
@@ -202,10 +320,8 @@ class LocalPiRunRecorder:
 
     def finish(self, *, ended_reason: str, error: str | None) -> None:
         """Report the terminal state and release the HTTP client."""
-        from wmo.runtime.platform.client import PlatformError
-
         status = "failed" if error is not None else "ended"
-        with contextlib.suppress(PlatformError):
+        with contextlib.suppress(platform_client.PlatformError):
             self._client.finish_local_pi_run(
                 self._org_id,
                 self._run_id,
@@ -241,28 +357,31 @@ class TerminalEventSink:
         if event.kind == "assistant_message":
             text = str(payload.get("text", ""))
             if text:
-                _console.print(f"\n[bold cyan]agent[/bold cyan] {text}")
+                _console.print(Text.assemble("\n", ("agent", "bold cyan"), " ", text))
         elif event.kind == "tool_call":
-            _console.print(f"[dim]$ {payload.get('name', '')} {payload.get('arguments', '')}[/dim]")
+            call = f"$ {payload.get('name', '')} {payload.get('arguments', '')}"
+            _console.print(Text(call, style="dim"))
         elif event.kind == "tool_output":
             _console.print(str(payload.get("text", "")), end="", markup=False, highlight=False)
         elif event.kind == "tool_result":
             if payload.get("is_error"):
-                _console.print(f"[red]{payload.get('content', '')}[/red]")
+                _console.print(Text(str(payload.get("content", "")), style="red"))
         elif event.kind == "submit":
-            _console.print(f"\n[bold green]submitted[/bold green] {payload.get('answer', '')}")
+            answer = str(payload.get("answer", ""))
+            _console.print(Text.assemble("\n", ("submitted", "bold green"), " ", answer))
         elif event.kind == "state":
             status = str(payload.get("status", ""))
             self._on_running(status == "running")
-            _console.print(f"[dim]({status})[/dim]")
+            _console.print(Text(f"({status})", style="dim"))
         elif event.kind == "error":
-            _console.print(f"[red]error: {payload.get('message', '')}[/red]")
+            message = str(payload.get("message", ""))
+            _console.print(Text(f"error: {message}", style="red"))
 
 
 class StdinCommandReader(threading.Thread):
     """Feed typed stdin lines as steer/interrupt/end intents to the session."""
 
-    def __init__(self, session: LiveSession) -> None:
+    def __init__(self, session: live_session.LiveSession) -> None:
         """Read stdin on a daemon thread; the session's intents are thread-safe."""
         super().__init__(daemon=True)
         self._session = session
@@ -307,23 +426,20 @@ class LocalLiveDriver:
         self._recorder = recorder
         self._instruction = instruction
         self._executor = LocalToolExecutor(jail_root)
-        self._channel: LocalStdioChannel | None = None
+        self._channel: pi_local.LocalStdioChannel | None = None
         self._interrupts = 0
 
     def run(self) -> None:
         """Boot the local runner, drive the session, and always tear down."""
-        from wmo.runtime.harness.live_session import LiveSession
-        from wmo.runtime.harness.pi_local import start_local_live_runner
-
         system, tool_specs, files, skill_bodies = _assemble(self._doc)
         _console.print("[dim]starting the built-in pi harness locally...[/dim]")
-        session: LiveSession | None = None
+        session: live_session.LiveSession | None = None
         reason = "user_ended"
         error: str | None = None
         try:
-            channel = start_local_live_runner()
+            channel = pi_local.start_local_live_runner()
             self._channel = channel
-            session = LiveSession(
+            session = live_session.LiveSession(
                 channel,
                 tools=tool_specs,
                 execute_tool=self._execute,
@@ -356,7 +472,7 @@ class LocalLiveDriver:
         except Exception as exc:  # noqa: BLE001 - report any driver failure, then tear down
             error = str(exc)
             reason = "error"
-            _console.print(f"[red]session failed: {exc}[/red]")
+            _console.print(Text(f"session failed: {exc}", style="red"))
         finally:
             self._teardown(session, reason=reason, error=error)
         if error is not None:
@@ -368,7 +484,7 @@ class LocalLiveDriver:
         """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
-    def _loop(self, session: LiveSession, stdin_eof: threading.Event) -> None:
+    def _loop(self, session: live_session.LiveSession, stdin_eof: threading.Event) -> None:
         """Pump until closed, treating closed stdin as one-shot after ``--task``."""
         last_tick = 0.0
         saw_running = False
@@ -392,7 +508,7 @@ class LocalLiveDriver:
                 if self._recorder is not None:
                     self._recorder.flush()
 
-    def _handle_sigint(self, session: LiveSession) -> None:
+    def _handle_sigint(self, session: live_session.LiveSession) -> None:
         """First Ctrl-C interrupts the current turn; a second ends the session."""
         self._interrupts += 1
         if self._interrupts == 1:
@@ -402,7 +518,13 @@ class LocalLiveDriver:
             _console.print("\n[yellow]ending session[/yellow]")
             session.end()
 
-    def _teardown(self, session: LiveSession | None, *, reason: str, error: str | None) -> None:
+    def _teardown(
+        self,
+        session: live_session.LiveSession | None,
+        *,
+        reason: str,
+        error: str | None,
+    ) -> None:
         if session is not None and not session.closed:
             with contextlib.suppress(Exception):
                 session.end()
@@ -417,7 +539,13 @@ class LocalLiveDriver:
 class RemoteWorldModelDriver:
     """Interactive terminal loop over the platform's world-model session API."""
 
-    def __init__(self, client: PlatformClient, target_id: str, name: str, task: str | None) -> None:
+    def __init__(
+        self,
+        client: platform_client.PlatformClient,
+        target_id: str,
+        name: str,
+        task: str | None,
+    ) -> None:
         """Store the resolved target and opening task."""
         self._client = client
         self._target_id = target_id
@@ -426,30 +554,25 @@ class RemoteWorldModelDriver:
 
     def run(self) -> None:
         """Create one hosted session and step it until the user exits."""
-        from wmo.runtime.platform.client import PlatformError
-
         try:
             session = self._client.create_world_model_session(self._target_id, task=self._task)
             _console.print(
                 Panel(
                     'Type an action such as [cyan]search {"q": "SFO"}[/cyan], '
                     "or a free-text message. Commands: [cyan]:help[/cyan], [cyan]:quit[/cyan].",
-                    title=f"[bold]running world model[/bold] {self._name}",
-                    subtitle=f"task: {self._task}" if self._task else "no task set",
+                    title=Text.assemble(("running world model", "bold"), " ", self._name),
+                    subtitle=Text(f"task: {self._task}" if self._task else "no task set"),
                     border_style="cyan",
                 )
             )
             self._loop(session.id)
-        except PlatformError as error:
+        except platform_client.PlatformError as error:
             raise typer.BadParameter(str(error)) from error
         finally:
             self._client.close()
 
     def _loop(self, session_id: str) -> None:
         """Read actions and render hosted observations."""
-        from wmo.runtime.platform.client import PlatformError
-        from wmo.simulation.model.play import parse_action
-
         while True:
             try:
                 line = _console.input("[bold]agent>[/bold] ").strip()
@@ -476,19 +599,21 @@ class RemoteWorldModelDriver:
             try:
                 action = parse_action(line)
             except ValueError as error:
-                _console.print(f"[red]parse error[/red]: {error}")
+                _console.print(Text(f"parse error: {error}", style="red"))
                 continue
             try:
                 with _console.status("[dim]world model thinking...[/dim]", spinner="dots"):
                     observation = self._client.step_world_model_session(session_id, action)
-            except PlatformError as error:
-                _console.print(f"[red]step failed[/red]: {error}")
+            except platform_client.PlatformError as error:
+                _console.print(Text(f"step failed: {error}", style="red"))
                 continue
             style = "red" if observation.is_error else "green"
             title = "error" if observation.is_error else "observation"
             _console.print(
                 Panel(
-                    observation.content or "[dim](empty)[/dim]",
+                    Text(observation.content)
+                    if observation.content
+                    else Text("(empty)", style="dim"),
                     title=title,
                     border_style=style,
                 )
@@ -512,16 +637,6 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         typer.BadParameter: The provider name is unknown, the model cannot do tool calling, or
             the backend cannot be prepared. Every message names `wmo providers set`.
     """
-    from wmo.common.config import load_settings
-    from wmo.common.providers.base import (
-        PreparableProvider,
-        ProviderConfig,
-        ProviderKind,
-        ToolCallingProvider,
-    )
-    from wmo.common.providers.models import model_types_for_provider, resolve_provider_model
-    from wmo.common.providers.registry import get_provider
-
     configured = load_settings().models.resolve("worker")
     provider_name = provider or (
         configured.provider if configured is not None else _DEFAULT_PROVIDER
@@ -549,7 +664,7 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         model_name = catalog[0]
     spec = resolve_provider_model(kind, model_name)
     use_configured_knobs = configured is not None and configured.provider == kind.value
-    built = get_provider(
+    built = provider_registry.get_provider(
         ProviderConfig(
             kind=kind,
             model_type=spec.model_type,
@@ -570,7 +685,7 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
     source = "settings models.worker" if configured is not None else "built-in default"
     if provider is not None or model is not None:
         source = "--provider/--model"
-    _console.print(f"[dim]worker: {kind.value}/{spec.model_id} ({source})[/dim]")
+    _console.print(Text(f"worker: {kind.value}/{spec.model_id} ({source})", style="dim"))
     if isinstance(built, PreparableProvider):
         try:
             built.prepare()
@@ -671,10 +786,7 @@ def _build_driver(
     confirm_local: Callable[[], None] | None = None,
 ) -> LocalLiveDriver | RemoteWorldModelDriver:
     """Resolve the execution kind once and assemble its driver."""
-    from wmo.runtime.platform.client import PlatformClient, PlatformError
-    from wmo.runtime.platform.credentials import load_credentials
-
-    credentials = load_credentials()
+    credentials = platform_credentials.load_credentials()
     logged_in = credentials.is_complete()
 
     if target is None:
@@ -702,14 +814,14 @@ def _build_driver(
             )
         if confirm_local is not None:
             confirm_local()
-        client = PlatformClient(str(credentials.api_url), str(credentials.token))
+        client = platform_client.PlatformClient(str(credentials.api_url), str(credentials.token))
         try:
             org_id = _default_org(client, credentials.default_org)
             run = client.create_local_pi_run(org_id)
         except typer.BadParameter:
             client.close()
             raise
-        except PlatformError as error:
+        except platform_client.PlatformError as error:
             client.close()
             raise typer.BadParameter(str(error)) from error
         recorder = LocalPiRunRecorder(client, org_id, run.id)
@@ -735,7 +847,7 @@ def _build_driver(
             "platform target runs use platform credentials; --provider/--model are not accepted"
         )
 
-    client = PlatformClient(str(credentials.api_url), str(credentials.token))
+    client = platform_client.PlatformClient(str(credentials.api_url), str(credentials.token))
     try:
         resolved = client.resolve_run_target(target)
         if resolved.kind == "world_model":
@@ -745,12 +857,12 @@ def _build_driver(
             "hosted agent sessions are unavailable because the platform no longer exposes "
             "their session API; omit the id to run the built-in pi harness locally"
         )
-    except PlatformError as error:
+    except platform_client.PlatformError as error:
         client.close()
         raise typer.BadParameter(str(error)) from error
 
 
-def _default_org(client: PlatformClient, configured: str | None) -> str:
+def _default_org(client: platform_client.PlatformClient, configured: str | None) -> str:
     """Resolve the login's organization, auto-picking only an unambiguous sole org."""
     if configured is not None:
         return configured

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -52,7 +52,7 @@ from wmo.runtime.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, Surfac
 from wmo.runtime.harness.live_session import SessionEvent, ToolOutcome
 from wmo.runtime.harness.pi_vendor import pi_agent_code_surfaces
 from wmo.runtime.harness.runner_link import provider_context_window
-from wmo.runtime.harness.tools import READ_SKILL, resolve_tools
+from wmo.runtime.harness.tools import READ_SKILL, ToolSpec, resolve_tools
 from wmo.simulation.model.play import parse_action
 
 _console = Console()
@@ -79,7 +79,7 @@ def _capped(content: str, *, is_error: bool = False, truncated: bool = False) ->
     return ToolOutcome(content=capped, is_error=is_error, truncated=True)
 
 
-def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str]]:
+def _assemble(doc: HarnessDoc) -> tuple[str, list[ToolSpec], dict[str, str], dict[str, str]]:
     """Derive the LiveSession inputs from a HarnessDoc (mirrors the hosted driver).
 
     Returns the assembled system prompt (prompt + rendered tools + skills index),
@@ -476,6 +476,7 @@ class StdinCommandReader(threading.Thread):
         """Read stdin on a daemon thread; the session's intents are thread-safe."""
         super().__init__(daemon=True)
         self._session = session
+        self.last_message_id: str | None = None
         self.eof = threading.Event()
 
     def run(self) -> None:
@@ -490,7 +491,7 @@ class StdinCommandReader(threading.Thread):
             if line == ":stop":
                 self._session.interrupt()
             elif line:
-                self._session.send_user_message(line)
+                self.last_message_id = self._session.send_user_message(line)
         # The driver owns EOF handling. It must wait until any submitted turn
         # returns to idle before ending the session.
         self.eof.set()
@@ -553,12 +554,12 @@ class LocalLiveDriver:
                 "[green]session ready[/green] - type to steer, [bold]:stop[/bold] to interrupt, "
                 "[bold]:quit[/bold] to end."
             )
+            opening_message_id = None
             if self._instruction:
-                session.send_user_message(self._instruction)
+                opening_message_id = session.send_user_message(self._instruction)
             reader = StdinCommandReader(session)
             reader.start()
-            stdin_eof = getattr(reader, "eof", threading.Event())
-            self._loop(session, stdin_eof)
+            self._loop(session, reader, opening_message_id)
             if session.status == "failed":
                 error = "local live session runner failed"
                 reason = "error"
@@ -578,7 +579,12 @@ class LocalLiveDriver:
         """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
-    def _loop(self, session: live_session.LiveSession, stdin_eof: threading.Event) -> None:
+    def _loop(
+        self,
+        session: live_session.LiveSession,
+        reader: StdinCommandReader,
+        opening_message_id: str | None,
+    ) -> None:
         """Pump until closed, treating closed stdin as one-shot after the final turn."""
         last_tick = 0.0
         end_sent = False
@@ -587,11 +593,17 @@ class LocalLiveDriver:
                 session.pump(timeout=0.5)
             except KeyboardInterrupt:
                 self._handle_sigint(session)
-            if stdin_eof.is_set() and not end_sent:
+            if reader.eof.is_set() and not end_sent:
                 # EOF is published only after the reader queues its final message. Drain any
-                # message that raced with the frame just received, then wait for its idle boundary.
+                # message that raced with the frame just received, then require the peer's idle
+                # acknowledgement for the final message rather than accepting a stale idle frame.
                 session.flush_pending_intents()
-                if session.status == "idle" and not session.turn_active:
+                final_message_id = reader.last_message_id or opening_message_id
+                final_turn_completed = (
+                    final_message_id is None
+                    or session.last_completed_message_id == final_message_id
+                )
+                if session.status == "idle" and final_turn_completed:
                     session.end()
                     end_sent = True
             now = time.monotonic()

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -666,9 +666,9 @@ def _build_driver(
     if target is None:
         if jail_root is None:
             raise typer.BadParameter("a working directory is required for the built-in pi harness")
-        if confirm_local is not None:
-            confirm_local()
         if not logged_in:
+            if confirm_local is not None:
+                confirm_local()
             _console.print(
                 "[dim]not logged in: running the built-in baseline agent with local "
                 "credentials[/dim]"
@@ -686,6 +686,8 @@ def _build_driver(
                 "logged-in runs use platform credentials; omit --provider/--model, "
                 "or run wmo logout to use local credentials"
             )
+        if confirm_local is not None:
+            confirm_local()
         client = PlatformClient(str(credentials.api_url), str(credentials.token))
         try:
             org_id = _default_org(client, credentials.default_org)

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -58,6 +58,7 @@ _console = Console()
 
 _TOOL_OUTPUT_CAP = 16_000
 _BASH_TIMEOUT_S = 300.0
+_PIPE_DRAIN_TIMEOUT_S = 0.25
 _TICK_S = 5.0
 _DEFAULT_PROVIDER = "bedrock"
 _DEFAULT_MODEL = "claude-opus-4-8"
@@ -186,15 +187,30 @@ class LocalToolExecutor:
             self._active_process = process
         if self._cancelled.is_set():
             _kill_process_group(process)
+        reader_stop = threading.Event()
         readers = (
             threading.Thread(
                 target=_drain_process_stream,
-                args=(process.stdout, "stdout", stdout_buffer, emit, emit_lock),
+                args=(
+                    process.stdout,
+                    "stdout",
+                    stdout_buffer,
+                    emit,
+                    emit_lock,
+                    reader_stop,
+                ),
                 daemon=True,
             ),
             threading.Thread(
                 target=_drain_process_stream,
-                args=(process.stderr, "stderr", stderr_buffer, emit, emit_lock),
+                args=(
+                    process.stderr,
+                    "stderr",
+                    stderr_buffer,
+                    emit,
+                    emit_lock,
+                    reader_stop,
+                ),
                 daemon=True,
             ),
         )
@@ -215,10 +231,17 @@ class LocalToolExecutor:
             # Re-signal after the leader exits so no just-forked descendant retains the pipes.
             if timed_out or self._cancelled.is_set():
                 _kill_process_group(process)
-            for reader in readers:
-                reader.join()
-            process.stdout.close()
-            process.stderr.close()
+            readers_stopped = _join_process_readers(readers, _PIPE_DRAIN_TIMEOUT_S)
+            if not readers_stopped:
+                # A background child can outlive bash while inheriting its stdout/stderr. Do not
+                # let that keep the tool call open: kill the exact process group, then ask the
+                # nonblocking readers to stop even if a detached descendant still owns a pipe.
+                _kill_process_group(process)
+                reader_stop.set()
+                readers_stopped = _join_process_readers(readers, _PIPE_DRAIN_TIMEOUT_S)
+            if readers_stopped:
+                process.stdout.close()
+                process.stderr.close()
             with self._process_lock:
                 if self._active_process is process:
                     self._active_process = None
@@ -286,17 +309,35 @@ def _drain_process_stream(
     output: _BoundedTextBuffer,
     emit: Callable[[str, str], None],
     emit_lock: threading.Lock,
+    stop: threading.Event,
 ) -> None:
-    """Drain a byte pipe in small chunks while retaining only bounded decoded text."""
+    """Drain a byte pipe without blocking forever on a descendant that inherited it."""
     decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
-    read: Callable[[int], bytes] = getattr(stream, "read1", stream.read)
-    while chunk := read(4096):
-        text = decoder.decode(chunk)
-        output.append(text)
-        _emit_safely(emit, emit_lock, stream_name, text)
+    os.set_blocking(stream.fileno(), False)
+    while not stop.is_set():
+        try:
+            chunk = os.read(stream.fileno(), 4096)
+        except BlockingIOError:
+            stop.wait(0.01)
+            continue
+        except OSError:
+            break
+        if not chunk:
+            break
+        decoded = decoder.decode(chunk)
+        output.append(decoded)
+        _emit_safely(emit, emit_lock, stream_name, decoded)
     tail = decoder.decode(b"", final=True)
     output.append(tail)
     _emit_safely(emit, emit_lock, stream_name, tail)
+
+
+def _join_process_readers(readers: tuple[threading.Thread, ...], timeout: float) -> bool:
+    """Give all pipe readers one shared bounded interval to finish."""
+    deadline = time.monotonic() + timeout
+    for reader in readers:
+        reader.join(timeout=max(0.0, deadline - time.monotonic()))
+    return not any(reader.is_alive() for reader in readers)
 
 
 def _emit_safely(
@@ -725,6 +766,27 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
     deployment = configured.deployment if use_configured_knobs else None
     api_version = configured.api_version if use_configured_knobs else None
     if kind is ProviderKind.AZURE_OPENAI:
+        configured_spec = (
+            resolve_provider_model(kind, configured.model) if use_configured_knobs else None
+        )
+        model_changed = (
+            model is not None
+            and configured_spec is not None
+            and configured_spec.model_id != spec.model_id
+        )
+        if (
+            model_changed
+            and configured is not None
+            and deployment is not None
+            and deployment not in (spec.model_type, spec.model_id)
+        ):
+            raise typer.BadParameter(
+                f"the configured azure worker serves {configured.model} from deployment "
+                f"{deployment!r}, and on Azure the deployment name is what is actually invoked, "
+                f"so --model {spec.model_type} needs the deployment that serves it. Run "
+                f"`wmo providers set --provider azure --model {spec.model_type} "
+                f"--deployment <deployment>` to point the worker role at it."
+            )
         deployment = deployment or spec.model_type
         api_version = api_version or DEFAULT_AZURE_API_VERSION
     built = provider_registry.get_provider(

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -476,6 +476,7 @@ class StdinCommandReader(threading.Thread):
         """Read stdin on a daemon thread; the session's intents are thread-safe."""
         super().__init__(daemon=True)
         self._session = session
+        self.submitted = threading.Event()
         self.eof = threading.Event()
 
     def run(self) -> None:
@@ -491,8 +492,9 @@ class StdinCommandReader(threading.Thread):
                 self._session.interrupt()
             elif line:
                 self._session.send_user_message(line)
-        # The driver owns EOF handling. For a one-shot ``--task`` it must wait
-        # until the opening turn returns to idle before ending the session.
+                self.submitted.set()
+        # The driver owns EOF handling. It must wait until any submitted turn
+        # returns to idle before ending the session.
         self.eof.set()
 
 
@@ -558,7 +560,8 @@ class LocalLiveDriver:
             reader = StdinCommandReader(session)
             reader.start()
             stdin_eof = getattr(reader, "eof", threading.Event())
-            self._loop(session, stdin_eof)
+            stdin_submitted = getattr(reader, "submitted", threading.Event())
+            self._loop(session, stdin_eof, stdin_submitted)
             if session.status == "failed":
                 error = "local live session runner failed"
                 reason = "error"
@@ -578,8 +581,14 @@ class LocalLiveDriver:
         """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
-    def _loop(self, session: live_session.LiveSession, stdin_eof: threading.Event) -> None:
-        """Pump until closed, treating closed stdin as one-shot after ``--task``."""
+    def _loop(
+        self,
+        session: live_session.LiveSession,
+        stdin_eof: threading.Event,
+        stdin_submitted: threading.Event | None = None,
+    ) -> None:
+        """Pump until closed, treating closed stdin as one-shot after the final turn."""
+        stdin_submitted = stdin_submitted or threading.Event()
         last_tick = 0.0
         saw_running = False
         end_sent = False
@@ -592,7 +601,10 @@ class LocalLiveDriver:
             if (
                 stdin_eof.is_set()
                 and not end_sent
-                and (self._instruction is None or (saw_running and session.status == "idle"))
+                and (
+                    (self._instruction is None and not stdin_submitted.is_set())
+                    or (saw_running and session.status == "idle")
+                )
             ):
                 session.end()
                 end_sent = True

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -774,6 +774,30 @@ class _FakeReader:
         pass
 
 
+def test_stdin_reader_marks_a_piped_turn_before_eof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Session:
+        closed = False
+
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def send_user_message(self, text: str) -> str:
+            self.messages.append(text)
+            return "msg-1"
+
+    session = _Session()
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO("fix the tests\n"))
+    reader = mod.StdinCommandReader(cast("mod.live_session.LiveSession", session))
+
+    reader.run()
+
+    assert session.messages == ["fix the tests"]
+    assert reader.submitted.is_set()
+    assert reader.eof.is_set()
+
+
 def _patch_driver_boundaries(
     monkeypatch: pytest.MonkeyPatch,
     channel: _FakeChannel,
@@ -842,6 +866,52 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
     driver._loop(cast("mod.live_session.LiveSession", session), stdin_eof)
 
     assert driver._instruction is None
+    assert session.ends == 1
+
+
+def test_local_driver_waits_for_a_piped_turn_to_return_idle_at_eof() -> None:
+    class _PipedTurnSession:
+        def __init__(self) -> None:
+            self.closed = False
+            self.status = "idle"
+            self.pumps = 0
+            self.ends = 0
+
+        def pump(self, timeout: float = 0.2) -> bool:
+            _ = timeout
+            self.pumps += 1
+            assert self.pumps <= 3, "the piped turn must end after returning to idle"
+            if self.pumps == 2:
+                self.status = "running"
+            elif self.pumps == 3:
+                self.status = "idle"
+            return True
+
+        def end(self) -> None:
+            self.ends += 1
+            self.closed = True
+
+    driver = mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=HarnessDoc.baseline("test"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction=None,
+    )
+    session = _PipedTurnSession()
+    stdin_eof = threading.Event()
+    stdin_eof.set()
+    stdin_submitted = threading.Event()
+    stdin_submitted.set()
+
+    driver._loop(
+        cast("mod.live_session.LiveSession", session),
+        stdin_eof,
+        stdin_submitted,
+    )
+
+    assert session.pumps == 3
     assert session.ends == 1
 
 

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -350,6 +350,29 @@ def test_platform_target_rejects_local_provider_before_resolution(
         )
 
 
+def test_logged_in_bare_run_rejects_local_provider_before_consent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        lambda: credentials,
+    )
+    prompted: list[bool] = []
+
+    with pytest.raises(typer.BadParameter, match="logged-in runs use platform credentials"):
+        mod._build_driver(
+            target=None,
+            jail_root=Path.cwd(),
+            provider="openai",
+            model=None,
+            task=None,
+            confirm_local=lambda: prompted.append(True),
+        )
+
+    assert prompted == []
+
+
 def test_run_command_dispatches_bare_path_after_consent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -112,6 +112,21 @@ def test_executor_bash_kills_the_process_group_on_timeout(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
+def test_executor_bash_does_not_wait_for_a_background_child_holding_its_pipes(
+    tmp_path: Path,
+) -> None:
+    started = time.monotonic()
+
+    result = mod.LocalToolExecutor(tmp_path)(
+        "bash", {"command": "sleep 5 & printf done"}, _noop_emit
+    )
+
+    assert time.monotonic() - started < 2
+    assert not result.is_error
+    assert result.content == "done"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
 def test_executor_cancel_stops_an_active_bash_command(tmp_path: Path) -> None:
     executor = mod.LocalToolExecutor(tmp_path)
     started = threading.Event()
@@ -365,6 +380,50 @@ def test_build_driver_azure_override_supplies_required_azure_defaults(
     assert config.model == "gpt-5.5"
     assert config.deployment == "gpt-5.5"
     assert config.api_version == mod.DEFAULT_AZURE_API_VERSION
+
+
+def test_build_driver_azure_model_override_rejects_a_stale_configured_deployment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                worker=ModelRole(
+                    provider="azure",
+                    model="gpt-5.4",
+                    endpoint="https://azure.example/v1",
+                    deployment="prod-54-canary",
+                )
+            )
+        ),
+        tmp_path / ".wmo",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    configs: list[ProviderConfig] = []
+    monkeypatch.setattr(
+        "wmo.common.providers.registry.get_provider",
+        lambda config: configs.append(config) or _FakeProvider(),
+    )
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        mod._build_driver(
+            target=None,
+            jail_root=tmp_path,
+            provider=None,
+            model="gpt-5.5",
+            task=None,
+        )
+
+    assert "prod-54-canary" in str(excinfo.value)
+    assert "wmo providers set --provider azure --model gpt-5.5 --deployment <deployment>" in str(
+        excinfo.value
+    )
+    assert configs == []
 
 
 def test_build_driver_logged_in_bare_run_uses_platform_proxy(

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -768,6 +768,7 @@ class _FakeReader:
     """A stdin reader that never touches stdin."""
 
     def __init__(self, _session: object) -> None:
+        self.last_message_id: str | None = None
         self.eof = threading.Event()
 
     def start(self) -> None:
@@ -794,6 +795,7 @@ def test_stdin_reader_queues_a_piped_turn_before_eof(
     reader.run()
 
     assert session.messages == ["fix the tests"]
+    assert reader.last_message_id == "msg-1"
     assert reader.eof.is_set()
 
 
@@ -837,7 +839,7 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
         def __init__(self) -> None:
             self.closed = False
             self.status = "idle"
-            self.turn_active = False
+            self.last_completed_message_id: str | None = None
             self.pumps = 0
             self.ends = 0
 
@@ -863,24 +865,30 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
         instruction="",
     )
     session = _IdleSession()
-    stdin_eof = threading.Event()
-    stdin_eof.set()
+    reader = _FakeReader(None)
+    reader.eof.set()
 
-    driver._loop(cast("mod.live_session.LiveSession", session), stdin_eof)
+    driver._loop(
+        cast("mod.live_session.LiveSession", session),
+        cast("mod.StdinCommandReader", reader),
+        None,
+    )
 
     assert driver._instruction is None
     assert session.ends == 1
 
 
 def test_local_driver_drains_a_delayed_piped_turn_before_eof_shutdown() -> None:
-    stdin_eof = threading.Event()
+    reader = _FakeReader(None)
+    reader.last_message_id = "second"
+    reader.eof.set()
 
     class _DelayedPipedTurnSession:
         def __init__(self) -> None:
             self.closed = False
             self.status = "running"
-            self.turn_active = True
-            self.pending_messages = 0
+            self.last_completed_message_id: str | None = None
+            self.pending_messages = 1
             self.pumps = 0
             self.flushes = 0
             self.ends = 0
@@ -890,24 +898,20 @@ def test_local_driver_drains_a_delayed_piped_turn_before_eof_shutdown() -> None:
             self.pumps += 1
             assert self.pumps <= 3, "the piped turn must end after returning to idle"
             if self.pumps == 1:
-                # The reader queues a second line after this pump drained intents but before it
-                # receives the first turn's idle frame, then publishes EOF.
-                self.pending_messages = 1
-                stdin_eof.set()
+                # This pump drains and sends the second line, then consumes the already-buffered
+                # idle frame for the first line. Only the message id distinguishes that stale idle.
+                self.pending_messages = 0
                 self.status = "idle"
-                self.turn_active = False
+                self.last_completed_message_id = "first"
             elif self.pumps == 2:
                 self.status = "running"
             elif self.pumps == 3:
                 self.status = "idle"
-                self.turn_active = False
+                self.last_completed_message_id = "second"
             return True
 
         def flush_pending_intents(self) -> None:
             self.flushes += 1
-            if self.pending_messages:
-                self.pending_messages = 0
-                self.turn_active = True
 
         def end(self) -> None:
             self.ends += 1
@@ -923,7 +927,11 @@ def test_local_driver_drains_a_delayed_piped_turn_before_eof_shutdown() -> None:
     )
     session = _DelayedPipedTurnSession()
 
-    driver._loop(cast("mod.live_session.LiveSession", session), stdin_eof)
+    driver._loop(
+        cast("mod.live_session.LiveSession", session),
+        cast("mod.StdinCommandReader", reader),
+        None,
+    )
 
     assert session.pumps == 3
     assert session.flushes == 3

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -61,6 +61,42 @@ def test_executor_reads_writes_and_jails(tmp_path: Path) -> None:
     assert absolute.is_error
 
 
+def test_executor_cancel_wins_the_race_before_a_file_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = mod.LocalToolExecutor(tmp_path)
+    resolved = threading.Event()
+    release = threading.Event()
+    outcomes: list[mod.ToolOutcome] = []
+    original_resolve = executor._resolve
+
+    def pause_after_initial_cancel_check(path: str) -> Path:
+        target = original_resolve(path)
+        resolved.set()
+        release.wait(timeout=2)
+        return target
+
+    monkeypatch.setattr(executor, "_resolve", pause_after_initial_cancel_check)
+    thread = threading.Thread(
+        target=lambda: outcomes.append(
+            executor("write_file", {"path": "sub/race.txt", "content": "stale"}, _noop_emit)
+        )
+    )
+    thread.start()
+    assert resolved.wait(1)
+
+    executor.cancel()
+    release.set()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    [result] = outcomes
+    assert result.is_error
+    assert result.content == "interrupted"
+    assert not (tmp_path / "sub").exists()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
 def test_executor_bash_runs_in_jail_and_reports_exit(tmp_path: Path) -> None:
     executor = mod.LocalToolExecutor(tmp_path)

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -214,6 +214,43 @@ def test_build_driver_uses_configured_local_worker(
     assert config.model == "gpt-5.4-mini"
 
 
+def test_build_driver_provider_override_uses_the_new_providers_default_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="bedrock", model="claude-sonnet-4-6"))
+        ),
+        tmp_path / ".wmo",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    configs: list[ProviderConfig] = []
+
+    def get_provider(config: ProviderConfig) -> _FakeProvider:
+        configs.append(config)
+        return _FakeProvider()
+
+    monkeypatch.setattr("wmo.common.providers.registry.get_provider", get_provider)
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=tmp_path,
+        provider="openai",
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    [config] = configs
+    assert config.kind is ProviderKind.OPENAI
+    assert config.model == "gpt-5.6-sol"
+
+
 def test_build_driver_logged_in_bare_run_uses_platform_proxy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -740,6 +740,22 @@ def test_run_command_dispatches_bare_path_after_consent(
     assert "THIS machine" in result.output
 
 
+def test_local_consent_renders_the_jail_path_literally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    jail = tmp_path / "[" / "items]"
+    jail.mkdir(parents=True)
+    console = Console(file=io.StringIO(), width=200, color_system=None)
+    monkeypatch.setattr(mod, "_console", console)
+
+    mod._confirm_local_execution(jail, yes=True)
+
+    output = cast("io.StringIO", console.file).getvalue()
+    assert str(jail) in output
+    assert "THIS machine" in output
+
+
 def test_run_command_rejects_a_directory_for_platform_target(tmp_path: Path) -> None:
     result = CliRunner().invoke(app, ["run", "wm-1", "--dir", str(tmp_path)])
 
@@ -1008,7 +1024,8 @@ def test_local_driver_drains_a_delayed_piped_turn_before_eof_shutdown() -> None:
 
 def test_ctrl_c_escalation_resets_after_the_turn_returns_idle() -> None:
     class _Session:
-        status = "running"
+        status = "idle"  # the peer's running acknowledgement can lag the queued turn
+        turn_active = True
 
         def __init__(self) -> None:
             self.interrupts = 0
@@ -1032,10 +1049,42 @@ def test_ctrl_c_escalation_resets_after_the_turn_returns_idle() -> None:
 
     driver._handle_sigint(cast("mod.live_session.LiveSession", session))
     driver._on_running(False)
-    session.status = "running"
+    session.turn_active = True
     driver._handle_sigint(cast("mod.live_session.LiveSession", session))
 
     assert session.interrupts == 2
+    assert session.ends == 0
+
+
+def test_ctrl_c_while_truly_idle_does_not_arm_the_next_press() -> None:
+    class _Session:
+        turn_active = False
+
+        def __init__(self) -> None:
+            self.interrupts = 0
+            self.ends = 0
+
+        def interrupt(self) -> None:
+            self.interrupts += 1
+
+        def end(self) -> None:
+            self.ends += 1
+
+    driver = mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=HarnessDoc.baseline("test"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction=None,
+    )
+    session = _Session()
+
+    driver._handle_sigint(cast("mod.live_session.LiveSession", session))
+    session.turn_active = True
+    driver._handle_sigint(cast("mod.live_session.LiveSession", session))
+
+    assert session.interrupts == 1
     assert session.ends == 0
 
 

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -1,0 +1,633 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for wmo run dispatch, local safety boundaries, and hosted world models."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import typer
+from rich.console import Console
+from typer.testing import CliRunner
+
+import wmo.cli.run_cmd as mod
+from wmo.cli.app import app
+from wmo.common.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmo.common.core.types import Action
+from wmo.common.providers.base import ProviderConfig, ProviderKind
+from wmo.common.vendor.waterfall.types import (
+    ChatChoice,
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ChatUsage,
+)
+from wmo.runtime.harness.doc import HarnessDoc
+from wmo.runtime.harness.live_session import SessionEvent
+from wmo.runtime.harness.pi_local import start_local_live_runner
+from wmo.runtime.platform.client import PlatformClient
+from wmo.runtime.platform.credentials import PlatformCredentials
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _noop_emit(_stream: str, _chunk: str) -> None:
+    """Discard streamed tool output."""
+
+
+def test_executor_reads_writes_and_jails(tmp_path: Path) -> None:
+    executor = mod.LocalToolExecutor(tmp_path)
+
+    wrote = executor("write_file", {"path": "sub/a.txt", "content": "hi"}, _noop_emit)
+    assert not wrote.is_error
+    assert (tmp_path / "sub" / "a.txt").read_text(encoding="utf-8") == "hi"
+
+    read = executor("read_file", {"path": "sub/a.txt"}, _noop_emit)
+    assert read.content == "hi"
+
+    escaped = executor("read_file", {"path": "../../etc/passwd"}, _noop_emit)
+    assert escaped.is_error
+    assert "escapes" in escaped.content
+
+    absolute = executor("write_file", {"path": "/tmp/evil.txt", "content": "x"}, _noop_emit)
+    assert absolute.is_error
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
+def test_executor_bash_runs_in_jail_and_reports_exit(tmp_path: Path) -> None:
+    executor = mod.LocalToolExecutor(tmp_path)
+    chunks: list[tuple[str, str]] = []
+
+    ok = executor("bash", {"command": "pwd && echo hello"}, lambda s, c: chunks.append((s, c)))
+    assert not ok.is_error
+    assert str(tmp_path.resolve()) in ok.content
+    assert "hello" in ok.content
+    assert any(stream == "stdout" for stream, _ in chunks)
+
+    failed = executor("bash", {"command": "exit 3"}, _noop_emit)
+    assert failed.is_error
+    assert "[exit 3]" in failed.content
+
+
+def test_executor_caps_large_output(tmp_path: Path) -> None:
+    (tmp_path / "big.txt").write_text(
+        "x" * (mod._TOOL_OUTPUT_CAP + 500),
+        encoding="utf-8",
+    )
+
+    result = mod.LocalToolExecutor(tmp_path)("read_file", {"path": "big.txt"}, _noop_emit)
+
+    assert result.truncated
+    assert "chars truncated" in result.content
+
+
+class _FakeProvider:
+    """A minimal tool-calling provider."""
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        _ = request
+        return ChatResponse(choices=[])
+
+
+class _FakeClient:
+    """Record target resolution and built-in pi proxy calls."""
+
+    def __init__(self) -> None:
+        self.worker_calls: list[ChatRequest] = []
+        self.target_kind = "agent"
+        self.closed = False
+        self.local_pi_created: list[str] = []
+        self.local_pi_finished: list[str] = []
+
+    def resolve_run_target(self, target_id: str) -> object:
+        return type(
+            "Target",
+            (),
+            {"id": target_id, "kind": self.target_kind, "name": "remote-target"},
+        )()
+
+    def create_local_pi_run(self, org_id: str) -> object:
+        self.local_pi_created.append(org_id)
+        return type("Run", (), {"id": "run-1"})()
+
+    def complete_local_pi_worker(
+        self,
+        org_id: str,
+        run_id: str,
+        request: ChatRequest,
+    ) -> ChatResponse:
+        _ = org_id, run_id
+        self.worker_calls.append(request)
+        return ChatResponse(
+            choices=[ChatChoice(message=ChatMessage(role="assistant", content="ok"))],
+            usage=ChatUsage(prompt_tokens=1, completion_tokens=1),
+        )
+
+    def finish_local_pi_run(
+        self,
+        org_id: str,
+        run_id: str,
+        *,
+        status: str,
+        ended_reason: str,
+        error: str | None = None,
+    ) -> None:
+        _ = org_id, status, ended_reason, error
+        self.local_pi_finished.append(run_id)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "wmo.common.providers.registry.get_provider",
+        lambda _config: _FakeProvider(),
+    )
+
+
+def test_build_driver_logged_out_runs_baseline_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    _patch_local_provider(monkeypatch)
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=Path.cwd(),
+        provider=None,
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    assert driver._recorder is None
+    assert driver._worker_fn is None
+    assert isinstance(driver._provider, _FakeProvider)
+    assert driver._doc.runtime_kind() == "pi-node"
+
+
+def test_build_driver_uses_configured_local_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="openai", model="gpt-5.4-mini"))
+        ),
+        tmp_path / ".wmo",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    configs: list[ProviderConfig] = []
+
+    def get_provider(config: ProviderConfig) -> _FakeProvider:
+        configs.append(config)
+        return _FakeProvider()
+
+    monkeypatch.setattr("wmo.common.providers.registry.get_provider", get_provider)
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=tmp_path,
+        provider=None,
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    [config] = configs
+    assert config.kind is ProviderKind.OPENAI
+    assert config.model == "gpt-5.4-mini"
+
+
+def test_build_driver_logged_in_bare_run_uses_platform_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = PlatformCredentials(
+        api_url="https://api.test",
+        token="xpl_test",
+        default_org="org-1",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        lambda: credentials,
+    )
+    client = _FakeClient()
+    monkeypatch.setattr(
+        "wmo.runtime.platform.client.PlatformClient",
+        lambda *_args, **_kwargs: client,
+    )
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=Path.cwd(),
+        provider=None,
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    assert driver._provider is None
+    assert driver._worker_fn is not None
+    assert isinstance(driver._recorder, mod.LocalPiRunRecorder)
+    assert client.local_pi_created == ["org-1"]
+
+    driver._worker_fn(ChatRequest(messages=[ChatMessage(role="user", content="hi")]))
+    assert len(client.worker_calls) == 1
+
+    driver._recorder.finish(ended_reason="user_ended", error=None)
+    assert client.local_pi_finished == ["run-1"]
+    assert client.closed
+
+
+def test_build_driver_world_model_uses_hosted_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        lambda: credentials,
+    )
+    client = _FakeClient()
+    client.target_kind = "world_model"
+    monkeypatch.setattr(
+        "wmo.runtime.platform.client.PlatformClient",
+        lambda *_args, **_kwargs: client,
+    )
+
+    driver = mod._build_driver(
+        target="wm-1",
+        jail_root=None,
+        provider=None,
+        model=None,
+        task="help the customer",
+    )
+
+    assert isinstance(driver, mod.RemoteWorldModelDriver)
+    assert driver._target_id == "wm-1"
+    assert not client.closed
+
+
+def test_build_driver_agent_id_names_removed_platform_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        lambda: credentials,
+    )
+    client = _FakeClient()
+    monkeypatch.setattr(
+        "wmo.runtime.platform.client.PlatformClient",
+        lambda *_args, **_kwargs: client,
+    )
+
+    with pytest.raises(typer.BadParameter, match="hosted agent sessions are unavailable"):
+        mod._build_driver(
+            target="agent-1",
+            jail_root=None,
+            provider=None,
+            model=None,
+            task=None,
+        )
+
+    assert client.closed
+
+
+def test_build_driver_target_without_login_is_a_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+
+    with pytest.raises(typer.BadParameter, match="wmo login"):
+        mod._build_driver(
+            target="wm-1",
+            jail_root=None,
+            provider=None,
+            model=None,
+            task=None,
+        )
+
+
+def test_platform_target_rejects_local_provider_before_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        lambda: credentials,
+    )
+    client = _FakeClient()
+    monkeypatch.setattr(
+        "wmo.runtime.platform.client.PlatformClient",
+        lambda *_args, **_kwargs: client,
+    )
+
+    with pytest.raises(typer.BadParameter, match="platform credentials"):
+        mod._build_driver(
+            target="wm-1",
+            jail_root=None,
+            provider="bedrock",
+            model=None,
+            task=None,
+        )
+
+
+def test_run_command_dispatches_bare_path_after_consent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class _Driver:
+        def run(self) -> None:
+            seen["ran"] = True
+
+    def build_driver(**kwargs: object) -> _Driver:
+        callback = cast("Callable[[], None]", kwargs["confirm_local"])
+        callback()
+        seen.update(kwargs)
+        return _Driver()
+
+    monkeypatch.setattr(mod, "_build_driver", build_driver)
+
+    result = CliRunner().invoke(
+        app,
+        ["run", "--dir", str(tmp_path), "--task", "fix it", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert seen["jail_root"] == tmp_path.resolve()
+    assert seen["task"] == "fix it"
+    assert seen["ran"] is True
+    assert "THIS machine" in result.output
+
+
+def test_run_command_rejects_a_directory_for_platform_target(tmp_path: Path) -> None:
+    result = CliRunner().invoke(app, ["run", "wm-1", "--dir", str(tmp_path)])
+
+    assert result.exit_code == 2
+    assert "--dir is only supported" in result.output
+
+
+def test_run_command_stops_when_local_execution_is_declined(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ran: list[bool] = []
+
+    class _Driver:
+        def run(self) -> None:
+            ran.append(True)
+
+    def build_driver(**kwargs: object) -> _Driver:
+        callback = cast("Callable[[], None]", kwargs["confirm_local"])
+        callback()
+        return _Driver()
+
+    monkeypatch.setattr(mod, "_build_driver", build_driver)
+
+    result = CliRunner().invoke(
+        app,
+        ["run", "--dir", str(tmp_path)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 1
+    assert ran == []
+    assert "continue?" in result.output
+
+
+class _FakeChannel:
+    """Record local runner teardown."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeLiveSession:
+    """Emit one idle state and then close."""
+
+    sent: list[str] = []
+
+    def __init__(
+        self,
+        _channel: object,
+        *,
+        on_event: Callable[[SessionEvent], None],
+        **_kwargs: object,
+    ) -> None:
+        self._on_event = on_event
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def status(self) -> str:
+        return "ended" if self._closed else "idle"
+
+    @property
+    def failure_message(self) -> str | None:
+        return None
+
+    def start(self, hello_timeout: float = 60.0) -> None:
+        _ = hello_timeout
+
+    def send_user_message(self, text: str) -> str:
+        self.sent.append(text)
+        return "msg-1"
+
+    def interrupt(self, reason: str = "user_interrupt") -> None:
+        _ = reason
+
+    def end(self) -> None:
+        self._closed = True
+
+    def pump(self, timeout: float = 0.2) -> bool:
+        _ = timeout
+        self._on_event(SessionEvent(kind="state", payload={"status": "idle"}))
+        self._closed = True
+        return False
+
+
+class _FakeReader:
+    """A stdin reader that never touches stdin."""
+
+    def __init__(self, _session: object) -> None:
+        self.eof = threading.Event()
+
+    def start(self) -> None:
+        pass
+
+
+def _patch_driver_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    channel: _FakeChannel,
+) -> None:
+    monkeypatch.setattr(
+        "wmo.runtime.harness.pi_local.start_local_live_runner",
+        lambda: channel,
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.harness.live_session.LiveSession",
+        _FakeLiveSession,
+    )
+    monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
+
+
+def test_local_driver_boots_sends_task_and_closes_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = _FakeChannel()
+    _FakeLiveSession.sent = []
+    _patch_driver_boundaries(monkeypatch, channel)
+
+    mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=HarnessDoc.baseline("test"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction="inspect the repo",
+    ).run()
+
+    assert _FakeLiveSession.sent == ["inspect the repo"]
+    assert channel.closed
+
+
+def test_remote_world_model_driver_creates_and_steps_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _WorldModelClient:
+        def __init__(self) -> None:
+            self.task: str | None = None
+            self.actions: list[Action] = []
+            self.closed = False
+
+        def create_world_model_session(self, _target: str, *, task: str | None) -> object:
+            self.task = task
+            return type("Session", (), {"id": "session-1"})()
+
+        def step_world_model_session(self, _session: str, action: Action) -> object:
+            self.actions.append(action)
+            return type("Observation", (), {"content": "found it", "is_error": False})()
+
+        def close(self) -> None:
+            self.closed = True
+
+    client = _WorldModelClient()
+    lines = iter(['search {"q": "SFO"}', ":quit"])
+    console = Console(file=io.StringIO(), width=200)
+    monkeypatch.setattr(console, "input", lambda *_args, **_kwargs: next(lines))
+    monkeypatch.setattr(mod, "_console", console)
+
+    mod.RemoteWorldModelDriver(
+        cast("PlatformClient", client),
+        "wm-1",
+        "Airline",
+        "find a flight",
+    ).run()
+
+    assert client.task == "find a flight"
+    assert len(client.actions) == 1
+    assert client.actions[0].name == "search"
+    assert client.closed
+
+
+def test_world_model_loop_rejects_detach(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Client:
+        def step_world_model_session(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail(":detach must never reach the world model as an action")
+
+        def close(self) -> None:
+            pass
+
+    lines = iter([":detach", ":quit"])
+    monkeypatch.setattr(mod._console, "input", lambda *_args, **_kwargs: next(lines))
+
+    mod.RemoteWorldModelDriver(
+        cast("PlatformClient", _Client()),
+        "wm-1",
+        "Model",
+        None,
+    )._loop("session-1")
+
+
+@pytest.mark.skipif(
+    os.environ.get("WMO_RUN_LIVE_INTEGRATION") != "1",
+    reason="set WMO_RUN_LIVE_INTEGRATION=1 to install pi and run the real Node peer",
+)
+def test_local_pi_runner_and_driver_complete_a_real_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Boot the retained Node runner and finish a one-shot task through the real driver."""
+    completion = ChatResponse.model_validate(
+        {
+            "id": "completion-1",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "submit",
+                                    "arguments": '{"answer":"done"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    )
+    channel = start_local_live_runner(runtime_dir=tmp_path / "pi-runtime")
+    console = Console(file=io.StringIO(), width=200)
+    monkeypatch.setattr(
+        "wmo.runtime.harness.pi_local.start_local_live_runner",
+        lambda: channel,
+    )
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr(mod, "_console", console)
+
+    mod.LocalLiveDriver(
+        jail_root=tmp_path,
+        doc=mod._pi_node_baseline(),
+        provider=None,
+        worker_fn=lambda _request: completion,
+        recorder=None,
+        instruction="finish successfully",
+    ).run()
+
+    output = cast("io.StringIO", console.file).getvalue()
+    assert "submitted done" in output
+    assert "session ended (user_ended)" in output

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -190,16 +190,48 @@ def test_executor_cancel_stops_an_active_bash_command(tmp_path: Path) -> None:
     assert result.content == "interrupted"
 
 
-def test_executor_caps_large_output(tmp_path: Path) -> None:
+def test_executor_streams_and_caps_large_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     (tmp_path / "big.txt").write_text(
-        "x" * (mod._TOOL_OUTPUT_CAP + 500),
+        "head" + "x" * (mod._TOOL_OUTPUT_CAP + 500) + "tail",
         encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda *_args, **_kwargs: pytest.fail("read_file must not materialize the whole file"),
     )
 
     result = mod.LocalToolExecutor(tmp_path)("read_file", {"path": "big.txt"}, _noop_emit)
 
     assert result.truncated
     assert "chars truncated" in result.content
+    assert result.content.startswith("head")
+    assert result.content.endswith("tail")
+    assert len(result.content) <= mod._TOOL_OUTPUT_CAP
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are not available on this platform")
+def test_executor_rejects_a_fifo_without_blocking(tmp_path: Path) -> None:
+    fifo = tmp_path / "blocked"
+    os.mkfifo(fifo)
+    outcomes: list[mod.ToolOutcome] = []
+    thread = threading.Thread(
+        target=lambda: outcomes.append(
+            mod.LocalToolExecutor(tmp_path)("read_file", {"path": "blocked"}, _noop_emit)
+        ),
+        daemon=True,
+    )
+
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    [result] = outcomes
+    assert result.is_error
+    assert "not a regular file" in result.content
 
 
 def test_terminal_sink_renders_agent_text_without_rich_markup(

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -774,7 +774,7 @@ class _FakeReader:
         pass
 
 
-def test_stdin_reader_marks_a_piped_turn_before_eof(
+def test_stdin_reader_queues_a_piped_turn_before_eof(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _Session:
@@ -794,7 +794,6 @@ def test_stdin_reader_marks_a_piped_turn_before_eof(
     reader.run()
 
     assert session.messages == ["fix the tests"]
-    assert reader.submitted.is_set()
     assert reader.eof.is_set()
 
 
@@ -838,6 +837,7 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
         def __init__(self) -> None:
             self.closed = False
             self.status = "idle"
+            self.turn_active = False
             self.pumps = 0
             self.ends = 0
 
@@ -846,6 +846,9 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
             self.pumps += 1
             assert self.pumps == 1, "an empty one-shot task must end on its first idle pump"
             return True
+
+        def flush_pending_intents(self) -> None:
+            pass
 
         def end(self) -> None:
             self.ends += 1
@@ -869,23 +872,42 @@ def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
     assert session.ends == 1
 
 
-def test_local_driver_waits_for_a_piped_turn_to_return_idle_at_eof() -> None:
-    class _PipedTurnSession:
+def test_local_driver_drains_a_delayed_piped_turn_before_eof_shutdown() -> None:
+    stdin_eof = threading.Event()
+
+    class _DelayedPipedTurnSession:
         def __init__(self) -> None:
             self.closed = False
-            self.status = "idle"
+            self.status = "running"
+            self.turn_active = True
+            self.pending_messages = 0
             self.pumps = 0
+            self.flushes = 0
             self.ends = 0
 
         def pump(self, timeout: float = 0.2) -> bool:
             _ = timeout
             self.pumps += 1
             assert self.pumps <= 3, "the piped turn must end after returning to idle"
-            if self.pumps == 2:
+            if self.pumps == 1:
+                # The reader queues a second line after this pump drained intents but before it
+                # receives the first turn's idle frame, then publishes EOF.
+                self.pending_messages = 1
+                stdin_eof.set()
+                self.status = "idle"
+                self.turn_active = False
+            elif self.pumps == 2:
                 self.status = "running"
             elif self.pumps == 3:
                 self.status = "idle"
+                self.turn_active = False
             return True
+
+        def flush_pending_intents(self) -> None:
+            self.flushes += 1
+            if self.pending_messages:
+                self.pending_messages = 0
+                self.turn_active = True
 
         def end(self) -> None:
             self.ends += 1
@@ -899,19 +921,12 @@ def test_local_driver_waits_for_a_piped_turn_to_return_idle_at_eof() -> None:
         recorder=None,
         instruction=None,
     )
-    session = _PipedTurnSession()
-    stdin_eof = threading.Event()
-    stdin_eof.set()
-    stdin_submitted = threading.Event()
-    stdin_submitted.set()
+    session = _DelayedPipedTurnSession()
 
-    driver._loop(
-        cast("mod.live_session.LiveSession", session),
-        stdin_eof,
-        stdin_submitted,
-    )
+    driver._loop(cast("mod.live_session.LiveSession", session), stdin_eof)
 
     assert session.pumps == 3
+    assert session.flushes == 3
     assert session.ends == 1
 
 

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -426,6 +426,50 @@ def test_build_driver_azure_model_override_rejects_a_stale_configured_deployment
     assert configs == []
 
 
+def test_build_driver_preserves_a_configured_tinker_models_base_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                worker=ModelRole(
+                    provider="tinker",
+                    model="tinker://run/weights/42",
+                    model_type="Qwen/Qwen3-8B",
+                    chat_max_tokens_field="max_tokens",
+                )
+            )
+        ),
+        tmp_path / ".wmo",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    configs: list[ProviderConfig] = []
+    monkeypatch.setattr(
+        "wmo.common.providers.registry.get_provider",
+        lambda config: configs.append(config) or _FakeProvider(),
+    )
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=tmp_path,
+        provider=None,
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    [config] = configs
+    assert config.kind is ProviderKind.TINKER
+    assert config.model == "tinker://run/weights/42"
+    assert config.model_type == "Qwen/Qwen3-8B"
+    assert config.chat_max_tokens_field == "max_tokens"
+
+
 def test_build_driver_logged_in_bare_run_uses_platform_proxy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -111,6 +111,34 @@ def test_executor_bash_kills_the_process_group_on_timeout(
     assert "[exit 124]" in result.content
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
+def test_executor_cancel_stops_an_active_bash_command(tmp_path: Path) -> None:
+    executor = mod.LocalToolExecutor(tmp_path)
+    started = threading.Event()
+    outcomes: list[object] = []
+
+    def emit(_stream: str, chunk: str) -> None:
+        if "started" in chunk:
+            started.set()
+
+    thread = threading.Thread(
+        target=lambda: outcomes.append(
+            executor("bash", {"command": "printf started; sleep 5"}, emit)
+        )
+    )
+    thread.start()
+    assert started.wait(1)
+
+    executor.cancel()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    [result] = outcomes
+    assert isinstance(result, mod.ToolOutcome)
+    assert result.is_error
+    assert result.content == "interrupted"
+
+
 def test_executor_caps_large_output(tmp_path: Path) -> None:
     (tmp_path / "big.txt").write_text(
         "x" * (mod._TOOL_OUTPUT_CAP + 500),
@@ -298,6 +326,45 @@ def test_build_driver_provider_override_uses_the_new_providers_default_model(
     [config] = configs
     assert config.kind is ProviderKind.OPENAI
     assert config.model == "gpt-5.6-sol"
+
+
+def test_build_driver_azure_override_supplies_required_azure_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="bedrock", model="claude-sonnet-4-6"))
+        ),
+        tmp_path / ".wmo",
+    )
+    monkeypatch.setattr(
+        "wmo.runtime.platform.credentials.load_credentials",
+        PlatformCredentials,
+    )
+    configs: list[ProviderConfig] = []
+
+    def get_provider(config: ProviderConfig) -> _FakeProvider:
+        configs.append(config)
+        return _FakeProvider()
+
+    monkeypatch.setattr("wmo.common.providers.registry.get_provider", get_provider)
+
+    driver = mod._build_driver(
+        target=None,
+        jail_root=tmp_path,
+        provider="azure",
+        model=None,
+        task=None,
+    )
+
+    assert isinstance(driver, mod.LocalLiveDriver)
+    [config] = configs
+    assert config.kind is ProviderKind.AZURE_OPENAI
+    assert config.model == "gpt-5.5"
+    assert config.deployment == "gpt-5.5"
+    assert config.api_version == mod.DEFAULT_AZURE_API_VERSION
 
 
 def test_build_driver_logged_in_bare_run_uses_platform_proxy(
@@ -626,6 +693,39 @@ def test_local_driver_boots_sends_task_and_closes_process(
     assert channel.closed
 
 
+def test_ctrl_c_escalation_resets_after_the_turn_returns_idle() -> None:
+    class _Session:
+        status = "running"
+
+        def __init__(self) -> None:
+            self.interrupts = 0
+            self.ends = 0
+
+        def interrupt(self) -> None:
+            self.interrupts += 1
+
+        def end(self) -> None:
+            self.ends += 1
+
+    driver = mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=HarnessDoc.baseline("test"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction=None,
+    )
+    session = _Session()
+
+    driver._handle_sigint(cast("mod.live_session.LiveSession", session))
+    driver._on_running(False)
+    session.status = "running"
+    driver._handle_sigint(cast("mod.live_session.LiveSession", session))
+
+    assert session.interrupts == 2
+    assert session.ends == 0
+
+
 def test_remote_world_model_driver_creates_and_steps_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -641,7 +741,11 @@ def test_remote_world_model_driver_creates_and_steps_session(
 
         def step_world_model_session(self, _session: str, action: Action) -> object:
             self.actions.append(action)
-            return type("Observation", (), {"content": "found it", "is_error": False})()
+            return type(
+                "Observation",
+                (),
+                {"content": "found list[str] and [/items] literally", "is_error": False},
+            )()
 
         def close(self) -> None:
             self.closed = True
@@ -663,6 +767,7 @@ def test_remote_world_model_driver_creates_and_steps_session(
     assert len(client.actions) == 1
     assert client.actions[0].name == "search"
     assert client.closed
+    assert "found list[str] and [/items] literally" in cast("io.StringIO", console.file).getvalue()
 
 
 def test_world_model_loop_rejects_detach(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -8,6 +8,7 @@ import io
 import os
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -76,6 +77,40 @@ def test_executor_bash_runs_in_jail_and_reports_exit(tmp_path: Path) -> None:
     assert "[exit 3]" in failed.content
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
+def test_executor_bash_streams_chunks_and_retains_bounded_output(tmp_path: Path) -> None:
+    chunks: list[tuple[str, str]] = []
+
+    result = mod.LocalToolExecutor(tmp_path)(
+        "bash",
+        {"command": "printf '%050000d' 0"},
+        lambda stream, chunk: chunks.append((stream, chunk)),
+    )
+
+    assert not result.is_error
+    assert result.truncated
+    assert len(result.content) <= mod._TOOL_OUTPUT_CAP
+    assert len(chunks) > 1
+    assert max(len(chunk) for _stream, chunk in chunks) <= 4096
+    assert sum(len(chunk) for _stream, chunk in chunks) == 50_000
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="LocalToolExecutor bash needs a Unix shell")
+def test_executor_bash_kills_the_process_group_on_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mod, "_BASH_TIMEOUT_S", 0.05)
+
+    started = time.monotonic()
+    result = mod.LocalToolExecutor(tmp_path)("bash", {"command": "sleep 5"}, _noop_emit)
+
+    assert time.monotonic() - started < 2
+    assert result.is_error
+    assert "timed out after 0.05s" in result.content
+    assert "[exit 124]" in result.content
+
+
 def test_executor_caps_large_output(tmp_path: Path) -> None:
     (tmp_path / "big.txt").write_text(
         "x" * (mod._TOOL_OUTPUT_CAP + 500),
@@ -86,6 +121,20 @@ def test_executor_caps_large_output(tmp_path: Path) -> None:
 
     assert result.truncated
     assert "chars truncated" in result.content
+
+
+def test_terminal_sink_renders_agent_text_without_rich_markup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    console = Console(file=io.StringIO(), width=200, color_system=None)
+    monkeypatch.setattr(mod, "_console", console)
+    text = "Keep list[str], [a link](https://example.test), and [/items] literal."
+
+    mod.TerminalEventSink(recorder=None, on_running=lambda _running: None)(
+        SessionEvent(kind="assistant_message", payload={"text": text})
+    )
+
+    assert text in cast("io.StringIO", console.file).getvalue()
 
 
 class _FakeProvider:

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -197,6 +197,9 @@ class _FakeClient:
         self.closed = False
         self.local_pi_created: list[str] = []
         self.local_pi_finished: list[str] = []
+        self.local_pi_worker_provider = "bedrock"
+        self.local_pi_worker_model = "claude-haiku-4-5"
+        self.local_pi_context_window: int | None = None
 
     def resolve_run_target(self, target_id: str) -> object:
         return type(
@@ -207,7 +210,14 @@ class _FakeClient:
 
     def create_local_pi_run(self, org_id: str) -> object:
         self.local_pi_created.append(org_id)
-        return type("Run", (), {"id": "run-1"})()
+        return mod.platform_client.LocalPiRunInfo(
+            id="run-1",
+            org_id=org_id,
+            status="running",
+            worker_provider=self.local_pi_worker_provider,
+            worker_model=self.local_pi_worker_model,
+            context_window=self.local_pi_context_window,
+        )
 
     def complete_local_pi_worker(
         self,
@@ -483,6 +493,8 @@ def test_build_driver_logged_in_bare_run_uses_platform_proxy(
         lambda: credentials,
     )
     client = _FakeClient()
+    client.local_pi_worker_provider = "tinker"
+    client.local_pi_worker_model = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16:peft:65536"
     monkeypatch.setattr(
         "wmo.runtime.platform.client.PlatformClient",
         lambda *_args, **_kwargs: client,
@@ -499,6 +511,7 @@ def test_build_driver_logged_in_bare_run_uses_platform_proxy(
     assert isinstance(driver, mod.LocalLiveDriver)
     assert driver._provider is None
     assert driver._worker_fn is not None
+    assert driver._context_window == 65_536
     assert isinstance(driver._recorder, mod.LocalPiRunRecorder)
     assert client.local_pi_created == ["org-1"]
 
@@ -794,6 +807,42 @@ def test_local_driver_boots_sends_task_and_closes_process(
 
     assert _FakeLiveSession.sent == ["inspect the repo"]
     assert channel.closed
+
+
+def test_local_driver_treats_an_empty_task_as_no_opening_turn_at_eof() -> None:
+    class _IdleSession:
+        def __init__(self) -> None:
+            self.closed = False
+            self.status = "idle"
+            self.pumps = 0
+            self.ends = 0
+
+        def pump(self, timeout: float = 0.2) -> bool:
+            _ = timeout
+            self.pumps += 1
+            assert self.pumps == 1, "an empty one-shot task must end on its first idle pump"
+            return True
+
+        def end(self) -> None:
+            self.ends += 1
+            self.closed = True
+
+    driver = mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=HarnessDoc.baseline("test"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction="",
+    )
+    session = _IdleSession()
+    stdin_eof = threading.Event()
+    stdin_eof.set()
+
+    driver._loop(cast("mod.live_session.LiveSession", session), stdin_eof)
+
+    assert driver._instruction is None
+    assert session.ends == 1
 
 
 def test_ctrl_c_escalation_resets_after_the_turn_returns_idle() -> None:

--- a/wmo/runtime/harness/__init__.py
+++ b/wmo/runtime/harness/__init__.py
@@ -8,9 +8,10 @@ What the loop runs with is a `HarnessDoc` - a typed document of identity-keyed s
 (prompt sections, tool policy, loop params, skills) stored as immutable versions with movable
 aliases (`wmo.runtime.harness.store`).
 
-The machinery that improves harnesses (delta search, mutation, population search, live
-sessions) lives in the agent-optimization repo and imports this runtime seam. Closed-loop
-evaluation and model optimization use the same execution contracts.
+The machinery that improves harnesses (delta search, mutation, population search) lives in the
+agent-optimization repo and imports this runtime seam. The live-session host stays here because it
+drives the retained local pi runner for `wmo run`. Closed-loop evaluation and model optimization
+use the same execution contracts.
 """
 
 from wmo.runtime.harness.doc import HarnessDoc, Surface, SurfaceKind

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -54,7 +54,13 @@ from pydantic import JsonValue
 from wmo.common.core.types import JsonObject
 from wmo.common.providers.base import ToolCallingProvider
 from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
-from wmo.runtime.harness.runner_link import Channel, TokenUsage, WorkerFn, params_schema
+from wmo.runtime.harness.runner_link import (
+    Channel,
+    TokenUsage,
+    WorkerFn,
+    params_schema,
+    provider_context_window,
+)
 from wmo.runtime.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS
 from wmo.runtime.harness.tools import READ_SKILL, SUBMIT, ToolSpec
 
@@ -166,6 +172,7 @@ class LiveSession:
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         temperature: float = 0.7,
         conversation_scope: ConversationScope = "session",
+        context_window: int | None = None,
         cancel_active: CancelHook | None = None,
         reset_cancel: CancelHook | None = None,
     ) -> None:
@@ -196,9 +203,21 @@ class LiveSession:
             raise ValueError("temperature must be in [0, 2]")
         if conversation_scope not in ("session", "turn"):
             raise ValueError("conversation_scope must be 'session' or 'turn'")
+        if context_window is not None and (
+            isinstance(context_window, bool) or not isinstance(context_window, int)
+        ):
+            raise ValueError("context_window must be an integer number of tokens when set")
+        if context_window is not None and context_window < 1024:
+            raise ValueError("context_window must be at least 1024 tokens when set")
         self._max_output_tokens = max_output_tokens
         self._temperature = temperature
         self._conversation_scope = conversation_scope
+        # A wrong assumed window is worse than no value: the live runner uses it to trim before
+        # provider requests. Prefer an explicit transport value, then the provider's served-model
+        # capability, and otherwise let the runner keep its documented fallback.
+        self._context_window = (
+            context_window if context_window is not None else provider_context_window(provider)
+        )
         self._cancel_active = cancel_active
         self._reset_cancel = reset_cancel
 
@@ -245,6 +264,7 @@ class LiveSession:
                 "max_output_tokens": self._max_output_tokens,
                 "temperature": self._temperature,
                 "conversation_scope": self._conversation_scope,
+                "context_window": self._context_window,
             }
         )
         # The runner sends `state:idle` once the agent is constructed and ready for the first

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -229,6 +229,7 @@ class LiveSession:
         self._status: str = "starting"
         self._closed = False
         self._failure_message: str | None = None
+        self._last_completed_message_id: str | None = None
         self._actions_this_turn = 0
         self._aborting = False
         self._turn_lock = threading.Lock()
@@ -254,10 +255,9 @@ class LiveSession:
         return self._failure_message
 
     @property
-    def turn_active(self) -> bool:
-        """Whether a submitted user turn is queued, running, or awaiting its idle boundary."""
-        with self._turn_lock:
-            return self._turn_active
+    def last_completed_message_id(self) -> str | None:
+        """Return the last user message acknowledged by a terminal idle frame."""
+        return self._last_completed_message_id
 
     def start(self, hello_timeout: float = 60.0) -> None:
         """Send `session_start` and block until the runner reports its first idle state."""
@@ -512,6 +512,9 @@ class LiveSession:
                 self._turn_active = True
             elif self._status == "idle":
                 self._turn_active = False
+        completed_message_id = frame.get("msg_id")
+        if self._status == "idle" and isinstance(completed_message_id, str):
+            self._last_completed_message_id = completed_message_id
         # Only the terminal `idle` frame is the cancelled turn's true boundary. The
         # runner emits `state:running` at each prompt start; clearing on that (or any
         # non-idle frame) could re-enable submit emission while the turn is still

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -45,6 +45,7 @@ import queue
 import threading
 import time
 import uuid
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal, cast
@@ -222,6 +223,7 @@ class LiveSession:
         self._reset_cancel = reset_cancel
 
         self._inbox: queue.Queue[_Intent] = queue.Queue()
+        self._deferred_messages: deque[_UserMessage] = deque()
         self._interrupt_requested = threading.Event()
         self._session_id = uuid.uuid4().hex
         self._status: str = "starting"
@@ -350,22 +352,13 @@ class LiveSession:
             except queue.Empty:
                 return
             if isinstance(intent, _UserMessage):
-                with self._turn_lock:
-                    # An idle boundary may race ahead of an already queued message. Preserve the
-                    # input as a fresh prompt rather than dropping it; its generation still lets
-                    # a stale interrupt queued before it be distinguished from one queued after.
-                    if not self._turn_active:
-                        self._turn_active = True
-                        self._turn_generation = max(self._turn_generation, intent.generation)
-                self._actions_this_turn = 0
-                # NB: do not clear `_aborting` here - a new message can be drained before
-                # the cancelled turn's in-flight submit frame is read, and clearing now
-                # would let that stale submit emit. The runner's next `state` frame (the
-                # real turn boundary) clears it in `_on_state`.
-                self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
-                self._safe_send(
-                    {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}
-                )
+                if self._aborting:
+                    # The peer still reports running until the aborted prompt reaches its idle
+                    # boundary. Sending now would turn this next instruction into a steer that
+                    # clearAllQueues discards, so hold it and start it from `_on_state` instead.
+                    self._deferred_messages.append(intent)
+                    continue
+                self._send_user_message(intent)
             elif isinstance(intent, _Interrupt):
                 with self._turn_lock:
                     targets_active_turn = (
@@ -531,6 +524,22 @@ class LiveSession:
         if isinstance(cleared, list) and cleared:
             payload["cleared_steers"] = cleared
         self._emit("state", payload)
+        if self._status == "idle":
+            while self._deferred_messages:
+                self._send_user_message(self._deferred_messages.popleft())
+
+    def _send_user_message(self, intent: _UserMessage) -> None:
+        """Send one queued message once it is safe for the peer to start or steer a turn."""
+        with self._turn_lock:
+            # An idle boundary may race ahead of an already queued message. Preserve the input as
+            # a fresh prompt rather than dropping it; its generation still distinguishes stale
+            # interrupts queued before it from a stop queued afterward.
+            if not self._turn_active:
+                self._turn_active = True
+                self._turn_generation = max(self._turn_generation, intent.generation)
+        self._actions_this_turn = 0
+        self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
+        self._safe_send({"type": "user_message", "msg_id": intent.msg_id, "text": intent.text})
 
     def _emit_assistant(self, completion: ChatResponse) -> None:
         if not completion.choices:

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -253,6 +253,12 @@ class LiveSession:
         """Return the runner or channel error that closed this session, when one exists."""
         return self._failure_message
 
+    @property
+    def turn_active(self) -> bool:
+        """Whether a submitted user turn is queued, running, or awaiting its idle boundary."""
+        with self._turn_lock:
+            return self._turn_active
+
     def start(self, hello_timeout: float = 60.0) -> None:
         """Send `session_start` and block until the runner reports its first idle state."""
         self._channel.send(

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -260,6 +260,12 @@ class LiveSession:
         return self._failure_message
 
     @property
+    def turn_active(self) -> bool:
+        """Return whether a user turn is queued or running, independent of peer state lag."""
+        with self._turn_lock:
+            return self._turn_active
+
+    @property
     def last_completed_message_id(self) -> str | None:
         """Return the last user message acknowledged by a terminal idle frame."""
         return self._last_completed_message_id

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -1,0 +1,543 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Interactive live sessions: the host engine that drives one long-lived pi runner.
+
+A *session* differs from an *episode* (`runner_link.RunnerLink`) in three ways: it is multi-turn
+(the user sends messages, steers a running turn, and interrupts, over one persistent transcript),
+its tools execute for REAL against a live filesystem/shell rather than being answered by a
+world-model simulation, and it emits a stream of typed events (assistant text, tool calls, tool
+output, state changes) that a UI renders live. Everything else is the RunnerLink model unchanged:
+the worker LLM is answered host-side so credentials never reach the runner, and the wire is the
+same length-prefixed / base64-line frame `Channel`.
+
+The engine is transport- and platform-agnostic. It answers `llm_request` frames host-side via a
+fully-configured `ToolCallingProvider`'s `complete_chat` (Bedrock or Azure - provider-agnostic per
+wmo #142) or an injected `worker_fn` (tests), and answers `tool_request` frames with an injected
+`ToolExecutor` (the platform runs bash/read_file/write_file against the session's E2B sandbox
+filesystem; a CLI would run them against a local directory). Because the host answers every
+`llm_request` and every `tool_request`, it *is* the trusted observer of what the agent did - the
+feed is derived from the frames the host itself produced/answered, so a compromised runner cannot
+narrate a different story than the actions it actually took.
+
+New session frames (additive to the RunnerLink vocabulary; unknown types are ignored on both
+sides, so eval episodes are unaffected):
+
+  host -> runner
+    session_start {session_id, system, tools, files, turn_cap, max_output_tokens, temperature,
+                   conversation_scope}
+    user_message  {msg_id, text}
+    abort         {reason}
+    ping          {nonce}
+    shutdown                       (reused; ends the runner process)
+  runner -> host
+    hello         {...}            (reused)
+    llm_request   {req_id, openai_body}   (reused)
+    tool_request  {req_id, name, arguments}  (reused)
+    state         {status: "idle"|"running", turns, reason?, cleared_steers?, msg_id?}
+    pong          {nonce}
+    episode_error {note}           (reused; a fatal runner error ends the session)
+"""
+
+from __future__ import annotations
+
+import queue
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from pydantic import JsonValue
+
+from wmo.common.core.types import JsonObject
+from wmo.common.providers.base import ToolCallingProvider
+from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
+from wmo.runtime.harness.runner_link import Channel, TokenUsage, WorkerFn, params_schema
+from wmo.runtime.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS
+from wmo.runtime.harness.tools import READ_SKILL, SUBMIT, ToolSpec
+
+# The action budget a single user turn may spend before the runner is told to stop - the live
+# analogue of `HostEpisode.max_env_actions`, so a champion optimized under that pressure behaves
+# the same way. It resets on every user message.
+DEFAULT_ACTIONS_PER_TURN = 40
+# Turns a single user message may run before the runner aborts it (distinct from a user interrupt).
+# 3x the doc default (20) - real tasks against a live filesystem legitimately run longer than the
+# short world-model-simulation tasks the harness was scored on.
+DEFAULT_TURN_CAP = 60
+
+# --------------------------------------------------------------------------------------------------
+# Events: the typed stream the engine emits; a UI renders these, a store persists them.
+# --------------------------------------------------------------------------------------------------
+EventKind = Literal[
+    "user_message",
+    "assistant_message",
+    "tool_call",
+    "tool_output",
+    "tool_result",
+    "submit",
+    "state",
+    "error",
+]
+ConversationScope = Literal["session", "turn"]
+
+
+@dataclass(frozen=True)
+class SessionEvent:
+    """One thing that happened in a session, in the order the host observed it."""
+
+    kind: EventKind
+    payload: JsonObject
+
+
+EventSink = Callable[[SessionEvent], None]
+
+# (name, arguments, emit_output) -> (content, is_error). `emit_output(stream, chunk)` streams
+# partial stdout/stderr so the UI shows a long command's output as it runs; the returned content is
+# the final (already length-capped by the executor) observation the agent sees.
+OutputEmitter = Callable[[str, str], None]
+ToolExecutor = Callable[[str, JsonObject, OutputEmitter], "ToolOutcome"]
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """The result of executing one real tool call: what the agent sees, and whether it failed."""
+
+    content: str
+    is_error: bool = False
+    truncated: bool = False
+
+
+# --------------------------------------------------------------------------------------------------
+# Inbox: user intents the driver feeds in from another thread, drained into frames on each pump.
+# --------------------------------------------------------------------------------------------------
+@dataclass
+class _UserMessage:
+    text: str
+    msg_id: str
+
+
+@dataclass
+class _Interrupt:
+    reason: str = "user_interrupt"
+
+
+@dataclass
+class _End:
+    pass
+
+
+_Intent = _UserMessage | _Interrupt | _End
+
+
+class LiveSession:
+    """Drives one interactive pi session over a `Channel`, emitting a typed event stream.
+
+    Lifecycle: `start()` sends `session_start` and waits for the runner's first `state:idle`; then
+    the driver loops calling `pump(timeout)` while feeding intents via `send_user_message`,
+    `interrupt`, and `end` (thread-safe - a driver may enqueue from a command-poll thread). `pump`
+    drains the inbox to frames, then processes one inbound frame (answering `llm_request` /
+    `tool_request`, emitting events). `closed` flips once the runner process ends or `end()` is
+    honored. `worker_usage` accumulates the metered worker-LLM spend across the whole session.
+    """
+
+    def __init__(
+        self,
+        channel: Channel,
+        *,
+        tools: list[ToolSpec],
+        execute_tool: ToolExecutor,
+        on_event: EventSink,
+        files: dict[str, str] | None = None,
+        system_prompt: str = "",
+        skill_bodies: dict[str, str] | None = None,
+        provider: ToolCallingProvider | None = None,
+        worker_fn: WorkerFn | None = None,
+        actions_per_turn: int = DEFAULT_ACTIONS_PER_TURN,
+        turn_cap: int = DEFAULT_TURN_CAP,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
+        temperature: float = 0.7,
+        conversation_scope: ConversationScope = "session",
+    ) -> None:
+        self._channel = channel
+        self._tools = list(tools)
+        self._execute_tool = execute_tool
+        self._on_event = on_event
+        self._files = dict(files or {})
+        self._system_prompt = system_prompt
+        self._skill_bodies = dict(skill_bodies or {})
+        if self._skill_bodies and READ_SKILL.name not in {tool.name for tool in self._tools}:
+            self._tools.append(READ_SKILL)
+        # The worker LLM is answered host-side by a fully-configured provider's
+        # `complete_chat` (Bedrock or Azure - provider-agnostic per #142), or an
+        # injected `worker_fn` (tests). Left unset, an `llm_request` is answered
+        # with an error instead of crashing the host.
+        if worker_fn is not None:
+            self._worker_fn: WorkerFn | None = worker_fn
+        elif provider is not None:
+            self._worker_fn = provider.complete_chat
+        else:
+            self._worker_fn = None
+        self._actions_per_turn = actions_per_turn
+        self._turn_cap = turn_cap
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
+        if not 0.0 <= temperature <= 2.0:
+            raise ValueError("temperature must be in [0, 2]")
+        if conversation_scope not in ("session", "turn"):
+            raise ValueError("conversation_scope must be 'session' or 'turn'")
+        self._max_output_tokens = max_output_tokens
+        self._temperature = temperature
+        self._conversation_scope = conversation_scope
+
+        self._inbox: queue.Queue[_Intent] = queue.Queue()
+        self._session_id = uuid.uuid4().hex
+        self._status: str = "starting"
+        self._closed = False
+        self._failure_message: str | None = None
+        self._actions_this_turn = 0
+        self._aborting = False
+        self._pending_ping: str | None = None
+        self.worker_usage = TokenUsage()
+
+    # -- lifecycle -------------------------------------------------------------------------------
+
+    @property
+    def status(self) -> str:
+        """The runner's last-known agent state: "starting" | "idle" | "running" | "ended"."""
+        return self._status
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def failure_message(self) -> str | None:
+        """Return the runner or channel error that closed this session, when one exists."""
+        return self._failure_message
+
+    def start(self, hello_timeout: float = 60.0) -> None:
+        """Send `session_start` and block until the runner reports its first idle state."""
+        self._channel.send(
+            {
+                "type": "session_start",
+                "session_id": self._session_id,
+                "system": self._system_prompt,
+                "tools": self._tool_specs(),
+                "files": self._files,
+                "turn_cap": self._turn_cap,
+                "max_output_tokens": self._max_output_tokens,
+                "temperature": self._temperature,
+                "conversation_scope": self._conversation_scope,
+            }
+        )
+        # The runner sends `state:idle` once the agent is constructed and ready for the first
+        # message; surface a fatal construction error (bad champion code) instead of hanging.
+        deadline = _Deadline(hello_timeout)
+        while not deadline.expired():
+            frame = self._recv(deadline.remaining())
+            if frame is None:
+                break
+            if self._handle_frame(frame):
+                if self._status in ("idle", "running"):
+                    return
+                if self._closed:
+                    break
+        if self._failure_message is not None:
+            raise RuntimeError(f"live session runner did not become ready: {self._failure_message}")
+        raise RuntimeError("live session runner did not become ready")
+
+    # -- driver-facing intents (thread-safe) -----------------------------------------------------
+
+    def send_user_message(self, text: str) -> str:
+        """Queue a user message; returns the msg_id echoed on its `user_message` event."""
+        msg_id = uuid.uuid4().hex
+        self._inbox.put(_UserMessage(text=text, msg_id=msg_id))
+        return msg_id
+
+    def interrupt(self, reason: str = "user_interrupt") -> None:
+        """Queue an interrupt: abort the current run (does not end the session)."""
+        self._inbox.put(_Interrupt(reason=reason))
+
+    def flush_pending_intents(self) -> None:
+        """Send queued controls without consuming another runner frame.
+
+        The driver uses this when it must abort and retire a session immediately. Calling
+        :meth:`pump` would also read one inbound frame, which could start another synchronous
+        provider or tool operation after cancellation was already observed.
+        """
+        if not self._closed:
+            self._drain_inbox()
+
+    def end(self) -> None:
+        """Queue a graceful end: abort any run, then shut the runner down."""
+        self._inbox.put(_End())
+
+    def ping(self) -> None:
+        """Send a liveness ping; a returned `pong` proves the runner event loop is alive."""
+        nonce = uuid.uuid4().hex
+        self._pending_ping = nonce
+        self._safe_send({"type": "ping", "nonce": nonce})
+
+    # -- pump ------------------------------------------------------------------------------------
+
+    def pump(self, timeout: float = 0.2) -> bool:
+        """Drain queued intents to frames, then process one inbound frame. False once closed."""
+        if self._closed:
+            return False
+        self._drain_inbox()
+        if self._closed:
+            return False
+        frame = self._recv(timeout)
+        if frame is None:
+            return not self._closed
+        self._handle_frame(frame)
+        return not self._closed
+
+    # -- internals -------------------------------------------------------------------------------
+
+    def _drain_inbox(self) -> None:
+        while True:
+            try:
+                intent = self._inbox.get_nowait()
+            except queue.Empty:
+                return
+            if isinstance(intent, _UserMessage):
+                self._actions_this_turn = 0
+                # NB: do not clear `_aborting` here - a new message can be drained before
+                # the cancelled turn's in-flight submit frame is read, and clearing now
+                # would let that stale submit emit. The runner's next `state` frame (the
+                # real turn boundary) clears it in `_on_state`.
+                self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
+                self._safe_send(
+                    {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}
+                )
+            elif isinstance(intent, _Interrupt):
+                # Mark the current turn as aborting so a `submit` tool_request that was
+                # already in flight when the interrupt fired does not emit a final submit
+                # event: the host, not the runner, owns event emission, so this gate is
+                # the only place the race can be closed. Cleared at the next turn boundary.
+                self._aborting = True
+                self._safe_send({"type": "abort", "reason": intent.reason})
+            else:  # _End
+                self._safe_send({"type": "abort", "reason": "shutdown"})
+                self._safe_send({"type": "shutdown"})
+                self._mark_closed("ended")
+
+    def _handle_frame(self, frame: JsonObject) -> bool:
+        kind = frame.get("type")
+        if kind == "llm_request":
+            self._answer_llm(frame)
+        elif kind == "tool_request":
+            self._answer_tool(frame)
+        elif kind == "state":
+            self._on_state(frame)
+        elif kind == "pong":
+            if frame.get("nonce") == self._pending_ping:
+                self._pending_ping = None
+        elif kind == "episode_error":
+            note = frame.get("note")
+            self._failure_message = note if isinstance(note, str) else "runner error"
+            self._emit("error", {"message": self._failure_message})
+            self._mark_closed("failed")
+        elif kind == "hello":
+            pass  # the pool already consumed the handshake; a duplicate is harmless
+        # unknown frames are ignored (forward-compatible)
+        return kind is not None
+
+    def _answer_llm(self, frame: JsonObject) -> None:
+        req_id = frame.get("req_id")
+        body = frame.get("openai_body")
+        if self._worker_fn is None:
+            self._emit("error", {"message": "live session has no worker configured"})
+            self._safe_send(
+                {"type": "llm_response", "req_id": req_id, "error": "no worker configured"}
+            )
+            return
+        try:
+            request_body = dict(body) if isinstance(body, dict) else {}
+            request_body["temperature"] = self._temperature
+            request = ChatRequest.model_validate(request_body)
+            completion = self._worker_fn(request)
+            self._meter(completion)
+            self._emit_assistant(completion)
+            self._safe_send(
+                {"type": "llm_response", "req_id": req_id, "completion": completion.wire_payload()}
+            )
+        except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
+            self._emit("error", {"message": f"worker LLM error: {exc}"})
+            self._safe_send({"type": "llm_response", "req_id": req_id, "error": str(exc)})
+
+    def _answer_tool(self, frame: JsonObject) -> None:
+        req_id = frame.get("req_id")
+        name = frame.get("name")
+        name = name if isinstance(name, str) else ""
+        args = frame.get("arguments")
+        args = cast("JsonObject", args) if isinstance(args, dict) else {}
+        call_id = uuid.uuid4().hex
+
+        if name == SUBMIT.name:
+            # If the turn is being interrupted, do NOT emit a final submit for it -
+            # the answer belongs to a cancelled run. Still respond so the runner's
+            # submit tool does not hang; the aborted run ends via `state:idle`.
+            if not self._aborting:
+                answer = args.get("answer")
+                self._emit("submit", {"answer": answer if isinstance(answer, str) else ""})
+            self._respond_tool(req_id, "submitted", is_error=False)
+            return
+
+        if self._aborting:
+            # The turn is being interrupted; do NOT run a real side-effecting tool
+            # (bash / write_file) for a cancelled run. Respond so the runner's tool
+            # call does not hang; the aborted run ends via `state:idle`.
+            self._respond_tool(req_id, "interrupted", is_error=True)
+            return
+
+        self._emit("tool_call", {"call_id": call_id, "name": name, "arguments": args})
+        known = {t.name for t in self._tools}
+        if name not in known:
+            outcome = ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+        elif name == READ_SKILL.name:
+            outcome = self._read_skill(args)
+        elif self._actions_this_turn >= self._actions_per_turn:
+            outcome = ToolOutcome(content="environment action budget exhausted", is_error=True)
+        else:
+            self._actions_this_turn += 1
+
+            def emit_output(stream: str, chunk: str) -> None:
+                if chunk:
+                    self._emit("tool_output", {"call_id": call_id, "stream": stream, "text": chunk})
+
+            try:
+                outcome = self._execute_tool(name, args, emit_output)
+            except Exception as exc:  # noqa: BLE001 - a tool failure must not crash the host loop
+                # A transient sandbox/FS error becomes an error result, so the runner
+                # always gets a tool_response and pump() keeps running.
+                outcome = ToolOutcome(content=f"tool {name!r} failed: {exc}", is_error=True)
+        self._emit(
+            "tool_result",
+            {
+                "call_id": call_id,
+                "content": outcome.content,
+                "is_error": outcome.is_error,
+                "truncated": outcome.truncated,
+            },
+        )
+        self._respond_tool(req_id, outcome.content, is_error=outcome.is_error)
+
+    def _read_skill(self, args: JsonObject) -> ToolOutcome:
+        raw_name = args.get("name")
+        name = raw_name if isinstance(raw_name, str) else ""
+        body = self._skill_bodies.get(name)
+        if body is None:
+            return ToolOutcome(content=f"no skill named {name!r}", is_error=True)
+        return ToolOutcome(content=body)
+
+    def _respond_tool(self, req_id: JsonValue, content: str, *, is_error: bool) -> None:
+        self._safe_send(
+            {"type": "tool_response", "req_id": req_id, "content": content, "is_error": is_error}
+        )
+
+    def _on_state(self, frame: JsonObject) -> None:
+        status = frame.get("status")
+        if isinstance(status, str):
+            self._status = status
+        # Only the terminal `idle` frame is the cancelled turn's true boundary. The
+        # runner emits `state:running` at each prompt start; clearing on that (or any
+        # non-idle frame) could re-enable submit emission while the turn is still
+        # aborting, letting a stale in-flight `submit` surface as a final answer.
+        if self._status == "idle":
+            self._aborting = False
+        payload: JsonObject = {"status": self._status}
+        for key in ("turns", "reason", "msg_id"):
+            if key in frame:
+                payload[key] = frame[key]
+        cleared = frame.get("cleared_steers")
+        if isinstance(cleared, list) and cleared:
+            payload["cleared_steers"] = cleared
+        self._emit("state", payload)
+
+    def _emit_assistant(self, completion: ChatResponse) -> None:
+        if not completion.choices:
+            return
+        text = completion.choices[0].message.content
+        if isinstance(text, str) and text.strip():
+            self._emit("assistant_message", {"text": text})
+
+    def _meter(self, completion: ChatResponse) -> None:
+        self.worker_usage.calls += 1
+        reported = completion.token_usage()
+        self.worker_usage.input_tokens += reported.input_tokens
+        self.worker_usage.output_tokens += reported.output_tokens
+
+    def _tool_specs(self) -> list[JsonObject]:
+        return [
+            {"name": t.name, "description": t.description, "parameters": params_schema(t)}
+            for t in self._tools
+        ]
+
+    def _emit(self, kind: EventKind, payload: JsonObject) -> None:
+        try:
+            self._on_event(SessionEvent(kind=kind, payload=payload))
+        except Exception:  # noqa: BLE001 - a sink error must never stop the session loop
+            pass
+
+    def _recv(self, timeout: float | None) -> JsonObject | None:
+        try:
+            frame = _recv_with_timeout(self._channel, timeout)
+        except TimeoutError:
+            return None
+        except Exception as exc:  # noqa: BLE001 - a dead runner ends the session, not the process
+            if not self._closed:
+                self._failure_message = str(exc)
+                self._emit("error", {"message": self._failure_message})
+                self._mark_closed("failed")
+            return None
+        if frame is None and not self._closed:
+            self._mark_closed("ended")
+        return frame
+
+    def _safe_send(self, frame: JsonObject) -> None:
+        if self._closed:
+            return
+        try:
+            self._channel.send(frame)
+        except Exception as exc:  # noqa: BLE001 - a broken channel ends the session cleanly
+            self._failure_message = f"channel send failed: {exc}"
+            self._emit("error", {"message": self._failure_message})
+            self._mark_closed("failed")
+
+    def _mark_closed(self, status: str) -> None:
+        self._closed = True
+        self._status = status
+
+
+def _recv_with_timeout(channel: Channel, timeout: float | None) -> JsonObject | None:
+    """Call `channel.recv`, passing `timeout` when the channel supports it (E2BStdioChannel does).
+
+    The bare `Channel` protocol has a no-arg `recv`; the E2B channel accepts an optional timeout so
+    the pump can wake to flush the inbox even while the runner is thinking. A channel without the
+    parameter blocks - acceptable for in-process test doubles that always have a frame ready.
+    """
+    recv: Any = channel.recv
+    try:
+        return cast("JsonObject | None", recv(timeout))
+    except TypeError:
+        return cast("JsonObject | None", recv())
+
+
+@dataclass
+class _Deadline:
+    seconds: float
+    _remaining: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        import time
+
+        self._end = time.monotonic() + self.seconds
+
+    def remaining(self) -> float:
+        import time
+
+        return max(0.0, self._end - time.monotonic())
+
+    def expired(self) -> bool:
+        return self.remaining() <= 0.0

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -34,6 +34,7 @@ sides, so eval episodes are unaffected):
     llm_request   {req_id, openai_body}   (reused)
     tool_request  {req_id, name, arguments}  (reused)
     state         {status: "idle"|"running", turns, reason?, cleared_steers?, msg_id?}
+                  (`msg_id` is absent only from the initial ready `idle` state)
     pong          {nonce}
     episode_error {note}           (reused; a fatal runner error ends the session)
 """
@@ -134,6 +135,7 @@ class _UserMessage:
 @dataclass
 class _Interrupt:
     generation: int
+    msg_id: str | None
     reason: str = "user_interrupt"
 
 
@@ -235,6 +237,9 @@ class LiveSession:
         self._turn_lock = threading.Lock()
         self._turn_generation = 0
         self._turn_active = False
+        self._last_enqueued_message_id: str | None = None
+        self._active_message_id: str | None = None
+        self._interrupted_message_id: str | None = None
         self._pending_ping: str | None = None
         self.worker_usage = TokenUsage()
 
@@ -301,17 +306,25 @@ class LiveSession:
                 self._turn_generation += 1
             self._turn_active = True
             generation = self._turn_generation
-        self._inbox.put(_UserMessage(text=text, msg_id=msg_id, generation=generation))
+            self._last_enqueued_message_id = msg_id
+            # Keep the queue order linearizable with interrupt(): once the latest message id is
+            # visible to Stop, its intent is already ahead of that Stop in the inbox.
+            self._inbox.put(_UserMessage(text=text, msg_id=msg_id, generation=generation))
         return msg_id
 
     def interrupt(self, reason: str = "user_interrupt") -> None:
         """Queue an interrupt: abort the current run (does not end the session)."""
         with self._turn_lock:
-            if not self._turn_active:
+            if not self._turn_active or self._interrupt_requested.is_set():
                 return
             generation = self._turn_generation
-        self._request_cancel()
-        self._inbox.put(_Interrupt(generation=generation, reason=reason))
+            # Messages queued before Stop drain before this interrupt. Bind cancellation to the
+            # newest one so an already-buffered idle frame for an older prompt cannot clear it.
+            message_id = self._last_enqueued_message_id or self._active_message_id
+            self._interrupted_message_id = message_id
+            self._interrupt_requested.set()
+            self._inbox.put(_Interrupt(generation=generation, msg_id=message_id, reason=reason))
+        self._invoke_cancel_hook()
 
     def flush_pending_intents(self) -> None:
         """Send queued controls without consuming another runner frame.
@@ -368,7 +381,9 @@ class LiveSession:
             elif isinstance(intent, _Interrupt):
                 with self._turn_lock:
                     targets_active_turn = (
-                        self._turn_active and intent.generation == self._turn_generation
+                        self._turn_active
+                        and intent.generation == self._turn_generation
+                        and intent.msg_id == self._active_message_id
                     )
                 if not targets_active_turn:
                     continue
@@ -502,26 +517,54 @@ class LiveSession:
         )
 
     def _on_state(self, frame: JsonObject) -> None:
-        status = frame.get("status")
-        if isinstance(status, str):
-            self._status = status
+        raw_status = frame.get("status")
+        incoming_status = raw_status if isinstance(raw_status, str) else None
+        completed_message_id = frame.get("msg_id")
+        completed_message_id = (
+            completed_message_id if isinstance(completed_message_id, str) else None
+        )
+        accept_state = True
         with self._turn_lock:
-            if self._status == "running":
+            if incoming_status == "running":
+                self._status = incoming_status
                 if not self._turn_active:
                     self._turn_generation += 1
                 self._turn_active = True
-            elif self._status == "idle":
-                self._turn_active = False
-        completed_message_id = frame.get("msg_id")
-        if self._status == "idle" and isinstance(completed_message_id, str):
+            elif incoming_status == "idle":
+                cancel_pending = self._interrupt_requested.is_set() or self._aborting
+                expected_message_id = (
+                    self._interrupted_message_id if cancel_pending else self._active_message_id
+                )
+                accept_state = (
+                    not cancel_pending
+                    or expected_message_id is None
+                    or completed_message_id == expected_message_id
+                )
+                if accept_state:
+                    self._status = incoming_status
+                    self._turn_active = False
+                    if completed_message_id == self._active_message_id:
+                        self._active_message_id = None
+                    if completed_message_id == self._last_enqueued_message_id:
+                        self._last_enqueued_message_id = None
+            elif incoming_status is not None:
+                self._status = incoming_status
+        if incoming_status == "idle" and completed_message_id is not None:
             self._last_completed_message_id = completed_message_id
+        if not accept_state:
+            # This is a real acknowledgement for an older prompt, but it is not the current
+            # session state. In particular, it must not reset cancellation or release messages
+            # deferred behind the interrupted prompt.
+            return
+        idle_boundary = incoming_status == "idle"
         # Only the terminal `idle` frame is the cancelled turn's true boundary. The
         # runner emits `state:running` at each prompt start; clearing on that (or any
         # non-idle frame) could re-enable submit emission while the turn is still
         # aborting, letting a stale in-flight `submit` surface as a final answer.
-        if self._status == "idle":
+        if idle_boundary:
             self._aborting = False
             self._interrupt_requested.clear()
+            self._interrupted_message_id = None
             if self._reset_cancel is not None:
                 with contextlib.suppress(Exception):
                     self._reset_cancel()
@@ -533,7 +576,7 @@ class LiveSession:
         if isinstance(cleared, list) and cleared:
             payload["cleared_steers"] = cleared
         self._emit("state", payload)
-        if self._status == "idle":
+        if idle_boundary:
             while self._deferred_messages:
                 self._send_user_message(self._deferred_messages.popleft())
 
@@ -546,6 +589,7 @@ class LiveSession:
             if not self._turn_active:
                 self._turn_active = True
                 self._turn_generation = max(self._turn_generation, intent.generation)
+            self._active_message_id = intent.msg_id
         self._actions_this_turn = 0
         self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
         self._safe_send({"type": "user_message", "msg_id": intent.msg_id, "text": intent.text})
@@ -601,6 +645,10 @@ class LiveSession:
     def _request_cancel(self) -> None:
         """Signal in-flight host work immediately, before the pump can drain the intent queue."""
         self._interrupt_requested.set()
+        self._invoke_cancel_hook()
+
+    def _invoke_cancel_hook(self) -> None:
+        """Cancel host-side tool work after the cancellation flag is already observable."""
         if self._cancel_active is not None:
             with contextlib.suppress(Exception):
                 self._cancel_active()

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -234,6 +234,10 @@ class LiveSession:
         self._last_completed_message_id: str | None = None
         self._actions_this_turn = 0
         self._aborting = False
+        # Serialize cancel and reset hooks with terminal idle transitions. Without this lock an
+        # interrupt can publish cancellation, lose the race to the matching idle reset, and only
+        # then invoke the cancel hook, poisoning the next turn's executor.
+        self._cancel_hook_lock = threading.RLock()
         self._turn_lock = threading.Lock()
         self._turn_generation = 0
         self._turn_active = False
@@ -320,17 +324,19 @@ class LiveSession:
 
     def interrupt(self, reason: str = "user_interrupt") -> None:
         """Queue an interrupt: abort the current run (does not end the session)."""
-        with self._turn_lock:
-            if not self._turn_active or self._interrupt_requested.is_set():
-                return
-            generation = self._turn_generation
-            # Messages queued before Stop drain before this interrupt. Bind cancellation to the
-            # newest one so an already-buffered idle frame for an older prompt cannot clear it.
-            message_id = self._last_enqueued_message_id or self._active_message_id
-            self._interrupted_message_id = message_id
-            self._interrupt_requested.set()
-            self._inbox.put(_Interrupt(generation=generation, msg_id=message_id, reason=reason))
-        self._invoke_cancel_hook()
+        with self._cancel_hook_lock:
+            with self._turn_lock:
+                if not self._turn_active or self._interrupt_requested.is_set():
+                    return
+                generation = self._turn_generation
+                # Messages queued before Stop drain before this interrupt. Bind cancellation to
+                # the newest one so an already-buffered idle frame for an older prompt cannot
+                # clear it.
+                message_id = self._last_enqueued_message_id or self._active_message_id
+                self._interrupted_message_id = message_id
+                self._interrupt_requested.set()
+                self._inbox.put(_Interrupt(generation=generation, msg_id=message_id, reason=reason))
+            self._invoke_cancel_hook()
 
     def flush_pending_intents(self) -> None:
         """Send queued controls without consuming another runner frame.
@@ -530,50 +536,60 @@ class LiveSession:
             completed_message_id if isinstance(completed_message_id, str) else None
         )
         accept_state = True
-        with self._turn_lock:
-            if incoming_status == "running":
-                self._status = incoming_status
-                if not self._turn_active:
-                    self._turn_generation += 1
-                self._turn_active = True
-            elif incoming_status == "idle":
-                cancel_pending = self._interrupt_requested.is_set() or self._aborting
-                expected_message_id = (
-                    self._interrupted_message_id
-                    if cancel_pending
-                    else self._last_enqueued_message_id or self._active_message_id
-                )
-                accept_state = (
-                    expected_message_id is None or completed_message_id == expected_message_id
-                )
-                if accept_state:
-                    self._status = incoming_status
-                    self._turn_active = False
-                    if completed_message_id == self._active_message_id:
-                        self._active_message_id = None
-                    if completed_message_id == self._last_enqueued_message_id:
-                        self._last_enqueued_message_id = None
-            elif incoming_status is not None:
-                self._status = incoming_status
-        if incoming_status == "idle" and completed_message_id is not None:
-            self._last_completed_message_id = completed_message_id
-        if not accept_state:
-            # This is a real acknowledgement for an older prompt, but it is not the current
-            # session state. In particular, it must not reset cancellation or release messages
-            # deferred behind the interrupted prompt.
-            return
+        deferred_messages: list[_UserMessage] = []
         idle_boundary = incoming_status == "idle"
-        # Only the terminal `idle` frame is the cancelled turn's true boundary. The
-        # runner emits `state:running` at each prompt start; clearing on that (or any
-        # non-idle frame) could re-enable submit emission while the turn is still
-        # aborting, letting a stale in-flight `submit` surface as a final answer.
-        if idle_boundary:
-            self._aborting = False
-            self._interrupt_requested.clear()
-            self._interrupted_message_id = None
-            if self._reset_cancel is not None:
-                with contextlib.suppress(Exception):
-                    self._reset_cancel()
+        with self._cancel_hook_lock:
+            with self._turn_lock:
+                if incoming_status == "running":
+                    self._status = incoming_status
+                    if not self._turn_active:
+                        self._turn_generation += 1
+                    self._turn_active = True
+                elif idle_boundary:
+                    cancel_pending = self._interrupt_requested.is_set() or self._aborting
+                    expected_message_id = (
+                        self._interrupted_message_id
+                        if cancel_pending
+                        else self._last_enqueued_message_id or self._active_message_id
+                    )
+                    accept_state = (
+                        expected_message_id is None or completed_message_id == expected_message_id
+                    )
+                    if accept_state:
+                        self._status = incoming_status
+                        self._turn_active = False
+                        if completed_message_id == self._active_message_id:
+                            self._active_message_id = None
+                        if completed_message_id == self._last_enqueued_message_id:
+                            self._last_enqueued_message_id = None
+                        # Reserve every deferred prompt as active before exposing the idle state to
+                        # callbacks. A Ctrl-C from that callback must target the queued prompt,
+                        # never observe a transient gap between turns and get discarded.
+                        while self._deferred_messages:
+                            intent = self._deferred_messages.popleft()
+                            self._activate_user_message_locked(intent)
+                            deferred_messages.append(intent)
+                elif incoming_status is not None:
+                    self._status = incoming_status
+            if idle_boundary and completed_message_id is not None:
+                self._last_completed_message_id = completed_message_id
+            if not accept_state:
+                # This is a real acknowledgement for an older prompt, but it is not the current
+                # session state. In particular, it must not reset cancellation or release messages
+                # deferred behind the interrupted prompt.
+                return
+            # Only the terminal `idle` frame is the cancelled turn's true boundary. The runner
+            # emits `state:running` at each prompt start; clearing on that (or any non-idle frame)
+            # could re-enable submit emission while the turn is still aborting, letting a stale
+            # in-flight `submit` surface as a final answer. Keep this reset serialized with the
+            # cancel hook so the hook cannot land after its matching reset.
+            if idle_boundary:
+                self._aborting = False
+                self._interrupt_requested.clear()
+                self._interrupted_message_id = None
+                if self._reset_cancel is not None:
+                    with contextlib.suppress(Exception):
+                        self._reset_cancel()
         payload: JsonObject = {"status": self._status}
         for key in ("turns", "reason", "msg_id"):
             if key in frame:
@@ -582,20 +598,27 @@ class LiveSession:
         if isinstance(cleared, list) and cleared:
             payload["cleared_steers"] = cleared
         self._emit("state", payload)
-        if idle_boundary:
-            while self._deferred_messages:
-                self._send_user_message(self._deferred_messages.popleft())
+        for intent in deferred_messages:
+            self._deliver_user_message(intent)
 
     def _send_user_message(self, intent: _UserMessage) -> None:
         """Send one queued message once it is safe for the peer to start or steer a turn."""
         with self._turn_lock:
-            # An idle boundary may race ahead of an already queued message. Preserve the input as
-            # a fresh prompt rather than dropping it; its generation still distinguishes stale
-            # interrupts queued before it from a stop queued afterward.
-            if not self._turn_active:
-                self._turn_active = True
-                self._turn_generation = max(self._turn_generation, intent.generation)
-            self._active_message_id = intent.msg_id
+            self._activate_user_message_locked(intent)
+        self._deliver_user_message(intent)
+
+    def _activate_user_message_locked(self, intent: _UserMessage) -> None:
+        """Mark one queued message active while the caller holds ``_turn_lock``."""
+        # An idle boundary may race ahead of an already queued message. Preserve the input as a
+        # fresh prompt rather than dropping it; its generation still distinguishes stale
+        # interrupts queued before it from a stop queued afterward.
+        if not self._turn_active:
+            self._turn_active = True
+            self._turn_generation = max(self._turn_generation, intent.generation)
+        self._active_message_id = intent.msg_id
+
+    def _deliver_user_message(self, intent: _UserMessage) -> None:
+        """Emit and send a message whose active state was already reserved."""
         self._actions_this_turn = 0
         self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
         self._safe_send({"type": "user_message", "msg_id": intent.msg_id, "text": intent.text})
@@ -650,8 +673,9 @@ class LiveSession:
 
     def _request_cancel(self) -> None:
         """Signal in-flight host work immediately, before the pump can drain the intent queue."""
-        self._interrupt_requested.set()
-        self._invoke_cancel_hook()
+        with self._cancel_hook_lock:
+            self._interrupt_requested.set()
+            self._invoke_cancel_hook()
 
     def _invoke_cancel_hook(self) -> None:
         """Cancel host-side tool work after the cancellation flag is already observable."""

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -47,7 +47,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal, cast
+from typing import Literal, cast
 
 from pydantic import JsonValue
 
@@ -121,10 +121,12 @@ class _OperationInterrupted(RuntimeError):
 class _UserMessage:
     text: str
     msg_id: str
+    generation: int
 
 
 @dataclass
 class _Interrupt:
+    generation: int
     reason: str = "user_interrupt"
 
 
@@ -208,6 +210,9 @@ class LiveSession:
         self._failure_message: str | None = None
         self._actions_this_turn = 0
         self._aborting = False
+        self._turn_lock = threading.Lock()
+        self._turn_generation = 0
+        self._turn_active = False
         self._pending_ping: str | None = None
         self.worker_usage = TokenUsage()
 
@@ -263,13 +268,22 @@ class LiveSession:
     def send_user_message(self, text: str) -> str:
         """Queue a user message; returns the msg_id echoed on its `user_message` event."""
         msg_id = uuid.uuid4().hex
-        self._inbox.put(_UserMessage(text=text, msg_id=msg_id))
+        with self._turn_lock:
+            if not self._turn_active:
+                self._turn_generation += 1
+            self._turn_active = True
+            generation = self._turn_generation
+        self._inbox.put(_UserMessage(text=text, msg_id=msg_id, generation=generation))
         return msg_id
 
     def interrupt(self, reason: str = "user_interrupt") -> None:
         """Queue an interrupt: abort the current run (does not end the session)."""
+        with self._turn_lock:
+            if not self._turn_active:
+                return
+            generation = self._turn_generation
         self._request_cancel()
-        self._inbox.put(_Interrupt(reason=reason))
+        self._inbox.put(_Interrupt(generation=generation, reason=reason))
 
     def flush_pending_intents(self) -> None:
         """Send queued controls without consuming another runner frame.
@@ -316,6 +330,13 @@ class LiveSession:
             except queue.Empty:
                 return
             if isinstance(intent, _UserMessage):
+                with self._turn_lock:
+                    # An idle boundary may race ahead of an already queued message. Preserve the
+                    # input as a fresh prompt rather than dropping it; its generation still lets
+                    # a stale interrupt queued before it be distinguished from one queued after.
+                    if not self._turn_active:
+                        self._turn_active = True
+                        self._turn_generation = max(self._turn_generation, intent.generation)
                 self._actions_this_turn = 0
                 # NB: do not clear `_aborting` here - a new message can be drained before
                 # the cancelled turn's in-flight submit frame is read, and clearing now
@@ -326,6 +347,12 @@ class LiveSession:
                     {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}
                 )
             elif isinstance(intent, _Interrupt):
+                with self._turn_lock:
+                    targets_active_turn = (
+                        self._turn_active and intent.generation == self._turn_generation
+                    )
+                if not targets_active_turn:
+                    continue
                 # Mark the current turn as aborting so a `submit` tool_request that was
                 # already in flight when the interrupt fired does not emit a final submit
                 # event: the host, not the runner, owns event emission, so this gate is
@@ -459,6 +486,13 @@ class LiveSession:
         status = frame.get("status")
         if isinstance(status, str):
             self._status = status
+        with self._turn_lock:
+            if self._status == "running":
+                if not self._turn_active:
+                    self._turn_generation += 1
+                self._turn_active = True
+            elif self._status == "idle":
+                self._turn_active = False
         # Only the terminal `idle` frame is the cancelled turn's true boundary. The
         # runner emits `state:running` at each prompt start; clearing on that (or any
         # non-idle frame) could re-enable submit emission while the turn is still
@@ -576,17 +610,8 @@ class LiveSession:
 
 
 def _recv_with_timeout(channel: Channel, timeout: float | None) -> JsonObject | None:
-    """Call `channel.recv`, passing `timeout` when the channel supports it (E2BStdioChannel does).
-
-    The bare `Channel` protocol has a no-arg `recv`; the E2B channel accepts an optional timeout so
-    the pump can wake to flush the inbox even while the runner is thinking. A channel without the
-    parameter blocks - acceptable for in-process test doubles that always have a frame ready.
-    """
-    recv: Any = channel.recv
-    try:
-        return cast("JsonObject | None", recv(timeout))
-    except TypeError:
-        return cast("JsonObject | None", recv())
+    """Receive one frame through the typed timeout-aware `Channel` protocol."""
+    return channel.recv(timeout)
 
 
 @dataclass

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -40,7 +40,10 @@ sides, so eval episodes are unaffected):
 
 from __future__ import annotations
 
+import contextlib
 import queue
+import threading
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -95,6 +98,7 @@ EventSink = Callable[[SessionEvent], None]
 # the final (already length-capped by the executor) observation the agent sees.
 OutputEmitter = Callable[[str, str], None]
 ToolExecutor = Callable[[str, JsonObject, OutputEmitter], "ToolOutcome"]
+CancelHook = Callable[[], None]
 
 
 @dataclass(frozen=True)
@@ -104,6 +108,10 @@ class ToolOutcome:
     content: str
     is_error: bool = False
     truncated: bool = False
+
+
+class _OperationInterrupted(RuntimeError):
+    """The user interrupted a host-side provider or tool operation."""
 
 
 # --------------------------------------------------------------------------------------------------
@@ -156,6 +164,8 @@ class LiveSession:
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         temperature: float = 0.7,
         conversation_scope: ConversationScope = "session",
+        cancel_active: CancelHook | None = None,
+        reset_cancel: CancelHook | None = None,
     ) -> None:
         self._channel = channel
         self._tools = list(tools)
@@ -187,8 +197,11 @@ class LiveSession:
         self._max_output_tokens = max_output_tokens
         self._temperature = temperature
         self._conversation_scope = conversation_scope
+        self._cancel_active = cancel_active
+        self._reset_cancel = reset_cancel
 
         self._inbox: queue.Queue[_Intent] = queue.Queue()
+        self._interrupt_requested = threading.Event()
         self._session_id = uuid.uuid4().hex
         self._status: str = "starting"
         self._closed = False
@@ -255,6 +268,7 @@ class LiveSession:
 
     def interrupt(self, reason: str = "user_interrupt") -> None:
         """Queue an interrupt: abort the current run (does not end the session)."""
+        self._request_cancel()
         self._inbox.put(_Interrupt(reason=reason))
 
     def flush_pending_intents(self) -> None:
@@ -269,6 +283,7 @@ class LiveSession:
 
     def end(self) -> None:
         """Queue a graceful end: abort any run, then shut the runner down."""
+        self._request_cancel()
         self._inbox.put(_End())
 
     def ping(self) -> None:
@@ -356,12 +371,14 @@ class LiveSession:
             request_body = dict(body) if isinstance(body, dict) else {}
             request_body["temperature"] = self._temperature
             request = ChatRequest.model_validate(request_body)
-            completion = self._worker_fn(request)
+            completion = self._call_worker(request)
             self._meter(completion)
             self._emit_assistant(completion)
             self._safe_send(
                 {"type": "llm_response", "req_id": req_id, "completion": completion.wire_payload()}
             )
+        except _OperationInterrupted:
+            self._safe_send({"type": "llm_response", "req_id": req_id, "error": "interrupted"})
         except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
             self._emit("error", {"message": f"worker LLM error: {exc}"})
             self._safe_send({"type": "llm_response", "req_id": req_id, "error": str(exc)})
@@ -378,13 +395,13 @@ class LiveSession:
             # If the turn is being interrupted, do NOT emit a final submit for it -
             # the answer belongs to a cancelled run. Still respond so the runner's
             # submit tool does not hang; the aborted run ends via `state:idle`.
-            if not self._aborting:
+            if not self._aborting and not self._interrupt_requested.is_set():
                 answer = args.get("answer")
                 self._emit("submit", {"answer": answer if isinstance(answer, str) else ""})
             self._respond_tool(req_id, "submitted", is_error=False)
             return
 
-        if self._aborting:
+        if self._aborting or self._interrupt_requested.is_set():
             # The turn is being interrupted; do NOT run a real side-effecting tool
             # (bash / write_file) for a cancelled run. Respond so the runner's tool
             # call does not hang; the aborted run ends via `state:idle`.
@@ -412,6 +429,8 @@ class LiveSession:
                 # A transient sandbox/FS error becomes an error result, so the runner
                 # always gets a tool_response and pump() keeps running.
                 outcome = ToolOutcome(content=f"tool {name!r} failed: {exc}", is_error=True)
+            if self._interrupt_requested.is_set():
+                outcome = ToolOutcome(content="interrupted", is_error=True)
         self._emit(
             "tool_result",
             {
@@ -446,6 +465,10 @@ class LiveSession:
         # aborting, letting a stale in-flight `submit` surface as a final answer.
         if self._status == "idle":
             self._aborting = False
+            self._interrupt_requested.clear()
+            if self._reset_cancel is not None:
+                with contextlib.suppress(Exception):
+                    self._reset_cancel()
         payload: JsonObject = {"status": self._status}
         for key in ("turns", "reason", "msg_id"):
             if key in frame:
@@ -467,6 +490,48 @@ class LiveSession:
         reported = completion.token_usage()
         self.worker_usage.input_tokens += reported.input_tokens
         self.worker_usage.output_tokens += reported.output_tokens
+
+    def _call_worker(self, request: ChatRequest) -> ChatResponse:
+        """Run one blocking provider request without preventing an immediate session interrupt.
+
+        Provider SDKs expose no shared cancellation API. The request therefore runs on a daemon
+        thread while the pump waits in short bounded intervals. An interrupt releases the session
+        immediately and ignores a later completion; provider-side timeout/retry policy still owns
+        the underlying request lifetime.
+        """
+        if self._worker_fn is None:  # narrowed by _answer_llm; defensive for direct calls
+            raise RuntimeError("live session has no worker configured")
+        if self._interrupt_requested.is_set():
+            raise _OperationInterrupted
+        results: queue.Queue[ChatResponse | Exception] = queue.Queue(maxsize=1)
+        worker_fn = self._worker_fn
+
+        def invoke() -> None:
+            try:
+                results.put(worker_fn(request))
+            except Exception as exc:  # noqa: BLE001 - re-raised on the pump thread below
+                results.put(exc)
+
+        threading.Thread(target=invoke, name="wmo-live-worker", daemon=True).start()
+        while True:
+            if self._interrupt_requested.is_set():
+                raise _OperationInterrupted
+            try:
+                result = results.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            if self._interrupt_requested.is_set():
+                raise _OperationInterrupted
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    def _request_cancel(self) -> None:
+        """Signal in-flight host work immediately, before the pump can drain the intent queue."""
+        self._interrupt_requested.set()
+        if self._cancel_active is not None:
+            with contextlib.suppress(Exception):
+                self._cancel_active()
 
     def _tool_specs(self) -> list[JsonObject]:
         return [
@@ -530,13 +595,9 @@ class _Deadline:
     _remaining: float = field(init=False)
 
     def __post_init__(self) -> None:
-        import time
-
         self._end = time.monotonic() + self.seconds
 
     def remaining(self) -> float:
-        import time
-
         return max(0.0, self._end - time.monotonic())
 
     def expired(self) -> bool:

--- a/wmo/runtime/harness/live_session.py
+++ b/wmo/runtime/harness/live_session.py
@@ -533,12 +533,12 @@ class LiveSession:
             elif incoming_status == "idle":
                 cancel_pending = self._interrupt_requested.is_set() or self._aborting
                 expected_message_id = (
-                    self._interrupted_message_id if cancel_pending else self._active_message_id
+                    self._interrupted_message_id
+                    if cancel_pending
+                    else self._last_enqueued_message_id or self._active_message_id
                 )
                 accept_state = (
-                    not cancel_pending
-                    or expected_message_id is None
-                    or completed_message_id == expected_message_id
+                    expected_message_id is None or completed_message_id == expected_message_id
                 )
                 if accept_state:
                     self._status = incoming_status

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from wmo.common.core.types import JsonObject
@@ -186,12 +188,28 @@ def test_submit_tool_response_is_answered_without_executor() -> None:
 
 
 def test_interrupt_sends_abort_frame() -> None:
-    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
-    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "idle", "reason": "aborted"},
+        ]
+    )
+    cancelled: list[bool] = []
+    resets: list[bool] = []
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda e: None,
+        cancel_active=lambda: cancelled.append(True),
+        reset_cancel=lambda: resets.append(True),
+    )
     session.start()
     session.interrupt()
     session.pump(timeout=0)
     assert any(f["type"] == "abort" and f["reason"] == "user_interrupt" for f in channel.sent)
+    assert cancelled == [True]
+    assert resets == [True, True]  # initial ready state, then the aborted turn boundary
 
 
 def test_end_sends_abort_then_shutdown_and_closes() -> None:
@@ -323,6 +341,50 @@ def test_worker_error_is_reported_not_raised() -> None:
     assert any(e.kind == "error" for e in events)
     resp = next(f for f in channel.sent if f["type"] == "llm_response")
     assert "provider down" in str(resp["error"])
+
+
+def test_interrupt_releases_a_blocking_worker_request() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        ]
+    )
+
+    def worker(_request: ChatRequest) -> ChatResponse:
+        started.set()
+        release.wait(timeout=2)
+        finished.set()
+        return _completion(text="too late")
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=events.append,
+        worker_fn=worker,
+    )
+    session.start()
+    pump = threading.Thread(target=session.pump)
+    pump.start()
+    assert started.wait(1)
+
+    session.interrupt()
+    pump.join(timeout=1)
+    session.flush_pending_intents()
+
+    assert not pump.is_alive()
+    response = next(frame for frame in channel.sent if frame["type"] == "llm_response")
+    assert response["error"] == "interrupted"
+    assert any(frame["type"] == "abort" for frame in channel.sent)
+    assert not any(event.kind == "assistant_message" for event in events)
+
+    release.set()
+    assert finished.wait(1)
 
 
 def test_channel_close_marks_session_ended() -> None:

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -155,6 +155,12 @@ def test_channel_type_error_is_not_retried_as_a_second_receive() -> None:
 
 def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     events: list[SessionEvent] = []
+    completed_state: JsonObject = {
+        "type": "state",
+        "status": "idle",
+        "reason": "completed",
+        "turns": 1,
+    }
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},  # consumed by start()
@@ -166,13 +172,7 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
                 "name": "submit",
                 "arguments": {"answer": "done"},
             },
-            {
-                "type": "state",
-                "status": "idle",
-                "reason": "completed",
-                "turns": 1,
-                "msg_id": "completed-1",
-            },
+            completed_state,
         ]
     )
 
@@ -191,7 +191,8 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     )
     session.start()
     events.clear()  # drop the initial "ready" state event; assert only the turn's events
-    session.send_user_message("list the files")
+    message_id = session.send_user_message("list the files")
+    completed_state["msg_id"] = message_id
     _drain(session)
 
     kinds = [e.kind for e in events]
@@ -216,7 +217,7 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     assert session.worker_usage.calls == 1
     assert session.worker_usage.input_tokens == 5
     assert session.worker_usage.output_tokens == 7
-    assert session.last_completed_message_id == "completed-1"
+    assert session.last_completed_message_id == message_id
 
 
 def test_submit_tool_response_is_answered_without_executor() -> None:
@@ -325,13 +326,68 @@ def test_stale_idle_does_not_reset_a_newer_interrupted_message() -> None:
     assert resets == [True]
 
 
-def test_interrupt_while_idle_is_ignored_and_does_not_poison_the_next_turn() -> None:
+def test_stale_idle_does_not_make_the_newer_message_uninterruptible() -> None:
+    """A stale pre-Stop idle state cannot make the current prompt appear inactive."""
+    first_running: JsonObject = {"type": "state", "status": "running"}
+    stale_idle: JsonObject = {"type": "state", "status": "idle", "reason": "completed"}
+    interrupted_idle: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},
-            {"type": "state", "status": "running"},
+            first_running,
+            stale_idle,
             {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}},
-            {"type": "state", "status": "idle", "reason": "completed"},
+            interrupted_idle,
+        ]
+    )
+    cancelled: list[bool] = []
+    ran: list[str] = []
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        ran.append(name)
+        return ToolOutcome(content="must not run")
+
+    session = LiveSession(
+        channel,
+        tools=[BASH],
+        execute_tool=execute,
+        on_event=lambda event: None,
+        cancel_active=lambda: cancelled.append(True),
+    )
+    session.start()
+    first_message_id = session.send_user_message("first")
+    first_running["msg_id"] = first_message_id
+    stale_idle["msg_id"] = first_message_id
+    session.pump(timeout=0)
+
+    second_message_id = session.send_user_message("second")
+    interrupted_idle["msg_id"] = second_message_id
+    session.pump(timeout=0)
+    assert session.status == "running"
+
+    session.interrupt()
+    session.pump(timeout=0)
+
+    assert cancelled == [True]
+    assert any(frame["type"] == "abort" for frame in channel.sent)
+    assert ran == []
+    response = next(frame for frame in channel.sent if frame["type"] == "tool_response")
+    assert response["content"] == "interrupted"
+    assert response["is_error"] is True
+
+    session.pump(timeout=0)
+    assert session.status == "idle"
+
+
+def test_interrupt_while_idle_is_ignored_and_does_not_poison_the_next_turn() -> None:
+    running_state: JsonObject = {"type": "state", "status": "running"}
+    completed_state: JsonObject = {"type": "state", "status": "idle", "reason": "completed"}
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            running_state,
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}},
+            completed_state,
         ]
     )
     cancelled: list[bool] = []
@@ -350,7 +406,9 @@ def test_interrupt_while_idle_is_ignored_and_does_not_poison_the_next_turn() -> 
     )
     session.start()
     session.interrupt()
-    session.send_user_message("go")
+    message_id = session.send_user_message("go")
+    running_state["msg_id"] = message_id
+    completed_state["msg_id"] = message_id
     _drain(session)
 
     assert cancelled == []

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -164,7 +164,13 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
                 "name": "submit",
                 "arguments": {"answer": "done"},
             },
-            {"type": "state", "status": "idle", "reason": "completed", "turns": 1},
+            {
+                "type": "state",
+                "status": "idle",
+                "reason": "completed",
+                "turns": 1,
+                "msg_id": "completed-1",
+            },
         ]
     )
 
@@ -184,7 +190,6 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     session.start()
     events.clear()  # drop the initial "ready" state event; assert only the turn's events
     session.send_user_message("list the files")
-    assert session.turn_active
     _drain(session)
 
     kinds = [e.kind for e in events]
@@ -209,7 +214,7 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     assert session.worker_usage.calls == 1
     assert session.worker_usage.input_tokens == 5
     assert session.worker_usage.output_tokens == 7
-    assert not session.turn_active
+    assert session.last_completed_message_id == "completed-1"
 
 
 def test_submit_tool_response_is_answered_without_executor() -> None:

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -31,7 +31,9 @@ class ScriptedChannel:
 
 
 def _completion(
-    text: str = "", tool_calls: list | None = None, usage: dict | None = None
+    text: str = "",
+    tool_calls: list[JsonObject] | None = None,
+    usage: JsonObject | None = None,
 ) -> ChatResponse:
     msg: JsonObject = {"role": "assistant", "content": text}
     if tool_calls is not None:

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -184,6 +184,7 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     session.start()
     events.clear()  # drop the initial "ready" state event; assert only the turn's events
     session.send_user_message("list the files")
+    assert session.turn_active
     _drain(session)
 
     kinds = [e.kind for e in events]
@@ -208,6 +209,7 @@ def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     assert session.worker_usage.calls == 1
     assert session.worker_usage.input_tokens == 5
     assert session.worker_usage.output_tokens == 7
+    assert not session.turn_active
 
 
 def test_submit_tool_response_is_answered_without_executor() -> None:

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -83,6 +83,29 @@ def test_start_can_scope_conversation_to_each_outer_turn() -> None:
     assert channel.sent[0]["conversation_scope"] == "turn"
 
 
+def test_start_carries_the_providers_served_context_window() -> None:
+    class ContextProvider:
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            _ = request
+            return _completion()
+
+        def context_window(self) -> int | None:
+            return 65_536
+
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        provider=ContextProvider(),
+    )
+
+    session.start()
+
+    assert channel.sent[0]["context_window"] == 65_536
+
+
 def test_rejects_unknown_conversation_scope() -> None:
     channel = ScriptedChannel([])
 

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -270,6 +270,111 @@ def test_interrupt_sends_abort_frame() -> None:
     assert resets == [True, True]  # initial ready state, then the aborted turn boundary
 
 
+def test_matching_idle_cannot_reset_before_the_cancel_hook_finishes() -> None:
+    """A delayed cancel hook must land before its matching terminal reset."""
+    idle_delivered = threading.Event()
+
+    class _SignallingChannel(ScriptedChannel):
+        def __init__(self, inbound: list[JsonObject]) -> None:
+            super().__init__(inbound)
+            self._receives = 0
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            self._receives += 1
+            frame = super().recv(timeout)
+            if self._receives == 2:
+                idle_delivered.set()
+            return frame
+
+    aborted_state: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
+    channel = _SignallingChannel([{"type": "state", "status": "idle"}, aborted_state])
+    cancel_entered = threading.Event()
+    release_cancel = threading.Event()
+    reset_called = threading.Event()
+    hook_order: list[str] = []
+    executor_cancelled = False
+
+    def cancel() -> None:
+        nonlocal executor_cancelled
+        cancel_entered.set()
+        release_cancel.wait(timeout=2)
+        executor_cancelled = True
+        hook_order.append("cancel")
+
+    def reset() -> None:
+        nonlocal executor_cancelled
+        executor_cancelled = False
+        hook_order.append("reset")
+        reset_called.set()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        cancel_active=cancel,
+        reset_cancel=reset,
+    )
+    session.start()
+    hook_order.clear()
+    reset_called.clear()
+    message_id = session.send_user_message("go")
+    aborted_state["msg_id"] = message_id
+
+    interrupt_thread = threading.Thread(target=session.interrupt)
+    interrupt_thread.start()
+    assert cancel_entered.wait(timeout=1)
+    pump_thread = threading.Thread(target=session.pump, kwargs={"timeout": 0})
+    pump_thread.start()
+    assert idle_delivered.wait(timeout=1)
+    reset_raced_ahead = reset_called.wait(timeout=0.1)
+    release_cancel.set()
+    interrupt_thread.join(timeout=1)
+    pump_thread.join(timeout=1)
+
+    assert not interrupt_thread.is_alive()
+    assert not pump_thread.is_alive()
+    assert not reset_raced_ahead
+    assert hook_order == ["cancel", "reset"]
+    assert executor_cancelled is False
+
+
+def test_idle_callback_can_interrupt_the_deferred_turn() -> None:
+    """The next prompt stays active while an aborted prompt crosses its idle boundary."""
+    aborted_state: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}, aborted_state])
+    holder: dict[str, LiveSession] = {}
+    cancellations: list[bool] = []
+
+    def on_event(event: SessionEvent) -> None:
+        if event.kind == "state" and event.payload.get("reason") == "aborted":
+            holder["session"].interrupt()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=on_event,
+        cancel_active=lambda: cancellations.append(True),
+    )
+    holder["session"] = session
+    session.start()
+    first_message_id = session.send_user_message("first")
+    aborted_state["msg_id"] = first_message_id
+    session.interrupt()
+    session.send_user_message("second")
+
+    session.pump(timeout=0)
+    session.flush_pending_intents()
+
+    sent_messages = [frame for frame in channel.sent if frame["type"] == "user_message"]
+    aborts = [frame for frame in channel.sent if frame["type"] == "abort"]
+    assert [frame["text"] for frame in sent_messages] == ["first", "second"]
+    assert len(aborts) == 2
+    assert cancellations == [True, True]
+    assert session.turn_active
+
+
 def test_stale_idle_does_not_reset_a_newer_interrupted_message() -> None:
     """An old idle acknowledgement cannot re-enable work for a newer cancelled prompt."""
     running_state: JsonObject = {"type": "state", "status": "running"}

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -1,0 +1,482 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for the LiveSession host engine, driven by a scripted in-process channel peer."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.common.core.types import JsonObject
+from wmo.common.vendor.waterfall import ChatRequest, ChatResponse
+from wmo.runtime.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+from wmo.runtime.harness.tools import BASH, READ_SKILL, SUBMIT
+
+
+class ScriptedChannel:
+    """A `Channel` whose `recv` replays a fixed inbound frame list; captures outbound sends."""
+
+    def __init__(self, inbound: list[JsonObject]) -> None:
+        self._inbound = list(inbound)
+        self.sent: list[JsonObject] = []
+
+    def send(self, frame: JsonObject) -> None:
+        self.sent.append(frame)
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        if self._inbound:
+            return self._inbound.pop(0)
+        return None  # exhausted = channel closed
+
+
+def _completion(
+    text: str = "", tool_calls: list | None = None, usage: dict | None = None
+) -> ChatResponse:
+    msg: JsonObject = {"role": "assistant", "content": text}
+    if tool_calls is not None:
+        msg["tool_calls"] = tool_calls
+    choice: JsonObject = {"index": 0, "message": msg, "finish_reason": "stop"}
+    completion: JsonObject = {"choices": [choice]}
+    if usage is not None:
+        completion["usage"] = usage
+    return ChatResponse.model_validate(completion)
+
+
+def _drain(session: LiveSession) -> None:
+    for _ in range(100):
+        if not session.pump(timeout=0):
+            return
+
+
+def test_start_waits_for_first_idle_state() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda e: None,
+        max_output_tokens=16384,
+        temperature=0.35,
+    )
+    session.start()
+    assert session.status == "idle"
+    assert channel.sent[0]["type"] == "session_start"
+    assert channel.sent[0]["turn_cap"] == 60
+    assert channel.sent[0]["max_output_tokens"] == 16384
+    assert channel.sent[0]["temperature"] == 0.35
+    assert channel.sent[0]["conversation_scope"] == "session"
+
+
+def test_start_can_scope_conversation_to_each_outer_turn() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda e: None,
+        conversation_scope="turn",
+    )
+
+    session.start()
+
+    assert channel.sent[0]["conversation_scope"] == "turn"
+
+
+def test_rejects_unknown_conversation_scope() -> None:
+    channel = ScriptedChannel([])
+
+    with pytest.raises(ValueError, match="conversation_scope"):
+        LiveSession(
+            channel,
+            tools=[],
+            execute_tool=_no_tool,
+            on_event=lambda e: None,
+            conversation_scope="message",  # ty: ignore[invalid-argument-type]
+        )
+
+
+def test_start_surfaces_the_runner_construction_error() -> None:
+    channel = ScriptedChannel(
+        [{"type": "episode_error", "note": "could not import the agent harness"}]
+    )
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+
+    with pytest.raises(RuntimeError, match="could not import the agent harness"):
+        session.start()
+
+
+def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},  # consumed by start()
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+            {"type": "tool_request", "req_id": 2, "name": "bash", "arguments": {"command": "ls"}},
+            {
+                "type": "tool_request",
+                "req_id": 3,
+                "name": "submit",
+                "arguments": {"answer": "done"},
+            },
+            {"type": "state", "status": "idle", "reason": "completed", "turns": 1},
+        ]
+    )
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        emit("stdout", "file-a\n")
+        return ToolOutcome(content="file-a\n", is_error=False)
+
+    session = LiveSession(
+        channel,
+        tools=[BASH, SUBMIT],
+        execute_tool=execute,
+        on_event=events.append,
+        worker_fn=lambda body: _completion(
+            text="on it", usage={"prompt_tokens": 5, "completion_tokens": 7}
+        ),
+    )
+    session.start()
+    events.clear()  # drop the initial "ready" state event; assert only the turn's events
+    session.send_user_message("list the files")
+    _drain(session)
+
+    kinds = [e.kind for e in events]
+    assert kinds == [
+        "user_message",
+        "assistant_message",
+        "tool_call",
+        "tool_output",
+        "tool_result",
+        "submit",
+        "state",
+    ]
+    assert events[1].payload["text"] == "on it"
+    assert events[2].payload["name"] == "bash"
+    assert events[4].payload["content"] == "file-a\n"
+    assert events[5].payload["answer"] == "done"
+
+    sent_types = [f["type"] for f in channel.sent]
+    assert sent_types.count("user_message") == 1
+    assert sent_types.count("llm_response") == 1
+    assert sent_types.count("tool_response") == 2  # bash + submit
+    assert session.worker_usage.calls == 1
+    assert session.worker_usage.input_tokens == 5
+    assert session.worker_usage.output_tokens == 7
+
+
+def test_submit_tool_response_is_answered_without_executor() -> None:
+    calls: list[str] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        calls.append(name)
+        return ToolOutcome(content="should not run")
+
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=execute, on_event=lambda e: None)
+    session.start()
+    _drain(session)
+    assert calls == []  # submit never routes to the real executor
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["content"] == "submitted"
+    assert resp["is_error"] is False
+
+
+def test_interrupt_sends_abort_frame() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    session.interrupt()
+    session.pump(timeout=0)
+    assert any(f["type"] == "abort" and f["reason"] == "user_interrupt" for f in channel.sent)
+
+
+def test_end_sends_abort_then_shutdown_and_closes() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    session.end()
+    assert session.pump(timeout=0) is False
+    tail = [f["type"] for f in channel.sent[-2:]]
+    assert tail == ["abort", "shutdown"]
+    assert session.closed
+
+
+def test_action_budget_exhausts_after_cap() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {"command": "a"}},
+            {"type": "tool_request", "req_id": 2, "name": "bash", "arguments": {"command": "b"}},
+        ]
+    )
+    ran: list[str] = []
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        ran.append(str(args.get("command")))
+        return ToolOutcome(content="ok")
+
+    session = LiveSession(
+        channel, tools=[BASH], execute_tool=execute, on_event=events.append, actions_per_turn=1
+    )
+    session.start()
+    session.send_user_message("go")
+    _drain(session)
+    assert ran == ["a"]  # second call is over budget, never executed
+    results = [e for e in events if e.kind == "tool_result"]
+    assert results[1].payload["is_error"] is True
+    assert "budget exhausted" in str(results[1].payload["content"])
+
+
+def test_read_skill_answered_from_bodies() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "tool_request",
+                "req_id": 1,
+                "name": "read_skill",
+                "arguments": {"name": "deploy"},
+            },
+            {
+                "type": "tool_request",
+                "req_id": 2,
+                "name": "read_skill",
+                "arguments": {"name": "missing"},
+            },
+        ]
+    )
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=events.append,
+        skill_bodies={"deploy": "run ./deploy.sh"},
+    )
+    session.start()
+    raw_tools = channel.sent[0]["tools"]
+    assert isinstance(raw_tools, list)
+    advertised = {tool["name"] for tool in raw_tools if isinstance(tool, dict) and "name" in tool}
+    assert READ_SKILL.name in advertised
+    _drain(session)
+    results = [e for e in events if e.kind == "tool_result"]
+    assert results[0].payload["content"] == "run ./deploy.sh"
+    assert results[1].payload["content"] == "no skill named 'missing'"
+    assert results[1].payload["is_error"] is True
+
+
+def test_harness_temperature_overrides_live_runner_request() -> None:
+    requests: list[ChatRequest] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "llm_request",
+                "req_id": 1,
+                "openai_body": {"messages": [], "temperature": 1.75},
+            },
+        ]
+    )
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        requests.append(request)
+        return _completion()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=worker,
+        temperature=0.35,
+    )
+    session.start()
+    _drain(session)
+
+    assert [request.temperature for request in requests] == [0.35]
+
+
+def test_worker_error_is_reported_not_raised() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        ]
+    )
+
+    def boom(request: ChatRequest) -> ChatResponse:
+        _ = request
+        msg = "provider down"
+        raise RuntimeError(msg)
+
+    session = LiveSession(
+        channel, tools=[], execute_tool=_no_tool, on_event=events.append, worker_fn=boom
+    )
+    session.start()
+    _drain(session)
+    assert any(e.kind == "error" for e in events)
+    resp = next(f for f in channel.sent if f["type"] == "llm_response")
+    assert "provider down" in str(resp["error"])
+
+
+def test_channel_close_marks_session_ended() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    assert session.pump(timeout=0) is False
+    assert session.closed
+    assert session.status == "ended"
+
+
+def test_unknown_tool_is_rejected() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "rm_rf", "arguments": {}},
+        ]
+    )
+    session = LiveSession(channel, tools=[BASH], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    _drain(session)
+    result = next(e for e in events if e.kind == "tool_result")
+    assert result.payload["is_error"] is True
+    assert "not available" in str(result.payload["content"])
+
+
+def _no_tool(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+    return ToolOutcome(content="", is_error=True)
+
+
+def test_interrupt_suppresses_a_racing_submit_event() -> None:
+    """A submit that arrives after an interrupt for the same turn emits no submit event."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            # The interrupt is queued (below) before this in-flight submit is processed.
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    events.clear()
+    session.interrupt()  # user hits Stop while the submit is racing
+    _drain(session)
+    # The abort was sent; the racing submit is answered but NOT surfaced as a submit event.
+    assert not any(e.kind == "submit" for e in events)
+    assert any(f["type"] == "abort" for f in channel.sent)
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["content"] == "submitted"  # runner still gets a response (no hang)
+
+
+def test_submit_after_state_boundary_is_not_suppressed() -> None:
+    """A fresh turn's submit is emitted normally after the aborted turn ended (state boundary)."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "idle", "reason": "aborted"},  # aborted turn ended
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "y"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    session.interrupt()
+    events.clear()
+    _drain(session)
+    assert any(e.kind == "submit" for e in events)
+
+
+def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
+    """A cancelled turn's in-flight submit is suppressed even if the user already sent a new
+    message: only the runner's next state frame (the turn boundary) clears the abort gate."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            # The cancelled turn's submit arrives AFTER the user's next message was drained.
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    session.interrupt()
+    session.send_user_message("do the next thing")  # queued before the stale submit is read
+    events.clear()
+    _drain(session)
+    assert not any(e.kind == "submit" for e in events)  # stale submit stays suppressed
+
+
+def test_running_state_does_not_clear_the_abort_gate() -> None:
+    """A `running` frame is a prompt start, not the cancelled turn's boundary: only `idle`
+    clears the gate, so a stale submit read after a `running` frame stays suppressed."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "running"},  # prompt-start frame, NOT the boundary
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    session.interrupt()
+    events.clear()
+    _drain(session)
+    assert not any(e.kind == "submit" for e in events)  # `running` did not re-enable submit
+
+
+def test_aborting_skips_real_tool_execution() -> None:
+    """While a turn is aborting, a side-effecting tool request is answered interrupted, not run."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {"command": "rm x"}},
+        ]
+    )
+    ran: list[str] = []
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        ran.append(name)
+        return ToolOutcome(content="ran")
+
+    session = LiveSession(channel, tools=[BASH], execute_tool=execute, on_event=lambda e: None)
+    session.start()
+    session.interrupt()  # user hits Stop while a bash request is already queued
+    _drain(session)
+    assert ran == []  # the tool never executed against the live sandbox
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["is_error"] is True
+    assert resp["content"] == "interrupted"
+
+
+def test_tool_executor_exception_becomes_error_result() -> None:
+    """A raising executor yields an error tool_result + response instead of crashing pump()."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {"command": "ls"}},
+        ]
+    )
+
+    def boom(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        raise RuntimeError("sandbox gone")
+
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[BASH], execute_tool=boom, on_event=events.append)
+    session.start()
+    session.send_user_message("go")
+    events.clear()
+    _drain(session)  # must not raise
+    result = next(e for e in events if e.kind == "tool_result")
+    assert result.payload["is_error"] is True
+    assert "failed" in str(result.payload["content"])
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["is_error"] is True

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -106,6 +106,28 @@ def test_start_surfaces_the_runner_construction_error() -> None:
         session.start()
 
 
+def test_channel_type_error_is_not_retried_as_a_second_receive() -> None:
+    class BrokenChannel:
+        def __init__(self) -> None:
+            self.receives = 0
+
+        def send(self, frame: JsonObject) -> None:
+            _ = frame
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            _ = timeout
+            self.receives += 1
+            raise TypeError("decoder bug")
+
+    channel = BrokenChannel()
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda event: None)
+
+    with pytest.raises(RuntimeError, match="decoder bug"):
+        session.start()
+
+    assert channel.receives == 1
+
+
 def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
     events: list[SessionEvent] = []
     channel = ScriptedChannel(
@@ -205,11 +227,48 @@ def test_interrupt_sends_abort_frame() -> None:
         reset_cancel=lambda: resets.append(True),
     )
     session.start()
+    session.send_user_message("go")
     session.interrupt()
     session.pump(timeout=0)
     assert any(f["type"] == "abort" and f["reason"] == "user_interrupt" for f in channel.sent)
     assert cancelled == [True]
     assert resets == [True, True]  # initial ready state, then the aborted turn boundary
+
+
+def test_interrupt_while_idle_is_ignored_and_does_not_poison_the_next_turn() -> None:
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "running"},
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}},
+            {"type": "state", "status": "idle", "reason": "completed"},
+        ]
+    )
+    cancelled: list[bool] = []
+    ran: list[str] = []
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        ran.append(name)
+        return ToolOutcome(content="ok")
+
+    session = LiveSession(
+        channel,
+        tools=[BASH],
+        execute_tool=execute,
+        on_event=lambda event: None,
+        cancel_active=lambda: cancelled.append(True),
+    )
+    session.start()
+    session.interrupt()
+    session.send_user_message("go")
+    _drain(session)
+
+    assert cancelled == []
+    assert not any(frame["type"] == "abort" for frame in channel.sent)
+    assert ran == ["bash"]
+    response = next(frame for frame in channel.sent if frame["type"] == "tool_response")
+    assert response["content"] == "ok"
+    assert response["is_error"] is False
 
 
 def test_end_sends_abort_then_shutdown_and_closes() -> None:
@@ -369,6 +428,7 @@ def test_interrupt_releases_a_blocking_worker_request() -> None:
         worker_fn=worker,
     )
     session.start()
+    session.send_user_message("go")
     pump = threading.Thread(target=session.pump)
     pump.start()
     assert started.wait(1)
@@ -428,6 +488,7 @@ def test_interrupt_suppresses_a_racing_submit_event() -> None:
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("go")
     events.clear()
     session.interrupt()  # user hits Stop while the submit is racing
     _drain(session)
@@ -450,8 +511,11 @@ def test_submit_after_state_boundary_is_not_suppressed() -> None:
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("first")
     session.interrupt()
     events.clear()
+    session.pump(timeout=0)  # consume the aborted turn's idle boundary
+    session.send_user_message("second")
     _drain(session)
     assert any(e.kind == "submit" for e in events)
 
@@ -469,6 +533,7 @@ def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("first")
     session.interrupt()
     session.send_user_message("do the next thing")  # queued before the stale submit is read
     events.clear()
@@ -489,6 +554,7 @@ def test_running_state_does_not_clear_the_abort_gate() -> None:
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("go")
     session.interrupt()
     events.clear()
     _drain(session)
@@ -511,6 +577,7 @@ def test_aborting_skips_real_tool_execution() -> None:
 
     session = LiveSession(channel, tools=[BASH], execute_tool=execute, on_event=lambda e: None)
     session.start()
+    session.send_user_message("go")
     session.interrupt()  # user hits Stop while a bash request is already queued
     _drain(session)
     assert ran == []  # the tool never executed against the live sandbox

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -242,10 +242,11 @@ def test_submit_tool_response_is_answered_without_executor() -> None:
 
 
 def test_interrupt_sends_abort_frame() -> None:
+    aborted_state: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},
-            {"type": "state", "status": "idle", "reason": "aborted"},
+            aborted_state,
         ]
     )
     cancelled: list[bool] = []
@@ -259,12 +260,69 @@ def test_interrupt_sends_abort_frame() -> None:
         reset_cancel=lambda: resets.append(True),
     )
     session.start()
-    session.send_user_message("go")
+    message_id = session.send_user_message("go")
+    aborted_state["msg_id"] = message_id
     session.interrupt()
     session.pump(timeout=0)
     assert any(f["type"] == "abort" and f["reason"] == "user_interrupt" for f in channel.sent)
     assert cancelled == [True]
     assert resets == [True, True]  # initial ready state, then the aborted turn boundary
+
+
+def test_stale_idle_does_not_reset_a_newer_interrupted_message() -> None:
+    """An old idle acknowledgement cannot re-enable work for a newer cancelled prompt."""
+    running_state: JsonObject = {"type": "state", "status": "running"}
+    stale_idle: JsonObject = {"type": "state", "status": "idle", "reason": "completed"}
+    interrupted_idle: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            running_state,
+            stale_idle,
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+            interrupted_idle,
+        ]
+    )
+    resets: list[bool] = []
+    worker_calls: list[ChatRequest] = []
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        worker_calls.append(request)
+        return _completion(text="must not run")
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=worker,
+        reset_cancel=lambda: resets.append(True),
+    )
+    session.start()
+    resets.clear()
+    first_message_id = session.send_user_message("first")
+    running_state["msg_id"] = first_message_id
+    stale_idle["msg_id"] = first_message_id
+    session.pump(timeout=0)
+
+    second_message_id = session.send_user_message("second")
+    interrupted_idle["msg_id"] = second_message_id
+    session.interrupt()
+    session.pump(timeout=0)
+
+    assert session.status == "running"
+    assert session.last_completed_message_id == first_message_id
+    assert resets == []
+
+    session.pump(timeout=0)
+    response = next(frame for frame in channel.sent if frame["type"] == "llm_response")
+    assert response["error"] == "interrupted"
+    assert worker_calls == []
+
+    session.pump(timeout=0)
+    assert session.status == "idle"
+    assert session.last_completed_message_id == second_message_id
+    assert resets == [True]
 
 
 def test_interrupt_while_idle_is_ignored_and_does_not_poison_the_next_turn() -> None:
@@ -533,17 +591,19 @@ def test_interrupt_suppresses_a_racing_submit_event() -> None:
 
 def test_submit_after_state_boundary_is_not_suppressed() -> None:
     """A fresh turn's submit is emitted normally after the aborted turn ended (state boundary)."""
+    aborted_state: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},
-            {"type": "state", "status": "idle", "reason": "aborted"},  # aborted turn ended
+            aborted_state,
             {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "y"}},
         ]
     )
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
-    session.send_user_message("first")
+    first_message_id = session.send_user_message("first")
+    aborted_state["msg_id"] = first_message_id
     session.interrupt()
     events.clear()
     session.pump(timeout=0)  # consume the aborted turn's idle boundary
@@ -554,18 +614,20 @@ def test_submit_after_state_boundary_is_not_suppressed() -> None:
 
 def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
     """Hold the next message until idle while suppressing the cancelled turn's stale submit."""
+    aborted_state: JsonObject = {"type": "state", "status": "idle", "reason": "aborted"}
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},
             {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
-            {"type": "state", "status": "idle", "reason": "aborted"},
+            aborted_state,
             {"type": "state", "status": "running"},
         ]
     )
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
-    session.send_user_message("first")
+    first_message_id = session.send_user_message("first")
+    aborted_state["msg_id"] = first_message_id
     session.interrupt()
     session.send_user_message("do the next thing")  # queued before the stale submit is read
     events.clear()

--- a/wmo/runtime/harness/live_session_test.py
+++ b/wmo/runtime/harness/live_session_test.py
@@ -544,13 +544,13 @@ def test_submit_after_state_boundary_is_not_suppressed() -> None:
 
 
 def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
-    """A cancelled turn's in-flight submit is suppressed even if the user already sent a new
-    message: only the runner's next state frame (the turn boundary) clears the abort gate."""
+    """Hold the next message until idle while suppressing the cancelled turn's stale submit."""
     channel = ScriptedChannel(
         [
             {"type": "state", "status": "idle"},
-            # The cancelled turn's submit arrives AFTER the user's next message was drained.
             {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+            {"type": "state", "status": "idle", "reason": "aborted"},
+            {"type": "state", "status": "running"},
         ]
     )
     events: list[SessionEvent] = []
@@ -560,6 +560,19 @@ def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
     session.interrupt()
     session.send_user_message("do the next thing")  # queued before the stale submit is read
     events.clear()
+
+    session.pump(timeout=0)  # suppress the stale submit; the next instruction remains held
+    sent_messages = [
+        str(frame["text"]) for frame in channel.sent if frame["type"] == "user_message"
+    ]
+    assert sent_messages == ["first"]
+
+    session.pump(timeout=0)  # idle is the boundary that releases the next instruction
+    sent_messages = [
+        str(frame["text"]) for frame in channel.sent if frame["type"] == "user_message"
+    ]
+    assert sent_messages == ["first", "do the next thing"]
+
     _drain(session)
     assert not any(e.kind == "submit" for e in events)  # stale submit stays suppressed
 

--- a/wmo/runtime/harness/pi_entry/runner_live.ts
+++ b/wmo/runtime/harness/pi_entry/runner_live.ts
@@ -401,6 +401,7 @@ class Session {
 	private conversationScope: "session" | "turn" = "session";
 	private interrupted = false;
 	private hitTurnCap = false;
+	private lastMessageId: string | undefined;
 
 	constructor(conn: StdioConn) {
 		this.conn = conn;
@@ -504,6 +505,8 @@ class Session {
 	handleUserMessage(frame: Frame): void {
 		const text = String(frame.text ?? "");
 		if (!this.agent) return;
+		const messageId = frame.msg_id;
+		if (typeof messageId === "string") this.lastMessageId = messageId;
 		if (this.running) {
 			this.agent.steer(userMessage(text));
 			return;
@@ -554,6 +557,7 @@ class Session {
 	private sendState(status: "idle" | "running", reason?: string): void {
 		const frame: Frame = { type: "state", status, turns: this.turns };
 		if (reason) frame.reason = reason;
+		if (this.lastMessageId) frame.msg_id = this.lastMessageId;
 		this.conn.send(frame);
 	}
 }

--- a/wmo/runtime/harness/pi_local_test.py
+++ b/wmo/runtime/harness/pi_local_test.py
@@ -247,10 +247,66 @@ def test_live_runner_turn_scope_clears_only_the_prior_outer_turn(tmp_path: Path)
                 process,
                 {"type": "user_message", "msg_id": f"m{index}", "text": f"round {index}"},
             )
-            assert _read_live_frame(process)["status"] == "running"
+            running = _read_live_frame(process)
+            assert running["status"] == "running"
+            assert running["msg_id"] == f"m{index}"
             terminal = _read_live_frame(process)
             assert terminal["status"] == "idle"
             assert terminal["reason"] == "completed"
+            assert terminal["msg_id"] == f"m{index}"
+    finally:
+        _stop_live_runner(process)
+
+
+def test_live_runner_idle_acknowledges_the_last_steered_message(tmp_path: Path) -> None:
+    """A terminal idle frame identifies every user message absorbed by that turn."""
+    node = _node_22()
+    env = os.environ.copy()
+    env.pop("WMO_LIVE_OUTBOX", None)
+    env["NODE_NO_WARNINGS"] = "1"
+    process = _start_live_runner(node, env, cwd=tmp_path)
+    agent_source = """export class Agent {
+  state = { messages: [] };
+  listeners = [];
+  pendingResolve = null;
+  constructor(_options) {}
+  subscribe(listener) { this.listeners.push(listener); return () => {}; }
+  steer(_message) { this.pendingResolve?.(); this.pendingResolve = null; }
+  abort() { this.pendingResolve?.(); this.pendingResolve = null; }
+  async prompt(_text) {
+    await new Promise((resolve) => { this.pendingResolve = resolve; });
+    for (const listener of this.listeners) await listener({ type: "turn_end" });
+  }
+}
+"""
+    try:
+        assert _read_live_frame(process)["type"] == "hello"
+        _send_live_frame(
+            process,
+            {
+                "type": "session_start",
+                "files": {"src/agent.ts": agent_source},
+                "tools": [],
+            },
+        )
+        assert _read_live_frame(process) == {"type": "state", "status": "idle", "turns": 0}
+
+        _send_live_frame(
+            process,
+            {"type": "user_message", "msg_id": "first", "text": "first instruction"},
+        )
+        running = _read_live_frame(process)
+        assert running["status"] == "running"
+        assert running["msg_id"] == "first"
+
+        _send_live_frame(
+            process,
+            {"type": "user_message", "msg_id": "second", "text": "second instruction"},
+        )
+        terminal = _read_live_frame(process)
+        assert terminal["status"] == "idle"
+        assert terminal["reason"] == "completed"
+        assert terminal["msg_id"] == "second"
     finally:
         _stop_live_runner(process)
 

--- a/wmo/runtime/harness/scoring_test.py
+++ b/wmo/runtime/harness/scoring_test.py
@@ -62,6 +62,32 @@ def test_score_weights_tasks_equally_and_keeps_raw_rewards() -> None:
     assert report.by_task()["b"][0].artifact_dir == "/jobs/b__x1"
 
 
+def test_live_session_prompt_change_gets_a_distinct_score_identity() -> None:
+    """A score report cannot be reused after changing an input sent to the live runner."""
+    from wmo.cli.run_cmd import _assemble, _pi_node_baseline
+
+    doc = _pi_node_baseline()
+    changed = HarnessDoc(
+        name=doc.name,
+        surfaces=[
+            surface.model_copy(update={"content": surface.content + "\nBe concise."})
+            if surface.id == "prompt:core"
+            else surface
+            for surface in doc.surfaces
+        ],
+    )
+    report = ScoreReport(
+        doc_hash=doc.doc_hash,
+        request=ScoreRequest(task_ids=("a",), attempts=1),
+        reward_mode="raw",
+        cells=(_cell("a", 1, 1.0),),
+    )
+
+    assert _assemble(doc)[0] != _assemble(changed)[0]
+    assert report.doc_hash != changed.doc_hash
+    assert ScoreReport.model_validate_json(report.model_dump_json()).doc_hash == doc.doc_hash
+
+
 def test_report_rejects_missing_duplicate_and_extra_cells() -> None:
     with pytest.raises(ValidationError, match="missing"):
         _report((_cell("a", 1, 1.0),), tasks=("a", "b"), attempts=1)

--- a/wmo/runtime/harness/store_test.py
+++ b/wmo/runtime/harness/store_test.py
@@ -290,6 +290,20 @@ def test_pi_node_source_tree_renders_and_round_trips(tmp_path: Path) -> None:
     assert reloaded_code == original_code
 
 
+def test_local_live_harness_round_trips_without_changing_session_inputs(tmp_path: Path) -> None:
+    """Persistence preserves every input the restored local LiveSession consumes."""
+    from wmo.cli.run_cmd import _assemble, _pi_node_baseline
+
+    store = HarnessStore(tmp_path)
+    saved = store.save_version(_pi_node_baseline())
+    loaded = store.load(saved.name, f"v{saved.version}")
+
+    assert loaded.doc_hash == saved.doc_hash
+    assert loaded.runtime_kind() == "pi-node"
+    assert _assemble(loaded) == _assemble(saved)
+    assert "src/agent.ts" in _assemble(loaded)[2]
+
+
 def test_code_surface_path_colliding_with_a_reserved_file_is_rejected(tmp_path: Path) -> None:
     """A pathful code surface may not shadow SYSTEM.md/config.toml/etc. in the export."""
     doc = HarnessDoc(

--- a/wmo/runtime/platform/client.py
+++ b/wmo/runtime/platform/client.py
@@ -217,6 +217,9 @@ class LocalPiRunInfo(BaseModel):
     status: str
     worker_provider: str
     worker_model: str
+    # Newer platforms resolve deployment-owned limits next to the worker credentials. Older
+    # deployments omit this field, so the CLI retains an identity-based best-effort fallback.
+    context_window: int | None = None
 
 
 def fetch_cli_config(web_url: str, *, transport: httpx.BaseTransport | None = None) -> str | None:

--- a/wmo/simulation/evaluation/closed_loop_test.py
+++ b/wmo/simulation/evaluation/closed_loop_test.py
@@ -699,3 +699,76 @@ def test_report_aggregates_worker_usage_from_self_metering_runtimes() -> None:
         tasks, lambda task: _StaticEnv(), _ScriptedRuntime(), _AnswerJudge(), k=1
     )
     assert silent.worker_usage is None
+
+
+def test_closed_loop_consumes_a_live_session_backed_result() -> None:
+    """The simulation consumer scores the answer and usage emitted by LiveSession."""
+    from wmo.common.core.types import JsonObject
+    from wmo.runtime.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+    from wmo.runtime.harness.tools import SUBMIT
+
+    class _Channel:
+        def __init__(self, inbound: list[JsonObject]) -> None:
+            self._inbound = inbound
+            self.sent: list[JsonObject] = []
+
+        def send(self, frame: JsonObject) -> None:
+            self.sent.append(frame)
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            _ = timeout
+            return self._inbound.pop(0) if self._inbound else None
+
+    class _LiveRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            _ = environment
+            completed: JsonObject = {
+                "type": "state",
+                "status": "idle",
+                "reason": "completed",
+            }
+            channel = _Channel(
+                [
+                    {"type": "state", "status": "idle"},
+                    {
+                        "type": "tool_request",
+                        "req_id": 1,
+                        "name": "submit",
+                        "arguments": {"answer": "pass"},
+                    },
+                    completed,
+                ]
+            )
+            events: list[SessionEvent] = []
+            session = LiveSession(
+                channel,
+                tools=[SUBMIT],
+                execute_tool=lambda name, args, emit: ToolOutcome(content="unused"),
+                on_event=events.append,
+            )
+            session.start()
+            message_id = session.send_user_message(instruction)
+            completed["msg_id"] = message_id
+            session.pump(timeout=0)
+            session.pump(timeout=0)
+            answer_event = next(event for event in events if event.kind == "submit")
+            answer = answer_event.payload["answer"]
+            assert isinstance(answer, str)
+            return RunResult(
+                task_id=task_id,
+                stop_reason=StopReason.SUBMITTED,
+                answer=answer,
+                worker_usage=session.worker_usage,
+            )
+
+    report = evaluate_with_env(
+        [TaskSpec(task_id="live-pass", instruction="finish", gold=["g"])],
+        lambda task: _StaticEnv(),
+        _LiveRuntime(),
+        _AnswerJudge(),
+        k=1,
+    )
+
+    assert report.success_rate == 1.0
+    assert report.per_task["live-pass"].attempts[0].answer == "pass"
+    assert report.worker_usage == TokenUsage()


### PR DESCRIPTION
## Summary

Restores the root-level `wmo run` command removed in #343, using the package layout that just landed.

- restores the live-session host under `wmo.runtime.harness`, matching the retained `runner_live.ts` peer
- restores bare local pi runs with explicit consent and the directory file-tool jail
- uses local provider credentials while logged out and the platform worker proxy while logged in
- restores hosted world-model target resolution, session creation, and interactive stepping
- detects hosted agent IDs and returns an actionable unsupported error because the platform agent-session API no longer exists
- streams shell and regular-file output through bounded head and tail buffers, rejects non-regular file reads, terminates lingering process groups, and makes active turns immediately interruptible
- serializes cancellation with local file writes so a cancelled turn cannot win a stale filesystem race
- binds interrupt cleanup to the stopped message ID so a buffered idle frame cannot re-enable provider or tool work
- preserves configured provider model contracts, rejects stale Azure deployments, and forwards the served context window to pi, including for platform-proxied workers
- holds post-interrupt messages until the runner is idle and acknowledges the final piped message before EOF shutdown

## Safety boundary

Only a bare run executes harness code and bash locally. The warning remains explicit, file tools resolve under the selected directory, and bash is described as not OS-sandboxed. Shell output retention and pipe draining are bounded, and timed-out or lingering process groups are terminated. Cancellation is serialized with filesystem mutation and reset only by the interrupted message's idle acknowledgement. This PR does not revive stale hosted-agent, workspace-sync, or detached-session endpoints.

## Validation

- exact head: `b1f5eb9f52974d9bc9789e3f0e54f6fce5b02877`
- Ruff lint and format clean
- Ty clean
- expanded affected and consumer suite: 312 passed; 1 opt-in integration test skipped
- real pinned Node runner integration passed end to end through `LocalLiveDriver` and a submit turn
- real Node peer regression verifies a terminal idle frame acknowledges the last steered user message
- deterministic cancellation races verify no directory or file is created after cancellation wins, and stale idle frames cannot reset or disable a newer interrupt
- bounded file-read regressions verify large files retain only capped head and tail content and FIFOs fail without blocking
- full suite: 4,142 passed, 17 skipped, and the same 94 documented baseline CLI failures
- source distribution and wheel built
- isolated wheel imports passed and wheel-only `wmo run --help` passed
- wheel contains `run_cmd.py`, `live_session.py`, `runner_live.ts`, and the vendored pi agent sources
- final README-only edit: 11 repository layout tests passed and package metadata build passed
