### PR TITLE
W2: canonical contracts and local project store

### DIFF
--- a/wmo/common/core/artifacts.py
+++ b/wmo/common/core/artifacts.py
@@ -11,6 +11,7 @@ import json
 import re
 from datetime import datetime
 from enum import StrEnum
+from pathlib import PurePosixPath
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
@@ -49,6 +50,10 @@ _SECRET_VALUE_PATTERNS = (
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
     re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b", re.IGNORECASE),
+)
+_SECRET_ENVIRONMENT_NAME_PATTERN = re.compile(
+    r"\b(?:[A-Z][A-Z0-9]*_)*(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|SECRET|"
+    r"CREDENTIAL)(?:_[A-Z0-9]+)*\b"
 )
 _SECRET_REFERENCE_PATTERN = re.compile(
     r"\b(?:"
@@ -215,6 +220,33 @@ def validate_artifact_id(value: str) -> str:
     return value
 
 
+def validate_artifact_file_path(value: str) -> PurePosixPath:
+    """Validate one portable relative data-file path inside an artifact directory.
+
+    Args:
+        value: Proposed POSIX relative path stored in an immutable manifest.
+
+    Returns:
+        A normalized relative POSIX path safe to join below an artifact directory.
+
+    Raises:
+        ValueError: The path is empty, absolute, or contains a non-portable component.
+    """
+    path = PurePosixPath(value)
+    components = value.split("/")
+    if (
+        not value
+        or path.is_absolute()
+        or "\x00" in value
+        or "\\" in value
+        or any(component in {"", ".", ".."} or ":" in component for component in components)
+    ):
+        raise ValueError(
+            "artifact file paths must be non-empty relative POSIX paths with ordinary components"
+        )
+    return path
+
+
 def assert_secret_free(value: BaseModel | JsonValue) -> None:
     """Reject secret values and credential references at immutable artifact boundaries.
 
@@ -241,7 +273,7 @@ def assert_text_secret_free(value: str) -> None:
     Raises:
         SecretBoundaryError: The text includes a credential reference or secret-like value.
     """
-    if _SECRET_REFERENCE_PATTERN.search(value):
+    if _SECRET_REFERENCE_PATTERN.search(value) or _SECRET_ENVIRONMENT_NAME_PATTERN.search(value):
         raise SecretBoundaryError("immutable artifacts cannot contain credential references")
     if any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
         raise SecretBoundaryError("immutable artifacts cannot contain secret-like values")
@@ -261,7 +293,12 @@ def _assert_json_value_secret_free(value: JsonValue, *, path: str) -> None:
         for index, nested_value in enumerate(value):
             _assert_json_value_secret_free(nested_value, path=f"{path}[{index}]")
         return
-    if isinstance(value, str) and any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
-        raise SecretBoundaryError(
-            f"immutable artifacts cannot contain a secret-like value at {path}"
-        )
+    if isinstance(value, str):
+        if any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
+            raise SecretBoundaryError(
+                f"immutable artifacts cannot contain a secret-like value at {path}"
+            )
+        if _SECRET_ENVIRONMENT_NAME_PATTERN.search(value):
+            raise SecretBoundaryError(
+                f"immutable artifacts cannot contain a credential environment name at {path}"
+            )

--- a/wmo/common/core/artifacts.py
+++ b/wmo/common/core/artifacts.py
@@ -1,0 +1,267 @@
+"""Canonical provenance, identity, hashing, and failure contracts.
+
+The models in this module are the small pieces shared by every new immutable WMO artifact.
+They deliberately contain no provider connection details or credential references.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+
+JsonObject = dict[str, JsonValue]
+
+ArtifactId = Annotated[
+    str,
+    Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+    ),
+]
+Sha256 = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "api_key_env",
+        "authorization",
+        "credential",
+        "credential_env",
+        "credential_ref",
+        "password",
+        "refresh_token",
+        "secret",
+        "secret_env",
+        "secret_ref",
+        "token_env",
+    }
+)
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b", re.IGNORECASE),
+)
+_SECRET_REFERENCE_PATTERN = re.compile(
+    r"\b(?:"
+    r"access[_ -]?token|"
+    r"api[_ -]?key(?:[_ -]?env)?|"
+    r"authorization|"
+    r"credential(?:[_ -]?(?:env|ref))?|"
+    r"password|"
+    r"refresh[_ -]?token|"
+    r"secret(?:[_ -]?(?:env|ref))?|"
+    r"token[_ -]?env"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class ContractModel(BaseModel):
+    """Base class for immutable, persisted contract boundaries."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class FailureCode(StrEnum):
+    """Stable categories for a partial artifact or operation failure."""
+
+    VALIDATION = "validation"
+    UNSUPPORTED = "unsupported"
+    TIMEOUT = "timeout"
+    CONTEXT_OVERFLOW = "context_overflow"
+    PROVIDER = "provider"
+    BUDGET = "budget"
+    CANCELLED = "cancelled"
+    INTERNAL = "internal"
+
+
+class StructuredFailure(ContractModel):
+    """A non-secret, machine-readable description of one failed operation."""
+
+    code: FailureCode
+    message: str = Field(min_length=1)
+    retryable: bool = False
+    exception_type: str | None = None
+    details: JsonObject = Field(default_factory=dict)
+
+
+class SourceIdentity(ContractModel):
+    """Identifies immutable source evidence without storing its raw payload."""
+
+    kind: Literal["file", "otlp", "production", "simulation", "manual", "generated"]
+    source_id: str = Field(min_length=1, max_length=512)
+    sha256: Sha256 | None = None
+
+
+class ArtifactInput(ContractModel):
+    """An immutable artifact consumed to produce another artifact."""
+
+    artifact_id: ArtifactId
+    sha256: Sha256
+
+
+class ArtifactEnvelope(ContractModel):
+    """Provenance shared by every completed immutable artifact.
+
+    Args:
+        schema_version: Version of the stored contract.
+        created_at: Time the completed artifact was materialized, with a timezone.
+        inputs: Sorted immutable artifacts used to produce this artifact.
+        code_revision: Exact code revision that wrote the artifact.
+        source: Direct external source identity, when the artifact has one.
+    """
+
+    schema_version: int = Field(ge=1)
+    created_at: datetime
+    inputs: tuple[ArtifactInput, ...] = ()
+    code_revision: str = Field(min_length=1, max_length=256)
+    source: SourceIdentity | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created_at must include a timezone")
+        return value
+
+    @field_validator("inputs")
+    @classmethod
+    def _require_unique_sorted_inputs(
+        cls, value: tuple[ArtifactInput, ...]
+    ) -> tuple[ArtifactInput, ...]:
+        input_ids = tuple(item.artifact_id for item in value)
+        if len(set(input_ids)) != len(input_ids):
+            raise ValueError("artifact inputs must not repeat an artifact_id")
+        if input_ids != tuple(sorted(input_ids)):
+            raise ValueError("artifact inputs must be sorted by artifact_id")
+        return value
+
+
+class SecretBoundaryError(ValueError):
+    """Raised when data intended for an immutable artifact names or contains a secret."""
+
+
+def canonical_json_bytes(value: BaseModel | JsonValue) -> bytes:
+    """Render a Pydantic model or JSON value as deterministic UTF-8 JSON.
+
+    Args:
+        value: The structured value to serialize.
+
+    Returns:
+        JSON with sorted keys, no insignificant whitespace, and no non-finite numbers.
+    """
+    payload: JsonValue
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json", by_alias=True, exclude_none=False)
+    else:
+        payload = value
+    return json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256_json(value: BaseModel | JsonValue) -> str:
+    """Return the SHA-256 digest of `value`'s deterministic JSON serialization."""
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def stable_id(prefix: str, value: BaseModel | JsonValue) -> str:
+    """Create a readable, content-addressed stable ID.
+
+    Args:
+        prefix: Lowercase artifact-kind prefix, such as ``task-set``.
+        value: The structured content that fixes the identifier.
+
+    Returns:
+        A valid artifact ID containing the first 20 hexadecimal digest characters.
+
+    Raises:
+        ValueError: If ``prefix`` cannot begin an artifact ID.
+    """
+    candidate = f"{prefix}-{sha256_json(value)[:20]}"
+    try:
+        return validate_artifact_id(candidate)
+    except ValueError as exc:
+        raise ValueError("stable ID prefixes must be lowercase artifact ID components") from exc
+
+
+def validate_artifact_id(value: str) -> str:
+    """Validate a stable identifier used as one local artifact path component.
+
+    Args:
+        value: Proposed stable identifier.
+
+    Returns:
+        The validated identifier.
+
+    Raises:
+        ValueError: The identifier is not a canonical lower-case artifact ID.
+    """
+    if not re.fullmatch(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$", value):
+        raise ValueError("stable IDs must be lowercase components separated by '.', '_', or '-'")
+    return value
+
+
+def assert_secret_free(value: BaseModel | JsonValue) -> None:
+    """Reject secret values and credential references at immutable artifact boundaries.
+
+    Args:
+        value: The structured content about to enter an immutable artifact.
+
+    Raises:
+        SecretBoundaryError: A credential-like key or well-known secret value was found.
+    """
+    payload: JsonValue
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json", by_alias=True, exclude_none=False)
+    else:
+        payload = value
+    _assert_json_value_secret_free(payload, path="$")
+
+
+def assert_text_secret_free(value: str) -> None:
+    """Reject known credential references and secret-like values in persisted text.
+
+    Args:
+        value: UTF-8 text about to enter an immutable artifact.
+
+    Raises:
+        SecretBoundaryError: The text includes a credential reference or secret-like value.
+    """
+    if _SECRET_REFERENCE_PATTERN.search(value):
+        raise SecretBoundaryError("immutable artifacts cannot contain credential references")
+    if any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
+        raise SecretBoundaryError("immutable artifacts cannot contain secret-like values")
+
+
+def _assert_json_value_secret_free(value: JsonValue, *, path: str) -> None:
+    """Recursively apply the immutable-artifact secret boundary."""
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            normalized_key = key.lower().replace("-", "_")
+            nested_path = f"{path}.{key}"
+            if normalized_key in _SECRET_FIELD_NAMES:
+                raise SecretBoundaryError(f"immutable artifacts cannot contain {nested_path}")
+            _assert_json_value_secret_free(nested_value, path=nested_path)
+        return
+    if isinstance(value, list):
+        for index, nested_value in enumerate(value):
+            _assert_json_value_secret_free(nested_value, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str) and any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
+        raise SecretBoundaryError(
+            f"immutable artifacts cannot contain a secret-like value at {path}"
+        )

--- a/wmo/common/core/artifacts_test.py
+++ b/wmo/common/core/artifacts_test.py
@@ -1,0 +1,82 @@
+"""Tests for canonical artifact provenance, stable IDs, and secret boundaries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactInput,
+    SecretBoundaryError,
+    SourceIdentity,
+    assert_secret_free,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+
+
+def test_deterministic_json_hash_and_stable_id_ignore_mapping_order() -> None:
+    """Canonical JSON makes equivalent mappings hash and identify identically."""
+    first = {"nested": {"b": 2, "a": 1}, "items": ["x", "y"]}
+    second = {"items": ["x", "y"], "nested": {"a": 1, "b": 2}}
+
+    assert canonical_json_bytes(first) == canonical_json_bytes(second)
+    assert sha256_json(first) == sha256_json(second)
+    assert stable_id("task-set", first) == stable_id("task-set", second)
+
+
+def test_envelope_requires_timezone_and_sorted_unique_inputs() -> None:
+    """Envelope provenance rejects ambiguous clocks and duplicate input identities."""
+    with pytest.raises(ValidationError, match="timezone"):
+        ArtifactEnvelope(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11),
+            code_revision="e7aad17",
+        )
+
+    with pytest.raises(ValidationError, match="sorted"):
+        ArtifactEnvelope(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            inputs=(
+                ArtifactInput(artifact_id="trace-b", sha256=_DIGEST_B),
+                ArtifactInput(artifact_id="trace-a", sha256=_DIGEST_A),
+            ),
+        )
+
+    with pytest.raises(ValidationError, match="repeat"):
+        ArtifactEnvelope(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            inputs=(
+                ArtifactInput(artifact_id="trace-a", sha256=_DIGEST_A),
+                ArtifactInput(artifact_id="trace-a", sha256=_DIGEST_B),
+            ),
+        )
+
+
+def test_source_identity_and_secret_boundary_round_trip() -> None:
+    """Source provenance serializes, while credential values and references do not."""
+    envelope = ArtifactEnvelope(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        source=SourceIdentity(kind="file", source_id="traces.jsonl", sha256=_DIGEST_A),
+    )
+
+    restored = ArtifactEnvelope.model_validate_json(envelope.model_dump_json())
+
+    assert restored == envelope
+    with pytest.raises(SecretBoundaryError, match="api_key_env"):
+        assert_secret_free({"api_key_env": "OPENAI_API_KEY"})
+    with pytest.raises(SecretBoundaryError, match="secret-like"):
+        assert_secret_free({"note": "sk-abcdefghijklmnopqrstuvwxyz123456"})

--- a/wmo/common/core/artifacts_test.py
+++ b/wmo/common/core/artifacts_test.py
@@ -16,6 +16,7 @@ from wmo.common.core.artifacts import (
     canonical_json_bytes,
     sha256_json,
     stable_id,
+    validate_artifact_file_path,
 )
 
 _DIGEST_A = "a" * 64
@@ -80,3 +81,13 @@ def test_source_identity_and_secret_boundary_round_trip() -> None:
         assert_secret_free({"api_key_env": "OPENAI_API_KEY"})
     with pytest.raises(SecretBoundaryError, match="secret-like"):
         assert_secret_free({"note": "sk-abcdefghijklmnopqrstuvwxyz123456"})
+    with pytest.raises(SecretBoundaryError, match="environment name"):
+        assert_secret_free({"connection_hint": "OPENAI_API_KEY"})
+
+
+def test_artifact_file_paths_reject_nonportable_components() -> None:
+    """Portable artifact paths cannot escape or change meaning on Windows."""
+    assert validate_artifact_file_path("nested/data.json").as_posix() == "nested/data.json"
+    for path in ("../outside.json", "nested\\outside.json", "C:/outside.json"):
+        with pytest.raises(ValueError, match="relative POSIX"):
+            validate_artifact_file_path(path)

--- a/wmo/common/evaluations/__init__.py
+++ b/wmo/common/evaluations/__init__.py
@@ -1,0 +1,23 @@
+"""Canonical sparse evaluation and fidelity contracts."""
+
+from wmo.common.evaluations.dataset import (
+    EvaluationDataset,
+    EvaluationDatasetManifest,
+    EvaluationProtocol,
+    EvaluationRow,
+    FidelityFailure,
+    FidelityReport,
+)
+from wmo.common.evaluations.plan import EvaluationCell, EvaluationPlan, FidelityGate
+
+__all__ = [
+    "EvaluationCell",
+    "EvaluationDataset",
+    "EvaluationDatasetManifest",
+    "EvaluationPlan",
+    "EvaluationProtocol",
+    "EvaluationRow",
+    "FidelityFailure",
+    "FidelityGate",
+    "FidelityReport",
+]

--- a/wmo/common/evaluations/dataset.py
+++ b/wmo/common/evaluations/dataset.py
@@ -14,6 +14,7 @@ from wmo.common.core.artifacts import (
     ContractModel,
     Sha256,
     StructuredFailure,
+    validate_artifact_file_path,
 )
 from wmo.common.models import ModelAlias, ModelSnapshot, NumericMeasurement, RoutedCandidateSnapshot
 
@@ -31,6 +32,20 @@ class EvaluationProtocol(ContractModel):
     judge_calibration_id: ArtifactId
     pricing_snapshot_id: ArtifactId
     fidelity_report_id: ArtifactId | None = None
+
+    @model_validator(mode="after")
+    def _require_source_specific_identity(self) -> EvaluationProtocol:
+        if self.evidence_source == "world_model":
+            if self.world_model is None or self.simulator_prompt_id is None:
+                raise ValueError("world-model protocols require world-model and prompt identities")
+        elif any(
+            value is not None
+            for value in (self.world_model, self.simulator_prompt_id, self.fidelity_report_id)
+        ):
+            raise ValueError(
+                "sandbox and production protocols must not name world-model or fidelity evidence"
+            )
+        return self
 
 
 class EvaluationRow(ContractModel):
@@ -66,10 +81,32 @@ class EvaluationRow(ContractModel):
     def _require_status_consistency(self) -> EvaluationRow:
         if self.status == "failed" and self.error is None:
             raise ValueError("failed evaluation rows require a structured error")
+        if self.status != "failed" and self.error is not None:
+            raise ValueError("only failed evaluation rows may contain a structured error")
         if self.status in {"completed", "observed"} and self.rollout_id is None:
             raise ValueError("completed and observed rows require a rollout_id")
-        if self.status == "not_run" and self.rollout_id is not None:
-            raise ValueError("not-run rows must not reference a rollout")
+        if self.status != "not_run" and self.source_run_id is None:
+            raise ValueError("started evaluation rows require a source_run_id")
+        if (self.judgment_id is None) != (self.score is None):
+            raise ValueError("evaluation scores and judgment IDs must be set together")
+        if self.status == "failed" and (self.judgment_id is not None or self.score is not None):
+            raise ValueError("failed evaluation rows must not contain a judgment or score")
+        if self.status == "not_run":
+            mutable_fields = (
+                self.rollout_id,
+                self.judgment_id,
+                self.score,
+                self.error,
+                self.source_run_id,
+                self.candidate_cost_usd,
+                self.candidate_latency_seconds,
+                self.world_model_cost_usd,
+                self.sandbox_cost_usd,
+                self.orchestration_cost_usd,
+                self.judge_cost_usd,
+            )
+            if any(value is not None for value in mutable_fields):
+                raise ValueError("not-run rows must not contain execution evidence")
         return self
 
 
@@ -96,14 +133,55 @@ class FidelityReport(ArtifactEnvelope):
     status: Literal["approved", "rejected", "insufficient"]
     approved_at: datetime | None = None
 
+    @field_validator("overlap_cell_ids")
+    @classmethod
+    def _require_unique_overlap_cells(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("fidelity reports must not repeat overlap cells")
+        return value
+
+    @field_validator("score_mae")
+    @classmethod
+    def _require_finite_score_mae(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("fidelity score MAE must be finite")
+        return value
+
     @model_validator(mode="after")
     def _require_consistent_fidelity_counts(self) -> FidelityReport:
+        if len(self.overlap_cell_ids) != self.planned_overlap_count:
+            raise ValueError("fidelity overlap cells must match the planned overlap count")
         if self.usable_overlap_count + self.failed_overlap_count > self.planned_overlap_count:
             raise ValueError("usable and failed overlap counts exceed the planned overlap count")
+        failure_cell_ids = tuple(failure.cell_id for failure in self.failures)
+        if len(set(failure_cell_ids)) != len(failure_cell_ids):
+            raise ValueError("fidelity failures must not repeat an overlap cell")
+        if not set(failure_cell_ids).issubset(self.overlap_cell_ids):
+            raise ValueError("fidelity failures must name planned overlap cells")
+        if len(self.failures) != self.failed_overlap_count:
+            raise ValueError("fidelity failure records must match the failed overlap count")
         if self.status == "approved" and self.approved_at is None:
             raise ValueError("approved fidelity reports require approved_at")
         if self.status != "approved" and self.approved_at is not None:
             raise ValueError("only approved fidelity reports may set approved_at")
+        if self.approved_at is not None and (
+            self.approved_at.tzinfo is None or self.approved_at.utcoffset() is None
+        ):
+            raise ValueError("fidelity approval times must include a timezone")
+        if self.status == "approved" and (
+            self.usable_overlap_count < 8 or self.score_mae is None or self.score_mae > 0.10
+        ):
+            raise ValueError(
+                "approved fidelity reports must satisfy the frozen 8-pair and 0.10 gate"
+            )
+        if self.status == "insufficient" and self.usable_overlap_count >= 8:
+            raise ValueError(
+                "fidelity reports with eight usable pairs must be approved or rejected"
+            )
+        if self.status == "rejected" and (
+            self.usable_overlap_count < 8 or self.score_mae is None or self.score_mae <= 0.10
+        ):
+            raise ValueError("rejected fidelity reports require eight pairs and MAE above 0.10")
         return self
 
 
@@ -121,6 +199,31 @@ class EvaluationDatasetManifest(ArtifactEnvelope):
     rows_path: str = Field(min_length=1)
     rows_sha256: Sha256
 
+    @field_validator("rows_path")
+    @classmethod
+    def _require_safe_rows_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+    @model_validator(mode="after")
+    def _require_consistent_dataset_scope(self) -> EvaluationDatasetManifest:
+        fit_task_ids = set(self.fit_task_ids)
+        held_out_task_ids = set(self.held_out_task_ids)
+        if len(fit_task_ids) != len(self.fit_task_ids):
+            raise ValueError("evaluation manifest fit task IDs must not repeat")
+        if len(held_out_task_ids) != len(self.held_out_task_ids):
+            raise ValueError("evaluation manifest held-out task IDs must not repeat")
+        if fit_task_ids.intersection(held_out_task_ids):
+            raise ValueError("evaluation manifest fit and held-out task IDs must be disjoint")
+        candidate_aliases = tuple(candidate.alias for candidate in self.candidate_snapshots)
+        if not candidate_aliases or len(set(candidate_aliases)) != len(candidate_aliases):
+            raise ValueError("evaluation manifest candidate aliases must be non-empty and unique")
+        protocol_ids = tuple(protocol.protocol_id for protocol in self.protocols)
+        if not protocol_ids or len(set(protocol_ids)) != len(protocol_ids):
+            raise ValueError("evaluation manifest protocol IDs must be non-empty and unique")
+        if len(set(self.fidelity_report_ids)) != len(self.fidelity_report_ids):
+            raise ValueError("evaluation manifest fidelity report IDs must not repeat")
+        return self
+
 
 class EvaluationDataset(ContractModel):
     """A materialized sparse dataset with a frozen manifest and explicit missing cells."""
@@ -135,3 +238,26 @@ class EvaluationDataset(ContractModel):
         if len(set(cell_ids)) != len(cell_ids):
             raise ValueError("evaluation datasets must not repeat a cell ID")
         return value
+
+    @model_validator(mode="after")
+    def _require_rows_to_match_manifest_scope(self) -> EvaluationDataset:
+        fit_task_ids = set(self.manifest.fit_task_ids)
+        held_out_task_ids = set(self.manifest.held_out_task_ids)
+        candidate_aliases = {candidate.alias for candidate in self.manifest.candidate_snapshots}
+        protocol_ids = {protocol.protocol_id for protocol in self.manifest.protocols}
+        for row in self.rows:
+            if row.task_id not in fit_task_ids.union(held_out_task_ids):
+                raise ValueError(f"evaluation row {row.cell_id} names a task outside the manifest")
+            if row.candidate_alias not in candidate_aliases:
+                raise ValueError(
+                    f"evaluation row {row.cell_id} names a candidate outside the manifest"
+                )
+            if row.protocol_id not in protocol_ids:
+                raise ValueError(
+                    f"evaluation row {row.cell_id} names a protocol outside the manifest"
+                )
+            if row.purpose == "held_out" and row.task_id not in held_out_task_ids:
+                raise ValueError("held-out evaluation rows must name held-out tasks")
+            if row.purpose in {"fit", "fidelity"} and row.task_id not in fit_task_ids:
+                raise ValueError("fit and fidelity evaluation rows must name fit tasks")
+        return self

--- a/wmo/common/evaluations/dataset.py
+++ b/wmo/common/evaluations/dataset.py
@@ -151,8 +151,10 @@ class FidelityReport(ArtifactEnvelope):
     def _require_consistent_fidelity_counts(self) -> FidelityReport:
         if len(self.overlap_cell_ids) != self.planned_overlap_count:
             raise ValueError("fidelity overlap cells must match the planned overlap count")
-        if self.usable_overlap_count + self.failed_overlap_count > self.planned_overlap_count:
-            raise ValueError("usable and failed overlap counts exceed the planned overlap count")
+        if self.usable_overlap_count + self.failed_overlap_count != self.planned_overlap_count:
+            raise ValueError(
+                "usable and failed overlap counts must match the planned overlap count"
+            )
         failure_cell_ids = tuple(failure.cell_id for failure in self.failures)
         if len(set(failure_cell_ids)) != len(failure_cell_ids):
             raise ValueError("fidelity failures must not repeat an overlap cell")

--- a/wmo/common/evaluations/dataset.py
+++ b/wmo/common/evaluations/dataset.py
@@ -1,0 +1,137 @@
+"""Canonical judged evaluation rows, datasets, and fidelity reports."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ContractModel,
+    Sha256,
+    StructuredFailure,
+)
+from wmo.common.models import ModelAlias, ModelSnapshot, NumericMeasurement, RoutedCandidateSnapshot
+
+
+class EvaluationProtocol(ContractModel):
+    """Exact identity and pricing provenance for one class of evidence rows."""
+
+    protocol_id: ArtifactId
+    evidence_source: Literal["world_model", "sandbox", "production"]
+    agent_id: str = Field(min_length=1, max_length=256)
+    simulator_id: str = Field(min_length=1, max_length=256)
+    world_model: ModelSnapshot | None = None
+    simulator_prompt_id: str | None = Field(default=None, max_length=256)
+    rubric_id: ArtifactId
+    judge_calibration_id: ArtifactId
+    pricing_snapshot_id: ArtifactId
+    fidelity_report_id: ArtifactId | None = None
+
+
+class EvaluationRow(ContractModel):
+    """One sparse, explicit task, candidate, and repeat measurement."""
+
+    cell_id: ArtifactId
+    task_id: ArtifactId
+    candidate_alias: ModelAlias
+    repeat: int = Field(ge=0)
+    protocol_id: ArtifactId
+    source_run_id: str | None = Field(default=None, max_length=512)
+    purpose: Literal["fit", "held_out", "fidelity"]
+    status: Literal["observed", "completed", "failed", "not_run"]
+    rollout_id: ArtifactId | None = None
+    judgment_id: ArtifactId | None = None
+    score: float | None = Field(default=None, ge=0, le=1)
+    candidate_cost_usd: NumericMeasurement | None = None
+    candidate_latency_seconds: NumericMeasurement | None = None
+    world_model_cost_usd: NumericMeasurement | None = None
+    sandbox_cost_usd: NumericMeasurement | None = None
+    orchestration_cost_usd: NumericMeasurement | None = None
+    judge_cost_usd: NumericMeasurement | None = None
+    error: StructuredFailure | None = None
+
+    @field_validator("score")
+    @classmethod
+    def _require_finite_score(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("evaluation scores must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def _require_status_consistency(self) -> EvaluationRow:
+        if self.status == "failed" and self.error is None:
+            raise ValueError("failed evaluation rows require a structured error")
+        if self.status in {"completed", "observed"} and self.rollout_id is None:
+            raise ValueError("completed and observed rows require a rollout_id")
+        if self.status == "not_run" and self.rollout_id is not None:
+            raise ValueError("not-run rows must not reference a rollout")
+        return self
+
+
+class FidelityFailure(ContractModel):
+    """A planned overlap that could not provide a usable fidelity pair."""
+
+    cell_id: ArtifactId
+    failure: StructuredFailure
+
+
+class FidelityReport(ArtifactEnvelope):
+    """Measured world-model agreement against precommitted observed overlap cells."""
+
+    fidelity_report_id: ArtifactId
+    protocol_sha256: Sha256
+    overlap_cell_ids: tuple[ArtifactId, ...]
+    planned_overlap_count: int = Field(ge=0)
+    usable_overlap_count: int = Field(ge=0)
+    failed_overlap_count: int = Field(ge=0)
+    score_mae: float | None = Field(default=None, ge=0)
+    failures: tuple[FidelityFailure, ...] = ()
+    gate_id: ArtifactId
+    gate_sha256: Sha256
+    status: Literal["approved", "rejected", "insufficient"]
+    approved_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _require_consistent_fidelity_counts(self) -> FidelityReport:
+        if self.usable_overlap_count + self.failed_overlap_count > self.planned_overlap_count:
+            raise ValueError("usable and failed overlap counts exceed the planned overlap count")
+        if self.status == "approved" and self.approved_at is None:
+            raise ValueError("approved fidelity reports require approved_at")
+        if self.status != "approved" and self.approved_at is not None:
+            raise ValueError("only approved fidelity reports may set approved_at")
+        return self
+
+
+class EvaluationDatasetManifest(ArtifactEnvelope):
+    """A frozen manifest for sparse JSONL evaluation rows."""
+
+    evaluation_id: ArtifactId
+    evaluation_plan_id: ArtifactId
+    task_set_id: ArtifactId
+    fit_task_ids: tuple[ArtifactId, ...]
+    held_out_task_ids: tuple[ArtifactId, ...]
+    candidate_snapshots: tuple[RoutedCandidateSnapshot, ...]
+    protocols: tuple[EvaluationProtocol, ...]
+    fidelity_report_ids: tuple[ArtifactId, ...] = ()
+    rows_path: str = Field(min_length=1)
+    rows_sha256: Sha256
+
+
+class EvaluationDataset(ContractModel):
+    """A materialized sparse dataset with a frozen manifest and explicit missing cells."""
+
+    manifest: EvaluationDatasetManifest
+    rows: tuple[EvaluationRow, ...]
+
+    @field_validator("rows")
+    @classmethod
+    def _require_unique_rows(cls, value: tuple[EvaluationRow, ...]) -> tuple[EvaluationRow, ...]:
+        cell_ids = tuple(row.cell_id for row in value)
+        if len(set(cell_ids)) != len(cell_ids):
+            raise ValueError("evaluation datasets must not repeat a cell ID")
+        return value

--- a/wmo/common/evaluations/dataset_test.py
+++ b/wmo/common/evaluations/dataset_test.py
@@ -13,6 +13,7 @@ from wmo.common.evaluations import (
     EvaluationDatasetManifest,
     EvaluationProtocol,
     EvaluationRow,
+    FidelityFailure,
     FidelityReport,
 )
 from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
@@ -27,6 +28,7 @@ def _row() -> EvaluationRow:
         candidate_alias="candidate-economy",
         repeat=0,
         protocol_id="protocol-1",
+        source_run_id="run-1",
         purpose="fit",
         status="completed",
         rollout_id="rollout-1",
@@ -50,6 +52,12 @@ def _manifest() -> EvaluationDatasetManifest:
         evidence_source="world_model",
         agent_id="customer-agent",
         simulator_id="world-model-v1",
+        world_model=ModelSnapshot(
+            provider="openai",
+            model_id="gpt-5.4-mini",
+            capabilities_sha256=_DIGEST,
+        ),
+        simulator_prompt_id="world-model-prompt-v1",
         rubric_id="rubric-1",
         judge_calibration_id="calibration-1",
         pricing_snapshot_id="pricing-1",
@@ -80,11 +88,21 @@ def test_dataset_and_fidelity_report_round_trip() -> None:
         code_revision="e7aad17",
         fidelity_report_id="fidelity-report-1",
         protocol_sha256=_DIGEST,
-        overlap_cell_ids=("cell-fidelity-1",),
+        overlap_cell_ids=tuple(f"cell-fidelity-{index}" for index in range(10)),
         planned_overlap_count=10,
         usable_overlap_count=8,
         failed_overlap_count=2,
         score_mae=0.08,
+        failures=(
+            FidelityFailure(
+                cell_id="cell-fidelity-8",
+                failure=StructuredFailure(code=FailureCode.TIMEOUT, message="simulator timed out"),
+            ),
+            FidelityFailure(
+                cell_id="cell-fidelity-9",
+                failure=StructuredFailure(code=FailureCode.PROVIDER, message="provider failed"),
+            ),
+        ),
         gate_id="fidelity-gate-v1",
         gate_sha256=_DIGEST,
         status="approved",
@@ -103,6 +121,7 @@ def test_rows_keep_failures_and_reject_duplicate_or_missing_evidence() -> None:
         candidate_alias="candidate-economy",
         repeat=0,
         protocol_id="protocol-1",
+        source_run_id="run-1",
         purpose="fit",
         status="failed",
         error=StructuredFailure(
@@ -124,3 +143,22 @@ def test_rows_keep_failures_and_reject_duplicate_or_missing_evidence() -> None:
         )
     with pytest.raises(ValidationError, match="repeat a cell ID"):
         EvaluationDataset(manifest=_manifest(), rows=(_row(), _row()))
+    with pytest.raises(ValidationError, match="started evaluation rows require a source_run_id"):
+        EvaluationRow.model_validate({**_row().model_dump(), "source_run_id": None})
+    with pytest.raises(ValidationError, match="frozen 8-pair"):
+        FidelityReport(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            fidelity_report_id="fidelity-report-2",
+            protocol_sha256=_DIGEST,
+            overlap_cell_ids=tuple(f"cell-fidelity-{index}" for index in range(10)),
+            planned_overlap_count=10,
+            usable_overlap_count=7,
+            failed_overlap_count=0,
+            score_mae=0.08,
+            gate_id="fidelity-gate-v1",
+            gate_sha256=_DIGEST,
+            status="approved",
+            approved_at=datetime(2026, 8, 11, tzinfo=UTC),
+        )

--- a/wmo/common/evaluations/dataset_test.py
+++ b/wmo/common/evaluations/dataset_test.py
@@ -1,0 +1,126 @@
+"""Tests for sparse judged evaluation rows and fidelity-report contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import FailureCode, StructuredFailure
+from wmo.common.evaluations import (
+    EvaluationDataset,
+    EvaluationDatasetManifest,
+    EvaluationProtocol,
+    EvaluationRow,
+    FidelityReport,
+)
+from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
+
+_DIGEST = "a" * 64
+
+
+def _row() -> EvaluationRow:
+    return EvaluationRow(
+        cell_id="cell-1",
+        task_id="task-1",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        protocol_id="protocol-1",
+        purpose="fit",
+        status="completed",
+        rollout_id="rollout-1",
+        judgment_id="judgment-1",
+        score=0.8,
+    )
+
+
+def _manifest() -> EvaluationDatasetManifest:
+    created_at = datetime(2026, 8, 11, tzinfo=UTC)
+    candidate = RoutedCandidateSnapshot(
+        alias="candidate-economy",
+        model=ModelSnapshot(
+            provider="openai",
+            model_id="gpt-5.4-mini",
+            capabilities_sha256=_DIGEST,
+        ),
+    )
+    protocol = EvaluationProtocol(
+        protocol_id="protocol-1",
+        evidence_source="world_model",
+        agent_id="customer-agent",
+        simulator_id="world-model-v1",
+        rubric_id="rubric-1",
+        judge_calibration_id="calibration-1",
+        pricing_snapshot_id="pricing-1",
+    )
+    return EvaluationDatasetManifest(
+        schema_version=1,
+        created_at=created_at,
+        code_revision="e7aad17",
+        evaluation_id="evaluation-1",
+        evaluation_plan_id="plan-1",
+        task_set_id="task-set-1",
+        fit_task_ids=("task-1",),
+        held_out_task_ids=("task-2",),
+        candidate_snapshots=(candidate,),
+        protocols=(protocol,),
+        rows_path="rows.jsonl",
+        rows_sha256=_DIGEST,
+    )
+
+
+def test_dataset_and_fidelity_report_round_trip() -> None:
+    """Sparse rows retain explicit protocols, missing-state semantics, and fidelity provenance."""
+    manifest = _manifest()
+    dataset = EvaluationDataset(manifest=manifest, rows=(_row(),))
+    report = FidelityReport(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        fidelity_report_id="fidelity-report-1",
+        protocol_sha256=_DIGEST,
+        overlap_cell_ids=("cell-fidelity-1",),
+        planned_overlap_count=10,
+        usable_overlap_count=8,
+        failed_overlap_count=2,
+        score_mae=0.08,
+        gate_id="fidelity-gate-v1",
+        gate_sha256=_DIGEST,
+        status="approved",
+        approved_at=datetime(2026, 8, 11, tzinfo=UTC),
+    )
+
+    assert EvaluationDataset.model_validate_json(dataset.model_dump_json()) == dataset
+    assert FidelityReport.model_validate_json(report.model_dump_json()) == report
+
+
+def test_rows_keep_failures_and_reject_duplicate_or_missing_evidence() -> None:
+    """Failed and not-run cells stay explicit while completed evidence cannot disappear."""
+    failed = EvaluationRow(
+        cell_id="cell-failed-1",
+        task_id="task-1",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        protocol_id="protocol-1",
+        purpose="fit",
+        status="failed",
+        error=StructuredFailure(
+            code=FailureCode.TIMEOUT,
+            message="candidate timed out",
+            retryable=True,
+        ),
+    )
+    assert failed.rollout_id is None
+    with pytest.raises(ValidationError, match="require a rollout_id"):
+        EvaluationRow(
+            cell_id="cell-completed-1",
+            task_id="task-1",
+            candidate_alias="candidate-economy",
+            repeat=0,
+            protocol_id="protocol-1",
+            purpose="fit",
+            status="completed",
+        )
+    with pytest.raises(ValidationError, match="repeat a cell ID"):
+        EvaluationDataset(manifest=_manifest(), rows=(_row(), _row()))

--- a/wmo/common/evaluations/dataset_test.py
+++ b/wmo/common/evaluations/dataset_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 
 import pytest
 from pydantic import ValidationError
@@ -75,6 +76,35 @@ def _manifest() -> EvaluationDatasetManifest:
         protocols=(protocol,),
         rows_path="rows.jsonl",
         rows_sha256=_DIGEST,
+    )
+
+
+def _fidelity_report(
+    *,
+    overlap_cell_ids: tuple[str, ...],
+    usable_overlap_count: int,
+    failed_overlap_count: int,
+    failures: tuple[FidelityFailure, ...] = (),
+    status: Literal["approved", "rejected", "insufficient"] = "insufficient",
+    score_mae: float | None = None,
+) -> FidelityReport:
+    approved_at = datetime(2026, 8, 11, tzinfo=UTC) if status == "approved" else None
+    return FidelityReport(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        fidelity_report_id="fidelity-report-1",
+        protocol_sha256=_DIGEST,
+        overlap_cell_ids=overlap_cell_ids,
+        planned_overlap_count=len(overlap_cell_ids),
+        usable_overlap_count=usable_overlap_count,
+        failed_overlap_count=failed_overlap_count,
+        score_mae=score_mae,
+        failures=failures,
+        gate_id="fidelity-gate-v1",
+        gate_sha256=_DIGEST,
+        status=status,
+        approved_at=approved_at,
     )
 
 
@@ -155,10 +185,80 @@ def test_rows_keep_failures_and_reject_duplicate_or_missing_evidence() -> None:
             overlap_cell_ids=tuple(f"cell-fidelity-{index}" for index in range(10)),
             planned_overlap_count=10,
             usable_overlap_count=7,
-            failed_overlap_count=0,
+            failed_overlap_count=3,
             score_mae=0.08,
+            failures=tuple(
+                FidelityFailure(
+                    cell_id=f"cell-fidelity-{index}",
+                    failure=StructuredFailure(
+                        code=FailureCode.TIMEOUT, message="simulator timed out"
+                    ),
+                )
+                for index in range(7, 10)
+            ),
             gate_id="fidelity-gate-v1",
             gate_sha256=_DIGEST,
             status="approved",
             approved_at=datetime(2026, 8, 11, tzinfo=UTC),
+        )
+
+
+def test_fidelity_reports_account_for_each_unique_planned_overlap() -> None:
+    """Empty, complete, and partial overlap sets retain an exact denominator."""
+    assert (
+        _fidelity_report(
+            overlap_cell_ids=(),
+            usable_overlap_count=0,
+            failed_overlap_count=0,
+        ).planned_overlap_count
+        == 0
+    )
+
+    full_overlap_ids = tuple(f"cell-fidelity-{index}" for index in range(10))
+    assert (
+        _fidelity_report(
+            overlap_cell_ids=full_overlap_ids,
+            usable_overlap_count=10,
+            failed_overlap_count=0,
+            status="approved",
+            score_mae=0.08,
+        ).usable_overlap_count
+        == 10
+    )
+
+    failures = (
+        FidelityFailure(
+            cell_id="cell-fidelity-8",
+            failure=StructuredFailure(code=FailureCode.TIMEOUT, message="simulator timed out"),
+        ),
+        FidelityFailure(
+            cell_id="cell-fidelity-9",
+            failure=StructuredFailure(code=FailureCode.PROVIDER, message="provider failed"),
+        ),
+    )
+    assert (
+        _fidelity_report(
+            overlap_cell_ids=full_overlap_ids,
+            usable_overlap_count=8,
+            failed_overlap_count=2,
+            failures=failures,
+            status="approved",
+            score_mae=0.08,
+        ).failed_overlap_count
+        == 2
+    )
+
+    with pytest.raises(ValidationError, match="must match the planned overlap count"):
+        _fidelity_report(
+            overlap_cell_ids=full_overlap_ids,
+            usable_overlap_count=8,
+            failed_overlap_count=0,
+            status="approved",
+            score_mae=0.08,
+        )
+    with pytest.raises(ValidationError, match="must not repeat overlap cells"):
+        _fidelity_report(
+            overlap_cell_ids=("cell-fidelity-0", "cell-fidelity-0"),
+            usable_overlap_count=2,
+            failed_overlap_count=0,
         )

--- a/wmo/common/evaluations/plan.py
+++ b/wmo/common/evaluations/plan.py
@@ -76,3 +76,36 @@ class EvaluationPlan(ArtifactEnvelope):
         if len(set(cell_ids)) != len(cell_ids):
             raise ValueError("evaluation plan cell IDs must be unique")
         return value
+
+    @model_validator(mode="after")
+    def _require_consistent_cell_references(self) -> EvaluationPlan:
+        candidate_aliases = {candidate.alias for candidate in self.candidate_snapshots}
+        cells_by_id = {cell.cell_id: cell for cell in self.cells}
+        planned_cell_keys: set[tuple[ArtifactId, ModelAlias, int, str]] = set()
+        for cell in self.cells:
+            if cell.candidate_alias not in candidate_aliases:
+                raise ValueError(
+                    f"evaluation cell {cell.cell_id} names a candidate outside the plan snapshots"
+                )
+            cell_key = (cell.task_id, cell.candidate_alias, cell.repeat, cell.purpose)
+            if cell_key in planned_cell_keys:
+                raise ValueError(
+                    "evaluation plan must not repeat a task, candidate, repeat, and purpose cell"
+                )
+            planned_cell_keys.add(cell_key)
+            if cell.purpose != "fidelity":
+                continue
+            comparison = cells_by_id.get(cell.comparison_observed_cell_id)
+            if comparison is None or comparison.execution != "observed":
+                raise ValueError("fidelity cells must reference an observed cell in the same plan")
+            if comparison.purpose != "fit":
+                raise ValueError("fidelity cells must compare against observed fit evidence")
+            if (comparison.task_id, comparison.candidate_alias, comparison.repeat) != (
+                cell.task_id,
+                cell.candidate_alias,
+                cell.repeat,
+            ):
+                raise ValueError(
+                    "fidelity cells must preserve the compared task, candidate, and repeat"
+                )
+        return self

--- a/wmo/common/evaluations/plan.py
+++ b/wmo/common/evaluations/plan.py
@@ -1,0 +1,78 @@
+"""Canonical sparse evaluation-plan and fidelity-gate contracts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel, Sha256
+from wmo.common.models import ModelAlias, RoutedCandidateSnapshot
+
+
+class EvaluationCell(ContractModel):
+    """One explicit task, candidate, and repeat cell in a frozen evaluation plan."""
+
+    cell_id: ArtifactId
+    task_id: ArtifactId
+    candidate_alias: ModelAlias
+    repeat: int = Field(ge=0)
+    purpose: Literal["fit", "held_out", "fidelity"]
+    execution: Literal["observed", "simulate"]
+    observed_rollout_id: ArtifactId | None = None
+    comparison_observed_cell_id: ArtifactId | None = None
+
+    @model_validator(mode="after")
+    def _require_explicit_evidence_shape(self) -> EvaluationCell:
+        if self.execution == "observed" and self.observed_rollout_id is None:
+            raise ValueError("observed evaluation cells require observed_rollout_id")
+        if self.execution == "simulate" and self.observed_rollout_id is not None:
+            raise ValueError("simulated evaluation cells must not name an observed rollout")
+        if self.purpose == "fidelity":
+            if self.execution != "simulate" or self.comparison_observed_cell_id is None:
+                raise ValueError("fidelity cells must simulate against an observed comparison cell")
+        elif self.comparison_observed_cell_id is not None:
+            raise ValueError("only fidelity cells may name a comparison observed cell")
+        return self
+
+
+class FidelityGate(ArtifactEnvelope):
+    """Frozen default threshold for accepting world-model overlap evidence."""
+
+    fidelity_gate_id: ArtifactId
+    planned_overlaps: Literal[10] = 10
+    minimum_usable_overlaps: Literal[8] = 8
+    maximum_score_mae: float = Field(default=0.10, ge=0)
+
+
+class EvaluationPlan(ArtifactEnvelope):
+    """A frozen sparse plan that names every observed and simulated evaluation cell."""
+
+    plan_id: ArtifactId
+    task_set_id: ArtifactId
+    candidate_snapshots: tuple[RoutedCandidateSnapshot, ...]
+    fidelity_gate_id: ArtifactId
+    fidelity_gate_sha256: Sha256
+    cells: tuple[EvaluationCell, ...]
+
+    @field_validator("candidate_snapshots")
+    @classmethod
+    def _require_unique_candidates(
+        cls, value: tuple[RoutedCandidateSnapshot, ...]
+    ) -> tuple[RoutedCandidateSnapshot, ...]:
+        aliases = tuple(candidate.alias for candidate in value)
+        if not aliases:
+            raise ValueError("an evaluation plan needs at least one candidate")
+        if len(set(aliases)) != len(aliases):
+            raise ValueError("evaluation plan candidate aliases must be unique")
+        return value
+
+    @field_validator("cells")
+    @classmethod
+    def _require_unique_cells(cls, value: tuple[EvaluationCell, ...]) -> tuple[EvaluationCell, ...]:
+        cell_ids = tuple(cell.cell_id for cell in value)
+        if not cell_ids:
+            raise ValueError("an evaluation plan needs at least one cell")
+        if len(set(cell_ids)) != len(cell_ids):
+            raise ValueError("evaluation plan cell IDs must be unique")
+        return value

--- a/wmo/common/evaluations/plan_test.py
+++ b/wmo/common/evaluations/plan_test.py
@@ -87,3 +87,54 @@ def test_evaluation_cells_reject_implicit_or_inconsistent_evidence() -> None:
             purpose="fidelity",
             execution="simulate",
         )
+    observed = EvaluationCell(
+        cell_id="cell-observed-1",
+        task_id="task-1",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        purpose="fit",
+        execution="observed",
+        observed_rollout_id="rollout-observed-1",
+    )
+    mismatched_fidelity = EvaluationCell(
+        cell_id="cell-fidelity-1",
+        task_id="task-2",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        purpose="fidelity",
+        execution="simulate",
+        comparison_observed_cell_id=observed.cell_id,
+    )
+    with pytest.raises(ValidationError, match="preserve the compared"):
+        EvaluationPlan(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            plan_id="plan-v1",
+            task_set_id="task-set-v1",
+            candidate_snapshots=(_candidate(),),
+            fidelity_gate_id="fidelity-gate-v1",
+            fidelity_gate_sha256=_DIGEST,
+            cells=(observed, mismatched_fidelity),
+        )
+    with pytest.raises(ValidationError, match="outside the plan snapshots"):
+        EvaluationPlan(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            plan_id="plan-v1",
+            task_set_id="task-set-v1",
+            candidate_snapshots=(_candidate(),),
+            fidelity_gate_id="fidelity-gate-v1",
+            fidelity_gate_sha256=_DIGEST,
+            cells=(
+                EvaluationCell(
+                    cell_id="cell-unknown-candidate",
+                    task_id="task-1",
+                    candidate_alias="candidate-unknown",
+                    repeat=0,
+                    purpose="fit",
+                    execution="simulate",
+                ),
+            ),
+        )

--- a/wmo/common/evaluations/plan_test.py
+++ b/wmo/common/evaluations/plan_test.py
@@ -1,0 +1,89 @@
+"""Tests for explicit sparse evaluation plans and frozen fidelity gates."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan, FidelityGate
+from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
+
+_DIGEST = "a" * 64
+
+
+def _candidate() -> RoutedCandidateSnapshot:
+    return RoutedCandidateSnapshot(
+        alias="candidate-economy",
+        model=ModelSnapshot(
+            provider="openai",
+            model_id="gpt-5.4-mini",
+            capabilities_sha256=_DIGEST,
+        ),
+    )
+
+
+def test_sparse_plan_and_fidelity_gate_round_trip() -> None:
+    """Every observed, simulated, and overlap cell has an explicit durable identity."""
+    created_at = datetime(2026, 8, 11, tzinfo=UTC)
+    gate = FidelityGate(
+        schema_version=1,
+        created_at=created_at,
+        code_revision="e7aad17",
+        fidelity_gate_id="fidelity-gate-v1",
+    )
+    observed = EvaluationCell(
+        cell_id="cell-observed-1",
+        task_id="task-1",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        purpose="fit",
+        execution="observed",
+        observed_rollout_id="rollout-observed-1",
+    )
+    fidelity = EvaluationCell(
+        cell_id="cell-fidelity-1",
+        task_id="task-1",
+        candidate_alias="candidate-economy",
+        repeat=0,
+        purpose="fidelity",
+        execution="simulate",
+        comparison_observed_cell_id=observed.cell_id,
+    )
+    plan = EvaluationPlan(
+        schema_version=1,
+        created_at=created_at,
+        code_revision="e7aad17",
+        plan_id="plan-v1",
+        task_set_id="task-set-v1",
+        candidate_snapshots=(_candidate(),),
+        fidelity_gate_id=gate.fidelity_gate_id,
+        fidelity_gate_sha256=_DIGEST,
+        cells=(observed, fidelity),
+    )
+
+    assert FidelityGate.model_validate_json(gate.model_dump_json()) == gate
+    assert EvaluationPlan.model_validate_json(plan.model_dump_json()) == plan
+
+
+def test_evaluation_cells_reject_implicit_or_inconsistent_evidence() -> None:
+    """A plan cannot hide a missing observed rollout or misuse fidelity comparisons."""
+    with pytest.raises(ValidationError, match="require observed_rollout_id"):
+        EvaluationCell(
+            cell_id="cell-observed-1",
+            task_id="task-1",
+            candidate_alias="candidate-economy",
+            repeat=0,
+            purpose="fit",
+            execution="observed",
+        )
+    with pytest.raises(ValidationError, match="fidelity cells"):
+        EvaluationCell(
+            cell_id="cell-fidelity-1",
+            task_id="task-1",
+            candidate_alias="candidate-economy",
+            repeat=0,
+            purpose="fidelity",
+            execution="simulate",
+        )

--- a/wmo/common/judging/__init__.py
+++ b/wmo/common/judging/__init__.py
@@ -1,0 +1,20 @@
+"""Canonical rubric, calibration, and judgment contracts."""
+
+from wmo.common.judging.judgment import DimensionJudgment, Judgment
+from wmo.common.judging.rubric import (
+    DimensionScoreMap,
+    JudgeCalibration,
+    Rubric,
+    RubricDimension,
+    ScoreAnchor,
+)
+
+__all__ = [
+    "DimensionJudgment",
+    "DimensionScoreMap",
+    "JudgeCalibration",
+    "Judgment",
+    "Rubric",
+    "RubricDimension",
+    "ScoreAnchor",
+]

--- a/wmo/common/judging/judgment.py
+++ b/wmo/common/judging/judgment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel
 from wmo.common.models import OperationEconomics
@@ -19,6 +19,17 @@ class DimensionJudgment(ContractModel):
     calibrated_score: float = Field(ge=0, le=5)
     evidence_span_ids: tuple[str, ...]
     feedback: str = Field(min_length=1)
+
+    @field_validator("evidence_span_ids")
+    @classmethod
+    def _require_unique_evidence_spans(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("dimension judgments require at least one cited evidence span")
+        if any(not span_id for span_id in value):
+            raise ValueError("dimension judgment evidence span IDs must be non-empty")
+        if len(set(value)) != len(value):
+            raise ValueError("dimension judgment evidence span IDs must not repeat")
+        return value
 
     @field_validator("calibrated_score")
     @classmethod
@@ -57,3 +68,12 @@ class Judgment(ArtifactEnvelope):
         if not math.isfinite(value):
             raise ValueError("overall_score must be finite")
         return value
+
+    @model_validator(mode="after")
+    def _require_equal_weight_overall_score(self) -> Judgment:
+        expected_score = sum(dimension.calibrated_score / 5 for dimension in self.dimensions) / len(
+            self.dimensions
+        )
+        if not math.isclose(self.overall_score, expected_score, rel_tol=1e-12, abs_tol=1e-12):
+            raise ValueError("overall_score must equal the equal-weight calibrated dimension mean")
+        return self

--- a/wmo/common/judging/judgment.py
+++ b/wmo/common/judging/judgment.py
@@ -1,0 +1,59 @@
+"""Canonical immutable judgment contracts for existing rollout evidence."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel
+from wmo.common.models import OperationEconomics
+
+
+class DimensionJudgment(ContractModel):
+    """A judge's raw and calibrated assessment of one rubric dimension."""
+
+    dimension_id: ArtifactId
+    raw_score: Literal[0, 1, 2, 3, 4, 5]
+    calibrated_score: float = Field(ge=0, le=5)
+    evidence_span_ids: tuple[str, ...]
+    feedback: str = Field(min_length=1)
+
+    @field_validator("calibrated_score")
+    @classmethod
+    def _require_finite_score(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("calibrated_score must be finite")
+        return value
+
+
+class Judgment(ArtifactEnvelope):
+    """A frozen score of one rollout under one rubric and calibration."""
+
+    judgment_id: ArtifactId
+    rollout_id: ArtifactId
+    rubric_id: ArtifactId
+    calibration_id: ArtifactId
+    dimensions: tuple[DimensionJudgment, ...]
+    overall_score: float = Field(ge=0, le=1)
+    judge_economics: OperationEconomics | None = None
+
+    @field_validator("dimensions")
+    @classmethod
+    def _require_unique_dimensions(
+        cls, value: tuple[DimensionJudgment, ...]
+    ) -> tuple[DimensionJudgment, ...]:
+        if not value:
+            raise ValueError("a judgment must score at least one rubric dimension")
+        dimension_ids = tuple(dimension.dimension_id for dimension in value)
+        if len(set(dimension_ids)) != len(dimension_ids):
+            raise ValueError("judgments must not repeat a rubric dimension")
+        return value
+
+    @field_validator("overall_score")
+    @classmethod
+    def _require_finite_overall_score(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("overall_score must be finite")
+        return value

--- a/wmo/common/judging/judgment_test.py
+++ b/wmo/common/judging/judgment_test.py
@@ -59,3 +59,23 @@ def test_judgment_rejects_duplicate_dimensions_and_nonfinite_scores() -> None:
             evidence_span_ids=("span-1",),
             feedback="Invalid score.",
         )
+    with pytest.raises(ValidationError, match="equal-weight"):
+        Judgment(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            judgment_id="judgment-1",
+            rollout_id="rollout-1",
+            rubric_id="support-rubric-v1",
+            calibration_id="judge-calibration-v1",
+            dimensions=(_dimension_judgment(),),
+            overall_score=0.75,
+        )
+    with pytest.raises(ValidationError, match="at least one cited"):
+        DimensionJudgment(
+            dimension_id="task-success",
+            raw_score=4,
+            calibrated_score=3.8,
+            evidence_span_ids=(),
+            feedback="The refund request includes the order and reason.",
+        )

--- a/wmo/common/judging/judgment_test.py
+++ b/wmo/common/judging/judgment_test.py
@@ -1,0 +1,61 @@
+"""Tests for immutable judgments linked to rollout and rubric evidence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.judging import DimensionJudgment, Judgment
+
+
+def _dimension_judgment() -> DimensionJudgment:
+    return DimensionJudgment(
+        dimension_id="task-success",
+        raw_score=4,
+        calibrated_score=3.8,
+        evidence_span_ids=("span-1",),
+        feedback="The refund request includes the order and reason.",
+    )
+
+
+def test_judgment_round_trip() -> None:
+    """A score stays linked to explicit rollout, rubric, and calibration identities."""
+    judgment = Judgment(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        judgment_id="judgment-1",
+        rollout_id="rollout-1",
+        rubric_id="support-rubric-v1",
+        calibration_id="judge-calibration-v1",
+        dimensions=(_dimension_judgment(),),
+        overall_score=0.76,
+    )
+
+    assert Judgment.model_validate_json(judgment.model_dump_json()) == judgment
+
+
+def test_judgment_rejects_duplicate_dimensions_and_nonfinite_scores() -> None:
+    """A judgment cannot silently score one rubric dimension twice or store NaN."""
+    with pytest.raises(ValidationError, match="repeat"):
+        Judgment(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            judgment_id="judgment-1",
+            rollout_id="rollout-1",
+            rubric_id="support-rubric-v1",
+            calibration_id="judge-calibration-v1",
+            dimensions=(_dimension_judgment(), _dimension_judgment()),
+            overall_score=0.76,
+        )
+    with pytest.raises(ValidationError):
+        DimensionJudgment(
+            dimension_id="task-success",
+            raw_score=4,
+            calibrated_score=float("nan"),
+            evidence_span_ids=("span-1",),
+            feedback="Invalid score.",
+        )

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -1,0 +1,117 @@
+"""Canonical rubric and judge-calibration contracts."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel
+from wmo.common.models import ModelSnapshot
+
+
+class ScoreAnchor(ContractModel):
+    """Plain-language anchor for one integer rubric score."""
+
+    score: Literal[0, 1, 2, 3, 4, 5]
+    description: str = Field(min_length=1)
+
+
+class RubricDimension(ContractModel):
+    """A zero-to-five quality dimension with complete scoring anchors."""
+
+    dimension_id: ArtifactId
+    name: str = Field(min_length=1, max_length=256)
+    description: str = Field(min_length=1)
+    anchors: tuple[ScoreAnchor, ...]
+
+    @field_validator("anchors")
+    @classmethod
+    def _require_exact_score_anchors(
+        cls, value: tuple[ScoreAnchor, ...]
+    ) -> tuple[ScoreAnchor, ...]:
+        expected_scores = (0, 1, 2, 3, 4, 5)
+        scores = tuple(anchor.score for anchor in value)
+        if scores != expected_scores:
+            raise ValueError("rubric anchors must contain scores zero through five in order")
+        return value
+
+
+class Rubric(ArtifactEnvelope):
+    """An immutable, versioned set of equal-weight quality dimensions."""
+
+    rubric_id: ArtifactId
+    dimensions: tuple[RubricDimension, ...]
+    source_task_set_id: ArtifactId
+    status: Literal["provisional", "human_approved"]
+    approved_at: datetime | None = None
+
+    @field_validator("dimensions")
+    @classmethod
+    def _require_unique_dimensions(
+        cls, value: tuple[RubricDimension, ...]
+    ) -> tuple[RubricDimension, ...]:
+        if not value:
+            raise ValueError("a rubric must contain at least one dimension")
+        dimension_ids = tuple(dimension.dimension_id for dimension in value)
+        if len(set(dimension_ids)) != len(dimension_ids):
+            raise ValueError("rubric dimensions must have unique IDs")
+        return value
+
+    @model_validator(mode="after")
+    def _require_consistent_approval(self) -> Rubric:
+        if self.status == "human_approved" and self.approved_at is None:
+            raise ValueError("human-approved rubrics require approved_at")
+        if self.status == "provisional" and self.approved_at is not None:
+            raise ValueError("provisional rubrics must not set approved_at")
+        return self
+
+
+class DimensionScoreMap(ContractModel):
+    """A monotonic mapping from raw judge scores to expected human scores."""
+
+    dimension_id: ArtifactId
+    calibrated_scores: tuple[float, float, float, float, float, float]
+
+    @field_validator("calibrated_scores")
+    @classmethod
+    def _require_monotonic_finite_scores(
+        cls, value: tuple[float, float, float, float, float, float]
+    ) -> tuple[float, float, float, float, float, float]:
+        if any(not math.isfinite(score) or score < 0 or score > 5 for score in value):
+            raise ValueError(
+                "calibrated rubric scores must be finite values from zero through five"
+            )
+        if tuple(sorted(value)) != value:
+            raise ValueError("calibrated rubric scores must be monotonic")
+        return value
+
+
+class JudgeCalibration(ArtifactEnvelope):
+    """Frozen judge model, prompt, label lineage, and score maps for one rubric."""
+
+    calibration_id: ArtifactId
+    rubric_id: ArtifactId
+    judge_model: ModelSnapshot
+    judge_prompt_id: str = Field(min_length=1, max_length=256)
+    label_set_id: ArtifactId
+    calibration_lineage_ids: tuple[ArtifactId, ...]
+    excluded_router_held_out_lineage_ids: tuple[ArtifactId, ...]
+    validation_method: Literal["grouped_k_fold"]
+    out_of_fold_report_id: ArtifactId
+    score_maps: tuple[DimensionScoreMap, ...]
+    approved_at: datetime | None = None
+
+    @field_validator("score_maps")
+    @classmethod
+    def _require_unique_score_maps(
+        cls, value: tuple[DimensionScoreMap, ...]
+    ) -> tuple[DimensionScoreMap, ...]:
+        dimension_ids = tuple(score_map.dimension_id for score_map in value)
+        if not dimension_ids:
+            raise ValueError("judge calibration needs a score map for every rubric dimension")
+        if len(set(dimension_ids)) != len(dimension_ids):
+            raise ValueError("judge calibration score maps must not repeat a dimension")
+        return value

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -66,6 +66,10 @@ class Rubric(ArtifactEnvelope):
             raise ValueError("human-approved rubrics require approved_at")
         if self.status == "provisional" and self.approved_at is not None:
             raise ValueError("provisional rubrics must not set approved_at")
+        if self.approved_at is not None and (
+            self.approved_at.tzinfo is None or self.approved_at.utcoffset() is None
+        ):
+            raise ValueError("rubric approval times must include a timezone")
         return self
 
 
@@ -104,6 +108,13 @@ class JudgeCalibration(ArtifactEnvelope):
     score_maps: tuple[DimensionScoreMap, ...]
     approved_at: datetime | None = None
 
+    @field_validator("calibration_lineage_ids", "excluded_router_held_out_lineage_ids")
+    @classmethod
+    def _require_unique_lineage_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("judge calibration lineage IDs must not repeat")
+        return value
+
     @field_validator("score_maps")
     @classmethod
     def _require_unique_score_maps(
@@ -115,3 +126,15 @@ class JudgeCalibration(ArtifactEnvelope):
         if len(set(dimension_ids)) != len(dimension_ids):
             raise ValueError("judge calibration score maps must not repeat a dimension")
         return value
+
+    @model_validator(mode="after")
+    def _require_sealed_calibration_lineages(self) -> JudgeCalibration:
+        if set(self.calibration_lineage_ids).intersection(
+            self.excluded_router_held_out_lineage_ids
+        ):
+            raise ValueError("calibration lineages must exclude router-held-out lineages")
+        if self.approved_at is not None and (
+            self.approved_at.tzinfo is None or self.approved_at.utcoffset() is None
+        ):
+            raise ValueError("judge calibration approval times must include a timezone")
+        return self

--- a/wmo/common/judging/rubric_test.py
+++ b/wmo/common/judging/rubric_test.py
@@ -97,3 +97,28 @@ def test_rubric_requires_ordered_complete_anchors_and_approval_time() -> None:
             source_task_set_id="task-set-v1",
             status="human_approved",
         )
+    with pytest.raises(ValidationError, match="exclude router-held-out"):
+        JudgeCalibration(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            calibration_id="judge-calibration-v1",
+            rubric_id="support-rubric-v1",
+            judge_model=ModelSnapshot(
+                provider="openai",
+                model_id="gpt-5.4-mini",
+                capabilities_sha256=_DIGEST,
+            ),
+            judge_prompt_id="judge-prompt-v1",
+            label_set_id="label-set-v1",
+            calibration_lineage_ids=("lineage-1",),
+            excluded_router_held_out_lineage_ids=("lineage-1",),
+            validation_method="grouped_k_fold",
+            out_of_fold_report_id="judge-report-v1",
+            score_maps=(
+                DimensionScoreMap(
+                    dimension_id="task-success",
+                    calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+                ),
+            ),
+        )

--- a/wmo/common/judging/rubric_test.py
+++ b/wmo/common/judging/rubric_test.py
@@ -1,0 +1,99 @@
+"""Tests for immutable zero-to-five rubric and calibration contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.judging import (
+    DimensionScoreMap,
+    JudgeCalibration,
+    Rubric,
+    RubricDimension,
+    ScoreAnchor,
+)
+from wmo.common.models import ModelSnapshot
+
+_DIGEST = "a" * 64
+
+
+def _dimension() -> RubricDimension:
+    return RubricDimension(
+        dimension_id="task-success",
+        name="Task success",
+        description="Whether the customer received a correct outcome.",
+        anchors=(
+            ScoreAnchor(score=0, description="Score 0 outcome."),
+            ScoreAnchor(score=1, description="Score 1 outcome."),
+            ScoreAnchor(score=2, description="Score 2 outcome."),
+            ScoreAnchor(score=3, description="Score 3 outcome."),
+            ScoreAnchor(score=4, description="Score 4 outcome."),
+            ScoreAnchor(score=5, description="Score 5 outcome."),
+        ),
+    )
+
+
+def test_rubric_and_calibration_round_trip() -> None:
+    """Approved rubric and calibration records retain their model and score-map provenance."""
+    approved_at = datetime(2026, 8, 11, tzinfo=UTC)
+    rubric = Rubric(
+        schema_version=1,
+        created_at=approved_at,
+        code_revision="e7aad17",
+        rubric_id="support-rubric-v1",
+        dimensions=(_dimension(),),
+        source_task_set_id="task-set-v1",
+        status="human_approved",
+        approved_at=approved_at,
+    )
+    calibration = JudgeCalibration(
+        schema_version=1,
+        created_at=approved_at,
+        code_revision="e7aad17",
+        calibration_id="judge-calibration-v1",
+        rubric_id=rubric.rubric_id,
+        judge_model=ModelSnapshot(
+            provider="openai",
+            model_id="gpt-5.4-mini",
+            capabilities_sha256=_DIGEST,
+        ),
+        judge_prompt_id="judge-prompt-v1",
+        label_set_id="label-set-v1",
+        calibration_lineage_ids=("lineage-fit-1",),
+        excluded_router_held_out_lineage_ids=("lineage-held-out-1",),
+        validation_method="grouped_k_fold",
+        out_of_fold_report_id="judge-report-v1",
+        score_maps=(
+            DimensionScoreMap(
+                dimension_id="task-success",
+                calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+            ),
+        ),
+        approved_at=approved_at,
+    )
+
+    assert Rubric.model_validate_json(rubric.model_dump_json()) == rubric
+    assert JudgeCalibration.model_validate_json(calibration.model_dump_json()) == calibration
+
+
+def test_rubric_requires_ordered_complete_anchors_and_approval_time() -> None:
+    """Incomplete anchors and unrecorded human approval fail before persistence."""
+    with pytest.raises(ValidationError, match="zero through five"):
+        RubricDimension(
+            dimension_id="task-success",
+            name="Task success",
+            description="Whether the customer received a correct outcome.",
+            anchors=(ScoreAnchor(score=0, description="Bad."),),
+        )
+    with pytest.raises(ValidationError, match="require approved_at"):
+        Rubric(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            rubric_id="support-rubric-v1",
+            dimensions=(_dimension(),),
+            source_task_set_id="task-set-v1",
+            status="human_approved",
+        )

--- a/wmo/common/models/__init__.py
+++ b/wmo/common/models/__init__.py
@@ -1,0 +1,43 @@
+"""Canonical model identities and data contracts."""
+
+from wmo.common.models.catalog import (
+    ConnectionConfig,
+    ModelCatalog,
+    ModelCatalogError,
+    ModelRecord,
+    ModelRoles,
+    load_model_catalog,
+    write_model_catalog,
+)
+from wmo.common.models.model import (
+    AssistantAction,
+    ModelAlias,
+    ModelMessage,
+    ModelResponse,
+    ModelSnapshot,
+    NumericMeasurement,
+    OperationEconomics,
+    RoutedCandidateSnapshot,
+    ToolCall,
+    Usage,
+)
+
+__all__ = [
+    "AssistantAction",
+    "ConnectionConfig",
+    "ModelCatalog",
+    "ModelCatalogError",
+    "ModelAlias",
+    "ModelMessage",
+    "ModelResponse",
+    "ModelRecord",
+    "ModelRoles",
+    "ModelSnapshot",
+    "NumericMeasurement",
+    "OperationEconomics",
+    "RoutedCandidateSnapshot",
+    "ToolCall",
+    "Usage",
+    "load_model_catalog",
+    "write_model_catalog",
+]

--- a/wmo/common/models/catalog.py
+++ b/wmo/common/models/catalog.py
@@ -10,7 +10,12 @@ from urllib.parse import urlsplit
 import tomli_w
 from pydantic import Field, field_validator, model_validator
 
-from wmo.common.core.artifacts import ContractModel, validate_artifact_id
+from wmo.common.core.artifacts import (
+    ContractModel,
+    SecretBoundaryError,
+    assert_secret_free,
+    validate_artifact_id,
+)
 from wmo.common.core.files import write_text_atomic
 
 _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -44,7 +49,17 @@ class ConnectionConfig(ContractModel):
             raise ValueError("base_url must be an absolute HTTP(S) URL")
         if parsed.username is not None or parsed.password is not None:
             raise ValueError("base_url must not embed credentials")
+        if parsed.query or parsed.fragment:
+            raise ValueError("base_url must not include query parameters or fragments")
         return value
+
+    @model_validator(mode="after")
+    def _require_secret_free_connection_metadata(self) -> ConnectionConfig:
+        try:
+            assert_secret_free({"provider": self.provider, "base_url": self.base_url})
+        except SecretBoundaryError as exc:
+            raise ValueError("connection metadata must not contain credential values") from exc
+        return self
 
 
 class ModelRecord(ContractModel):
@@ -53,6 +68,20 @@ class ModelRecord(ContractModel):
     connection: str = Field(min_length=1, max_length=128)
     model: str = Field(min_length=1, max_length=512)
     revision: str | None = Field(default=None, max_length=256)
+
+    @model_validator(mode="after")
+    def _require_secret_free_model_identity(self) -> ModelRecord:
+        try:
+            assert_secret_free(
+                {
+                    "connection": self.connection,
+                    "model": self.model,
+                    "revision": self.revision,
+                }
+            )
+        except SecretBoundaryError as exc:
+            raise ValueError("model identity must not contain credential values") from exc
+        return self
 
 
 class ModelRoles(ContractModel):

--- a/wmo/common/models/catalog.py
+++ b/wmo/common/models/catalog.py
@@ -1,0 +1,165 @@
+"""Typed local `.wmo/models.toml` catalog loading without credential values."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import tomli_w
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ContractModel, validate_artifact_id
+from wmo.common.core.files import write_text_atomic
+
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class ModelCatalogError(ValueError):
+    """A local model catalog was malformed or named a credential value."""
+
+
+class ConnectionConfig(ContractModel):
+    """Local provider connection metadata, with an optional credential environment name only."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    base_url: str | None = Field(default=None, max_length=2_048)
+    api_key_env: str | None = Field(default=None, max_length=256)
+
+    @field_validator("api_key_env")
+    @classmethod
+    def _require_environment_variable_name(cls, value: str | None) -> str | None:
+        if value is not None and not _ENVIRONMENT_NAME.fullmatch(value):
+            raise ValueError("api_key_env must name one environment variable")
+        return value
+
+    @field_validator("base_url")
+    @classmethod
+    def _reject_embedded_credentials(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("base_url must be an absolute HTTP(S) URL")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("base_url must not embed credentials")
+        return value
+
+
+class ModelRecord(ContractModel):
+    """A stable local model alias's connection and provider-side model name."""
+
+    connection: str = Field(min_length=1, max_length=128)
+    model: str = Field(min_length=1, max_length=512)
+    revision: str | None = Field(default=None, max_length=256)
+
+
+class ModelRoles(ContractModel):
+    """Project roles that select stable aliases without revealing credentials."""
+
+    candidates: tuple[str, ...] = ()
+    incumbent: str | None = None
+    world_model: str | None = None
+    judge: str | None = None
+    rubric_proposer: str | None = None
+    embedder: str | None = None
+    teacher: str | None = None
+
+    @field_validator("candidates")
+    @classmethod
+    def _require_unique_candidates(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("candidate aliases must not repeat")
+        return value
+
+
+class ModelCatalog(ContractModel):
+    """The local model aliases, connection metadata, and project role assignments."""
+
+    schema_version: int = Field(default=1, ge=1)
+    connections: dict[str, ConnectionConfig]
+    models: dict[str, ModelRecord]
+    roles: ModelRoles = Field(default_factory=ModelRoles)
+
+    @field_validator("connections")
+    @classmethod
+    def _require_valid_connection_names(
+        cls, value: dict[str, ConnectionConfig]
+    ) -> dict[str, ConnectionConfig]:
+        if not value:
+            raise ValueError("models.toml needs at least one connection")
+        for connection_name in value:
+            validate_artifact_id(connection_name)
+        return value
+
+    @field_validator("models")
+    @classmethod
+    def _require_valid_model_aliases(cls, value: dict[str, ModelRecord]) -> dict[str, ModelRecord]:
+        if not value:
+            raise ValueError("models.toml needs at least one model alias")
+        for alias in value:
+            validate_artifact_id(alias)
+        return value
+
+    @model_validator(mode="after")
+    def _require_referenced_connections_and_roles(self) -> ModelCatalog:
+        for alias, record in self.models.items():
+            if record.connection not in self.connections:
+                raise ValueError(
+                    f"model alias {alias!r} names unknown connection {record.connection!r}"
+                )
+        assigned_aliases = self.roles.candidates + tuple(
+            alias
+            for alias in (
+                self.roles.incumbent,
+                self.roles.world_model,
+                self.roles.judge,
+                self.roles.rubric_proposer,
+                self.roles.embedder,
+                self.roles.teacher,
+            )
+            if alias is not None
+        )
+        unknown_aliases = sorted(set(assigned_aliases).difference(self.models))
+        if unknown_aliases:
+            raise ValueError(f"roles name unknown model aliases: {', '.join(unknown_aliases)}")
+        if self.roles.incumbent is not None and self.roles.incumbent not in self.roles.candidates:
+            raise ValueError("incumbent must also appear in roles.candidates")
+        return self
+
+
+def load_model_catalog(path: Path) -> ModelCatalog:
+    """Load and validate `.wmo/models.toml` without reading its environment variables.
+
+    Args:
+        path: Path to the local model catalog.
+
+    Returns:
+        Typed aliases, connection metadata, and role assignments.
+
+    Raises:
+        ModelCatalogError: The catalog is missing, malformed, or violates the no-secret contract.
+    """
+    try:
+        with path.open("rb") as handle:
+            raw_catalog = tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise ModelCatalogError(f"model catalog does not exist: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ModelCatalogError(f"model catalog is invalid TOML: {path}") from exc
+    try:
+        return ModelCatalog.model_validate(raw_catalog)
+    except ValueError as exc:
+        raise ModelCatalogError(f"model catalog is invalid: {exc}") from exc
+
+
+def write_model_catalog(path: Path, catalog: ModelCatalog) -> None:
+    """Atomically write validated model metadata and environment-variable names only.
+
+    Args:
+        path: Destination `.wmo/models.toml` path.
+        catalog: Typed catalog containing no credential values.
+    """
+    payload = tomli_w.dumps(catalog.model_dump(mode="json", exclude_none=True))
+    write_text_atomic(path, payload)

--- a/wmo/common/models/catalog_test.py
+++ b/wmo/common/models/catalog_test.py
@@ -78,8 +78,37 @@ model = "private-world-model"
 """.strip(),
         encoding="utf-8",
     )
+    query_credential_path = tmp_path / "query-credential.toml"
+    query_credential_path.write_text(
+        """
+[connections.private-world-model]
+provider = "openai-compatible"
+base_url = "https://models.example.com/v1?api_key=sk-abcdefghijklmnopqrstuvwxyz123456"
+
+[models.world-model]
+connection = "private-world-model"
+model = "private-world-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    model_credential_path = tmp_path / "model-credential.toml"
+    model_credential_path.write_text(
+        """
+[connections.openrouter]
+provider = "openrouter"
+
+[models.candidate-economy]
+connection = "openrouter"
+model = "sk-abcdefghijklmnopqrstuvwxyz123456"
+""".strip(),
+        encoding="utf-8",
+    )
 
     with pytest.raises(ModelCatalogError, match="api_key"):
         load_model_catalog(raw_key_path)
     with pytest.raises(ModelCatalogError, match="embed credentials"):
         load_model_catalog(embedded_credential_path)
+    with pytest.raises(ModelCatalogError, match="query parameters"):
+        load_model_catalog(query_credential_path)
+    with pytest.raises(ModelCatalogError, match="model identity"):
+        load_model_catalog(model_credential_path)

--- a/wmo/common/models/catalog_test.py
+++ b/wmo/common/models/catalog_test.py
@@ -1,0 +1,85 @@
+"""Tests for local model-catalog TOML loading and credential boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmo.common.models import (
+    ConnectionConfig,
+    ModelCatalog,
+    ModelCatalogError,
+    ModelRecord,
+    ModelRoles,
+    load_model_catalog,
+    write_model_catalog,
+)
+
+
+def _catalog() -> ModelCatalog:
+    return ModelCatalog(
+        connections={
+            "openrouter": ConnectionConfig(
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key_env="OPENROUTER_API_KEY",
+            )
+        },
+        models={
+            "candidate-economy": ModelRecord(
+                connection="openrouter",
+                model="deepseek/deepseek-v4-flash",
+            )
+        },
+        roles=ModelRoles(candidates=("candidate-economy",), incumbent="candidate-economy"),
+    )
+
+
+def test_model_catalog_round_trip_preserves_aliases_and_environment_name(tmp_path: Path) -> None:
+    """Models TOML records aliases and an environment variable name, never its value."""
+    path = tmp_path / "models.toml"
+    catalog = _catalog()
+
+    write_model_catalog(path, catalog)
+
+    assert load_model_catalog(path) == catalog
+    assert "OPENROUTER_API_KEY" in path.read_text(encoding="utf-8")
+    assert "api_key =" not in path.read_text(encoding="utf-8")
+
+
+def test_model_catalog_rejects_credential_values_and_embedded_url_credentials(
+    tmp_path: Path,
+) -> None:
+    """The catalog permits a credential environment name but no secret value or URL credentials."""
+    raw_key_path = tmp_path / "raw-key.toml"
+    raw_key_path.write_text(
+        """
+[connections.openrouter]
+provider = "openrouter"
+api_key = "sk-abcdefghijklmnopqrstuvwxyz123456"
+
+[models.candidate-economy]
+connection = "openrouter"
+model = "deepseek/deepseek-v4-flash"
+""".strip(),
+        encoding="utf-8",
+    )
+    embedded_credential_path = tmp_path / "embedded.toml"
+    embedded_credential_path.write_text(
+        """
+[connections.private-world-model]
+provider = "openai-compatible"
+base_url = "https://user:password@models.example.com/v1"
+
+[models.world-model]
+connection = "private-world-model"
+model = "private-world-model"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModelCatalogError, match="api_key"):
+        load_model_catalog(raw_key_path)
+    with pytest.raises(ModelCatalogError, match="embed credentials"):
+        load_model_catalog(embedded_credential_path)

--- a/wmo/common/models/model.py
+++ b/wmo/common/models/model.py
@@ -1,0 +1,104 @@
+"""Canonical model identities, actions, usage, and economics."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256
+
+ModelAlias = ArtifactId
+
+
+class ModelSnapshot(ContractModel):
+    """Resolved model identity captured at an immutable artifact boundary."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    model_id: str = Field(min_length=1, max_length=512)
+    revision: str | None = Field(default=None, max_length=256)
+    capabilities_sha256: Sha256
+
+
+class RoutedCandidateSnapshot(ContractModel):
+    """A stable local alias paired with the model identity used at evaluation time."""
+
+    alias: ModelAlias
+    model: ModelSnapshot
+
+
+class Usage(ContractModel):
+    """Provider-neutral token accounting for one operation."""
+
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    cached_input_tokens: int | None = Field(default=None, ge=0)
+
+
+class NumericMeasurement(ContractModel):
+    """A numeric value with explicit observed versus estimated provenance."""
+
+    value: float
+    provenance: Literal["observed", "estimated"]
+
+    @field_validator("value")
+    @classmethod
+    def _require_finite_value(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("numeric measurements must be finite")
+        return value
+
+
+class OperationEconomics(ContractModel):
+    """Usage, cost, and latency observed for one isolated operation."""
+
+    usage: Usage | None = None
+    cost_usd: NumericMeasurement | None = None
+    latency_seconds: NumericMeasurement | None = None
+
+
+class ToolCall(ContractModel):
+    """One complete tool invocation emitted by an assistant."""
+
+    call_id: str = Field(min_length=1, max_length=256)
+    name: str = Field(min_length=1, max_length=256)
+    arguments: JsonObject = Field(default_factory=dict)
+
+
+class AssistantAction(ContractModel):
+    """One complete assistant output, including zero or more tool calls."""
+
+    content: str | None = None
+    tool_calls: tuple[ToolCall, ...] = ()
+
+    @model_validator(mode="after")
+    def _require_content_or_tool_call(self) -> AssistantAction:
+        if self.content is None and not self.tool_calls:
+            raise ValueError("an assistant action needs content or at least one tool call")
+        return self
+
+
+class ModelMessage(ContractModel):
+    """One request-visible message exchanged with a model."""
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | None = None
+    tool_call_id: str | None = None
+    assistant_action: AssistantAction | None = None
+
+    @model_validator(mode="after")
+    def _require_message_payload(self) -> ModelMessage:
+        if self.content is None and self.assistant_action is None:
+            raise ValueError("a model message needs text or an assistant action")
+        if self.role != "tool" and self.tool_call_id is not None:
+            raise ValueError("tool_call_id is valid only for tool messages")
+        return self
+
+
+class ModelResponse(ContractModel):
+    """A completed model response with resolved identity and operation accounting."""
+
+    output: AssistantAction
+    model: ModelSnapshot
+    economics: OperationEconomics

--- a/wmo/common/models/model_test.py
+++ b/wmo/common/models/model_test.py
@@ -1,0 +1,55 @@
+"""Tests for canonical model data contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.models import (
+    AssistantAction,
+    ModelResponse,
+    ModelSnapshot,
+    NumericMeasurement,
+    OperationEconomics,
+    ToolCall,
+    Usage,
+)
+
+_CAPABILITIES_DIGEST = "a" * 64
+
+
+def _snapshot() -> ModelSnapshot:
+    return ModelSnapshot(
+        provider="openai",
+        model_id="gpt-5.4",
+        revision="2026-08-11",
+        capabilities_sha256=_CAPABILITIES_DIGEST,
+    )
+
+
+def test_model_response_round_trip_preserves_tool_action_and_economics() -> None:
+    """A complete model result round trips through its deterministic Pydantic boundary."""
+    response = ModelResponse(
+        output=AssistantAction(
+            content="I created the ticket.",
+            tool_calls=(
+                ToolCall(call_id="call-1", name="create_ticket", arguments={"priority": "high"}),
+            ),
+        ),
+        model=_snapshot(),
+        economics=OperationEconomics(
+            usage=Usage(input_tokens=30, output_tokens=12),
+            cost_usd=NumericMeasurement(value=0.004, provenance="estimated"),
+            latency_seconds=NumericMeasurement(value=1.2, provenance="observed"),
+        ),
+    )
+
+    assert ModelResponse.model_validate_json(response.model_dump_json()) == response
+
+
+def test_actions_need_payload_and_measurements_are_finite() -> None:
+    """Invalid empty actions and non-finite economics fail at the shared boundary."""
+    with pytest.raises(ValidationError, match="content or at least one tool"):
+        AssistantAction()
+    with pytest.raises(ValidationError, match="finite"):
+        NumericMeasurement(value=float("inf"), provenance="observed")

--- a/wmo/common/observability/telemetry.py
+++ b/wmo/common/observability/telemetry.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 from atexit import register
+from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -20,11 +22,79 @@ POSTHOG_PROJECT_API_KEY = "phc_rPFfCufWpxyctR7duEZTTXovP4k5kbHqSqzd4Z4MQJdL"
 POSTHOG_HOST = "https://us.i.posthog.com"
 
 TelemetryValue = str | int | float | bool | None
-TelemetryProperties = dict[str, TelemetryValue]
+TelemetryProperties = Mapping[str, TelemetryValue]
 
 _FALSE_VALUES = {"0", "false", "off", "no"}
 _TRUE_VALUES = {"1", "true", "on", "yes"}
 _CLIENTS: dict[tuple[str, str], Posthog] = {}
+_ALLOWED_EVENT_PROPERTIES: dict[str, frozenset[str]] = {
+    "wmo build completed": frozenset(
+        {
+            "success",
+            "input_trace_count",
+            "input_step_count",
+            "train_trace_count",
+            "val_trace_count",
+            "heldout_trace_count",
+            "indexed_step_count",
+            "rollouts_used",
+            "frontier_size",
+            "duration_seconds",
+            "llm_call_count",
+            "input_tokens",
+            "output_tokens",
+            "cost_usd",
+        }
+    ),
+    "wmo eval completed": frozenset(
+        {
+            "success",
+            "eval_mode",
+            "file_count",
+            "scored_step_count",
+            "rag_enabled",
+            "train_split",
+            "top_k",
+        }
+    ),
+    "wmo generated trace started": frozenset({"generated_trace_count"}),
+    "wmo generated step failed": frozenset({"success", "duration_seconds"}),
+    "wmo generated step completed": frozenset(
+        {
+            "success",
+            "generated_step_count",
+            "session_step_count",
+            "duration_seconds",
+            "input_tokens",
+            "output_tokens",
+            "cost_usd",
+        }
+    ),
+}
+_BOOLEAN_PROPERTIES = frozenset({"success", "rag_enabled"})
+_COUNT_PROPERTIES = frozenset(
+    {
+        "input_trace_count",
+        "input_step_count",
+        "train_trace_count",
+        "val_trace_count",
+        "heldout_trace_count",
+        "indexed_step_count",
+        "rollouts_used",
+        "frontier_size",
+        "llm_call_count",
+        "input_tokens",
+        "output_tokens",
+        "file_count",
+        "scored_step_count",
+        "top_k",
+        "generated_trace_count",
+        "generated_step_count",
+        "session_step_count",
+    }
+)
+_NONNEGATIVE_MEASUREMENTS = frozenset({"duration_seconds", "cost_usd"})
+_EVAL_MODES = frozenset({"ad_hoc", "suite"})
 
 
 @dataclass
@@ -81,6 +151,9 @@ def capture(
     root: str | Path = ARTIFACT_DIR,
 ) -> bool:
     """Send one anonymous metadata-only event. Returns False when skipped or failed."""
+    safe_properties = _sanitize_properties(event, properties)
+    if safe_properties is None:
+        return False
     if not _enabled(root):
         return False
     api_key = os.getenv("WMO_POSTHOG_PROJECT_API_KEY", POSTHOG_PROJECT_API_KEY).strip()
@@ -89,20 +162,19 @@ def capture(
     host = os.getenv("WMO_POSTHOG_HOST", POSTHOG_HOST).rstrip("/")
     try:
         distinct_id = ensure_telemetry_anonymous_id(root)
-        event_properties: TelemetryProperties = {
+        event_properties = {
             "$process_person_profile": False,
             "wmo_version": _wmo_version(),
             "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
-            **(properties or {}),
         }
-        # Never log prompts, traces, actions, observations, paths, models, credentials, or text.
+        event_properties.update(safe_properties)
         message_id = _posthog_client(api_key, host).capture(
             event,
             distinct_id=distinct_id,
             properties=event_properties,
         )
         return message_id is not None
-    except (OSError, ValueError):
+    except Exception:  # noqa: BLE001
         return False
 
 
@@ -125,7 +197,6 @@ def capture_build_completed(
             "val_trace_count": stats.val_trace_count,
             "heldout_trace_count": stats.heldout_trace_count,
             "indexed_step_count": stats.indexed_step_count,
-            "gepa_budget": gepa_budget,
             "rollouts_used": rollouts_used,
             "frontier_size": frontier_size,
             "duration_seconds": round(record.duration_seconds, 3),
@@ -135,6 +206,62 @@ def capture_build_completed(
             "cost_usd": round(record.total.cost_usd, 6),
         },
         root=root,
+    )
+
+
+def _sanitize_properties(
+    event: str,
+    properties: TelemetryProperties | None,
+) -> dict[str, TelemetryValue] | None:
+    """Return validated aggregate metadata, rejecting arbitrary telemetry egress."""
+    allowed_properties = _ALLOWED_EVENT_PROPERTIES.get(event)
+    if allowed_properties is None:
+        return None
+    supplied_properties: TelemetryProperties = {} if properties is None else properties
+    if not set(supplied_properties).issubset(allowed_properties):
+        return None
+    safe_properties: dict[str, TelemetryValue] = {}
+    for name, value in supplied_properties.items():
+        if value is None:
+            continue
+        if not _is_safe_property_value(name, value):
+            return None
+        safe_properties[name] = value
+    return safe_properties
+
+
+def _is_safe_property_value(name: str, value: TelemetryValue) -> bool:
+    """Validate one explicitly permitted aggregate property value."""
+    if name in _BOOLEAN_PROPERTIES:
+        return isinstance(value, bool)
+    if name in _COUNT_PROPERTIES:
+        return type(value) is int and value >= 0
+    if name in _NONNEGATIVE_MEASUREMENTS:
+        return _is_nonnegative_finite_number(value)
+    if name == "train_split":
+        return _is_unit_interval_number(value)
+    if name == "eval_mode":
+        return isinstance(value, str) and value in _EVAL_MODES
+    return False
+
+
+def _is_nonnegative_finite_number(value: TelemetryValue) -> bool:
+    """Return whether a telemetry measurement is finite and nonnegative."""
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def _is_unit_interval_number(value: TelemetryValue) -> bool:
+    """Return whether a telemetry fraction is finite and falls from zero through one."""
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(value)
+        and 0 <= value <= 1
     )
 
 
@@ -157,7 +284,6 @@ def capture_eval_completed(
             "file_count": file_count,
             "scored_step_count": scored_step_count,
             "rag_enabled": rag_enabled,
-            "sample_turns": sample_turns,
             "train_split": train_split,
             "top_k": top_k,
         },

--- a/wmo/common/observability/telemetry_test.py
+++ b/wmo/common/observability/telemetry_test.py
@@ -9,11 +9,12 @@ import pytest
 
 import wmo.common.observability.telemetry as telemetry
 from wmo.common.config.settings import set_telemetry_enabled
-from wmo.common.observability.telemetry import capture
+from wmo.common.observability.telemetry import capture, capture_eval_completed
 
 
 class _FakePosthog:
     instances: list[_FakePosthog] = []
+    raise_on_capture = False
 
     def __init__(self, project_api_key: str, **kwargs: object) -> None:
         self.project_api_key = project_api_key
@@ -24,6 +25,8 @@ class _FakePosthog:
 
     def capture(self, event: str, **kwargs: object) -> str:
         self.calls.append((event, kwargs))
+        if self.raise_on_capture:
+            raise RuntimeError("simulated PostHog outage")
         return "message-id"
 
     def shutdown(self) -> None:
@@ -32,6 +35,7 @@ class _FakePosthog:
 
 def _install_fake_posthog(monkeypatch: pytest.MonkeyPatch) -> list[_FakePosthog]:
     _FakePosthog.instances = []
+    _FakePosthog.raise_on_capture = False
     telemetry._CLIENTS.clear()
     monkeypatch.setattr(telemetry, "Posthog", _FakePosthog)
     return _FakePosthog.instances
@@ -45,7 +49,19 @@ def test_capture_posts_anonymous_metadata_event(
     monkeypatch.setenv("WMO_TELEMETRY", "1")
     monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
 
-    assert capture("wmo test event", {"generated_step_count": 1}, root=tmp_path / ".wmo")
+    assert capture(
+        "wmo generated step completed",
+        {
+            "success": True,
+            "generated_step_count": 1,
+            "session_step_count": 1,
+            "duration_seconds": 0.25,
+            "input_tokens": 4,
+            "output_tokens": 2,
+            "cost_usd": 0.001,
+        },
+        root=tmp_path / ".wmo",
+    )
 
     assert len(clients) == 1
     client = clients[0]
@@ -55,10 +71,22 @@ def test_capture_posts_anonymous_metadata_event(
     assert len(client.calls) == 1
     event, kwargs = client.calls[0]
     properties = cast(dict[str, object], kwargs["properties"])
-    assert event == "wmo test event"
+    assert event == "wmo generated step completed"
     assert isinstance(kwargs["distinct_id"], str)
     assert properties["$process_person_profile"] is False
     assert properties["generated_step_count"] == 1
+    assert set(properties) == {
+        "$process_person_profile",
+        "wmo_version",
+        "python_version",
+        "success",
+        "generated_step_count",
+        "session_step_count",
+        "duration_seconds",
+        "input_tokens",
+        "output_tokens",
+        "cost_usd",
+    }
 
 
 def test_capture_respects_project_opt_out(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -70,8 +98,32 @@ def test_capture_respects_project_opt_out(monkeypatch: pytest.MonkeyPatch, tmp_p
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
 
-    assert capture("wmo test event", root=root) is False
+    assert capture("wmo generated trace started", root=root) is False
     assert clients == []
+
+
+def test_eval_capture_omits_user_supplied_sample_turn_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clients = _install_fake_posthog(monkeypatch)
+    monkeypatch.setenv("WMO_TELEMETRY", "1")
+    monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    capture_eval_completed(
+        mode="suite",
+        file_count=1,
+        scored_step_count=4,
+        rag_enabled=True,
+        sample_turns="customer-provided sample content",
+        train_split=0.8,
+        top_k=5,
+        root=tmp_path / ".wmo",
+    )
+
+    assert len(clients) == 1
+    _event, kwargs = clients[0].calls[0]
+    properties = cast(dict[str, object], kwargs["properties"])
+    assert "sample_turns" not in properties
 
 
 def test_capture_skips_when_settings_file_cannot_be_read(
@@ -87,7 +139,7 @@ def test_capture_skips_when_settings_file_cannot_be_read(
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
 
-    assert capture("wmo test event", root=tmp_path / ".wmo") is False
+    assert capture("wmo generated trace started", root=tmp_path / ".wmo") is False
     assert clients == []
 
 
@@ -97,7 +149,7 @@ def test_do_not_track_wins_over_env_enable(monkeypatch: pytest.MonkeyPatch, tmp_
     monkeypatch.setenv("WMO_TELEMETRY", "1")
     monkeypatch.setenv("DO_NOT_TRACK", "1")
 
-    assert capture("wmo test event", root=tmp_path / ".wmo") is False
+    assert capture("wmo generated trace started", root=tmp_path / ".wmo") is False
     assert clients == []
 
 
@@ -113,9 +165,58 @@ def test_capture_uses_unknown_version_when_distribution_metadata_is_missing(
     monkeypatch.setenv("WMO_TELEMETRY", "1")
     monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
 
-    assert capture("wmo test event", root=tmp_path / ".wmo")
+    assert capture("wmo generated trace started", root=tmp_path / ".wmo")
 
     assert len(clients) == 1
     _event, kwargs = clients[0].calls[0]
     properties = cast(dict[str, object], kwargs["properties"])
     assert properties["wmo_version"] == "unknown"
+
+
+def test_capture_rejects_unapproved_events_and_unsafe_properties(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clients = _install_fake_posthog(monkeypatch)
+    monkeypatch.setenv("WMO_TELEMETRY", "1")
+    monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    assert (
+        capture(
+            "wmo build completed",
+            {
+                "prompt": "customer prompt",
+                "trace": "raw trace content",
+                "action": "tool action",
+                "observation": "tool observation",
+                "path": "/customer/files/trace.jsonl",
+                "model_response": "raw model response",
+                "environment_id": "customer-environment",
+                "api_key": "sk-abcdefghijklmnopqrstuvwxyz123456",
+                "$process_person_profile": True,
+            },
+            root=tmp_path / ".wmo",
+        )
+        is False
+    )
+    assert capture("wmo arbitrary event", {"input_trace_count": 1}, root=tmp_path / ".wmo") is False
+    assert clients == []
+
+
+def test_capture_isolates_posthog_delivery_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clients = _install_fake_posthog(monkeypatch)
+    _FakePosthog.raise_on_capture = True
+    monkeypatch.setenv("WMO_TELEMETRY", "1")
+    monkeypatch.setenv("WMO_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    assert (
+        capture(
+            "wmo generated trace started",
+            {"generated_trace_count": 1},
+            root=tmp_path / ".wmo",
+        )
+        is False
+    )
+    assert len(clients) == 1
+    assert len(clients[0].calls) == 1

--- a/wmo/common/project/__init__.py
+++ b/wmo/common/project/__init__.py
@@ -1,0 +1,40 @@
+"""Canonical project configuration and immutable local artifact storage."""
+
+from wmo.common.project.manifests import ArtifactFile, ArtifactManifest, artifact_input
+from wmo.common.project.paths import ProjectPathError, ProjectPaths
+from wmo.common.project.project import (
+    AgentConfiguration,
+    ProjectConfig,
+    ProjectConfigError,
+    load_project_config,
+    write_project_config,
+)
+from wmo.common.project.store import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactStore,
+    ArtifactStoreError,
+    ProjectStore,
+    ProjectStoreError,
+    StoredArtifact,
+)
+
+__all__ = [
+    "AgentConfiguration",
+    "ArtifactAlreadyExistsError",
+    "ArtifactCorruptionError",
+    "ArtifactFile",
+    "ArtifactManifest",
+    "ArtifactStore",
+    "ArtifactStoreError",
+    "ProjectConfig",
+    "ProjectConfigError",
+    "ProjectPathError",
+    "ProjectPaths",
+    "ProjectStore",
+    "ProjectStoreError",
+    "StoredArtifact",
+    "artifact_input",
+    "load_project_config",
+    "write_project_config",
+]

--- a/wmo/common/project/manifests.py
+++ b/wmo/common/project/manifests.py
@@ -1,0 +1,73 @@
+"""Immutable artifact-manifest contracts for the local project store."""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import Field, field_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    sha256_json,
+)
+from wmo.common.project.paths import validate_artifact_file_path
+
+
+class ArtifactFile(ContractModel):
+    """A digest-addressed data file owned by one completed immutable artifact."""
+
+    path: str = Field(min_length=1)
+    sha256: Sha256
+    size_bytes: int = Field(ge=0)
+
+    @field_validator("path")
+    @classmethod
+    def _require_safe_relative_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+
+class ArtifactManifest(ArtifactEnvelope):
+    """The single immutable manifest for a completed local artifact directory."""
+
+    artifact_id: ArtifactId
+    artifact_type: ArtifactId
+    files: tuple[ArtifactFile, ...]
+
+    @field_validator("files")
+    @classmethod
+    def _require_sorted_unique_files(
+        cls, value: tuple[ArtifactFile, ...]
+    ) -> tuple[ArtifactFile, ...]:
+        if not value:
+            raise ValueError("completed artifacts need at least one data file")
+        paths = tuple(file.path for file in value)
+        if len(set(paths)) != len(paths):
+            raise ValueError("artifact manifests must not repeat a data-file path")
+        if paths != tuple(sorted(paths)):
+            raise ValueError("artifact manifest data files must be sorted by path")
+        return value
+
+
+def artifact_input(manifest: ArtifactManifest) -> ArtifactInput:
+    """Create the immutable input reference used by a dependent artifact.
+
+    Args:
+        manifest: Verified manifest for the completed input artifact.
+
+    Returns:
+        The input's stable ID and canonical manifest digest.
+    """
+    return ArtifactInput(artifact_id=manifest.artifact_id, sha256=sha256_json(manifest))
+
+
+def file_digest(path: str, payload: bytes) -> ArtifactFile:
+    """Build one file digest record from complete staged bytes."""
+    return ArtifactFile(
+        path=path,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        size_bytes=len(payload),
+    )

--- a/wmo/common/project/manifests.py
+++ b/wmo/common/project/manifests.py
@@ -13,8 +13,8 @@ from wmo.common.core.artifacts import (
     ContractModel,
     Sha256,
     sha256_json,
+    validate_artifact_file_path,
 )
-from wmo.common.project.paths import validate_artifact_file_path
 
 
 class ArtifactFile(ContractModel):

--- a/wmo/common/project/paths.py
+++ b/wmo/common/project/paths.py
@@ -1,0 +1,121 @@
+"""Safe paths for the small project-local `.wmo` layout."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from wmo.common.core.artifacts import validate_artifact_id
+
+
+class ProjectPathError(ValueError):
+    """A caller supplied an unsafe project, artifact, or artifact-file path."""
+
+
+def validate_local_id(value: str, *, label: str) -> str:
+    """Validate an ID that becomes one local filesystem path component.
+
+    Args:
+        value: Proposed project or artifact identifier.
+        label: Human-readable identifier category for an error message.
+
+    Returns:
+        The validated identifier.
+
+    Raises:
+        ProjectPathError: The identifier is not a single canonical local path component.
+    """
+    try:
+        return validate_artifact_id(value)
+    except ValueError as exc:
+        raise ProjectPathError(f"invalid {label} {value!r}: use a lowercase stable ID") from exc
+
+
+def validate_artifact_file_path(value: str) -> PurePosixPath:
+    """Validate a relative POSIX data-file path inside one artifact directory.
+
+    Args:
+        value: Proposed artifact data-file path.
+
+    Returns:
+        A safe, non-empty relative POSIX path.
+
+    Raises:
+        ProjectPathError: The path could escape an artifact directory.
+    """
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ProjectPathError("artifact file paths must be non-empty relative paths without '..'")
+    return path
+
+
+@dataclass(frozen=True)
+class ProjectPaths:
+    """Resolves the canonical local layout for one named WMO project."""
+
+    root: Path
+    project_id: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root", Path(self.root))
+        validate_local_id(self.project_id, label="project ID")
+
+    @property
+    def projects_directory(self) -> Path:
+        """Return the root directory that contains named project directories."""
+        return self.root / "projects"
+
+    @property
+    def project_directory(self) -> Path:
+        """Return this project's directory under `.wmo/projects/`."""
+        return self.projects_directory / self.project_id
+
+    @property
+    def project_toml(self) -> Path:
+        """Return the immutable project configuration file path."""
+        return self.project_directory / "project.toml"
+
+    @property
+    def review_json(self) -> Path:
+        """Return the sole mutable review-draft file path."""
+        return self.project_directory / "review.json"
+
+    @property
+    def artifacts_directory(self) -> Path:
+        """Return the directory that contains completed immutable artifacts."""
+        return self.project_directory / "artifacts"
+
+    def artifact_directory(self, artifact_id: str) -> Path:
+        """Return the safe directory reserved for one immutable artifact.
+
+        Args:
+            artifact_id: Stable local artifact identifier.
+
+        Returns:
+            The path beneath this project's artifact directory.
+        """
+        return self.artifacts_directory / validate_local_id(artifact_id, label="artifact ID")
+
+    def artifact_file(self, artifact_id: str, relative_path: str) -> Path:
+        """Return a safe data-file path inside one immutable artifact directory.
+
+        Args:
+            artifact_id: Stable local artifact identifier.
+            relative_path: Relative POSIX path owned by the artifact.
+
+        Returns:
+            A checked descendant path.
+        """
+        directory = self.artifact_directory(artifact_id)
+        relative = validate_artifact_file_path(relative_path)
+        candidate = directory.joinpath(*relative.parts)
+        _assert_descendant(candidate, directory)
+        return candidate
+
+
+def _assert_descendant(candidate: Path, directory: Path) -> None:
+    """Reject a resolved path that escapes its intended directory."""
+    resolved_directory = directory.resolve()
+    resolved_candidate = candidate.resolve()
+    if not resolved_candidate.is_relative_to(resolved_directory):
+        raise ProjectPathError(f"artifact file path escapes {directory}")

--- a/wmo/common/project/paths.py
+++ b/wmo/common/project/paths.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
-from wmo.common.core.artifacts import validate_artifact_id
+from wmo.common.core.artifacts import validate_artifact_file_path, validate_artifact_id
 
 
 class ProjectPathError(ValueError):
@@ -29,24 +29,6 @@ def validate_local_id(value: str, *, label: str) -> str:
         return validate_artifact_id(value)
     except ValueError as exc:
         raise ProjectPathError(f"invalid {label} {value!r}: use a lowercase stable ID") from exc
-
-
-def validate_artifact_file_path(value: str) -> PurePosixPath:
-    """Validate a relative POSIX data-file path inside one artifact directory.
-
-    Args:
-        value: Proposed artifact data-file path.
-
-    Returns:
-        A safe, non-empty relative POSIX path.
-
-    Raises:
-        ProjectPathError: The path could escape an artifact directory.
-    """
-    path = PurePosixPath(value)
-    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
-        raise ProjectPathError("artifact file paths must be non-empty relative paths without '..'")
-    return path
 
 
 @dataclass(frozen=True)
@@ -107,7 +89,10 @@ class ProjectPaths:
             A checked descendant path.
         """
         directory = self.artifact_directory(artifact_id)
-        relative = validate_artifact_file_path(relative_path)
+        try:
+            relative = validate_artifact_file_path(relative_path)
+        except ValueError as exc:
+            raise ProjectPathError(str(exc)) from exc
         candidate = directory.joinpath(*relative.parts)
         _assert_descendant(candidate, directory)
         return candidate

--- a/wmo/common/project/paths.py
+++ b/wmo/common/project/paths.py
@@ -87,6 +87,9 @@ class ProjectPaths:
 
         Returns:
             A checked descendant path.
+
+        Raises:
+            ProjectPathError: If the artifact ID or relative path is unsafe.
         """
         directory = self.artifact_directory(artifact_id)
         try:

--- a/wmo/common/project/paths_test.py
+++ b/wmo/common/project/paths_test.py
@@ -1,0 +1,34 @@
+"""Tests for safe project and immutable artifact path construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmo.common.project import ProjectPathError, ProjectPaths
+
+
+def test_project_paths_reject_traversal_and_absolute_artifact_file_paths(tmp_path: Path) -> None:
+    """Artifact path helpers cannot escape the assigned project directory."""
+    paths = ProjectPaths(root=tmp_path / ".wmo", project_id="support-project")
+
+    with pytest.raises(ProjectPathError):
+        paths.artifact_directory("../outside")
+    with pytest.raises(ProjectPathError):
+        paths.artifact_file("artifact-1", "../outside.json")
+    with pytest.raises(ProjectPathError):
+        paths.artifact_file("artifact-1", "/outside.json")
+
+
+def test_project_paths_reject_a_symlink_escape(tmp_path: Path) -> None:
+    """Resolved artifact data paths must remain below their artifact directory."""
+    paths = ProjectPaths(root=tmp_path / ".wmo", project_id="support-project")
+    artifact_directory = paths.artifact_directory("artifact-1")
+    artifact_directory.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (artifact_directory / "link").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ProjectPathError, match="escapes"):
+        paths.artifact_file("artifact-1", "link/data.json")

--- a/wmo/common/project/project.py
+++ b/wmo/common/project/project.py
@@ -1,0 +1,81 @@
+"""Project configuration contract and TOML loading for the new local layout."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import tomli_w
+from pydantic import Field
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ContractModel,
+    SecretBoundaryError,
+    assert_secret_free,
+)
+from wmo.common.core.files import write_text_atomic
+
+
+class ProjectConfigError(ValueError):
+    """A project configuration file was absent, malformed, or violated its local contract."""
+
+
+class AgentConfiguration(ContractModel):
+    """Optional explicit factory for a customer-provided injectable agent runtime."""
+
+    factory: str = Field(min_length=1, max_length=512)
+
+
+class ProjectConfig(ContractModel):
+    """Project-local configuration that names no provider credentials or secret references."""
+
+    schema_version: int = Field(default=1, ge=1)
+    project_id: ArtifactId
+    agent: AgentConfiguration | None = None
+    redacted_field_names: tuple[str, ...] = ()
+
+
+def load_project_config(path: Path) -> ProjectConfig:
+    """Load and validate one project TOML file.
+
+    Args:
+        path: Path to ``project.toml``.
+
+    Returns:
+        The immutable typed configuration.
+
+    Raises:
+        ProjectConfigError: The file is missing, malformed, or does not satisfy the contract.
+    """
+    try:
+        with path.open("rb") as handle:
+            raw_config = tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise ProjectConfigError(f"project configuration does not exist: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ProjectConfigError(f"project configuration is invalid TOML: {path}") from exc
+    try:
+        config = ProjectConfig.model_validate(raw_config)
+        assert_secret_free(config)
+    except (SecretBoundaryError, ValueError) as exc:
+        raise ProjectConfigError(f"project configuration is invalid: {exc}") from exc
+    return config
+
+
+def write_project_config(path: Path, config: ProjectConfig) -> None:
+    """Atomically materialize a typed project configuration.
+
+    Args:
+        path: Destination ``project.toml`` path.
+        config: Validated project configuration.
+
+    Raises:
+        ProjectConfigError: The configuration violates the no-secret project boundary.
+    """
+    try:
+        assert_secret_free(config)
+    except SecretBoundaryError as exc:
+        raise ProjectConfigError(f"project configuration is invalid: {exc}") from exc
+    payload = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
+    write_text_atomic(path, payload)

--- a/wmo/common/project/project_test.py
+++ b/wmo/common/project/project_test.py
@@ -1,0 +1,44 @@
+"""Tests for project TOML loading and immutable initialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmo.common.project import (
+    AgentConfiguration,
+    ProjectConfig,
+    ProjectConfigError,
+    load_project_config,
+    write_project_config,
+)
+
+
+def test_project_config_round_trip_preserves_safe_local_metadata(tmp_path: Path) -> None:
+    """Project TOML contains customer wiring metadata but no provider credential references."""
+    path = tmp_path / "project.toml"
+    config = ProjectConfig(
+        project_id="support-project",
+        agent=AgentConfiguration(factory="acme_support.wmo:create_agent_runtime"),
+        redacted_field_names=("email", "phone"),
+    )
+
+    write_project_config(path, config)
+
+    assert load_project_config(path) == config
+
+
+def test_project_config_rejects_secret_reference(tmp_path: Path) -> None:
+    """Project TOML cannot become an alternate home for model credential configuration."""
+    path = tmp_path / "project.toml"
+    path.write_text(
+        """
+project_id = "support-project"
+api_key_env = "OPENAI_API_KEY"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectConfigError, match="api_key_env"):
+        load_project_config(path)

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -19,11 +19,12 @@ from wmo.common.core.artifacts import (
     assert_secret_free,
     assert_text_secret_free,
     canonical_json_bytes,
+    validate_artifact_file_path,
 )
 from wmo.common.core.files import write_bytes_atomic
 from wmo.common.core.locks import file_write_lock
 from wmo.common.project.manifests import ArtifactManifest, file_digest
-from wmo.common.project.paths import ProjectPaths, validate_artifact_file_path, validate_local_id
+from wmo.common.project.paths import ProjectPaths, validate_local_id
 from wmo.common.project.project import ProjectConfig, load_project_config, write_project_config
 
 logger = logging.getLogger(__name__)
@@ -93,7 +94,10 @@ class ArtifactStore:
         seen_paths: set[str] = set()
         manifest_files = []
         for relative_path, payload in sorted(files.items()):
-            validated_path = validate_artifact_file_path(relative_path).as_posix()
+            try:
+                validated_path = validate_artifact_file_path(relative_path).as_posix()
+            except ValueError as exc:
+                raise ArtifactStoreError(str(exc)) from exc
             if validated_path == "manifest.json":
                 raise ArtifactStoreError("artifact data files cannot replace manifest.json")
             if validated_path in seen_paths:

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -168,6 +168,9 @@ class ArtifactStore:
 
         Returns:
             The completed digest-verified manifest.
+
+        Raises:
+            ArtifactStoreError: If a path or record violates the artifact contract.
         """
         serialized_files: dict[str, bytes] = {}
         for relative_path, value in files.items():
@@ -290,6 +293,10 @@ class ArtifactStore:
 
         Returns:
             Complete verified file bytes.
+
+        Raises:
+            ArtifactCorruptionError: If the artifact or requested file is invalid.
+            ValueError: If the relative path is not a safe artifact file path.
         """
         stored = self.read(artifact_id)
         validated_path = validate_artifact_file_path(relative_path).as_posix()
@@ -300,7 +307,11 @@ class ArtifactStore:
         return (stored.directory / validated_path).read_bytes()
 
     def list_ids(self) -> tuple[str, ...]:
-        """Return completed artifact IDs, excluding partial directories and lock files."""
+        """Return completed artifact IDs, excluding partial directories and lock files.
+
+        Returns:
+            Sorted IDs for completed artifact directories that pass local ID validation.
+        """
         directory = self._paths.artifacts_directory
         if not directory.is_dir():
             return ()
@@ -357,7 +368,14 @@ class ProjectStore:
                 raise ProjectStoreError(str(exc)) from exc
 
     def load_project(self) -> ProjectConfig:
-        """Load this store's typed immutable project configuration."""
+        """Load this store's typed immutable project configuration.
+
+        Returns:
+            The parsed project configuration.
+
+        Raises:
+            ProjectStoreError: If the configuration is missing or invalid.
+        """
         try:
             return load_project_config(self.paths.project_toml)
         except ValueError as exc:
@@ -379,7 +397,14 @@ class ProjectStore:
         write_bytes_atomic(self.paths.review_json, canonical_json_bytes(review))
 
     def read_review(self) -> JsonValue | None:
-        """Load the mutable review draft, returning ``None`` before any draft exists."""
+        """Load the mutable review draft, returning ``None`` before any draft exists.
+
+        Returns:
+            The parsed review JSON, or ``None`` when no draft exists.
+
+        Raises:
+            ProjectStoreError: If the draft cannot be read or is not valid JSON.
+        """
         if not self.paths.review_json.exists():
             return None
         try:

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -1,0 +1,457 @@
+"""Atomic immutable artifact storage in the canonical project-local `.wmo` layout."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import BaseModel, JsonValue, TypeAdapter, ValidationError
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    SecretBoundaryError,
+    assert_secret_free,
+    assert_text_secret_free,
+    canonical_json_bytes,
+)
+from wmo.common.core.files import write_bytes_atomic
+from wmo.common.core.locks import file_write_lock
+from wmo.common.project.manifests import ArtifactManifest, file_digest
+from wmo.common.project.paths import ProjectPaths, validate_artifact_file_path, validate_local_id
+from wmo.common.project.project import ProjectConfig, load_project_config, write_project_config
+
+logger = logging.getLogger(__name__)
+
+_JSON_VALUE_ADAPTER = TypeAdapter(JsonValue)
+
+
+class ArtifactStoreError(RuntimeError):
+    """Base error for immutable local artifact storage failures."""
+
+
+class ArtifactAlreadyExistsError(ArtifactStoreError):
+    """A completed artifact ID was reused instead of creating a new artifact."""
+
+
+class ArtifactCorruptionError(ArtifactStoreError):
+    """A completed artifact no longer matches its immutable manifest."""
+
+
+class ProjectStoreError(RuntimeError):
+    """Project initialization or mutable review-draft persistence failed."""
+
+
+@dataclass(frozen=True)
+class StoredArtifact:
+    """A digest-verified immutable artifact directory and its parsed manifest."""
+
+    directory: Path
+    manifest: ArtifactManifest
+
+
+class ArtifactStore:
+    """Writes and reads immutable, digest-verified artifact directories for one project."""
+
+    def __init__(self, paths: ProjectPaths) -> None:
+        """Create a store rooted at one project's canonical artifact directory."""
+        self._paths = paths
+
+    def write(
+        self,
+        *,
+        artifact_id: str,
+        artifact_type: str,
+        envelope: ArtifactEnvelope,
+        files: Mapping[str, bytes],
+    ) -> ArtifactManifest:
+        """Atomically write one completed immutable artifact directory.
+
+        Args:
+            artifact_id: New stable artifact identifier. Existing IDs cannot be overwritten.
+            artifact_type: Stable domain type, such as ``task-set`` or ``evaluation``.
+            envelope: Shared provenance for the completed artifact.
+            files: Complete data-file payloads keyed by safe relative POSIX path.
+
+        Returns:
+            The immutable manifest that names and digests every data file.
+
+        Raises:
+            ArtifactAlreadyExistsError: A completed artifact already has this ID.
+            ArtifactStoreError: A path, secret boundary, or atomic write requirement failed.
+        """
+        validated_artifact_id = validate_local_id(artifact_id, label="artifact ID")
+        validated_artifact_type = validate_local_id(artifact_type, label="artifact type")
+        if not files:
+            raise ArtifactStoreError("completed artifacts need at least one data file")
+        normalized_files = []
+        seen_paths: set[str] = set()
+        manifest_files = []
+        for relative_path, payload in sorted(files.items()):
+            validated_path = validate_artifact_file_path(relative_path).as_posix()
+            if validated_path == "manifest.json":
+                raise ArtifactStoreError("artifact data files cannot replace manifest.json")
+            if validated_path in seen_paths:
+                raise ArtifactStoreError(
+                    f"artifact data files repeat normalized path {validated_path}"
+                )
+            _assert_payload_secret_free(validated_path, payload)
+            seen_paths.add(validated_path)
+            normalized_files.append((validated_path, payload))
+            manifest_files.append(file_digest(validated_path, payload))
+        manifest = ArtifactManifest(
+            artifact_id=validated_artifact_id,
+            artifact_type=validated_artifact_type,
+            schema_version=envelope.schema_version,
+            created_at=envelope.created_at,
+            inputs=envelope.inputs,
+            code_revision=envelope.code_revision,
+            source=envelope.source,
+            files=tuple(manifest_files),
+        )
+        try:
+            assert_secret_free(manifest)
+        except SecretBoundaryError as exc:
+            raise ArtifactStoreError(str(exc)) from exc
+        self._paths.artifacts_directory.mkdir(parents=True, exist_ok=True)
+        destination = self._paths.artifact_directory(validated_artifact_id)
+        with file_write_lock(destination, what=f"artifact {validated_artifact_id}"):
+            if destination.exists():
+                raise ArtifactAlreadyExistsError(
+                    f"completed artifact already exists and is immutable: {validated_artifact_id}"
+                )
+            staging = self._paths.artifacts_directory / (
+                f".{validated_artifact_id}.{uuid4().hex}.partial"
+            )
+            try:
+                staging.mkdir(mode=0o700)
+                for relative_path, payload in normalized_files:
+                    _write_staged_file(staging / relative_path, payload)
+                _write_staged_file(staging / "manifest.json", canonical_json_bytes(manifest))
+                _fsync_staging_tree(staging)
+                if destination.exists():
+                    raise ArtifactAlreadyExistsError(
+                        "completed artifact already exists and is immutable: "
+                        f"{validated_artifact_id}"
+                    )
+                os.rename(staging, destination)
+            except BaseException:
+                shutil.rmtree(staging, ignore_errors=True)
+                raise
+        _fsync_directory_best_effort(self._paths.artifacts_directory)
+        return manifest
+
+    def write_json(
+        self,
+        *,
+        artifact_id: str,
+        artifact_type: str,
+        envelope: ArtifactEnvelope,
+        files: Mapping[str, BaseModel | JsonValue],
+    ) -> ArtifactManifest:
+        """Persist deterministic secret-free JSON files as one immutable artifact.
+
+        Args:
+            artifact_id: New stable artifact identifier.
+            artifact_type: Stable domain type for the manifest.
+            envelope: Shared immutable provenance.
+            files: Structured records keyed by their JSON file paths.
+
+        Returns:
+            The completed digest-verified manifest.
+        """
+        serialized_files: dict[str, bytes] = {}
+        for relative_path, value in files.items():
+            if Path(relative_path).suffix != ".json":
+                raise ArtifactStoreError("write_json requires .json data-file paths")
+            try:
+                assert_secret_free(value)
+            except SecretBoundaryError as exc:
+                raise ArtifactStoreError(str(exc)) from exc
+            serialized_files[relative_path] = canonical_json_bytes(value)
+        return self.write(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            envelope=envelope,
+            files=serialized_files,
+        )
+
+    def write_jsonl(
+        self,
+        *,
+        artifact_id: str,
+        artifact_type: str,
+        envelope: ArtifactEnvelope,
+        files: Mapping[str, Sequence[BaseModel | JsonValue]],
+    ) -> ArtifactManifest:
+        """Persist deterministic secret-free JSONL records as one immutable artifact.
+
+        Args:
+            artifact_id: New stable artifact identifier.
+            artifact_type: Stable domain type for the manifest.
+            envelope: Shared immutable provenance.
+            files: Ordered structured records keyed by their JSONL file paths.
+
+        Returns:
+            The completed digest-verified manifest.
+
+        Raises:
+            ArtifactStoreError: A file is not JSONL or one record violates the secret boundary.
+        """
+        serialized_files: dict[str, bytes] = {}
+        for relative_path, records in files.items():
+            if Path(relative_path).suffix != ".jsonl":
+                raise ArtifactStoreError("write_jsonl requires .jsonl data-file paths")
+            serialized_records = []
+            for record in records:
+                try:
+                    assert_secret_free(record)
+                except SecretBoundaryError as exc:
+                    raise ArtifactStoreError(str(exc)) from exc
+                serialized_records.append(canonical_json_bytes(record))
+            payload = b"\n".join(serialized_records)
+            if payload:
+                payload += b"\n"
+            serialized_files[relative_path] = payload
+        return self.write(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            envelope=envelope,
+            files=serialized_files,
+        )
+
+    def read(self, artifact_id: str) -> StoredArtifact:
+        """Read and fully verify one completed immutable artifact.
+
+        Args:
+            artifact_id: Stable ID of the artifact to verify and open.
+
+        Returns:
+            A parsed manifest and its verified directory.
+
+        Raises:
+            ArtifactCorruptionError: The directory, manifest, file list, or digest is invalid.
+        """
+        directory = self._paths.artifact_directory(artifact_id)
+        if not directory.is_dir() or directory.is_symlink():
+            raise ArtifactCorruptionError(f"completed artifact is missing or unsafe: {artifact_id}")
+        manifest_path = directory / "manifest.json"
+        if not manifest_path.is_file() or manifest_path.is_symlink():
+            raise ArtifactCorruptionError(f"artifact {artifact_id} has no safe manifest.json")
+        try:
+            manifest = ArtifactManifest.model_validate_json(manifest_path.read_bytes())
+            assert_secret_free(manifest)
+        except (OSError, ValidationError, ValueError, SecretBoundaryError) as exc:
+            raise ArtifactCorruptionError(
+                f"artifact {artifact_id} has an invalid manifest"
+            ) from exc
+        if manifest.artifact_id != artifact_id:
+            raise ArtifactCorruptionError(
+                f"artifact directory {artifact_id} does not match manifest ID "
+                f"{manifest.artifact_id}"
+            )
+        expected_files = {entry.path: entry for entry in manifest.files}
+        actual_files = _artifact_data_files(directory)
+        if set(actual_files) != set(expected_files):
+            raise ArtifactCorruptionError(
+                f"artifact {artifact_id} data files do not match its manifest"
+            )
+        for relative_path, entry in expected_files.items():
+            payload = (directory / relative_path).read_bytes()
+            actual_digest = hashlib.sha256(payload).hexdigest()
+            if len(payload) != entry.size_bytes or actual_digest != entry.sha256:
+                raise ArtifactCorruptionError(
+                    f"artifact {artifact_id} data file digest mismatch: {relative_path}"
+                )
+            try:
+                _assert_payload_secret_free(relative_path, payload)
+            except ArtifactStoreError as exc:
+                raise ArtifactCorruptionError(
+                    f"artifact {artifact_id} data file violates the secret boundary: "
+                    f"{relative_path}"
+                ) from exc
+        return StoredArtifact(directory=directory, manifest=manifest)
+
+    def read_bytes(self, artifact_id: str, relative_path: str) -> bytes:
+        """Read a named data file after verifying the complete immutable artifact.
+
+        Args:
+            artifact_id: Stable ID of the artifact to open.
+            relative_path: Safe artifact-relative data-file path.
+
+        Returns:
+            Complete verified file bytes.
+        """
+        stored = self.read(artifact_id)
+        validated_path = validate_artifact_file_path(relative_path).as_posix()
+        if validated_path not in {entry.path for entry in stored.manifest.files}:
+            raise ArtifactCorruptionError(
+                f"artifact {artifact_id} does not own data file {validated_path}"
+            )
+        return (stored.directory / validated_path).read_bytes()
+
+    def list_ids(self) -> tuple[str, ...]:
+        """Return completed artifact IDs, excluding partial directories and lock files."""
+        directory = self._paths.artifacts_directory
+        if not directory.is_dir():
+            return ()
+        artifact_ids = []
+        for candidate in directory.iterdir():
+            if candidate.name.startswith(".") or not candidate.is_dir() or candidate.is_symlink():
+                continue
+            try:
+                artifact_ids.append(validate_local_id(candidate.name, label="artifact ID"))
+            except ValueError:
+                continue
+        return tuple(sorted(artifact_ids))
+
+
+class ProjectStore:
+    """Owns project configuration, the sole mutable review draft, and immutable artifacts."""
+
+    def __init__(self, root: Path, project_id: str) -> None:
+        """Create a project-local store without writing state until an explicit method is called."""
+        self.paths = ProjectPaths(root=root, project_id=project_id)
+        self.artifacts = ArtifactStore(self.paths)
+
+    @property
+    def model_catalog_path(self) -> Path:
+        """Return this `.wmo` root's local `models.toml` path."""
+        return self.paths.root / "models.toml"
+
+    def initialize(self, config: ProjectConfig) -> None:
+        """Create an immutable project configuration, or verify the existing identical one.
+
+        Args:
+            config: Configuration whose project ID matches this store.
+
+        Raises:
+            ProjectStoreError: The project ID differs or existing configuration is not identical.
+        """
+        if config.project_id != self.paths.project_id:
+            raise ProjectStoreError("project configuration ID does not match the store project ID")
+        self.paths.project_directory.mkdir(parents=True, exist_ok=True)
+        with file_write_lock(self.paths.project_toml, what="project configuration"):
+            if self.paths.project_toml.exists():
+                try:
+                    existing = load_project_config(self.paths.project_toml)
+                except ValueError as exc:
+                    raise ProjectStoreError(str(exc)) from exc
+                if existing != config:
+                    raise ProjectStoreError(
+                        "project.toml already exists with different immutable config"
+                    )
+                return
+            try:
+                write_project_config(self.paths.project_toml, config)
+            except ValueError as exc:
+                raise ProjectStoreError(str(exc)) from exc
+
+    def load_project(self) -> ProjectConfig:
+        """Load this store's typed immutable project configuration."""
+        try:
+            return load_project_config(self.paths.project_toml)
+        except ValueError as exc:
+            raise ProjectStoreError(str(exc)) from exc
+
+    def write_review(self, review: BaseModel | JsonValue) -> None:
+        """Atomically replace the sole mutable local review draft.
+
+        Args:
+            review: Structured draft task, rubric, or calibration review state.
+
+        Raises:
+            ProjectStoreError: The draft crosses the local no-secret boundary.
+        """
+        try:
+            assert_secret_free(review)
+        except SecretBoundaryError as exc:
+            raise ProjectStoreError(str(exc)) from exc
+        write_bytes_atomic(self.paths.review_json, canonical_json_bytes(review))
+
+    def read_review(self) -> JsonValue | None:
+        """Load the mutable review draft, returning ``None`` before any draft exists."""
+        if not self.paths.review_json.exists():
+            return None
+        try:
+            return _JSON_VALUE_ADAPTER.validate_json(self.paths.review_json.read_bytes())
+        except (OSError, ValidationError) as exc:
+            raise ProjectStoreError("review.json is not valid JSON") from exc
+
+
+def _assert_payload_secret_free(relative_path: str, payload: bytes) -> None:
+    """Apply secret checks to structured JSON and UTF-8 text artifact data."""
+    suffix = Path(relative_path).suffix
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    try:
+        if suffix == ".json":
+            assert_secret_free(_JSON_VALUE_ADAPTER.validate_json(payload))
+        elif suffix == ".jsonl":
+            for _line_number, line in enumerate(text.splitlines(), start=1):
+                if line:
+                    assert_secret_free(_JSON_VALUE_ADAPTER.validate_json(line))
+        else:
+            assert_text_secret_free(text)
+    except (SecretBoundaryError, ValidationError) as exc:
+        raise ArtifactStoreError(
+            f"artifact data file {relative_path} violates the secret boundary"
+        ) from exc
+
+
+def _artifact_data_files(directory: Path) -> tuple[str, ...]:
+    """Return all regular artifact data paths, rejecting symlinks and unexpected files."""
+    data_files = []
+    for candidate in directory.rglob("*"):
+        if candidate.is_symlink():
+            raise ArtifactCorruptionError(f"artifact contains unsupported symlink: {candidate}")
+        if candidate.is_file():
+            relative_path = candidate.relative_to(directory).as_posix()
+            if relative_path != "manifest.json":
+                data_files.append(relative_path)
+    return tuple(sorted(data_files))
+
+
+def _write_staged_file(path: Path, payload: bytes) -> None:
+    """Write and fsync one new file inside a private artifact staging directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory_strict(directory: Path) -> None:
+    """Persist a staged directory before atomically exposing it to readers."""
+    file_descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(file_descriptor)
+    finally:
+        os.close(file_descriptor)
+
+
+def _fsync_staging_tree(directory: Path) -> None:
+    """Persist nested staged directory entries before their top-level atomic rename."""
+    child_directories = [path for path in directory.rglob("*") if path.is_dir()]
+    for child_directory in sorted(
+        child_directories, key=lambda path: len(path.parts), reverse=True
+    ):
+        _fsync_directory_strict(child_directory)
+    _fsync_directory_strict(directory)
+
+
+def _fsync_directory_best_effort(directory: Path) -> None:
+    """Attempt to persist a completed directory rename without misreporting a landed write."""
+    try:
+        _fsync_directory_strict(directory)
+    except OSError as exc:
+        logger.warning(
+            "artifact rename at %s landed but directory fsync failed: %s", directory, exc
+        )

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -6,9 +6,10 @@ import hashlib
 import logging
 import os
 import shutil
+import stat
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
 from pydantic import BaseModel, JsonValue, TypeAdapter, ValidationError
@@ -23,7 +24,7 @@ from wmo.common.core.artifacts import (
 )
 from wmo.common.core.files import write_bytes_atomic
 from wmo.common.core.locks import file_write_lock
-from wmo.common.project.manifests import ArtifactManifest, file_digest
+from wmo.common.project.manifests import ArtifactFile, ArtifactManifest, file_digest
 from wmo.common.project.paths import ProjectPaths, validate_local_id
 from wmo.common.project.project import ProjectConfig, load_project_config, write_project_config
 
@@ -268,20 +269,8 @@ class ArtifactStore:
             raise ArtifactCorruptionError(
                 f"artifact {artifact_id} data files do not match its manifest"
             )
-        for relative_path, entry in expected_files.items():
-            payload = (directory / relative_path).read_bytes()
-            actual_digest = hashlib.sha256(payload).hexdigest()
-            if len(payload) != entry.size_bytes or actual_digest != entry.sha256:
-                raise ArtifactCorruptionError(
-                    f"artifact {artifact_id} data file digest mismatch: {relative_path}"
-                )
-            try:
-                _assert_payload_secret_free(relative_path, payload)
-            except ArtifactStoreError as exc:
-                raise ArtifactCorruptionError(
-                    f"artifact {artifact_id} data file violates the secret boundary: "
-                    f"{relative_path}"
-                ) from exc
+        for entry in expected_files.values():
+            _read_verified_artifact_file(directory, artifact_id, entry)
         return StoredArtifact(directory=directory, manifest=manifest)
 
     def read_bytes(self, artifact_id: str, relative_path: str) -> bytes:
@@ -300,11 +289,13 @@ class ArtifactStore:
         """
         stored = self.read(artifact_id)
         validated_path = validate_artifact_file_path(relative_path).as_posix()
-        if validated_path not in {entry.path for entry in stored.manifest.files}:
+        expected_files = {entry.path: entry for entry in stored.manifest.files}
+        entry = expected_files.get(validated_path)
+        if entry is None:
             raise ArtifactCorruptionError(
                 f"artifact {artifact_id} does not own data file {validated_path}"
             )
-        return (stored.directory / validated_path).read_bytes()
+        return _read_verified_artifact_file(stored.directory, artifact_id, entry)
 
     def list_ids(self) -> tuple[str, ...]:
         """Return completed artifact IDs, excluding partial directories and lock files.
@@ -433,6 +424,71 @@ def _assert_payload_secret_free(relative_path: str, payload: bytes) -> None:
         raise ArtifactStoreError(
             f"artifact data file {relative_path} violates the secret boundary"
         ) from exc
+
+
+def _read_verified_artifact_file(
+    directory: Path,
+    artifact_id: str,
+    entry: ArtifactFile,
+) -> bytes:
+    """Read one artifact file from a stable descriptor and verify those exact bytes."""
+    try:
+        payload = _read_artifact_file_snapshot(directory, entry.path)
+    except OSError as exc:
+        raise ArtifactCorruptionError(
+            f"artifact {artifact_id} has an unsafe or unreadable data file: {entry.path}"
+        ) from exc
+    actual_digest = hashlib.sha256(payload).hexdigest()
+    if len(payload) != entry.size_bytes or actual_digest != entry.sha256:
+        raise ArtifactCorruptionError(
+            f"artifact {artifact_id} data file digest mismatch: {entry.path}"
+        )
+    try:
+        _assert_payload_secret_free(entry.path, payload)
+    except ArtifactStoreError as exc:
+        raise ArtifactCorruptionError(
+            f"artifact {artifact_id} data file violates the secret boundary: {entry.path}"
+        ) from exc
+    return payload
+
+
+def _read_artifact_file_snapshot(directory: Path, relative_path: str) -> bytes:
+    """Read a regular descendant without following a replaced path component."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise OSError("secure artifact reads require O_NOFOLLOW")
+    directory_fd = os.open(directory, os.O_RDONLY | os.O_NOFOLLOW)
+    current_fd = directory_fd
+    try:
+        if not stat.S_ISDIR(os.fstat(current_fd).st_mode):
+            raise OSError("artifact directory is not a directory")
+        parts = PurePosixPath(relative_path).parts
+        for component in parts[:-1]:
+            next_fd = os.open(component, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=current_fd)
+            try:
+                if not stat.S_ISDIR(os.fstat(next_fd).st_mode):
+                    raise OSError("artifact data path has a non-directory component")
+            except OSError:
+                os.close(next_fd)
+                raise
+            os.close(current_fd)
+            current_fd = next_fd
+        file_descriptor = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=current_fd)
+        try:
+            if not stat.S_ISREG(os.fstat(file_descriptor).st_mode):
+                raise OSError("artifact data path is not a regular file")
+            return _read_file_descriptor(file_descriptor)
+        finally:
+            os.close(file_descriptor)
+    finally:
+        os.close(current_fd)
+
+
+def _read_file_descriptor(file_descriptor: int) -> bytes:
+    """Read all available bytes from one already-open regular file descriptor."""
+    chunks: list[bytes] = []
+    while chunk := os.read(file_descriptor, 1024 * 1024):
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _artifact_data_files(directory: Path) -> tuple[str, ...]:

--- a/wmo/common/project/store_test.py
+++ b/wmo/common/project/store_test.py
@@ -1,0 +1,129 @@
+"""Tests for atomic immutable artifacts, corruption detection, and mutable review state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import wmo.common.project.store as project_store_module
+from wmo.common.core.artifacts import ArtifactEnvelope
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactStoreError,
+    ProjectConfig,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
+
+
+def _envelope() -> ArtifactEnvelope:
+    return ArtifactEnvelope(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+    )
+
+
+def _store(tmp_path: Path) -> ProjectStore:
+    store = ProjectStore(tmp_path / ".wmo", "support-project")
+    store.initialize(ProjectConfig(project_id="support-project"))
+    return store
+
+
+def test_artifact_round_trip_is_digest_verified_and_immutable(tmp_path: Path) -> None:
+    """Completed JSON artifacts round trip, reference by manifest digest, and never overwrite."""
+    store = _store(tmp_path)
+    manifest = store.artifacts.write_json(
+        artifact_id="task-set-v1",
+        artifact_type="task-set",
+        envelope=_envelope(),
+        files={"tasks.json": {"task_ids": ["task-1"]}},
+    )
+
+    stored = store.artifacts.read("task-set-v1")
+
+    assert stored.manifest == manifest
+    assert artifact_input(manifest).artifact_id == "task-set-v1"
+    assert store.artifacts.read_bytes("task-set-v1", "tasks.json") == b'{"task_ids":["task-1"]}'
+    jsonl_manifest = store.artifacts.write_jsonl(
+        artifact_id="traces-v1",
+        artifact_type="trace-set",
+        envelope=_envelope(),
+        files={"traces.jsonl": ({"trace_id": "trace-1"}, {"trace_id": "trace-2"})},
+    )
+    assert jsonl_manifest.files[0].path == "traces.jsonl"
+    assert store.artifacts.read_bytes("traces-v1", "traces.jsonl") == (
+        b'{"trace_id":"trace-1"}\n{"trace_id":"trace-2"}\n'
+    )
+    with pytest.raises(ArtifactAlreadyExistsError, match="immutable"):
+        store.artifacts.write_json(
+            artifact_id="task-set-v1",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"tasks.json": {"task_ids": ["task-2"]}},
+        )
+    assert store.artifacts.read("task-set-v1").manifest == manifest
+
+
+def test_corruption_and_crash_do_not_create_valid_partial_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Digest mutation fails reads, and a failed rename leaves no valid partial artifact."""
+    store = _store(tmp_path)
+    store.artifacts.write_json(
+        artifact_id="task-set-v1",
+        artifact_type="task-set",
+        envelope=_envelope(),
+        files={"tasks.json": {"task_ids": ["task-1"]}},
+    )
+    store.paths.artifact_file("task-set-v1", "tasks.json").write_text(
+        '{"task_ids":["task-2"]}', encoding="utf-8"
+    )
+    with pytest.raises(ArtifactCorruptionError, match="digest mismatch"):
+        store.artifacts.read("task-set-v1")
+
+    def fail_rename(source: Path, destination: Path) -> None:
+        raise OSError("simulated crash before promotion")
+
+    monkeypatch.setattr(project_store_module.os, "rename", fail_rename)
+    with pytest.raises(OSError, match="simulated crash"):
+        store.artifacts.write_json(
+            artifact_id="task-set-v2",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"tasks.json": {"task_ids": ["task-2"]}},
+        )
+    assert not store.paths.artifact_directory("task-set-v2").exists()
+    assert not tuple(store.paths.artifacts_directory.glob(".task-set-v2.*.partial"))
+
+
+def test_secret_boundary_and_only_mutable_review_file(tmp_path: Path) -> None:
+    """Artifacts reject credentials while review JSON may be atomically replaced as a draft."""
+    store = _store(tmp_path)
+    with pytest.raises(ArtifactStoreError, match="api_key_env"):
+        store.artifacts.write_json(
+            artifact_id="unsafe-v1",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"tasks.json": {"api_key_env": "OPENAI_API_KEY"}},
+        )
+    with pytest.raises(ArtifactStoreError, match="secret boundary"):
+        store.artifacts.write(
+            artifact_id="unsafe-text-v1",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"notes.md": b"Use api-key environment configuration."},
+        )
+
+    store.write_review({"rubric_status": "draft-one"})
+    store.write_review({"rubric_status": "draft-two"})
+
+    assert store.read_review() == {"rubric_status": "draft-two"}
+    with pytest.raises(ProjectStoreError, match="different immutable"):
+        store.initialize(
+            ProjectConfig(project_id="support-project", redacted_field_names=("email",))
+        )

