### PR TITLE
Release 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "world-model-optimizer"
-version = "0.2.2"
+version = "0.3.0"
 description = "Run agents, build world models from traces, and optimize agent harnesses."
 readme = "README.md"
 # harbor 0.20.0 requires Python >=3.12; the harbor evaluator is a first-class optimize

--- a/uv.lock
+++ b/uv.lock
@@ -3918,7 +3918,7 @@ wheels = [
 
 [[package]]
 name = "world-model-optimizer"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump the `world-model-optimizer` package version to `0.3.0`.
- Update the matching editable package entry in `uv.lock`.
- Prepare the trusted-publisher GitHub release flow for PyPI.

## Validation

- `uv lock --check`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ty check`
- `uv build --package world-model-optimizer --no-sources`
- Installed the built wheel into an isolated environment.
- Verified package metadata reports `0.3.0`.
- Verified `import wmo, wmo.common.vendor.waterfall`.
- Verified `wmo --help` and `wmo run --help`.

The full local pytest process reached the existing CLI failure cluster, then macOS MLX aborted the interpreter in `route_app_test.py`. This PR only changes the two version fields; the release-specific build and isolated wheel checks pass.