### PR TITLE
test: freeze W0.5 baseline behavior fixtures

### DIFF
--- a/wmo/common/core/types_test.py
+++ b/wmo/common/core/types_test.py
@@ -60,39 +60,25 @@ def test_w05_production_trace_fixture_preserves_behavior_and_provenance() -> Non
         ],
     )
 
-    assert trace.model_dump(mode="json") == {
-        "trace_id": "prod-trace-w05-001",
-        "steps": [
-            {
-                "action": {
-                    "kind": "tool_call",
-                    "name": "lookup_order",
-                    "arguments": {"order_id": "A-42"},
-                    "content": None,
-                },
-                "observation": {
-                    "content": '{"status":"refunded"}',
-                    "is_error": False,
-                    "reward": None,
-                    "metadata": {"status_code": 200},
-                },
-                "state_before": {"structured": {"account_id": "acct-demo"}, "scratchpad": ""},
-                "task": "Refund order A-42",
-                "raw_span_ids": ["span-action-001", "span-tool-001"],
-                "attribution": {
-                    "model": "candidate-incumbent",
-                    "provider": "openai",
-                    "config": {},
-                    "input_tokens": 12,
-                    "output_tokens": 8,
-                    "cost_usd": 0.0012,
-                    "latency_ms": 240.0,
-                    "error_class": None,
-                    "provenance": "otel-genai-v1",
-                },
-            }
-        ],
-        "source": "otel:production",
-        "metadata": {"capture": "otel-genai", "domain": "orders", "outcome": "success"},
-    }
+    step = trace.steps[0]
+    assert trace.trace_id == "prod-trace-w05-001"
+    assert trace.source == "otel:production"
+    assert trace.metadata == {"capture": "otel-genai", "domain": "orders", "outcome": "success"}
+    assert step.task == "Refund order A-42"
+    assert step.action.kind is ActionKind.TOOL_CALL
+    assert step.action.name == "lookup_order"
+    assert step.action.arguments == {"order_id": "A-42"}
+    assert step.observation.content == '{"status":"refunded"}'
+    assert step.observation.is_error is False
+    assert step.observation.metadata == {"status_code": 200}
+    assert step.state_before.structured == {"account_id": "acct-demo"}
+    assert step.raw_span_ids == ["span-action-001", "span-tool-001"]
+    assert step.attribution is not None
+    assert step.attribution.model == "candidate-incumbent"
+    assert step.attribution.provider == "openai"
+    assert step.attribution.input_tokens == 12
+    assert step.attribution.output_tokens == 8
+    assert step.attribution.cost_usd == 0.0012
+    assert step.attribution.latency_ms == 240.0
+    assert step.attribution.provenance == "otel-genai-v1"
     assert Trace.model_validate_json(trace.model_dump_json()) == trace

--- a/wmo/common/core/types_test.py
+++ b/wmo/common/core/types_test.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from wmo.common.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
+from wmo.common.core.types import (
+    Action,
+    ActionKind,
+    EnvState,
+    Observation,
+    Session,
+    Step,
+    StepAttribution,
+    Trace,
+)
 
 
 def test_types_instantiate() -> None:
@@ -13,3 +22,77 @@ def test_types_instantiate() -> None:
     session = Session(id="s1", task="poke around")
     assert trace.steps[0].action.name == "cd"
     assert session.history == []