--- a/wmo/common/project/store_test.py
+++ b/wmo/common/project/store_test.py
@@ -111,6 +111,20 @@ def test_secret_boundary_and_only_mutable_review_file(tmp_path: Path) -> None:
             envelope=_envelope(),
             files={"tasks.json": {"api_key_env": "OPENAI_API_KEY"}},
         )
+    with pytest.raises(ArtifactStoreError, match="credential environment name"):
+        store.artifacts.write_json(
+            artifact_id="unsafe-variable-v1",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"tasks.json": {"connection_hint": "OPENAI_API_KEY"}},
+        )
+    with pytest.raises(ArtifactStoreError, match="relative POSIX"):
+        store.artifacts.write_json(
+            artifact_id="unsafe-path-v1",
+            artifact_type="task-set",
+            envelope=_envelope(),
+            files={"../tasks.json": {"task_ids": ["task-1"]}},
+        )
     with pytest.raises(ArtifactStoreError, match="secret boundary"):
         store.artifacts.write(
             artifact_id="unsafe-text-v1",

--- a/wmo/common/project/store_test.py
+++ b/wmo/common/project/store_test.py
@@ -101,6 +101,59 @@ def test_corruption_and_crash_do_not_create_valid_partial_artifacts(
     assert not tuple(store.paths.artifacts_directory.glob(".task-set-v2.*.partial"))
 
 
+def test_read_bytes_rechecks_the_exact_file_snapshot_after_full_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replacement after `read` cannot make `read_bytes` return unchecked data."""
+    store = _store(tmp_path)
+    store.artifacts.write_json(
+        artifact_id="task-set-v1",
+        artifact_type="task-set",
+        envelope=_envelope(),
+        files={"tasks.json": {"task_ids": ["task-1"]}},
+    )
+    target = store.paths.artifact_file("task-set-v1", "tasks.json")
+    verified_read = store.artifacts.read
+
+    def replace_after_verification(artifact_id: str) -> project_store_module.StoredArtifact:
+        stored = verified_read(artifact_id)
+        target.write_bytes(b'{"task_ids":["task-replaced"]}')
+        return stored
+
+    monkeypatch.setattr(store.artifacts, "read", replace_after_verification)
+
+    with pytest.raises(ArtifactCorruptionError, match="digest mismatch"):
+        store.artifacts.read_bytes("task-set-v1", "tasks.json")
+
+
+def test_read_bytes_rejects_a_symlink_swapped_after_full_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replacement symlink cannot escape an artifact after `read` verified it."""
+    store = _store(tmp_path)
+    store.artifacts.write_json(
+        artifact_id="task-set-v1",
+        artifact_type="task-set",
+        envelope=_envelope(),
+        files={"tasks.json": {"task_ids": ["task-1"]}},
+    )
+    target = store.paths.artifact_file("task-set-v1", "tasks.json")
+    outside = tmp_path / "outside.json"
+    outside.write_bytes(b'{"task_ids":["outside"]}')
+    verified_read = store.artifacts.read
+
+    def replace_after_verification(artifact_id: str) -> project_store_module.StoredArtifact:
+        stored = verified_read(artifact_id)
+        target.unlink()
+        target.symlink_to(outside)
+        return stored
+
+    monkeypatch.setattr(store.artifacts, "read", replace_after_verification)
+
+    with pytest.raises(ArtifactCorruptionError, match="unsafe or unreadable"):
+        store.artifacts.read_bytes("task-set-v1", "tasks.json")
+
+
 def test_secret_boundary_and_only_mutable_review_file(tmp_path: Path) -> None:
     """Artifacts reject credentials while review JSON may be atomically replaced as a draft."""
     store = _store(tmp_path)

--- a/wmo/common/rollouts/__init__.py
+++ b/wmo/common/rollouts/__init__.py
@@ -1,0 +1,31 @@
+"""Canonical simulation artifact and rollout contracts."""
+
+from wmo.common.rollouts.artifact import (
+    RolloutArtifact,
+    SimulationArtifact,
+    SimulationArtifactSet,
+    SimulationMode,
+    StopReason,
+)
+from wmo.common.rollouts.otel import (
+    ProductionSimulatorSnapshot,
+    RolloutEventKind,
+    RolloutSpan,
+    SandboxSimulatorSnapshot,
+    SimulatorSnapshot,
+    WorldModelSimulatorSnapshot,
+)
+
+__all__ = [
+    "ProductionSimulatorSnapshot",
+    "RolloutArtifact",
+    "RolloutEventKind",
+    "RolloutSpan",
+    "SandboxSimulatorSnapshot",
+    "SimulationArtifact",
+    "SimulationArtifactSet",
+    "SimulationMode",
+    "SimulatorSnapshot",
+    "StopReason",
+    "WorldModelSimulatorSnapshot",
+]

--- a/wmo/common/rollouts/artifact.py
+++ b/wmo/common/rollouts/artifact.py
@@ -1,0 +1,107 @@
+"""Canonical immutable simulation and rollout artifact contracts."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, Sha256, StructuredFailure
+from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics
+from wmo.common.rollouts.otel import RolloutSpan, SimulatorSnapshot
+
+
+class SimulationMode(StrEnum):
+    """Execution mode selected by an immutable simulation specification."""
+
+    WORLD_MODEL = "world_model"
+    SANDBOX = "sandbox"
+    MIXED_REALITY = "mixed_reality"
+
+
+class StopReason(StrEnum):
+    """Terminal reason captured for an agent episode."""
+
+    COMPLETED = "completed"
+    AGENT_STOP = "agent_stop"
+    MAXIMUM_STEPS = "maximum_steps"
+    MAXIMUM_COST = "maximum_cost"
+    CONTEXT_OVERFLOW = "context_overflow"
+    LENGTH = "length"
+    FAILURE = "failure"
+    CANCELLED = "cancelled"
+
+
+class SimulationArtifact(ArtifactEnvelope):
+    """Shared envelope emitted by a concrete simulator for one planned cell."""
+
+    artifact_id: ArtifactId
+    simulation_id: ArtifactId
+    cell_id: ArtifactId
+    mode: SimulationMode
+
+
+class RolloutArtifact(SimulationArtifact):
+    """The v1 simulation artifact subtype that preserves one full agent episode."""
+
+    artifact_kind: Literal["rollout"] = "rollout"
+    rollout_id: ArtifactId
+    trace_id: str = Field(min_length=1, max_length=512)
+    evidence_source: Literal["production", "world_model", "sandbox"]
+    source_run_id: str = Field(min_length=1, max_length=512)
+    task_id: ArtifactId
+    candidate: ModelSnapshot
+    agent_id: str = Field(min_length=1, max_length=256)
+    simulator: SimulatorSnapshot
+    world_model: ModelSnapshot | None = None
+    seed: int | None = None
+    repeat: int = Field(ge=0)
+    spans: tuple[RolloutSpan, ...]
+    final_output: AssistantAction | None = None
+    stop_reason: StopReason
+    failure: StructuredFailure | None = None
+    candidate_economics: OperationEconomics
+    world_model_economics: OperationEconomics | None = None
+    sandbox_economics: OperationEconomics | None = None
+    orchestration_economics: OperationEconomics | None = None
+    simulation_spec_sha256: Sha256 | None = None
+
+    @field_validator("spans")
+    @classmethod
+    def _require_unique_span_ids(cls, value: tuple[RolloutSpan, ...]) -> tuple[RolloutSpan, ...]:
+        if not value:
+            raise ValueError("a rollout must contain at least one span")
+        span_ids = tuple(span.span_id for span in value)
+        if len(set(span_ids)) != len(span_ids):
+            raise ValueError("rollout span IDs must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def _require_consistent_source_provenance(self) -> RolloutArtifact:
+        if self.evidence_source == "production" and self.simulation_spec_sha256 is not None:
+            raise ValueError("production rollouts must not name a simulation specification")
+        if self.evidence_source != "production" and self.simulation_spec_sha256 is None:
+            raise ValueError("simulated rollouts require a simulation specification digest")
+        if self.stop_reason == StopReason.FAILURE and self.failure is None:
+            raise ValueError("failed rollouts require a structured failure")
+        return self
+
+
+class SimulationArtifactSet(ArtifactEnvelope):
+    """A frozen set of completed artifacts emitted for one simulation specification."""
+
+    artifact_set_id: ArtifactId
+    simulation_id: ArtifactId
+    artifact_ids: tuple[ArtifactId, ...]
+    artifacts_path: str = Field(min_length=1)
+    artifacts_sha256: Sha256
+
+    @field_validator("artifact_ids")
+    @classmethod
+    def _require_unique_artifact_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if not value:
+            raise ValueError("a simulation artifact set must contain at least one artifact")
+        if len(set(value)) != len(value):
+            raise ValueError("artifact_ids must not contain duplicates")
+        return value

--- a/wmo/common/rollouts/artifact.py
+++ b/wmo/common/rollouts/artifact.py
@@ -7,9 +7,21 @@ from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, Sha256, StructuredFailure
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    Sha256,
+    StructuredFailure,
+    validate_artifact_file_path,
+)
 from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics
-from wmo.common.rollouts.otel import RolloutSpan, SimulatorSnapshot
+from wmo.common.rollouts.otel import (
+    ProductionSimulatorSnapshot,
+    RolloutSpan,
+    SandboxSimulatorSnapshot,
+    SimulatorSnapshot,
+    WorldModelSimulatorSnapshot,
+)
 
 
 class SimulationMode(StrEnum):
@@ -85,6 +97,25 @@ class RolloutArtifact(SimulationArtifact):
             raise ValueError("simulated rollouts require a simulation specification digest")
         if self.stop_reason == StopReason.FAILURE and self.failure is None:
             raise ValueError("failed rollouts require a structured failure")
+        if self.evidence_source == "production":
+            if not isinstance(self.simulator, ProductionSimulatorSnapshot):
+                raise ValueError("production rollouts require a production simulator snapshot")
+            if self.world_model is not None:
+                raise ValueError("production rollouts must not name a world model")
+        elif self.evidence_source == "world_model":
+            if self.mode != SimulationMode.WORLD_MODEL:
+                raise ValueError("world-model rollouts require world_model mode")
+            if not isinstance(self.simulator, WorldModelSimulatorSnapshot):
+                raise ValueError("world-model rollouts require a world-model simulator snapshot")
+            if self.world_model != self.simulator.world_model:
+                raise ValueError("world-model rollout identity must match its simulator snapshot")
+        elif self.evidence_source == "sandbox":
+            if self.mode != SimulationMode.SANDBOX:
+                raise ValueError("sandbox rollouts require sandbox mode")
+            if not isinstance(self.simulator, SandboxSimulatorSnapshot):
+                raise ValueError("sandbox rollouts require a sandbox simulator snapshot")
+            if self.world_model is not None:
+                raise ValueError("sandbox rollouts must not name a world model")
         return self
 
 
@@ -96,6 +127,11 @@ class SimulationArtifactSet(ArtifactEnvelope):
     artifact_ids: tuple[ArtifactId, ...]
     artifacts_path: str = Field(min_length=1)
     artifacts_sha256: Sha256
+
+    @field_validator("artifacts_path")
+    @classmethod
+    def _require_safe_artifacts_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
 
     @field_validator("artifact_ids")
     @classmethod

--- a/wmo/common/rollouts/artifact_test.py
+++ b/wmo/common/rollouts/artifact_test.py
@@ -7,9 +7,10 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from pydantic import ValidationError
 
-from wmo.common.core.artifacts import FailureCode, StructuredFailure
+from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
 from wmo.common.models import ModelSnapshot, OperationEconomics
 from wmo.common.rollouts import (
+    ProductionSimulatorSnapshot,
     RolloutArtifact,
     RolloutEventKind,
     RolloutSpan,
@@ -102,6 +103,10 @@ def test_rollout_rejects_missing_simulation_digest_and_failure_details() -> None
             **rollout.model_dump(),
             "evidence_source": "production",
             "simulation_spec_sha256": None,
+            "world_model": None,
+            "simulator": ProductionSimulatorSnapshot(
+                source=SourceIdentity(kind="production", source_id="trace-1", sha256=_DIGEST)
+            ).model_dump(),
             "failure": StructuredFailure(
                 code=FailureCode.PROVIDER,
                 message="captured failure",
@@ -110,3 +115,14 @@ def test_rollout_rejects_missing_simulation_digest_and_failure_details() -> None
     )
 
     assert production.evidence_source == "production"
+    assert rollout.world_model is not None
+    with pytest.raises(ValidationError, match="identity must match"):
+        RolloutArtifact.model_validate(
+            {
+                **rollout.model_dump(),
+                "world_model": {
+                    **rollout.world_model.model_dump(),
+                    "model_id": "different-world-model",
+                },
+            }
+        )

--- a/wmo/common/rollouts/artifact_test.py
+++ b/wmo/common/rollouts/artifact_test.py
@@ -1,0 +1,112 @@
+"""Tests for canonical simulation artifact and rollout subtype contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import FailureCode, StructuredFailure
+from wmo.common.models import ModelSnapshot, OperationEconomics
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    RolloutSpan,
+    SimulationArtifactSet,
+    SimulationMode,
+    StopReason,
+    WorldModelSimulatorSnapshot,
+)
+
+_DIGEST = "a" * 64
+
+
+def _model() -> ModelSnapshot:
+    return ModelSnapshot(
+        provider="openai",
+        model_id="gpt-5.4",
+        capabilities_sha256=_DIGEST,
+    )
+
+
+def _rollout() -> RolloutArtifact:
+    started_at = datetime(2026, 8, 11, tzinfo=UTC)
+    return RolloutArtifact(
+        schema_version=1,
+        created_at=started_at,
+        code_revision="e7aad17",
+        artifact_id="rollout-artifact-1",
+        simulation_id="simulation-1",
+        cell_id="cell-1",
+        mode=SimulationMode.WORLD_MODEL,
+        rollout_id="rollout-1",
+        trace_id="0123456789abcdef0123456789abcdef",
+        evidence_source="world_model",
+        source_run_id="run-1",
+        task_id="task-1",
+        candidate=_model(),
+        agent_id="customer-agent",
+        simulator=WorldModelSimulatorSnapshot(
+            simulator_id="world-model-v1",
+            prompt_id="world-prompt-v1",
+            world_model=_model(),
+        ),
+        world_model=_model(),
+        seed=7,
+        repeat=0,
+        spans=(
+            RolloutSpan(
+                span_id="span-1",
+                kind=RolloutEventKind.AGENT_MODEL_CALL,
+                started_at=started_at,
+                ended_at=started_at + timedelta(seconds=1),
+                model=_model(),
+            ),
+        ),
+        stop_reason=StopReason.COMPLETED,
+        candidate_economics=OperationEconomics(),
+        simulation_spec_sha256=_DIGEST,
+    )
+
+
+def test_rollout_subtype_and_artifact_set_round_trip() -> None:
+    """A completed rollout remains a simulation artifact with complete provenance."""
+    rollout = _rollout()
+    artifact_set = SimulationArtifactSet(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        artifact_set_id="rollout-set-1",
+        simulation_id="simulation-1",
+        artifact_ids=(rollout.artifact_id,),
+        artifacts_path="rollouts.jsonl",
+        artifacts_sha256=_DIGEST,
+    )
+
+    assert RolloutArtifact.model_validate_json(rollout.model_dump_json()) == rollout
+    assert SimulationArtifactSet.model_validate_json(artifact_set.model_dump_json()) == artifact_set
+
+
+def test_rollout_rejects_missing_simulation_digest_and_failure_details() -> None:
+    """Simulated and failed episodes preserve exactly the required provenance evidence."""
+    rollout = _rollout()
+    with pytest.raises(ValidationError, match="require a simulation specification"):
+        RolloutArtifact.model_validate({**rollout.model_dump(), "simulation_spec_sha256": None})
+    with pytest.raises(ValidationError, match="require a structured failure"):
+        RolloutArtifact.model_validate(
+            {**rollout.model_dump(), "stop_reason": "failure", "failure": None}
+        )
+    production = RolloutArtifact.model_validate(
+        {
+            **rollout.model_dump(),
+            "evidence_source": "production",
+            "simulation_spec_sha256": None,
+            "failure": StructuredFailure(
+                code=FailureCode.PROVIDER,
+                message="captured failure",
+            ).model_dump(),
+        }
+    )
+
+    assert production.evidence_source == "production"

--- a/wmo/common/rollouts/otel.py
+++ b/wmo/common/rollouts/otel.py
@@ -1,0 +1,75 @@
+"""OpenTelemetry-aligned spans and simulator identity for rollout artifacts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import Field, model_validator
+
+from wmo.common.core.artifacts import ContractModel, JsonObject, SourceIdentity, StructuredFailure
+from wmo.common.models import ModelSnapshot, Usage
+
+
+class RolloutEventKind(StrEnum):
+    """Typed events preserved inside a completed agent rollout."""
+
+    AGENT_MODEL_CALL = "agent_model_call"
+    SIMULATOR_WORLD_MODEL_CALL = "simulator_world_model_call"
+    TOOL_CALL = "tool_call"
+    OBSERVATION = "observation"
+    MESSAGE = "message"
+
+
+class RolloutSpan(ContractModel):
+    """One ordered OpenTelemetry-style span emitted during an agent episode."""
+
+    span_id: str = Field(min_length=1, max_length=256)
+    parent_span_id: str | None = Field(default=None, min_length=1, max_length=256)
+    kind: RolloutEventKind
+    started_at: datetime
+    ended_at: datetime
+    payload: JsonObject = Field(default_factory=dict)
+    model: ModelSnapshot | None = None
+    tool_name: str | None = Field(default=None, max_length=256)
+    usage: Usage | None = None
+    failure: StructuredFailure | None = None
+
+    @model_validator(mode="after")
+    def _require_valid_timestamps(self) -> RolloutSpan:
+        if self.started_at.tzinfo is None or self.ended_at.tzinfo is None:
+            raise ValueError("rollout span timestamps must include timezones")
+        if self.ended_at < self.started_at:
+            raise ValueError("rollout span ended_at cannot be before started_at")
+        return self
+
+
+class ProductionSimulatorSnapshot(ContractModel):
+    """Simulator identity for evidence reconstructed from a production trace."""
+
+    kind: Literal["production"] = "production"
+    source: SourceIdentity
+
+
+class WorldModelSimulatorSnapshot(ContractModel):
+    """Simulator identity for a text world-model rollout."""
+
+    kind: Literal["world_model"] = "world_model"
+    simulator_id: str = Field(min_length=1, max_length=256)
+    prompt_id: str = Field(min_length=1, max_length=256)
+    world_model: ModelSnapshot
+
+
+class SandboxSimulatorSnapshot(ContractModel):
+    """Simulator identity for an executable environment rollout."""
+
+    kind: Literal["sandbox"] = "sandbox"
+    simulator_id: str = Field(min_length=1, max_length=256)
+    environment_id: str = Field(min_length=1, max_length=256)
+
+
+SimulatorSnapshot = Annotated[
+    ProductionSimulatorSnapshot | WorldModelSimulatorSnapshot | SandboxSimulatorSnapshot,
+    Field(discriminator="kind"),
+]

--- a/wmo/common/routing/__init__.py
+++ b/wmo/common/routing/__init__.py
@@ -1,0 +1,5 @@
+"""Canonical router-policy and routing-decision contracts."""
+
+from wmo.common.routing.policy import KnnGuard, KnnRouterPolicy, RouterPolicy, RoutingDecision
+
+__all__ = ["KnnGuard", "KnnRouterPolicy", "RouterPolicy", "RoutingDecision"]

--- a/wmo/common/routing/policy.py
+++ b/wmo/common/routing/policy.py
@@ -27,6 +27,12 @@ class KnnGuard(ContractModel):
             raise ValueError("kNN guard values must be finite")
         return value
 
+    @model_validator(mode="after")
+    def _require_reachable_minimum_pairs(self) -> KnnGuard:
+        if self.minimum_paired_observations > self.maximum_neighbors:
+            raise ValueError("minimum paired observations cannot exceed maximum neighbors")
+        return self
+
 
 class RoutingDecision(ContractModel):
     """One persisted explanation of a single frozen-policy model selection."""
@@ -51,6 +57,14 @@ class RoutingDecision(ContractModel):
         if value is not None and not math.isfinite(value):
             raise ValueError("routing decision metrics must be finite")
         return value
+
+    @model_validator(mode="after")
+    def _require_paired_count_within_neighbors(self) -> RoutingDecision:
+        if self.paired_count > self.neighbor_count:
+            raise ValueError(
+                "routing decisions cannot have more paired observations than neighbors"
+            )
+        return self
 
 
 class KnnRouterPolicy(ArtifactEnvelope):

--- a/wmo/common/routing/policy.py
+++ b/wmo/common/routing/policy.py
@@ -1,0 +1,85 @@
+"""Canonical frozen router-policy and routing-decision contracts."""
+
+from __future__ import annotations
+
+import math
+from typing import Annotated, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel, Sha256
+from wmo.common.models import ModelAlias, ModelSnapshot, RoutedCandidateSnapshot
+
+
+class KnnGuard(ContractModel):
+    """Conservative evidence thresholds used by the offline guarded kNN policy."""
+
+    maximum_neighbors: int = Field(gt=0)
+    minimum_paired_observations: int = Field(gt=0)
+    relative_similarity_threshold: float = Field(ge=0, le=1)
+    uncertainty_multiplier: float = Field(ge=0)
+    quality_tolerance: float
+
+    @field_validator("relative_similarity_threshold", "uncertainty_multiplier", "quality_tolerance")
+    @classmethod
+    def _require_finite_threshold(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("kNN guard values must be finite")
+        return value
+
+
+class RoutingDecision(ContractModel):
+    """One persisted explanation of a single frozen-policy model selection."""
+
+    decision_id: ArtifactId
+    policy_id: ArtifactId
+    policy_sha256: Sha256
+    request_sha256: Sha256
+    episode_id: str = Field(min_length=1, max_length=512)
+    selected_alias: ModelAlias
+    baseline_alias: ModelAlias
+    neighbor_count: int = Field(ge=0)
+    paired_count: int = Field(ge=0)
+    best_similarity: float | None = Field(default=None, ge=0, le=1)
+    estimated_quality_difference: float | None = None
+    uncertainty: float | None = Field(default=None, ge=0)
+    fallback_reason: str | None = Field(default=None, max_length=512)
+
+    @field_validator("best_similarity", "estimated_quality_difference", "uncertainty")
+    @classmethod
+    def _require_finite_optional_values(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("routing decision metrics must be finite")
+        return value
+
+
+class KnnRouterPolicy(ArtifactEnvelope):
+    """The v1 frozen guarded kNN policy and its fit-time identity pins."""
+
+    kind: Literal["knn"] = "knn"
+    policy_id: ArtifactId
+    baseline_alias: ModelAlias
+    candidates: tuple[RoutedCandidateSnapshot, ...]
+    embedder: ModelSnapshot
+    feature_extractor_id: ArtifactId
+    feature_schema_sha256: Sha256
+    pricing_snapshot_id: ArtifactId
+    bank_artifact_id: ArtifactId
+    bank_sha256: Sha256
+    guard: KnnGuard
+    fit_evaluation_id: ArtifactId
+    judgment_status: Literal["provisional", "human_calibrated"]
+
+    @model_validator(mode="after")
+    def _require_baseline_candidate(self) -> KnnRouterPolicy:
+        aliases = tuple(candidate.alias for candidate in self.candidates)
+        if not aliases:
+            raise ValueError("a router policy needs at least one candidate")
+        if len(set(aliases)) != len(aliases):
+            raise ValueError("router policy candidate aliases must be unique")
+        if self.baseline_alias not in aliases:
+            raise ValueError("router policy baseline_alias must name a candidate")
+        return self
+
+
+RouterPolicy = Annotated[KnnRouterPolicy, Field(discriminator="kind")]

--- a/wmo/common/routing/policy_test.py
+++ b/wmo/common/routing/policy_test.py
@@ -1,0 +1,92 @@
+"""Tests for frozen guarded-kNN router policy and decision contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
+from wmo.common.routing import KnnGuard, KnnRouterPolicy, RoutingDecision
+
+_DIGEST = "a" * 64
+
+
+def _candidate(alias: str) -> RoutedCandidateSnapshot:
+    return RoutedCandidateSnapshot(
+        alias=alias,
+        model=ModelSnapshot(
+            provider="openai",
+            model_id=f"{alias}-model",
+            capabilities_sha256=_DIGEST,
+        ),
+    )
+
+
+def _policy() -> KnnRouterPolicy:
+    return KnnRouterPolicy(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        policy_id="router-policy-v1",
+        baseline_alias="candidate-incumbent",
+        candidates=(_candidate("candidate-economy"), _candidate("candidate-incumbent")),
+        embedder=ModelSnapshot(
+            provider="openai",
+            model_id="text-embedding-3-small",
+            capabilities_sha256=_DIGEST,
+        ),
+        feature_extractor_id="request-visible-v1",
+        feature_schema_sha256=_DIGEST,
+        pricing_snapshot_id="pricing-v1",
+        bank_artifact_id="bank-v1",
+        bank_sha256=_DIGEST,
+        guard=KnnGuard(
+            maximum_neighbors=50,
+            minimum_paired_observations=8,
+            relative_similarity_threshold=0.95,
+            uncertainty_multiplier=0.5,
+            quality_tolerance=0,
+        ),
+        fit_evaluation_id="evaluation-v1",
+        judgment_status="provisional",
+    )
+
+
+def test_policy_and_decision_round_trip() -> None:
+    """A policy pins all fit-time identities and a decision names its policy digest."""
+    policy = _policy()
+    decision = RoutingDecision(
+        decision_id="decision-1",
+        policy_id=policy.policy_id,
+        policy_sha256=_DIGEST,
+        request_sha256=_DIGEST,
+        episode_id="episode-1",
+        selected_alias="candidate-economy",
+        baseline_alias="candidate-incumbent",
+        neighbor_count=12,
+        paired_count=10,
+        best_similarity=0.98,
+        estimated_quality_difference=0.01,
+        uncertainty=0.02,
+    )
+
+    assert KnnRouterPolicy.model_validate_json(policy.model_dump_json()) == policy
+    assert RoutingDecision.model_validate_json(decision.model_dump_json()) == decision
+
+
+def test_policy_rejects_unpinned_baseline_and_nonfinite_guard_values() -> None:
+    """The online runtime can rely on a baseline candidate and finite guard thresholds."""
+    with pytest.raises(ValidationError, match="baseline_alias"):
+        KnnRouterPolicy.model_validate(
+            {**_policy().model_dump(), "baseline_alias": "candidate-missing"}
+        )
+    with pytest.raises(ValidationError, match="finite"):
+        KnnGuard(
+            maximum_neighbors=50,
+            minimum_paired_observations=8,
+            relative_similarity_threshold=0.95,
+            uncertainty_multiplier=float("inf"),
+            quality_tolerance=0,
+        )

--- a/wmo/common/routing/policy_test.py
+++ b/wmo/common/routing/policy_test.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
-from wmo.common.routing import KnnGuard, KnnRouterPolicy, RoutingDecision
+from wmo.common.routing import KnnGuard, KnnRouterPolicy, RouterPolicy, RoutingDecision
 
 _DIGEST = "a" * 64
 
@@ -74,6 +74,7 @@ def test_policy_and_decision_round_trip() -> None:
 
     assert KnnRouterPolicy.model_validate_json(policy.model_dump_json()) == policy
     assert RoutingDecision.model_validate_json(decision.model_dump_json()) == decision
+    assert TypeAdapter(RouterPolicy).validate_json(policy.model_dump_json()) == policy
 
 
 def test_policy_rejects_unpinned_baseline_and_nonfinite_guard_values() -> None:
@@ -89,4 +90,24 @@ def test_policy_rejects_unpinned_baseline_and_nonfinite_guard_values() -> None:
             relative_similarity_threshold=0.95,
             uncertainty_multiplier=float("inf"),
             quality_tolerance=0,
+        )
+    with pytest.raises(ValidationError, match="cannot exceed maximum"):
+        KnnGuard(
+            maximum_neighbors=7,
+            minimum_paired_observations=8,
+            relative_similarity_threshold=0.95,
+            uncertainty_multiplier=0.5,
+            quality_tolerance=0,
+        )
+    with pytest.raises(ValidationError, match="more paired observations"):
+        RoutingDecision(
+            decision_id="decision-1",
+            policy_id="router-policy-v1",
+            policy_sha256=_DIGEST,
+            request_sha256=_DIGEST,
+            episode_id="episode-1",
+            selected_alias="candidate-economy",
+            baseline_alias="candidate-incumbent",
+            neighbor_count=2,
+            paired_count=3,
         )

