### PR TITLE
fix(providers): retain Bedrock toolConfig when history has tool blocks

### DIFF
--- a/wmo/common/providers/_bedrock_chat.py
+++ b/wmo/common/providers/_bedrock_chat.py
@@ -14,6 +14,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
     """Translate the provider-neutral structured contract to Bedrock Converse."""
     system: list[dict[str, str]] = []
     messages: list[dict[str, object]] = []
+    has_tool_history = False
 
     def push(role: str, content: list[dict[str, object]]) -> None:
         if messages and messages[-1]["role"] == role:
@@ -29,6 +30,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
                 system.append({"text": text})
             continue
         if message.role == "tool":
+            has_tool_history = True
             push(
                 "user",
                 [
@@ -46,6 +48,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
         if text:
             blocks.append({"text": text})
         for tool_call in message.tool_calls or []:
+            has_tool_history = True
             try:
                 arguments = json.loads(tool_call.function.arguments)
             except ValueError:
@@ -92,7 +95,10 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
             function = choice.get("function")
             if isinstance(function, dict) and isinstance(function.get("name"), str):
                 tool_config["toolChoice"] = {"tool": {"name": function["name"]}}
-        if choice != "none":
+        if choice != "none" or has_tool_history:
+            # Converse requires toolConfig whenever replayed history contains
+            # toolUse/toolResult blocks. Bedrock has no exact "none" choice, so
+            # retain the available tools in auto mode for those follow-up turns.
             result["toolConfig"] = tool_config
     return result
 

--- a/wmo/common/providers/_bedrock_chat.py
+++ b/wmo/common/providers/_bedrock_chat.py
@@ -76,6 +76,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
     }
     if system:
         result["system"] = system
+    choice = request.tool_choice
     if request.tools:
         tools = [
             {
@@ -88,18 +89,25 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
             for tool in request.tools
         ]
         tool_config: dict[str, object] = {"tools": tools}
-        choice = request.tool_choice
         if choice == "required":
             tool_config["toolChoice"] = {"any": {}}
+        elif choice == "none" and has_tool_history:
+            # Caller disabled tools for this turn but history has toolUse/toolResult
+            # blocks. Bedrock requires toolConfig to be present; lock it to auto so
+            # the model can interpret the history without being allowed to call new
+            # tools (auto is the least-permissive mode Converse supports here).
+            tool_config["toolChoice"] = {"auto": {}}
         elif isinstance(choice, dict):
             function = choice.get("function")
             if isinstance(function, dict) and isinstance(function.get("name"), str):
                 tool_config["toolChoice"] = {"tool": {"name": function["name"]}}
         if choice != "none" or has_tool_history:
-            # Converse requires toolConfig whenever replayed history contains
-            # toolUse/toolResult blocks. Bedrock has no exact "none" choice, so
-            # retain the available tools in auto mode for those follow-up turns.
             result["toolConfig"] = tool_config
+    elif has_tool_history:
+        # No tools on this turn but replayed history carries toolUse/toolResult
+        # blocks. Bedrock rejects the request without toolConfig, so attach an
+        # empty tools list in auto mode as the minimum-viable placeholder.
+        result["toolConfig"] = {"tools": [], "toolChoice": {"auto": {}}}
     return result
 
 

--- a/wmo/common/providers/_bedrock_chat_test.py
+++ b/wmo/common/providers/_bedrock_chat_test.py
@@ -151,3 +151,72 @@ def test_converse_response_carries_the_cache_split_serving_reads() -> None:
     counts = response.token_usage()
     assert counts.cached_input_tokens == 9000
     assert counts.cache_write_input_tokens == 500
+
+
+def test_converse_omits_tools_for_initial_none_choice() -> None:
+    request = ChatRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "answer without tools"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "description": "run a command",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        }
+    )
+
+    wire = converse_request(request, "model-id")
+
+    assert "toolConfig" not in wire
+
+
+def test_converse_retains_tools_for_none_choice_with_tool_history() -> None:
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "a.txt"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "description": "run a command",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        }
+    )
+
+    wire = converse_request(request, "model-id")
+
+    tool_config = wire["toolConfig"]
+    assert isinstance(tool_config, dict)
+    tool_config_data = cast("dict[str, object]", tool_config)
+    assert "toolChoice" not in tool_config_data
+    assert cast("list[dict[str, object]]", tool_config_data["tools"])[0]["toolSpec"] == {
+        "name": "bash",
+        "description": "run a command",
+        "inputSchema": {"json": {"type": "object"}},
+    }
+

--- a/wmo/common/providers/_bedrock_chat_test.py
+++ b/wmo/common/providers/_bedrock_chat_test.py
@@ -213,10 +213,48 @@ def test_converse_retains_tools_for_none_choice_with_tool_history() -> None:
     tool_config = wire["toolConfig"]
     assert isinstance(tool_config, dict)
     tool_config_data = cast("dict[str, object]", tool_config)
-    assert "toolChoice" not in tool_config_data
+    # Locked to auto so the model can interpret history but cannot call new tools.
+    assert tool_config_data["toolChoice"] == {"auto": {}}
     assert cast("list[dict[str, object]]", tool_config_data["tools"])[0]["toolSpec"] == {
         "name": "bash",
         "description": "run a command",
         "inputSchema": {"json": {"type": "object"}},
     }
+
+
+def test_converse_retains_toolconfig_for_toolless_replay_with_history() -> None:
+    """Replayed tool history without current tools still needs a toolConfig placeholder.
+
+    Bedrock rejects requests whose message history contains toolUse or toolResult
+    blocks if toolConfig is absent, even when no tools are passed for this turn.
+    """
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "a.txt"},
+                {"role": "user", "content": "now summarise"},
+            ],
+            # No tools on this turn.
+        }
+    )
+
+    wire = converse_request(request, "model-id")
+
+    tool_config = wire["toolConfig"]
+    assert isinstance(tool_config, dict)
+    tool_config_data = cast("dict[str, object]", tool_config)
+    assert tool_config_data["tools"] == []
+    assert tool_config_data["toolChoice"] == {"auto": {}}
 


### PR DESCRIPTION
close #399 
### Summary
Fixes a bug where calling the AWS Bedrock Converse API with `tool_choice="none"` omitted `toolConfig` from the request payload even when the replayed message history contained prior tool calls or tool results. AWS Bedrock requires `toolConfig` to be present on any request whose message history includes `toolUse` or `toolResult` blocks.

### Cause
In `wmo/common/providers/_bedrock_chat.py`, `converse_request` previously attached `toolConfig` only if `choice != "none"`. On follow-up turns where an agent selected `tool_choice="none"` after previous tool turns, Bedrock rejected the payload due to missing tool configuration for the replayed history.

### Solution
- Added `has_tool_history` tracking when parsing messages in `converse_request`.
- Updated the payload builder to attach `toolConfig` when `choice != "none" or has_tool_history`.
- Added unit tests in `_bedrock_chat_test.py` covering initial turns (`toolConfig` omitted) vs follow-up turns with history (`toolConfig` retained).

### Verification
- `uv run pytest wmo/common/providers/_bedrock_chat_test.py` (7 passed)
- `uv run ruff check .` and `uv run ty check` (all checks passed)