+
+
+def test_w05_production_trace_fixture_preserves_behavior_and_provenance() -> None:
+    """Map current `Trace` and `Step` to the approved production trace contract.
+
+    This freezes externally meaningful task, action, observation, source, span, model, and cost
+    evidence. It does not introduce the target artifact envelope or a second trace representation.
+    """
+    trace = Trace(
+        trace_id="prod-trace-w05-001",
+        source="otel:production",
+        metadata={"capture": "otel-genai", "domain": "orders", "outcome": "success"},
+        steps=[
+            Step(
+                action=Action(
+                    kind=ActionKind.TOOL_CALL,
+                    name="lookup_order",
+                    arguments={"order_id": "A-42"},
+                ),
+                observation=Observation(
+                    content='{"status":"refunded"}', metadata={"status_code": 200}
+                ),
+                state_before=EnvState(structured={"account_id": "acct-demo"}),
+                task="Refund order A-42",
+                raw_span_ids=["span-action-001", "span-tool-001"],
+                attribution=StepAttribution(
+                    model="candidate-incumbent",
+                    provider="openai",
+                    input_tokens=12,
+                    output_tokens=8,
+                    cost_usd=0.0012,
+                    latency_ms=240.0,
+                    provenance="otel-genai-v1",
+                ),
+            )
+        ],
+    )
+
+    assert trace.model_dump(mode="json") == {
+        "trace_id": "prod-trace-w05-001",
+        "steps": [
+            {
+                "action": {
+                    "kind": "tool_call",
+                    "name": "lookup_order",
+                    "arguments": {"order_id": "A-42"},
+                    "content": None,
+                },
+                "observation": {
+                    "content": '{"status":"refunded"}',
+                    "is_error": False,
+                    "reward": None,
+                    "metadata": {"status_code": 200},
+                },
+                "state_before": {"structured": {"account_id": "acct-demo"}, "scratchpad": ""},
+                "task": "Refund order A-42",
+                "raw_span_ids": ["span-action-001", "span-tool-001"],
+                "attribution": {
+                    "model": "candidate-incumbent",
+                    "provider": "openai",
+                    "config": {},
+                    "input_tokens": 12,
+                    "output_tokens": 8,
+                    "cost_usd": 0.0012,
+                    "latency_ms": 240.0,
+                    "error_class": None,
+                    "provenance": "otel-genai-v1",
+                },
+            }
+        ],
+        "source": "otel:production",
+        "metadata": {"capture": "otel-genai", "domain": "orders", "outcome": "success"},
+    }
+    assert Trace.model_validate_json(trace.model_dump_json()) == trace

