### PR TITLE
Add guarded manual PyPI publish

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,13 @@ on:
       - "wmo/**"
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish the built distribution to PyPI"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -26,7 +33,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve the latest published release
+        id: release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          published_tag="$(
+            gh release view --repo "$GITHUB_REPOSITORY" \
+              --json isDraft,publishedAt,tagName \
+              --jq 'select(.isDraft == false and .publishedAt != null) | .tagName'
+          )"
+          test -n "$published_tag"
+          echo "tag=$published_tag" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', steps.release.outputs.tag) || github.ref }}
       - uses: astral-sh/setup-uv@v6
       - name: Build the WMO distribution
         run: uv build --package world-model-optimizer --no-sources
@@ -42,7 +64,10 @@ jobs:
           path: dist/
 
   publish:
-    if: github.event_name == 'release'
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' && inputs.publish)
     needs: build
     runs-on: ubuntu-latest
     environment: pypi


### PR DESCRIPTION
## Summary

- Add a manual dispatch input to the existing Python package workflow.
- Resolve the latest published, non-draft GitHub release and build its tag for manual runs.
- Allow trusted PyPI publishing only when `publish=true` and the dispatch ref is `main`.
- Preserve the existing GitHub release publish path unchanged.

## Why

GitHub recorded the `v0.3.0` release publish events but did not queue the package workflow. This provides an explicit recovery path while retaining the existing PyPI environment and OIDC trusted publishing boundary.

## Validation

- Parsed `.github/workflows/python-package.yml` as YAML.
- Confirmed the release resolver returns `v0.3.0`.
- `git diff --check`
- Confirmed the diff only changes the workflow trigger, source resolution, and publish condition.