--- a/wmo/common/tasks/__init__.py
+++ b/wmo/common/tasks/__init__.py
@@ -1,0 +1,5 @@
+"""Canonical representative task contracts."""
+
+from wmo.common.tasks.task import TaskCase, TaskSet, ToolSchema
+
+__all__ = ["TaskCase", "TaskSet", "ToolSchema"]

--- a/wmo/common/tasks/task.py
+++ b/wmo/common/tasks/task.py
@@ -1,0 +1,71 @@
+"""Canonical representative task and task-set contracts."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ContractModel,
+    JsonObject,
+    Sha256,
+)
+
+
+class ToolSchema(ContractModel):
+    """A task-visible tool definition available to the customer agent."""
+
+    name: str = Field(min_length=1, max_length=256)
+    description: str = Field(min_length=1)
+    input_schema: JsonObject
+
+
+class TaskCase(ContractModel):
+    """One selected real task with request-visible inputs and source provenance."""
+
+    task_id: ArtifactId
+    lineage_group_id: ArtifactId
+    partition: Literal["fit", "held_out"]
+    instruction: str = Field(min_length=1)
+    initial_context: JsonObject = Field(default_factory=dict)
+    tools: tuple[ToolSchema, ...] = ()
+    workload_weight: float = Field(gt=0)
+    source_trace_ids: tuple[str, ...] = ()
+
+    @field_validator("workload_weight")
+    @classmethod
+    def _require_finite_weight(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("workload_weight must be finite")
+        return value
+
+    @field_validator("source_trace_ids")
+    @classmethod
+    def _require_unique_sources(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("source_trace_ids must not contain duplicates")
+        return value
+
+
+class TaskSet(ArtifactEnvelope):
+    """A frozen task-set manifest that references hashed task and coverage files."""
+
+    task_set_id: ArtifactId
+    task_ids: tuple[ArtifactId, ...]
+    tasks_path: str = Field(min_length=1)
+    tasks_sha256: Sha256
+    coverage_path: str | None = None
+    coverage_sha256: Sha256 | None = None
+
+    @field_validator("task_ids")
+    @classmethod
+    def _require_unique_task_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if not value:
+            raise ValueError("a task set must contain at least one task")
+        if len(set(value)) != len(value):
+            raise ValueError("task_ids must not contain duplicates")
+        return value

--- a/wmo/common/tasks/task.py
+++ b/wmo/common/tasks/task.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from wmo.common.core.artifacts import (
     ArtifactEnvelope,
@@ -13,6 +13,7 @@ from wmo.common.core.artifacts import (
     ContractModel,
     JsonObject,
     Sha256,
+    validate_artifact_file_path,
 )
 
 
@@ -34,7 +35,7 @@ class TaskCase(ContractModel):
     initial_context: JsonObject = Field(default_factory=dict)
     tools: tuple[ToolSchema, ...] = ()
     workload_weight: float = Field(gt=0)
-    source_trace_ids: tuple[str, ...] = ()
+    source_trace_ids: tuple[str, ...] = Field(min_length=1)
 
     @field_validator("workload_weight")
     @classmethod
@@ -61,6 +62,18 @@ class TaskSet(ArtifactEnvelope):
     coverage_path: str | None = None
     coverage_sha256: Sha256 | None = None
 
+    @field_validator("tasks_path")
+    @classmethod
+    def _require_safe_tasks_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+    @field_validator("coverage_path")
+    @classmethod
+    def _require_safe_coverage_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_artifact_file_path(value).as_posix()
+
     @field_validator("task_ids")
     @classmethod
     def _require_unique_task_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
@@ -69,3 +82,9 @@ class TaskSet(ArtifactEnvelope):
         if len(set(value)) != len(value):
             raise ValueError("task_ids must not contain duplicates")
         return value
+
+    @model_validator(mode="after")
+    def _require_complete_coverage_reference(self) -> TaskSet:
+        if (self.coverage_path is None) != (self.coverage_sha256 is None):
+            raise ValueError("task-set coverage path and digest must be set together")
+        return self

--- a/wmo/common/tasks/task_test.py
+++ b/wmo/common/tasks/task_test.py
@@ -59,6 +59,7 @@ def test_task_rejects_nonfinite_weight_and_duplicate_source_trace_ids() -> None:
             partition="fit",
             instruction="Help the customer request a refund.",
             workload_weight=float("nan"),
+            source_trace_ids=("trace-1",),
         )
     with pytest.raises(ValidationError, match="duplicates"):
         TaskCase(
@@ -68,4 +69,25 @@ def test_task_rejects_nonfinite_weight_and_duplicate_source_trace_ids() -> None:
             instruction="Help the customer request a refund.",
             workload_weight=1,
             source_trace_ids=("trace-1", "trace-1"),
+        )
+    with pytest.raises(ValidationError, match="Field required"):
+        TaskCase.model_validate(
+            {
+                "task_id": "refund-12",
+                "lineage_group_id": "refund-lineage",
+                "partition": "fit",
+                "instruction": "Help the customer request a refund.",
+                "workload_weight": 1,
+            }
+        )
+    with pytest.raises(ValidationError, match="coverage path and digest"):
+        TaskSet(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            task_set_id="task-set-v1",
+            task_ids=("refund-12",),
+            tasks_path="tasks.jsonl",
+            tasks_sha256=_DIGEST,
+            coverage_path="coverage.json",
         )

--- a/wmo/common/tasks/task_test.py
+++ b/wmo/common/tasks/task_test.py
@@ -1,0 +1,71 @@
+"""Tests for canonical representative task contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.tasks import TaskCase, TaskSet, ToolSchema
+
+_DIGEST = "a" * 64
+
+
+def _task() -> TaskCase:
+    return TaskCase(
+        task_id="refund-12",
+        lineage_group_id="refund-lineage",
+        partition="fit",
+        instruction="Help the customer request a refund.",
+        initial_context={"customer_tier": "standard"},
+        tools=(
+            ToolSchema(
+                name="lookup_order",
+                description="Look up an order by ID.",
+                input_schema={"type": "object"},
+            ),
+        ),
+        workload_weight=3.5,
+        source_trace_ids=("0123456789abcdef0123456789abcdef",),
+    )
+
+
+def test_task_and_task_set_round_trip() -> None:
+    """Representative task provenance and task-set hashes round trip without conversion."""
+    task = _task()
+    task_set = TaskSet(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        task_set_id="task-set-v1",
+        task_ids=(task.task_id,),
+        tasks_path="tasks.jsonl",
+        tasks_sha256=_DIGEST,
+        coverage_path="coverage.json",
+        coverage_sha256=_DIGEST,
+    )
+
+    assert TaskCase.model_validate_json(task.model_dump_json()) == task
+    assert TaskSet.model_validate_json(task_set.model_dump_json()) == task_set
+
+
+def test_task_rejects_nonfinite_weight_and_duplicate_source_trace_ids() -> None:
+    """Weighting remains finite and source trace provenance remains unambiguous."""
+    with pytest.raises(ValidationError):
+        TaskCase(
+            task_id="refund-12",
+            lineage_group_id="refund-lineage",
+            partition="fit",
+            instruction="Help the customer request a refund.",
+            workload_weight=float("nan"),
+        )
+    with pytest.raises(ValidationError, match="duplicates"):
+        TaskCase(
+            task_id="refund-12",
+            lineage_group_id="refund-lineage",
+            partition="fit",
+            instruction="Help the customer request a refund.",
+            workload_weight=1,
+            source_trace_ids=("trace-1", "trace-1"),
+        )