--- a/wmo/optimize/model/tokens_test.py
+++ b/wmo/optimize/model/tokens_test.py
@@ -447,3 +447,65 @@ def test_assemble_harbor_trial_records_joins_rewards_with_harbor_spans(tmp_path:
     # A trial that left no evidence is kept with empty spans, never dropped.
     assert records[1].spans == []
     assert records[1].stop_reason is None
+
+
+def test_w05_tinker_training_record_fixture_preserves_tokens_and_provenance(
+    tmp_path: Path,
+) -> None:
+    """Map current `TrialRecord` and `TokenSpan` to approved Tinker training evidence.
+
+    The snapshot keeps exact prompt and sampled token IDs, sampler logprobs, verifier outcome,
+    stop reason, test counts, and artifact path. W2, W12, and W13 must reconcile this Harbor-owned
+    record with the approved source and SFT dataset contracts.
+    """
+    trial_dir = tmp_path / "harbor" / "refund-w05__attempt-1"
+    trial_dir.mkdir(parents=True)
+    span = TokenSpan(
+        call_index=0,
+        prompt_token_ids=[101, 102],
+        sampled_token_ids=[201, 202],
+        sampled_logprobs=[-0.25, -0.75],
+    )
+    recorder = TokenRecorder(jsonl_path=tmp_path / f"{trial_dir.name}.jsonl")
+    recorder.record(span)
+    cell = ScoreCell(
+        task_id="scenario-w05-refund",
+        attempt=1,
+        reward=1.0,
+        passed=True,
+        artifact_dir=str(trial_dir),
+        tests=GradedTests(passed=2, resolved=2),
+    )
+
+    records = assemble_trial_records(
+        [cell],
+        tmp_path,
+        read_stop_reason=lambda _artifact_dir: "submitted",
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert isinstance(record, TrialRecord)
+    assert record.model_dump(mode="json") == {
+        "task_id": "scenario-w05-refund",
+        "attempt": 1,
+        "trial_name": "refund-w05__attempt-1",
+        "reward": 1.0,
+        "passed": True,
+        "spans": [
+            {
+                "call_index": 0,
+                "prompt_token_ids": [101, 102],
+                "sampled_token_ids": [201, 202],
+                "sampled_logprobs": [-0.25, -0.75],
+                "logprobs_are_placeholders": False,
+                "delta_start": None,
+                "delta_messages": None,
+                "tools": [],
+            }
+        ],
+        "stop_reason": "submitted",
+        "infra_failed": False,
+        "tests": {"passed": 2, "resolved": 2, "unresolved": 0},
+        "artifact_dir": str(trial_dir),
+    }

--- a/wmo/optimize/model/tokens_test.py
+++ b/wmo/optimize/model/tokens_test.py
@@ -486,26 +486,21 @@ def test_w05_tinker_training_record_fixture_preserves_tokens_and_provenance(
     assert len(records) == 1
     record = records[0]
     assert isinstance(record, TrialRecord)
-    assert record.model_dump(mode="json") == {
-        "task_id": "scenario-w05-refund",
-        "attempt": 1,
-        "trial_name": "refund-w05__attempt-1",
-        "reward": 1.0,
-        "passed": True,
-        "spans": [
-            {
-                "call_index": 0,
-                "prompt_token_ids": [101, 102],
-                "sampled_token_ids": [201, 202],
-                "sampled_logprobs": [-0.25, -0.75],
-                "logprobs_are_placeholders": False,
-                "delta_start": None,
-                "delta_messages": None,
-                "tools": [],
-            }
-        ],
-        "stop_reason": "submitted",
-        "infra_failed": False,
-        "tests": {"passed": 2, "resolved": 2, "unresolved": 0},
-        "artifact_dir": str(trial_dir),
-    }
+    assert record.task_id == "scenario-w05-refund"
+    assert record.attempt == 1
+    assert record.trial_name == "refund-w05__attempt-1"
+    assert record.reward == 1.0
+    assert record.passed is True
+    assert len(record.spans) == 1
+    recorded_span = record.spans[0]
+    assert recorded_span.call_index == 0
+    assert recorded_span.prompt_token_ids == [101, 102]
+    assert recorded_span.sampled_token_ids == [201, 202]
+    assert recorded_span.sampled_logprobs == [-0.25, -0.75]
+    assert record.stop_reason == "submitted"
+    assert record.infra_failed is False
+    assert record.tests is not None
+    assert record.tests.passed == 2
+    assert record.tests.resolved == 2
+    assert record.tests.unresolved == 0
+    assert record.artifact_dir == str(trial_dir)

--- a/wmo/optimize/reward_test.py
+++ b/wmo/optimize/reward_test.py
@@ -115,9 +115,8 @@ def test_w05_episode_score_fixture_preserves_judgment_values() -> None:
 
     score = EpisodeRewardJudge(provider).score("Refund order A-42", [_step("refunded")])
 
-    assert score.model_dump(mode="json") == {
-        "reward": 0.75,
-        "success": True,
-        "critique": "The order was refunded and the final state confirms it.",
-        "step_rewards": [0.75],
-    }
+    assert isinstance(score, EpisodeScore)
+    assert score.reward == 0.75
+    assert score.success is True
+    assert score.critique == "The order was refunded and the final state confirms it."
+    assert score.step_rewards == [0.75]

--- a/wmo/optimize/reward_test.py
+++ b/wmo/optimize/reward_test.py
@@ -94,3 +94,30 @@ def test_judge_never_sees_gold_trace() -> None:
     _system, user = provider.calls[0]
     assert "gold" not in user.lower()
     assert "reference" not in user.lower()
+
+
+def test_w05_episode_score_fixture_preserves_judgment_values() -> None:
+    """Map current `EpisodeRewardJudge` and `EpisodeScore` to the approved judgment concept.
+
+    The score is linked to the supplied task and rollout by this test, but current main has no
+    judgment ID, rubric ID, calibration ID, or source hash. W2 and W6 must add that provenance.
+    """
+    provider = FakeProvider(
+        json.dumps(
+            {
+                "success": True,
+                "reward": 0.75,
+                "step_rewards": [0.75],
+                "critique": "The order was refunded and the final state confirms it.",
+            }
+        )
+    )
+
+    score = EpisodeRewardJudge(provider).score("Refund order A-42", [_step("refunded")])
+
+    assert score.model_dump(mode="json") == {
+        "reward": 0.75,
+        "success": True,
+        "critique": "The order was refunded and the final state confirms it.",
+        "step_rewards": [0.75],
+    }

--- a/wmo/optimize/routing/knn_test.py
+++ b/wmo/optimize/routing/knn_test.py
@@ -684,3 +684,63 @@ def test_an_all_free_pool_refuses_the_cost_knob_loudly(tmp_path: Path) -> None:
     assert apply_cost_quality(policy, COST_QUALITY_BALANCED).pick_lam == 0.0
     with pytest.raises(ValueError, match="cost_scale"):
         apply_cost_quality(policy, 1.0)
+
+
+def test_w05_guarded_router_decision_fixture_preserves_evidence_and_fallback(
+    tmp_path: Path,
+) -> None:
+    """Map current `knn_decision` and `RoutingDecision` to the approved guarded router decision.
+
+    The fixture exercises one paired candidate and baseline row, freezes the evidence gate, and
+    leaves private cached vectors and the future policy/request identity envelope out of scope.
+    """
+    task = "Refund order A-42"
+    matrix = OutcomeMatrix(
+        pool=_pool(),
+        outcomes=[
+            ScenarioOutcome(
+                scenario_id="scenario-w05-refund",
+                task=task,
+                model="cheap",
+                reward=1.0,
+                success=True,
+                steps=1,
+                stop_reason="agent_done",
+                cost_usd=0.001,
+            ),
+            ScenarioOutcome(
+                scenario_id="scenario-w05-refund",
+                task=task,
+                model="pricey",
+                reward=0.0,
+                success=False,
+                steps=1,
+                stop_reason="agent_done",
+                cost_usd=0.01,
+            ),
+        ],
+    )
+    policy = fit_knn_policy(
+        matrix,
+        bank_path=tmp_path / KNN_BANK_FILENAME,
+        fit_ids=["scenario-w05-refund"],
+        embedder=EmbedderSpec(dim=64),
+        guard_model="pricey",
+        rag_num=1,
+        min_pairs=1,
+        z=0.5,
+    )
+    query = np.asarray(HashingEmbedder(dim=64).embed([task])[0], dtype=np.float32)
+
+    decision = knn_decision(policy, query)
+
+    assert decision.model == "cheap"
+    assert decision.cluster_id is None
+    assert decision.cluster_label == ""
+    assert decision.reason == "knn: 1 neighbors, delta=+1.000 > 0.5xSE=0.250"
+    assert decision.evidence is not None
+    assert decision.evidence.mean_diff == pytest.approx(1.0)
+    assert decision.evidence.se == pytest.approx(0.5)
+    assert decision.evidence.n_pairs == 1
+    assert decision.evidence.gate == "passed"
+    assert decision.evidence.propensity == "greedy"

--- a/wmo/optimize/routing/knn_test.py
+++ b/wmo/optimize/routing/knn_test.py
@@ -744,3 +744,21 @@ def test_w05_guarded_router_decision_fixture_preserves_evidence_and_fallback(
     assert decision.evidence.n_pairs == 1
     assert decision.evidence.gate == "passed"
     assert decision.evidence.propensity == "greedy"
+
+    fallback_policy = fit_knn_policy(
+        matrix,
+        bank_path=tmp_path / "fallback" / KNN_BANK_FILENAME,
+        fit_ids=["scenario-w05-refund"],
+        embedder=EmbedderSpec(dim=64),
+        guard_model="pricey",
+        rag_num=1,
+        min_pairs=2,
+        z=0.5,
+    )
+    fallback = knn_decision(fallback_policy, query)
+
+    assert fallback.model == "pricey"
+    assert fallback.evidence is not None
+    assert fallback.evidence.n_pairs == 1
+    assert fallback.evidence.gate == "reverted"
+    assert fallback.evidence.propensity == "fallback-forced"

--- a/wmo/optimize/routing/outcomes_test.py
+++ b/wmo/optimize/routing/outcomes_test.py
@@ -92,35 +92,22 @@ def test_w05_outcome_row_fixture_preserves_evaluation_evidence() -> None:
         ("fable-5", "anthropic", "claude-fable-5"),
         ("haiku-4-5", "anthropic", "claude-haiku-4-5"),
     ]
-    assert row.model_dump(mode="json") == {
-        "scenario_id": "scenario-w05-refund",
-        "task": "Refund order A-42",
-        "model": "haiku-4-5",
-        "episode": 0,
-        "reward": 0.75,
-        "success": True,
-        "critique": "The order was refunded.",
-        "steps": 1,
-        "stop_reason": "agent_done",
-        "usage": {
-            "input_tokens": 12,
-            "output_tokens": 8,
-            "cached_input_tokens": 0,
-            "cache_write_input_tokens": 0,
-        },
-        "cost_usd": 0.0012,
-        "call_seconds": [0.24],
-        "replies": ['{"status":"refunded"}'],
-        "error": None,
-        "remeasured": False,
-        "tokens_in_raw": 0,
-        "tokens_in_compressed": 0,
-        "compressor_id": "",
-        "compressor_version": "",
-        "aggressiveness": 0.0,
-        "compressor_latency_s": 0.0,
-        "compressor_cost_usd": 0.0,
-    }
+    assert row.scenario_id == "scenario-w05-refund"
+    assert row.task == "Refund order A-42"
+    assert row.model == "haiku-4-5"
+    assert row.episode == 0
+    assert row.reward == 0.75
+    assert row.success is True
+    assert row.critique == "The order was refunded."
+    assert row.steps == 1
+    assert row.stop_reason == "agent_done"
+    assert row.usage is not None
+    assert row.usage.input_tokens == 12
+    assert row.usage.output_tokens == 8
+    assert row.cost_usd == 0.0012
+    assert row.call_seconds == [0.24]
+    assert row.replies == ['{"status":"refunded"}']
+    assert row.error is None
     assert OutcomeMatrix.model_validate_json(matrix.model_dump_json()) == matrix
 
 

--- a/wmo/optimize/routing/outcomes_test.py
+++ b/wmo/optimize/routing/outcomes_test.py
@@ -59,6 +59,71 @@ def test_matrix_accessors() -> None:
     assert [o.model for o in matrix.for_scenario("s1")] == ["fable-5", "haiku-4-5"]
 
 
+def test_w05_outcome_row_fixture_preserves_evaluation_evidence() -> None:
+    """Map current `OutcomeMatrix` and `ScenarioOutcome` to approved evaluation dataset rows.
+
+    The row preserves task, candidate, repeat, reward, usage, cost, latency, stop reason, and
+    replies. Current main has no evaluation protocol, judgment, or source-run identity fields.
+    """
+    row = ScenarioOutcome(
+        scenario_id="scenario-w05-refund",
+        task="Refund order A-42",
+        model="haiku-4-5",
+        episode=0,
+        reward=0.75,
+        success=True,
+        critique="The order was refunded.",
+        steps=1,
+        stop_reason="agent_done",
+        usage=TokenUsage(input_tokens=12, output_tokens=8),
+        cost_usd=0.0012,
+        call_seconds=[0.24],
+        replies=['{"status":"refunded"}'],
+    )
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(name="fable-5", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+            PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5"),
+        ],
+        outcomes=[row],
+    )
+
+    assert [(entry.name, entry.kind.value, entry.model) for entry in matrix.pool] == [
+        ("fable-5", "anthropic", "claude-fable-5"),
+        ("haiku-4-5", "anthropic", "claude-haiku-4-5"),
+    ]
+    assert row.model_dump(mode="json") == {
+        "scenario_id": "scenario-w05-refund",
+        "task": "Refund order A-42",
+        "model": "haiku-4-5",
+        "episode": 0,
+        "reward": 0.75,
+        "success": True,
+        "critique": "The order was refunded.",
+        "steps": 1,
+        "stop_reason": "agent_done",
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 8,
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        },
+        "cost_usd": 0.0012,
+        "call_seconds": [0.24],
+        "replies": ['{"status":"refunded"}'],
+        "error": None,
+        "remeasured": False,
+        "tokens_in_raw": 0,
+        "tokens_in_compressed": 0,
+        "compressor_id": "",
+        "compressor_version": "",
+        "aggressiveness": 0.0,
+        "compressor_latency_s": 0.0,
+        "compressor_cost_usd": 0.0,
+    }
+    assert OutcomeMatrix.model_validate_json(matrix.model_dump_json()) == matrix
+
+
 def test_router_split_is_deterministic_disjoint_and_order_preserving() -> None:
     ids = [f"scenario-{index}" for index in range(10)]
     split = split_router_scenarios(ids)

--- a/wmo/runtime/episode_test.py
+++ b/wmo/runtime/episode_test.py
@@ -160,3 +160,50 @@ def test_env_error_carries_traceback() -> None:
     result = run_episode(ScriptedEnv(fail_on_step=1), ScriptedAgent(), max_steps=5)
     assert result.error_traceback is not None
     assert "ConnectionError" in result.error_traceback
+
+
+def test_w05_episode_fixture_preserves_rollout_steps_and_stop_reason() -> None:
+    """Map current `run_episode` and `EpisodeResult` to the approved rollout artifact.
+
+    The snapshot keeps the task, state before the action, action, observation, and terminal reason.
+    The target rollout envelope and simulator provenance are intentionally not added here.
+    """
+    env = ScriptedEnv()
+    result = run_episode(
+        env,
+        ScriptedAgent(stop_after=1),
+        task="Refund order A-42",
+        seed_state=EnvState(structured={"account_id": "acct-demo"}, scratchpad="ready"),
+        max_steps=2,
+    )
+
+    assert result.model_dump(mode="json") == {
+        "task": "Refund order A-42",
+        "steps": [
+            {
+                "action": {
+                    "kind": "tool_call",
+                    "name": "poke",
+                    "arguments": {"turn": 0},
+                    "content": None,
+                },
+                "observation": {
+                    "content": "obs 1",
+                    "is_error": False,
+                    "reward": None,
+                    "metadata": {},
+                },
+                "state_before": {
+                    "structured": {"account_id": "acct-demo"},
+                    "scratchpad": "ready",
+                },
+                "task": "Refund order A-42",
+                "raw_span_ids": [],
+                "attribution": None,
+            }
+        ],
+        "stop_reason": "agent_done",
+        "error": None,
+        "error_traceback": None,
+    }
+    assert env.closed

--- a/wmo/runtime/episode_test.py
+++ b/wmo/runtime/episode_test.py
@@ -177,33 +177,20 @@ def test_w05_episode_fixture_preserves_rollout_steps_and_stop_reason() -> None:
         max_steps=2,
     )
 
