### PR TITLE
W4: add canonical customer agent runtime

### DIFF
--- a/wmo/common/core/artifacts.py
+++ b/wmo/common/core/artifacts.py
@@ -89,6 +89,17 @@ class FailureCode(StrEnum):
     INTERNAL = "internal"
 
 
+class FailureAttribution(StrEnum):
+    """The runtime boundary that owns an operation failure."""
+
+    AGENT = "agent"
+    MODEL = "model"
+    TOOL = "tool"
+    ENVIRONMENT = "environment"
+    RESET = "reset"
+    CLEANUP = "cleanup"
+
+
 class StructuredFailure(ContractModel):
     """A non-secret, machine-readable description of one failed operation."""
 
@@ -96,6 +107,7 @@ class StructuredFailure(ContractModel):
     message: str = Field(min_length=1)
     retryable: bool = False
     exception_type: str | None = None
+    attribution: FailureAttribution | None = None
     details: JsonObject = Field(default_factory=dict)
 
 

--- a/wmo/common/core/artifacts_test.py
+++ b/wmo/common/core/artifacts_test.py
@@ -10,8 +10,11 @@ from pydantic import ValidationError
 from wmo.common.core.artifacts import (
     ArtifactEnvelope,
     ArtifactInput,
+    FailureAttribution,
+    FailureCode,
     SecretBoundaryError,
     SourceIdentity,
+    StructuredFailure,
     assert_secret_free,
     canonical_json_bytes,
     sha256_json,
@@ -91,3 +94,14 @@ def test_artifact_file_paths_reject_nonportable_components() -> None:
     for path in ("../outside.json", "nested\\outside.json", "C:/outside.json"):
         with pytest.raises(ValueError, match="relative POSIX"):
             validate_artifact_file_path(path)
+
+
+def test_structured_failures_preserve_runtime_attribution() -> None:
+    """A failure distinguishes model and environment lifecycle ownership."""
+    failure = StructuredFailure(
+        code=FailureCode.INTERNAL,
+        message="environment cleanup failed",
+        attribution=FailureAttribution.CLEANUP,
+    )
+
+    assert StructuredFailure.model_validate_json(failure.model_dump_json()) == failure

--- a/wmo/common/rollouts/otel.py
+++ b/wmo/common/rollouts/otel.py
@@ -20,6 +20,7 @@ class RolloutEventKind(StrEnum):
     TOOL_CALL = "tool_call"
     OBSERVATION = "observation"
     MESSAGE = "message"
+    LIFECYCLE = "lifecycle"
 
 
 class RolloutSpan(ContractModel):

--- a/wmo/runtime/agents/__init__.py
+++ b/wmo/runtime/agents/__init__.py
@@ -7,13 +7,19 @@ from wmo.runtime.agents.interface import (
     preflight_agent_runtime,
 )
 from wmo.runtime.agents.lifecycle import execute_agent_episode
-from wmo.runtime.agents.pi import PiAgentRuntime, PiRuntimePreflightError, PiTranscriptError
+from wmo.runtime.agents.pi import (
+    PiAgentRuntime,
+    PiInvocationTimeoutError,
+    PiRuntimePreflightError,
+    PiTranscriptError,
+)
 
 __all__ = [
     "AgentAdapterPreflightError",
     "AgentEpisode",
     "AgentRuntime",
     "PiAgentRuntime",
+    "PiInvocationTimeoutError",
     "PiRuntimePreflightError",
     "PiTranscriptError",
     "execute_agent_episode",

--- a/wmo/runtime/agents/__init__.py
+++ b/wmo/runtime/agents/__init__.py
@@ -1,11 +1,21 @@
-"""Built-in agent definitions.
+"""Whole-episode customer-agent runtime contracts and the built-in Pi adapter."""
 
-The optimizer, meta, and project agents moved to the agent-optimization repo with
-the harness-search program; what ships here is the default agent the playground
-and distillation seed from.
-"""
+from wmo.runtime.agents.interface import (
+    AgentAdapterPreflightError,
+    AgentEpisode,
+    AgentRuntime,
+    preflight_agent_runtime,
+)
+from wmo.runtime.agents.lifecycle import execute_agent_episode
+from wmo.runtime.agents.pi import PiAgentRuntime, PiRuntimePreflightError, PiTranscriptError
 
-from wmo.runtime.agents.default import default_agent
-from wmo.runtime.agents.llm import LLMAgent
-
-__all__ = ["LLMAgent", "default_agent"]
+__all__ = [
+    "AgentAdapterPreflightError",
+    "AgentEpisode",
+    "AgentRuntime",
+    "PiAgentRuntime",
+    "PiRuntimePreflightError",
+    "PiTranscriptError",
+    "execute_agent_episode",
+    "preflight_agent_runtime",
+]

--- a/wmo/runtime/agents/interface.py
+++ b/wmo/runtime/agents/interface.py
@@ -13,6 +13,11 @@ from wmo.common.rollouts import RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.environments import EnvironmentSession
 
+# Mandatory W3 restack after c44569df is available in this worktree:
+# replace the temporary object annotations in AgentRuntime.run, lifecycle.py, and pi.py with
+# wmo.common.models.ModelClient. Update every temporary model fixture in interface_test.py,
+# lifecycle_test.py, and pi_test.py with a conforming fake. Do not define a local protocol.
+
 
 class AgentEpisode(ContractModel):
     """In-memory events and terminal state emitted by one customer-agent run."""
@@ -46,7 +51,7 @@ class AgentRuntime(Protocol):
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: object,  # W3 restack: use the canonical common ModelClient.
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         """Run the agent's own loop with an injected model and execute-only environment.

--- a/wmo/runtime/agents/interface.py
+++ b/wmo/runtime/agents/interface.py
@@ -8,15 +8,10 @@ from typing import Protocol, runtime_checkable
 from pydantic import model_validator
 
 from wmo.common.core.artifacts import ContractModel, StructuredFailure
-from wmo.common.models import AssistantAction, Usage
+from wmo.common.models import AssistantAction, ModelClient, Usage
 from wmo.common.rollouts import RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.environments import EnvironmentSession
-
-# Mandatory W3 restack after c44569df is available in this worktree:
-# replace the temporary object annotations in AgentRuntime.run, lifecycle.py, and pi.py with
-# wmo.common.models.ModelClient. Update every temporary model fixture in interface_test.py,
-# lifecycle_test.py, and pi_test.py with a conforming fake. Do not define a local protocol.
 
 
 class AgentEpisode(ContractModel):
@@ -51,7 +46,7 @@ class AgentRuntime(Protocol):
         self,
         task: TaskCase,
         *,
-        model: object,  # W3 restack: use the canonical common ModelClient.
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         """Run the agent's own loop with an injected model and execute-only environment.

--- a/wmo/runtime/agents/interface.py
+++ b/wmo/runtime/agents/interface.py
@@ -1,0 +1,97 @@
+"""Customer-agent contracts for one complete model-injected episode."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Protocol, runtime_checkable
+
+from pydantic import model_validator
+
+from wmo.common.core.artifacts import ContractModel, StructuredFailure
+from wmo.common.models import AssistantAction, Usage
+from wmo.common.rollouts import RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments import EnvironmentSession
+
+
+class AgentEpisode(ContractModel):
+    """In-memory events and terminal state emitted by one customer-agent run."""
+
+    events: tuple[RolloutSpan, ...] = ()
+    final_action: AssistantAction | None = None
+    stop_reason: StopReason
+    usage: Usage | None = None
+    failure: StructuredFailure | None = None
+
+    @model_validator(mode="after")
+    def _require_consistent_terminal_state(self) -> AgentEpisode:
+        span_ids = tuple(event.span_id for event in self.events)
+        if len(span_ids) != len(set(span_ids)):
+            raise ValueError("agent episode event IDs must be unique")
+        for previous, current in zip(self.events, self.events[1:], strict=False):
+            if current.started_at < previous.ended_at:
+                raise ValueError("agent episode events must be ordered by completion time")
+        if self.stop_reason == StopReason.FAILURE and self.failure is None:
+            raise ValueError("failed agent episodes require a structured failure")
+        if self.stop_reason != StopReason.FAILURE and self.failure is not None:
+            raise ValueError("only failed agent episodes may contain a structured failure")
+        return self
+
+
+@runtime_checkable
+class AgentRuntime(Protocol):
+    """Runs one whole customer-agent episode with dependencies supplied by WMO."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Run the agent's own loop with an injected model and execute-only environment.
+
+        Args:
+            task: The task and allowed tool schemas for this episode.
+            model: The candidate model selected by WMO for this episode.
+            environment: The simulator-owned session that permits only tool execution.
+
+        Returns:
+            Ordered agent events, terminal output, usage, and stop reason.
+        """
+
+
+class AgentAdapterPreflightError(ValueError):
+    """A customer agent cannot expose the required model injection seam."""
+
+
+def preflight_agent_runtime(agent: AgentRuntime) -> None:
+    """Validate that a customer adapter accepts WMO's injected dependencies.
+
+    Args:
+        agent: Customer adapter expected to implement the whole-episode contract.
+
+    Raises:
+        AgentAdapterPreflightError: The adapter does not name keyword-addressable model and
+            environment parameters.
+    """
+    try:
+        parameters = inspect.signature(agent.run).parameters
+    except (TypeError, ValueError) as exc:
+        raise AgentAdapterPreflightError(
+            "Customer agent adapters must expose "
+            "run(task, *, model: ModelClient, environment: EnvironmentSession) -> AgentEpisode. "
+            "Expose that method so WMO can inject each candidate model."
+        ) from exc
+    missing = tuple(
+        name
+        for name in ("model", "environment")
+        if name not in parameters or parameters[name].kind is inspect.Parameter.POSITIONAL_ONLY
+    )
+    if missing:
+        names = ", ".join(missing)
+        raise AgentAdapterPreflightError(
+            "Customer agent adapters must expose "
+            "run(task, *, model: ModelClient, environment: EnvironmentSession) -> AgentEpisode. "
+            f"Add keyword-addressable {names} parameter(s) so WMO can inject each candidate model."
+        )

--- a/wmo/runtime/agents/interface_test.py
+++ b/wmo/runtime/agents/interface_test.py
@@ -56,7 +56,7 @@ def test_preflight_rejects_positional_only_model_injection() -> None:
 
 
 class _ConformingAgent:
-    """Implements the temporary W3-seam shape used by W4 local tests."""
+    """Implements the temporary model seam pending the mandatory W3 fake-client restack."""
 
     def run(
         self,

--- a/wmo/runtime/agents/interface_test.py
+++ b/wmo/runtime/agents/interface_test.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from wmo.common.core.artifacts import FailureAttribution, FailureCode, StructuredFailure
+from wmo.common.models import ModelClient
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import (
@@ -56,13 +57,13 @@ def test_preflight_rejects_positional_only_model_injection() -> None:
 
 
 class _ConformingAgent:
-    """Implements the temporary model seam pending the mandatory W3 fake-client restack."""
+    """Implements the canonical model-injection seam."""
 
     def run(
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         return AgentEpisode(stop_reason=StopReason.COMPLETED)
@@ -74,7 +75,7 @@ class _PositionalModelAgent:
     def run(
         self,
         task: TaskCase,
-        model: object,
+        model: ModelClient,
         /,
         *,
         environment: EnvironmentSession,

--- a/wmo/runtime/agents/interface_test.py
+++ b/wmo/runtime/agents/interface_test.py
@@ -1,0 +1,92 @@
+"""Tests for the customer whole-episode agent contract."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import FailureAttribution, FailureCode, StructuredFailure
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents.interface import (
+    AgentAdapterPreflightError,
+    AgentEpisode,
+    AgentRuntime,
+    preflight_agent_runtime,
+)
+from wmo.runtime.environments import EnvironmentSession
+
+
+def test_episode_requires_ordered_unique_events_and_consistent_failure() -> None:
+    first = _span("first", datetime(2026, 8, 11, tzinfo=UTC))
+    second = _span("second", first.ended_at + timedelta(seconds=1))
+    failure = StructuredFailure(
+        code=FailureCode.PROVIDER,
+        message="candidate model failed",
+        attribution=FailureAttribution.MODEL,
+    )
+
+    episode = AgentEpisode(
+        events=(first, second),
+        stop_reason=StopReason.FAILURE,
+        failure=failure,
+    )
+
+    assert episode.events == (first, second)
+    with pytest.raises(ValidationError, match="unique"):
+        AgentEpisode(events=(first, first), stop_reason=StopReason.COMPLETED)
+    with pytest.raises(ValidationError, match="ordered"):
+        AgentEpisode(events=(second, first), stop_reason=StopReason.COMPLETED)
+    with pytest.raises(ValidationError, match="require a structured failure"):
+        AgentEpisode(stop_reason=StopReason.FAILURE)
+    with pytest.raises(ValidationError, match="only failed"):
+        AgentEpisode(stop_reason=StopReason.COMPLETED, failure=failure)
+
+
+def test_preflight_accepts_the_keyword_model_and_environment_seam() -> None:
+    preflight_agent_runtime(_ConformingAgent())
+
+
+def test_preflight_rejects_positional_only_model_injection() -> None:
+    with pytest.raises(AgentAdapterPreflightError, match="Add keyword-addressable model"):
+        preflight_agent_runtime(cast(AgentRuntime, _PositionalModelAgent()))
+
+
+class _ConformingAgent:
+    """Implements the temporary W3-seam shape used by W4 local tests."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        return AgentEpisode(stop_reason=StopReason.COMPLETED)
+
+
+class _PositionalModelAgent:
+    """Makes model positional-only and therefore unavailable for injection."""
+
+    def run(
+        self,
+        task: TaskCase,
+        model: object,
+        /,
+        *,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        return AgentEpisode(stop_reason=StopReason.COMPLETED)
+
+
+def _span(span_id: str, timestamp: datetime) -> RolloutSpan:
+    return RolloutSpan(
+        span_id=span_id,
+        kind=RolloutEventKind.MESSAGE,
+        started_at=timestamp,
+        ended_at=timestamp,
+        payload={"fixture": span_id},
+    )

--- a/wmo/runtime/agents/lifecycle.py
+++ b/wmo/runtime/agents/lifecycle.py
@@ -14,7 +14,7 @@ from wmo.common.core.artifacts import (
     JsonObject,
     StructuredFailure,
 )
-from wmo.common.models import ToolCall
+from wmo.common.models import ModelClient, ToolCall
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import AgentEpisode, AgentRuntime, preflight_agent_runtime
@@ -34,7 +34,7 @@ def execute_agent_episode(
     agent: AgentRuntime,
     environment_runtime: EnvironmentRuntime,
     task: TaskCase,
-    model: object,  # W3 restack: replace with the canonical ModelClient.
+    model: ModelClient,
 ) -> AgentEpisode:
     """Run one agent while retaining reset, cleanup, and exception evidence.
 
@@ -86,7 +86,7 @@ def execute_agent_episode(
 def _run_agent(
     agent: AgentRuntime,
     task: TaskCase,
-    model: object,  # W3 restack: replace with the canonical ModelClient.
+    model: ModelClient,
     environment: EnvironmentSession,
 ) -> AgentEpisode:
     """Call the customer adapter while preserving its exception as a typed episode failure."""

--- a/wmo/runtime/agents/lifecycle.py
+++ b/wmo/runtime/agents/lifecycle.py
@@ -1,0 +1,179 @@
+"""Simulator-side lifecycle composition for one model-injected customer episode."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from wmo.common.core.artifacts import (
+    FailureAttribution,
+    FailureCode,
+    JsonObject,
+    StructuredFailure,
+)
+from wmo.common.models import ToolCall
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents.interface import AgentEpisode, AgentRuntime, preflight_agent_runtime
+from wmo.runtime.environments import EnvironmentRuntime, EnvironmentSession, Observation
+
+
+def execute_agent_episode(
+    agent: AgentRuntime,
+    environment_runtime: EnvironmentRuntime,
+    task: TaskCase,
+    model: object,
+) -> AgentEpisode:
+    """Run one agent while retaining reset, cleanup, and exception evidence.
+
+    This is the simulator-side composition point. It opens the environment once, gives the agent
+    only the execute-capable session, and always returns an episode result, including cleanup
+    failures that occur after the customer agent has returned.
+
+    Args:
+        agent: Customer-owned whole-episode runtime.
+        environment_runtime: Simulator-owned source of isolated environment sessions.
+        task: Task whose already-open session the agent may execute against.
+        model: Candidate model injected into the customer agent.
+
+    Returns:
+        A complete in-memory episode with ordered events and structured failure attribution.
+    """
+    preflight_agent_runtime(agent)
+    opened = False
+    episode: AgentEpisode | None = None
+    try:
+        with environment_runtime.open(task) as environment:
+            opened = True
+            episode = _run_agent(agent, task, model, _ExecuteOnlySession(environment))
+    except Exception as exc:  # noqa: BLE001 - every lifecycle failure becomes episode evidence
+        if not opened:
+            return _failed_episode("reset", FailureAttribution.RESET, exc)
+        if episode is None:
+            return _failed_episode("agent", FailureAttribution.AGENT, exc)
+        return _append_cleanup_failure(episode, exc)
+    if episode is None:
+        return _failed_episode("agent", FailureAttribution.AGENT, RuntimeError("no episode"))
+    return episode
+
+
+def _run_agent(
+    agent: AgentRuntime,
+    task: TaskCase,
+    model: object,
+    environment: EnvironmentSession,
+) -> AgentEpisode:
+    """Call the customer adapter while preserving its exception as a typed episode failure."""
+    try:
+        episode = agent.run(task, model=model, environment=environment)
+        if not isinstance(episode, AgentEpisode):
+            raise TypeError(
+                f"customer agent adapters must return AgentEpisode, not {type(episode).__name__}"
+            )
+        return episode
+    except _ToolExecutionError as exc:
+        return _failed_episode("tool", FailureAttribution.TOOL, exc.cause)
+    except TimeoutError as exc:
+        return _failed_episode("agent timeout", FailureAttribution.AGENT, exc, FailureCode.TIMEOUT)
+    except Exception as exc:  # noqa: BLE001 - customer adapter failures are episode evidence
+        return _failed_episode("agent", FailureAttribution.AGENT, exc)
+
+
+def _failed_episode(
+    phase: str,
+    attribution: FailureAttribution,
+    exception: Exception,
+    code: FailureCode = FailureCode.INTERNAL,
+) -> AgentEpisode:
+    """Build an event-preserving terminal result for one boundary failure."""
+    failure = StructuredFailure(
+        code=code,
+        message=f"{phase} failed with {type(exception).__name__}",
+        exception_type=type(exception).__name__,
+        attribution=attribution,
+        details={"phase": phase},
+    )
+    return AgentEpisode(
+        events=(_lifecycle_span(phase, failure),),
+        stop_reason=StopReason.FAILURE,
+        failure=failure,
+    )
+
+
+def _append_cleanup_failure(episode: AgentEpisode, exception: Exception) -> AgentEpisode:
+    """Replace terminal state with cleanup failure while retaining every prior event and output."""
+    details: JsonObject = {
+        "phase": "cleanup",
+        "prior_stop_reason": episode.stop_reason.value,
+    }
+    if episode.failure is not None:
+        details["prior_failure"] = _failure_details(episode.failure)
+    failure = StructuredFailure(
+        code=FailureCode.INTERNAL,
+        message=f"cleanup failed with {type(exception).__name__}",
+        exception_type=type(exception).__name__,
+        attribution=FailureAttribution.CLEANUP,
+        details=details,
+    )
+    return AgentEpisode(
+        events=(*episode.events, _lifecycle_span("cleanup", failure, episode.events)),
+        final_action=episode.final_action,
+        stop_reason=StopReason.FAILURE,
+        usage=episode.usage,
+        failure=failure,
+    )
+
+
+def _lifecycle_span(
+    phase: str,
+    failure: StructuredFailure,
+    prior_events: tuple[RolloutSpan, ...] = (),
+) -> RolloutSpan:
+    """Create one ordered lifecycle span for a failure that prevented normal agent progress."""
+    now = datetime.now(UTC)
+    if prior_events:
+        now = max(now, prior_events[-1].ended_at)
+    return RolloutSpan(
+        span_id=f"lifecycle-{uuid4().hex}",
+        kind=RolloutEventKind.LIFECYCLE,
+        started_at=now,
+        ended_at=now,
+        payload={"phase": phase},
+        failure=failure,
+    )
+
+
+class _ExecuteOnlySession:
+    """Hide simulator lifecycle methods from the customer agent."""
+
+    __slots__ = ("_environment",)
+
+    def __init__(self, environment: EnvironmentSession) -> None:
+        self._environment = environment
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Forward one action to the simulator-owned session."""
+        try:
+            return self._environment.execute(action)
+        except Exception as exc:  # noqa: BLE001 - tool boundary failures become episode evidence
+            raise _ToolExecutionError(exc) from exc
+
+
+class _ToolExecutionError(RuntimeError):
+    """Preserve the original environment exception across the execute-only proxy."""
+
+    def __init__(self, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+
+
+def _failure_details(failure: StructuredFailure) -> JsonObject:
+    """Return the complete previously structured failure as JSON-safe cleanup evidence."""
+    return {
+        "code": failure.code.value,
+        "message": failure.message,
+        "retryable": failure.retryable,
+        "exception_type": failure.exception_type,
+        "attribution": failure.attribution.value if failure.attribution is not None else None,
+        "details": failure.details,
+    }

--- a/wmo/runtime/agents/lifecycle.py
+++ b/wmo/runtime/agents/lifecycle.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -15,14 +18,22 @@ from wmo.common.models import ToolCall
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import AgentEpisode, AgentRuntime, preflight_agent_runtime
-from wmo.runtime.environments import EnvironmentRuntime, EnvironmentSession, Observation
+from wmo.runtime.environments import (
+    EnvironmentResetError,
+    EnvironmentRuntime,
+    EnvironmentSession,
+    Observation,
+)
+
+_ExecuteAction = Callable[[ToolCall], Observation]
+_execute_action: ContextVar[_ExecuteAction | None] = ContextVar("wmo_execute_action", default=None)
 
 
 def execute_agent_episode(
     agent: AgentRuntime,
     environment_runtime: EnvironmentRuntime,
     task: TaskCase,
-    model: object,
+    model: object,  # W3 restack: replace with the canonical ModelClient.
 ) -> AgentEpisode:
     """Run one agent while retaining reset, cleanup, and exception evidence.
 
@@ -40,15 +51,29 @@ def execute_agent_episode(
         A complete in-memory episode with ordered events and structured failure attribution.
     """
     preflight_agent_runtime(agent)
-    opened = False
+    try:
+        environment_context = environment_runtime.open(task)
+    except EnvironmentResetError as exc:
+        return _failed_episode("reset", FailureAttribution.RESET, exc)
+    except Exception as exc:  # noqa: BLE001 - environment allocation is episode evidence
+        return _failed_episode("environment open", FailureAttribution.ENVIRONMENT, exc)
+
+    entered = False
     episode: AgentEpisode | None = None
     try:
-        with environment_runtime.open(task) as environment:
-            opened = True
-            episode = _run_agent(agent, task, model, _ExecuteOnlySession(environment))
-    except Exception as exc:  # noqa: BLE001 - every lifecycle failure becomes episode evidence
-        if not opened:
+        with environment_context as environment:
+            entered = True
+            with _execute_only_session(environment) as execute_session:
+                episode = _run_agent(agent, task, model, execute_session)
+    except EnvironmentResetError as exc:
+        if not entered:
             return _failed_episode("reset", FailureAttribution.RESET, exc)
+        if episode is None:
+            return _failed_episode("agent", FailureAttribution.AGENT, exc)
+        return _append_cleanup_failure(episode, exc)
+    except Exception as exc:  # noqa: BLE001 - every lifecycle failure becomes episode evidence
+        if not entered:
+            return _failed_episode("environment open", FailureAttribution.ENVIRONMENT, exc)
         if episode is None:
             return _failed_episode("agent", FailureAttribution.AGENT, exc)
         return _append_cleanup_failure(episode, exc)
@@ -60,7 +85,7 @@ def execute_agent_episode(
 def _run_agent(
     agent: AgentRuntime,
     task: TaskCase,
-    model: object,
+    model: object,  # W3 restack: replace with the canonical ModelClient.
     environment: EnvironmentSession,
 ) -> AgentEpisode:
     """Call the customer adapter while preserving its exception as a typed episode failure."""
@@ -72,7 +97,13 @@ def _run_agent(
             )
         return episode
     except _ToolExecutionError as exc:
-        return _failed_episode("tool", FailureAttribution.TOOL, exc.cause)
+        timeout = isinstance(exc.cause, TimeoutError)
+        return _failed_episode(
+            "tool timeout" if timeout else "tool",
+            FailureAttribution.TOOL,
+            exc.cause,
+            FailureCode.TIMEOUT if timeout else FailureCode.INTERNAL,
+        )
     except TimeoutError as exc:
         return _failed_episode("agent timeout", FailureAttribution.AGENT, exc, FailureCode.TIMEOUT)
     except Exception as exc:  # noqa: BLE001 - customer adapter failures are episode evidence
@@ -143,18 +174,35 @@ def _lifecycle_span(
     )
 
 
+@contextmanager
+def _execute_only_session(environment: EnvironmentSession) -> Iterator[EnvironmentSession]:
+    """Scope one raw session to a capability that exposes only execute.
+
+    The capability itself retains no raw-session attribute. The lifecycle owns the context-local
+    executor for the duration of the customer call, so reset and close remain unavailable through
+    the object passed to the agent.
+    """
+    token = _execute_action.set(environment.execute)
+    try:
+        yield _ExecuteOnlySession()
+    finally:
+        _execute_action.reset(token)
+
+
 class _ExecuteOnlySession:
-    """Hide simulator lifecycle methods from the customer agent."""
+    """A capability object that exposes only the current episode's execute operation."""
 
-    __slots__ = ("_environment",)
-
-    def __init__(self, environment: EnvironmentSession) -> None:
-        self._environment = environment
+    __slots__ = ()
 
     def execute(self, action: ToolCall) -> Observation:
-        """Forward one action to the simulator-owned session."""
+        """Execute one action through the lifecycle-owned session capability."""
+        executor = _execute_action.get()
+        if executor is None:
+            raise RuntimeError(
+                "the execute-only environment session is unavailable outside its episode"
+            )
         try:
-            return self._environment.execute(action)
+            return executor(action)
         except Exception as exc:  # noqa: BLE001 - tool boundary failures become episode evidence
             raise _ToolExecutionError(exc) from exc
 

--- a/wmo/runtime/agents/lifecycle.py
+++ b/wmo/runtime/agents/lifecycle.py
@@ -27,6 +27,7 @@ from wmo.runtime.environments import (
 
 _ExecuteAction = Callable[[ToolCall], Observation]
 _execute_action: ContextVar[_ExecuteAction | None] = ContextVar("wmo_execute_action", default=None)
+_LIFECYCLE_EVENT_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
 
 def execute_agent_episode(
@@ -43,7 +44,7 @@ def execute_agent_episode(
 
     Args:
         agent: Customer-owned whole-episode runtime.
-        environment_runtime: Simulator-owned source of isolated environment sessions.
+        environment_runtime: Simulator-owned source of per-episode environment sessions.
         task: Task whose already-open session the agent may execute against.
         model: Candidate model injected into the customer agent.
 
@@ -160,15 +161,17 @@ def _lifecycle_span(
     failure: StructuredFailure,
     prior_events: tuple[RolloutSpan, ...] = (),
 ) -> RolloutSpan:
-    """Create one ordered lifecycle span for a failure that prevented normal agent progress."""
-    now = datetime.now(UTC)
-    if prior_events:
-        now = max(now, prior_events[-1].ended_at)
+    """Create one ordered lifecycle span without inventing a wall-clock event time.
+
+    Failure spans follow the most recent event when one exists. A failure before any event uses a
+    fixed epoch, which records ordering without claiming a source timestamp that was not observed.
+    """
+    timestamp = prior_events[-1].ended_at if prior_events else _LIFECYCLE_EVENT_EPOCH
     return RolloutSpan(
         span_id=f"lifecycle-{uuid4().hex}",
         kind=RolloutEventKind.LIFECYCLE,
-        started_at=now,
-        ended_at=now,
+        started_at=timestamp,
+        ended_at=timestamp,
         payload={"phase": phase},
         failure=failure,
     )
@@ -179,8 +182,8 @@ def _execute_only_session(environment: EnvironmentSession) -> Iterator[Environme
     """Scope one raw session to a capability that exposes only execute.
 
     The capability itself retains no raw-session attribute. The lifecycle owns the context-local
-    executor for the duration of the customer call, so reset and close remain unavailable through
-    the object passed to the agent.
+    executor for the duration of the customer call, so reset and close are not attributes of the
+    object passed to the agent. This API restriction does not itself sandbox customer code.
     """
     token = _execute_action.set(environment.execute)
     try:

--- a/wmo/runtime/agents/lifecycle_test.py
+++ b/wmo/runtime/agents/lifecycle_test.py
@@ -17,6 +17,7 @@ from wmo.runtime.agents.lifecycle import execute_agent_episode
 from wmo.runtime.environments import EnvironmentResetError, EnvironmentSession, Observation
 
 _EVENT_TIME = datetime(2026, 8, 11, tzinfo=UTC)
+_LIFECYCLE_EVENT_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
 
 def test_complete_episode_injects_model_and_hides_environment_lifecycle() -> None:
@@ -128,6 +129,8 @@ def test_agent_exception_is_attributed_without_losing_the_episode() -> None:
     assert episode.failure is not None
     assert episode.failure.attribution == FailureAttribution.AGENT
     assert episode.events[0].payload == {"phase": "agent"}
+    assert episode.events[0].started_at == _LIFECYCLE_EVENT_EPOCH
+    assert episode.events[0].ended_at == _LIFECYCLE_EVENT_EPOCH
     assert runtime.close_calls == 1
 
 
@@ -185,7 +188,7 @@ def test_cleanup_failure_replaces_terminal_state_and_preserves_ordered_events() 
         episode.events[1].span_id,
     )
     assert episode.events[1].kind == RolloutEventKind.LIFECYCLE
-    assert episode.events[1].started_at >= episode.events[0].ended_at
+    assert episode.events[1].started_at == episode.events[0].ended_at
     assert runtime.close_calls == 1
 
 

--- a/wmo/runtime/agents/lifecycle_test.py
+++ b/wmo/runtime/agents/lifecycle_test.py
@@ -9,7 +9,7 @@ from typing import cast
 import pytest
 
 from wmo.common.core.artifacts import FailureAttribution, FailureCode, StructuredFailure
-from wmo.common.models import AssistantAction, ToolCall
+from wmo.common.models import AssistantAction, ModelClient, ModelRequest, ModelResponse, ToolCall
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import AgentAdapterPreflightError, AgentEpisode, AgentRuntime
@@ -221,14 +221,18 @@ def test_preflight_names_the_required_customer_adapter_change() -> None:
 
 
 class _Model:
-    """A temporary stand-in that must conform to ModelClient during the W3 restack."""
+    """A canonical model client that is never called by these lifecycle fixtures."""
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Reject unexpected completion calls outside an agent-owned loop."""
+        raise AssertionError(f"unexpected model request: {request!r}")
 
 
 class _SuccessfulAgent:
     """Returns a complete result after one execute-only environment call."""
 
     def __init__(self) -> None:
-        self.model: object | None = None
+        self.model: ModelClient | None = None
         self.observation: Observation | None = None
         self.saw_reset = False
         self.saw_close = False
@@ -237,7 +241,7 @@ class _SuccessfulAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         self.model = model
@@ -261,7 +265,7 @@ class _AdversarialAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         self.environment = environment
@@ -276,7 +280,7 @@ class _TimeoutAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         raise TimeoutError("agent turn exceeded its deadline")
@@ -289,7 +293,7 @@ class _ReportedModelFailureAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         failure = StructuredFailure(
@@ -311,7 +315,7 @@ class _FailingAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         raise RuntimeError("customer code failed")
@@ -324,7 +328,7 @@ class _InvalidResultAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> str:
         return "not an episode"
@@ -337,7 +341,7 @@ class _ToolFailureAgent:
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         environment.execute(ToolCall(call_id="call-1", name="run", arguments={}))

--- a/wmo/runtime/agents/lifecycle_test.py
+++ b/wmo/runtime/agents/lifecycle_test.py
@@ -14,7 +14,7 @@ from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import AgentAdapterPreflightError, AgentEpisode, AgentRuntime
 from wmo.runtime.agents.lifecycle import execute_agent_episode
-from wmo.runtime.environments import EnvironmentSession, Observation
+from wmo.runtime.environments import EnvironmentResetError, EnvironmentSession, Observation
 
 _EVENT_TIME = datetime(2026, 8, 11, tzinfo=UTC)
 
@@ -47,6 +47,25 @@ def test_executable_environment_is_execute_only_to_the_customer_agent() -> None:
     assert runtime.close_calls == 1
 
 
+def test_execute_only_capability_does_not_expose_the_raw_lifecycle_owner() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+    agent = _AdversarialAgent()
+
+    episode = execute_agent_episode(agent, runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert agent.environment is not None
+    for attribute in ("_environment", "__dict__", "_ExecuteOnlySession__environment"):
+        with pytest.raises(AttributeError):
+            getattr(agent.environment, attribute)
+    capability = agent.environment.execute.__self__
+    assert capability is agent.environment
+    for lifecycle_method in ("reset", "close"):
+        with pytest.raises(AttributeError):
+            getattr(capability, lifecycle_method)
+    assert runtime.close_calls == 1
+
+
 def test_timeout_failure_is_retained_and_cleanup_runs_once() -> None:
     runtime = _EnvironmentRuntime(_TextSession())
 
@@ -57,6 +76,20 @@ def test_timeout_failure_is_retained_and_cleanup_runs_once() -> None:
     assert episode.failure.code == FailureCode.TIMEOUT
     assert episode.failure.attribution == FailureAttribution.AGENT
     assert _lifecycle_phases(episode) == ["agent timeout"]
+    assert runtime.close_calls == 1
+
+
+def test_execute_timeout_retains_timeout_classification() -> None:
+    runtime = _EnvironmentRuntime(_TimeoutToolSession())
+
+    episode = execute_agent_episode(_ToolFailureAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.code == FailureCode.TIMEOUT
+    assert episode.failure.attribution == FailureAttribution.TOOL
+    assert episode.failure.exception_type == "TimeoutError"
+    assert _lifecycle_phases(episode) == ["tool timeout"]
     assert runtime.close_calls == 1
 
 
@@ -114,7 +147,7 @@ def test_invalid_adapter_result_is_retained_as_an_agent_failure() -> None:
 
 
 def test_reset_failure_becomes_a_structured_episode_failure() -> None:
-    runtime = _EnvironmentRuntime(_TextSession(), fail_on_enter=True)
+    runtime = _EnvironmentRuntime(_TextSession(), fail_on_reset=True)
 
     episode = execute_agent_episode(_SuccessfulAgent(), runtime, _task(), _Model())
 
@@ -123,6 +156,20 @@ def test_reset_failure_becomes_a_structured_episode_failure() -> None:
     assert episode.failure.attribution == FailureAttribution.RESET
     assert _lifecycle_phases(episode) == ["reset"]
     assert runtime.close_calls == 1
+
+
+def test_environment_open_failure_is_not_classified_as_reset() -> None:
+    runtime = _EnvironmentRuntime(_TextSession(), fail_on_open=True)
+
+    episode = execute_agent_episode(_SuccessfulAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.code == FailureCode.INTERNAL
+    assert episode.failure.attribution == FailureAttribution.ENVIRONMENT
+    assert episode.failure.exception_type == "OSError"
+    assert _lifecycle_phases(episode) == ["environment open"]
+    assert runtime.close_calls == 0
 
 
 def test_cleanup_failure_replaces_terminal_state_and_preserves_ordered_events() -> None:
@@ -171,7 +218,7 @@ def test_preflight_names_the_required_customer_adapter_change() -> None:
 
 
 class _Model:
-    """A deterministic stand-in for W3's future injected ModelClient."""
+    """A temporary stand-in that must conform to ModelClient during the W3 restack."""
 
 
 class _SuccessfulAgent:
@@ -199,6 +246,24 @@ class _SuccessfulAgent:
             final_action=AssistantAction(content="finished"),
             stop_reason=StopReason.COMPLETED,
         )
+
+
+class _AdversarialAgent:
+    """Retains the supplied capability and probes for hidden lifecycle ownership."""
+
+    def __init__(self) -> None:
+        self.environment: EnvironmentSession | None = None
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        self.environment = environment
+        environment.execute(ToolCall(call_id="call-1", name="run", arguments={}))
+        return AgentEpisode(stop_reason=StopReason.COMPLETED)
 
 
 class _TimeoutAgent:
@@ -310,24 +375,35 @@ class _FailingToolSession:
         raise OSError("tool process exited unexpectedly")
 
 
+class _TimeoutToolSession:
+    """A fake executable session whose requested tool reaches its own deadline."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        raise TimeoutError("tool process exceeded its deadline")
+
+
 class _EnvironmentRuntime:
     """Creates one deterministic session and records simulator-owned cleanup."""
 
     def __init__(
         self,
-        session: _TextSession | _ExecutableSession | _FailingToolSession,
+        session: _TextSession | _ExecutableSession | _FailingToolSession | _TimeoutToolSession,
         *,
-        fail_on_enter: bool = False,
+        fail_on_open: bool = False,
+        fail_on_reset: bool = False,
         fail_on_exit: bool = False,
     ) -> None:
         self._session = session
-        self._fail_on_enter = fail_on_enter
+        self._fail_on_open = fail_on_open
+        self._fail_on_reset = fail_on_reset
         self._fail_on_exit = fail_on_exit
         self.open_calls = 0
         self.close_calls = 0
 
     def open(self, task: TaskCase) -> _EnvironmentContext:
         self.open_calls += 1
+        if self._fail_on_open:
+            raise OSError("environment transport allocation failed")
         return _EnvironmentContext(self)
 
 
@@ -337,10 +413,12 @@ class _EnvironmentContext:
     def __init__(self, runtime: _EnvironmentRuntime) -> None:
         self._runtime = runtime
 
-    def __enter__(self) -> _TextSession | _ExecutableSession | _FailingToolSession:
-        if self._runtime._fail_on_enter:
+    def __enter__(
+        self,
+    ) -> _TextSession | _ExecutableSession | _FailingToolSession | _TimeoutToolSession:
+        if self._runtime._fail_on_reset:
             self._runtime.close_calls += 1
-            raise RuntimeError("environment reset failed")
+            raise EnvironmentResetError("environment reset failed")
         return self._runtime._session
 
     def __exit__(

--- a/wmo/runtime/agents/lifecycle_test.py
+++ b/wmo/runtime/agents/lifecycle_test.py
@@ -1,0 +1,380 @@
+"""Tests for simulator-owned customer-agent episode lifecycle composition."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import TracebackType
+from typing import cast
+
+import pytest
+
+from wmo.common.core.artifacts import FailureAttribution, FailureCode, StructuredFailure
+from wmo.common.models import AssistantAction, ToolCall
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents.interface import AgentAdapterPreflightError, AgentEpisode, AgentRuntime
+from wmo.runtime.agents.lifecycle import execute_agent_episode
+from wmo.runtime.environments import EnvironmentSession, Observation
+
+_EVENT_TIME = datetime(2026, 8, 11, tzinfo=UTC)
+
+
+def test_complete_episode_injects_model_and_hides_environment_lifecycle() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+    model = _Model()
+    agent = _SuccessfulAgent()
+
+    episode = execute_agent_episode(agent, runtime, _task(), model)
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert episode.final_action == AssistantAction(content="finished")
+    assert agent.model is model
+    assert agent.observation == Observation(content="text observation")
+    assert agent.saw_reset is False
+    assert agent.saw_close is False
+    assert runtime.open_calls == 1
+    assert runtime.close_calls == 1
+
+
+def test_executable_environment_is_execute_only_to_the_customer_agent() -> None:
+    runtime = _EnvironmentRuntime(_ExecutableSession())
+    agent = _SuccessfulAgent()
+
+    episode = execute_agent_episode(agent, runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert agent.observation == Observation(content="executed: echo hello")
+    assert runtime.close_calls == 1
+
+
+def test_timeout_failure_is_retained_and_cleanup_runs_once() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+
+    episode = execute_agent_episode(_TimeoutAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.code == FailureCode.TIMEOUT
+    assert episode.failure.attribution == FailureAttribution.AGENT
+    assert _lifecycle_phases(episode) == ["agent timeout"]
+    assert runtime.close_calls == 1
+
+
+def test_customer_reported_model_failure_keeps_its_attribution() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+    agent = _ReportedModelFailureAgent()
+
+    episode = execute_agent_episode(agent, runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.MODEL
+    assert episode.failure.code == FailureCode.PROVIDER
+    assert runtime.close_calls == 1
+
+
+def test_execute_failure_is_attributed_to_the_tool_boundary() -> None:
+    runtime = _EnvironmentRuntime(_FailingToolSession())
+
+    episode = execute_agent_episode(_ToolFailureAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.TOOL
+    assert episode.failure.exception_type == "OSError"
+    assert _lifecycle_phases(episode) == ["tool"]
+    assert runtime.close_calls == 1
+
+
+def test_agent_exception_is_attributed_without_losing_the_episode() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+
+    episode = execute_agent_episode(_FailingAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.AGENT
+    assert episode.events[0].payload == {"phase": "agent"}
+    assert runtime.close_calls == 1
+
+
+def test_invalid_adapter_result_is_retained_as_an_agent_failure() -> None:
+    runtime = _EnvironmentRuntime(_TextSession())
+
+    episode = execute_agent_episode(
+        cast(AgentRuntime, _InvalidResultAgent()), runtime, _task(), _Model()
+    )
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.AGENT
+    assert episode.failure.exception_type == "TypeError"
+    assert _lifecycle_phases(episode) == ["agent"]
+    assert runtime.close_calls == 1
+
+
+def test_reset_failure_becomes_a_structured_episode_failure() -> None:
+    runtime = _EnvironmentRuntime(_TextSession(), fail_on_enter=True)
+
+    episode = execute_agent_episode(_SuccessfulAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.RESET
+    assert _lifecycle_phases(episode) == ["reset"]
+    assert runtime.close_calls == 1
+
+
+def test_cleanup_failure_replaces_terminal_state_and_preserves_ordered_events() -> None:
+    runtime = _EnvironmentRuntime(_TextSession(), fail_on_exit=True)
+
+    episode = execute_agent_episode(_SuccessfulAgent(), runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.CLEANUP
+    assert tuple(event.span_id for event in episode.events) == (
+        "agent-1",
+        episode.events[1].span_id,
+    )
+    assert episode.events[1].kind == RolloutEventKind.LIFECYCLE
+    assert episode.events[1].started_at >= episode.events[0].ended_at
+    assert runtime.close_calls == 1
+
+
+def test_cleanup_failure_retains_a_prior_structured_failure() -> None:
+    runtime = _EnvironmentRuntime(_TextSession(), fail_on_exit=True)
+
+    episode = execute_agent_episode(_ReportedModelFailureAgent(), runtime, _task(), _Model())
+
+    assert episode.failure is not None
+    assert episode.failure.attribution == FailureAttribution.CLEANUP
+    assert episode.failure.details["prior_failure"] == {
+        "code": FailureCode.PROVIDER.value,
+        "message": "customer loop failed",
+        "retryable": False,
+        "exception_type": None,
+        "attribution": FailureAttribution.MODEL.value,
+        "details": {},
+    }
+    assert runtime.close_calls == 1
+
+
+def test_preflight_names_the_required_customer_adapter_change() -> None:
+    with pytest.raises(AgentAdapterPreflightError, match="model: ModelClient"):
+        execute_agent_episode(
+            cast(AgentRuntime, _NoModelInjectionAgent()),
+            _EnvironmentRuntime(_TextSession()),
+            _task(),
+            _Model(),
+        )
+
+
+class _Model:
+    """A deterministic stand-in for W3's future injected ModelClient."""
+
+
+class _SuccessfulAgent:
+    """Returns a complete result after one execute-only environment call."""
+
+    def __init__(self) -> None:
+        self.model: object | None = None
+        self.observation: Observation | None = None
+        self.saw_reset = False
+        self.saw_close = False
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        self.model = model
+        self.saw_reset = hasattr(environment, "reset")
+        self.saw_close = hasattr(environment, "close")
+        self.observation = environment.execute(ToolCall(call_id="call-1", name="run", arguments={}))
+        return AgentEpisode(
+            events=(_span("agent-1"),),
+            final_action=AssistantAction(content="finished"),
+            stop_reason=StopReason.COMPLETED,
+        )
+
+
+class _TimeoutAgent:
+    """Raises the timeout W4 must preserve as an episode result."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        raise TimeoutError("agent turn exceeded its deadline")
+
+
+class _ReportedModelFailureAgent:
+    """Returns a model failure discovered inside its own loop."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        failure = StructuredFailure(
+            code=FailureCode.PROVIDER,
+            message="customer loop failed",
+            attribution=FailureAttribution.MODEL,
+        )
+        return AgentEpisode(
+            events=(_span("agent-failure"),),
+            stop_reason=StopReason.FAILURE,
+            failure=failure,
+        )
+
+
+class _FailingAgent:
+    """Raises an unclassified customer-agent exception."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        raise RuntimeError("customer code failed")
+
+
+class _InvalidResultAgent:
+    """Violates the whole-episode return contract for a lifecycle regression fixture."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> str:
+        return "not an episode"
+
+
+class _ToolFailureAgent:
+    """Lets an execute failure escape so W4 can attribute the tool boundary."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        environment.execute(ToolCall(call_id="call-1", name="run", arguments={}))
+        raise AssertionError("the tool fixture should fail before this line")
+
+
+class _NoModelInjectionAgent:
+    """Omits model injection to exercise the actionable preflight failure."""
+
+    def run(self, task: TaskCase, *, environment: EnvironmentSession) -> AgentEpisode:
+        return AgentEpisode(stop_reason=StopReason.COMPLETED)
+
+
+class _TextSession:
+    """A fake text environment that exposes an intentionally hidden close method."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        return Observation(content="text observation")
+
+    def reset(self) -> None:
+        """Represent a legacy reset capability that must not reach the agent."""
+
+    def close(self) -> None:
+        """Represent a legacy close capability that must not reach the agent."""
+
+
+class _ExecutableSession:
+    """A fake executable environment with the same execute-only public surface."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        return Observation(content="executed: echo hello")
+
+
+class _FailingToolSession:
+    """A fake executable session whose requested tool fails deterministically."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        raise OSError("tool process exited unexpectedly")
+
+
+class _EnvironmentRuntime:
+    """Creates one deterministic session and records simulator-owned cleanup."""
+
+    def __init__(
+        self,
+        session: _TextSession | _ExecutableSession | _FailingToolSession,
+        *,
+        fail_on_enter: bool = False,
+        fail_on_exit: bool = False,
+    ) -> None:
+        self._session = session
+        self._fail_on_enter = fail_on_enter
+        self._fail_on_exit = fail_on_exit
+        self.open_calls = 0
+        self.close_calls = 0
+
+    def open(self, task: TaskCase) -> _EnvironmentContext:
+        self.open_calls += 1
+        return _EnvironmentContext(self)
+
+
+class _EnvironmentContext:
+    """Context manager that makes cleanup ownership observable in a fixture."""
+
+    def __init__(self, runtime: _EnvironmentRuntime) -> None:
+        self._runtime = runtime
+
+    def __enter__(self) -> _TextSession | _ExecutableSession | _FailingToolSession:
+        if self._runtime._fail_on_enter:
+            self._runtime.close_calls += 1
+            raise RuntimeError("environment reset failed")
+        return self._runtime._session
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        self._runtime.close_calls += 1
+        if self._runtime._fail_on_exit:
+            raise RuntimeError("environment cleanup failed")
+        return False
+
+
+def _task() -> TaskCase:
+    return TaskCase(
+        task_id="task-1",
+        lineage_group_id="lineage-1",
+        partition="held_out",
+        instruction="Complete the deterministic fixture.",
+        workload_weight=1.0,
+        source_trace_ids=("trace-1",),
+    )
+
+
+def _span(span_id: str) -> RolloutSpan:
+    return RolloutSpan(
+        span_id=span_id,
+        kind=RolloutEventKind.MESSAGE,
+        started_at=_EVENT_TIME,
+        ended_at=_EVENT_TIME,
+        payload={"fixture": span_id},
+    )
+
+
+def _lifecycle_phases(episode: AgentEpisode) -> list[str]:
+    return [str(event.payload["phase"]) for event in episode.events]

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -45,6 +45,7 @@ _DETERMINISTIC_EVENT_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 _WMO_PI_PROVIDER = "wmo-injected"
 _WMO_PI_MODEL = "wmo-injected-model"
 _DEFAULT_TIMEOUT_SECONDS = 300.0
+_UNIX_MILLISECOND_MAGNITUDE = 100_000_000_000
 
 
 class PiRuntimePreflightError(RuntimeError):
@@ -877,10 +878,11 @@ def _event_timestamp(
 ) -> datetime:
     """Return an ordered event timestamp without manufacturing wall-clock provenance.
 
-    A supplied timezone-aware Pi timestamp or finite Unix-millisecond value is used unless it
-    would move ordering backwards. A missing timestamp becomes the Unix epoch plus its one-based
-    JSONL line number in microseconds. That explicit synthetic policy keeps all-missing
-    transcripts deterministic and source-ordered.
+    A supplied timezone-aware Pi timestamp or finite Unix-seconds or Unix-milliseconds value is
+    used unless it would move ordering backwards. Numeric values with at least the magnitude of a
+    plausible modern millisecond timestamp use milliseconds; smaller values use seconds. A
+    missing timestamp becomes the Unix epoch plus its one-based JSONL line number in microseconds.
+    That explicit synthetic policy keeps all-missing transcripts deterministic and source-ordered.
     """
     raw_timestamp = event.get("timestamp")
     if raw_timestamp is None:
@@ -888,8 +890,9 @@ def _event_timestamp(
     elif isinstance(raw_timestamp, (int, float)) and not isinstance(raw_timestamp, bool):
         if isinstance(raw_timestamp, float) and not math.isfinite(raw_timestamp):
             raise PiTranscriptError(f"Pi JSON event line {line_number} has an invalid timestamp")
+        unit = "milliseconds" if abs(raw_timestamp) >= _UNIX_MILLISECOND_MAGNITUDE else "seconds"
         try:
-            timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(milliseconds=raw_timestamp)
+            timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(**{unit: raw_timestamp})
         except OverflowError as exc:
             raise PiTranscriptError(
                 f"Pi JSON event line {line_number} has an invalid timestamp"

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -68,10 +68,12 @@ class _PiModelRequest(ContractModel):
 
 @dataclass(frozen=True)
 class _PiInvocation:
-    """The process arguments and environment for one installed-Pi execution."""
+    """The process arguments, input, environment, and root for one installed-Pi execution."""
 
     command: tuple[str, ...]
     environment: dict[str, str]
+    input_text: str
+    cwd: Path
 
 
 class PiAgentRuntime:
@@ -80,7 +82,8 @@ class PiAgentRuntime:
     The adapter configures Pi with an ephemeral custom provider that sends every model request to
     the model WMO supplied for this episode. Its explicit extension forwards task-visible tool
     calls to the supplied execute-only environment. This configuration prevents ambient Pi model
-    selection, but it is not a sandbox or a security boundary for the installed Pi process.
+    selection. Its private working directory isolates evaluator inputs from caller project Pi
+    settings and prompts. It is not a security sandbox for the installed Pi process.
 
     Args:
         executable: Name or path of the externally installed Pi executable.
@@ -249,9 +252,10 @@ class _PiBridge(AbstractContextManager["_PiBridge"]):
                 _WMO_PI_PROVIDER,
                 "--model",
                 _WMO_PI_MODEL,
-                instruction,
             ),
             environment=process_environment,
+            input_text=instruction,
+            cwd=root,
         )
 
     def complete_model(self, payload: JsonObject) -> ModelResponse:
@@ -461,7 +465,9 @@ def _invoke_installed_pi(
             invocation.command,
             capture_output=True,
             check=False,
+            cwd=invocation.cwd,
             env=invocation.environment,
+            input=invocation.input_text,
             text=True,
             timeout=timeout_seconds,
         )

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -3,79 +3,110 @@
 from __future__ import annotations
 
 import json
+import math
+import os
 import subprocess
+import threading
 from collections.abc import Callable
-from datetime import UTC, datetime
+from contextlib import AbstractContextManager
+from contextvars import copy_context
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from shutil import which
+from tempfile import TemporaryDirectory
+from typing import cast
+from urllib.parse import unquote, urlparse
 
 from pydantic import TypeAdapter, ValidationError
 
-from wmo.common.core.artifacts import JsonObject
-from wmo.common.models import AssistantAction, ToolCall
+from wmo.common.core.artifacts import (
+    ContractModel,
+    FailureAttribution,
+    FailureCode,
+    JsonObject,
+    StructuredFailure,
+)
+from wmo.common.models import AssistantAction, ModelMessage, ModelResponse, ToolCall
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
-from wmo.common.tasks import TaskCase
+from wmo.common.tasks import TaskCase, ToolSchema
 from wmo.runtime.agents.interface import AgentEpisode
-from wmo.runtime.environments import EnvironmentSession
-
-type PiTranscriptRunner = Callable[[TaskCase, object, EnvironmentSession], JsonObject]
-"""A deterministic test seam that returns a WMO-shaped Pi episode transcript."""
+from wmo.runtime.environments import EnvironmentSession, Observation
 
 _JSON_OBJECT = TypeAdapter(JsonObject)
-_PI_JSON_OPTIONS = (
-    "--mode",
-    "json",
-    "--no-session",
-    "--no-context-files",
-    "--no-extensions",
-    "--no-skills",
-    "--no-prompt-templates",
-    "--no-themes",
-    "--offline",
-    "--no-tools",
-)
+_DETERMINISTIC_EVENT_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_WMO_PI_PROVIDER = "wmo-injected"
+_WMO_PI_MODEL = "wmo-injected-model"
+_DEFAULT_TIMEOUT_SECONDS = 300.0
 
 
 class PiRuntimePreflightError(RuntimeError):
-    """An installed Pi executable is unavailable or could not complete its local process run."""
+    """An installed Pi executable is unavailable or cannot complete its local process run."""
+
+
+class PiInvocationTimeoutError(TimeoutError):
+    """The bounded installed-Pi process did not finish before its episode deadline."""
 
 
 class PiTranscriptError(ValueError):
     """An installed Pi JSON event stream cannot be represented as an agent episode."""
 
 
-class PiAgentRuntime:
-    """Run installed Pi in its local JSON-event mode and return a WMO episode.
+class _PiModelRequest(ContractModel):
+    """Temporary private request mapping for the W3 ModelClient restack.
 
-    Pi's executable remains an external dependency. The default invokes its JSON-event mode with
-    sessions, context discovery, built-in tools, and Pi startup network activity disabled. A
-    supplied ``transcript_runner`` remains a deterministic test seam for WMO-shaped transcripts.
+    This is only the wire conversion required by the installed-Pi bridge while this worktree is
+    still based on W2. The W3 restack replaces it with common ``ModelRequest`` and the injected
+    ``ModelClient`` annotation, without changing Pi's process invocation or tool bridge.
+    """
+
+    messages: tuple[ModelMessage, ...]
+    tools: tuple[ToolSchema, ...]
+
+
+@dataclass(frozen=True)
+class _PiInvocation:
+    """The process arguments and environment for one installed-Pi execution."""
+
+    command: tuple[str, ...]
+    environment: dict[str, str]
+
+
+class PiAgentRuntime:
+    """Run installed Pi in local JSON-event mode through WMO's injected dependencies.
+
+    The adapter configures Pi with an ephemeral custom provider that sends every model request to
+    the model WMO supplied for this episode. Its explicit extension forwards task-visible tool
+    calls to the supplied execute-only environment. This configuration prevents ambient Pi model
+    selection, but it is not a sandbox or a security boundary for the installed Pi process.
 
     Args:
         executable: Name or path of the externally installed Pi executable.
-        transcript_runner: Deterministic test bridge returning a JSON-compatible WMO transcript.
+        timeout_seconds: Positive upper bound for the installed Pi subprocess.
     """
 
     def __init__(
         self,
         *,
         executable: str = "pi",
-        transcript_runner: PiTranscriptRunner | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         if not executable:
             raise ValueError("Pi executable must be a non-empty command or path")
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("Pi timeout_seconds must be a finite positive value")
         self._executable = executable
-        self._transcript_runner = transcript_runner
+        self._timeout_seconds = timeout_seconds
 
     def preflight(self) -> None:
         """Confirm that WMO can call the configured installed Pi executable.
 
-        The deterministic transcript seam is deliberately exempt because it invokes no process.
-
         Raises:
             PiRuntimePreflightError: The configured Pi executable cannot be found.
         """
-        if self._transcript_runner is None:
-            self._resolve_executable()
+        self._resolve_executable()
 
     def run(
         self,
@@ -96,13 +127,17 @@ class PiAgentRuntime:
 
         Raises:
             PiRuntimePreflightError: Pi cannot be found or its local process exits unsuccessfully.
+            PiInvocationTimeoutError: The installed Pi process exceeds its configured deadline.
             PiTranscriptError: Pi emitted an invalid or incomplete JSON event transcript.
         """
-        runner = self._transcript_runner
-        if runner is not None:
-            return _episode_from_wmo_transcript(runner(task, model, environment))
         executable = self._resolve_executable()
-        return _episode_from_pi_events(_invoke_installed_pi(executable, task))
+        with _PiBridge(task, model, environment) as bridge:
+            output = _invoke_installed_pi(
+                executable,
+                bridge.invocation(executable, task.instruction),
+                self._timeout_seconds,
+            )
+        return _episode_from_pi_events(output)
 
     def _resolve_executable(self) -> str:
         """Resolve the configured Pi command and raise an actionable local-install error."""
@@ -115,15 +150,326 @@ class PiAgentRuntime:
         return executable_path
 
 
-def _invoke_installed_pi(executable: str, task: TaskCase) -> str:
-    """Run one isolated installed-Pi JSON process without triggering Pi startup network work."""
+class _PiBridge(AbstractContextManager["_PiBridge"]):
+    """Bind one Pi process to one WMO model and execute-only environment session."""
+
+    def __init__(self, task: TaskCase, model: object, environment: EnvironmentSession) -> None:
+        self._task = task
+        self._model = model
+        self._environment = environment
+        self._tools_by_name = {tool.name: tool for tool in task.tools}
+        if len(self._tools_by_name) != len(task.tools):
+            raise ValueError("Pi bridge requires task-visible tool names to be unique")
+        self._model_context = copy_context()
+        self._model_lock = threading.Lock()
+        self._environment_context = copy_context()
+        self._tool_lock = threading.Lock()
+        self._temporary_directory: TemporaryDirectory[str] | None = None
+        self._server: _PiBridgeHttpServer | None = None
+        self._server_thread: threading.Thread | None = None
+
+    def __enter__(self) -> _PiBridge:
+        """Start the ephemeral local bridge and write Pi's per-invocation configuration."""
+        temporary_directory = TemporaryDirectory(prefix="wmo-pi-")
+        self._temporary_directory = temporary_directory
+        root = Path(temporary_directory.name)
+        config_directory = root / "agent"
+        config_directory.mkdir()
+        server = _PiBridgeHttpServer(("127.0.0.1", 0), self)
+        self._server = server
+        thread = threading.Thread(target=server.serve_forever, name="wmo-pi-bridge", daemon=True)
+        self._server_thread = thread
+        thread.start()
+        bridge_url = f"http://127.0.0.1:{server.server_port}"
+        (config_directory / "models.json").write_text(
+            json.dumps(_pi_models_config(bridge_url), separators=(",", ":")), encoding="utf-8"
+        )
+        (root / "tools.json").write_text(
+            json.dumps(_pi_tools_config(self._task.tools), separators=(",", ":")), encoding="utf-8"
+        )
+        (root / "wmo-pi-tools.mjs").write_text(_PI_EXTENSION_SOURCE, encoding="utf-8")
+        return self
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: object | None,
+    ) -> bool:
+        """Stop the bridge before removing its ephemeral configuration files."""
+        server = self._server
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        thread = self._server_thread
+        if thread is not None:
+            thread.join()
+        temporary_directory = self._temporary_directory
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+        self._server = None
+        self._server_thread = None
+        self._temporary_directory = None
+        return False
+
+    def invocation(self, executable: str, instruction: str) -> _PiInvocation:
+        """Build one Pi invocation that can use only this bridge's selected model and tools."""
+        temporary_directory = self._temporary_directory
+        server = self._server
+        if temporary_directory is None or server is None:
+            raise RuntimeError("Pi bridge invocation requested outside its active context")
+        root = Path(temporary_directory.name)
+        process_environment = os.environ.copy()
+        process_environment.update(
+            {
+                "PI_CODING_AGENT_DIR": str(root / "agent"),
+                "PI_OFFLINE": "1",
+                "PI_TELEMETRY": "0",
+                "PI_SKIP_VERSION_CHECK": "1",
+                "WMO_PI_BRIDGE_URL": f"http://127.0.0.1:{server.server_port}",
+                "WMO_PI_TOOLS_PATH": str(root / "tools.json"),
+            }
+        )
+        return _PiInvocation(
+            command=(
+                executable,
+                "--mode",
+                "json",
+                "--no-session",
+                "--no-context-files",
+                "--no-extensions",
+                "-e",
+                str(root / "wmo-pi-tools.mjs"),
+                "--no-skills",
+                "--no-prompt-templates",
+                "--no-themes",
+                "--offline",
+                "--no-builtin-tools",
+                "--provider",
+                _WMO_PI_PROVIDER,
+                "--model",
+                _WMO_PI_MODEL,
+                instruction,
+            ),
+            environment=process_environment,
+        )
+
+    def complete_model(self, payload: JsonObject) -> ModelResponse:
+        """Convert one Pi OpenAI-compatible request and call the WMO-injected model object."""
+        completion = getattr(self._model, "complete", None)
+        if not callable(completion):
+            raise _PiBridgeError(
+                "WMO's injected model must provide complete(request) for the installed Pi adapter"
+            )
+        request = _PiModelRequest(
+            messages=_model_messages_from_pi(payload),
+            tools=self._task.tools,
+        )
+        with self._model_lock:
+            response = self._model_context.run(
+                cast(Callable[[_PiModelRequest], object], completion), request
+            )
+        if not isinstance(response, ModelResponse):
+            raise _PiBridgeError(
+                "WMO's injected model returned an unsupported completion for the installed Pi "
+                "adapter"
+            )
+        return response
+
+    def execute_tool(self, tool_name: str, payload: JsonObject) -> Observation:
+        """Execute one Pi extension tool through WMO's supplied environment session."""
+        if tool_name not in self._tools_by_name:
+            raise _PiBridgeError(
+                f"Pi requested tool {tool_name!r}, which is not visible to this task"
+            )
+        call_id = payload.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise _PiBridgeError("Pi tool bridge request requires a non-empty call_id")
+        try:
+            arguments = _JSON_OBJECT.validate_python(payload.get("arguments", {}))
+        except ValidationError as exc:
+            raise _PiBridgeError("Pi tool bridge request has non-object arguments") from exc
+        with self._tool_lock:
+            return self._environment_context.run(
+                self._environment.execute,
+                ToolCall(call_id=call_id, name=tool_name, arguments=arguments),
+            )
+
+
+class _PiBridgeHttpServer(ThreadingHTTPServer):
+    """Threading HTTP server whose handler delegates only to one active Pi bridge."""
+
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], bridge: _PiBridge) -> None:
+        super().__init__(address, _PiBridgeRequestHandler)
+        self.bridge = bridge
+
+
+class _PiBridgeRequestHandler(BaseHTTPRequestHandler):
+    """Handle the two local HTTP endpoints that Pi's custom provider and extension require."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler hook name
+        """Route one local Pi model or tool request without logging its contents."""
+        try:
+            payload = self._read_payload()
+            parsed_path = urlparse(self.path)
+            if parsed_path.path == "/v1/chat/completions":
+                self._write_completion(payload)
+                return
+            prefix = "/tools/"
+            if parsed_path.path.startswith(prefix):
+                self._write_tool_result(unquote(parsed_path.path.removeprefix(prefix)), payload)
+                return
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "unknown Pi bridge endpoint"})
+        except _PiBridgeError as exc:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception:  # noqa: BLE001 - bridge failures must not expose episode payloads
+            self._write_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "Pi bridge execution failed"}
+            )
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress HTTP request logging because bridge payloads are episode-visible data."""
+
+    def _read_payload(self) -> JsonObject:
+        """Read a JSON object body with an explicit content-length requirement."""
+        raw_length = self.headers.get("Content-Length")
+        if raw_length is None:
+            raise _PiBridgeError("Pi bridge request requires Content-Length")
+        try:
+            length = int(raw_length)
+        except ValueError as exc:
+            raise _PiBridgeError("Pi bridge request has an invalid Content-Length") from exc
+        if length < 0:
+            raise _PiBridgeError("Pi bridge request has a negative Content-Length")
+        try:
+            return _JSON_OBJECT.validate_json(self.rfile.read(length))
+        except ValidationError as exc:
+            raise _PiBridgeError("Pi bridge request body must be a JSON object") from exc
+
+    def _write_completion(self, payload: JsonObject) -> None:
+        """Return a model response in the OpenAI-compatible shape Pi's custom provider uses."""
+        response = self._bridge.complete_model(payload)
+        if payload.get("stream") is True:
+            self._write_sse(_streaming_completion_events(response))
+            return
+        self._write_json(HTTPStatus.OK, _non_streaming_completion(response))
+
+    def _write_tool_result(self, tool_name: str, payload: JsonObject) -> None:
+        """Run an explicit task tool and return its canonical observation to Pi's extension."""
+        observation = self._bridge.execute_tool(tool_name, payload)
+        self._write_json(
+            HTTPStatus.OK,
+            {
+                "content": observation.content,
+                "is_error": observation.is_error,
+                "metadata": observation.metadata,
+            },
+        )
+
+    @property
+    def _bridge(self) -> _PiBridge:
+        """Return the bridge bound to this server's single active process invocation."""
+        return cast(_PiBridgeHttpServer, self.server).bridge
+
+    def _write_json(self, status: HTTPStatus, payload: JsonObject) -> None:
+        """Write one compact JSON response with no cacheable transport state."""
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _write_sse(self, events: tuple[JsonObject, ...]) -> None:
+        """Write the minimal chunk sequence required by Pi's streaming OpenAI provider."""
+        body = (
+            b"".join(
+                b"data: " + json.dumps(event, separators=(",", ":")).encode("utf-8") + b"\n\n"
+                for event in events
+            )
+            + b"data: [DONE]\n\n"
+        )
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _PiBridgeError(ValueError):
+    """A local conversion or execution request cannot cross the Pi bridge."""
+
+
+def _pi_models_config(bridge_url: str) -> JsonObject:
+    """Return Pi's ephemeral custom-provider configuration for one injected WMO model."""
+    return {
+        "providers": {
+            _WMO_PI_PROVIDER: {
+                "baseUrl": f"{bridge_url}/v1",
+                "api": "openai-completions",
+                "apiKey": "wmo-local-bridge",
+                "compat": {
+                    "maxTokensField": "max_tokens",
+                    "supportsDeveloperRole": False,
+                    "supportsReasoningEffort": False,
+                    "supportsUsageInStreaming": False,
+                },
+                "models": [
+                    {
+                        "id": _WMO_PI_MODEL,
+                        "name": _WMO_PI_MODEL,
+                        "reasoning": False,
+                        "input": ["text"],
+                        "contextWindow": 128000,
+                        "maxTokens": 16384,
+                        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                    }
+                ],
+            }
+        }
+    }
+
+
+def _pi_tools_config(tools: tuple[ToolSchema, ...]) -> JsonObject:
+    """Serialize exactly the task-visible tools for Pi's explicit bridge extension."""
+    return {
+        "tools": [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.input_schema,
+            }
+            for tool in tools
+        ]
+    }
+
+
+def _invoke_installed_pi(
+    executable: str,
+    invocation: _PiInvocation,
+    timeout_seconds: float,
+) -> str:
+    """Run one bounded installed-Pi JSON process with its per-episode binding configuration."""
     try:
         result = subprocess.run(
-            (executable, *_PI_JSON_OPTIONS, task.instruction),
+            invocation.command,
             capture_output=True,
             check=False,
+            env=invocation.environment,
             text=True,
+            timeout=timeout_seconds,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise PiInvocationTimeoutError(
+            "PiAgentRuntime's installed Pi process exceeded its "
+            f"{timeout_seconds:g}-second deadline"
+        ) from exc
     except OSError as exc:
         raise PiRuntimePreflightError(
             f"PiAgentRuntime could not start installed Pi at {executable!r}: {type(exc).__name__}"
@@ -136,21 +482,210 @@ def _invoke_installed_pi(executable: str, task: TaskCase) -> str:
     return result.stdout
 
 
-def _episode_from_wmo_transcript(transcript: JsonObject) -> AgentEpisode:
-    """Validate a deterministic WMO-shaped test transcript returned by an injected bridge."""
+def _model_messages_from_pi(payload: JsonObject) -> tuple[ModelMessage, ...]:
+    """Map Pi's OpenAI-compatible request messages to WMO's temporary W2 bridge shape."""
+    raw_messages = payload.get("messages")
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise _PiBridgeError("Pi model bridge request requires a non-empty messages list")
+    messages: list[ModelMessage] = []
+    for index, raw_message in enumerate(raw_messages):
+        try:
+            message = _JSON_OBJECT.validate_python(raw_message)
+        except ValidationError as exc:
+            raise _PiBridgeError(f"Pi model bridge message {index} must be an object") from exc
+        role = message.get("role")
+        if role == "developer":
+            role = "system"
+        if role not in {"system", "user", "assistant", "tool"}:
+            raise _PiBridgeError(f"Pi model bridge message {index} has unsupported role {role!r}")
+        content = _pi_message_text(message.get("content"), index)
+        if role == "assistant":
+            action = _assistant_action_from_pi_message(message, content, index)
+            messages.append(
+                ModelMessage(role="assistant", content=content, assistant_action=action)
+            )
+            continue
+        if content is None:
+            raise _PiBridgeError(f"Pi model bridge message {index} has no text content")
+        if role == "tool":
+            tool_call_id = message.get("tool_call_id")
+            if not isinstance(tool_call_id, str) or not tool_call_id:
+                raise _PiBridgeError(f"Pi model bridge tool message {index} has no tool_call_id")
+            messages.append(ModelMessage(role="tool", content=content, tool_call_id=tool_call_id))
+            continue
+        if role == "system":
+            messages.append(ModelMessage(role="system", content=content))
+        else:
+            messages.append(ModelMessage(role="user", content=content))
+    return tuple(messages)
+
+
+def _pi_message_text(value: object, index: int) -> str | None:
+    """Extract textual OpenAI-compatible content while rejecting unsupported multimodal blocks."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        raise _PiBridgeError(f"Pi model bridge message {index} has unsupported content")
+    parts: list[str] = []
+    for block in value:
+        try:
+            content_block = _JSON_OBJECT.validate_python(block)
+        except ValidationError as exc:
+            raise _PiBridgeError(
+                f"Pi model bridge message {index} has a non-object content block"
+            ) from exc
+        if content_block.get("type") != "text" or not isinstance(content_block.get("text"), str):
+            raise _PiBridgeError(f"Pi model bridge message {index} has unsupported content block")
+        parts.append(cast(str, content_block["text"]))
+    return "".join(parts)
+
+
+def _assistant_action_from_pi_message(
+    message: JsonObject,
+    content: str | None,
+    index: int,
+) -> AssistantAction:
+    """Map OpenAI-compatible assistant content and function calls into a WMO action."""
+    raw_tool_calls = message.get("tool_calls")
+    if raw_tool_calls is None:
+        if content is None:
+            raise _PiBridgeError(f"Pi model bridge assistant message {index} has no output")
+        return AssistantAction(content=content)
+    if not isinstance(raw_tool_calls, list):
+        raise _PiBridgeError(f"Pi model bridge assistant message {index} has invalid tool_calls")
+    tool_calls: list[ToolCall] = []
+    for tool_index, raw_tool_call in enumerate(raw_tool_calls):
+        try:
+            tool_call = _JSON_OBJECT.validate_python(raw_tool_call)
+        except ValidationError as exc:
+            raise _PiBridgeError(
+                "Pi model bridge assistant message "
+                f"{index} tool call {tool_index} must be an object"
+            ) from exc
+        tool_calls.append(_tool_call_from_openai(tool_call, index, tool_index))
+    return AssistantAction(content=content, tool_calls=tuple(tool_calls))
+
+
+def _tool_call_from_openai(
+    tool_call: JsonObject,
+    message_index: int,
+    tool_index: int,
+) -> ToolCall:
+    """Convert one OpenAI-compatible function call to WMO's canonical action contract."""
+    call_id = tool_call.get("id")
+    function = tool_call.get("function")
+    if not isinstance(call_id, str):
+        raise _PiBridgeError(
+            f"Pi model bridge assistant message {message_index} tool call {tool_index} has no id"
+        )
     try:
-        return AgentEpisode.model_validate(transcript)
+        function_object = _JSON_OBJECT.validate_python(function)
     except ValidationError as exc:
-        raise PiTranscriptError(
-            "Pi transcript does not satisfy the WMO AgentEpisode contract. "
-            "Update the deterministic Pi bridge to emit ordered events and terminal state."
+        raise _PiBridgeError(
+            "Pi model bridge assistant message "
+            f"{message_index} tool call {tool_index} has no function"
         ) from exc
+    name = function_object.get("name")
+    raw_arguments = function_object.get("arguments", "{}")
+    if not isinstance(name, str) or not isinstance(raw_arguments, str):
+        raise _PiBridgeError(
+            f"Pi model bridge assistant message {message_index} tool call {tool_index} is invalid"
+        )
+    try:
+        arguments = _JSON_OBJECT.validate_json(raw_arguments)
+    except ValidationError as exc:
+        raise _PiBridgeError(
+            "Pi model bridge assistant message "
+            f"{message_index} tool call {tool_index} has invalid arguments"
+        ) from exc
+    return ToolCall(call_id=call_id, name=name, arguments=arguments)
+
+
+def _non_streaming_completion(response: ModelResponse) -> JsonObject:
+    """Render one injected WMO model response as an OpenAI-compatible completed response."""
+    return {
+        "id": "wmo-pi-completion",
+        "object": "chat.completion",
+        "created": 0,
+        "model": _WMO_PI_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": _openai_assistant_message(response.output),
+                "finish_reason": "tool_calls" if response.output.tool_calls else "stop",
+            }
+        ],
+    }
+
+
+def _streaming_completion_events(response: ModelResponse) -> tuple[JsonObject, ...]:
+    """Render one injected WMO model response as deterministic OpenAI-compatible SSE chunks."""
+    action = response.output
+    first_delta: JsonObject = {"role": "assistant"}
+    if action.content is not None:
+        first_delta["content"] = action.content
+    if action.tool_calls:
+        first_delta["tool_calls"] = [
+            {
+                "index": index,
+                "id": tool_call.call_id,
+                "type": "function",
+                "function": {
+                    "name": tool_call.name,
+                    "arguments": json.dumps(tool_call.arguments, separators=(",", ":")),
+                },
+            }
+            for index, tool_call in enumerate(action.tool_calls)
+        ]
+    base: JsonObject = {
+        "id": "wmo-pi-completion",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": _WMO_PI_MODEL,
+    }
+    return (
+        {
+            **base,
+            "choices": [{"index": 0, "delta": first_delta, "finish_reason": None}],
+        },
+        {
+            **base,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "tool_calls" if action.tool_calls else "stop",
+                }
+            ],
+        },
+    )
+
+
+def _openai_assistant_message(action: AssistantAction) -> JsonObject:
+    """Render a WMO assistant action as the assistant message Pi's provider accepts."""
+    message: JsonObject = {"role": "assistant", "content": action.content}
+    if action.tool_calls:
+        message["tool_calls"] = [
+            {
+                "id": tool_call.call_id,
+                "type": "function",
+                "function": {
+                    "name": tool_call.name,
+                    "arguments": json.dumps(tool_call.arguments, separators=(",", ":")),
+                },
+            }
+            for tool_call in action.tool_calls
+        ]
+    return message
 
 
 def _episode_from_pi_events(output: str) -> AgentEpisode:
     """Translate Pi JSON mode's ordered local events into the WMO episode representation."""
     spans: list[RolloutSpan] = []
     final_action: AssistantAction | None = None
+    failure: StructuredFailure | None = None
     last_event_time: datetime | None = None
     saw_agent_end = False
 
@@ -163,11 +698,13 @@ def _episode_from_pi_events(output: str) -> AgentEpisode:
             raise PiTranscriptError(f"Pi JSON event line {line_number} has no string type")
         if event_type == "message_end":
             message = _require_object(event, "message", line_number)
-            span, action = _message_span(message, line_number, last_event_time)
+            span, action, message_failure = _message_span(message, line_number, last_event_time)
             spans.append(span)
             last_event_time = span.ended_at
             if action is not None:
                 final_action = action
+            if message_failure is not None:
+                failure = message_failure
         elif event_type in {"tool_execution_start", "tool_execution_end"}:
             span = _tool_span(event, line_number, last_event_time)
             spans.append(span)
@@ -177,6 +714,13 @@ def _episode_from_pi_events(output: str) -> AgentEpisode:
 
     if not saw_agent_end:
         raise PiTranscriptError("Pi JSON transcript ended before an agent_end event")
+    if failure is not None:
+        return AgentEpisode(
+            events=tuple(spans),
+            final_action=final_action,
+            stop_reason=StopReason.FAILURE,
+            failure=failure,
+        )
     return AgentEpisode(
         events=tuple(spans),
         final_action=final_action,
@@ -207,8 +751,8 @@ def _message_span(
     message: JsonObject,
     line_number: int,
     previous_time: datetime | None,
-) -> tuple[RolloutSpan, AssistantAction | None]:
-    """Convert one completed Pi message to an ordered message span and possible final action."""
+) -> tuple[RolloutSpan, AssistantAction | None, StructuredFailure | None]:
+    """Convert one completed Pi message to an ordered message span and terminal evidence."""
     role = message.get("role")
     if not isinstance(role, str):
         raise PiTranscriptError(f"Pi JSON event line {line_number} message has no string role")
@@ -224,6 +768,9 @@ def _message_span(
     action = None
     if role == "assistant" and (text is not None or tool_calls):
         action = AssistantAction(content=text, tool_calls=tool_calls)
+    failure = _assistant_stop_failure(message, line_number) if role == "assistant" else None
+    if failure is not None:
+        payload["stop_reason"] = str(failure.details["pi_stop_reason"])
     return (
         RolloutSpan(
             span_id=f"pi-message-{line_number}",
@@ -231,9 +778,31 @@ def _message_span(
             started_at=timestamp,
             ended_at=timestamp,
             payload=payload,
+            failure=failure,
         ),
         action,
+        failure,
     )
+
+
+def _assistant_stop_failure(message: JsonObject, line_number: int) -> StructuredFailure | None:
+    """Map Pi's unsuccessful assistant stop reasons to explicit WMO terminal failures."""
+    stop_reason = message.get("stopReason")
+    if stop_reason == "error":
+        return StructuredFailure(
+            code=FailureCode.PROVIDER,
+            message=f"installed Pi assistant event line {line_number} stopped with error",
+            attribution=FailureAttribution.MODEL,
+            details={"pi_stop_reason": stop_reason},
+        )
+    if stop_reason == "aborted":
+        return StructuredFailure(
+            code=FailureCode.CANCELLED,
+            message=f"installed Pi assistant event line {line_number} was aborted",
+            attribution=FailureAttribution.AGENT,
+            details={"pi_stop_reason": stop_reason},
+        )
+    return None
 
 
 def _tool_span(
@@ -315,10 +884,15 @@ def _event_timestamp(
     line_number: int,
     previous_time: datetime | None,
 ) -> datetime:
-    """Return an ordered Pi timestamp, falling back to the local process clock."""
+    """Return an ordered event timestamp without manufacturing wall-clock provenance.
+
+    A supplied timezone-aware Pi timestamp is used unless it would move ordering backwards. A
+    missing timestamp becomes the Unix epoch plus its one-based JSONL line number in microseconds.
+    That explicit synthetic policy keeps all-missing transcripts deterministic and source-ordered.
+    """
     raw_timestamp = event.get("timestamp")
     if raw_timestamp is None:
-        timestamp = datetime.now(UTC)
+        timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=line_number)
     elif not isinstance(raw_timestamp, str):
         raise PiTranscriptError(f"Pi JSON event line {line_number} has a non-string timestamp")
     else:
@@ -333,3 +907,47 @@ def _event_timestamp(
                 f"Pi JSON event line {line_number} timestamp must include a timezone"
             )
     return max(timestamp, previous_time) if previous_time is not None else timestamp
+
+
+_PI_EXTENSION_SOURCE = r"""import { readFile } from "node:fs/promises";
+import { Type } from "typebox";
+
+const bridgeUrl = process.env.WMO_PI_BRIDGE_URL;
+const toolsPath = process.env.WMO_PI_TOOLS_PATH;
+
+async function request(path, body) {
+  if (!bridgeUrl) throw new Error("WMO_PI_BRIDGE_URL is required");
+  const response = await fetch(`${bridgeUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json();
+  if (!response.ok) throw new Error("WMO Pi bridge rejected the request");
+  return payload;
+}
+
+export default async function (pi) {
+  if (!toolsPath) throw new Error("WMO_PI_TOOLS_PATH is required");
+  const config = JSON.parse(await readFile(toolsPath, "utf8"));
+  for (const tool of config.tools) {
+    pi.registerTool({
+      name: tool.name,
+      label: tool.name,
+      description: tool.description,
+      parameters: Type.Unsafe(tool.input_schema),
+      async execute(toolCallId, params) {
+        const result = await request(`/tools/${encodeURIComponent(tool.name)}`, {
+          call_id: toolCallId,
+          arguments: params,
+        });
+        return {
+          content: [{ type: "text", text: result.content }],
+          details: result.metadata,
+          isError: result.is_error,
+        };
+      },
+    });
+  }
+}
+"""

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -886,13 +886,23 @@ def _event_timestamp(
 ) -> datetime:
     """Return an ordered event timestamp without manufacturing wall-clock provenance.
 
-    A supplied timezone-aware Pi timestamp is used unless it would move ordering backwards. A
-    missing timestamp becomes the Unix epoch plus its one-based JSONL line number in microseconds.
-    That explicit synthetic policy keeps all-missing transcripts deterministic and source-ordered.
+    A supplied timezone-aware Pi timestamp or finite Unix-millisecond value is used unless it
+    would move ordering backwards. A missing timestamp becomes the Unix epoch plus its one-based
+    JSONL line number in microseconds. That explicit synthetic policy keeps all-missing
+    transcripts deterministic and source-ordered.
     """
     raw_timestamp = event.get("timestamp")
     if raw_timestamp is None:
         timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=line_number)
+    elif isinstance(raw_timestamp, (int, float)) and not isinstance(raw_timestamp, bool):
+        if not math.isfinite(raw_timestamp):
+            raise PiTranscriptError(f"Pi JSON event line {line_number} has an invalid timestamp")
+        try:
+            timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(milliseconds=raw_timestamp)
+        except OverflowError as exc:
+            raise PiTranscriptError(
+                f"Pi JSON event line {line_number} has an invalid timestamp"
+            ) from exc
     elif not isinstance(raw_timestamp, str):
         raise PiTranscriptError(f"Pi JSON event line {line_number} has a non-string timestamp")
     else:

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -901,7 +901,7 @@ def _event_timestamp(
     if raw_timestamp is None:
         timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=line_number)
     elif isinstance(raw_timestamp, (int, float)) and not isinstance(raw_timestamp, bool):
-        if not math.isfinite(raw_timestamp):
+        if isinstance(raw_timestamp, float) and not math.isfinite(raw_timestamp):
             raise PiTranscriptError(f"Pi JSON event line {line_number} has an invalid timestamp")
         try:
             timestamp = _DETERMINISTIC_EVENT_EPOCH + timedelta(milliseconds=raw_timestamp)

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -1,0 +1,105 @@
+"""Thin adapter from an installed Pi bridge to the WMO agent contract."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from shutil import which
+
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents.interface import AgentEpisode
+from wmo.runtime.environments import EnvironmentSession
+
+PiTranscriptRunner = Callable[[TaskCase, object, EnvironmentSession], JsonObject]
+"""Converts one installed Pi run into a JSON-compatible WMO episode transcript."""
+
+
+class PiRuntimePreflightError(RuntimeError):
+    """An installed Pi executable or its WMO bridge is unavailable."""
+
+
+class PiTranscriptError(ValueError):
+    """An installed Pi bridge emitted a transcript outside the WMO episode contract."""
+
+
+class PiAgentRuntime:
+    """Runs installed Pi through a narrow model-injected transcript bridge.
+
+    Args:
+        executable: Name or path of the externally installed Pi executable.
+        transcript_runner: Adapter that invokes installed Pi and returns its transcript as JSON.
+            It receives WMO's injected model and execute-only environment. Tests can supply a
+            deterministic runner without installing or invoking Pi.
+    """
+
+    def __init__(
+        self,
+        *,
+        executable: str = "pi",
+        transcript_runner: PiTranscriptRunner | None = None,
+    ) -> None:
+        if not executable:
+            raise ValueError("Pi executable must be a non-empty command or path")
+        self._executable = executable
+        self._transcript_runner = transcript_runner
+
+    def preflight(self) -> None:
+        """Confirm that WMO can call an installed Pi integration without vendored source.
+
+        Raises:
+            PiRuntimePreflightError: No deterministic bridge is configured for the installed Pi
+                executable, or the executable cannot be found.
+        """
+        if self._transcript_runner is not None:
+            return
+        executable_path = which(self._executable)
+        if executable_path is None:
+            raise PiRuntimePreflightError(
+                "PiAgentRuntime could not find an installed Pi executable named "
+                f"{self._executable!r}. Install Pi outside WMO, then configure a transcript_runner "
+                "that accepts WMO's injected model and execute-only environment. WMO does not "
+                "ship Pi source."
+            )
+        raise PiRuntimePreflightError(
+            "PiAgentRuntime found an installed Pi executable at "
+            f"{executable_path!r}, but no transcript_runner bridge is configured. Add a bridge "
+            "that accepts WMO's injected model and execute-only environment; WMO intentionally "
+            "does not vendor Pi source."
+        )
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Run Pi with injected dependencies and normalize its transcript to an episode.
+
+        Args:
+            task: Task and tool schemas for the installed Pi process.
+            model: Candidate model supplied by WMO's pending common model-client contract.
+            environment: Execute-only session supplied by the simulator.
+
+        Returns:
+            The canonical in-memory episode reconstructed from Pi's transcript.
+
+        Raises:
+            PiRuntimePreflightError: Pi cannot be invoked through the configured bridge.
+            PiTranscriptError: The bridge returned an invalid episode transcript.
+        """
+        self.preflight()
+        runner = self._transcript_runner
+        if runner is None:
+            raise AssertionError("Pi preflight returned without a transcript runner")
+        transcript = runner(task, model, environment)
+        try:
+            return AgentEpisode.model_validate(transcript)
+        except ValidationError as exc:
+            raise PiTranscriptError(
+                "Pi transcript does not satisfy the WMO AgentEpisode contract. "
+                "Update the installed Pi bridge to emit ordered events, terminal state, and any "
+                "structured failure."
+            ) from exc

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -7,7 +7,6 @@ import math
 import os
 import subprocess
 import threading
-from collections.abc import Callable
 from contextlib import AbstractContextManager
 from contextvars import copy_context
 from dataclasses import dataclass
@@ -23,13 +22,19 @@ from urllib.parse import unquote, urlparse
 from pydantic import TypeAdapter, ValidationError
 
 from wmo.common.core.artifacts import (
-    ContractModel,
     FailureAttribution,
     FailureCode,
     JsonObject,
     StructuredFailure,
 )
-from wmo.common.models import AssistantAction, ModelMessage, ModelResponse, ToolCall
+from wmo.common.models import (
+    AssistantAction,
+    ModelClient,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCall,
+)
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase, ToolSchema
 from wmo.runtime.agents.interface import AgentEpisode
@@ -52,18 +57,6 @@ class PiInvocationTimeoutError(TimeoutError):
 
 class PiTranscriptError(ValueError):
     """An installed Pi JSON event stream cannot be represented as an agent episode."""
-
-
-class _PiModelRequest(ContractModel):
-    """Temporary private request mapping for the W3 ModelClient restack.
-
-    This is only the wire conversion required by the installed-Pi bridge while this worktree is
-    still based on W2. The W3 restack replaces it with common ``ModelRequest`` and the injected
-    ``ModelClient`` annotation, without changing Pi's process invocation or tool bridge.
-    """
-
-    messages: tuple[ModelMessage, ...]
-    tools: tuple[ToolSchema, ...]
 
 
 @dataclass(frozen=True)
@@ -115,14 +108,14 @@ class PiAgentRuntime:
         self,
         task: TaskCase,
         *,
-        model: object,  # W3 restack: replace with the canonical ModelClient.
+        model: ModelClient,
         environment: EnvironmentSession,
     ) -> AgentEpisode:
         """Run Pi and normalize its final local JSON event stream to an episode.
 
         Args:
             task: Task and tool schemas for the installed Pi process.
-            model: Candidate model supplied by WMO's pending common model-client contract.
+            model: Candidate model supplied through WMO's canonical model-client contract.
             environment: Execute-only session supplied by the simulator.
 
         Returns:
@@ -156,7 +149,12 @@ class PiAgentRuntime:
 class _PiBridge(AbstractContextManager["_PiBridge"]):
     """Bind one Pi process to one WMO model and execute-only environment session."""
 
-    def __init__(self, task: TaskCase, model: object, environment: EnvironmentSession) -> None:
+    def __init__(
+        self,
+        task: TaskCase,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> None:
         self._task = task
         self._model = model
         self._environment = environment
@@ -259,26 +257,13 @@ class _PiBridge(AbstractContextManager["_PiBridge"]):
         )
 
     def complete_model(self, payload: JsonObject) -> ModelResponse:
-        """Convert one Pi OpenAI-compatible request and call the WMO-injected model object."""
-        completion = getattr(self._model, "complete", None)
-        if not callable(completion):
-            raise _PiBridgeError(
-                "WMO's injected model must provide complete(request) for the installed Pi adapter"
-            )
-        request = _PiModelRequest(
+        """Convert one Pi OpenAI-compatible request and call the WMO-injected model client."""
+        request = ModelRequest(
             messages=_model_messages_from_pi(payload),
             tools=self._task.tools,
         )
         with self._model_lock:
-            response = self._model_context.run(
-                cast(Callable[[_PiModelRequest], object], completion), request
-            )
-        if not isinstance(response, ModelResponse):
-            raise _PiBridgeError(
-                "WMO's injected model returned an unsupported completion for the installed Pi "
-                "adapter"
-            )
-        return response
+            return self._model_context.run(self._model.complete, request)
 
     def execute_tool(self, tool_name: str, payload: JsonObject) -> Observation:
         """Execute one Pi extension tool through WMO's supplied environment session."""
@@ -489,7 +474,7 @@ def _invoke_installed_pi(
 
 
 def _model_messages_from_pi(payload: JsonObject) -> tuple[ModelMessage, ...]:
-    """Map Pi's OpenAI-compatible request messages to WMO's temporary W2 bridge shape."""
+    """Map Pi's OpenAI-compatible request messages to WMO's canonical request shape."""
     raw_messages = payload.get("messages")
     if not isinstance(raw_messages, list) or not raw_messages:
         raise _PiBridgeError("Pi model bridge request requires a non-empty messages list")

--- a/wmo/runtime/agents/pi.py
+++ b/wmo/runtime/agents/pi.py
@@ -1,37 +1,58 @@
-"""Thin adapter from an installed Pi bridge to the WMO agent contract."""
+"""Adapter from an installed Pi JSON-event process to the WMO agent contract."""
 
 from __future__ import annotations
 
+import json
+import subprocess
 from collections.abc import Callable
+from datetime import UTC, datetime
 from shutil import which
 
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import AssistantAction, ToolCall
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.interface import AgentEpisode
 from wmo.runtime.environments import EnvironmentSession
 
-PiTranscriptRunner = Callable[[TaskCase, object, EnvironmentSession], JsonObject]
-"""Converts one installed Pi run into a JSON-compatible WMO episode transcript."""
+type PiTranscriptRunner = Callable[[TaskCase, object, EnvironmentSession], JsonObject]
+"""A deterministic test seam that returns a WMO-shaped Pi episode transcript."""
+
+_JSON_OBJECT = TypeAdapter(JsonObject)
+_PI_JSON_OPTIONS = (
+    "--mode",
+    "json",
+    "--no-session",
+    "--no-context-files",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--offline",
+    "--no-tools",
+)
 
 
 class PiRuntimePreflightError(RuntimeError):
-    """An installed Pi executable or its WMO bridge is unavailable."""
+    """An installed Pi executable is unavailable or could not complete its local process run."""
 
 
 class PiTranscriptError(ValueError):
-    """An installed Pi bridge emitted a transcript outside the WMO episode contract."""
+    """An installed Pi JSON event stream cannot be represented as an agent episode."""
 
 
 class PiAgentRuntime:
-    """Runs installed Pi through a narrow model-injected transcript bridge.
+    """Run installed Pi in its local JSON-event mode and return a WMO episode.
+
+    Pi's executable remains an external dependency. The default invokes its JSON-event mode with
+    sessions, context discovery, built-in tools, and Pi startup network activity disabled. A
+    supplied ``transcript_runner`` remains a deterministic test seam for WMO-shaped transcripts.
 
     Args:
         executable: Name or path of the externally installed Pi executable.
-        transcript_runner: Adapter that invokes installed Pi and returns its transcript as JSON.
-            It receives WMO's injected model and execute-only environment. Tests can supply a
-            deterministic runner without installing or invoking Pi.
+        transcript_runner: Deterministic test bridge returning a JSON-compatible WMO transcript.
     """
 
     def __init__(
@@ -46,37 +67,24 @@ class PiAgentRuntime:
         self._transcript_runner = transcript_runner
 
     def preflight(self) -> None:
-        """Confirm that WMO can call an installed Pi integration without vendored source.
+        """Confirm that WMO can call the configured installed Pi executable.
+
+        The deterministic transcript seam is deliberately exempt because it invokes no process.
 
         Raises:
-            PiRuntimePreflightError: No deterministic bridge is configured for the installed Pi
-                executable, or the executable cannot be found.
+            PiRuntimePreflightError: The configured Pi executable cannot be found.
         """
-        if self._transcript_runner is not None:
-            return
-        executable_path = which(self._executable)
-        if executable_path is None:
-            raise PiRuntimePreflightError(
-                "PiAgentRuntime could not find an installed Pi executable named "
-                f"{self._executable!r}. Install Pi outside WMO, then configure a transcript_runner "
-                "that accepts WMO's injected model and execute-only environment. WMO does not "
-                "ship Pi source."
-            )
-        raise PiRuntimePreflightError(
-            "PiAgentRuntime found an installed Pi executable at "
-            f"{executable_path!r}, but no transcript_runner bridge is configured. Add a bridge "
-            "that accepts WMO's injected model and execute-only environment; WMO intentionally "
-            "does not vendor Pi source."
-        )
+        if self._transcript_runner is None:
+            self._resolve_executable()
 
     def run(
         self,
         task: TaskCase,
         *,
-        model: object,
+        model: object,  # W3 restack: replace with the canonical ModelClient.
         environment: EnvironmentSession,
     ) -> AgentEpisode:
-        """Run Pi with injected dependencies and normalize its transcript to an episode.
+        """Run Pi and normalize its final local JSON event stream to an episode.
 
         Args:
             task: Task and tool schemas for the installed Pi process.
@@ -84,22 +92,244 @@ class PiAgentRuntime:
             environment: Execute-only session supplied by the simulator.
 
         Returns:
-            The canonical in-memory episode reconstructed from Pi's transcript.
+            The canonical in-memory episode reconstructed from Pi's JSON events.
 
         Raises:
-            PiRuntimePreflightError: Pi cannot be invoked through the configured bridge.
-            PiTranscriptError: The bridge returned an invalid episode transcript.
+            PiRuntimePreflightError: Pi cannot be found or its local process exits unsuccessfully.
+            PiTranscriptError: Pi emitted an invalid or incomplete JSON event transcript.
         """
-        self.preflight()
         runner = self._transcript_runner
-        if runner is None:
-            raise AssertionError("Pi preflight returned without a transcript runner")
-        transcript = runner(task, model, environment)
+        if runner is not None:
+            return _episode_from_wmo_transcript(runner(task, model, environment))
+        executable = self._resolve_executable()
+        return _episode_from_pi_events(_invoke_installed_pi(executable, task))
+
+    def _resolve_executable(self) -> str:
+        """Resolve the configured Pi command and raise an actionable local-install error."""
+        executable_path = which(self._executable)
+        if executable_path is None:
+            raise PiRuntimePreflightError(
+                "PiAgentRuntime could not find an installed Pi executable named "
+                f"{self._executable!r}. Install Pi outside WMO, or configure the executable path."
+            )
+        return executable_path
+
+
+def _invoke_installed_pi(executable: str, task: TaskCase) -> str:
+    """Run one isolated installed-Pi JSON process without triggering Pi startup network work."""
+    try:
+        result = subprocess.run(
+            (executable, *_PI_JSON_OPTIONS, task.instruction),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as exc:
+        raise PiRuntimePreflightError(
+            f"PiAgentRuntime could not start installed Pi at {executable!r}: {type(exc).__name__}"
+        ) from exc
+    if result.returncode != 0:
+        raise PiRuntimePreflightError(
+            "PiAgentRuntime's installed Pi process exited with "
+            f"status {result.returncode}. Check that the executable supports Pi JSON mode."
+        )
+    return result.stdout
+
+
+def _episode_from_wmo_transcript(transcript: JsonObject) -> AgentEpisode:
+    """Validate a deterministic WMO-shaped test transcript returned by an injected bridge."""
+    try:
+        return AgentEpisode.model_validate(transcript)
+    except ValidationError as exc:
+        raise PiTranscriptError(
+            "Pi transcript does not satisfy the WMO AgentEpisode contract. "
+            "Update the deterministic Pi bridge to emit ordered events and terminal state."
+        ) from exc
+
+
+def _episode_from_pi_events(output: str) -> AgentEpisode:
+    """Translate Pi JSON mode's ordered local events into the WMO episode representation."""
+    spans: list[RolloutSpan] = []
+    final_action: AssistantAction | None = None
+    last_event_time: datetime | None = None
+    saw_agent_end = False
+
+    for line_number, line in enumerate(output.splitlines(), start=1):
+        if not line.strip():
+            continue
+        event = _decode_event(line, line_number)
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            raise PiTranscriptError(f"Pi JSON event line {line_number} has no string type")
+        if event_type == "message_end":
+            message = _require_object(event, "message", line_number)
+            span, action = _message_span(message, line_number, last_event_time)
+            spans.append(span)
+            last_event_time = span.ended_at
+            if action is not None:
+                final_action = action
+        elif event_type in {"tool_execution_start", "tool_execution_end"}:
+            span = _tool_span(event, line_number, last_event_time)
+            spans.append(span)
+            last_event_time = span.ended_at
+        elif event_type == "agent_end":
+            saw_agent_end = True
+
+    if not saw_agent_end:
+        raise PiTranscriptError("Pi JSON transcript ended before an agent_end event")
+    return AgentEpisode(
+        events=tuple(spans),
+        final_action=final_action,
+        stop_reason=StopReason.COMPLETED,
+    )
+
+
+def _decode_event(line: str, line_number: int) -> JsonObject:
+    """Decode one Pi JSONL event while rejecting non-object payloads with a useful error."""
+    try:
+        raw_event = json.loads(line)
+        return _JSON_OBJECT.validate_python(raw_event)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        raise PiTranscriptError(f"Pi JSON event line {line_number} is not a JSON object") from exc
+
+
+def _require_object(event: JsonObject, field: str, line_number: int) -> JsonObject:
+    """Read one required nested JSON object from a Pi event."""
+    try:
+        return _JSON_OBJECT.validate_python(event.get(field))
+    except ValidationError as exc:
+        raise PiTranscriptError(
+            f"Pi JSON event line {line_number} needs an object {field!r} field"
+        ) from exc
+
+
+def _message_span(
+    message: JsonObject,
+    line_number: int,
+    previous_time: datetime | None,
+) -> tuple[RolloutSpan, AssistantAction | None]:
+    """Convert one completed Pi message to an ordered message span and possible final action."""
+    role = message.get("role")
+    if not isinstance(role, str):
+        raise PiTranscriptError(f"Pi JSON event line {line_number} message has no string role")
+    text, tool_calls = _message_contents(message, line_number)
+    timestamp = _event_timestamp(message, line_number, previous_time)
+    payload: JsonObject = {
+        "source": "installed-pi",
+        "event": "message_end",
+        "role": role,
+    }
+    if text is not None:
+        payload["content"] = text
+    action = None
+    if role == "assistant" and (text is not None or tool_calls):
+        action = AssistantAction(content=text, tool_calls=tool_calls)
+    return (
+        RolloutSpan(
+            span_id=f"pi-message-{line_number}",
+            kind=RolloutEventKind.MESSAGE,
+            started_at=timestamp,
+            ended_at=timestamp,
+            payload=payload,
+        ),
+        action,
+    )
+
+
+def _tool_span(
+    event: JsonObject,
+    line_number: int,
+    previous_time: datetime | None,
+) -> RolloutSpan:
+    """Convert one Pi tool lifecycle event to the corresponding WMO span."""
+    event_type = event.get("type")
+    tool_name = event.get("toolName")
+    if not isinstance(event_type, str) or not isinstance(tool_name, str):
+        raise PiTranscriptError(f"Pi JSON event line {line_number} has no string tool name")
+    timestamp = _event_timestamp(event, line_number, previous_time)
+    payload: JsonObject = {"source": "installed-pi", "event": event_type}
+    if event_type == "tool_execution_end":
+        is_error = event.get("isError")
+        if isinstance(is_error, bool):
+            payload["is_error"] = is_error
+    return RolloutSpan(
+        span_id=f"pi-tool-{line_number}",
+        kind=(
+            RolloutEventKind.TOOL_CALL
+            if event_type == "tool_execution_start"
+            else RolloutEventKind.OBSERVATION
+        ),
+        started_at=timestamp,
+        ended_at=timestamp,
+        payload=payload,
+        tool_name=tool_name,
+    )
+
+
+def _message_contents(
+    message: JsonObject, line_number: int
+) -> tuple[str | None, tuple[ToolCall, ...]]:
+    """Extract visible text and complete Pi tool calls from one completed assistant message."""
+    raw_contents = message.get("content")
+    if not isinstance(raw_contents, list):
+        return None, ()
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+    for content in raw_contents:
         try:
-            return AgentEpisode.model_validate(transcript)
+            block = _JSON_OBJECT.validate_python(content)
         except ValidationError as exc:
             raise PiTranscriptError(
-                "Pi transcript does not satisfy the WMO AgentEpisode contract. "
-                "Update the installed Pi bridge to emit ordered events, terminal state, and any "
-                "structured failure."
+                f"Pi JSON event line {line_number} has a non-object message content block"
             ) from exc
+        content_type = block.get("type")
+        if content_type == "text":
+            text = block.get("text")
+            if not isinstance(text, str):
+                raise PiTranscriptError(
+                    f"Pi JSON event line {line_number} has a text block without string text"
+                )
+            text_parts.append(text)
+        elif content_type == "toolCall":
+            tool_calls.append(_tool_call(block, line_number))
+    return ("".join(text_parts) if text_parts else None), tuple(tool_calls)
+
+
+def _tool_call(block: JsonObject, line_number: int) -> ToolCall:
+    """Convert one complete Pi tool-call content block to WMO's canonical action shape."""
+    call_id = block.get("id")
+    name = block.get("name")
+    if not isinstance(call_id, str) or not isinstance(name, str):
+        raise PiTranscriptError(f"Pi JSON event line {line_number} has an invalid Pi tool call")
+    try:
+        arguments = _JSON_OBJECT.validate_python(block.get("arguments", {}))
+    except ValidationError as exc:
+        raise PiTranscriptError(
+            f"Pi JSON event line {line_number} tool call {name!r} has non-object arguments"
+        ) from exc
+    return ToolCall(call_id=call_id, name=name, arguments=arguments)
+
+
+def _event_timestamp(
+    event: JsonObject,
+    line_number: int,
+    previous_time: datetime | None,
+) -> datetime:
+    """Return an ordered Pi timestamp, falling back to the local process clock."""
+    raw_timestamp = event.get("timestamp")
+    if raw_timestamp is None:
+        timestamp = datetime.now(UTC)
+    elif not isinstance(raw_timestamp, str):
+        raise PiTranscriptError(f"Pi JSON event line {line_number} has a non-string timestamp")
+    else:
+        try:
+            timestamp = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise PiTranscriptError(
+                f"Pi JSON event line {line_number} has an invalid timestamp"
+            ) from exc
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise PiTranscriptError(
+                f"Pi JSON event line {line_number} timestamp must include a timezone"
+            )
+    return max(timestamp, previous_time) if previous_time is not None else timestamp

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
+from stat import S_IXUSR
 
 import pytest
 
 from wmo.common.core.artifacts import JsonObject
-from wmo.common.models import ToolCall
+from wmo.common.models import AssistantAction, ToolCall
 from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
 from wmo.common.tasks import TaskCase
 from wmo.runtime.agents.pi import PiAgentRuntime, PiRuntimePreflightError, PiTranscriptError
@@ -32,11 +35,41 @@ def test_pi_runner_receives_injected_model_and_normalizes_transcript() -> None:
     assert episode.events[0].payload == {"source": "installed-pi"}
 
 
-def test_pi_preflight_names_the_external_install_and_injected_bridge() -> None:
+def test_default_pi_runtime_invokes_the_installed_json_executable_and_translates_events(
+    tmp_path: Path,
+) -> None:
+    runtime = PiAgentRuntime(executable=str(_write_pi_json_fixture(tmp_path)))
+
+    episode = runtime.run(_task(), model=_Model(), environment=_Environment())
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert episode.final_action == AssistantAction(
+        content="Pi completed the task",
+        tool_calls=(ToolCall(call_id="pi-call", name="lookup", arguments={"id": "record-1"}),),
+    )
+    assert [(event.kind, event.tool_name) for event in episode.events] == [
+        (RolloutEventKind.MESSAGE, None),
+        (RolloutEventKind.TOOL_CALL, "lookup"),
+        (RolloutEventKind.OBSERVATION, "lookup"),
+    ]
+    assert episode.events[0].payload == {
+        "source": "installed-pi",
+        "event": "message_end",
+        "role": "assistant",
+        "content": "Pi completed the task",
+    }
+    assert episode.events[2].payload == {
+        "source": "installed-pi",
+        "event": "tool_execution_end",
+        "is_error": False,
+    }
+
+
+def test_pi_runtime_names_the_missing_external_install() -> None:
     runtime = PiAgentRuntime(executable="wmo-pi-not-installed")
 
     with pytest.raises(PiRuntimePreflightError, match="Install Pi outside WMO"):
-        runtime.preflight()
+        runtime.run(_task(), model=_Model(), environment=_Environment())
 
 
 def test_pi_rejects_an_invalid_bridge_transcript() -> None:
@@ -47,7 +80,7 @@ def test_pi_rejects_an_invalid_bridge_transcript() -> None:
 
 
 class _Model:
-    """A deterministic stand-in for W3's pending ModelClient contract."""
+    """A temporary stand-in that must conform to ModelClient during the W3 restack."""
 
 
 class _Environment:
@@ -105,3 +138,66 @@ def _task() -> TaskCase:
         workload_weight=1.0,
         source_trace_ids=("trace-1",),
     )
+
+
+def _write_pi_json_fixture(tmp_path: Path) -> Path:
+    """Write a local executable that mimics Pi's documented JSON event stream."""
+    executable = tmp_path / "pi-json-fixture"
+    executable.write_text(
+        f"""#!{sys.executable}
+import json
+import sys
+
+expected = [
+    "--mode",
+    "json",
+    "--no-session",
+    "--no-context-files",
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--offline",
+    "--no-tools",
+    "Complete the deterministic Pi fixture.",
+]
+if sys.argv[1:] != expected:
+    raise SystemExit(17)
+events = [
+    {{"type": "session", "version": 3}},
+    {{"type": "agent_start"}},
+    {{
+        "type": "message_end",
+        "message": {{
+            "role": "assistant",
+            "timestamp": "2026-08-11T00:00:00+00:00",
+            "content": [
+                {{"type": "text", "text": "Pi completed the task"}},
+                {{
+                    "type": "toolCall",
+                    "id": "pi-call",
+                    "name": "lookup",
+                    "arguments": {{"id": "record-1"}},
+                }},
+            ],
+        }},
+    }},
+    {{
+        "type": "tool_execution_start",
+        "timestamp": "2026-08-11T00:00:01+00:00",
+        "toolName": "lookup",
+    }},
+    {{
+        "type": "tool_execution_end",
+        "timestamp": "2026-08-11T00:00:02+00:00",
+        "toolName": "lookup",
+        "isError": False,
+    }},
+    {{"type": "agent_end"}},
+]
+sys.stdout.write("\\n".join(json.dumps(event) for event in events) + "\\n")
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | S_IXUSR)
+    return executable

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -70,6 +70,17 @@ def test_default_pi_runtime_binds_the_injected_model_and_environment(
     }
 
 
+def test_installed_pi_parses_a_0731_numeric_millisecond_timestamp(tmp_path: Path) -> None:
+    """Pi 0.73.1 JSON mode preserves numeric assistant message timestamps through WMO."""
+    runtime = PiAgentRuntime(executable=str(_write_pi_0731_timestamp_fixture(tmp_path)))
+
+    episode = execute_agent_episode(runtime, _EnvironmentRuntime(), _task(), _Model())
+
+    expected_timestamp = datetime(2024, 12, 3, 14, 2, 47, 890000, tzinfo=UTC)
+    assert episode.events[0].started_at == expected_timestamp
+    assert episode.events[0].ended_at == expected_timestamp
+
+
 @pytest.mark.parametrize(
     ("pi_stop_reason", "code", "attribution"),
     [
@@ -405,6 +416,43 @@ events = [
         "isError": False,
     }},
     {{"type": "agent_end"}},
+]
+sys.stdout.write("\\n".join(json.dumps(event) for event in events) + "\\n")
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | S_IXUSR)
+    return executable
+
+
+def _write_pi_0731_timestamp_fixture(tmp_path: Path) -> Path:
+    """Write a static Pi 0.73.1 JSON-mode transcript with a numeric message timestamp."""
+    executable = tmp_path / "pi-0731-timestamp-fixture"
+    executable.write_text(
+        f"""#!{sys.executable}
+import json
+import sys
+
+message = {{
+    "role": "assistant",
+    "content": [{{"type": "text", "text": "Pi completed the timestamp fixture."}}],
+    "api": "openai-responses",
+    "provider": "wmo-injected",
+    "model": "wmo-injected-model",
+    "usage": {{
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "totalTokens": 0,
+        "cost": {{"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "total": 0}},
+    }},
+    "stopReason": "stop",
+    "timestamp": 1733234567890,
+}}
+events = [
+    {{"type": "message_end", "message": message}},
+    {{"type": "agent_end", "messages": [message]}},
 ]
 sys.stdout.write("\\n".join(json.dumps(event) for event in events) + "\\n")
 """,

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -70,6 +70,45 @@ def test_default_pi_runtime_binds_the_injected_model_and_environment(
     }
 
 
+@pytest.mark.parametrize("instruction", ("@candidate", "--candidate"))
+def test_installed_pi_keeps_special_task_text_out_of_argv(
+    tmp_path: Path,
+    instruction: str,
+) -> None:
+    """Literal task text reaches the injected model through stdin rather than Pi argv."""
+    model = _Model()
+    task = _task(instruction)
+    runtime = PiAgentRuntime(executable=str(_write_pi_binding_fixture(tmp_path)))
+
+    episode = execute_agent_episode(runtime, _EnvironmentRuntime(), task, model)
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert [message.content for message in model.requests[0].messages] == [instruction]
+
+
+def test_installed_pi_uses_private_cwd_without_caller_pi_system_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller project Pi prompts cannot affect an isolated installed-Pi invocation."""
+    caller_cwd = tmp_path / "caller"
+    pi_directory = caller_cwd / ".pi"
+    pi_directory.mkdir(parents=True)
+    (pi_directory / "SYSTEM.md").write_text("hostile system prompt", encoding="utf-8")
+    (pi_directory / "APPEND_SYSTEM.md").write_text("hostile appended prompt", encoding="utf-8")
+    monkeypatch.chdir(caller_cwd)
+    monkeypatch.setenv("WMO_TEST_CALLER_CWD", str(caller_cwd))
+    model = _Model()
+    task = _task()
+    runtime = PiAgentRuntime(executable=str(_write_pi_binding_fixture(tmp_path)))
+
+    episode = execute_agent_episode(runtime, _EnvironmentRuntime(), task, model)
+
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert Path.cwd() == caller_cwd
+    assert [message.content for message in model.requests[0].messages] == [task.instruction]
+
+
 def test_installed_pi_parses_a_0731_numeric_millisecond_timestamp(tmp_path: Path) -> None:
     """Pi 0.73.1 JSON mode preserves numeric assistant message timestamps through WMO."""
     runtime = PiAgentRuntime(executable=str(_write_pi_0731_timestamp_fixture(tmp_path)))
@@ -301,13 +340,13 @@ class _EnvironmentContext(AbstractContextManager[EnvironmentSession]):
         return False
 
 
-def _task() -> TaskCase:
+def _task(instruction: str = "Complete the deterministic Pi fixture.") -> TaskCase:
     """Return one task whose explicit tool schema the local binding fixture verifies."""
     return TaskCase(
         task_id="task-1",
         lineage_group_id="lineage-1",
         partition="held_out",
-        instruction="Complete the deterministic Pi fixture.",
+        instruction=instruction,
         tools=(
             ToolSchema(
                 name="lookup",
@@ -340,7 +379,7 @@ import sys
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-instruction = {_task().instruction!r}
+instruction = sys.stdin.read()
 arguments = sys.argv[1:]
 if "--no-tools" in arguments:
     raise SystemExit(10)
@@ -358,9 +397,19 @@ if (
     or "WMO_PI_BRIDGE_URL" not in extension_source
 ):
     raise SystemExit(14)
-if arguments[-1] != instruction:
+if instruction in arguments:
     raise SystemExit(15)
+if "@candidate" in arguments:
+    raise SystemExit(21)
+if "--candidate" in arguments:
+    raise SystemExit(22)
 agent_dir = Path(os.environ["PI_CODING_AGENT_DIR"])
+caller_cwd = os.environ.get("WMO_TEST_CALLER_CWD")
+if caller_cwd is not None and (
+    Path.cwd().resolve() != agent_dir.parent.resolve()
+    or Path.cwd().resolve() == Path(caller_cwd).resolve()
+):
+    raise SystemExit(23)
 model_config = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
 provider = model_config["providers"]["wmo-injected"]
 if provider["models"][0]["id"] != "wmo-injected-model":
@@ -369,6 +418,13 @@ tools = json.loads(Path(os.environ["WMO_PI_TOOLS_PATH"]).read_text(encoding="utf
 if tools["tools"][0]["name"] != "lookup":
     raise SystemExit(17)
 bridge_url = os.environ["WMO_PI_BRIDGE_URL"]
+system_messages = []
+for system_filename in ("SYSTEM.md", "APPEND_SYSTEM.md"):
+    system_path = Path(".pi") / system_filename
+    if system_path.exists():
+        system_messages.append(
+            {{"role": "system", "content": system_path.read_text(encoding="utf-8")}}
+        )
 def post(path, payload):
     request = Request(
         bridge_url + path,
@@ -379,7 +435,7 @@ def post(path, payload):
     with urlopen(request) as response:
         return response.read()
 completion = post("/v1/chat/completions", {{
-    "messages": [{{"role": "user", "content": instruction}}],
+    "messages": [*system_messages, {{"role": "user", "content": instruction}}],
     "stream": True,
 }})
 if b"Injected model output." not in completion or b'"name":"lookup"' not in completion:

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -1,0 +1,107 @@
+"""Tests for the installed-Pi adapter seam."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import ToolCall
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents.pi import PiAgentRuntime, PiRuntimePreflightError, PiTranscriptError
+from wmo.runtime.environments import EnvironmentSession, Observation
+
+
+def test_pi_runner_receives_injected_model_and_normalizes_transcript() -> None:
+    model = _Model()
+    environment = _Environment()
+    runner = _TranscriptRunner()
+    runtime = PiAgentRuntime(transcript_runner=runner)
+
+    episode = runtime.run(_task(), model=model, environment=environment)
+
+    assert runner.model is model
+    assert runner.observation == Observation(content="tool response")
+    assert episode.stop_reason == StopReason.COMPLETED
+    assert episode.final_action is not None
+    assert episode.final_action.content == "Pi completed the task"
+    assert len(episode.events) == 1
+    assert episode.events[0].kind == RolloutEventKind.TOOL_CALL
+    assert episode.events[0].payload == {"source": "installed-pi"}
+
+
+def test_pi_preflight_names_the_external_install_and_injected_bridge() -> None:
+    runtime = PiAgentRuntime(executable="wmo-pi-not-installed")
+
+    with pytest.raises(PiRuntimePreflightError, match="Install Pi outside WMO"):
+        runtime.preflight()
+
+
+def test_pi_rejects_an_invalid_bridge_transcript() -> None:
+    runtime = PiAgentRuntime(transcript_runner=_invalid_transcript)
+
+    with pytest.raises(PiTranscriptError, match="AgentEpisode"):
+        runtime.run(_task(), model=_Model(), environment=_Environment())
+
+
+class _Model:
+    """A deterministic stand-in for W3's pending ModelClient contract."""
+
+
+class _Environment:
+    """A fake execute-only session accepted by the installed Pi bridge."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        return Observation(content="tool response")
+
+
+class _TranscriptRunner:
+    """Captures injected dependencies and emits a representative Pi JSON transcript."""
+
+    def __init__(self) -> None:
+        self.model: object | None = None
+        self.observation: Observation | None = None
+
+    def __call__(
+        self,
+        task: TaskCase,
+        model: object,
+        environment: EnvironmentSession,
+    ) -> JsonObject:
+        self.model = model
+        self.observation = environment.execute(
+            ToolCall(call_id="pi-call", name="bash", arguments={})
+        )
+        event = RolloutSpan(
+            span_id="pi-tool-1",
+            kind=RolloutEventKind.TOOL_CALL,
+            started_at=datetime(2026, 8, 11, tzinfo=UTC),
+            ended_at=datetime(2026, 8, 11, tzinfo=UTC),
+            payload={"source": "installed-pi"},
+        )
+        return {
+            "events": [event.model_dump(mode="json")],
+            "final_action": {"content": "Pi completed the task"},
+            "stop_reason": StopReason.COMPLETED.value,
+        }
+
+
+def _invalid_transcript(
+    task: TaskCase,
+    model: object,
+    environment: EnvironmentSession,
+) -> JsonObject:
+    return {"events": [], "stop_reason": StopReason.FAILURE.value}
+
+
+def _task() -> TaskCase:
+    return TaskCase(
+        task_id="task-1",
+        lineage_group_id="lineage-1",
+        partition="held_out",
+        instruction="Complete the deterministic Pi fixture.",
+        workload_weight=1.0,
+        source_trace_ids=("trace-1",),
+    )

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -120,6 +120,26 @@ def test_installed_pi_parses_a_0731_numeric_millisecond_timestamp(tmp_path: Path
     assert episode.events[0].ended_at == expected_timestamp
 
 
+def test_pi_rejects_an_absurd_numeric_millisecond_timestamp() -> None:
+    """Unrepresentable integer timestamps are transcript errors, not leaked overflows."""
+    with pytest.raises(PiTranscriptError, match="invalid timestamp"):
+        _episode_from_pi_events(
+            _pi_events(
+                [
+                    {
+                        "type": "message_end",
+                        "message": {
+                            "role": "assistant",
+                            "timestamp": 10**100,
+                            "content": [],
+                        },
+                    },
+                    {"type": "agent_end"},
+                ]
+            )
+        )
+
+
 @pytest.mark.parametrize(
     ("pi_stop_reason", "code", "attribution"),
     [

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -1,46 +1,51 @@
-"""Tests for the installed-Pi adapter seam."""
+"""Tests for the installed-Pi adapter's injected model and environment bridge."""
 
 from __future__ import annotations
 
+import json
 import sys
-from datetime import UTC, datetime
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from stat import S_IXUSR
+from types import TracebackType
+from typing import Protocol
 
 import pytest
 
-from wmo.common.core.artifacts import JsonObject
-from wmo.common.models import AssistantAction, ToolCall
-from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
-from wmo.common.tasks import TaskCase
-from wmo.runtime.agents.pi import PiAgentRuntime, PiRuntimePreflightError, PiTranscriptError
+from wmo.common.core.artifacts import FailureAttribution, FailureCode
+from wmo.common.models import (
+    AssistantAction,
+    ModelMessage,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+)
+from wmo.common.rollouts import RolloutEventKind, StopReason
+from wmo.common.tasks import TaskCase, ToolSchema
+from wmo.runtime.agents import execute_agent_episode
+from wmo.runtime.agents.pi import (
+    PiAgentRuntime,
+    PiRuntimePreflightError,
+    PiTranscriptError,
+    _episode_from_pi_events,
+)
 from wmo.runtime.environments import EnvironmentSession, Observation
 
-
-def test_pi_runner_receives_injected_model_and_normalizes_transcript() -> None:
-    model = _Model()
-    environment = _Environment()
-    runner = _TranscriptRunner()
-    runtime = PiAgentRuntime(transcript_runner=runner)
-
-    episode = runtime.run(_task(), model=model, environment=environment)
-
-    assert runner.model is model
-    assert runner.observation == Observation(content="tool response")
-    assert episode.stop_reason == StopReason.COMPLETED
-    assert episode.final_action is not None
-    assert episode.final_action.content == "Pi completed the task"
-    assert len(episode.events) == 1
-    assert episode.events[0].kind == RolloutEventKind.TOOL_CALL
-    assert episode.events[0].payload == {"source": "installed-pi"}
+_DETERMINISTIC_EVENT_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_DIGEST = "a" * 64
 
 
-def test_default_pi_runtime_invokes_the_installed_json_executable_and_translates_events(
+def test_default_pi_runtime_binds_the_injected_model_and_environment(
     tmp_path: Path,
 ) -> None:
-    runtime = PiAgentRuntime(executable=str(_write_pi_json_fixture(tmp_path)))
+    """The deterministic executable exercises the same process binding as installed Pi."""
+    model = _Model()
+    environment_runtime = _EnvironmentRuntime()
+    runtime = PiAgentRuntime(executable=str(_write_pi_binding_fixture(tmp_path)))
 
-    episode = runtime.run(_task(), model=_Model(), environment=_Environment())
+    episode = execute_agent_episode(runtime, environment_runtime, _task(), model)
 
     assert episode.stop_reason == StopReason.COMPLETED
     assert episode.final_action == AssistantAction(
@@ -52,12 +57,12 @@ def test_default_pi_runtime_invokes_the_installed_json_executable_and_translates
         (RolloutEventKind.TOOL_CALL, "lookup"),
         (RolloutEventKind.OBSERVATION, "lookup"),
     ]
-    assert episode.events[0].payload == {
-        "source": "installed-pi",
-        "event": "message_end",
-        "role": "assistant",
-        "content": "Pi completed the task",
-    }
+    assert model.requests[0].messages[-1].content == _task().instruction
+    assert model.requests[0].tools == _task().tools
+    assert environment_runtime.actions == [
+        ToolCall(call_id="pi-call", name="lookup", arguments={"id": "record-1"})
+    ]
+    assert environment_runtime.close_calls == 1
     assert episode.events[2].payload == {
         "source": "installed-pi",
         "event": "tool_execution_end",
@@ -65,123 +70,329 @@ def test_default_pi_runtime_invokes_the_installed_json_executable_and_translates
     }
 
 
+@pytest.mark.parametrize(
+    ("pi_stop_reason", "code", "attribution"),
+    [
+        ("error", FailureCode.PROVIDER, FailureAttribution.MODEL),
+        ("aborted", FailureCode.CANCELLED, FailureAttribution.AGENT),
+    ],
+)
+def test_unsuccessful_assistant_stop_reason_is_a_failed_episode_with_partial_evidence(
+    pi_stop_reason: str,
+    code: FailureCode,
+    attribution: FailureAttribution,
+) -> None:
+    """Pi error and aborted message ends retain all parsed evidence before failing terminally."""
+    episode = _episode_from_pi_events(
+        _pi_events(
+            [
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "timestamp": "2026-08-11T00:00:00+00:00",
+                        "content": [
+                            {"type": "text", "text": "Partial response."},
+                            {
+                                "type": "toolCall",
+                                "id": "pi-call",
+                                "name": "lookup",
+                                "arguments": {"id": "record-1"},
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "tool_execution_start",
+                    "timestamp": "2026-08-11T00:00:01+00:00",
+                    "toolName": "lookup",
+                },
+                {
+                    "type": "tool_execution_end",
+                    "timestamp": "2026-08-11T00:00:02+00:00",
+                    "toolName": "lookup",
+                    "isError": False,
+                },
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "timestamp": "2026-08-11T00:00:03+00:00",
+                        "stopReason": pi_stop_reason,
+                        "content": [{"type": "text", "text": "Last partial output."}],
+                    },
+                },
+                {"type": "agent_end"},
+            ]
+        )
+    )
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.code == code
+    assert episode.failure.attribution == attribution
+    assert episode.failure.details == {"pi_stop_reason": pi_stop_reason}
+    assert [event.span_id for event in episode.events] == [
+        "pi-message-1",
+        "pi-tool-2",
+        "pi-tool-3",
+        "pi-message-4",
+    ]
+    assert episode.events[-1].failure == episode.failure
+    assert episode.final_action == AssistantAction(content="Last partial output.")
+
+
+def test_missing_pi_timestamps_use_deterministic_jsonl_ordering() -> None:
+    """Timestamp-less Pi events retain deterministic ordering without using the process clock."""
+    episode = _episode_from_pi_events(
+        _pi_events(
+            [
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "First response."}],
+                    },
+                },
+                {"type": "tool_execution_start", "toolName": "lookup"},
+                {"type": "tool_execution_end", "toolName": "lookup", "isError": False},
+                {"type": "agent_end"},
+            ]
+        )
+    )
+
+    assert [event.started_at for event in episode.events] == [
+        _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=1),
+        _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=2),
+        _DETERMINISTIC_EVENT_EPOCH + timedelta(microseconds=3),
+    ]
+
+
+def test_installed_pi_timeout_becomes_lifecycle_timeout_and_closes_environment(
+    tmp_path: Path,
+) -> None:
+    """The bounded Pi process reaches the existing lifecycle timeout and cleanup outcome."""
+    environment_runtime = _EnvironmentRuntime()
+    agent = PiAgentRuntime(
+        executable=str(_write_sleeping_pi_fixture(tmp_path)),
+        timeout_seconds=0.01,
+    )
+
+    episode = execute_agent_episode(agent, environment_runtime, _task(), _Model())
+
+    assert episode.stop_reason == StopReason.FAILURE
+    assert episode.failure is not None
+    assert episode.failure.code == FailureCode.TIMEOUT
+    assert episode.failure.attribution == FailureAttribution.AGENT
+    assert episode.failure.exception_type == "PiInvocationTimeoutError"
+    assert episode.events[0].payload == {"phase": "agent timeout"}
+    assert environment_runtime.close_calls == 1
+
+
 def test_pi_runtime_names_the_missing_external_install() -> None:
+    """Missing executable errors retain an actionable external-install remedy."""
     runtime = PiAgentRuntime(executable="wmo-pi-not-installed")
 
     with pytest.raises(PiRuntimePreflightError, match="Install Pi outside WMO"):
         runtime.run(_task(), model=_Model(), environment=_Environment())
 
 
-def test_pi_rejects_an_invalid_bridge_transcript() -> None:
-    runtime = PiAgentRuntime(transcript_runner=_invalid_transcript)
-
-    with pytest.raises(PiTranscriptError, match="AgentEpisode"):
-        runtime.run(_task(), model=_Model(), environment=_Environment())
+def test_pi_rejects_a_transcript_that_ends_before_agent_end() -> None:
+    """Pi transcripts must contain an explicit terminal agent event."""
+    with pytest.raises(PiTranscriptError, match="agent_end"):
+        _episode_from_pi_events(_pi_events([]))
 
 
 class _Model:
-    """A temporary stand-in that must conform to ModelClient during the W3 restack."""
+    """A deterministic W2 temporary model client used by the Pi binding fixture."""
+
+    def __init__(self) -> None:
+        self.requests: list[_PiRequestView] = []
+
+    def complete(self, request: _PiRequestView) -> ModelResponse:
+        """Record the private bridge request and return a deterministic injected completion."""
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(
+                content="Injected model output.",
+                tool_calls=(
+                    ToolCall(call_id="pi-call", name="lookup", arguments={"id": "record-1"}),
+                ),
+            ),
+            model=ModelSnapshot(
+                provider="fixture",
+                model_id="fixture-model",
+                capabilities_sha256=_DIGEST,
+            ),
+            economics=OperationEconomics(),
+        )
+
+
+class _PiRequestView(Protocol):
+    """The W2 bridge fields the deterministic fixture needs to inspect."""
+
+    @property
+    def messages(self) -> tuple[ModelMessage, ...]:
+        """Return the WMO-visible messages forwarded from Pi."""
+
+    @property
+    def tools(self) -> tuple[ToolSchema, ...]:
+        """Return the task-visible tools forwarded from Pi."""
 
 
 class _Environment:
-    """A fake execute-only session accepted by the installed Pi bridge."""
+    """A fake execute-only session that records tools crossing the Pi binding."""
+
+    def __init__(self) -> None:
+        self.actions: list[ToolCall] = []
 
     def execute(self, action: ToolCall) -> Observation:
+        """Record one routed tool call and return a deterministic observation."""
+        self.actions.append(action)
         return Observation(content="tool response")
 
 
-class _TranscriptRunner:
-    """Captures injected dependencies and emits a representative Pi JSON transcript."""
+class _EnvironmentRuntime:
+    """A cleanup-owning fake used to prove subprocess timeout lifecycle behavior."""
 
     def __init__(self) -> None:
-        self.model: object | None = None
-        self.observation: Observation | None = None
+        self.close_calls = 0
+        self._session = _Environment()
 
-    def __call__(
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Open the one deterministic execute-only session."""
+        return _EnvironmentContext(self)
+
+    @property
+    def actions(self) -> list[ToolCall]:
+        """Return tool calls recorded by the session owned for this lifecycle fixture."""
+        return self._session.actions
+
+
+class _EnvironmentContext(AbstractContextManager[EnvironmentSession]):
+    """Context manager that makes lifecycle cleanup observable in the timeout regression test."""
+
+    def __init__(self, runtime: _EnvironmentRuntime) -> None:
+        self._runtime = runtime
+
+    def __enter__(self) -> EnvironmentSession:
+        """Return the fake session that the timeout fixture never reaches."""
+        return self._runtime._session
+
+    def __exit__(
         self,
-        task: TaskCase,
-        model: object,
-        environment: EnvironmentSession,
-    ) -> JsonObject:
-        self.model = model
-        self.observation = environment.execute(
-            ToolCall(call_id="pi-call", name="bash", arguments={})
-        )
-        event = RolloutSpan(
-            span_id="pi-tool-1",
-            kind=RolloutEventKind.TOOL_CALL,
-            started_at=datetime(2026, 8, 11, tzinfo=UTC),
-            ended_at=datetime(2026, 8, 11, tzinfo=UTC),
-            payload={"source": "installed-pi"},
-        )
-        return {
-            "events": [event.model_dump(mode="json")],
-            "final_action": {"content": "Pi completed the task"},
-            "stop_reason": StopReason.COMPLETED.value,
-        }
-
-
-def _invalid_transcript(
-    task: TaskCase,
-    model: object,
-    environment: EnvironmentSession,
-) -> JsonObject:
-    return {"events": [], "stop_reason": StopReason.FAILURE.value}
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Record environment cleanup after the agent's bounded subprocess fails."""
+        self._runtime.close_calls += 1
+        return False
 
 
 def _task() -> TaskCase:
+    """Return one task whose explicit tool schema the local binding fixture verifies."""
     return TaskCase(
         task_id="task-1",
         lineage_group_id="lineage-1",
         partition="held_out",
         instruction="Complete the deterministic Pi fixture.",
+        tools=(
+            ToolSchema(
+                name="lookup",
+                description="Look up one deterministic record.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                },
+            ),
+        ),
         workload_weight=1.0,
         source_trace_ids=("trace-1",),
     )
 
 
-def _write_pi_json_fixture(tmp_path: Path) -> Path:
-    """Write a local executable that mimics Pi's documented JSON event stream."""
-    executable = tmp_path / "pi-json-fixture"
+def _pi_events(events: list[dict[str, object]]) -> str:
+    """Serialize a deterministic Pi JSONL stream with no unrelated process behavior."""
+    return "\n".join(json.dumps(event) for event in events)
+
+
+def _write_pi_binding_fixture(tmp_path: Path) -> Path:
+    """Write a local executable that exercises the installed-Pi invocation binding end to end."""
+    executable = tmp_path / "pi-binding-fixture"
     executable.write_text(
         f"""#!{sys.executable}
 import json
+import os
 import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
 
-expected = [
-    "--mode",
-    "json",
-    "--no-session",
-    "--no-context-files",
-    "--no-extensions",
-    "--no-skills",
-    "--no-prompt-templates",
-    "--no-themes",
-    "--offline",
-    "--no-tools",
-    "Complete the deterministic Pi fixture.",
-]
-if sys.argv[1:] != expected:
+instruction = {_task().instruction!r}
+arguments = sys.argv[1:]
+if "--no-tools" in arguments:
+    raise SystemExit(10)
+if arguments[arguments.index("--provider") + 1] != "wmo-injected":
+    raise SystemExit(11)
+if arguments[arguments.index("--model") + 1] != "wmo-injected-model":
+    raise SystemExit(12)
+if "--no-builtin-tools" not in arguments or "--no-extensions" not in arguments:
+    raise SystemExit(13)
+extension = Path(arguments[arguments.index("-e") + 1])
+extension_source = extension.read_text(encoding="utf-8")
+if (
+    'import {{ Type }} from "typebox";' not in extension_source
+    or "registerTool" not in extension_source
+    or "WMO_PI_BRIDGE_URL" not in extension_source
+):
+    raise SystemExit(14)
+if arguments[-1] != instruction:
+    raise SystemExit(15)
+agent_dir = Path(os.environ["PI_CODING_AGENT_DIR"])
+model_config = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
+provider = model_config["providers"]["wmo-injected"]
+if provider["models"][0]["id"] != "wmo-injected-model":
+    raise SystemExit(16)
+tools = json.loads(Path(os.environ["WMO_PI_TOOLS_PATH"]).read_text(encoding="utf-8"))
+if tools["tools"][0]["name"] != "lookup":
     raise SystemExit(17)
+bridge_url = os.environ["WMO_PI_BRIDGE_URL"]
+def post(path, payload):
+    request = Request(
+        bridge_url + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={{"content-type": "application/json"}},
+        method="POST",
+    )
+    with urlopen(request) as response:
+        return response.read()
+completion = post("/v1/chat/completions", {{
+    "messages": [{{"role": "user", "content": instruction}}],
+    "stream": True,
+}})
+if b"Injected model output." not in completion or b'"name":"lookup"' not in completion:
+    raise SystemExit(18)
+if b"data: [DONE]" not in completion:
+    raise SystemExit(20)
+tool_result = post("/tools/lookup", {{"call_id": "pi-call", "arguments": {{"id": "record-1"}}}})
+tool_result = json.loads(tool_result)
+if tool_result["content"] != "tool response" or tool_result["is_error"]:
+    raise SystemExit(19)
 events = [
-    {{"type": "session", "version": 3}},
-    {{"type": "agent_start"}},
-    {{
-        "type": "message_end",
-        "message": {{
-            "role": "assistant",
-            "timestamp": "2026-08-11T00:00:00+00:00",
-            "content": [
-                {{"type": "text", "text": "Pi completed the task"}},
-                {{
-                    "type": "toolCall",
-                    "id": "pi-call",
-                    "name": "lookup",
-                    "arguments": {{"id": "record-1"}},
-                }},
-            ],
-        }},
-    }},
+    {{"type": "message_end", "message": {{
+        "role": "assistant",
+        "timestamp": "2026-08-11T00:00:00+00:00",
+        "content": [
+            {{"type": "text", "text": "Pi completed the task"}},
+            {{
+                "type": "toolCall",
+                "id": "pi-call",
+                "name": "lookup",
+                "arguments": {{"id": "record-1"}},
+            }},
+        ],
+    }}}},
     {{
         "type": "tool_execution_start",
         "timestamp": "2026-08-11T00:00:01+00:00",
@@ -197,6 +408,17 @@ events = [
 ]
 sys.stdout.write("\\n".join(json.dumps(event) for event in events) + "\\n")
 """,
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | S_IXUSR)
+    return executable
+
+
+def _write_sleeping_pi_fixture(tmp_path: Path) -> Path:
+    """Write a deterministic local executable that exceeds the supplied subprocess deadline."""
+    executable = tmp_path / "pi-sleeping-fixture"
+    executable.write_text(
+        f"#!{sys.executable}\nimport time\ntime.sleep(60)\n",
         encoding="utf-8",
     )
     executable.chmod(executable.stat().st_mode | S_IXUSR)

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -119,6 +119,29 @@ def test_installed_pi_parses_a_0731_numeric_millisecond_timestamp(tmp_path: Path
     assert episode.events[0].ended_at == expected_timestamp
 
 
+def test_pi_distinguishes_numeric_second_timestamps_from_milliseconds() -> None:
+    """Unix seconds keep their wall-clock value instead of collapsing near the epoch."""
+    episode = _episode_from_pi_events(
+        _pi_events(
+            [
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "timestamp": 1_733_234_567.89,
+                        "content": [{"type": "text", "text": "Complete."}],
+                    },
+                },
+                {"type": "agent_end"},
+            ]
+        )
+    )
+
+    expected_timestamp = datetime(2024, 12, 3, 14, 2, 47, 890000, tzinfo=UTC)
+    assert episode.events[0].started_at == expected_timestamp
+    assert episode.events[0].ended_at == expected_timestamp
+
+
 def test_pi_rejects_an_absurd_numeric_millisecond_timestamp() -> None:
     """Unrepresentable integer timestamps are transcript errors, not leaked overflows."""
     with pytest.raises(PiTranscriptError, match="invalid timestamp"):

--- a/wmo/runtime/agents/pi_test.py
+++ b/wmo/runtime/agents/pi_test.py
@@ -9,14 +9,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from stat import S_IXUSR
 from types import TracebackType
-from typing import Protocol
 
 import pytest
 
 from wmo.common.core.artifacts import FailureAttribution, FailureCode
 from wmo.common.models import (
     AssistantAction,
-    ModelMessage,
+    ModelRequest,
     ModelResponse,
     ModelSnapshot,
     OperationEconomics,
@@ -274,13 +273,13 @@ def test_pi_rejects_a_transcript_that_ends_before_agent_end() -> None:
 
 
 class _Model:
-    """A deterministic W2 temporary model client used by the Pi binding fixture."""
+    """A deterministic canonical model client used by the Pi binding fixture."""
 
     def __init__(self) -> None:
-        self.requests: list[_PiRequestView] = []
+        self.requests: list[ModelRequest] = []
 
-    def complete(self, request: _PiRequestView) -> ModelResponse:
-        """Record the private bridge request and return a deterministic injected completion."""
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Record the canonical request and return a deterministic injected completion."""
         self.requests.append(request)
         return ModelResponse(
             output=AssistantAction(
@@ -293,21 +292,10 @@ class _Model:
                 provider="fixture",
                 model_id="fixture-model",
                 capabilities_sha256=_DIGEST,
+                connection_sha256=_DIGEST,
             ),
             economics=OperationEconomics(),
         )
-
-
-class _PiRequestView(Protocol):
-    """The W2 bridge fields the deterministic fixture needs to inspect."""
-
-    @property
-    def messages(self) -> tuple[ModelMessage, ...]:
-        """Return the WMO-visible messages forwarded from Pi."""
-
-    @property
-    def tools(self) -> tuple[ToolSchema, ...]:
-        """Return the task-visible tools forwarded from Pi."""
 
 
 class _Environment:

--- a/wmo/runtime/environments/__init__.py
+++ b/wmo/runtime/environments/__init__.py
@@ -1,9 +1,10 @@
 """Customer executable-environment contracts."""
 
 from wmo.runtime.environments.interface import (
+    EnvironmentResetError,
     EnvironmentRuntime,
     EnvironmentSession,
     Observation,
 )
 
-__all__ = ["EnvironmentRuntime", "EnvironmentSession", "Observation"]
+__all__ = ["EnvironmentResetError", "EnvironmentRuntime", "EnvironmentSession", "Observation"]

--- a/wmo/runtime/environments/__init__.py
+++ b/wmo/runtime/environments/__init__.py
@@ -1,0 +1,9 @@
+"""Customer executable-environment contracts."""
+
+from wmo.runtime.environments.interface import (
+    EnvironmentRuntime,
+    EnvironmentSession,
+    Observation,
+)
+
+__all__ = ["EnvironmentRuntime", "EnvironmentSession", "Observation"]

--- a/wmo/runtime/environments/interface.py
+++ b/wmo/runtime/environments/interface.py
@@ -1,4 +1,4 @@
-"""The executable-environment boundary owned by a simulator."""
+"""The executable environment interface owned by a simulator."""
 
 from __future__ import annotations
 
@@ -41,13 +41,13 @@ class EnvironmentSession(Protocol):
 
 @runtime_checkable
 class EnvironmentRuntime(Protocol):
-    """Creates isolated environment sessions and owns their context-exit cleanup."""
+    """Creates per-episode environment sessions and owns their context-exit cleanup."""
 
     def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
         """Open a clean environment session for one task.
 
         Args:
-            task: The task whose executable state the session will isolate.
+            task: The task whose executable state the session serves.
 
         Returns:
             A context manager that releases the session when it exits.

--- a/wmo/runtime/environments/interface.py
+++ b/wmo/runtime/environments/interface.py
@@ -20,6 +20,10 @@ class Observation(ContractModel):
     metadata: JsonObject = Field(default_factory=dict)
 
 
+class EnvironmentResetError(RuntimeError):
+    """An environment could not reset a clean session for one episode."""
+
+
 @runtime_checkable
 class EnvironmentSession(Protocol):
     """Executes actions inside one environment already opened by a simulator."""

--- a/wmo/runtime/environments/interface.py
+++ b/wmo/runtime/environments/interface.py
@@ -1,0 +1,50 @@
+"""The executable-environment boundary owned by a simulator."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Protocol, runtime_checkable
+
+from pydantic import Field
+
+from wmo.common.core.artifacts import ContractModel, JsonObject
+from wmo.common.models import ToolCall
+from wmo.common.tasks import TaskCase
+
+
+class Observation(ContractModel):
+    """The structured result of one executable tool call."""
+
+    content: str
+    is_error: bool = False
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+@runtime_checkable
+class EnvironmentSession(Protocol):
+    """Executes actions inside one environment already opened by a simulator."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Execute one tool action and return its observation.
+
+        Args:
+            action: The complete tool invocation emitted by the customer agent.
+
+        Returns:
+            The structured observation produced by the executable environment.
+        """
+
+
+@runtime_checkable
+class EnvironmentRuntime(Protocol):
+    """Creates isolated environment sessions and owns their context-exit cleanup."""
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Open a clean environment session for one task.
+
+        Args:
+            task: The task whose executable state the session will isolate.
+
+        Returns:
+            A context manager that releases the session when it exits.
+        """

--- a/wmo/runtime/environments/interface_test.py
+++ b/wmo/runtime/environments/interface_test.py
@@ -1,0 +1,57 @@
+"""Tests for the simulator-owned executable-environment interfaces."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from types import TracebackType
+
+from wmo.common.models import ToolCall
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments.interface import EnvironmentRuntime, EnvironmentSession, Observation
+
+
+def test_execute_only_session_and_runtime_protocols_accept_conforming_fakes() -> None:
+    runtime = _Runtime()
+    session = _Session()
+
+    assert isinstance(runtime, EnvironmentRuntime)
+    assert isinstance(session, EnvironmentSession)
+    assert session.execute(ToolCall(call_id="call-1", name="lookup")) == Observation(content="ok")
+
+
+def test_observation_round_trips_with_structured_metadata() -> None:
+    observation = Observation(content="tool output", metadata={"exit_code": 0})
+
+    assert Observation.model_validate_json(observation.model_dump_json()) == observation
+
+
+class _Session:
+    """A fake session exposing only the one canonical executable operation."""
+
+    def execute(self, action: ToolCall) -> Observation:
+        return Observation(content="ok")
+
+
+class _Runtime:
+    """A fake simulator owner that opens a clean executable session."""
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        return _Context(_Session())
+
+
+class _Context(AbstractContextManager[EnvironmentSession]):
+    """A basic cleanup-owning context used to prove the protocol boundary."""
+
+    def __init__(self, session: EnvironmentSession) -> None:
+        self._session = session
+
+    def __enter__(self) -> EnvironmentSession:
+        return self._session
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return False


### PR DESCRIPTION
## Summary

- add canonical whole-episode `AgentRuntime`, `AgentEpisode`, `EnvironmentRuntime`, and execute-only `EnvironmentSession` contracts
- compose simulator-owned reset, execution, cleanup, failure attribution, and ordered lifecycle evidence
- add a thin installed-Pi adapter that injects the canonical `ModelClient` and `ModelRequest` plus the supplied environment
- keep task text on stdin, use a private working directory, and normalize ISO, numeric-second, and numeric-millisecond Pi timestamps with bounded integer validation
- retain PostHog telemetry unchanged

## W4.5 deferred physical deletion

W4.5 remains a clean cutover, with no compatibility shim and no new legacy consumers. Physical deletion is deferred until the named W6 and W9 callers migrate because current main still has live consumers.

Exact frozen deletion or adaptation inventory:

- vendored Pi: `wmo/runtime/harness/vendor/pi-agent/`, `wmo/runtime/harness/vendor/manifest.sha256`, `wmo/runtime/harness/vendor/vendor_pi.sh`, and `wmo/runtime/harness/pi_vendor.py`
- legacy Env and episode loop: `wmo/runtime/__init__.py`, `wmo/runtime/environment.py`, `wmo/runtime/episode.py`, and `wmo/runtime/agents/llm.py`
- legacy default vendored-Pi document: `wmo/runtime/agents/default.py`
- duplicate harness execution contracts: `wmo/runtime/harness/environment.py` and `wmo/runtime/harness/runtime.py`
- scoring-on-close owner: `wmo/simulation/environment.py`

Blocking live consumer groups are `wmo/cli/run_cmd.py` and `wmo/cli/model_app.py`, the current closed-loop and routing paths, and Harbor/E2B lifecycle code under `wmo/runtime/evaluation/harbor/` and `wmo/runtime/harness/`. W6 owns judgment and scoring migration. W9 owns Harbor/E2B adaptation. The Harbor ledger, template, retry, transcript, lifecycle, and cleanup inputs remain intact for W9.

This branch adds no import of the vendored Pi or legacy Env, episode, AgentEnvironment, harness runtime, or scoring-on-close owners.

## Validation

- `uv run pytest -q wmo/runtime/agents wmo/runtime/environments`: 55 passed
- `uv run pytest --collect-only -q`: 3,887 collected
- root, package, import, CLI, and line guardrails: 86 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run --locked ty check`: passed
- changed hand-authored files: maximum 957 lines
- fresh Greptile review on `60d575da`: 5/5, no blocking failure

## Change accounting

- production: 8 files, 1,386 lines added, 9 removed
- tests: 5 files, 1,189 lines added
- dependencies: unchanged