--- a/wmo/common/traces/__init__.py
+++ b/wmo/common/traces/__init__.py
@@ -1,0 +1,5 @@
+"""Canonical normalized production-trace contracts."""
+
+from wmo.common.traces.trace import Trace, TraceDataset, TraceOutcome, TraceSource, TraceSpan
+
+__all__ = ["Trace", "TraceDataset", "TraceOutcome", "TraceSource", "TraceSpan"]

--- a/wmo/common/traces/trace.py
+++ b/wmo/common/traces/trace.py
@@ -15,6 +15,7 @@ from wmo.common.core.artifacts import (
     Sha256,
     SourceIdentity,
     StructuredFailure,
+    validate_artifact_file_path,
 )
 from wmo.common.models import ModelSnapshot, Usage
 from wmo.common.tasks import ToolSchema
@@ -93,6 +94,11 @@ class TraceDataset(ArtifactEnvelope):
     traces_path: str = Field(min_length=1)
     traces_sha256: Sha256
     trace_ids: tuple[str, ...]
+
+    @field_validator("traces_path")
+    @classmethod
+    def _require_safe_traces_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
 
     @field_validator("trace_ids")
     @classmethod

--- a/wmo/common/traces/trace.py
+++ b/wmo/common/traces/trace.py
@@ -1,0 +1,104 @@
+"""Canonical normalized production-trace contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ContractModel,
+    JsonObject,
+    Sha256,
+    SourceIdentity,
+    StructuredFailure,
+)
+from wmo.common.models import ModelSnapshot, Usage
+from wmo.common.tasks import ToolSchema
+
+
+class TraceSource(ContractModel):
+    """Origin and semantic-convention version for a normalized production trace."""
+
+    identity: SourceIdentity
+    semantic_convention_version: str = Field(min_length=1, max_length=128)
+
+
+class TraceOutcome(ContractModel):
+    """Captured terminal outcome for one production trace."""
+
+    status: Literal["success", "failure", "abandoned", "unknown"]
+    outcome_name: str | None = Field(default=None, max_length=256)
+    failure: StructuredFailure | None = None
+
+    @model_validator(mode="after")
+    def _require_failure_for_failed_outcome(self) -> TraceOutcome:
+        if self.status == "failure" and self.failure is None:
+            raise ValueError("failed trace outcomes require a structured failure")
+        return self
+
+
+class TraceSpan(ContractModel):
+    """One ordered OpenTelemetry-style event in a normalized production trace."""
+
+    span_id: str = Field(min_length=1, max_length=256)
+    parent_span_id: str | None = Field(default=None, min_length=1, max_length=256)
+    name: str = Field(min_length=1, max_length=256)
+    started_at: datetime
+    ended_at: datetime
+    attributes: JsonObject = Field(default_factory=dict)
+    model: ModelSnapshot | None = None
+    usage: Usage | None = None
+    failure: StructuredFailure | None = None
+
+    @model_validator(mode="after")
+    def _require_ordered_timestamps(self) -> TraceSpan:
+        if self.started_at.tzinfo is None or self.ended_at.tzinfo is None:
+            raise ValueError("trace span timestamps must include timezones")
+        if self.ended_at < self.started_at:
+            raise ValueError("trace span ended_at cannot be before started_at")
+        return self
+
+
+class Trace(ContractModel):
+    """One normalized customer agent trace with source provenance."""
+
+    trace_id: str = Field(min_length=1, max_length=512)
+    conversation_id: str | None = Field(default=None, max_length=512)
+    task: str = Field(min_length=1)
+    initial_context: JsonObject = Field(default_factory=dict)
+    tools: tuple[ToolSchema, ...] = ()
+    spans: tuple[TraceSpan, ...]
+    outcome: TraceOutcome | None = None
+    source: TraceSource
+
+    @field_validator("spans")
+    @classmethod
+    def _require_unique_span_ids(cls, value: tuple[TraceSpan, ...]) -> tuple[TraceSpan, ...]:
+        if not value:
+            raise ValueError("a trace must contain at least one span")
+        span_ids = tuple(span.span_id for span in value)
+        if len(set(span_ids)) != len(span_ids):
+            raise ValueError("trace span IDs must be unique")
+        return value
+
+
+class TraceDataset(ArtifactEnvelope):
+    """A frozen normalized trace-dataset manifest."""
+
+    dataset_id: ArtifactId
+    traces_path: str = Field(min_length=1)
+    traces_sha256: Sha256
+    trace_ids: tuple[str, ...]
+
+    @field_validator("trace_ids")
+    @classmethod
+    def _require_unique_trace_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("a trace dataset must contain at least one trace")
+        if len(set(value)) != len(value):
+            raise ValueError("trace_ids must not contain duplicates")
+        return value

--- a/wmo/common/traces/trace_test.py
+++ b/wmo/common/traces/trace_test.py
@@ -86,3 +86,13 @@ def test_trace_requires_ordered_unique_spans_and_structured_failure() -> None:
         ).failure
         is not None
     )
+    with pytest.raises(ValidationError, match="relative POSIX"):
+        TraceDataset(
+            schema_version=1,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="e7aad17",
+            dataset_id="traces-20260811",
+            traces_path="../traces.jsonl",
+            traces_sha256=_DIGEST,
+            trace_ids=(trace.trace_id,),
+        )

--- a/wmo/common/traces/trace_test.py
+++ b/wmo/common/traces/trace_test.py
@@ -1,0 +1,88 @@
+"""Tests for canonical normalized production-trace contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
+from wmo.common.models import ModelSnapshot
+from wmo.common.traces import Trace, TraceDataset, TraceOutcome, TraceSource, TraceSpan
+
+_DIGEST = "a" * 64
+
+
+def _trace() -> Trace:
+    started_at = datetime(2026, 8, 11, tzinfo=UTC)
+    return Trace(
+        trace_id="0123456789abcdef0123456789abcdef",
+        conversation_id="conversation-12",
+        task="Help the customer request a refund.",
+        spans=(
+            TraceSpan(
+                span_id="span-1",
+                name="agent.model_call",
+                started_at=started_at,
+                ended_at=started_at + timedelta(seconds=1),
+                model=ModelSnapshot(
+                    provider="openai",
+                    model_id="gpt-5.4",
+                    capabilities_sha256=_DIGEST,
+                ),
+            ),
+        ),
+        outcome=TraceOutcome(status="success", outcome_name="refund_requested"),
+        source=TraceSource(
+            identity=SourceIdentity(kind="otlp", source_id="upload-1", sha256=_DIGEST),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def test_trace_and_dataset_round_trip() -> None:
+    """Normalized trace evidence and its dataset manifest serialize without loss."""
+    trace = _trace()
+    dataset = TraceDataset(
+        schema_version=1,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="e7aad17",
+        dataset_id="traces-20260811",
+        traces_path="traces.jsonl",
+        traces_sha256=_DIGEST,
+        trace_ids=(trace.trace_id,),
+    )
+
+    assert Trace.model_validate_json(trace.model_dump_json()) == trace
+    assert TraceDataset.model_validate_json(dataset.model_dump_json()) == dataset
+
+
+def test_trace_requires_ordered_unique_spans_and_structured_failure() -> None:
+    """Corrupt timing, repeated IDs, and failed outcomes do not silently normalize."""
+    trace = _trace()
+    span = trace.spans[0]
+    with pytest.raises(ValidationError, match="cannot be before"):
+        TraceSpan(
+            span_id="bad-span",
+            name="agent.model_call",
+            started_at=span.ended_at,
+            ended_at=span.started_at,
+        )
+    with pytest.raises(ValidationError, match="unique"):
+        Trace.model_validate(
+            {**trace.model_dump(), "spans": [span.model_dump(), span.model_dump()]}
+        )
+    with pytest.raises(ValidationError, match="require a structured failure"):
+        TraceOutcome(status="failure")
+    assert (
+        TraceOutcome(
+            status="failure",
+            failure=StructuredFailure(
+                code=FailureCode.PROVIDER,
+                message="timed out",
+                retryable=True,
+            ),
+        ).failure
+        is not None
+    )


### PR DESCRIPTION
## Summary

Introduces the W2 common-contract foundation for the approved WMO architecture:

- Canonical typed schemas for models, traces, tasks, rollouts, rubrics, judgments, evaluation evidence, and offline routing policy.
- Immutable, atomic project-local `.wmo` artifacts with explicit provenance, content digests, and a narrow mutable review draft.
- Anonymous, aggregate-only PostHog product telemetry. It retains project and environment opt-outs, short best-effort delivery, anonymous IDs, and no customer content.

## Follow-up fixes in this head

- Fidelity reports must account for every planned overlap as usable or as a recorded failure.
- Artifact reads now verify the exact file descriptor bytes returned by `read_bytes`, including a replacement or symlink swap after the initial whole-artifact verification.
- Telemetry has an explicit event and aggregate-property allowlist. It rejects arbitrary payloads, removes customer-supplied evaluation text, and isolates client delivery failures.

## Scope boundary

This is the shared foundation only. W3 through W14 consume these contracts in their respective verticals. W2.5 legacy caller migration and deletion remains with those consuming workstreams.

## Validation

- `uv run --frozen pytest -q` across the 15 focused common-contract and telemetry test modules: 42 passed.
- `uv run --frozen pytest -q` across repository layout, docstring, import-boundary, and structure gates: 64 passed.
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check` using lockfile-pinned `ty 0.0.56`.
- `uv build` produced the source distribution and wheel.

The known broad-suite origin/main baseline remains outside this PR's focused regression evidence.