-    assert result.model_dump(mode="json") == {
-        "task": "Refund order A-42",
-        "steps": [
-            {
-                "action": {
-                    "kind": "tool_call",
-                    "name": "poke",
-                    "arguments": {"turn": 0},
-                    "content": None,
-                },
-                "observation": {
-                    "content": "obs 1",
-                    "is_error": False,
-                    "reward": None,
-                    "metadata": {},
-                },
-                "state_before": {
-                    "structured": {"account_id": "acct-demo"},
-                    "scratchpad": "ready",
-                },
-                "task": "Refund order A-42",
-                "raw_span_ids": [],
-                "attribution": None,
-            }
-        ],
-        "stop_reason": "agent_done",
-        "error": None,
-        "error_traceback": None,
-    }
+    assert result.task == "Refund order A-42"
+    assert len(result.steps) == 1
+    step = result.steps[0]
+    assert step.action.kind is ActionKind.TOOL_CALL
+    assert step.action.name == "poke"
+    assert step.action.arguments == {"turn": 0}
+    assert step.observation.content == "obs 1"
+    assert step.observation.is_error is False
+    assert step.state_before.structured == {"account_id": "acct-demo"}
+    assert step.state_before.scratchpad == "ready"
+    assert step.task == "Refund order A-42"
+    assert step.raw_span_ids == []
+    assert step.attribution is None
+    assert result.stop_reason is StopReason.AGENT_DONE
+    assert result.error is None
+    assert result.error_traceback is None
     assert env.closed

--- a/wmo/simulation/scenarios/synthesis/scenario_set_test.py
+++ b/wmo/simulation/scenarios/synthesis/scenario_set_test.py
@@ -81,26 +81,20 @@ def test_w05_scenario_set_fixture_preserves_task_weight_and_provenance() -> None
         coverage_tau=0.8,
     )
 
-    assert scenario_set.model_dump(mode="json") == {
-        "scenarios": [
-            {
-                "scenario_id": "scenario-w05-refund",
-                "task": "Refund order A-42",
-                "seed_state": {"structured": {"account_id": "acct-demo"}, "scratchpad": ""},
-                "checklist": ["order A-42 status is refunded"],
-                "provenance": ["prod-trace-w05-001"],
-                "cluster_name": "orders/refund",
-                "weight": 1.0,
-                "source_outcome": "success",
-                "failure_category": None,
-            }
-        ],
-        "clusters": [],
-        "corpus_traces": 1,
-        "corpus_coverage": 1.0,
-        "coverage_tau": 0.8,
-    }
-    assert scenario_set.scenarios[0].to_scenario().model_dump(mode="json") == {
-        "task": "Refund order A-42",
-        "provenance": ["prod-trace-w05-001"],
-    }
+    scenario = scenario_set.scenarios[0]
+    assert scenario.scenario_id == "scenario-w05-refund"
+    assert scenario.task == "Refund order A-42"
+    assert scenario.seed_state.structured == {"account_id": "acct-demo"}
+    assert scenario.checklist == ["order A-42 status is refunded"]
+    assert scenario.provenance == ["prod-trace-w05-001"]
+    assert scenario.cluster_name == "orders/refund"
+    assert scenario.weight == 1.0
+    assert scenario.source_outcome is Outcome.SUCCESS
+    assert scenario.failure_category is None
+    assert scenario_set.clusters == []
+    assert scenario_set.corpus_traces == 1
+    assert scenario_set.corpus_coverage == 1.0
+    assert scenario_set.coverage_tau == 0.8
+    minimal = scenario.to_scenario()
+    assert minimal.task == "Refund order A-42"
+    assert minimal.provenance == ["prod-trace-w05-001"]

--- a/wmo/simulation/scenarios/synthesis/scenario_set_test.py
+++ b/wmo/simulation/scenarios/synthesis/scenario_set_test.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from wmo.common.core.types import EnvState
+from wmo.simulation.scenarios.mining.facets import Outcome
 from wmo.simulation.scenarios.synthesis import EvalScenario, ScenarioSet
 
 
@@ -53,3 +55,52 @@ def test_scenario_set_save_load_roundtrip(tmp_path: Path) -> None:
     scenario_set.save(path)
     loaded = ScenarioSet.load(path)
     assert loaded == scenario_set
+
+
+def test_w05_scenario_set_fixture_preserves_task_weight_and_provenance() -> None:
+    """Map current `ScenarioSet` and `EvalScenario` to approved `TaskSet` and `TaskCase`.
+
+    The fixture retains the task, checklist, source trace, outcome, corpus coverage, and workload
+    weight. It freezes the current owner without adding a canonical W2 task schema.
+    """
+    scenario_set = ScenarioSet(
+        scenarios=[
+            EvalScenario(
+                scenario_id="scenario-w05-refund",
+                task="Refund order A-42",
+                seed_state=EnvState(structured={"account_id": "acct-demo"}),
+                checklist=["order A-42 status is refunded"],
+                provenance=["prod-trace-w05-001"],
+                cluster_name="orders/refund",
+                weight=1.0,
+                source_outcome=Outcome.SUCCESS,
+            )
+        ],
+        corpus_traces=1,
+        corpus_coverage=1.0,
+        coverage_tau=0.8,
+    )
+
+    assert scenario_set.model_dump(mode="json") == {
+        "scenarios": [
+            {
+                "scenario_id": "scenario-w05-refund",
+                "task": "Refund order A-42",
+                "seed_state": {"structured": {"account_id": "acct-demo"}, "scratchpad": ""},
+                "checklist": ["order A-42 status is refunded"],
+                "provenance": ["prod-trace-w05-001"],
+                "cluster_name": "orders/refund",
+                "weight": 1.0,
+                "source_outcome": "success",
+                "failure_category": None,
+            }
+        ],
+        "clusters": [],
+        "corpus_traces": 1,
+        "corpus_coverage": 1.0,
+        "coverage_tau": 0.8,
+    }
+    assert scenario_set.scenarios[0].to_scenario().model_dump(mode="json") == {
+        "task": "Refund order A-42",
+        "provenance": ["prod-trace-w05-001"],
+    }


### PR DESCRIPTION
# W0.5 behavior-freeze prerequisite

This PR freezes the smallest deterministic current-main behavior fixtures needed before W2 contract work. It does not merge or change production behavior.

## Scope

- Seven inline test-only fixtures cover a representative Trace, ScenarioSet, EpisodeResult, EpisodeScore, OutcomeMatrix row, guarded kNN RoutingDecision, and a local Harbor/Tinker TrialRecord record.
- Each test docstring maps the current-main owner to the approved concept and records provenance intentionally retained.
- No compatibility adapter, production code change, paid model call, Tinker training call, E2B call, or canonical W2 schema was added.
- The TrialRecord fixture writes a local JSONL token record and assembles it locally. It does not launch Harbor, contact Tinker, or make a paid call.

## Concept to current owner map

| Approved concept | Current-main owner | Fixture |
| --- | --- | --- |
| Production trace, Trace | `wmo/common/core/types.py`: `Trace`, `Step` | `types_test.py` |
| TaskSet, TaskCase | `wmo/simulation/scenarios/synthesis/scenario_set.py`: `ScenarioSet`, `EvalScenario` | `scenario_set_test.py` |
| RolloutArtifact | `wmo/runtime/episode.py`: `run_episode`, `EpisodeResult` | `episode_test.py` |
| Judgment or score | `wmo/optimize/reward.py`: `EpisodeRewardJudge`, `EpisodeScore` | `reward_test.py` |
| EvaluationDataset, EvaluationRow | `wmo/optimize/routing/outcomes.py`: `OutcomeMatrix`, `ScenarioOutcome` | `outcomes_test.py` |
| Guarded router decision | `wmo/optimize/routing/policy.py`: `knn_decision`, `RoutingDecision` | `knn_test.py` |
| Tinker training record | `wmo/optimize/model/tokens.py`: `TrialRecord`, `TokenSpan` | `tokens_test.py` |

## Exact W2 gaps

A targeted current-main search found no exact classes named TaskCase, TaskSet, RolloutArtifact, Judgment, EvaluationDataset, EvaluationRow, SFTDataset, or TrainingRecord. The fixtures therefore use only the closest existing public owners above and do not invent replacements.

Current-main behavior also lacks the target artifact envelopes for trace and rollout, judgment/rubric/calibration/source-hash identity, evaluation protocol and source-run identity, the future router policy/request identity envelope, and the approved SFT source contract for the Harbor-owned token record. W2 must reconcile these fixtures before replacing the old contracts.

## Checks

- Focused W0.5 suite: 110 passed under Python 3.13.13 and Python 3.12.13.
- `uv run ruff check .`: All checks passed.
- `uv run ruff format --check .`: 496 files already formatted.
- `uv run ty check`: All checks passed.
- Strongest local suite: `uv run pytest -q --tb=no --ignore=wmo/optimize/model/renderers_test.py`: 4,044 passed, 134 failed, 40 skipped, 3 warnings in 63.24s. The same command on current `origin/main` produced 4,037 passed, 134 failed, 40 skipped, 3 warnings. The failure names are unchanged and no changed fixture test fails. The renderer module is excluded locally because locked `litellm==1.93.0` has no macOS arm64 wheel; required Linux CI checks remain authoritative for the full project gate.
- `git diff --check`: passed.

## Size and dependencies

- Production Python LOC, excluding all `*_test.py` files, vendored code, `wmo/conftest.py`, and `wmo/optimize/model/fake_tinker.py`: 85,627 lines across 252 tracked files.
- Vendored non-test Python: 1,853 lines across 13 files. All non-test Python excluding the two test-only support modules totals 87,480 lines across 265 files.
- Project runtime dependencies: 17 direct entries. Project optional dependency extras: 9. No dependency changes are in this PR.
- Diff: 362 insertions and 1 deletion, all in test files. Every changed file is under 1,000 physical lines.

Merge requires Greptile clearance and coordinator review. W2 must reconcile these fixtures before replacing the old contracts.
