### PR TITLE
W12: build frozen SFT datasets

### DIFF
--- a/wmo/common/traces/__init__.py
+++ b/wmo/common/traces/__init__.py
@@ -1,5 +1,14 @@
 """Canonical normalized production-trace contracts."""
 
+from wmo.common.traces.store import LoadedTraceDataset, load_trace_dataset
 from wmo.common.traces.trace import Trace, TraceDataset, TraceOutcome, TraceSource, TraceSpan
 
-__all__ = ["Trace", "TraceDataset", "TraceOutcome", "TraceSource", "TraceSpan"]
+__all__ = [
+    "LoadedTraceDataset",
+    "Trace",
+    "TraceDataset",
+    "TraceOutcome",
+    "TraceSource",
+    "TraceSpan",
+    "load_trace_dataset",
+]

--- a/wmo/common/traces/store.py
+++ b/wmo/common/traces/store.py
@@ -1,0 +1,74 @@
+"""Verified immutable reads of canonical normalized trace-dataset artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from wmo.common.project import ArtifactCorruptionError, ArtifactStore
+from wmo.common.traces.trace import Trace, TraceDataset
+
+
+@dataclass(frozen=True)
+class LoadedTraceDataset:
+    """One verified trace-dataset envelope and its exact ordered canonical traces.
+
+    Args:
+        dataset: Immutable trace-dataset envelope that names the canonical trace file.
+        traces: Exact ordered trace records parsed from the verified canonical payload.
+    """
+
+    dataset: TraceDataset
+    traces: tuple[Trace, ...]
+
+
+def load_trace_dataset(store: ArtifactStore, dataset_id: str) -> LoadedTraceDataset:
+    """Load one immutable trace-dataset artifact and verify every retained record.
+
+    Args:
+        store: Project-local artifact store that owns the trace-dataset artifact.
+        dataset_id: Exact immutable trace-dataset artifact identity.
+
+    Returns:
+        The verified trace-dataset envelope and exact canonical trace records.
+
+    Raises:
+        ArtifactCorruptionError: The artifact is absent, corrupt, wrong-typed, or internally
+            inconsistent.
+    """
+    stored = store.read(dataset_id)
+    if stored.manifest.artifact_type != "trace-dataset":
+        raise ArtifactCorruptionError(f"artifact {dataset_id} is not a trace-dataset")
+    try:
+        dataset = TraceDataset.model_validate_json(
+            store.read_bytes(dataset_id, "trace-dataset.json")
+        )
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset_id} has an invalid envelope"
+        ) from exc
+    if dataset.dataset_id != dataset_id:
+        raise ArtifactCorruptionError(
+            f"trace-dataset envelope ID {dataset.dataset_id} does not match artifact {dataset_id}"
+        )
+    payload = store.read_bytes(dataset_id, dataset.traces_path)
+    if hashlib.sha256(payload).hexdigest() != dataset.traces_sha256:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset_id} trace digest does not match envelope"
+        )
+    try:
+        traces = tuple(
+            Trace.model_validate_json(line) for line in payload.decode("utf-8").splitlines() if line
+        )
+    except (UnicodeDecodeError, ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset_id} has invalid trace records"
+        ) from exc
+    trace_ids = tuple(trace.trace_id for trace in traces)
+    if trace_ids != dataset.trace_ids:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset_id} trace records do not match ordered trace IDs"
+        )
+    return LoadedTraceDataset(dataset=dataset, traces=traces)

--- a/wmo/common/traces/store_test.py
+++ b/wmo/common/traces/store_test.py
@@ -1,0 +1,72 @@
+"""Tests for verified immutable trace-dataset reads."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from wmo.common.core.artifacts import SourceIdentity
+from wmo.common.project import ArtifactCorruptionError, ArtifactStore, ProjectPaths
+from wmo.common.traces import Trace, TraceSource, TraceSpan
+from wmo.common.traces.store import load_trace_dataset
+from wmo.simulation.ingest.dataset import persist_trace_dataset
+from wmo.simulation.ingest.otlp import TraceNormalizationResult
+
+
+def _store(tmp_path: Path) -> ArtifactStore:
+    """Create one isolated artifact store for trace-dataset read coverage."""
+    return ArtifactStore(ProjectPaths(root=tmp_path, project_id="trace-load"))
+
+
+def _trace(trace_id: str) -> Trace:
+    """Create one exact canonical trace fixture."""
+    return Trace(
+        trace_id=trace_id,
+        task="Resolve support request.",
+        spans=(
+            TraceSpan(
+                span_id="span-1",
+                name="agent.model_call",
+                started_at=datetime(2026, 8, 12, tzinfo=UTC),
+                ended_at=datetime(2026, 8, 12, 0, 0, 1, tzinfo=UTC),
+            ),
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(kind="otlp", source_id="fixture", sha256="a" * 64),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def test_load_trace_dataset_returns_verified_envelope_and_records(tmp_path: Path) -> None:
+    """The loader returns only records from a digest-verified canonical payload."""
+    store = _store(tmp_path)
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(_trace("trace-1"),), issues=()),
+        store,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        code_revision="test",
+    )
+
+    loaded = load_trace_dataset(store, persisted.dataset.dataset_id)
+
+    assert loaded.dataset == persisted.dataset
+    assert loaded.traces == persisted.traces
+
+
+def test_load_trace_dataset_rejects_payload_corruption(tmp_path: Path) -> None:
+    """A changed source record cannot be hydrated into an SFT build."""
+    store = _store(tmp_path)
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(_trace("trace-1"),), issues=()),
+        store,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        code_revision="test",
+    )
+    path = store.read(persisted.dataset.dataset_id).directory / persisted.dataset.traces_path
+    path.write_text('{"trace_id":"forged"}\n', encoding="utf-8")
+
+    with pytest.raises(ArtifactCorruptionError, match="data file digest mismatch"):
+        load_trace_dataset(store, persisted.dataset.dataset_id)

--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -1,0 +1,63 @@
+"""Frozen, leakage-safe SFT dataset construction from accepted WMO evidence."""
+
+from wmo.optimize.model.sft.builder import (
+    SFTBuildError,
+    SFTBuildSpec,
+    build_sft_dataset,
+    ensure_no_cross_split_fingerprints,
+    load_sft_dataset,
+    write_sft_dataset,
+)
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    HumanApproval,
+    InfrastructureFailureEvent,
+    PartitionedSFTExample,
+    ProductionAcceptanceEvidence,
+    ProductionAcceptanceRule,
+    ProductionSFTSource,
+    SFTDataset,
+    SFTDatasetArtifact,
+    SFTExample,
+    SFTMessage,
+    SFTTranscript,
+    TeacherAcceptanceEvidence,
+    TeacherAcceptanceRule,
+    TeacherSFTSource,
+    ToolEvent,
+)
+from wmo.optimize.model.sft.rendering import (
+    CanonicalSFTTurn,
+    context_target_fingerprint,
+    parse_rendered_turn,
+    render_context_target,
+)
+
+__all__ = [
+    "AssistantActionEvent",
+    "CanonicalSFTTurn",
+    "HumanApproval",
+    "InfrastructureFailureEvent",
+    "PartitionedSFTExample",
+    "ProductionAcceptanceEvidence",
+    "ProductionAcceptanceRule",
+    "ProductionSFTSource",
+    "SFTBuildError",
+    "SFTBuildSpec",
+    "SFTDataset",
+    "SFTDatasetArtifact",
+    "SFTExample",
+    "SFTMessage",
+    "SFTTranscript",
+    "TeacherAcceptanceEvidence",
+    "TeacherAcceptanceRule",
+    "TeacherSFTSource",
+    "ToolEvent",
+    "build_sft_dataset",
+    "context_target_fingerprint",
+    "ensure_no_cross_split_fingerprints",
+    "load_sft_dataset",
+    "parse_rendered_turn",
+    "render_context_target",
+    "write_sft_dataset",
+]

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -443,16 +443,12 @@ def _prepare_teacher_source(source: TeacherSFTSource) -> tuple[_PreparedSource, 
     """Normalize one teacher bundle and verify its immutable acceptance chain."""
     rollout_sha256 = sha256_json(source.rollout)
     evidence_sha256 = sha256_json(source.acceptance_evidence)
-    lineage_group_id = stable_id(
-        "sft-lineage",
-        {"kind": "teacher_rollout", "source_lineage": source.rollout.task_id},
-    )
     prepared = _PreparedSource(
         kind="teacher_rollout",
         source_id=source.rollout.rollout_id,
         source_sha256=rollout_sha256,
-        leakage_group_id=lineage_group_id,
-        task=source.task,
+        leakage_group_id=source.task.lineage_group_id,
+        task=source.task.instruction,
         transcript_events=source.transcript.events,
         example_source=RolloutExampleSource(
             rollout_id=source.rollout.rollout_id,
@@ -527,6 +523,10 @@ def _teacher_acceptance_error(source: TeacherSFTSource, rollout_sha256: Sha256) 
         return "teacher rollout has a recorded infrastructure span failure"
     if source.rollout.evidence_source not in {"world_model", "sandbox"}:
         return "teacher rollout must come from a world-model or sandbox simulation"
+    if source.rollout.task_id != source.task.task_id:
+        return "teacher rollout names a different canonical task"
+    if source.task.task_id not in source.task_set.task_ids:
+        return "teacher task is not a member of the supplied task set"
     if evidence.rollout_id != source.rollout.rollout_id:
         return "teacher acceptance evidence names a different rollout"
     if evidence.rollout_sha256 != rollout_sha256:
@@ -803,6 +803,7 @@ def _teacher_inputs(source: TeacherSFTSource) -> tuple[ArtifactInput, ...]:
             artifact_id=source.rollout.artifact_id,
             sha256=sha256_json(source.rollout),
         ),
+        _model_input(source.task_set.task_set_id, source.task_set),
         _model_input(source.acceptance_rule.acceptance_rule_id, source.acceptance_rule),
         _model_input(source.acceptance_evidence.acceptance_evidence_id, source.acceptance_evidence),
         _model_input(source.judgment.judgment_id, source.judgment),

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -30,7 +30,6 @@ from wmo.optimize.model.sft.contracts import (
     InfrastructureFailureEvent,
     PartitionedSFTExample,
     ProductionSFTSource,
-    RolloutExampleSource,
     SFTContextEvent,
     SFTDataset,
     SFTDatasetArtifact,
@@ -50,6 +49,12 @@ from wmo.optimize.model.sft.rendering import (
     context_target_fingerprint,
     partitioned_rows_sha256,
 )
+from wmo.optimize.model.sft.sources import (
+    PreparedSFTSource,
+    SFTSourceVerificationError,
+    resolve_production_source,
+    resolve_teacher_source,
+)
 
 
 class SFTBuildError(ValueError):
@@ -65,29 +70,10 @@ class SFTBuildSpec(ContractModel):
 
 
 @dataclass(frozen=True)
-class _PreparedSource:
-    """One accepted source normalized before transcript scanning."""
-
-    kind: Literal["production_trace", "teacher_rollout"]
-    source_id: str
-    source_sha256: Sha256
-    leakage_group_id: ArtifactId
-    task: str
-    transcript_events: tuple[
-        SFTMessage | AssistantActionEvent | ToolEvent | InfrastructureFailureEvent, ...
-    ]
-    example_source: TraceExampleSource | RolloutExampleSource
-    score: float | None
-    direct_inputs: tuple[ArtifactInput, ...]
-    acceptance_rule_id: ArtifactId
-    acceptance_evidence_id: ArtifactId
-
-
-@dataclass(frozen=True)
 class _ScannedAction:
     """A canonical target discovered before partition assignment or row emission."""
 
-    source: _PreparedSource
+    source: PreparedSFTSource
     source_step_index: int
     history: tuple[SFTContextEvent, ...]
     fingerprint: Sha256
@@ -122,6 +108,7 @@ class _UnionFind:
 
 def build_sft_dataset(
     *,
+    store: ProjectStore,
     production_sources: Sequence[ProductionSFTSource],
     teacher_sources: Sequence[TeacherSFTSource],
     spec: SFTBuildSpec,
@@ -131,8 +118,9 @@ def build_sft_dataset(
     """Build one deterministic SFT dataset from accepted production and teacher evidence.
 
     Args:
-        production_sources: Typed production traces with immutable acceptance decisions.
-        teacher_sources: Typed teacher rollouts with judgment, calibration, and fidelity evidence.
+        store: One project-local immutable artifact store that owns every source chain.
+        production_sources: Pointers to persisted production-acceptance artifacts.
+        teacher_sources: Pointers to persisted teacher-acceptance artifacts.
         spec: Frozen split and sampling controls for this build.
         created_at: Time recorded in the resulting immutable dataset envelope.
         code_revision: Exact revision that built the artifact.
@@ -141,72 +129,39 @@ def build_sft_dataset(
         A complete in-memory dataset, including rows, manifest metadata, and exclusions.
 
     Raises:
-        SFTBuildError: Source identities repeat or a computed leakage invariant is violated.
+        SFTBuildError: A source cannot be verified from ``store``, identities repeat, or a
+            computed leakage invariant is violated.
     """
     _require_timezone(created_at, label="dataset creation")
     if not code_revision:
         raise SFTBuildError("code_revision must be non-empty")
 
-    prepared: list[_PreparedSource] = []
+    prepared: list[PreparedSFTSource] = []
     source_references: list[SFTSourceReference] = []
     exclusions: list[SFTExclusion] = []
     seen_source_keys: set[tuple[str, str]] = set()
 
-    for source in sorted(production_sources, key=lambda item: item.trace.trace_id):
-        source_key = ("production_trace", source.trace.trace_id)
-        _require_unique_source_key(seen_source_keys, source_key)
-        candidate, error = _prepare_production_source(source)
-        source_references.append(
-            SFTSourceReference(
-                kind="production_trace",
-                source_id=candidate.source_id,
-                source_sha256=candidate.source_sha256,
-                leakage_group_id=candidate.leakage_group_id,
-                acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-                acceptance_evidence_sha256=sha256_json(source.acceptance_evidence),
-                accepted=error is None,
-                exclusion_reason=error,
-            )
-        )
-        if error is not None:
-            exclusions.append(
-                SFTExclusion(
-                    source_kind="production_trace",
-                    source_id=candidate.source_id,
-                    reason="invalid_production_acceptance",
-                    detail=error,
-                )
-            )
-            continue
+    for source in sorted(production_sources, key=lambda item: item.acceptance_evidence_id):
+        try:
+            candidate = resolve_production_source(store, source)
+        except SFTSourceVerificationError as exc:
+            raise SFTBuildError(
+                f"production source {source.acceptance_evidence_id} is not accepted evidence: {exc}"
+            ) from exc
+        _require_unique_source_key(seen_source_keys, (candidate.kind, candidate.source_id))
         prepared.append(candidate)
+        source_references.append(candidate.reference())
 
-    for source in sorted(teacher_sources, key=lambda item: item.rollout.rollout_id):
-        source_key = ("teacher_rollout", source.rollout.rollout_id)
-        _require_unique_source_key(seen_source_keys, source_key)
-        candidate, error = _prepare_teacher_source(source)
-        source_references.append(
-            SFTSourceReference(
-                kind="teacher_rollout",
-                source_id=candidate.source_id,
-                source_sha256=candidate.source_sha256,
-                leakage_group_id=candidate.leakage_group_id,
-                acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-                acceptance_evidence_sha256=sha256_json(source.acceptance_evidence),
-                accepted=error is None,
-                exclusion_reason=error,
-            )
-        )
-        if error is not None:
-            exclusions.append(
-                SFTExclusion(
-                    source_kind="teacher_rollout",
-                    source_id=candidate.source_id,
-                    reason="invalid_teacher_acceptance",
-                    detail=error,
-                )
-            )
-            continue
+    for source in sorted(teacher_sources, key=lambda item: item.acceptance_evidence_id):
+        try:
+            candidate = resolve_teacher_source(store, source)
+        except SFTSourceVerificationError as exc:
+            raise SFTBuildError(
+                f"teacher source {source.acceptance_evidence_id} is not accepted evidence: {exc}"
+            ) from exc
+        _require_unique_source_key(seen_source_keys, (candidate.kind, candidate.source_id))
         prepared.append(candidate)
+        source_references.append(candidate.reference())
 
     scanned_actions: list[_ScannedAction] = []
     for source in prepared:
@@ -408,169 +363,8 @@ def load_sft_dataset(
     return artifact
 
 
-def _prepare_production_source(
-    source: ProductionSFTSource,
-) -> tuple[_PreparedSource, str | None]:
-    """Normalize one production bundle and verify its immutable acceptance chain."""
-    trace_sha256 = sha256_json(source.trace)
-    evidence_sha256 = sha256_json(source.acceptance_evidence)
-    lineage_key = source.trace.conversation_id or source.trace.trace_id
-    lineage_group_id = stable_id(
-        "sft-lineage",
-        {"kind": "production_trace", "source_lineage": lineage_key},
-    )
-    prepared = _PreparedSource(
-        kind="production_trace",
-        source_id=source.trace.trace_id,
-        source_sha256=trace_sha256,
-        leakage_group_id=lineage_group_id,
-        task=source.trace.task,
-        transcript_events=source.transcript.events,
-        example_source=TraceExampleSource(
-            trace_id=source.trace.trace_id,
-            acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-            acceptance_evidence_sha256=evidence_sha256,
-        ),
-        score=None,
-        direct_inputs=_production_inputs(source),
-        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
-        acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-    )
-    return prepared, _production_acceptance_error(source, trace_sha256)
-
-
-def _prepare_teacher_source(source: TeacherSFTSource) -> tuple[_PreparedSource, str | None]:
-    """Normalize one teacher bundle and verify its immutable acceptance chain."""
-    rollout_sha256 = sha256_json(source.rollout)
-    evidence_sha256 = sha256_json(source.acceptance_evidence)
-    prepared = _PreparedSource(
-        kind="teacher_rollout",
-        source_id=source.rollout.rollout_id,
-        source_sha256=rollout_sha256,
-        leakage_group_id=source.task.lineage_group_id,
-        task=source.task.instruction,
-        transcript_events=source.transcript.events,
-        example_source=RolloutExampleSource(
-            rollout_id=source.rollout.rollout_id,
-            acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-            acceptance_evidence_sha256=evidence_sha256,
-        ),
-        score=source.acceptance_evidence.observed_overall_score,
-        direct_inputs=_teacher_inputs(source),
-        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
-        acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
-    )
-    return prepared, _teacher_acceptance_error(source, rollout_sha256)
-
-
-def _production_acceptance_error(source: ProductionSFTSource, trace_sha256: Sha256) -> str | None:
-    """Return the first explicit production-acceptance failure, if any."""
-    try:
-        ProductionSFTSource.model_validate(source.model_dump(mode="python"))
-    except ValidationError:
-        return "production source contains invalid immutable acceptance evidence"
-    evidence = source.acceptance_evidence
-    rule = source.acceptance_rule
-    if evidence.trace_id != source.trace.trace_id:
-        return "acceptance evidence names a different production trace"
-    if evidence.trace_sha256 != trace_sha256:
-        return "production trace digest does not match acceptance evidence"
-    if evidence.acceptance_rule_id != rule.acceptance_rule_id:
-        return "production acceptance evidence names a different rule"
-    if evidence.acceptance_rule_sha256 != sha256_json(rule):
-        return "production acceptance-rule digest does not match"
-    if source.trace.outcome is not None and source.trace.outcome.status == "failure":
-        return "production trace has a terminal infrastructure failure"
-    if any(span.failure is not None for span in source.trace.spans):
-        return "production trace has a recorded infrastructure span failure"
-    if evidence.decision == "trusted_outcome":
-        outcome = source.trace.outcome
-        if outcome is None or outcome.status != "success":
-            return "trusted-outcome evidence requires a successful production outcome"
-        if evidence.outcome_sha256 != sha256_json(outcome):
-            return "production outcome digest does not match acceptance evidence"
-        if outcome.outcome_name not in rule.accepted_outcomes:
-            return "production outcome is not trusted by the acceptance rule"
-        return None
-    approval = source.human_approval
-    if not rule.allow_human_approval:
-        return "production acceptance rule does not allow human approval"
-    if approval is None:
-        return "human-approval evidence requires the immutable approval record"
-    if approval.trace_id != source.trace.trace_id:
-        return "human approval names a different production trace"
-    if evidence.human_approval_id != approval.approval_id:
-        return "human approval identity does not match acceptance evidence"
-    if evidence.human_approval_sha256 != sha256_json(approval):
-        return "human approval digest does not match acceptance evidence"
-    return None
-
-
-def _teacher_acceptance_error(source: TeacherSFTSource, rollout_sha256: Sha256) -> str | None:
-    """Return the first explicit teacher-acceptance failure, if any."""
-    try:
-        TeacherSFTSource.model_validate(source.model_dump(mode="python"))
-    except ValidationError:
-        return "teacher source contains invalid immutable acceptance evidence"
-    evidence = source.acceptance_evidence
-    rule = source.acceptance_rule
-    judgment_sha256 = sha256_json(source.judgment)
-    calibration_sha256 = sha256_json(source.calibration)
-    fidelity_sha256 = sha256_json(source.fidelity)
-    if source.rollout.failure is not None or source.rollout.stop_reason != "completed":
-        return "teacher rollout has an infrastructure or execution failure"
-    if any(span.failure is not None for span in source.rollout.spans):
-        return "teacher rollout has a recorded infrastructure span failure"
-    if source.rollout.evidence_source not in {"world_model", "sandbox"}:
-        return "teacher rollout must come from a world-model or sandbox simulation"
-    if source.rollout.task_id != source.task.task_id:
-        return "teacher rollout names a different canonical task"
-    if source.task.task_id not in source.task_set.task_ids:
-        return "teacher task is not a member of the supplied task set"
-    if evidence.rollout_id != source.rollout.rollout_id:
-        return "teacher acceptance evidence names a different rollout"
-    if evidence.rollout_sha256 != rollout_sha256:
-        return "teacher rollout digest does not match acceptance evidence"
-    if evidence.judgment_id != source.judgment.judgment_id:
-        return "teacher acceptance evidence names a different judgment"
-    if evidence.judgment_sha256 != judgment_sha256:
-        return "teacher judgment digest does not match acceptance evidence"
-    if evidence.calibration_id != source.calibration.calibration_id:
-        return "teacher acceptance evidence names a different calibration"
-    if evidence.calibration_sha256 != calibration_sha256:
-        return "teacher calibration digest does not match acceptance evidence"
-    if evidence.fidelity_report_id != source.fidelity.fidelity_report_id:
-        return "teacher acceptance evidence names a different fidelity report"
-    if evidence.fidelity_report_sha256 != fidelity_sha256:
-        return "teacher fidelity digest does not match acceptance evidence"
-    if evidence.acceptance_rule_id != rule.acceptance_rule_id:
-        return "teacher acceptance evidence names a different rule"
-    if evidence.acceptance_rule_sha256 != sha256_json(rule):
-        return "teacher acceptance-rule digest does not match"
-    if source.judgment.rollout_id != source.rollout.rollout_id:
-        return "teacher judgment does not belong to the accepted rollout"
-    if source.judgment.calibration_id != source.calibration.calibration_id:
-        return "teacher judgment does not use the accepted calibration"
-    if source.calibration.status != "human_calibrated" or source.calibration.approved_at is None:
-        return "teacher rollout requires an approved human-calibrated judge"
-    if rule.required_calibration_id != source.calibration.calibration_id:
-        return "teacher acceptance rule requires a different calibration"
-    if source.fidelity.status != "approved" or source.fidelity.approved_at is None:
-        return "teacher rollout requires approved fidelity evidence"
-    if not math.isclose(
-        evidence.observed_overall_score,
-        source.judgment.overall_score,
-        rel_tol=1e-12,
-        abs_tol=1e-12,
-    ):
-        return "teacher acceptance score does not match the frozen judgment"
-    if evidence.observed_overall_score < rule.minimum_overall_score:
-        return "teacher judgment score does not meet the acceptance rule"
-    return None
-
-
 def _scan_source_actions(
-    source: _PreparedSource,
+    source: PreparedSFTSource,
 ) -> tuple[list[_ScannedAction], list[SFTExclusion]]:
     """Scan targets and fingerprints without emitting examples or assigning a partition."""
     history: list[SFTContextEvent] = []
@@ -783,41 +577,6 @@ def _globally_deduplicate(
                 )
             )
     return tuple(kept), tuple(exclusions)
-
-
-def _production_inputs(source: ProductionSFTSource) -> tuple[ArtifactInput, ...]:
-    """Collect immutable production provenance retained by the final dataset envelope."""
-    inputs = [
-        _model_input(source.acceptance_rule.acceptance_rule_id, source.acceptance_rule),
-        _model_input(source.acceptance_evidence.acceptance_evidence_id, source.acceptance_evidence),
-    ]
-    if source.human_approval is not None:
-        inputs.append(_model_input(source.human_approval.approval_id, source.human_approval))
-    return tuple(inputs)
-
-
-def _teacher_inputs(source: TeacherSFTSource) -> tuple[ArtifactInput, ...]:
-    """Collect immutable teacher provenance retained by the final dataset envelope."""
-    return (
-        ArtifactInput(
-            artifact_id=source.rollout.artifact_id,
-            sha256=sha256_json(source.rollout),
-        ),
-        _model_input(source.task_set.task_set_id, source.task_set),
-        _model_input(source.acceptance_rule.acceptance_rule_id, source.acceptance_rule),
-        _model_input(source.acceptance_evidence.acceptance_evidence_id, source.acceptance_evidence),
-        _model_input(source.judgment.judgment_id, source.judgment),
-        _model_input(source.calibration.calibration_id, source.calibration),
-        ArtifactInput(
-            artifact_id=source.fidelity.fidelity_report_id,
-            sha256=sha256_json(source.fidelity),
-        ),
-    )
-
-
-def _model_input(artifact_id: ArtifactId, value: ContractModel) -> ArtifactInput:
-    """Create a deterministic artifact-style reference for one frozen typed record."""
-    return ArtifactInput(artifact_id=artifact_id, sha256=sha256_json(value))
 
 
 def _sorted_inputs(inputs: Iterable[ArtifactInput]) -> tuple[ArtifactInput, ...]:

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -1,0 +1,961 @@
+"""Build, inspect, persist, and reload frozen leakage-safe SFT datasets."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, ValidationError
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ProjectStore,
+)
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    InfrastructureFailureEvent,
+    PartitionedSFTExample,
+    ProductionSFTSource,
+    RolloutExampleSource,
+    SFTContextEvent,
+    SFTDataset,
+    SFTDatasetArtifact,
+    SFTDatasetMetadata,
+    SFTExample,
+    SFTExclusion,
+    SFTInspectionReport,
+    SFTMessage,
+    SFTPartition,
+    SFTSourceReference,
+    TeacherSFTSource,
+    ToolEvent,
+    TraceExampleSource,
+)
+from wmo.optimize.model.sft.rendering import (
+    canonical_partitioned_rows_jsonl,
+    context_target_fingerprint,
+    partitioned_rows_sha256,
+)
+
+
+class SFTBuildError(ValueError):
+    """Raised when SFT input provenance, partitioning, or artifact integrity is invalid."""
+
+
+class SFTBuildSpec(ContractModel):
+    """Deterministic controls for one frozen SFT dataset build."""
+
+    held_out_fraction: float = Field(default=0.20, gt=0, lt=1)
+    representative_sample_count: int = Field(default=3, ge=0)
+    split_salt: str = Field(default="wmo-sft-split-v1", min_length=1, max_length=256)
+
+
+@dataclass(frozen=True)
+class _PreparedSource:
+    """One accepted source normalized before transcript scanning."""
+
+    kind: Literal["production_trace", "teacher_rollout"]
+    source_id: str
+    source_sha256: Sha256
+    leakage_group_id: ArtifactId
+    task: str
+    transcript_events: tuple[
+        SFTMessage | AssistantActionEvent | ToolEvent | InfrastructureFailureEvent, ...
+    ]
+    example_source: TraceExampleSource | RolloutExampleSource
+    score: float | None
+    direct_inputs: tuple[ArtifactInput, ...]
+    acceptance_rule_id: ArtifactId
+    acceptance_evidence_id: ArtifactId
+
+
+@dataclass(frozen=True)
+class _ScannedAction:
+    """A canonical target discovered before partition assignment or row emission."""
+
+    source: _PreparedSource
+    source_step_index: int
+    history: tuple[SFTContextEvent, ...]
+    fingerprint: Sha256
+    target: AssistantActionEvent
+
+
+class _UnionFind:
+    """A deterministic disjoint-set structure for leakage-component construction."""
+
+    def __init__(self, values: Iterable[ArtifactId]) -> None:
+        self._parent = {value: value for value in values}
+
+    def find(self, value: ArtifactId) -> ArtifactId:
+        """Return the canonical root of one leakage group."""
+        parent = self._parent[value]
+        if parent != value:
+            parent = self.find(parent)
+            self._parent[value] = parent
+        return parent
+
+    def union(self, left: ArtifactId, right: ArtifactId) -> None:
+        """Join two groups while retaining the lexically stable root."""
+        left_root = self.find(left)
+        right_root = self.find(right)
+        if left_root == right_root:
+            return
+        if left_root < right_root:
+            self._parent[right_root] = left_root
+        else:
+            self._parent[left_root] = right_root
+
+
+def build_sft_dataset(
+    *,
+    production_sources: Sequence[ProductionSFTSource],
+    teacher_sources: Sequence[TeacherSFTSource],
+    spec: SFTBuildSpec,
+    created_at: datetime,
+    code_revision: str,
+) -> SFTDatasetArtifact:
+    """Build one deterministic SFT dataset from accepted production and teacher evidence.
+
+    Args:
+        production_sources: Typed production traces with immutable acceptance decisions.
+        teacher_sources: Typed teacher rollouts with judgment, calibration, and fidelity evidence.
+        spec: Frozen split and sampling controls for this build.
+        created_at: Time recorded in the resulting immutable dataset envelope.
+        code_revision: Exact revision that built the artifact.
+
+    Returns:
+        A complete in-memory dataset, including rows, manifest metadata, and exclusions.
+
+    Raises:
+        SFTBuildError: Source identities repeat or a computed leakage invariant is violated.
+    """
+    _require_timezone(created_at, label="dataset creation")
+    if not code_revision:
+        raise SFTBuildError("code_revision must be non-empty")
+
+    prepared: list[_PreparedSource] = []
+    source_references: list[SFTSourceReference] = []
+    exclusions: list[SFTExclusion] = []
+    seen_source_keys: set[tuple[str, str]] = set()
+
+    for source in sorted(production_sources, key=lambda item: item.trace.trace_id):
+        source_key = ("production_trace", source.trace.trace_id)
+        _require_unique_source_key(seen_source_keys, source_key)
+        candidate, error = _prepare_production_source(source)
+        source_references.append(
+            SFTSourceReference(
+                kind="production_trace",
+                source_id=candidate.source_id,
+                source_sha256=candidate.source_sha256,
+                leakage_group_id=candidate.leakage_group_id,
+                acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+                acceptance_evidence_sha256=sha256_json(source.acceptance_evidence),
+                accepted=error is None,
+                exclusion_reason=error,
+            )
+        )
+        if error is not None:
+            exclusions.append(
+                SFTExclusion(
+                    source_kind="production_trace",
+                    source_id=candidate.source_id,
+                    reason="invalid_production_acceptance",
+                    detail=error,
+                )
+            )
+            continue
+        prepared.append(candidate)
+
+    for source in sorted(teacher_sources, key=lambda item: item.rollout.rollout_id):
+        source_key = ("teacher_rollout", source.rollout.rollout_id)
+        _require_unique_source_key(seen_source_keys, source_key)
+        candidate, error = _prepare_teacher_source(source)
+        source_references.append(
+            SFTSourceReference(
+                kind="teacher_rollout",
+                source_id=candidate.source_id,
+                source_sha256=candidate.source_sha256,
+                leakage_group_id=candidate.leakage_group_id,
+                acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+                acceptance_evidence_sha256=sha256_json(source.acceptance_evidence),
+                accepted=error is None,
+                exclusion_reason=error,
+            )
+        )
+        if error is not None:
+            exclusions.append(
+                SFTExclusion(
+                    source_kind="teacher_rollout",
+                    source_id=candidate.source_id,
+                    reason="invalid_teacher_acceptance",
+                    detail=error,
+                )
+            )
+            continue
+        prepared.append(candidate)
+
+    scanned_actions: list[_ScannedAction] = []
+    for source in prepared:
+        scanned, source_exclusions = _scan_source_actions(source)
+        scanned_actions.extend(scanned)
+        exclusions.extend(source_exclusions)
+
+    group_partitions, partitions = _build_partitions(scanned_actions, spec)
+    provisional_rows = _expand_scanned_actions(scanned_actions, group_partitions)
+    ensure_no_cross_split_fingerprints(provisional_rows)
+    rows, dedupe_exclusions = _globally_deduplicate(provisional_rows, scanned_actions)
+    exclusions.extend(dedupe_exclusions)
+    rows = tuple(sorted(rows, key=_row_sort_key))
+    exclusions = sorted(exclusions, key=_exclusion_sort_key)
+
+    all_inputs = _sorted_inputs(
+        input_item for source in prepared for input_item in source.direct_inputs
+    )
+    source_references = sorted(source_references, key=lambda item: (item.kind, item.source_id))
+    partitions = tuple(sorted(partitions, key=lambda item: item.component_id))
+    build_sha256 = _build_digest(
+        spec=spec,
+        sources=tuple(source_references),
+        partitions=partitions,
+        rows=rows,
+        exclusions=tuple(exclusions),
+        inputs=all_inputs,
+    )
+    dataset_id = stable_id("sft-dataset", {"build_sha256": build_sha256})
+
+    train_rows = tuple(row for row in rows if row.partition == "train")
+    held_out_rows = tuple(row for row in rows if row.partition == "held_out")
+    train_groups = tuple(
+        sorted(group_id for group_id, partition in group_partitions.items() if partition == "train")
+    )
+    held_out_groups = tuple(
+        sorted(
+            group_id for group_id, partition in group_partitions.items() if partition == "held_out"
+        )
+    )
+    sample_count = spec.representative_sample_count
+    representative_samples = train_rows[:sample_count] + held_out_rows[:sample_count]
+
+    dataset = SFTDataset(
+        schema_version=1,
+        created_at=created_at,
+        inputs=all_inputs,
+        code_revision=code_revision,
+        dataset_id=dataset_id,
+        build_sha256=build_sha256,
+        status="accepted" if train_rows else "insufficient",
+        acceptance_rule_ids=tuple(sorted({source.acceptance_rule_id for source in prepared})),
+        acceptance_evidence_ids=tuple(
+            sorted({source.acceptance_evidence_id for source in prepared})
+        ),
+        train_leakage_group_ids=train_groups,
+        held_out_leakage_group_ids=held_out_groups,
+        train_example_ids=tuple(sorted(row.example.example_id for row in train_rows)),
+        held_out_example_ids=tuple(sorted(row.example.example_id for row in held_out_rows)),
+        examples_path="examples.jsonl",
+        examples_sha256=partitioned_rows_sha256(rows),
+    )
+    inspection = SFTInspectionReport(
+        report_id=stable_id(
+            "sft-inspection",
+            {"dataset_id": dataset_id, "build_sha256": build_sha256},
+        ),
+        dataset_id=dataset_id,
+        build_sha256=build_sha256,
+        source_count=len(source_references),
+        accepted_source_count=len(prepared),
+        eligible_action_count=len(scanned_actions),
+        fingerprint_count=len({item.fingerprint for item in scanned_actions}),
+        connected_component_count=len(partitions),
+        train_example_count=len(train_rows),
+        held_out_example_count=len(held_out_rows),
+        exclusions=tuple(exclusions),
+        representative_train_example_ids=tuple(
+            row.example.example_id for row in train_rows[:sample_count]
+        ),
+        representative_held_out_example_ids=tuple(
+            row.example.example_id for row in held_out_rows[:sample_count]
+        ),
+    )
+    return SFTDatasetArtifact(
+        dataset=dataset,
+        sources=tuple(source_references),
+        partitions=partitions,
+        inspection=inspection,
+        representative_samples=representative_samples,
+        rows=rows,
+    )
+
+
+def ensure_no_cross_split_fingerprints(rows: Sequence[PartitionedSFTExample]) -> None:
+    """Reject a normalized context-target fingerprint that appears in both partitions.
+
+    Args:
+        rows: Partitioned examples before or after global deduplication.
+
+    Raises:
+        SFTBuildError: The same normalized example crosses the held-out boundary.
+    """
+    partition_by_fingerprint: dict[Sha256, str] = {}
+    for row in rows:
+        existing = partition_by_fingerprint.get(row.fingerprint)
+        if existing is not None and existing != row.partition:
+            raise SFTBuildError(
+                "canonical context-target fingerprint appears in both train and held_out"
+            )
+        partition_by_fingerprint[row.fingerprint] = row.partition
+
+
+def write_sft_dataset(store: ProjectStore, artifact: SFTDatasetArtifact) -> SFTDatasetArtifact:
+    """Persist one dataset as immutable manifest metadata plus canonical JSONL example rows.
+
+    Args:
+        store: Project-local immutable artifact store.
+        artifact: Completed in-memory dataset to freeze.
+
+    Returns:
+        The supplied dataset or its safe idempotent existing equivalent.
+
+    Raises:
+        SFTBuildError: Existing data conflicts or serialized rows violate dataset invariants.
+    """
+    _validate_artifact_rows(artifact)
+    files = {
+        "dataset.json": artifact.metadata().model_dump(mode="json", exclude_none=False),
+        "examples.jsonl": canonical_partitioned_rows_jsonl(artifact.rows),
+    }
+    try:
+        store.artifacts.write(
+            artifact_id=artifact.dataset.dataset_id,
+            artifact_type="sft-dataset",
+            envelope=artifact.dataset,
+            files={
+                "dataset.json": _canonical_metadata_bytes(artifact),
+                "examples.jsonl": files["examples.jsonl"],
+            },
+        )
+    except ArtifactAlreadyExistsError:
+        existing = load_sft_dataset(store, artifact.dataset.dataset_id, require_accepted=False)
+        if (
+            existing.dataset.build_sha256 != artifact.dataset.build_sha256
+            or existing.dataset.examples_sha256 != artifact.dataset.examples_sha256
+        ):
+            raise SFTBuildError(
+                "an existing SFT dataset ID has a different build or example digest"
+            ) from None
+        return existing
+    return artifact
+
+
+def load_sft_dataset(
+    store: ProjectStore, dataset_id: ArtifactId, *, require_accepted: bool = True
+) -> SFTDatasetArtifact:
+    """Load only a verified, previously frozen SFT dataset artifact.
+
+    Args:
+        store: Project-local immutable artifact store.
+        dataset_id: Existing SFT dataset artifact identifier.
+        require_accepted: Reject insufficient datasets that later training must not consume.
+
+    Returns:
+        The verified metadata and example rows suitable for later training work.
+
+    Raises:
+        SFTBuildError: The named artifact is absent, corrupt, wrong-typed, or inconsistent.
+    """
+    try:
+        stored = store.artifacts.read(dataset_id)
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTBuildError(f"frozen SFT dataset is unavailable: {dataset_id}") from exc
+    if stored.manifest.artifact_type != "sft-dataset":
+        raise SFTBuildError(f"artifact {dataset_id} is not an sft-dataset")
+    try:
+        metadata = SFTDatasetMetadata.model_validate_json(
+            store.artifacts.read_bytes(dataset_id, "dataset.json")
+        )
+        rows = _parse_rows(store.artifacts.read_bytes(dataset_id, "examples.jsonl"))
+    except (ArtifactCorruptionError, ValidationError, ValueError) as exc:
+        raise SFTBuildError(f"frozen SFT dataset {dataset_id} has invalid data files") from exc
+    artifact = SFTDatasetArtifact(
+        dataset=metadata.dataset,
+        sources=metadata.sources,
+        partitions=metadata.partitions,
+        inspection=metadata.inspection,
+        representative_samples=metadata.representative_samples,
+        rows=rows,
+    )
+    if artifact.dataset.dataset_id != dataset_id:
+        raise SFTBuildError("SFT dataset metadata does not match its artifact directory")
+    _validate_artifact_rows(artifact)
+    if require_accepted and artifact.dataset.status != "accepted":
+        raise SFTBuildError(
+            f"SFT dataset {dataset_id} is insufficient and cannot be consumed for training"
+        )
+    return artifact
+
+
+def _prepare_production_source(
+    source: ProductionSFTSource,
+) -> tuple[_PreparedSource, str | None]:
+    """Normalize one production bundle and verify its immutable acceptance chain."""
+    trace_sha256 = sha256_json(source.trace)
+    evidence_sha256 = sha256_json(source.acceptance_evidence)
+    lineage_key = source.trace.conversation_id or source.trace.trace_id
+    lineage_group_id = stable_id(
+        "sft-lineage",
+        {"kind": "production_trace", "source_lineage": lineage_key},
+    )
+    prepared = _PreparedSource(
+        kind="production_trace",
+        source_id=source.trace.trace_id,
+        source_sha256=trace_sha256,
+        leakage_group_id=lineage_group_id,
+        task=source.trace.task,
+        transcript_events=source.transcript.events,
+        example_source=TraceExampleSource(
+            trace_id=source.trace.trace_id,
+            acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+            acceptance_evidence_sha256=evidence_sha256,
+        ),
+        score=None,
+        direct_inputs=_production_inputs(source),
+        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
+        acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+    )
+    return prepared, _production_acceptance_error(source, trace_sha256)
+
+
+def _prepare_teacher_source(source: TeacherSFTSource) -> tuple[_PreparedSource, str | None]:
+    """Normalize one teacher bundle and verify its immutable acceptance chain."""
+    rollout_sha256 = sha256_json(source.rollout)
+    evidence_sha256 = sha256_json(source.acceptance_evidence)
+    lineage_group_id = stable_id(
+        "sft-lineage",
+        {"kind": "teacher_rollout", "source_lineage": source.rollout.task_id},
+    )
+    prepared = _PreparedSource(
+        kind="teacher_rollout",
+        source_id=source.rollout.rollout_id,
+        source_sha256=rollout_sha256,
+        leakage_group_id=lineage_group_id,
+        task=source.task,
+        transcript_events=source.transcript.events,
+        example_source=RolloutExampleSource(
+            rollout_id=source.rollout.rollout_id,
+            acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+            acceptance_evidence_sha256=evidence_sha256,
+        ),
+        score=source.acceptance_evidence.observed_overall_score,
+        direct_inputs=_teacher_inputs(source),
+        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
+        acceptance_evidence_id=source.acceptance_evidence.acceptance_evidence_id,
+    )
+    return prepared, _teacher_acceptance_error(source, rollout_sha256)
+
+
+def _production_acceptance_error(source: ProductionSFTSource, trace_sha256: Sha256) -> str | None:
+    """Return the first explicit production-acceptance failure, if any."""
+    try:
+        ProductionSFTSource.model_validate(source.model_dump(mode="python"))
+    except ValidationError:
+        return "production source contains invalid immutable acceptance evidence"
+    evidence = source.acceptance_evidence
+    rule = source.acceptance_rule
+    if evidence.trace_id != source.trace.trace_id:
+        return "acceptance evidence names a different production trace"
+    if evidence.trace_sha256 != trace_sha256:
+        return "production trace digest does not match acceptance evidence"
+    if evidence.acceptance_rule_id != rule.acceptance_rule_id:
+        return "production acceptance evidence names a different rule"
+    if evidence.acceptance_rule_sha256 != sha256_json(rule):
+        return "production acceptance-rule digest does not match"
+    if source.trace.outcome is not None and source.trace.outcome.status == "failure":
+        return "production trace has a terminal infrastructure failure"
+    if any(span.failure is not None for span in source.trace.spans):
+        return "production trace has a recorded infrastructure span failure"
+    if evidence.decision == "trusted_outcome":
+        outcome = source.trace.outcome
+        if outcome is None or outcome.status != "success":
+            return "trusted-outcome evidence requires a successful production outcome"
+        if evidence.outcome_sha256 != sha256_json(outcome):
+            return "production outcome digest does not match acceptance evidence"
+        if outcome.outcome_name not in rule.accepted_outcomes:
+            return "production outcome is not trusted by the acceptance rule"
+        return None
+    approval = source.human_approval
+    if not rule.allow_human_approval:
+        return "production acceptance rule does not allow human approval"
+    if approval is None:
+        return "human-approval evidence requires the immutable approval record"
+    if approval.trace_id != source.trace.trace_id:
+        return "human approval names a different production trace"
+    if evidence.human_approval_id != approval.approval_id:
+        return "human approval identity does not match acceptance evidence"
+    if evidence.human_approval_sha256 != sha256_json(approval):
+        return "human approval digest does not match acceptance evidence"
+    return None
+
+
+def _teacher_acceptance_error(source: TeacherSFTSource, rollout_sha256: Sha256) -> str | None:
+    """Return the first explicit teacher-acceptance failure, if any."""
+    try:
+        TeacherSFTSource.model_validate(source.model_dump(mode="python"))
+    except ValidationError:
+        return "teacher source contains invalid immutable acceptance evidence"
+    evidence = source.acceptance_evidence
+    rule = source.acceptance_rule
+    judgment_sha256 = sha256_json(source.judgment)
+    calibration_sha256 = sha256_json(source.calibration)
+    fidelity_sha256 = sha256_json(source.fidelity)
+    if source.rollout.failure is not None or source.rollout.stop_reason != "completed":
+        return "teacher rollout has an infrastructure or execution failure"
+    if any(span.failure is not None for span in source.rollout.spans):
+        return "teacher rollout has a recorded infrastructure span failure"
+    if source.rollout.evidence_source not in {"world_model", "sandbox"}:
+        return "teacher rollout must come from a world-model or sandbox simulation"
+    if evidence.rollout_id != source.rollout.rollout_id:
+        return "teacher acceptance evidence names a different rollout"
+    if evidence.rollout_sha256 != rollout_sha256:
+        return "teacher rollout digest does not match acceptance evidence"
+    if evidence.judgment_id != source.judgment.judgment_id:
+        return "teacher acceptance evidence names a different judgment"
+    if evidence.judgment_sha256 != judgment_sha256:
+        return "teacher judgment digest does not match acceptance evidence"
+    if evidence.calibration_id != source.calibration.calibration_id:
+        return "teacher acceptance evidence names a different calibration"
+    if evidence.calibration_sha256 != calibration_sha256:
+        return "teacher calibration digest does not match acceptance evidence"
+    if evidence.fidelity_report_id != source.fidelity.fidelity_report_id:
+        return "teacher acceptance evidence names a different fidelity report"
+    if evidence.fidelity_report_sha256 != fidelity_sha256:
+        return "teacher fidelity digest does not match acceptance evidence"
+    if evidence.acceptance_rule_id != rule.acceptance_rule_id:
+        return "teacher acceptance evidence names a different rule"
+    if evidence.acceptance_rule_sha256 != sha256_json(rule):
+        return "teacher acceptance-rule digest does not match"
+    if source.judgment.rollout_id != source.rollout.rollout_id:
+        return "teacher judgment does not belong to the accepted rollout"
+    if source.judgment.calibration_id != source.calibration.calibration_id:
+        return "teacher judgment does not use the accepted calibration"
+    if source.calibration.status != "human_calibrated" or source.calibration.approved_at is None:
+        return "teacher rollout requires an approved human-calibrated judge"
+    if rule.required_calibration_id != source.calibration.calibration_id:
+        return "teacher acceptance rule requires a different calibration"
+    if source.fidelity.status != "approved" or source.fidelity.approved_at is None:
+        return "teacher rollout requires approved fidelity evidence"
+    if not math.isclose(
+        evidence.observed_overall_score,
+        source.judgment.overall_score,
+        rel_tol=1e-12,
+        abs_tol=1e-12,
+    ):
+        return "teacher acceptance score does not match the frozen judgment"
+    if evidence.observed_overall_score < rule.minimum_overall_score:
+        return "teacher judgment score does not meet the acceptance rule"
+    return None
+
+
+def _scan_source_actions(
+    source: _PreparedSource,
+) -> tuple[list[_ScannedAction], list[SFTExclusion]]:
+    """Scan targets and fingerprints without emitting examples or assigning a partition."""
+    history: list[SFTContextEvent] = []
+    scanned: list[_ScannedAction] = []
+    exclusions: list[SFTExclusion] = []
+    failed_action_indexes = {
+        event.action_index
+        for event in source.transcript_events
+        if isinstance(event, InfrastructureFailureEvent)
+    }
+    for index, event in enumerate(source.transcript_events):
+        if isinstance(event, SFTMessage):
+            history.append(event)
+            continue
+        if isinstance(event, ToolEvent):
+            history.append(event)
+            exclusions.append(
+                SFTExclusion(
+                    source_kind=source.kind,
+                    source_id=source.source_id,
+                    action_index=index,
+                    reason="observation_context_only",
+                    detail="tool observations remain context and are never SFT targets",
+                )
+            )
+            continue
+        if isinstance(event, InfrastructureFailureEvent):
+            exclusions.append(
+                SFTExclusion(
+                    source_kind=source.kind,
+                    source_id=source.source_id,
+                    action_index=event.action_index,
+                    reason="infrastructure_failure",
+                    detail="infrastructure failures are excluded from SFT targets",
+                )
+            )
+            continue
+        if index in failed_action_indexes:
+            exclusions.append(
+                SFTExclusion(
+                    source_kind=source.kind,
+                    source_id=source.source_id,
+                    action_index=index,
+                    reason="infrastructure_failure",
+                    detail="assistant action has a recorded infrastructure failure",
+                )
+            )
+            history.append(event)
+            continue
+        if not event.approved:
+            exclusions.append(
+                SFTExclusion(
+                    source_kind=source.kind,
+                    source_id=source.source_id,
+                    action_index=index,
+                    reason="unapproved_action",
+                    detail="unapproved assistant actions are never SFT targets",
+                )
+            )
+            history.append(event)
+            continue
+        history_snapshot = tuple(history)
+        scanned.append(
+            _ScannedAction(
+                source=source,
+                source_step_index=index,
+                history=history_snapshot,
+                fingerprint=context_target_fingerprint(
+                    task=source.task,
+                    history=history_snapshot,
+                    target=event.action,
+                ),
+                target=event,
+            )
+        )
+        history.append(event)
+    return scanned, exclusions
+
+
+def _build_partitions(
+    scanned_actions: Sequence[_ScannedAction], spec: SFTBuildSpec
+) -> tuple[dict[ArtifactId, Literal["train", "held_out"]], tuple[SFTPartition, ...]]:
+    """Union shared fingerprints, then split only complete leakage components."""
+    group_ids = tuple(sorted({action.source.leakage_group_id for action in scanned_actions}))
+    if not group_ids:
+        return {}, ()
+    groups = _UnionFind(group_ids)
+    first_group_by_fingerprint: dict[Sha256, ArtifactId] = {}
+    for action in scanned_actions:
+        first_group = first_group_by_fingerprint.setdefault(
+            action.fingerprint, action.source.leakage_group_id
+        )
+        groups.union(first_group, action.source.leakage_group_id)
+
+    component_groups: dict[ArtifactId, list[ArtifactId]] = {}
+    component_fingerprints: dict[ArtifactId, set[Sha256]] = {}
+    for group_id in group_ids:
+        root = groups.find(group_id)
+        component_groups.setdefault(root, []).append(group_id)
+    for action in scanned_actions:
+        root = groups.find(action.source.leakage_group_id)
+        component_fingerprints.setdefault(root, set()).add(action.fingerprint)
+
+    components: list[tuple[ArtifactId, tuple[ArtifactId, ...], tuple[Sha256, ...]]] = []
+    for root in sorted(component_groups):
+        lineage_group_ids = tuple(sorted(component_groups[root]))
+        fingerprints = tuple(sorted(component_fingerprints[root]))
+        component_id = stable_id(
+            "sft-component",
+            {"leakage_group_ids": list(lineage_group_ids)},
+        )
+        components.append((component_id, lineage_group_ids, fingerprints))
+
+    held_out_component_count = _held_out_component_count(len(components), spec.held_out_fraction)
+    ranked_components = sorted(
+        components,
+        key=lambda item: hashlib.sha256(f"{spec.split_salt}:{item[0]}".encode()).hexdigest(),
+    )
+    held_out_component_ids = {
+        component_id
+        for component_id, _lineage_group_ids, _fingerprints in ranked_components[
+            :held_out_component_count
+        ]
+    }
+    group_partitions: dict[ArtifactId, Literal["train", "held_out"]] = {}
+    partitions: list[SFTPartition] = []
+    for component_id, lineage_group_ids, fingerprints in components:
+        partition: Literal["train", "held_out"] = (
+            "held_out" if component_id in held_out_component_ids else "train"
+        )
+        for group_id in lineage_group_ids:
+            group_partitions[group_id] = partition
+        partitions.append(
+            SFTPartition(
+                component_id=component_id,
+                partition=partition,
+                leakage_group_ids=lineage_group_ids,
+                fingerprints=fingerprints,
+            )
+        )
+    return group_partitions, tuple(partitions)
+
+
+def _held_out_component_count(component_count: int, held_out_fraction: float) -> int:
+    """Choose a deterministic nonempty held-out component set when splitting is possible."""
+    if component_count < 2:
+        return 0
+    target = math.floor(component_count * held_out_fraction + 0.5)
+    return min(component_count - 1, max(1, target))
+
+
+def _expand_scanned_actions(
+    scanned_actions: Sequence[_ScannedAction],
+    group_partitions: dict[ArtifactId, Literal["train", "held_out"]],
+) -> tuple[PartitionedSFTExample, ...]:
+    """Expand only post-split scans into complete SFT examples."""
+    rows: list[PartitionedSFTExample] = []
+    for action in scanned_actions:
+        partition = group_partitions[action.source.leakage_group_id]
+        rows.append(
+            PartitionedSFTExample(
+                partition=partition,
+                fingerprint=action.fingerprint,
+                example=SFTExample(
+                    example_id=stable_id("sft-example", {"fingerprint": action.fingerprint}),
+                    leakage_group_id=action.source.leakage_group_id,
+                    task=action.source.task,
+                    history=action.history,
+                    target=action.target.action,
+                    source=action.source.example_source,
+                    source_step_index=action.source_step_index,
+                    score=action.source.score,
+                ),
+            )
+        )
+    return tuple(rows)
+
+
+def _globally_deduplicate(
+    rows: Sequence[PartitionedSFTExample],
+    scanned_actions: Sequence[_ScannedAction],
+) -> tuple[tuple[PartitionedSFTExample, ...], tuple[SFTExclusion, ...]]:
+    """Keep one deterministic representative for every normalized fingerprint globally."""
+    scanned_by_row_key = {
+        (action.fingerprint, action.source.source_id, action.source_step_index): action
+        for action in scanned_actions
+    }
+    rows_by_fingerprint: dict[Sha256, list[PartitionedSFTExample]] = {}
+    for row in rows:
+        rows_by_fingerprint.setdefault(row.fingerprint, []).append(row)
+    kept: list[PartitionedSFTExample] = []
+    exclusions: list[SFTExclusion] = []
+    for fingerprint in sorted(rows_by_fingerprint):
+        candidates = sorted(rows_by_fingerprint[fingerprint], key=_dedupe_row_sort_key)
+        kept.append(candidates[0])
+        for duplicate in candidates[1:]:
+            key = (
+                duplicate.fingerprint,
+                _source_id_from_example(duplicate.example),
+                duplicate.example.source_step_index,
+            )
+            scanned = scanned_by_row_key[key]
+            exclusions.append(
+                SFTExclusion(
+                    source_kind=scanned.source.kind,
+                    source_id=scanned.source.source_id,
+                    action_index=scanned.source_step_index,
+                    reason="duplicate_normalized_example",
+                    detail="the normalized context-target fingerprint is already retained",
+                )
+            )
+    return tuple(kept), tuple(exclusions)
+
+
+def _production_inputs(source: ProductionSFTSource) -> tuple[ArtifactInput, ...]:
+    """Collect immutable production provenance retained by the final dataset envelope."""
+    inputs = [
+        _model_input(source.acceptance_rule.acceptance_rule_id, source.acceptance_rule),
+        _model_input(source.acceptance_evidence.acceptance_evidence_id, source.acceptance_evidence),
+    ]
+    if source.human_approval is not None:
+        inputs.append(_model_input(source.human_approval.approval_id, source.human_approval))
+    return tuple(inputs)
+
+
+def _teacher_inputs(source: TeacherSFTSource) -> tuple[ArtifactInput, ...]:
+    """Collect immutable teacher provenance retained by the final dataset envelope."""
+    return (
+        ArtifactInput(
+            artifact_id=source.rollout.artifact_id,
+            sha256=sha256_json(source.rollout),
+        ),
+        _model_input(source.acceptance_rule.acceptance_rule_id, source.acceptance_rule),
+        _model_input(source.acceptance_evidence.acceptance_evidence_id, source.acceptance_evidence),
+        _model_input(source.judgment.judgment_id, source.judgment),
+        _model_input(source.calibration.calibration_id, source.calibration),
+        ArtifactInput(
+            artifact_id=source.fidelity.fidelity_report_id,
+            sha256=sha256_json(source.fidelity),
+        ),
+    )
+
+
+def _model_input(artifact_id: ArtifactId, value: ContractModel) -> ArtifactInput:
+    """Create a deterministic artifact-style reference for one frozen typed record."""
+    return ArtifactInput(artifact_id=artifact_id, sha256=sha256_json(value))
+
+
+def _sorted_inputs(inputs: Iterable[ArtifactInput]) -> tuple[ArtifactInput, ...]:
+    """Sort verified input identities and reject conflicting hashes for one artifact ID."""
+    by_id: dict[ArtifactId, ArtifactInput] = {}
+    for item in inputs:
+        existing = by_id.get(item.artifact_id)
+        if existing is not None and existing != item:
+            raise SFTBuildError(
+                f"immutable dataset input {item.artifact_id} has conflicting digests"
+            )
+        by_id[item.artifact_id] = item
+    return tuple(by_id[item_id] for item_id in sorted(by_id))
+
+
+def _build_digest(
+    *,
+    spec: SFTBuildSpec,
+    sources: tuple[SFTSourceReference, ...],
+    partitions: tuple[SFTPartition, ...],
+    rows: tuple[PartitionedSFTExample, ...],
+    exclusions: tuple[SFTExclusion, ...],
+    inputs: tuple[ArtifactInput, ...],
+) -> Sha256:
+    """Hash semantic build content while excluding wall-clock artifact materialization time."""
+    return sha256_json(
+        {
+            "format": "wmo-sft-build.v1",
+            "spec": spec.model_dump(mode="json", exclude_none=False),
+            "sources": [item.model_dump(mode="json", exclude_none=False) for item in sources],
+            "partitions": [item.model_dump(mode="json", exclude_none=False) for item in partitions],
+            "rows": [item.model_dump(mode="json", exclude_none=False) for item in rows],
+            "exclusions": [item.model_dump(mode="json", exclude_none=False) for item in exclusions],
+            "inputs": [item.model_dump(mode="json", exclude_none=False) for item in inputs],
+        }
+    )
+
+
+def _canonical_metadata_bytes(artifact: SFTDatasetArtifact) -> bytes:
+    """Serialize stored metadata through the same canonical SFT rendering boundary."""
+    return canonical_json_bytes(artifact.metadata())
+
+
+def _parse_rows(payload: bytes) -> tuple[PartitionedSFTExample, ...]:
+    """Parse deterministic JSONL SFT rows after the artifact store verifies file bytes."""
+    if not payload:
+        return ()
+    return tuple(
+        PartitionedSFTExample.model_validate_json(line) for line in payload.splitlines() if line
+    )
+
+
+def _validate_artifact_rows(artifact: SFTDatasetArtifact) -> None:
+    """Verify persisted dataset metadata agrees with exact rows and partition invariants."""
+    rows = artifact.rows
+    if artifact.dataset.examples_sha256 != partitioned_rows_sha256(rows):
+        raise SFTBuildError("SFT examples digest does not match the supplied rows")
+    ensure_no_cross_split_fingerprints(rows)
+    train_rows = tuple(row for row in rows if row.partition == "train")
+    held_out_rows = tuple(row for row in rows if row.partition == "held_out")
+    if artifact.dataset.train_example_ids != tuple(
+        sorted(row.example.example_id for row in train_rows)
+    ):
+        raise SFTBuildError("SFT train example IDs do not match stored rows")
+    if artifact.dataset.held_out_example_ids != tuple(
+        sorted(row.example.example_id for row in held_out_rows)
+    ):
+        raise SFTBuildError("SFT held-out example IDs do not match stored rows")
+    if artifact.dataset.status == "accepted" and not train_rows:
+        raise SFTBuildError("accepted SFT datasets require at least one train example")
+    if artifact.dataset.status == "insufficient" and rows:
+        raise SFTBuildError("insufficient SFT datasets must not contain example rows")
+    if artifact.inspection.dataset_id != artifact.dataset.dataset_id:
+        raise SFTBuildError("SFT inspection report names a different dataset")
+    if artifact.inspection.build_sha256 != artifact.dataset.build_sha256:
+        raise SFTBuildError("SFT inspection report names a different build digest")
+    if artifact.inspection.train_example_count != len(train_rows):
+        raise SFTBuildError("SFT inspection train count does not match stored rows")
+    if artifact.inspection.held_out_example_count != len(held_out_rows):
+        raise SFTBuildError("SFT inspection held-out count does not match stored rows")
+    if any(sample not in rows for sample in artifact.representative_samples):
+        raise SFTBuildError("SFT representative samples must be rows in the frozen dataset")
+    sample_train_ids = tuple(
+        sample.example.example_id
+        for sample in artifact.representative_samples
+        if sample.partition == "train"
+    )
+    sample_held_out_ids = tuple(
+        sample.example.example_id
+        for sample in artifact.representative_samples
+        if sample.partition == "held_out"
+    )
+    if artifact.inspection.representative_train_example_ids != sample_train_ids:
+        raise SFTBuildError("SFT inspection train samples do not match stored samples")
+    if artifact.inspection.representative_held_out_example_ids != sample_held_out_ids:
+        raise SFTBuildError("SFT inspection held-out samples do not match stored samples")
+
+
+def _require_unique_source_key(seen: set[tuple[str, str]], key: tuple[str, str]) -> None:
+    """Reject ambiguous repeated source identities before scanning or deduplication."""
+    if key in seen:
+        raise SFTBuildError(f"SFT build repeats source {key[0]}:{key[1]}")
+    seen.add(key)
+
+
+def _require_timezone(value: datetime, *, label: str) -> None:
+    """Reject an artifact timestamp that cannot safely round trip as immutable provenance."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise SFTBuildError(f"{label} time must include a timezone")
+
+
+def _source_id_from_example(example: SFTExample) -> str:
+    """Return the source identifier encoded by one normalized SFT example."""
+    if isinstance(example.source, TraceExampleSource):
+        return example.source.trace_id
+    return example.source.rollout_id
+
+
+def _row_sort_key(row: PartitionedSFTExample) -> tuple[int, ArtifactId]:
+    """Order train rows before held-out rows and stabilize within each partition."""
+    partition_order = 0 if row.partition == "train" else 1
+    return partition_order, row.example.example_id
+
+
+def _dedupe_row_sort_key(row: PartitionedSFTExample) -> tuple[str, str, int]:
+    """Choose the same duplicate representative regardless of source input ordering."""
+    return (
+        row.example.source.kind,
+        _source_id_from_example(row.example),
+        row.example.source_step_index,
+    )
+
+
+def _exclusion_sort_key(exclusion: SFTExclusion) -> tuple[str, str, int, str, str]:
+    """Make exclusion reports stable across equivalent input ordering."""
+    return (
+        exclusion.source_kind,
+        exclusion.source_id,
+        -1 if exclusion.action_index is None else exclusion.action_index,
+        exclusion.reason,
+        exclusion.detail,
+    )

--- a/wmo/optimize/model/sft/builder_test.py
+++ b/wmo/optimize/model/sft/builder_test.py
@@ -1,0 +1,764 @@
+"""Focused tests for accepted, leakage-safe frozen SFT dataset construction."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from wmo.common.core.artifacts import (
+    ArtifactInput,
+    FailureCode,
+    SourceIdentity,
+    StructuredFailure,
+    sha256_json,
+)
+from wmo.common.evaluations import FidelityReport
+from wmo.common.judging import DimensionJudgment, DimensionScoreMap, JudgeCalibration, Judgment
+from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics, ToolCall
+from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    RolloutSpan,
+    SimulationMode,
+    StopReason,
+    WorldModelSimulatorSnapshot,
+)
+from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.optimize.model.sft.builder import (
+    SFTBuildError,
+    SFTBuildSpec,
+    build_sft_dataset,
+    ensure_no_cross_split_fingerprints,
+    load_sft_dataset,
+    write_sft_dataset,
+)
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    HumanApproval,
+    InfrastructureFailureEvent,
+    ProductionAcceptanceEvidence,
+    ProductionAcceptanceRule,
+    ProductionSFTSource,
+    RolloutExampleSource,
+    SFTDatasetArtifact,
+    SFTMessage,
+    SFTTranscript,
+    TeacherAcceptanceEvidence,
+    TeacherAcceptanceRule,
+    TeacherSFTSource,
+    ToolEvent,
+    TraceExampleSource,
+)
+
+_DIGEST = "a" * 64
+_TIME = datetime(2026, 8, 11, tzinfo=UTC)
+
+
+def _inputs(*items: ArtifactInput) -> tuple[ArtifactInput, ...]:
+    return tuple(sorted(items, key=lambda item: item.artifact_id))
+
+
+def _model() -> ModelSnapshot:
+    return ModelSnapshot(provider="test", model_id="teacher-v1", capabilities_sha256=_DIGEST)
+
+
+def _trace(trace_id: str, conversation_id: str, task: str) -> Trace:
+    return Trace(
+        trace_id=trace_id,
+        conversation_id=conversation_id,
+        task=task,
+        spans=(
+            TraceSpan(
+                span_id=f"span-{trace_id}",
+                name="agent.model_call",
+                started_at=_TIME,
+                ended_at=_TIME + timedelta(seconds=1),
+            ),
+        ),
+        outcome=TraceOutcome(status="success", outcome_name="resolved"),
+        source=TraceSource(
+            identity=SourceIdentity(kind="production", source_id=f"source-{trace_id}"),
+            semantic_convention_version="1.0",
+        ),
+    )
+
+
+def _tool_action() -> AssistantAction:
+    return AssistantAction(
+        content="I will verify the order and issue the refund.",
+        tool_calls=(
+            ToolCall(call_id="lookup-1", name="lookup_order", arguments={"order_id": "o-17"}),
+            ToolCall(call_id="refund-1", name="issue_refund", arguments={"order_id": "o-17"}),
+        ),
+    )
+
+
+def _transcript(*, approved: bool = True, failed: bool = False) -> SFTTranscript:
+    events = [
+        SFTMessage(role="system", content="Follow the support policy."),
+        SFTMessage(role="user", content="Please refund order o-17."),
+        AssistantActionEvent(action=_tool_action(), approved=approved),
+        ToolEvent(tool_call_id="lookup-1", tool_name="lookup_order", content="order is eligible"),
+        ToolEvent(tool_call_id="refund-1", tool_name="issue_refund", content="refund issued"),
+    ]
+    if failed:
+        events.append(
+            InfrastructureFailureEvent(
+                action_index=2,
+                failure=StructuredFailure(
+                    code=FailureCode.TIMEOUT, message="tool transport timed out"
+                ),
+            )
+        )
+    else:
+        events.append(
+            AssistantActionEvent(
+                action=AssistantAction(content="Your refund is complete."), approved=approved
+            )
+        )
+    return SFTTranscript(events=tuple(events))
+
+
+def _production_source(
+    tag: str,
+    *,
+    task: str = "Refund order o-17.",
+    approved: bool = True,
+    failed: bool = False,
+) -> ProductionSFTSource:
+    trace = _trace(f"trace-{tag}", f"conversation-{tag}", task)
+    rule = ProductionAcceptanceRule(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        acceptance_rule_id=f"production-rule-{tag}",
+        accepted_outcomes=("resolved",),
+        allow_human_approval=True,
+    )
+    evidence = ProductionAcceptanceEvidence(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=_inputs(
+            ArtifactInput(artifact_id=rule.acceptance_rule_id, sha256=sha256_json(rule))
+        ),
+        code_revision="w12-test",
+        acceptance_evidence_id=f"production-evidence-{tag}",
+        trace_id=trace.trace_id,
+        trace_sha256=sha256_json(trace),
+        acceptance_rule_id=rule.acceptance_rule_id,
+        acceptance_rule_sha256=sha256_json(rule),
+        decision="trusted_outcome",
+        outcome_sha256=sha256_json(trace.outcome),
+        accepted_at=_TIME,
+    )
+    return ProductionSFTSource(
+        trace=trace,
+        transcript=_transcript(approved=approved, failed=failed),
+        acceptance_rule=rule,
+        acceptance_evidence=evidence,
+    )
+
+
+def _human_approved_production_source(tag: str) -> ProductionSFTSource:
+    """Build a locally approved production source with complete immutable references."""
+    source = _production_source(tag)
+    approval = HumanApproval(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        approval_id=f"human-approval-{tag}",
+        trace_id=source.trace.trace_id,
+        approved_at=_TIME,
+    )
+    evidence = ProductionAcceptanceEvidence(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=_inputs(
+            ArtifactInput(
+                artifact_id=source.acceptance_rule.acceptance_rule_id,
+                sha256=sha256_json(source.acceptance_rule),
+            ),
+            ArtifactInput(artifact_id=approval.approval_id, sha256=sha256_json(approval)),
+        ),
+        code_revision="w12-test",
+        acceptance_evidence_id=f"human-evidence-{tag}",
+        trace_id=source.trace.trace_id,
+        trace_sha256=sha256_json(source.trace),
+        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
+        acceptance_rule_sha256=sha256_json(source.acceptance_rule),
+        decision="human_approval",
+        human_approval_id=approval.approval_id,
+        human_approval_sha256=sha256_json(approval),
+        accepted_at=_TIME,
+    )
+    return source.model_copy(update={"acceptance_evidence": evidence, "human_approval": approval})
+
+
+def _rollout(tag: str) -> RolloutArtifact:
+    model = _model()
+    return RolloutArtifact(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        artifact_id=f"rollout-artifact-{tag}",
+        simulation_id=f"simulation-{tag}",
+        cell_id=f"cell-{tag}",
+        mode=SimulationMode.WORLD_MODEL,
+        rollout_id=f"rollout-{tag}",
+        trace_id=f"teacher-trace-{tag}",
+        evidence_source="world_model",
+        source_run_id=f"run-{tag}",
+        task_id=f"task-{tag}",
+        candidate=model,
+        agent_id="customer-agent",
+        simulator=WorldModelSimulatorSnapshot(
+            simulator_id="world-model-v1",
+            prompt_id="world-prompt-v1",
+            world_model=model,
+        ),
+        world_model=model,
+        seed=7,
+        repeat=0,
+        spans=(
+            RolloutSpan(
+                span_id=f"rollout-span-{tag}",
+                kind=RolloutEventKind.AGENT_MODEL_CALL,
+                started_at=_TIME,
+                ended_at=_TIME + timedelta(seconds=1),
+                model=model,
+            ),
+        ),
+        stop_reason=StopReason.COMPLETED,
+        candidate_economics=OperationEconomics(),
+        simulation_spec_sha256=_DIGEST,
+    )
+
+
+def _calibration(
+    tag: str, *, status: Literal["human_calibrated", "insufficient"] = "human_calibrated"
+) -> JudgeCalibration:
+    return JudgeCalibration(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        calibration_id=f"calibration-{tag}",
+        rubric_id=f"rubric-{tag}",
+        judge_model=_model(),
+        judge_prompt_id="judge-prompt-v1",
+        judge_prompt_sha256=_DIGEST,
+        label_set_id=f"labels-{tag}",
+        calibration_lineage_ids=(f"lineage-{tag}",),
+        excluded_router_held_out_lineage_ids=(),
+        validation_method="grouped_k_fold",
+        out_of_fold_report_id=f"calibration-report-{tag}",
+        out_of_fold_report_sha256=_DIGEST,
+        score_maps=(
+            DimensionScoreMap(
+                dimension_id="quality",
+                calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+            ),
+        ),
+        label_count=1,
+        status=status,
+        approved_at=_TIME if status == "human_calibrated" else None,
+    )
+
+
+def _teacher_source(
+    tag: str,
+    *,
+    task: str = "Refund order o-17.",
+    score: float = 1.0,
+    minimum_score: float = 0.8,
+    calibration_status: Literal["human_calibrated", "insufficient"] = "human_calibrated",
+    fidelity_status: Literal["approved", "rejected", "insufficient"] = "approved",
+) -> TeacherSFTSource:
+    rollout = _rollout(tag)
+    calibration = _calibration(tag, status=calibration_status)
+    raw_score = 5 if score == 1.0 else 4
+    judgment = Judgment(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        judgment_id=f"judgment-{tag}",
+        rollout_id=rollout.rollout_id,
+        rubric_id=calibration.rubric_id,
+        calibration_id=calibration.calibration_id,
+        judge_model=_model(),
+        judge_prompt_id="judge-prompt-v1",
+        judge_prompt_sha256=_DIGEST,
+        dimensions=(
+            DimensionJudgment(
+                dimension_id="quality",
+                raw_score=raw_score,
+                calibrated_score=score * 5,
+                evidence_span_ids=(f"rollout-span-{tag}",),
+                feedback="The rollout completed the requested action.",
+            ),
+        ),
+        overall_score=score,
+    )
+    if fidelity_status == "approved":
+        usable_overlap_count, score_mae = 8, 0.08
+    elif fidelity_status == "rejected":
+        usable_overlap_count, score_mae = 8, 0.12
+    else:
+        usable_overlap_count, score_mae = 7, None
+    fidelity = FidelityReport(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        fidelity_report_id=f"fidelity-{tag}",
+        protocol_sha256=_DIGEST,
+        overlap_cell_ids=tuple(f"fidelity-cell-{tag}-{index}" for index in range(10)),
+        planned_overlap_count=10,
+        usable_overlap_count=usable_overlap_count,
+        failed_overlap_count=0,
+        score_mae=score_mae,
+        gate_id=f"fidelity-gate-{tag}",
+        gate_sha256=_DIGEST,
+        status=fidelity_status,
+        approved_at=_TIME if fidelity_status == "approved" else None,
+    )
+    rule = TeacherAcceptanceRule(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        acceptance_rule_id=f"teacher-rule-{tag}",
+        minimum_overall_score=minimum_score,
+        required_calibration_id=calibration.calibration_id,
+    )
+    evidence = TeacherAcceptanceEvidence(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=_inputs(
+            ArtifactInput(artifact_id=rollout.rollout_id, sha256=sha256_json(rollout)),
+            ArtifactInput(artifact_id=judgment.judgment_id, sha256=sha256_json(judgment)),
+            ArtifactInput(artifact_id=calibration.calibration_id, sha256=sha256_json(calibration)),
+            ArtifactInput(
+                artifact_id=fidelity.fidelity_report_id,
+                sha256=sha256_json(fidelity),
+            ),
+            ArtifactInput(artifact_id=rule.acceptance_rule_id, sha256=sha256_json(rule)),
+        ),
+        code_revision="w12-test",
+        acceptance_evidence_id=f"teacher-evidence-{tag}",
+        rollout_id=rollout.rollout_id,
+        rollout_sha256=sha256_json(rollout),
+        judgment_id=judgment.judgment_id,
+        judgment_sha256=sha256_json(judgment),
+        calibration_id=calibration.calibration_id,
+        calibration_sha256=sha256_json(calibration),
+        fidelity_report_id=fidelity.fidelity_report_id,
+        fidelity_report_sha256=sha256_json(fidelity),
+        acceptance_rule_id=rule.acceptance_rule_id,
+        acceptance_rule_sha256=sha256_json(rule),
+        observed_overall_score=score,
+        accepted_at=_TIME,
+    )
+    return TeacherSFTSource(
+        rollout=rollout,
+        task=task,
+        transcript=_transcript(),
+        acceptance_rule=rule,
+        acceptance_evidence=evidence,
+        judgment=judgment,
+        calibration=calibration,
+        fidelity=fidelity,
+    )
+
+
+def _build(
+    production: tuple[ProductionSFTSource, ...] = (),
+    teacher: tuple[TeacherSFTSource, ...] = (),
+    *,
+    created_at: datetime = _TIME,
+) -> SFTDatasetArtifact:
+    return build_sft_dataset(
+        production_sources=production,
+        teacher_sources=teacher,
+        spec=SFTBuildSpec(held_out_fraction=0.5, representative_sample_count=2),
+        created_at=created_at,
+        code_revision="w12-test",
+    )
+
+
+def test_production_acceptance_filters_unapproved_failed_and_observation_events() -> None:
+    """Only accepted assistant actions become targets, never tools, failures, or unapproved turns.
+
+    The source ledger still records why excluded events were not targets.
+    """
+    valid = _production_source("valid")
+    invalid_evidence = _production_source("invalid")
+    invalid_evidence = invalid_evidence.model_copy(
+        update={
+            "acceptance_evidence": invalid_evidence.acceptance_evidence.model_copy(
+                update={"trace_sha256": "f" * 64}
+            )
+        }
+    )
+    unapproved = _production_source("unapproved", approved=False)
+    failed = _production_source("failed", failed=True)
+
+    artifact = _build((valid, invalid_evidence, unapproved, failed))
+
+    assert {row.example.target.content for row in artifact.rows} == {
+        "I will verify the order and issue the refund.",
+        "Your refund is complete.",
+    }
+    reasons = {exclusion.reason for exclusion in artifact.inspection.exclusions}
+    assert "invalid_production_acceptance" in reasons
+    assert "unapproved_action" in reasons
+    assert "infrastructure_failure" in reasons
+    assert "observation_context_only" in reasons
+    assert all(row.example.source.kind == "production_trace" for row in artifact.rows)
+
+
+def test_ineligible_assistant_actions_remain_visible_context_for_later_targets() -> None:
+    """An excluded assistant action is not learned, but later visible context remains faithful."""
+    source = _production_source("context")
+    excluded_action = AssistantActionEvent(
+        action=AssistantAction(content="This action was not approved."), approved=False
+    )
+    accepted_action = AssistantActionEvent(
+        action=AssistantAction(content="This approved action follows it.")
+    )
+    source = source.model_copy(
+        update={
+            "transcript": SFTTranscript(
+                events=(
+                    SFTMessage(role="user", content="Complete the request."),
+                    excluded_action,
+                    accepted_action,
+                )
+            )
+        }
+    )
+
+    artifact = _build((source,))
+
+    assert len(artifact.rows) == 1
+    assert artifact.rows[0].example.target == accepted_action.action
+    assert artifact.rows[0].example.history[-1] == excluded_action
+
+
+def test_production_acceptance_requires_verified_outcome_or_human_references() -> None:
+    """Every production evidence branch rejects missing or mismatched immutable references."""
+    valid_human_approval = _human_approved_production_source("human-valid")
+    missing_human_approval = _human_approved_production_source("human-missing")
+    missing_human_approval = missing_human_approval.model_copy(update={"human_approval": None})
+    mismatched_human_approval = _human_approved_production_source("human-hash")
+    mismatched_human_approval = mismatched_human_approval.model_copy(
+        update={
+            "acceptance_evidence": mismatched_human_approval.acceptance_evidence.model_copy(
+                update={"human_approval_sha256": "d" * 64}
+            )
+        }
+    )
+    mismatched_trace = _production_source("trace-hash")
+    mismatched_trace = mismatched_trace.model_copy(
+        update={
+            "acceptance_evidence": mismatched_trace.acceptance_evidence.model_copy(
+                update={"trace_sha256": "d" * 64}
+            )
+        }
+    )
+    mismatched_rule = _production_source("rule-hash")
+    mismatched_rule = mismatched_rule.model_copy(
+        update={
+            "acceptance_evidence": mismatched_rule.acceptance_evidence.model_copy(
+                update={"acceptance_rule_sha256": "d" * 64}
+            )
+        }
+    )
+    mismatched_outcome = _production_source("outcome-hash")
+    mismatched_outcome = mismatched_outcome.model_copy(
+        update={
+            "acceptance_evidence": mismatched_outcome.acceptance_evidence.model_copy(
+                update={"outcome_sha256": "d" * 64}
+            )
+        }
+    )
+    disallowed_human_approval = _human_approved_production_source("human-disallowed")
+    disallowed_rule = disallowed_human_approval.acceptance_rule.model_copy(
+        update={"allow_human_approval": False}
+    )
+    approval = disallowed_human_approval.human_approval
+    assert approval is not None
+    disallowed_human_approval = disallowed_human_approval.model_copy(
+        update={
+            "acceptance_rule": disallowed_rule,
+            "acceptance_evidence": disallowed_human_approval.acceptance_evidence.model_copy(
+                update={
+                    "acceptance_rule_sha256": sha256_json(disallowed_rule),
+                    "inputs": _inputs(
+                        ArtifactInput(
+                            artifact_id=disallowed_rule.acceptance_rule_id,
+                            sha256=sha256_json(disallowed_rule),
+                        ),
+                        ArtifactInput(
+                            artifact_id=approval.approval_id,
+                            sha256=sha256_json(approval),
+                        ),
+                    ),
+                }
+            ),
+        }
+    )
+    untrusted_outcome = _production_source("untrusted-outcome")
+    alternate_outcome = TraceOutcome(status="success", outcome_name="declined")
+    alternate_trace = untrusted_outcome.trace.model_copy(update={"outcome": alternate_outcome})
+    untrusted_outcome = untrusted_outcome.model_copy(
+        update={
+            "trace": alternate_trace,
+            "acceptance_evidence": untrusted_outcome.acceptance_evidence.model_copy(
+                update={
+                    "trace_sha256": sha256_json(alternate_trace),
+                    "outcome_sha256": sha256_json(alternate_outcome),
+                }
+            ),
+        }
+    )
+
+    artifact = _build(
+        (
+            valid_human_approval,
+            missing_human_approval,
+            mismatched_human_approval,
+            mismatched_trace,
+            mismatched_rule,
+            mismatched_outcome,
+            disallowed_human_approval,
+            untrusted_outcome,
+        )
+    )
+
+    assert {
+        row.example.source.trace_id
+        for row in artifact.rows
+        if isinstance(row.example.source, TraceExampleSource)
+    } == {"trace-human-valid"}
+    excluded_ids = {
+        exclusion.source_id
+        for exclusion in artifact.inspection.exclusions
+        if exclusion.reason == "invalid_production_acceptance"
+    }
+    assert excluded_ids == {
+        "trace-human-missing",
+        "trace-human-hash",
+        "trace-trace-hash",
+        "trace-rule-hash",
+        "trace-outcome-hash",
+        "trace-human-disallowed",
+        "trace-untrusted-outcome",
+    }
+
+
+def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
+    """Every teacher evidence reference and acceptance gate must be proven before training."""
+    valid = _teacher_source("valid")
+    bad_rollout_hash = _teacher_source("rollout-hash")
+    bad_rollout_hash = bad_rollout_hash.model_copy(
+        update={
+            "acceptance_evidence": bad_rollout_hash.acceptance_evidence.model_copy(
+                update={"rollout_sha256": "c" * 64}
+            )
+        }
+    )
+    bad_judgment_hash = _teacher_source("judgment-hash")
+    bad_judgment_hash = bad_judgment_hash.model_copy(
+        update={
+            "acceptance_evidence": bad_judgment_hash.acceptance_evidence.model_copy(
+                update={"judgment_sha256": "c" * 64}
+            )
+        }
+    )
+    bad_calibration_hash = _teacher_source("calibration-hash")
+    bad_calibration_hash = bad_calibration_hash.model_copy(
+        update={
+            "acceptance_evidence": bad_calibration_hash.acceptance_evidence.model_copy(
+                update={"calibration_sha256": "c" * 64}
+            )
+        }
+    )
+    bad_fidelity_hash = _teacher_source("fidelity-hash")
+    bad_fidelity_hash = bad_fidelity_hash.model_copy(
+        update={
+            "acceptance_evidence": bad_fidelity_hash.acceptance_evidence.model_copy(
+                update={"fidelity_report_sha256": "c" * 64}
+            )
+        }
+    )
+    bad_rule_hash = _teacher_source("rule-hash")
+    bad_rule_hash = bad_rule_hash.model_copy(
+        update={
+            "acceptance_evidence": bad_rule_hash.acceptance_evidence.model_copy(
+                update={"acceptance_rule_sha256": "c" * 64}
+            )
+        }
+    )
+    insufficient_calibration = _teacher_source("calibration", calibration_status="insufficient")
+    rejected_fidelity = _teacher_source("fidelity-rejected", fidelity_status="rejected")
+    insufficient_fidelity = _teacher_source("fidelity-insufficient", fidelity_status="insufficient")
+    low_score = _teacher_source("score", score=0.8, minimum_score=0.9)
+    unfinished = _teacher_source("unfinished")
+    unfinished = unfinished.model_copy(
+        update={
+            "rollout": unfinished.rollout.model_copy(
+                update={"stop_reason": StopReason.MAXIMUM_STEPS}
+            )
+        }
+    )
+    unproven = _teacher_source("unproven")
+    unproven = unproven.model_copy(
+        update={
+            "acceptance_evidence": unproven.acceptance_evidence.model_copy(update={"inputs": ()})
+        }
+    )
+
+    artifact = _build(
+        teacher=(
+            valid,
+            bad_rollout_hash,
+            bad_judgment_hash,
+            bad_calibration_hash,
+            bad_fidelity_hash,
+            bad_rule_hash,
+            insufficient_calibration,
+            rejected_fidelity,
+            insufficient_fidelity,
+            low_score,
+            unfinished,
+            unproven,
+        )
+    )
+
+    assert {
+        row.example.source.rollout_id
+        for row in artifact.rows
+        if isinstance(row.example.source, RolloutExampleSource)
+    } == {"rollout-valid"}
+    excluded_ids = {
+        exclusion.source_id
+        for exclusion in artifact.inspection.exclusions
+        if exclusion.reason == "invalid_teacher_acceptance"
+    }
+    assert excluded_ids == {
+        "rollout-rollout-hash",
+        "rollout-judgment-hash",
+        "rollout-calibration-hash",
+        "rollout-fidelity-hash",
+        "rollout-rule-hash",
+        "rollout-calibration",
+        "rollout-fidelity-rejected",
+        "rollout-fidelity-insufficient",
+        "rollout-score",
+        "rollout-unfinished",
+        "rollout-unproven",
+    }
+
+
+def test_shared_fingerprints_union_lineages_before_split_and_deduplicate_globally() -> None:
+    """Identical context-target content cannot leak across partitions and keeps one row globally."""
+    first = _production_source("one")
+    second = _production_source("two")
+    distinct = _production_source("three", task="Cancel order o-17.")
+
+    artifact = _build((first, second, distinct))
+
+    references = {source.source_id: source for source in artifact.sources}
+    first_group = references["trace-one"].leakage_group_id
+    second_group = references["trace-two"].leakage_group_id
+    shared_partition = next(
+        partition for partition in artifact.partitions if first_group in partition.leakage_group_ids
+    )
+    assert second_group in shared_partition.leakage_group_ids
+    assert any(
+        exclusion.reason == "duplicate_normalized_example"
+        for exclusion in artifact.inspection.exclusions
+    )
+    fingerprints_by_partition: dict[str, set[str]] = {"train": set(), "held_out": set()}
+    for row in artifact.rows:
+        fingerprints_by_partition[row.partition].add(row.fingerprint)
+    assert not fingerprints_by_partition["train"].intersection(
+        fingerprints_by_partition["held_out"]
+    )
+
+
+def test_cross_split_fingerprint_is_explicitly_rejected() -> None:
+    """Corrupt rows cannot place one normalized example in both train and held-out data."""
+    row = _build((_production_source("cross-split"),)).rows[0]
+    held_out_copy = row.model_copy(update={"partition": "held_out"})
+
+    with pytest.raises(SFTBuildError, match="appears in both"):
+        ensure_no_cross_split_fingerprints((row, held_out_copy))
+
+
+def test_same_sources_produce_the_same_digest_regardless_of_input_order_or_build_time() -> None:
+    """The semantic digest is stable while materialization time remains provenance."""
+    first = _production_source("first")
+    second = _production_source("second", task="Cancel order o-17.")
+
+    forward = _build((first, second), created_at=_TIME)
+    reversed_build = _build((second, first), created_at=_TIME + timedelta(days=1))
+
+    assert forward.dataset.build_sha256 == reversed_build.dataset.build_sha256
+    assert forward.dataset.dataset_id == reversed_build.dataset.dataset_id
+    assert forward.rows == reversed_build.rows
+
+
+def test_frozen_artifact_contains_provenance_samples_exclusions_and_training_gate(
+    tmp_path: Path,
+) -> None:
+    """Only a prior accepted immutable artifact can be loaded for later training consumption."""
+    accepted = _build((_production_source("artifact"), _production_source("other", task="Other.")))
+    store = ProjectStore(tmp_path / ".wmo", "sft-project")
+    store.initialize(ProjectConfig(project_id="sft-project"))
+
+    written = write_sft_dataset(store, accepted)
+    loaded = load_sft_dataset(store, written.dataset.dataset_id)
+    stored = store.artifacts.read(written.dataset.dataset_id)
+    metadata = written.metadata()
+
+    assert loaded == written
+    assert {file.path for file in stored.manifest.files} == {"dataset.json", "examples.jsonl"}
+    assert metadata.sources
+    assert metadata.partitions
+    assert metadata.inspection.exclusions
+    assert metadata.representative_samples
+    source_reference = next(source for source in metadata.sources if source.accepted)
+    assert source_reference.acceptance_evidence_id == "production-evidence-artifact"
+    assert source_reference.acceptance_evidence_sha256 == sha256_json(
+        _production_source("artifact").acceptance_evidence
+    )
+    assert {item.artifact_id for item in metadata.dataset.inputs} == {
+        "production-evidence-artifact",
+        "production-evidence-other",
+        "production-rule-artifact",
+        "production-rule-other",
+    }
+    assert metadata.inspection.dataset_id == metadata.dataset.dataset_id
+    assert all(sample in written.rows for sample in metadata.representative_samples)
+
+    invalid = _production_source("nope")
+    invalid = invalid.model_copy(
+        update={
+            "acceptance_evidence": invalid.acceptance_evidence.model_copy(
+                update={"acceptance_rule_sha256": "d" * 64}
+            )
+        }
+    )
+    insufficient = _build((invalid,))
+    write_sft_dataset(store, insufficient)
+    with pytest.raises(ValueError, match="insufficient"):
+        load_sft_dataset(store, insufficient.dataset.dataset_id)
+    assert (
+        load_sft_dataset(
+            store, insufficient.dataset.dataset_id, require_accepted=False
+        ).dataset.status
+        == "insufficient"
+    )

--- a/wmo/optimize/model/sft/builder_test.py
+++ b/wmo/optimize/model/sft/builder_test.py
@@ -374,7 +374,9 @@ def _rollout(tag: str, task_id: str) -> RolloutArtifact:
     )
 
 
-def _write_teacher_source(store: ProjectStore) -> _TeacherFixture:
+def _write_teacher_source(
+    store: ProjectStore, *, bind_fidelity_to_teacher_rollout: bool = True
+) -> _TeacherFixture:
     """Persist a complete W5, W6, rollout, fidelity, and acceptance chain for one teacher row."""
     task, task_set, task_set_input = _task_set(store)
     rubric = _rubric(task_set_input)
@@ -520,6 +522,9 @@ def _write_teacher_source(store: ProjectStore) -> _TeacherFixture:
             files={"rollout.json": final_rollout},
         )
     )
+    fidelity_rollout_input = (
+        rollout_input if bind_fidelity_to_teacher_rollout else rollout_inputs[0]
+    )
     final_judgment = LMJudge(
         _FakeJudgeClient(
             model,
@@ -549,7 +554,7 @@ def _write_teacher_source(store: ProjectStore) -> _TeacherFixture:
     fidelity = FidelityReport(
         schema_version=1,
         created_at=_TIME,
-        inputs=(task_set_input,),
+        inputs=_inputs(task_set_input, fidelity_rollout_input),
         code_revision="w12-test",
         fidelity_report_id="fidelity-teacher",
         protocol_sha256=_DIGEST,
@@ -835,6 +840,15 @@ def test_teacher_rejects_forged_score_and_recursively_unverifiable_calibration(
                 ),
             ),
         )
+
+
+def test_teacher_rejects_fidelity_report_bound_to_another_rollout(tmp_path: Path) -> None:
+    """Teacher evidence cannot reuse an approved fidelity report from another rollout."""
+    store = _store(tmp_path)
+    fixture = _write_teacher_source(store, bind_fidelity_to_teacher_rollout=False)
+
+    with pytest.raises(SFTBuildError, match="fidelity report does not bind the stored rollout"):
+        _build(store, teacher=(fixture.source,))
 
 
 def test_teacher_rejects_corrupt_full_task_case_and_preserves_task_set_lineage(

--- a/wmo/optimize/model/sft/builder_test.py
+++ b/wmo/optimize/model/sft/builder_test.py
@@ -1,24 +1,49 @@
-"""Focused tests for accepted, leakage-safe frozen SFT dataset construction."""
+"""Store-backed regression tests for frozen, leakage-safe SFT dataset construction."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Literal
 
 import pytest
+from pydantic import ValidationError
 
 from wmo.common.core.artifacts import (
     ArtifactInput,
     FailureCode,
     SourceIdentity,
     StructuredFailure,
+    canonical_json_bytes,
     sha256_json,
 )
-from wmo.common.evaluations import FidelityFailure, FidelityReport
-from wmo.common.judging import DimensionJudgment, DimensionScoreMap, JudgeCalibration, Judgment
-from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics, ToolCall
-from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.common.evaluations import FidelityReport
+from wmo.common.judging import (
+    HumanScore,
+    HumanScoreReview,
+    JudgeCalibration,
+    JudgeCalibrationService,
+    JudgeScoreObservation,
+    Judgment,
+    LMJudge,
+    PromptDefinition,
+    RouterLineageAssignment,
+    RouterLineageSplit,
+    Rubric,
+    RubricDimension,
+    ScoreAnchor,
+    write_router_lineage_split,
+)
+from wmo.common.models import (
+    AssistantAction,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+)
+from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
 from wmo.common.rollouts import (
     RolloutArtifact,
     RolloutEventKind,
@@ -44,42 +69,96 @@ from wmo.optimize.model.sft.contracts import (
     ProductionAcceptanceEvidence,
     ProductionAcceptanceRule,
     ProductionSFTSource,
-    RolloutExampleSource,
     SFTDatasetArtifact,
     SFTMessage,
     SFTTranscript,
     TeacherAcceptanceEvidence,
     TeacherAcceptanceRule,
     TeacherSFTSource,
-    ToolEvent,
-    TraceExampleSource,
 )
+from wmo.simulation.ingest.dataset import persist_trace_dataset
+from wmo.simulation.ingest.otlp import TraceNormalizationResult
 
 _DIGEST = "a" * 64
-_TIME = datetime(2026, 8, 11, tzinfo=UTC)
+_TIME = datetime(2026, 8, 12, tzinfo=UTC)
 
 
-def _inputs(*items: ArtifactInput) -> tuple[ArtifactInput, ...]:
-    return tuple(sorted(items, key=lambda item: item.artifact_id))
+class _FakeJudgeClient:
+    """Return one fixed structured judgment without network access or provider credentials."""
+
+    def __init__(self, model: ModelSnapshot, content: str) -> None:
+        self._model = model
+        self._content = content
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Return the configured model identity and structured payload."""
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(content=self._content),
+            model=self._model,
+            economics=OperationEconomics(),
+        )
 
 
-def _model() -> ModelSnapshot:
+@dataclass(frozen=True)
+class _TeacherFixture:
+    """Verified teacher-evidence IDs retained for adversarial SFT consumption tests."""
+
+    source: TeacherSFTSource
+    evidence: TeacherAcceptanceEvidence
+    rollout_input: ArtifactInput
+    task_set_input: ArtifactInput
+    judgment_input: ArtifactInput
+    calibration_input: ArtifactInput
+    fidelity_input: ArtifactInput
+    rule_input: ArtifactInput
+    transcript: SFTTranscript
+
+
+def _store(tmp_path: Path, project_id: str = "sft-project") -> ProjectStore:
+    """Create one initialized project-local immutable store."""
+    store = ProjectStore(tmp_path / ".wmo", project_id)
+    store.initialize(ProjectConfig(project_id=project_id))
+    return store
+
+
+def _inputs(*values: ArtifactInput) -> tuple[ArtifactInput, ...]:
+    """Return exact artifact references in the canonical input ordering."""
+    return tuple(sorted(values, key=lambda value: value.artifact_id))
+
+
+def _model(model_id: str = "judge-model") -> ModelSnapshot:
+    """Build one fixed resolved model identity for local immutable test evidence."""
     return ModelSnapshot(
         provider="test",
-        model_id="teacher-v1",
+        model_id=model_id,
         capabilities_sha256=_DIGEST,
         connection_sha256=_DIGEST,
     )
 
 
-def _trace(trace_id: str, conversation_id: str, task: str) -> Trace:
+def _transcript(tag: str) -> SFTTranscript:
+    """Build one canonical source transcript with two trainable assistant actions."""
+    return SFTTranscript(
+        events=(
+            SFTMessage(role="system", content="Follow the support policy."),
+            SFTMessage(role="user", content=f"Resolve support request {tag}."),
+            AssistantActionEvent(action=AssistantAction(content=f"Investigating {tag}.")),
+            AssistantActionEvent(action=AssistantAction(content=f"Resolved {tag}.")),
+        )
+    )
+
+
+def _trace(tag: str, *, task: str | None = None) -> Trace:
+    """Build one normalized successful production trace eligible for trace-dataset storage."""
     return Trace(
-        trace_id=trace_id,
-        conversation_id=conversation_id,
-        task=task,
+        trace_id=f"trace-{tag}",
+        conversation_id=f"conversation-{tag}",
+        task=task or f"Resolve support request {tag}.",
         spans=(
             TraceSpan(
-                span_id=f"span-{trace_id}",
+                span_id=f"trace-span-{tag}",
                 name="agent.model_call",
                 started_at=_TIME,
                 ended_at=_TIME + timedelta(seconds=1),
@@ -87,56 +166,34 @@ def _trace(trace_id: str, conversation_id: str, task: str) -> Trace:
         ),
         outcome=TraceOutcome(status="success", outcome_name="resolved"),
         source=TraceSource(
-            identity=SourceIdentity(kind="production", source_id=f"source-{trace_id}"),
-            semantic_convention_version="1.0",
+            identity=SourceIdentity(kind="otlp", source_id="fixture", sha256=_DIGEST),
+            semantic_convention_version="1.37.0",
         ),
     )
 
 
-def _tool_action() -> AssistantAction:
-    return AssistantAction(
-        content="I will verify the order and issue the refund.",
-        tool_calls=(
-            ToolCall(call_id="lookup-1", name="lookup_order", arguments={"order_id": "o-17"}),
-            ToolCall(call_id="refund-1", name="issue_refund", arguments={"order_id": "o-17"}),
-        ),
+def _write_trace_dataset(store: ProjectStore, trace: Trace) -> ArtifactInput:
+    """Persist canonical W5-style trace evidence and return its manifest-derived input."""
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(trace,), issues=()),
+        store.artifacts,
+        created_at=_TIME,
+        code_revision="w12-test",
     )
+    return artifact_input(persisted.manifest)
 
 
-def _transcript(*, approved: bool = True, failed: bool = False) -> SFTTranscript:
-    events = [
-        SFTMessage(role="system", content="Follow the support policy."),
-        SFTMessage(role="user", content="Please refund order o-17."),
-        AssistantActionEvent(action=_tool_action(), approved=approved),
-        ToolEvent(tool_call_id="lookup-1", tool_name="lookup_order", content="order is eligible"),
-        ToolEvent(tool_call_id="refund-1", tool_name="issue_refund", content="refund issued"),
-    ]
-    if failed:
-        events.append(
-            InfrastructureFailureEvent(
-                action_index=2,
-                failure=StructuredFailure(
-                    code=FailureCode.TIMEOUT, message="tool transport timed out"
-                ),
-            )
-        )
-    else:
-        events.append(
-            AssistantActionEvent(
-                action=AssistantAction(content="Your refund is complete."), approved=approved
-            )
-        )
-    return SFTTranscript(events=tuple(events))
-
-
-def _production_source(
+def _write_production_source(
+    store: ProjectStore,
     tag: str,
     *,
-    task: str = "Refund order o-17.",
-    approved: bool = True,
-    failed: bool = False,
+    human_approval: bool = False,
+    task: str | None = None,
+    transcript: SFTTranscript | None = None,
 ) -> ProductionSFTSource:
-    trace = _trace(f"trace-{tag}", f"conversation-{tag}", task)
+    """Persist production acceptance evidence whose transcript is owned by that artifact."""
+    trace = _trace(tag, task=task)
+    trace_input = _write_trace_dataset(store, trace)
     rule = ProductionAcceptanceRule(
         schema_version=1,
         created_at=_TIME,
@@ -145,90 +202,138 @@ def _production_source(
         accepted_outcomes=("resolved",),
         allow_human_approval=True,
     )
+    rule_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=rule.acceptance_rule_id,
+            artifact_type="sft-production-acceptance-rule",
+            envelope=rule,
+            files={"rule.json": rule},
+        )
+    )
+    approval_input: ArtifactInput | None = None
+    if human_approval:
+        approval = HumanApproval(
+            schema_version=1,
+            created_at=_TIME,
+            inputs=(trace_input,),
+            code_revision="w12-test",
+            approval_id=f"human-approval-{tag}",
+            trace_dataset=trace_input,
+            trace_id=trace.trace_id,
+            approved_at=_TIME,
+        )
+        approval_input = artifact_input(
+            store.artifacts.write_json(
+                artifact_id=approval.approval_id,
+                artifact_type="sft-human-approval",
+                envelope=approval,
+                files={"approval.json": approval},
+            )
+        )
+    transcript = transcript or _transcript(tag)
+    transcript_payload = canonical_json_bytes(transcript)
     evidence = ProductionAcceptanceEvidence(
         schema_version=1,
         created_at=_TIME,
-        inputs=_inputs(
-            ArtifactInput(artifact_id=rule.acceptance_rule_id, sha256=sha256_json(rule))
+        inputs=(
+            _inputs(trace_input, rule_input)
+            if approval_input is None
+            else _inputs(trace_input, rule_input, approval_input)
         ),
         code_revision="w12-test",
         acceptance_evidence_id=f"production-evidence-{tag}",
+        trace_dataset=trace_input,
         trace_id=trace.trace_id,
         trace_sha256=sha256_json(trace),
-        acceptance_rule_id=rule.acceptance_rule_id,
-        acceptance_rule_sha256=sha256_json(rule),
-        decision="trusted_outcome",
-        outcome_sha256=sha256_json(trace.outcome),
+        acceptance_rule=rule_input,
+        decision="human_approval" if approval_input is not None else "trusted_outcome",
+        outcome_sha256=None if approval_input is not None else sha256_json(trace.outcome),
+        human_approval=approval_input,
+        transcript_path="transcript.json",
+        transcript_sha256=hashlib.sha256(transcript_payload).hexdigest(),
         accepted_at=_TIME,
     )
-    return ProductionSFTSource(
-        trace=trace,
-        transcript=_transcript(approved=approved, failed=failed),
-        acceptance_rule=rule,
-        acceptance_evidence=evidence,
+    store.artifacts.write(
+        artifact_id=evidence.acceptance_evidence_id,
+        artifact_type="sft-production-acceptance",
+        envelope=evidence,
+        files={
+            "evidence.json": canonical_json_bytes(evidence),
+            "transcript.json": transcript_payload,
+        },
     )
+    return ProductionSFTSource(acceptance_evidence_id=evidence.acceptance_evidence_id)
 
 
-def _human_approved_production_source(tag: str) -> ProductionSFTSource:
-    """Build a locally approved production source with complete immutable references."""
-    source = _production_source(tag)
-    approval = HumanApproval(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision="w12-test",
-        approval_id=f"human-approval-{tag}",
-        trace_id=source.trace.trace_id,
-        approved_at=_TIME,
-    )
-    evidence = ProductionAcceptanceEvidence(
-        schema_version=1,
-        created_at=_TIME,
-        inputs=_inputs(
-            ArtifactInput(
-                artifact_id=source.acceptance_rule.acceptance_rule_id,
-                sha256=sha256_json(source.acceptance_rule),
-            ),
-            ArtifactInput(artifact_id=approval.approval_id, sha256=sha256_json(approval)),
-        ),
-        code_revision="w12-test",
-        acceptance_evidence_id=f"human-evidence-{tag}",
-        trace_id=source.trace.trace_id,
-        trace_sha256=sha256_json(source.trace),
-        acceptance_rule_id=source.acceptance_rule.acceptance_rule_id,
-        acceptance_rule_sha256=sha256_json(source.acceptance_rule),
-        decision="human_approval",
-        human_approval_id=approval.approval_id,
-        human_approval_sha256=sha256_json(approval),
-        accepted_at=_TIME,
-    )
-    return source.model_copy(update={"acceptance_evidence": evidence, "human_approval": approval})
-
-
-def _task_case(tag: str, instruction: str) -> TaskCase:
-    return TaskCase(
-        task_id=f"task-{tag}",
-        lineage_group_id=f"task-lineage-{tag}",
+def _task_set(store: ProjectStore) -> tuple[TaskCase, TaskSet, ArtifactInput]:
+    """Persist a W5-shaped task set with trace-input lineage and exact task payload bytes."""
+    source_trace = _trace("task-source")
+    source_input = _write_trace_dataset(store, source_trace)
+    task = TaskCase(
+        task_id="task-teacher",
+        lineage_group_id="task-lineage-teacher",
         partition="fit",
-        instruction=instruction,
+        instruction="Resolve the teacher support request.",
         workload_weight=1.0,
-        source_trace_ids=(f"teacher-trace-{tag}",),
+        source_trace_ids=(source_trace.trace_id,),
     )
-
-
-def _task_set(task: TaskCase) -> TaskSet:
-    return TaskSet(
+    task_payload = canonical_json_bytes(task) + b"\n"
+    task_set = TaskSet(
         schema_version=1,
         created_at=_TIME,
+        inputs=(source_input,),
         code_revision="w12-test",
-        task_set_id=f"task-set-{task.task_id.removeprefix('task-')}",
+        task_set_id="task-set-teacher",
         task_ids=(task.task_id,),
         tasks_path="tasks.jsonl",
-        tasks_sha256=_DIGEST,
+        tasks_sha256=hashlib.sha256(task_payload).hexdigest(),
+    )
+    task_set_input = artifact_input(
+        store.artifacts.write(
+            artifact_id=task_set.task_set_id,
+            artifact_type="task-set",
+            envelope=task_set,
+            files={
+                "task-set.json": canonical_json_bytes(task_set),
+                "tasks.jsonl": task_payload,
+            },
+        )
+    )
+    return task, task_set, task_set_input
+
+
+def _rubric(task_set_input: ArtifactInput) -> Rubric:
+    """Build a one-dimensional, human-approved rubric tied to one canonical task set."""
+    return Rubric(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(task_set_input,),
+        code_revision="w12-test",
+        rubric_id="rubric-teacher",
+        dimensions=(
+            RubricDimension(
+                dimension_id="quality",
+                name="Quality",
+                description="Whether the rollout resolved the requested support work.",
+                anchors=(
+                    ScoreAnchor(score=0, description="Quality level 0."),
+                    ScoreAnchor(score=1, description="Quality level 1."),
+                    ScoreAnchor(score=2, description="Quality level 2."),
+                    ScoreAnchor(score=3, description="Quality level 3."),
+                    ScoreAnchor(score=4, description="Quality level 4."),
+                    ScoreAnchor(score=5, description="Quality level 5."),
+                ),
+            ),
+        ),
+        source_task_set_id=task_set_input.artifact_id,
+        status="human_approved",
+        approved_at=_TIME,
     )
 
 
 def _rollout(tag: str, task_id: str) -> RolloutArtifact:
-    model = _model()
+    """Build one successful world-model rollout suitable for authoritative W6 judging."""
+    model = _model("candidate-model")
     return RolloutArtifact(
         schema_version=1,
         created_at=_TIME,
@@ -250,7 +355,7 @@ def _rollout(tag: str, task_id: str) -> RolloutArtifact:
             world_model=model,
         ),
         world_model=model,
-        seed=7,
+        seed=1,
         repeat=0,
         spans=(
             RolloutSpan(
@@ -258,564 +363,591 @@ def _rollout(tag: str, task_id: str) -> RolloutArtifact:
                 kind=RolloutEventKind.AGENT_MODEL_CALL,
                 started_at=_TIME,
                 ended_at=_TIME + timedelta(seconds=1),
+                payload={"result": "resolved"},
                 model=model,
             ),
         ),
+        final_output=AssistantAction(content="Resolved support request."),
         stop_reason=StopReason.COMPLETED,
         candidate_economics=OperationEconomics(),
         simulation_spec_sha256=_DIGEST,
     )
 
 
-def _calibration(
-    tag: str, *, status: Literal["human_calibrated", "insufficient"] = "human_calibrated"
-) -> JudgeCalibration:
-    return JudgeCalibration(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision="w12-test",
-        calibration_id=f"calibration-{tag}",
-        rubric_id=f"rubric-{tag}",
-        judge_model=_model(),
-        judge_prompt_id="judge-prompt-v1",
-        judge_prompt_sha256=_DIGEST,
-        label_set_id=f"labels-{tag}",
-        calibration_lineage_ids=(f"lineage-{tag}",),
-        excluded_router_held_out_lineage_ids=(),
-        validation_method="grouped_k_fold",
-        out_of_fold_report_id=f"calibration-report-{tag}",
-        out_of_fold_report_sha256=_DIGEST,
-        score_maps=(
-            DimensionScoreMap(
-                dimension_id="quality",
-                calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
-            ),
-        ),
-        label_count=1,
-        status=status,
-        approved_at=_TIME if status == "human_calibrated" else None,
+def _write_teacher_source(store: ProjectStore) -> _TeacherFixture:
+    """Persist a complete W5, W6, rollout, fidelity, and acceptance chain for one teacher row."""
+    task, task_set, task_set_input = _task_set(store)
+    rubric = _rubric(task_set_input)
+    store.artifacts.write_json(
+        artifact_id=rubric.rubric_id,
+        artifact_type="rubric",
+        envelope=rubric,
+        files={"rubric.json": rubric},
     )
-
-
-def _teacher_source(
-    tag: str,
-    *,
-    task: str = "Refund order o-17.",
-    score: float = 1.0,
-    minimum_score: float = 0.8,
-    calibration_status: Literal["human_calibrated", "insufficient"] = "human_calibrated",
-    fidelity_status: Literal["approved", "rejected", "insufficient"] = "approved",
-) -> TeacherSFTSource:
-    task_case = _task_case(tag, task)
-    task_set = _task_set(task_case)
-    rollout = _rollout(tag, task_case.task_id)
-    calibration = _calibration(tag, status=calibration_status)
-    raw_score = 5 if score == 1.0 else 4
-    judgment = Judgment(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision="w12-test",
-        judgment_id=f"judgment-{tag}",
-        rollout_id=rollout.rollout_id,
-        rubric_id=calibration.rubric_id,
-        calibration_id=calibration.calibration_id,
-        judge_model=_model(),
-        judge_prompt_id="judge-prompt-v1",
-        judge_prompt_sha256=_DIGEST,
-        dimensions=(
-            DimensionJudgment(
-                dimension_id="quality",
-                raw_score=raw_score,
-                calibrated_score=score * 5,
-                evidence_span_ids=(f"rollout-span-{tag}",),
-                feedback="The rollout completed the requested action.",
-            ),
-        ),
-        overall_score=score,
-    )
-    if fidelity_status == "approved":
-        usable_overlap_count, score_mae = 8, 0.08
-    elif fidelity_status == "rejected":
-        usable_overlap_count, score_mae = 8, 0.12
-    else:
-        usable_overlap_count, score_mae = 7, None
-    failures = tuple(
-        FidelityFailure(
-            cell_id=f"fidelity-cell-{tag}-{index}",
-            failure=StructuredFailure(code=FailureCode.TIMEOUT, message="overlap unavailable"),
+    prompt = PromptDefinition.from_text("judge-prompt-v1", "Return structured judgment JSON.")
+    model = _model()
+    rollouts = tuple(_rollout(f"calibration-{index}", task.task_id) for index in range(2))
+    rollout_inputs: list[ArtifactInput] = []
+    for rollout in rollouts:
+        rollout_inputs.append(
+            artifact_input(
+                store.artifacts.write_json(
+                    artifact_id=rollout.artifact_id,
+                    artifact_type="rollout",
+                    envelope=rollout,
+                    files={"rollout.json": rollout},
+                )
+            )
         )
-        for index in range(usable_overlap_count, 10)
+    split = write_router_lineage_split(
+        store,
+        RouterLineageSplit(
+            schema_version=1,
+            created_at=_TIME,
+            inputs=(task_set_input,),
+            code_revision="w12-test",
+            split_id="router-lineage-split-teacher",
+            source_task_set_id=task_set.task_set_id,
+            fit_lineage_ids=("calibration-lineage-0", "calibration-lineage-1"),
+            held_out_lineage_ids=(),
+            assignments=tuple(
+                RouterLineageAssignment(
+                    rollout_id=rollout.rollout_id,
+                    lineage_id=f"calibration-lineage-{index}",
+                )
+                for index, rollout in enumerate(rollouts)
+            ),
+        ),
     )
+    review = HumanScoreReview.open(store)
+    empty_labels = review.finalize(
+        rubric_id=rubric.rubric_id,
+        code_revision="w12-test",
+        created_at=_TIME,
+    )
+    calibration_service = JudgeCalibrationService()
+    provisional = calibration_service.bootstrap_provisional(
+        store,
+        rubric_id=rubric.rubric_id,
+        label_set_id=empty_labels.label_set_id,
+        router_lineage_split_id=split.split_id,
+        judge_model=model,
+        judge_prompt=prompt,
+        created_at=_TIME,
+        code_revision="w12-test",
+    )
+    observations: list[JudgeScoreObservation] = []
+    for index, rollout in enumerate(rollouts):
+        span_id = rollout.spans[0].span_id
+        judgment = LMJudge(
+            _FakeJudgeClient(
+                model,
+                json.dumps(
+                    {
+                        "dimensions": [
+                            {
+                                "dimension_id": "quality",
+                                "raw_score": 5,
+                                "evidence_span_ids": [span_id],
+                                "feedback": "The rollout resolved the request.",
+                            }
+                        ]
+                    }
+                ),
+            ),
+            prompt,
+            code_revision="w12-test",
+            clock=lambda: _TIME,
+        ).judge_and_write(
+            store,
+            rollout_artifact_id=rollout.artifact_id,
+            rubric_artifact_id=rubric.rubric_id,
+            calibration_artifact_id=provisional.calibration_id,
+        )
+        judgment_input = artifact_input(store.artifacts.read(judgment.judgment_id).manifest)
+        observations.append(
+            JudgeScoreObservation(
+                judgment=judgment_input,
+                source_rollout=rollout_inputs[index],
+                dimension_id="quality",
+                raw_score=5,
+                evidence_span_ids=(span_id,),
+            )
+        )
+        review.append(
+            HumanScore(
+                label_id=f"human-label-{index}",
+                rubric_id=rubric.rubric_id,
+                rollout_id=rollout.rollout_id,
+                lineage_id=f"calibration-lineage-{index}",
+                dimension_id="quality",
+                score=5,
+                created_at=_TIME,
+            )
+        )
+    labels = review.finalize(
+        rubric_id=rubric.rubric_id,
+        code_revision="w12-test",
+        created_at=_TIME,
+    )
+    report = calibration_service.build_report(
+        store,
+        rubric_id=rubric.rubric_id,
+        label_set_id=labels.label_set_id,
+        router_lineage_split_id=split.split_id,
+        observations=tuple(observations),
+        created_at=_TIME,
+        code_revision="w12-test",
+    )
+    calibration_service.write_report(store, report)
+    calibration = calibration_service.write_calibration(
+        store,
+        report=report,
+        calibration=calibration_service.approve(
+            store,
+            report,
+            approved_at=_TIME,
+            accept_insufficient_labels=True,
+        ),
+    )
+    calibration_input = artifact_input(store.artifacts.read(calibration.calibration_id).manifest)
+    final_rollout = _rollout("teacher", task.task_id)
+    rollout_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=final_rollout.artifact_id,
+            artifact_type="rollout",
+            envelope=final_rollout,
+            files={"rollout.json": final_rollout},
+        )
+    )
+    final_judgment = LMJudge(
+        _FakeJudgeClient(
+            model,
+            json.dumps(
+                {
+                    "dimensions": [
+                        {
+                            "dimension_id": "quality",
+                            "raw_score": 5,
+                            "evidence_span_ids": [final_rollout.spans[0].span_id],
+                            "feedback": "The teacher resolved the request.",
+                        }
+                    ]
+                }
+            ),
+        ),
+        prompt,
+        code_revision="w12-test",
+        clock=lambda: _TIME,
+    ).judge_and_write(
+        store,
+        rollout_artifact_id=final_rollout.artifact_id,
+        rubric_artifact_id=rubric.rubric_id,
+        calibration_artifact_id=calibration.calibration_id,
+    )
+    judgment_input = artifact_input(store.artifacts.read(final_judgment.judgment_id).manifest)
     fidelity = FidelityReport(
         schema_version=1,
         created_at=_TIME,
+        inputs=(task_set_input,),
         code_revision="w12-test",
-        fidelity_report_id=f"fidelity-{tag}",
+        fidelity_report_id="fidelity-teacher",
         protocol_sha256=_DIGEST,
-        overlap_cell_ids=tuple(f"fidelity-cell-{tag}-{index}" for index in range(10)),
-        planned_overlap_count=10,
-        usable_overlap_count=usable_overlap_count,
-        failed_overlap_count=len(failures),
-        score_mae=score_mae,
-        failures=failures,
-        gate_id=f"fidelity-gate-{tag}",
+        overlap_cell_ids=tuple(f"fidelity-cell-{index}" for index in range(8)),
+        planned_overlap_count=8,
+        usable_overlap_count=8,
+        failed_overlap_count=0,
+        score_mae=0.05,
+        gate_id="fidelity-gate-teacher",
         gate_sha256=_DIGEST,
-        status=fidelity_status,
-        approved_at=_TIME if fidelity_status == "approved" else None,
+        status="approved",
+        approved_at=_TIME,
+    )
+    fidelity_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=fidelity.fidelity_report_id,
+            artifact_type="fidelity-report",
+            envelope=fidelity,
+            files={"fidelity-report.json": fidelity},
+        )
     )
     rule = TeacherAcceptanceRule(
         schema_version=1,
         created_at=_TIME,
+        inputs=(calibration_input,),
         code_revision="w12-test",
-        acceptance_rule_id=f"teacher-rule-{tag}",
-        minimum_overall_score=minimum_score,
-        required_calibration_id=calibration.calibration_id,
+        acceptance_rule_id="teacher-rule",
+        minimum_overall_score=0.8,
+        required_calibration=calibration_input,
     )
+    rule_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=rule.acceptance_rule_id,
+            artifact_type="sft-teacher-acceptance-rule",
+            envelope=rule,
+            files={"rule.json": rule},
+        )
+    )
+    transcript = _transcript("teacher")
+    transcript_payload = canonical_json_bytes(transcript)
     evidence = TeacherAcceptanceEvidence(
         schema_version=1,
         created_at=_TIME,
         inputs=_inputs(
-            ArtifactInput(artifact_id=rollout.rollout_id, sha256=sha256_json(rollout)),
-            ArtifactInput(artifact_id=judgment.judgment_id, sha256=sha256_json(judgment)),
-            ArtifactInput(artifact_id=calibration.calibration_id, sha256=sha256_json(calibration)),
-            ArtifactInput(
-                artifact_id=fidelity.fidelity_report_id,
-                sha256=sha256_json(fidelity),
-            ),
-            ArtifactInput(artifact_id=rule.acceptance_rule_id, sha256=sha256_json(rule)),
+            rollout_input,
+            task_set_input,
+            judgment_input,
+            calibration_input,
+            fidelity_input,
+            rule_input,
         ),
         code_revision="w12-test",
-        acceptance_evidence_id=f"teacher-evidence-{tag}",
-        rollout_id=rollout.rollout_id,
-        rollout_sha256=sha256_json(rollout),
-        judgment_id=judgment.judgment_id,
-        judgment_sha256=sha256_json(judgment),
-        calibration_id=calibration.calibration_id,
-        calibration_sha256=sha256_json(calibration),
-        fidelity_report_id=fidelity.fidelity_report_id,
-        fidelity_report_sha256=sha256_json(fidelity),
-        acceptance_rule_id=rule.acceptance_rule_id,
-        acceptance_rule_sha256=sha256_json(rule),
-        observed_overall_score=score,
+        acceptance_evidence_id="teacher-evidence",
+        rollout=rollout_input,
+        task_set=task_set_input,
+        task_set_tasks_sha256=task_set.tasks_sha256,
+        task_set_inputs=task_set.inputs,
+        task_id=task.task_id,
+        task_sha256=sha256_json(task),
+        judgment=judgment_input,
+        calibration=calibration_input,
+        fidelity_report=fidelity_input,
+        acceptance_rule=rule_input,
+        transcript_path="transcript.json",
+        transcript_sha256=hashlib.sha256(transcript_payload).hexdigest(),
         accepted_at=_TIME,
     )
-    return TeacherSFTSource(
-        rollout=rollout,
-        task=task_case,
-        task_set=task_set,
-        transcript=_transcript(),
-        acceptance_rule=rule,
-        acceptance_evidence=evidence,
-        judgment=judgment,
-        calibration=calibration,
-        fidelity=fidelity,
+    store.artifacts.write(
+        artifact_id=evidence.acceptance_evidence_id,
+        artifact_type="sft-teacher-acceptance",
+        envelope=evidence,
+        files={
+            "evidence.json": canonical_json_bytes(evidence),
+            "transcript.json": transcript_payload,
+        },
+    )
+    return _TeacherFixture(
+        source=TeacherSFTSource(acceptance_evidence_id=evidence.acceptance_evidence_id),
+        evidence=evidence,
+        rollout_input=rollout_input,
+        task_set_input=task_set_input,
+        judgment_input=judgment_input,
+        calibration_input=calibration_input,
+        fidelity_input=fidelity_input,
+        rule_input=rule_input,
+        transcript=transcript,
     )
 
 
 def _build(
+    store: ProjectStore,
+    *,
     production: tuple[ProductionSFTSource, ...] = (),
     teacher: tuple[TeacherSFTSource, ...] = (),
-    *,
-    created_at: datetime = _TIME,
 ) -> SFTDatasetArtifact:
+    """Build one SFT dataset through the public store-backed composition boundary."""
     return build_sft_dataset(
+        store=store,
         production_sources=production,
         teacher_sources=teacher,
         spec=SFTBuildSpec(held_out_fraction=0.5, representative_sample_count=2),
-        created_at=created_at,
+        created_at=_TIME,
         code_revision="w12-test",
     )
 
 
-def test_production_acceptance_filters_unapproved_failed_and_observation_events() -> None:
-    """Only accepted assistant actions become targets, never tools, failures, or unapproved turns.
+def test_store_backed_sources_hydrate_transcripts_and_preserve_full_actions(tmp_path: Path) -> None:
+    """Production and teacher rows come from verified evidence, not caller-owned transcripts."""
+    store = _store(tmp_path)
+    production = _write_production_source(store, "production", human_approval=True)
+    teacher = _write_teacher_source(store)
 
-    The source ledger still records why excluded events were not targets.
-    """
-    valid = _production_source("valid")
-    invalid_evidence = _production_source("invalid")
-    invalid_evidence = invalid_evidence.model_copy(
-        update={
-            "acceptance_evidence": invalid_evidence.acceptance_evidence.model_copy(
-                update={"trace_sha256": "f" * 64}
-            )
-        }
-    )
-    unapproved = _production_source("unapproved", approved=False)
-    failed = _production_source("failed", failed=True)
+    artifact = _build(store, production=(production,), teacher=(teacher.source,))
 
-    artifact = _build((valid, invalid_evidence, unapproved, failed))
-
+    assert {row.example.source.kind for row in artifact.rows} == {
+        "production_trace",
+        "teacher_rollout",
+    }
     assert {row.example.target.content for row in artifact.rows} == {
-        "I will verify the order and issue the refund.",
-        "Your refund is complete.",
+        "Investigating production.",
+        "Resolved production.",
+        "Investigating teacher.",
+        "Resolved teacher.",
     }
-    reasons = {exclusion.reason for exclusion in artifact.inspection.exclusions}
-    assert "invalid_production_acceptance" in reasons
-    assert "unapproved_action" in reasons
-    assert "infrastructure_failure" in reasons
-    assert "observation_context_only" in reasons
-    assert all(row.example.source.kind == "production_trace" for row in artifact.rows)
-
-
-def test_ineligible_assistant_actions_remain_visible_context_for_later_targets() -> None:
-    """An excluded assistant action is not learned, but later visible context remains faithful."""
-    source = _production_source("context")
-    excluded_action = AssistantActionEvent(
-        action=AssistantAction(content="This action was not approved."), approved=False
-    )
-    accepted_action = AssistantActionEvent(
-        action=AssistantAction(content="This approved action follows it.")
-    )
-    source = source.model_copy(
-        update={
-            "transcript": SFTTranscript(
-                events=(
-                    SFTMessage(role="user", content="Complete the request."),
-                    excluded_action,
-                    accepted_action,
-                )
-            )
-        }
-    )
-
-    artifact = _build((source,))
-
-    assert len(artifact.rows) == 1
-    assert artifact.rows[0].example.target == accepted_action.action
-    assert artifact.rows[0].example.history[-1] == excluded_action
-
-
-def test_production_acceptance_requires_verified_outcome_or_human_references() -> None:
-    """Every production evidence branch rejects missing or mismatched immutable references."""
-    valid_human_approval = _human_approved_production_source("human-valid")
-    missing_human_approval = _human_approved_production_source("human-missing")
-    missing_human_approval = missing_human_approval.model_copy(update={"human_approval": None})
-    mismatched_human_approval = _human_approved_production_source("human-hash")
-    mismatched_human_approval = mismatched_human_approval.model_copy(
-        update={
-            "acceptance_evidence": mismatched_human_approval.acceptance_evidence.model_copy(
-                update={"human_approval_sha256": "d" * 64}
-            )
-        }
-    )
-    mismatched_trace = _production_source("trace-hash")
-    mismatched_trace = mismatched_trace.model_copy(
-        update={
-            "acceptance_evidence": mismatched_trace.acceptance_evidence.model_copy(
-                update={"trace_sha256": "d" * 64}
-            )
-        }
-    )
-    mismatched_rule = _production_source("rule-hash")
-    mismatched_rule = mismatched_rule.model_copy(
-        update={
-            "acceptance_evidence": mismatched_rule.acceptance_evidence.model_copy(
-                update={"acceptance_rule_sha256": "d" * 64}
-            )
-        }
-    )
-    mismatched_outcome = _production_source("outcome-hash")
-    mismatched_outcome = mismatched_outcome.model_copy(
-        update={
-            "acceptance_evidence": mismatched_outcome.acceptance_evidence.model_copy(
-                update={"outcome_sha256": "d" * 64}
-            )
-        }
-    )
-    disallowed_human_approval = _human_approved_production_source("human-disallowed")
-    disallowed_rule = disallowed_human_approval.acceptance_rule.model_copy(
-        update={"allow_human_approval": False}
-    )
-    approval = disallowed_human_approval.human_approval
-    assert approval is not None
-    disallowed_human_approval = disallowed_human_approval.model_copy(
-        update={
-            "acceptance_rule": disallowed_rule,
-            "acceptance_evidence": disallowed_human_approval.acceptance_evidence.model_copy(
-                update={
-                    "acceptance_rule_sha256": sha256_json(disallowed_rule),
-                    "inputs": _inputs(
-                        ArtifactInput(
-                            artifact_id=disallowed_rule.acceptance_rule_id,
-                            sha256=sha256_json(disallowed_rule),
-                        ),
-                        ArtifactInput(
-                            artifact_id=approval.approval_id,
-                            sha256=sha256_json(approval),
-                        ),
-                    ),
-                }
-            ),
-        }
-    )
-    untrusted_outcome = _production_source("untrusted-outcome")
-    alternate_outcome = TraceOutcome(status="success", outcome_name="declined")
-    alternate_trace = untrusted_outcome.trace.model_copy(update={"outcome": alternate_outcome})
-    untrusted_outcome = untrusted_outcome.model_copy(
-        update={
-            "trace": alternate_trace,
-            "acceptance_evidence": untrusted_outcome.acceptance_evidence.model_copy(
-                update={
-                    "trace_sha256": sha256_json(alternate_trace),
-                    "outcome_sha256": sha256_json(alternate_outcome),
-                }
-            ),
-        }
-    )
-
-    artifact = _build(
-        (
-            valid_human_approval,
-            missing_human_approval,
-            mismatched_human_approval,
-            mismatched_trace,
-            mismatched_rule,
-            mismatched_outcome,
-            disallowed_human_approval,
-            untrusted_outcome,
+    assert "transcript" not in ProductionSFTSource.model_fields
+    assert "transcript" not in TeacherSFTSource.model_fields
+    assert "observed_overall_score" not in TeacherAcceptanceEvidence.model_fields
+    assert teacher.task_set_input in artifact.dataset.inputs
+    assert teacher.calibration_input in artifact.dataset.inputs
+    assert teacher.evidence.task_set_tasks_sha256
+    with pytest.raises(ValidationError):
+        ProductionSFTSource.model_validate(
+            {
+                "acceptance_evidence_id": production.acceptance_evidence_id,
+                "transcript": _transcript("caller-controlled").model_dump(mode="json"),
+            }
         )
-    )
-
-    assert {
-        row.example.source.trace_id
-        for row in artifact.rows
-        if isinstance(row.example.source, TraceExampleSource)
-    } == {"trace-human-valid"}
-    excluded_ids = {
-        exclusion.source_id
-        for exclusion in artifact.inspection.exclusions
-        if exclusion.reason == "invalid_production_acceptance"
-    }
-    assert excluded_ids == {
-        "trace-human-missing",
-        "trace-human-hash",
-        "trace-trace-hash",
-        "trace-rule-hash",
-        "trace-outcome-hash",
-        "trace-human-disallowed",
-        "trace-untrusted-outcome",
-    }
 
 
-def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
-    """Every teacher evidence reference and acceptance gate must be proven before training."""
-    valid = _teacher_source("valid")
-    bad_rollout_hash = _teacher_source("rollout-hash")
-    bad_rollout_hash = bad_rollout_hash.model_copy(
-        update={
-            "acceptance_evidence": bad_rollout_hash.acceptance_evidence.model_copy(
-                update={"rollout_sha256": "c" * 64}
-            )
-        }
-    )
-    bad_judgment_hash = _teacher_source("judgment-hash")
-    bad_judgment_hash = bad_judgment_hash.model_copy(
-        update={
-            "acceptance_evidence": bad_judgment_hash.acceptance_evidence.model_copy(
-                update={"judgment_sha256": "c" * 64}
-            )
-        }
-    )
-    bad_calibration_hash = _teacher_source("calibration-hash")
-    bad_calibration_hash = bad_calibration_hash.model_copy(
-        update={
-            "acceptance_evidence": bad_calibration_hash.acceptance_evidence.model_copy(
-                update={"calibration_sha256": "c" * 64}
-            )
-        }
-    )
-    bad_fidelity_hash = _teacher_source("fidelity-hash")
-    bad_fidelity_hash = bad_fidelity_hash.model_copy(
-        update={
-            "acceptance_evidence": bad_fidelity_hash.acceptance_evidence.model_copy(
-                update={"fidelity_report_sha256": "c" * 64}
-            )
-        }
-    )
-    bad_rule_hash = _teacher_source("rule-hash")
-    bad_rule_hash = bad_rule_hash.model_copy(
-        update={
-            "acceptance_evidence": bad_rule_hash.acceptance_evidence.model_copy(
-                update={"acceptance_rule_sha256": "c" * 64}
-            )
-        }
-    )
-    insufficient_calibration = _teacher_source("calibration", calibration_status="insufficient")
-    rejected_fidelity = _teacher_source("fidelity-rejected", fidelity_status="rejected")
-    insufficient_fidelity = _teacher_source("fidelity-insufficient", fidelity_status="insufficient")
-    low_score = _teacher_source("score", score=0.8, minimum_score=0.9)
-    unfinished = _teacher_source("unfinished")
-    unfinished = unfinished.model_copy(
-        update={
-            "rollout": unfinished.rollout.model_copy(
-                update={"stop_reason": StopReason.MAXIMUM_STEPS}
-            )
-        }
-    )
-    mismatched_task = _teacher_source("task-mismatch")
-    mismatched_task = mismatched_task.model_copy(
-        update={"task": _task_case("different", "A different canonical task.")}
-    )
-    task_outside_set = _teacher_source("task-outside-set")
-    task_outside_set = task_outside_set.model_copy(
-        update={
-            "task_set": task_outside_set.task_set.model_copy(
-                update={"task_ids": ("task-not-this-one",)}
-            )
-        }
-    )
-    unproven = _teacher_source("unproven")
-    unproven = unproven.model_copy(
-        update={
-            "acceptance_evidence": unproven.acceptance_evidence.model_copy(update={"inputs": ()})
-        }
-    )
-
-    artifact = _build(
-        teacher=(
-            valid,
-            bad_rollout_hash,
-            bad_judgment_hash,
-            bad_calibration_hash,
-            bad_fidelity_hash,
-            bad_rule_hash,
-            insufficient_calibration,
-            rejected_fidelity,
-            insufficient_fidelity,
-            low_score,
-            unfinished,
-            mismatched_task,
-            task_outside_set,
-            unproven,
-        )
-    )
-
-    assert {
-        row.example.source.rollout_id
-        for row in artifact.rows
-        if isinstance(row.example.source, RolloutExampleSource)
-    } == {"rollout-valid"}
-    assert "task-set-valid" in {item.artifact_id for item in artifact.dataset.inputs}
-    excluded_ids = {
-        exclusion.source_id
-        for exclusion in artifact.inspection.exclusions
-        if exclusion.reason == "invalid_teacher_acceptance"
-    }
-    assert excluded_ids == {
-        "rollout-rollout-hash",
-        "rollout-judgment-hash",
-        "rollout-calibration-hash",
-        "rollout-fidelity-hash",
-        "rollout-rule-hash",
-        "rollout-calibration",
-        "rollout-fidelity-rejected",
-        "rollout-fidelity-insufficient",
-        "rollout-score",
-        "rollout-unfinished",
-        "rollout-task-mismatch",
-        "rollout-task-outside-set",
-        "rollout-unproven",
-    }
-
-
-def test_shared_fingerprints_union_lineages_before_split_and_deduplicate_globally() -> None:
-    """Identical context-target content cannot leak across partitions and keeps one row globally."""
-    first = _production_source("one")
-    second = _production_source("two")
-    distinct = _production_source("three", task="Cancel order o-17.")
-
-    artifact = _build((first, second, distinct))
-
-    references = {source.source_id: source for source in artifact.sources}
-    first_group = references["trace-one"].leakage_group_id
-    second_group = references["trace-two"].leakage_group_id
-    shared_partition = next(
-        partition for partition in artifact.partitions if first_group in partition.leakage_group_ids
-    )
-    assert second_group in shared_partition.leakage_group_ids
-    assert any(
-        exclusion.reason == "duplicate_normalized_example"
-        for exclusion in artifact.inspection.exclusions
-    )
-    fingerprints_by_partition: dict[str, set[str]] = {"train": set(), "held_out": set()}
-    for row in artifact.rows:
-        fingerprints_by_partition[row.partition].add(row.fingerprint)
-    assert not fingerprints_by_partition["train"].intersection(
-        fingerprints_by_partition["held_out"]
-    )
-
-
-def test_cross_split_fingerprint_is_explicitly_rejected() -> None:
-    """Corrupt rows cannot place one normalized example in both train and held-out data."""
-    row = _build((_production_source("cross-split"),)).rows[0]
-    held_out_copy = row.model_copy(update={"partition": "held_out"})
-
-    with pytest.raises(SFTBuildError, match="appears in both"):
-        ensure_no_cross_split_fingerprints((row, held_out_copy))
-
-
-def test_same_sources_produce_the_same_digest_regardless_of_input_order_or_build_time() -> None:
-    """The semantic digest is stable while materialization time remains provenance."""
-    first = _production_source("first")
-    second = _production_source("second", task="Cancel order o-17.")
-
-    forward = _build((first, second), created_at=_TIME)
-    reversed_build = _build((second, first), created_at=_TIME + timedelta(days=1))
-
-    assert forward.dataset.build_sha256 == reversed_build.dataset.build_sha256
-    assert forward.dataset.dataset_id == reversed_build.dataset.dataset_id
-    assert forward.rows == reversed_build.rows
-
-
-def test_frozen_artifact_contains_provenance_samples_exclusions_and_training_gate(
+def test_store_backed_source_rejects_corrupt_transcript_and_cross_store_pointer(
     tmp_path: Path,
 ) -> None:
-    """Only a prior accepted immutable artifact can be loaded for later training consumption."""
-    accepted = _build((_production_source("artifact"), _production_source("other", task="Other.")))
-    store = ProjectStore(tmp_path / ".wmo", "sft-project")
-    store.initialize(ProjectConfig(project_id="sft-project"))
-
-    written = write_sft_dataset(store, accepted)
-    loaded = load_sft_dataset(store, written.dataset.dataset_id)
-    stored = store.artifacts.read(written.dataset.dataset_id)
-    metadata = written.metadata()
-
-    assert loaded == written
-    assert {file.path for file in stored.manifest.files} == {"dataset.json", "examples.jsonl"}
-    assert metadata.sources
-    assert metadata.partitions
-    assert metadata.inspection.exclusions
-    assert metadata.representative_samples
-    source_reference = next(source for source in metadata.sources if source.accepted)
-    assert source_reference.acceptance_evidence_id == "production-evidence-artifact"
-    assert source_reference.acceptance_evidence_sha256 == sha256_json(
-        _production_source("artifact").acceptance_evidence
+    """An accepted pointer cannot inject arbitrary transcript bytes or cross project boundaries."""
+    source_store = _store(tmp_path / "source")
+    source = _write_production_source(source_store, "corrupt")
+    transcript_path = (
+        source_store.artifacts.read(source.acceptance_evidence_id).directory / "transcript.json"
     )
-    assert {item.artifact_id for item in metadata.dataset.inputs} == {
-        "production-evidence-artifact",
-        "production-evidence-other",
-        "production-rule-artifact",
-        "production-rule-other",
-    }
-    assert metadata.inspection.dataset_id == metadata.dataset.dataset_id
-    assert all(sample in written.rows for sample in metadata.representative_samples)
+    transcript_path.write_text('{"events":[]}\n', encoding="utf-8")
 
-    invalid = _production_source("nope")
-    invalid = invalid.model_copy(
+    with pytest.raises(SFTBuildError, match="not accepted evidence"):
+        _build(source_store, production=(source,))
+
+    other_store = _store(tmp_path / "other")
+    with pytest.raises(SFTBuildError, match="not accepted evidence"):
+        _build(other_store, production=(source,))
+
+    teacher_source = _write_teacher_source(source_store)
+    with pytest.raises(SFTBuildError, match="not accepted evidence"):
+        _build(other_store, teacher=(teacher_source.source,))
+
+
+def test_teacher_rejects_forged_score_and_recursively_unverifiable_calibration(
+    tmp_path: Path,
+) -> None:
+    """Teacher acceptance recomputes score and invokes W6 recursive calibration verification."""
+    store = _store(tmp_path)
+    fixture = _write_teacher_source(store)
+    original = Judgment.model_validate_json(
+        store.artifacts.read_bytes(fixture.judgment_input.artifact_id, "judgment.json")
+    )
+    forged_dimension = original.dimensions[0].model_copy(update={"calibrated_score": 4.0})
+    forged_judgment = original.model_copy(
         update={
-            "acceptance_evidence": invalid.acceptance_evidence.model_copy(
-                update={"acceptance_rule_sha256": "d" * 64}
-            )
+            "judgment_id": "forged-teacher-judgment",
+            "dimensions": (forged_dimension,),
+            "overall_score": 0.8,
         }
     )
-    insufficient = _build((invalid,))
-    write_sft_dataset(store, insufficient)
-    with pytest.raises(ValueError, match="insufficient"):
-        load_sft_dataset(store, insufficient.dataset.dataset_id)
-    assert (
-        load_sft_dataset(
-            store, insufficient.dataset.dataset_id, require_accepted=False
-        ).dataset.status
-        == "insufficient"
+    forged_judgment_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=forged_judgment.judgment_id,
+            artifact_type="judgment",
+            envelope=forged_judgment,
+            files={"judgment.json": forged_judgment},
+        )
+    )
+    forged_evidence = fixture.evidence.model_copy(
+        update={
+            "acceptance_evidence_id": "teacher-evidence-forged-score",
+            "inputs": _inputs(
+                fixture.rollout_input,
+                fixture.task_set_input,
+                forged_judgment_input,
+                fixture.calibration_input,
+                fixture.fidelity_input,
+                fixture.rule_input,
+            ),
+            "judgment": forged_judgment_input,
+        }
+    )
+    store.artifacts.write(
+        artifact_id=forged_evidence.acceptance_evidence_id,
+        artifact_type="sft-teacher-acceptance",
+        envelope=forged_evidence,
+        files={
+            "evidence.json": canonical_json_bytes(forged_evidence),
+            "transcript.json": canonical_json_bytes(fixture.transcript),
+        },
+    )
+    with pytest.raises(SFTBuildError, match="calibrated dimension"):
+        _build(
+            store,
+            teacher=(
+                TeacherSFTSource(acceptance_evidence_id=forged_evidence.acceptance_evidence_id),
+            ),
+        )
+
+    calibration = JudgeCalibration.model_validate_json(
+        store.artifacts.read_bytes(fixture.calibration_input.artifact_id, "calibration.json")
+    )
+    forged_calibration = calibration.model_copy(
+        update={
+            "calibration_id": "forged-teacher-calibration",
+            "out_of_fold_report_sha256": "b" * 64,
+        }
+    )
+    forged_calibration_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=forged_calibration.calibration_id,
+            artifact_type="judge-calibration",
+            envelope=forged_calibration,
+            files={"calibration.json": forged_calibration},
+        )
+    )
+    forged_rule = TeacherAcceptanceRule(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(forged_calibration_input,),
+        code_revision="w12-test",
+        acceptance_rule_id="teacher-rule-forged-calibration",
+        minimum_overall_score=0.8,
+        required_calibration=forged_calibration_input,
+    )
+    forged_rule_input = artifact_input(
+        store.artifacts.write_json(
+            artifact_id=forged_rule.acceptance_rule_id,
+            artifact_type="sft-teacher-acceptance-rule",
+            envelope=forged_rule,
+            files={"rule.json": forged_rule},
+        )
+    )
+    forged_calibration_evidence = fixture.evidence.model_copy(
+        update={
+            "acceptance_evidence_id": "teacher-evidence-forged-calibration",
+            "inputs": _inputs(
+                fixture.rollout_input,
+                fixture.task_set_input,
+                fixture.judgment_input,
+                forged_calibration_input,
+                fixture.fidelity_input,
+                forged_rule_input,
+            ),
+            "calibration": forged_calibration_input,
+            "acceptance_rule": forged_rule_input,
+        }
+    )
+    store.artifacts.write(
+        artifact_id=forged_calibration_evidence.acceptance_evidence_id,
+        artifact_type="sft-teacher-acceptance",
+        envelope=forged_calibration_evidence,
+        files={
+            "evidence.json": canonical_json_bytes(forged_calibration_evidence),
+            "transcript.json": canonical_json_bytes(fixture.transcript),
+        },
+    )
+    with pytest.raises(SFTBuildError, match="recursive W6 provenance"):
+        _build(
+            store,
+            teacher=(
+                TeacherSFTSource(
+                    acceptance_evidence_id=forged_calibration_evidence.acceptance_evidence_id
+                ),
+            ),
+        )
+
+
+def test_teacher_rejects_corrupt_full_task_case_and_preserves_task_set_lineage(
+    tmp_path: Path,
+) -> None:
+    """Task IDs alone never authorize teacher data, task bytes and task-set inputs are verified."""
+    store = _store(tmp_path)
+    fixture = _write_teacher_source(store)
+    task_path = store.artifacts.read(fixture.task_set_input.artifact_id).directory / "tasks.jsonl"
+    task_path.write_text('{"task_id":"task-teacher"}\n', encoding="utf-8")
+
+    with pytest.raises(SFTBuildError, match="not accepted evidence"):
+        _build(store, teacher=(fixture.source,))
+
+
+def test_ineligible_actions_remain_context_but_never_become_sft_targets(tmp_path: Path) -> None:
+    """Verified transcript events retain context while excluding failed and unapproved targets."""
+    store = _store(tmp_path)
+    unapproved = AssistantActionEvent(
+        action=AssistantAction(content="This action was not approved."), approved=False
+    )
+    failed = AssistantActionEvent(action=AssistantAction(content="This action failed."))
+    accepted = AssistantActionEvent(action=AssistantAction(content="This action is approved."))
+    source = _write_production_source(
+        store,
+        "context",
+        transcript=SFTTranscript(
+            events=(
+                SFTMessage(role="user", content="Complete the request."),
+                unapproved,
+                failed,
+                InfrastructureFailureEvent(
+                    action_index=2,
+                    failure=StructuredFailure(
+                        code=FailureCode.TIMEOUT,
+                        message="tool transport timed out",
+                    ),
+                ),
+                accepted,
+            )
+        ),
+    )
+
+    artifact = _build(store, production=(source,))
+
+    assert [row.example.target for row in artifact.rows] == [accepted.action]
+    assert artifact.rows[0].example.history[-1] == failed
+    assert {item.reason for item in artifact.inspection.exclusions} == {
+        "infrastructure_failure",
+        "unapproved_action",
+    }
+
+
+def test_shared_fingerprints_union_lineages_and_build_digest_is_order_independent(
+    tmp_path: Path,
+) -> None:
+    """Keep duplicate verified examples in one split and preserve source-order invariance."""
+    store = _store(tmp_path)
+    shared_transcript = SFTTranscript(
+        events=(
+            SFTMessage(role="user", content="Resolve the shared request."),
+            AssistantActionEvent(action=AssistantAction(content="Resolved the shared request.")),
+        )
+    )
+    first = _write_production_source(
+        store,
+        "shared-one",
+        task="Resolve the shared request.",
+        transcript=shared_transcript,
+    )
+    second = _write_production_source(
+        store,
+        "shared-two",
+        task="Resolve the shared request.",
+        transcript=shared_transcript,
+    )
+    distinct = _write_production_source(store, "distinct")
+
+    forward = _build(store, production=(first, second, distinct))
+    reversed_build = _build(store, production=(distinct, second, first))
+
+    references = {item.source_id: item for item in forward.sources}
+    shared_partition = next(
+        item
+        for item in forward.partitions
+        if references["trace-shared-one"].leakage_group_id in item.leakage_group_ids
+    )
+    assert references["trace-shared-two"].leakage_group_id in shared_partition.leakage_group_ids
+    assert any(
+        item.reason == "duplicate_normalized_example" for item in forward.inspection.exclusions
+    )
+    assert forward.dataset.build_sha256 == reversed_build.dataset.build_sha256
+    assert forward.rows == reversed_build.rows
+
+    row = forward.rows[0]
+    with pytest.raises(SFTBuildError, match="appears in both"):
+        ensure_no_cross_split_fingerprints((row, row.model_copy(update={"partition": "held_out"})))
+
+
+def test_frozen_dataset_round_trips_only_after_store_backed_build(tmp_path: Path) -> None:
+    """A persisted SFT artifact retains verified source manifests and rejects later corruption."""
+    store = _store(tmp_path)
+    artifact = _build(
+        store,
+        production=(
+            _write_production_source(store, "one"),
+            _write_production_source(store, "two"),
+        ),
+    )
+    written = write_sft_dataset(store, artifact)
+
+    assert load_sft_dataset(store, written.dataset.dataset_id) == written
+    assert all(reference.source_artifact in written.dataset.inputs for reference in written.sources)
+    assert all(
+        reference.acceptance_evidence in written.dataset.inputs for reference in written.sources
     )

--- a/wmo/optimize/model/sft/builder_test.py
+++ b/wmo/optimize/model/sft/builder_test.py
@@ -15,7 +15,7 @@ from wmo.common.core.artifacts import (
     StructuredFailure,
     sha256_json,
 )
-from wmo.common.evaluations import FidelityReport
+from wmo.common.evaluations import FidelityFailure, FidelityReport
 from wmo.common.judging import DimensionJudgment, DimensionScoreMap, JudgeCalibration, Judgment
 from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics, ToolCall
 from wmo.common.project import ProjectConfig, ProjectStore
@@ -27,6 +27,7 @@ from wmo.common.rollouts import (
     StopReason,
     WorldModelSimulatorSnapshot,
 )
+from wmo.common.tasks import TaskCase, TaskSet
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.optimize.model.sft.builder import (
     SFTBuildError,
@@ -63,7 +64,12 @@ def _inputs(*items: ArtifactInput) -> tuple[ArtifactInput, ...]:
 
 
 def _model() -> ModelSnapshot:
-    return ModelSnapshot(provider="test", model_id="teacher-v1", capabilities_sha256=_DIGEST)
+    return ModelSnapshot(
+        provider="test",
+        model_id="teacher-v1",
+        capabilities_sha256=_DIGEST,
+        connection_sha256=_DIGEST,
+    )
 
 
 def _trace(trace_id: str, conversation_id: str, task: str) -> Trace:
@@ -198,7 +204,30 @@ def _human_approved_production_source(tag: str) -> ProductionSFTSource:
     return source.model_copy(update={"acceptance_evidence": evidence, "human_approval": approval})
 
 
-def _rollout(tag: str) -> RolloutArtifact:
+def _task_case(tag: str, instruction: str) -> TaskCase:
+    return TaskCase(
+        task_id=f"task-{tag}",
+        lineage_group_id=f"task-lineage-{tag}",
+        partition="fit",
+        instruction=instruction,
+        workload_weight=1.0,
+        source_trace_ids=(f"teacher-trace-{tag}",),
+    )
+
+
+def _task_set(task: TaskCase) -> TaskSet:
+    return TaskSet(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="w12-test",
+        task_set_id=f"task-set-{task.task_id.removeprefix('task-')}",
+        task_ids=(task.task_id,),
+        tasks_path="tasks.jsonl",
+        tasks_sha256=_DIGEST,
+    )
+
+
+def _rollout(tag: str, task_id: str) -> RolloutArtifact:
     model = _model()
     return RolloutArtifact(
         schema_version=1,
@@ -212,7 +241,7 @@ def _rollout(tag: str) -> RolloutArtifact:
         trace_id=f"teacher-trace-{tag}",
         evidence_source="world_model",
         source_run_id=f"run-{tag}",
-        task_id=f"task-{tag}",
+        task_id=task_id,
         candidate=model,
         agent_id="customer-agent",
         simulator=WorldModelSimulatorSnapshot(
@@ -277,7 +306,9 @@ def _teacher_source(
     calibration_status: Literal["human_calibrated", "insufficient"] = "human_calibrated",
     fidelity_status: Literal["approved", "rejected", "insufficient"] = "approved",
 ) -> TeacherSFTSource:
-    rollout = _rollout(tag)
+    task_case = _task_case(tag, task)
+    task_set = _task_set(task_case)
+    rollout = _rollout(tag, task_case.task_id)
     calibration = _calibration(tag, status=calibration_status)
     raw_score = 5 if score == 1.0 else 4
     judgment = Judgment(
@@ -308,6 +339,13 @@ def _teacher_source(
         usable_overlap_count, score_mae = 8, 0.12
     else:
         usable_overlap_count, score_mae = 7, None
+    failures = tuple(
+        FidelityFailure(
+            cell_id=f"fidelity-cell-{tag}-{index}",
+            failure=StructuredFailure(code=FailureCode.TIMEOUT, message="overlap unavailable"),
+        )
+        for index in range(usable_overlap_count, 10)
+    )
     fidelity = FidelityReport(
         schema_version=1,
         created_at=_TIME,
@@ -317,8 +355,9 @@ def _teacher_source(
         overlap_cell_ids=tuple(f"fidelity-cell-{tag}-{index}" for index in range(10)),
         planned_overlap_count=10,
         usable_overlap_count=usable_overlap_count,
-        failed_overlap_count=0,
+        failed_overlap_count=len(failures),
         score_mae=score_mae,
+        failures=failures,
         gate_id=f"fidelity-gate-{tag}",
         gate_sha256=_DIGEST,
         status=fidelity_status,
@@ -362,7 +401,8 @@ def _teacher_source(
     )
     return TeacherSFTSource(
         rollout=rollout,
-        task=task,
+        task=task_case,
+        task_set=task_set,
         transcript=_transcript(),
         acceptance_rule=rule,
         acceptance_evidence=evidence,
@@ -613,6 +653,18 @@ def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
             )
         }
     )
+    mismatched_task = _teacher_source("task-mismatch")
+    mismatched_task = mismatched_task.model_copy(
+        update={"task": _task_case("different", "A different canonical task.")}
+    )
+    task_outside_set = _teacher_source("task-outside-set")
+    task_outside_set = task_outside_set.model_copy(
+        update={
+            "task_set": task_outside_set.task_set.model_copy(
+                update={"task_ids": ("task-not-this-one",)}
+            )
+        }
+    )
     unproven = _teacher_source("unproven")
     unproven = unproven.model_copy(
         update={
@@ -633,6 +685,8 @@ def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
             insufficient_fidelity,
             low_score,
             unfinished,
+            mismatched_task,
+            task_outside_set,
             unproven,
         )
     )
@@ -642,6 +696,7 @@ def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
         for row in artifact.rows
         if isinstance(row.example.source, RolloutExampleSource)
     } == {"rollout-valid"}
+    assert "task-set-valid" in {item.artifact_id for item in artifact.dataset.inputs}
     excluded_ids = {
         exclusion.source_id
         for exclusion in artifact.inspection.exclusions
@@ -658,6 +713,8 @@ def test_teacher_acceptance_requires_every_immutable_prerequisite() -> None:
         "rollout-fidelity-insufficient",
         "rollout-score",
         "rollout-unfinished",
+        "rollout-task-mismatch",
+        "rollout-task-outside-set",
         "rollout-unproven",
     }
 

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -20,6 +20,7 @@ from wmo.common.evaluations import FidelityReport
 from wmo.common.judging import JudgeCalibration, Judgment
 from wmo.common.models import AssistantAction
 from wmo.common.rollouts import RolloutArtifact
+from wmo.common.tasks import TaskCase, TaskSet
 from wmo.common.traces import Trace
 
 
@@ -258,7 +259,8 @@ class TeacherSFTSource(ContractModel):
     """One teacher rollout, canonical transcript, and immutable accepted quality evidence."""
 
     rollout: RolloutArtifact
-    task: str = Field(min_length=1)
+    task: TaskCase
+    task_set: TaskSet
     transcript: SFTTranscript
     acceptance_rule: TeacherAcceptanceRule
     acceptance_evidence: TeacherAcceptanceEvidence

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -1,0 +1,478 @@
+"""Typed immutable contracts for frozen, leakage-safe SFT dataset construction."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ContractModel,
+    Sha256,
+    StructuredFailure,
+    validate_artifact_file_path,
+)
+from wmo.common.evaluations import FidelityReport
+from wmo.common.judging import JudgeCalibration, Judgment
+from wmo.common.models import AssistantAction
+from wmo.common.rollouts import RolloutArtifact
+from wmo.common.traces import Trace
+
+
+def _require_timezone(value: datetime, *, label: str) -> datetime:
+    """Require one explicit timezone-aware immutable record timestamp."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{label} must include a timezone")
+    return value
+
+
+class SFTMessage(ContractModel):
+    """A non-assistant message retained verbatim in canonical SFT context."""
+
+    kind: Literal["message"] = "message"
+    role: Literal["system", "user", "observation"]
+    content: str
+
+
+class AssistantActionEvent(ContractModel):
+    """A complete assistant turn and its explicit source-side approval state."""
+
+    kind: Literal["assistant_action"] = "assistant_action"
+    action: AssistantAction
+    approved: bool = True
+
+
+class ToolEvent(ContractModel):
+    """One ordered tool result retained as SFT context and never used as a target."""
+
+    kind: Literal["tool"] = "tool"
+    tool_call_id: str = Field(min_length=1, max_length=256)
+    content: str
+    tool_name: str | None = Field(default=None, min_length=1, max_length=256)
+
+
+class InfrastructureFailureEvent(ContractModel):
+    """A source event that proves an associated action cannot be an SFT target."""
+
+    kind: Literal["infrastructure_failure"] = "infrastructure_failure"
+    action_index: int = Field(ge=0)
+    failure: StructuredFailure
+
+
+SFTContextEvent = Annotated[
+    SFTMessage | AssistantActionEvent | ToolEvent,
+    Field(discriminator="kind"),
+]
+SFTTranscriptEvent = Annotated[
+    SFTMessage | AssistantActionEvent | ToolEvent | InfrastructureFailureEvent,
+    Field(discriminator="kind"),
+]
+
+
+class SFTTranscript(ContractModel):
+    """The ordered source transcript from which assistant turns can be extracted."""
+
+    events: tuple[SFTTranscriptEvent, ...]
+
+    @field_validator("events")
+    @classmethod
+    def _require_nonempty_linked_events(
+        cls, value: tuple[SFTTranscriptEvent, ...]
+    ) -> tuple[SFTTranscriptEvent, ...]:
+        if not value:
+            raise ValueError("SFT transcripts need at least one event")
+        tool_names: dict[str, str] = {}
+        for index, event in enumerate(value):
+            if isinstance(event, AssistantActionEvent):
+                for call in event.action.tool_calls:
+                    if call.call_id in tool_names:
+                        raise ValueError("SFT transcripts must not repeat a tool call ID")
+                    tool_names[call.call_id] = call.name
+            elif isinstance(event, ToolEvent):
+                expected_name = tool_names.get(event.tool_call_id)
+                if expected_name is None:
+                    raise ValueError("SFT tool events must name an earlier assistant tool call")
+                if event.tool_name is not None and event.tool_name != expected_name:
+                    raise ValueError("SFT tool event name must match its assistant tool call")
+            elif isinstance(event, InfrastructureFailureEvent):
+                if event.action_index >= index or not isinstance(
+                    value[event.action_index], AssistantActionEvent
+                ):
+                    raise ValueError(
+                        "SFT infrastructure failures must name an earlier assistant action index"
+                    )
+        return value
+
+
+class ProductionAcceptanceRule(ArtifactEnvelope):
+    """Immutable policy that admits trusted production outcomes or human approvals."""
+
+    acceptance_rule_id: ArtifactId
+    accepted_outcomes: tuple[str, ...]
+    allow_human_approval: bool
+
+    @field_validator("accepted_outcomes")
+    @classmethod
+    def _require_sorted_unique_outcomes(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("production acceptance rules require at least one trusted outcome")
+        if any(not outcome for outcome in value):
+            raise ValueError("production acceptance outcomes must be non-empty")
+        if len(set(value)) != len(value):
+            raise ValueError("production acceptance outcomes must not repeat")
+        if value != tuple(sorted(value)):
+            raise ValueError("production acceptance outcomes must be sorted")
+        return value
+
+
+class TeacherAcceptanceRule(ArtifactEnvelope):
+    """Immutable score, calibration, and fidelity policy for teacher rollout acceptance."""
+
+    acceptance_rule_id: ArtifactId
+    minimum_overall_score: float = Field(ge=0, le=1)
+    required_calibration_id: ArtifactId
+    require_approved_fidelity: Literal[True] = True
+
+    @field_validator("minimum_overall_score")
+    @classmethod
+    def _require_finite_score(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("teacher acceptance score must be finite")
+        return value
+
+
+class HumanApproval(ArtifactEnvelope):
+    """One explicit immutable human approval bound to a production trace."""
+
+    approval_id: ArtifactId
+    trace_id: str = Field(min_length=1, max_length=512)
+    decision: Literal["approved"] = "approved"
+    approved_at: datetime
+
+    @field_validator("approved_at")
+    @classmethod
+    def _require_approved_at_timezone(cls, value: datetime) -> datetime:
+        return _require_timezone(value, label="human approval time")
+
+
+class ProductionAcceptanceEvidence(ArtifactEnvelope):
+    """Immutable evidence that one production trace satisfies a production acceptance rule."""
+
+    acceptance_evidence_id: ArtifactId
+    trace_id: str = Field(min_length=1, max_length=512)
+    trace_sha256: Sha256
+    acceptance_rule_id: ArtifactId
+    acceptance_rule_sha256: Sha256
+    decision: Literal["trusted_outcome", "human_approval"]
+    outcome_sha256: Sha256 | None = None
+    human_approval_id: ArtifactId | None = None
+    human_approval_sha256: Sha256 | None = None
+    accepted_at: datetime
+
+    @field_validator("accepted_at")
+    @classmethod
+    def _require_accepted_at_timezone(cls, value: datetime) -> datetime:
+        return _require_timezone(value, label="production acceptance time")
+
+    @model_validator(mode="after")
+    def _require_complete_evidence_branch(self) -> ProductionAcceptanceEvidence:
+        expected_inputs = {self.acceptance_rule_id: self.acceptance_rule_sha256}
+        if self.decision == "trusted_outcome":
+            if self.outcome_sha256 is None:
+                raise ValueError("trusted-outcome evidence requires an outcome digest")
+            if self.human_approval_id is not None or self.human_approval_sha256 is not None:
+                raise ValueError("trusted-outcome evidence must not name human approval")
+        else:
+            if self.outcome_sha256 is not None:
+                raise ValueError("human-approval evidence must not name an outcome digest")
+            if self.human_approval_id is None or self.human_approval_sha256 is None:
+                raise ValueError("human-approval evidence requires approval identity and digest")
+            expected_inputs[self.human_approval_id] = self.human_approval_sha256
+        actual_inputs = {item.artifact_id: item.sha256 for item in self.inputs}
+        if actual_inputs != expected_inputs:
+            raise ValueError("production acceptance evidence inputs must match its references")
+        return self
+
+
+class TeacherAcceptanceEvidence(ArtifactEnvelope):
+    """Immutable evidence that one teacher rollout passed all required quality gates."""
+
+    acceptance_evidence_id: ArtifactId
+    rollout_id: ArtifactId
+    rollout_sha256: Sha256
+    judgment_id: ArtifactId
+    judgment_sha256: Sha256
+    calibration_id: ArtifactId
+    calibration_sha256: Sha256
+    fidelity_report_id: ArtifactId
+    fidelity_report_sha256: Sha256
+    acceptance_rule_id: ArtifactId
+    acceptance_rule_sha256: Sha256
+    observed_overall_score: float = Field(ge=0, le=1)
+    accepted_at: datetime
+
+    @field_validator("observed_overall_score")
+    @classmethod
+    def _require_finite_score(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("teacher acceptance score must be finite")
+        return value
+
+    @field_validator("accepted_at")
+    @classmethod
+    def _require_accepted_at_timezone(cls, value: datetime) -> datetime:
+        return _require_timezone(value, label="teacher acceptance time")
+
+    @model_validator(mode="after")
+    def _require_complete_references(self) -> TeacherAcceptanceEvidence:
+        expected_inputs = {
+            self.rollout_id: self.rollout_sha256,
+            self.judgment_id: self.judgment_sha256,
+            self.calibration_id: self.calibration_sha256,
+            self.fidelity_report_id: self.fidelity_report_sha256,
+            self.acceptance_rule_id: self.acceptance_rule_sha256,
+        }
+        actual_inputs = {item.artifact_id: item.sha256 for item in self.inputs}
+        if actual_inputs != expected_inputs:
+            raise ValueError(
+                "teacher acceptance evidence inputs must match every required reference"
+            )
+        return self
+
+
+class ProductionSFTSource(ContractModel):
+    """One production trace, canonical transcript, and immutable acceptance chain."""
+
+    trace: Trace
+    transcript: SFTTranscript
+    acceptance_rule: ProductionAcceptanceRule
+    acceptance_evidence: ProductionAcceptanceEvidence
+    human_approval: HumanApproval | None = None
+
+
+class TeacherSFTSource(ContractModel):
+    """One teacher rollout, canonical transcript, and immutable accepted quality evidence."""
+
+    rollout: RolloutArtifact
+    task: str = Field(min_length=1)
+    transcript: SFTTranscript
+    acceptance_rule: TeacherAcceptanceRule
+    acceptance_evidence: TeacherAcceptanceEvidence
+    judgment: Judgment
+    calibration: JudgeCalibration
+    fidelity: FidelityReport
+
+
+class TraceExampleSource(ContractModel):
+    """Production trace provenance retained on an extracted SFT example."""
+
+    kind: Literal["production_trace"] = "production_trace"
+    trace_id: str = Field(min_length=1, max_length=512)
+    acceptance_evidence_id: ArtifactId
+    acceptance_evidence_sha256: Sha256
+
+
+class RolloutExampleSource(ContractModel):
+    """Teacher rollout provenance retained on an extracted SFT example."""
+
+    kind: Literal["teacher_rollout"] = "teacher_rollout"
+    rollout_id: ArtifactId
+    acceptance_evidence_id: ArtifactId
+    acceptance_evidence_sha256: Sha256
+
+
+SFTExampleSource = Annotated[
+    TraceExampleSource | RolloutExampleSource,
+    Field(discriminator="kind"),
+]
+
+
+class SFTExample(ContractModel):
+    """Canonical task context plus one complete assistant-action target."""
+
+    example_id: ArtifactId
+    leakage_group_id: ArtifactId
+    task: str = Field(min_length=1)
+    history: tuple[SFTContextEvent, ...]
+    target: AssistantAction
+    source: SFTExampleSource
+    source_step_index: int = Field(ge=0)
+    score: float | None = Field(default=None, ge=0, le=1)
+
+    @field_validator("score")
+    @classmethod
+    def _require_finite_score(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("SFT example scores must be finite")
+        return value
+
+
+class PartitionedSFTExample(ContractModel):
+    """One persisted SFT example assigned to train or held-out data with its fingerprint."""
+
+    partition: Literal["train", "held_out"]
+    fingerprint: Sha256
+    example: SFTExample
+
+
+class SFTPartition(ContractModel):
+    """One connected leakage component and its deterministic frozen partition."""
+
+    component_id: ArtifactId
+    partition: Literal["train", "held_out"]
+    leakage_group_ids: tuple[ArtifactId, ...]
+    fingerprints: tuple[Sha256, ...]
+
+    @field_validator("leakage_group_ids", "fingerprints")
+    @classmethod
+    def _require_sorted_unique_values(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("SFT leakage components need at least one lineage and fingerprint")
+        if len(set(value)) != len(value):
+            raise ValueError("SFT leakage component values must not repeat")
+        if value != tuple(sorted(value)):
+            raise ValueError("SFT leakage component values must be sorted")
+        return value
+
+
+class SFTSourceReference(ContractModel):
+    """An auditable source and acceptance-evidence reference in a frozen dataset manifest."""
+
+    kind: Literal["production_trace", "teacher_rollout"]
+    source_id: str = Field(min_length=1, max_length=512)
+    source_sha256: Sha256
+    leakage_group_id: ArtifactId
+    acceptance_evidence_id: ArtifactId
+    acceptance_evidence_sha256: Sha256
+    accepted: bool
+    exclusion_reason: str | None = None
+
+    @model_validator(mode="after")
+    def _require_consistent_source_status(self) -> SFTSourceReference:
+        if self.accepted and self.exclusion_reason is not None:
+            raise ValueError("accepted SFT sources must not carry an exclusion reason")
+        if not self.accepted and self.exclusion_reason is None:
+            raise ValueError("excluded SFT sources must name an exclusion reason")
+        return self
+
+
+class SFTExclusion(ContractModel):
+    """One source-level or action-level reason data was withheld from an SFT dataset."""
+
+    source_kind: Literal["production_trace", "teacher_rollout"]
+    source_id: str = Field(min_length=1, max_length=512)
+    action_index: int | None = Field(default=None, ge=0)
+    reason: Literal[
+        "duplicate_normalized_example",
+        "infrastructure_failure",
+        "invalid_production_acceptance",
+        "invalid_teacher_acceptance",
+        "observation_context_only",
+        "unapproved_action",
+    ]
+    detail: str = Field(min_length=1)
+
+
+class SFTDataset(ArtifactEnvelope):
+    """Frozen accepted SFT dataset envelope and paths to its exact normalized example rows."""
+
+    dataset_id: ArtifactId
+    build_sha256: Sha256
+    status: Literal["accepted", "insufficient"]
+    acceptance_rule_ids: tuple[ArtifactId, ...]
+    acceptance_evidence_ids: tuple[ArtifactId, ...]
+    train_leakage_group_ids: tuple[ArtifactId, ...]
+    held_out_leakage_group_ids: tuple[ArtifactId, ...]
+    train_example_ids: tuple[ArtifactId, ...]
+    held_out_example_ids: tuple[ArtifactId, ...]
+    examples_path: str = Field(min_length=1)
+    examples_sha256: Sha256
+
+    @field_validator("examples_path")
+    @classmethod
+    def _require_safe_examples_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+    @field_validator(
+        "acceptance_rule_ids",
+        "acceptance_evidence_ids",
+        "train_leakage_group_ids",
+        "held_out_leakage_group_ids",
+        "train_example_ids",
+        "held_out_example_ids",
+    )
+    @classmethod
+    def _require_sorted_unique_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("frozen SFT dataset IDs must not repeat")
+        if value != tuple(sorted(value)):
+            raise ValueError("frozen SFT dataset IDs must be sorted")
+        return value
+
+    @model_validator(mode="after")
+    def _require_disjoint_partitions(self) -> SFTDataset:
+        if set(self.train_leakage_group_ids).intersection(self.held_out_leakage_group_ids):
+            raise ValueError("SFT train and held-out lineage groups must be disjoint")
+        if set(self.train_example_ids).intersection(self.held_out_example_ids):
+            raise ValueError("SFT train and held-out examples must be disjoint")
+        return self
+
+
+class SFTInspectionReport(ContractModel):
+    """Deterministic provenance, coverage, sample, and exclusion report for a frozen dataset."""
+
+    report_id: ArtifactId
+    dataset_id: ArtifactId
+    build_sha256: Sha256
+    source_count: int = Field(ge=0)
+    accepted_source_count: int = Field(ge=0)
+    eligible_action_count: int = Field(ge=0)
+    fingerprint_count: int = Field(ge=0)
+    connected_component_count: int = Field(ge=0)
+    train_example_count: int = Field(ge=0)
+    held_out_example_count: int = Field(ge=0)
+    exclusions: tuple[SFTExclusion, ...]
+    representative_train_example_ids: tuple[ArtifactId, ...]
+    representative_held_out_example_ids: tuple[ArtifactId, ...]
+
+    @field_validator("representative_train_example_ids", "representative_held_out_example_ids")
+    @classmethod
+    def _require_unique_sample_ids(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("SFT representative samples must not repeat")
+        return value
+
+
+class SFTDatasetMetadata(ContractModel):
+    """All non-row frozen manifest data persisted beside canonical SFT JSONL examples."""
+
+    dataset: SFTDataset
+    sources: tuple[SFTSourceReference, ...]
+    partitions: tuple[SFTPartition, ...]
+    inspection: SFTInspectionReport
+    representative_samples: tuple[PartitionedSFTExample, ...]
+
+
+class SFTDatasetArtifact(ContractModel):
+    """Materialized dataset rows plus the immutable metadata required to reload and inspect them."""
+
+    dataset: SFTDataset
+    sources: tuple[SFTSourceReference, ...]
+    partitions: tuple[SFTPartition, ...]
+    inspection: SFTInspectionReport
+    representative_samples: tuple[PartitionedSFTExample, ...]
+    rows: tuple[PartitionedSFTExample, ...]
+
+    def metadata(self) -> SFTDatasetMetadata:
+        """Return the immutable metadata file stored beside the canonical JSONL rows."""
+        return SFTDatasetMetadata(
+            dataset=self.dataset,
+            sources=self.sources,
+            partitions=self.partitions,
+            inspection=self.inspection,
+            representative_samples=self.representative_samples,
+        )

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -11,17 +11,13 @@ from pydantic import Field, field_validator, model_validator
 from wmo.common.core.artifacts import (
     ArtifactEnvelope,
     ArtifactId,
+    ArtifactInput,
     ContractModel,
     Sha256,
     StructuredFailure,
     validate_artifact_file_path,
 )
-from wmo.common.evaluations import FidelityReport
-from wmo.common.judging import JudgeCalibration, Judgment
 from wmo.common.models import AssistantAction
-from wmo.common.rollouts import RolloutArtifact
-from wmo.common.tasks import TaskCase, TaskSet
-from wmo.common.traces import Trace
 
 
 def _require_timezone(value: datetime, *, label: str) -> datetime:
@@ -135,7 +131,7 @@ class TeacherAcceptanceRule(ArtifactEnvelope):
 
     acceptance_rule_id: ArtifactId
     minimum_overall_score: float = Field(ge=0, le=1)
-    required_calibration_id: ArtifactId
+    required_calibration: ArtifactInput
     require_approved_fidelity: Literal[True] = True
 
     @field_validator("minimum_overall_score")
@@ -145,11 +141,18 @@ class TeacherAcceptanceRule(ArtifactEnvelope):
             raise ValueError("teacher acceptance score must be finite")
         return value
 
+    @model_validator(mode="after")
+    def _require_calibration_binding(self) -> TeacherAcceptanceRule:
+        if self.inputs != (self.required_calibration,):
+            raise ValueError("teacher acceptance rules must hash exactly their calibration")
+        return self
+
 
 class HumanApproval(ArtifactEnvelope):
     """One explicit immutable human approval bound to a production trace."""
 
     approval_id: ArtifactId
+    trace_dataset: ArtifactInput
     trace_id: str = Field(min_length=1, max_length=512)
     decision: Literal["approved"] = "approved"
     approved_at: datetime
@@ -159,20 +162,32 @@ class HumanApproval(ArtifactEnvelope):
     def _require_approved_at_timezone(cls, value: datetime) -> datetime:
         return _require_timezone(value, label="human approval time")
 
+    @model_validator(mode="after")
+    def _require_trace_dataset_binding(self) -> HumanApproval:
+        if self.inputs != (self.trace_dataset,):
+            raise ValueError("human approvals must hash exactly their trace-dataset artifact")
+        return self
+
 
 class ProductionAcceptanceEvidence(ArtifactEnvelope):
     """Immutable evidence that one production trace satisfies a production acceptance rule."""
 
     acceptance_evidence_id: ArtifactId
+    trace_dataset: ArtifactInput
     trace_id: str = Field(min_length=1, max_length=512)
     trace_sha256: Sha256
-    acceptance_rule_id: ArtifactId
-    acceptance_rule_sha256: Sha256
+    acceptance_rule: ArtifactInput
     decision: Literal["trusted_outcome", "human_approval"]
     outcome_sha256: Sha256 | None = None
-    human_approval_id: ArtifactId | None = None
-    human_approval_sha256: Sha256 | None = None
+    human_approval: ArtifactInput | None = None
+    transcript_path: str = Field(min_length=1)
+    transcript_sha256: Sha256
     accepted_at: datetime
+
+    @field_validator("transcript_path")
+    @classmethod
+    def _require_safe_transcript_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
 
     @field_validator("accepted_at")
     @classmethod
@@ -181,20 +196,19 @@ class ProductionAcceptanceEvidence(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_complete_evidence_branch(self) -> ProductionAcceptanceEvidence:
-        expected_inputs = {self.acceptance_rule_id: self.acceptance_rule_sha256}
+        expected_inputs = [self.trace_dataset, self.acceptance_rule]
         if self.decision == "trusted_outcome":
             if self.outcome_sha256 is None:
                 raise ValueError("trusted-outcome evidence requires an outcome digest")
-            if self.human_approval_id is not None or self.human_approval_sha256 is not None:
+            if self.human_approval is not None:
                 raise ValueError("trusted-outcome evidence must not name human approval")
         else:
             if self.outcome_sha256 is not None:
                 raise ValueError("human-approval evidence must not name an outcome digest")
-            if self.human_approval_id is None or self.human_approval_sha256 is None:
-                raise ValueError("human-approval evidence requires approval identity and digest")
-            expected_inputs[self.human_approval_id] = self.human_approval_sha256
-        actual_inputs = {item.artifact_id: item.sha256 for item in self.inputs}
-        if actual_inputs != expected_inputs:
+            if self.human_approval is None:
+                raise ValueError("human-approval evidence requires an approval artifact")
+            expected_inputs.append(self.human_approval)
+        if self.inputs != tuple(sorted(expected_inputs, key=lambda item: item.artifact_id)):
             raise ValueError("production acceptance evidence inputs must match its references")
         return self
 
@@ -203,25 +217,35 @@ class TeacherAcceptanceEvidence(ArtifactEnvelope):
     """Immutable evidence that one teacher rollout passed all required quality gates."""
 
     acceptance_evidence_id: ArtifactId
-    rollout_id: ArtifactId
-    rollout_sha256: Sha256
-    judgment_id: ArtifactId
-    judgment_sha256: Sha256
-    calibration_id: ArtifactId
-    calibration_sha256: Sha256
-    fidelity_report_id: ArtifactId
-    fidelity_report_sha256: Sha256
-    acceptance_rule_id: ArtifactId
-    acceptance_rule_sha256: Sha256
-    observed_overall_score: float = Field(ge=0, le=1)
+    rollout: ArtifactInput
+    task_set: ArtifactInput
+    task_set_tasks_sha256: Sha256
+    task_set_inputs: tuple[ArtifactInput, ...]
+    task_id: ArtifactId
+    task_sha256: Sha256
+    judgment: ArtifactInput
+    calibration: ArtifactInput
+    fidelity_report: ArtifactInput
+    acceptance_rule: ArtifactInput
+    transcript_path: str = Field(min_length=1)
+    transcript_sha256: Sha256
     accepted_at: datetime
 
-    @field_validator("observed_overall_score")
+    @field_validator("task_set_inputs")
     @classmethod
-    def _require_finite_score(cls, value: float) -> float:
-        if not math.isfinite(value):
-            raise ValueError("teacher acceptance score must be finite")
+    def _require_sorted_unique_task_set_inputs(
+        cls, value: tuple[ArtifactInput, ...]
+    ) -> tuple[ArtifactInput, ...]:
+        if len({item.artifact_id for item in value}) != len(value):
+            raise ValueError("teacher task-set inputs must not repeat artifact IDs")
+        if value != tuple(sorted(value, key=lambda item: item.artifact_id)):
+            raise ValueError("teacher task-set inputs must be sorted by artifact ID")
         return value
+
+    @field_validator("transcript_path")
+    @classmethod
+    def _require_safe_transcript_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
 
     @field_validator("accepted_at")
     @classmethod
@@ -230,15 +254,20 @@ class TeacherAcceptanceEvidence(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_complete_references(self) -> TeacherAcceptanceEvidence:
-        expected_inputs = {
-            self.rollout_id: self.rollout_sha256,
-            self.judgment_id: self.judgment_sha256,
-            self.calibration_id: self.calibration_sha256,
-            self.fidelity_report_id: self.fidelity_report_sha256,
-            self.acceptance_rule_id: self.acceptance_rule_sha256,
-        }
-        actual_inputs = {item.artifact_id: item.sha256 for item in self.inputs}
-        if actual_inputs != expected_inputs:
+        expected_inputs = tuple(
+            sorted(
+                (
+                    self.rollout,
+                    self.task_set,
+                    self.judgment,
+                    self.calibration,
+                    self.fidelity_report,
+                    self.acceptance_rule,
+                ),
+                key=lambda item: item.artifact_id,
+            )
+        )
+        if self.inputs != expected_inputs:
             raise ValueError(
                 "teacher acceptance evidence inputs must match every required reference"
             )
@@ -246,27 +275,15 @@ class TeacherAcceptanceEvidence(ArtifactEnvelope):
 
 
 class ProductionSFTSource(ContractModel):
-    """One production trace, canonical transcript, and immutable acceptance chain."""
+    """A pointer to one persisted production-acceptance evidence artifact."""
 
-    trace: Trace
-    transcript: SFTTranscript
-    acceptance_rule: ProductionAcceptanceRule
-    acceptance_evidence: ProductionAcceptanceEvidence
-    human_approval: HumanApproval | None = None
+    acceptance_evidence_id: ArtifactId
 
 
 class TeacherSFTSource(ContractModel):
-    """One teacher rollout, canonical transcript, and immutable accepted quality evidence."""
+    """A pointer to one persisted teacher-acceptance evidence artifact."""
 
-    rollout: RolloutArtifact
-    task: TaskCase
-    task_set: TaskSet
-    transcript: SFTTranscript
-    acceptance_rule: TeacherAcceptanceRule
-    acceptance_evidence: TeacherAcceptanceEvidence
-    judgment: Judgment
-    calibration: JudgeCalibration
-    fidelity: FidelityReport
+    acceptance_evidence_id: ArtifactId
 
 
 class TraceExampleSource(ContractModel):
@@ -274,8 +291,7 @@ class TraceExampleSource(ContractModel):
 
     kind: Literal["production_trace"] = "production_trace"
     trace_id: str = Field(min_length=1, max_length=512)
-    acceptance_evidence_id: ArtifactId
-    acceptance_evidence_sha256: Sha256
+    acceptance_evidence: ArtifactInput
 
 
 class RolloutExampleSource(ContractModel):
@@ -283,8 +299,7 @@ class RolloutExampleSource(ContractModel):
 
     kind: Literal["teacher_rollout"] = "teacher_rollout"
     rollout_id: ArtifactId
-    acceptance_evidence_id: ArtifactId
-    acceptance_evidence_sha256: Sha256
+    acceptance_evidence: ArtifactInput
 
 
 SFTExampleSource = Annotated[
@@ -346,10 +361,10 @@ class SFTSourceReference(ContractModel):
 
     kind: Literal["production_trace", "teacher_rollout"]
     source_id: str = Field(min_length=1, max_length=512)
-    source_sha256: Sha256
+    source_artifact: ArtifactInput
+    source_record_sha256: Sha256
     leakage_group_id: ArtifactId
-    acceptance_evidence_id: ArtifactId
-    acceptance_evidence_sha256: Sha256
+    acceptance_evidence: ArtifactInput
     accepted: bool
     exclusion_reason: str | None = None
 

--- a/wmo/optimize/model/sft/rendering.py
+++ b/wmo/optimize/model/sft/rendering.py
@@ -91,7 +91,14 @@ def context_target_fingerprint(
 
 
 def canonical_partitioned_rows_jsonl(rows: Sequence[PartitionedSFTExample]) -> bytes:
-    """Render ordered partitioned SFT rows as deterministic newline-terminated JSONL."""
+    """Render ordered partitioned SFT rows as deterministic newline-terminated JSONL.
+
+    Args:
+        rows: Already ordered examples to serialize into the frozen dataset payload.
+
+    Returns:
+        Canonical JSONL bytes, or empty bytes when no examples are present.
+    """
     if not rows:
         return b""
     return b"\n".join(canonical_json_bytes(row) for row in rows) + b"\n"

--- a/wmo/optimize/model/sft/rendering.py
+++ b/wmo/optimize/model/sft/rendering.py
@@ -1,0 +1,128 @@
+"""Canonical source-independent rendering and hashing for structured SFT examples."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from wmo.common.core.artifacts import ContractModel, Sha256, canonical_json_bytes, sha256_json
+from wmo.common.models import AssistantAction
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    PartitionedSFTExample,
+    SFTContextEvent,
+    SFTMessage,
+    ToolEvent,
+)
+
+
+class CanonicalSFTMessage(ContractModel):
+    """One canonical non-assistant message in a normalized SFT context."""
+
+    kind: Literal["message"] = "message"
+    role: Literal["system", "user", "observation"]
+    content: str
+
+
+class CanonicalSFTAssistantAction(ContractModel):
+    """One canonical prior assistant action without source-only approval metadata."""
+
+    kind: Literal["assistant"] = "assistant"
+    action: AssistantAction
+
+
+class CanonicalSFTToolEvent(ContractModel):
+    """One canonical tool result in a normalized SFT context."""
+
+    kind: Literal["tool"] = "tool"
+    tool_call_id: str
+    content: str
+    tool_name: str | None = None
+
+
+CanonicalSFTContextEvent = Annotated[
+    CanonicalSFTMessage | CanonicalSFTAssistantAction | CanonicalSFTToolEvent,
+    Field(discriminator="kind"),
+]
+
+
+class CanonicalSFTTurn(ContractModel):
+    """The source-independent task, ordered context, and complete assistant-action target."""
+
+    task: str
+    history: tuple[CanonicalSFTContextEvent, ...]
+    target: AssistantAction
+
+
+def render_context_target(
+    *, task: str, history: tuple[SFTContextEvent, ...], target: AssistantAction
+) -> str:
+    """Render one complete context and target as deterministic JSON.
+
+    Source-only approval metadata is intentionally absent from the rendering. The target retains
+    the whole `AssistantAction`, including text and all ordered tool calls.
+
+    Args:
+        task: Task text supplied with the source trace or rollout.
+        history: Ordered previous messages, assistant actions, and tool results.
+        target: The complete next assistant action to learn.
+
+    Returns:
+        Canonical compact JSON that round-trips through `parse_rendered_turn`.
+    """
+    return canonical_json_bytes(_canonical_turn(task=task, history=history, target=target)).decode(
+        "utf-8"
+    )
+
+
+def parse_rendered_turn(rendered: str) -> CanonicalSFTTurn:
+    """Parse one canonical context-target rendering without losing action or tool-call structure."""
+    return CanonicalSFTTurn.model_validate_json(rendered)
+
+
+def context_target_fingerprint(
+    *, task: str, history: tuple[SFTContextEvent, ...], target: AssistantAction
+) -> Sha256:
+    """Return the stable SHA-256 fingerprint used for lineage union and deduplication."""
+    return sha256_json(_canonical_turn(task=task, history=history, target=target))
+
+
+def canonical_partitioned_rows_jsonl(rows: Sequence[PartitionedSFTExample]) -> bytes:
+    """Render ordered partitioned SFT rows as deterministic newline-terminated JSONL."""
+    if not rows:
+        return b""
+    return b"\n".join(canonical_json_bytes(row) for row in rows) + b"\n"
+
+
+def partitioned_rows_sha256(rows: Sequence[PartitionedSFTExample]) -> Sha256:
+    """Return the SHA-256 digest of persisted canonical partitioned SFT JSONL rows."""
+    return hashlib.sha256(canonical_partitioned_rows_jsonl(rows)).hexdigest()
+
+
+def _canonical_turn(
+    *, task: str, history: tuple[SFTContextEvent, ...], target: AssistantAction
+) -> CanonicalSFTTurn:
+    """Build one typed canonical turn from source-visible context and its assistant target."""
+    return CanonicalSFTTurn(
+        task=task,
+        history=tuple(_canonical_event(event) for event in history),
+        target=target,
+    )
+
+
+def _canonical_event(event: SFTContextEvent) -> CanonicalSFTContextEvent:
+    """Remove source-only approval metadata while preserving one context event exactly."""
+    if isinstance(event, SFTMessage):
+        return CanonicalSFTMessage(role=event.role, content=event.content)
+    if isinstance(event, AssistantActionEvent):
+        return CanonicalSFTAssistantAction(action=event.action)
+    if isinstance(event, ToolEvent):
+        return CanonicalSFTToolEvent(
+            tool_call_id=event.tool_call_id,
+            content=event.content,
+            tool_name=event.tool_name,
+        )
+    raise ValueError("canonical SFT context cannot contain an infrastructure failure")

--- a/wmo/optimize/model/sft/rendering_test.py
+++ b/wmo/optimize/model/sft/rendering_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from wmo.common.core.artifacts import ArtifactInput
 from wmo.common.models import AssistantAction, ToolCall
 from wmo.optimize.model.sft.contracts import (
     AssistantActionEvent,
@@ -77,8 +78,10 @@ def test_structured_example_round_trips_with_complete_target_and_tool_context() 
         target=_action(),
         source=TraceExampleSource(
             trace_id="trace-1",
-            acceptance_evidence_id="production-evidence-1",
-            acceptance_evidence_sha256=_DIGEST,
+            acceptance_evidence=ArtifactInput(
+                artifact_id="production-evidence-1",
+                sha256=_DIGEST,
+            ),
         ),
         source_step_index=1,
     )
@@ -100,8 +103,10 @@ def test_teacher_structured_example_round_trips_with_complete_target_and_tool_co
         target=_action(),
         source=RolloutExampleSource(
             rollout_id="rollout-1",
-            acceptance_evidence_id="teacher-evidence-1",
-            acceptance_evidence_sha256=_DIGEST,
+            acceptance_evidence=ArtifactInput(
+                artifact_id="teacher-evidence-1",
+                sha256=_DIGEST,
+            ),
         ),
         source_step_index=3,
         score=1.0,

--- a/wmo/optimize/model/sft/rendering_test.py
+++ b/wmo/optimize/model/sft/rendering_test.py
@@ -1,0 +1,110 @@
+"""Tests for canonical context-target SFT rendering."""
+
+from __future__ import annotations
+
+from wmo.common.models import AssistantAction, ToolCall
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    RolloutExampleSource,
+    SFTExample,
+    SFTMessage,
+    ToolEvent,
+    TraceExampleSource,
+)
+from wmo.optimize.model.sft.rendering import (
+    context_target_fingerprint,
+    parse_rendered_turn,
+    render_context_target,
+)
+
+_DIGEST = "a" * 64
+
+
+def _action() -> AssistantAction:
+    return AssistantAction(
+        content="I will look up the order, then issue the refund.",
+        tool_calls=(
+            ToolCall(call_id="lookup-1", name="lookup_order", arguments={"order_id": "o-17"}),
+            ToolCall(call_id="refund-1", name="issue_refund", arguments={"order_id": "o-17"}),
+        ),
+    )
+
+
+def test_complete_assistant_action_round_trips_in_context_target_rendering() -> None:
+    """Text and every ordered tool call survive canonical rendering exactly."""
+    history = (
+        SFTMessage(role="system", content="Follow the support policy."),
+        AssistantActionEvent(action=AssistantAction(content="I will investigate.")),
+        ToolEvent(tool_call_id="prior-lookup", tool_name="lookup_order", content="order exists"),
+    )
+    target = _action()
+
+    restored = parse_rendered_turn(
+        render_context_target(task="Refund order o-17.", history=history, target=target)
+    )
+
+    assert restored.task == "Refund order o-17."
+    assert restored.target == target
+    assert restored.target.tool_calls[0].arguments == {"order_id": "o-17"}
+    assert restored.target.tool_calls[1].name == "issue_refund"
+    assert restored.history[1].kind == "assistant"
+    assert restored.history[2].kind == "tool"
+
+
+def test_source_only_approval_does_not_change_normalized_fingerprint() -> None:
+    """Eligibility metadata cannot stop identical model-visible examples from being deduplicated."""
+    action = AssistantAction(content="Investigating the account.")
+    approved_history = (AssistantActionEvent(action=action, approved=True),)
+    unapproved_history = (AssistantActionEvent(action=action, approved=False),)
+
+    assert context_target_fingerprint(
+        task="Check the account.", history=approved_history, target=_action()
+    ) == context_target_fingerprint(
+        task="Check the account.", history=unapproved_history, target=_action()
+    )
+
+
+def test_structured_example_round_trips_with_complete_target_and_tool_context() -> None:
+    """The frozen SFT example contract preserves production-style structure losslessly."""
+    example = SFTExample(
+        example_id="sft-example-1",
+        leakage_group_id="sft-lineage-1",
+        task="Refund order o-17.",
+        history=(
+            SFTMessage(role="user", content="Please refund my order."),
+            ToolEvent(tool_call_id="lookup-1", tool_name="lookup_order", content="eligible"),
+        ),
+        target=_action(),
+        source=TraceExampleSource(
+            trace_id="trace-1",
+            acceptance_evidence_id="production-evidence-1",
+            acceptance_evidence_sha256=_DIGEST,
+        ),
+        source_step_index=1,
+    )
+
+    assert SFTExample.model_validate_json(example.model_dump_json()) == example
+
+
+def test_teacher_structured_example_round_trips_with_complete_target_and_tool_context() -> None:
+    """The frozen SFT example contract preserves teacher rollout structure losslessly."""
+    example = SFTExample(
+        example_id="sft-example-teacher-1",
+        leakage_group_id="sft-lineage-task-1",
+        task="Refund order o-17.",
+        history=(
+            SFTMessage(role="user", content="Please refund my order."),
+            AssistantActionEvent(action=AssistantAction(content="I will verify eligibility.")),
+            ToolEvent(tool_call_id="lookup-1", tool_name="lookup_order", content="eligible"),
+        ),
+        target=_action(),
+        source=RolloutExampleSource(
+            rollout_id="rollout-1",
+            acceptance_evidence_id="teacher-evidence-1",
+            acceptance_evidence_sha256=_DIGEST,
+        ),
+        source_step_index=3,
+        score=1.0,
+    )
+
+    assert SFTExample.model_validate_json(example.model_dump_json()) == example

--- a/wmo/optimize/model/sft/sources.py
+++ b/wmo/optimize/model/sft/sources.py
@@ -439,6 +439,8 @@ def _verify_teacher_decision(
         )
     if fidelity.status != "approved" or fidelity.approved_at is None:
         raise SFTSourceVerificationError("teacher rollout requires an approved fidelity report")
+    if rollout_input not in fidelity.inputs:
+        raise SFTSourceVerificationError("teacher fidelity report does not bind the stored rollout")
     if judgment.rollout_id != rollout.rollout_id:
         raise SFTSourceVerificationError("teacher judgment does not belong to the stored rollout")
     if judgment.calibration_id != calibration.calibration_id:

--- a/wmo/optimize/model/sft/sources.py
+++ b/wmo/optimize/model/sft/sources.py
@@ -1,0 +1,597 @@
+"""Store-backed acceptance-chain verification for frozen SFT source evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, ValidationError
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    Sha256,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.evaluations import FidelityReport
+from wmo.common.judging import (
+    CalibrationError,
+    JudgeCalibration,
+    Judgment,
+    Rubric,
+    verify_persisted_calibration,
+)
+from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
+from wmo.common.project import ArtifactCorruptionError, ProjectStore, artifact_input
+from wmo.common.rollouts import RolloutArtifact
+from wmo.common.tasks import TaskCase, load_task_set
+from wmo.common.traces import Trace, load_trace_dataset
+from wmo.optimize.model.sft.contracts import (
+    HumanApproval,
+    InfrastructureFailureEvent,
+    ProductionAcceptanceEvidence,
+    ProductionAcceptanceRule,
+    ProductionSFTSource,
+    RolloutExampleSource,
+    SFTContextEvent,
+    SFTSourceReference,
+    SFTTranscript,
+    TeacherAcceptanceEvidence,
+    TeacherAcceptanceRule,
+    TeacherSFTSource,
+    TraceExampleSource,
+)
+
+
+class SFTSourceVerificationError(ValueError):
+    """Raised when an SFT source cannot be proven from one project-local artifact store."""
+
+
+@dataclass(frozen=True)
+class PreparedSFTSource:
+    """One accepted source hydrated exclusively from verified immutable artifact bytes."""
+
+    kind: Literal["production_trace", "teacher_rollout"]
+    source_id: str
+    source_artifact: ArtifactInput
+    source_record_sha256: Sha256
+    leakage_group_id: ArtifactId
+    task: str
+    transcript_events: tuple[
+        SFTContextEvent | InfrastructureFailureEvent,
+        ...,
+    ]
+    example_source: TraceExampleSource | RolloutExampleSource
+    score: float | None
+    direct_inputs: tuple[ArtifactInput, ...]
+    acceptance_rule_id: ArtifactId
+    acceptance_evidence_id: ArtifactId
+    acceptance_evidence: ArtifactInput
+
+    def reference(self) -> SFTSourceReference:
+        """Return the auditable immutable-source record for a frozen dataset manifest."""
+        return SFTSourceReference(
+            kind=self.kind,
+            source_id=self.source_id,
+            source_artifact=self.source_artifact,
+            source_record_sha256=self.source_record_sha256,
+            leakage_group_id=self.leakage_group_id,
+            acceptance_evidence=self.acceptance_evidence,
+            accepted=True,
+        )
+
+
+def resolve_production_source(
+    store: ProjectStore, source: ProductionSFTSource
+) -> PreparedSFTSource:
+    """Hydrate one accepted production source from its immutable acceptance artifact.
+
+    Args:
+        store: Project store that owns every acceptance and trace artifact.
+        source: A caller-supplied pointer, never caller-supplied trace or transcript data.
+
+    Returns:
+        The verified source ready for leakage partitioning and example extraction.
+
+    Raises:
+        SFTSourceVerificationError: The pointer, evidence chain, source trace, or transcript is
+            absent, corrupt, cross-bound, or not accepted.
+    """
+    evidence, evidence_input = _read_json(
+        store,
+        artifact_id=source.acceptance_evidence_id,
+        artifact_type="sft-production-acceptance",
+        relative_path="evidence.json",
+        model_type=ProductionAcceptanceEvidence,
+    )
+    if evidence.acceptance_evidence_id != source.acceptance_evidence_id:
+        raise SFTSourceVerificationError("production acceptance evidence has the wrong identity")
+    trace, trace_input = _load_trace(store, evidence)
+    rule, rule_input = _read_json(
+        store,
+        artifact_id=evidence.acceptance_rule.artifact_id,
+        artifact_type="sft-production-acceptance-rule",
+        relative_path="rule.json",
+        model_type=ProductionAcceptanceRule,
+        expected_input=evidence.acceptance_rule,
+    )
+    if rule.acceptance_rule_id != rule_input.artifact_id:
+        raise SFTSourceVerificationError("production acceptance rule has the wrong identity")
+    approval_input = _verify_production_decision(store, evidence, trace, trace_input, rule)
+    transcript = _load_transcript(
+        store,
+        evidence_id=evidence_input.artifact_id,
+        transcript_path=evidence.transcript_path,
+        transcript_sha256=evidence.transcript_sha256,
+    )
+    lineage_key = trace.conversation_id or trace.trace_id
+    source_artifact = trace_input
+    return PreparedSFTSource(
+        kind="production_trace",
+        source_id=trace.trace_id,
+        source_artifact=source_artifact,
+        source_record_sha256=sha256_json(trace),
+        leakage_group_id=stable_id(
+            "sft-lineage",
+            {"kind": "production_trace", "source_lineage": lineage_key},
+        ),
+        task=trace.task,
+        transcript_events=transcript.events,
+        example_source=TraceExampleSource(
+            trace_id=trace.trace_id,
+            acceptance_evidence=evidence_input,
+        ),
+        score=None,
+        direct_inputs=_sorted_inputs(
+            (trace_input, rule_input, evidence_input)
+            if approval_input is None
+            else (trace_input, rule_input, approval_input, evidence_input)
+        ),
+        acceptance_rule_id=rule.acceptance_rule_id,
+        acceptance_evidence_id=evidence.acceptance_evidence_id,
+        acceptance_evidence=evidence_input,
+    )
+
+
+def resolve_teacher_source(store: ProjectStore, source: TeacherSFTSource) -> PreparedSFTSource:
+    """Hydrate one accepted teacher source from its immutable acceptance artifact.
+
+    Args:
+        store: Project store that owns every rollout, task, judge, and acceptance artifact.
+        source: A caller-supplied pointer, never caller-supplied rollout, score, or transcript data.
+
+    Returns:
+        The verified source ready for leakage partitioning and example extraction.
+
+    Raises:
+        SFTSourceVerificationError: A required source is absent, corrupt, mismatched, or fails
+            teacher acceptance policy.
+    """
+    evidence, evidence_input = _read_json(
+        store,
+        artifact_id=source.acceptance_evidence_id,
+        artifact_type="sft-teacher-acceptance",
+        relative_path="evidence.json",
+        model_type=TeacherAcceptanceEvidence,
+    )
+    if evidence.acceptance_evidence_id != source.acceptance_evidence_id:
+        raise SFTSourceVerificationError("teacher acceptance evidence has the wrong identity")
+    rollout, rollout_input = _read_json(
+        store,
+        artifact_id=evidence.rollout.artifact_id,
+        artifact_type="rollout",
+        relative_path="rollout.json",
+        model_type=RolloutArtifact,
+        expected_input=evidence.rollout,
+    )
+    if rollout.artifact_id != rollout_input.artifact_id:
+        raise SFTSourceVerificationError("teacher rollout has the wrong artifact identity")
+    task, task_set_input, task_set_inputs = _load_task(store, evidence)
+    rule, rule_input = _read_json(
+        store,
+        artifact_id=evidence.acceptance_rule.artifact_id,
+        artifact_type="sft-teacher-acceptance-rule",
+        relative_path="rule.json",
+        model_type=TeacherAcceptanceRule,
+        expected_input=evidence.acceptance_rule,
+    )
+    if rule.acceptance_rule_id != rule_input.artifact_id:
+        raise SFTSourceVerificationError("teacher acceptance rule has the wrong identity")
+    judgment, judgment_input = _read_json(
+        store,
+        artifact_id=evidence.judgment.artifact_id,
+        artifact_type="judgment",
+        relative_path="judgment.json",
+        model_type=Judgment,
+        expected_input=evidence.judgment,
+    )
+    if judgment.judgment_id != judgment_input.artifact_id:
+        raise SFTSourceVerificationError("teacher judgment has the wrong identity")
+    calibration, calibration_input = _verify_calibration(store, evidence)
+    fidelity, fidelity_input = _read_json(
+        store,
+        artifact_id=evidence.fidelity_report.artifact_id,
+        artifact_type="fidelity-report",
+        relative_path="fidelity-report.json",
+        model_type=FidelityReport,
+        expected_input=evidence.fidelity_report,
+    )
+    if fidelity.fidelity_report_id != fidelity_input.artifact_id:
+        raise SFTSourceVerificationError("teacher fidelity report has the wrong identity")
+    transcript = _load_transcript(
+        store,
+        evidence_id=evidence_input.artifact_id,
+        transcript_path=evidence.transcript_path,
+        transcript_sha256=evidence.transcript_sha256,
+    )
+    score, rubric_input = _verify_teacher_decision(
+        store,
+        evidence=evidence,
+        rollout=rollout,
+        rollout_input=rollout_input,
+        task=task,
+        task_set_input=task_set_input,
+        rule=rule,
+        rule_input=rule_input,
+        judgment=judgment,
+        judgment_input=judgment_input,
+        calibration=calibration,
+        calibration_input=calibration_input,
+        fidelity=fidelity,
+        fidelity_input=fidelity_input,
+    )
+    return PreparedSFTSource(
+        kind="teacher_rollout",
+        source_id=rollout.rollout_id,
+        source_artifact=rollout_input,
+        source_record_sha256=sha256_json(rollout),
+        leakage_group_id=task.lineage_group_id,
+        task=task.instruction,
+        transcript_events=transcript.events,
+        example_source=RolloutExampleSource(
+            rollout_id=rollout.rollout_id,
+            acceptance_evidence=evidence_input,
+        ),
+        score=score,
+        direct_inputs=_sorted_inputs(
+            (
+                rollout_input,
+                task_set_input,
+                *task_set_inputs,
+                rule_input,
+                judgment_input,
+                calibration_input,
+                fidelity_input,
+                evidence_input,
+                rubric_input,
+                *calibration.inputs,
+            )
+        ),
+        acceptance_rule_id=rule.acceptance_rule_id,
+        acceptance_evidence_id=evidence.acceptance_evidence_id,
+        acceptance_evidence=evidence_input,
+    )
+
+
+def _load_trace(
+    store: ProjectStore, evidence: ProductionAcceptanceEvidence
+) -> tuple[Trace, ArtifactInput]:
+    """Load the exact persisted trace named by accepted production evidence."""
+    try:
+        loaded = load_trace_dataset(store.artifacts, evidence.trace_dataset.artifact_id)
+        trace_manifest = store.artifacts.read(evidence.trace_dataset.artifact_id).manifest
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTSourceVerificationError(
+            "production trace dataset is unavailable or corrupt"
+        ) from exc
+    trace_input = artifact_input(trace_manifest)
+    if trace_input != evidence.trace_dataset:
+        raise SFTSourceVerificationError(
+            "production evidence trace-dataset manifest does not match local evidence"
+        )
+    trace = next((item for item in loaded.traces if item.trace_id == evidence.trace_id), None)
+    if trace is None:
+        raise SFTSourceVerificationError(
+            "production evidence names a trace absent from its dataset"
+        )
+    if sha256_json(trace) != evidence.trace_sha256:
+        raise SFTSourceVerificationError(
+            "production evidence trace digest does not match stored trace"
+        )
+    return trace, trace_input
+
+
+def _verify_production_decision(
+    store: ProjectStore,
+    evidence: ProductionAcceptanceEvidence,
+    trace: Trace,
+    trace_input: ArtifactInput,
+    rule: ProductionAcceptanceRule,
+) -> ArtifactInput | None:
+    """Verify a production decision against canonical trace, rule, and approval artifacts."""
+    if trace.outcome is not None and trace.outcome.status == "failure":
+        raise SFTSourceVerificationError("production trace has a terminal infrastructure failure")
+    if any(span.failure is not None for span in trace.spans):
+        raise SFTSourceVerificationError(
+            "production trace has a recorded infrastructure span failure"
+        )
+    if evidence.decision == "trusted_outcome":
+        outcome = trace.outcome
+        if outcome is None or outcome.status != "success":
+            raise SFTSourceVerificationError(
+                "trusted production acceptance requires a successful stored outcome"
+            )
+        if sha256_json(outcome) != evidence.outcome_sha256:
+            raise SFTSourceVerificationError(
+                "production acceptance outcome digest does not match stored trace"
+            )
+        if outcome.outcome_name not in rule.accepted_outcomes:
+            raise SFTSourceVerificationError("production outcome is not accepted by its rule")
+        return None
+    if not rule.allow_human_approval:
+        raise SFTSourceVerificationError("production rule does not allow human approval")
+    if evidence.human_approval is None:
+        raise SFTSourceVerificationError("production approval evidence is missing")
+    approval, approval_input = _read_json(
+        store,
+        artifact_id=evidence.human_approval.artifact_id,
+        artifact_type="sft-human-approval",
+        relative_path="approval.json",
+        model_type=HumanApproval,
+        expected_input=evidence.human_approval,
+    )
+    if approval.approval_id != approval_input.artifact_id:
+        raise SFTSourceVerificationError("human approval has the wrong artifact identity")
+    if approval.trace_dataset != trace_input or approval.trace_id != trace.trace_id:
+        raise SFTSourceVerificationError("human approval does not bind the accepted stored trace")
+    return approval_input
+
+
+def _load_task(
+    store: ProjectStore, evidence: TeacherAcceptanceEvidence
+) -> tuple[TaskCase, ArtifactInput, tuple[ArtifactInput, ...]]:
+    """Load the exact immutable task record and task-set lineage named by teacher evidence."""
+    try:
+        loaded = load_task_set(store.artifacts, evidence.task_set.artifact_id)
+        task_set_manifest = store.artifacts.read(evidence.task_set.artifact_id).manifest
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTSourceVerificationError("teacher task set is unavailable or corrupt") from exc
+    task_set_input = artifact_input(task_set_manifest)
+    if task_set_input != evidence.task_set:
+        raise SFTSourceVerificationError(
+            "teacher evidence task-set manifest does not match local immutable evidence"
+        )
+    if loaded.task_set.tasks_sha256 != evidence.task_set_tasks_sha256:
+        raise SFTSourceVerificationError("teacher evidence task payload digest does not match")
+    if loaded.task_set.inputs != evidence.task_set_inputs:
+        raise SFTSourceVerificationError("teacher evidence task-set input lineage does not match")
+    task = next((item for item in loaded.tasks if item.task_id == evidence.task_id), None)
+    if task is None:
+        raise SFTSourceVerificationError("teacher evidence task is absent from its task set")
+    if sha256_json(task) != evidence.task_sha256:
+        raise SFTSourceVerificationError("teacher evidence task content does not match stored task")
+    return task, task_set_input, loaded.task_set.inputs
+
+
+def _verify_calibration(
+    store: ProjectStore, evidence: TeacherAcceptanceEvidence
+) -> tuple[JudgeCalibration, ArtifactInput]:
+    """Resolve a calibration only through W6's recursive persisted-evidence verifier."""
+    try:
+        calibration, calibration_input = verify_persisted_calibration(
+            store, evidence.calibration.artifact_id
+        )
+    except CalibrationError as exc:
+        raise SFTSourceVerificationError(
+            "teacher calibration is unavailable or fails recursive W6 provenance verification"
+        ) from exc
+    if calibration_input != evidence.calibration:
+        raise SFTSourceVerificationError(
+            "teacher evidence calibration manifest does not match local immutable evidence"
+        )
+    if calibration.calibration_id != calibration_input.artifact_id:
+        raise SFTSourceVerificationError("teacher calibration has the wrong artifact identity")
+    return calibration, calibration_input
+
+
+def _verify_teacher_decision(
+    store: ProjectStore,
+    *,
+    evidence: TeacherAcceptanceEvidence,
+    rollout: RolloutArtifact,
+    rollout_input: ArtifactInput,
+    task: TaskCase,
+    task_set_input: ArtifactInput,
+    rule: TeacherAcceptanceRule,
+    rule_input: ArtifactInput,
+    judgment: Judgment,
+    judgment_input: ArtifactInput,
+    calibration: JudgeCalibration,
+    calibration_input: ArtifactInput,
+    fidelity: FidelityReport,
+    fidelity_input: ArtifactInput,
+) -> tuple[float, ArtifactInput]:
+    """Verify all teacher gates and recompute the usable score from persisted judgment maps."""
+    if rule.required_calibration != calibration_input:
+        raise SFTSourceVerificationError("teacher acceptance rule names a different calibration")
+    if rollout.failure is not None or rollout.stop_reason != "completed":
+        raise SFTSourceVerificationError(
+            "teacher rollout has an infrastructure or execution failure"
+        )
+    if any(span.failure is not None for span in rollout.spans):
+        raise SFTSourceVerificationError(
+            "teacher rollout has a recorded infrastructure span failure"
+        )
+    if rollout.evidence_source not in {"world_model", "sandbox"}:
+        raise SFTSourceVerificationError(
+            "teacher rollout must come from a world-model or sandbox simulation"
+        )
+    if rollout.task_id != task.task_id:
+        raise SFTSourceVerificationError("teacher rollout names a different canonical task")
+    if calibration.status != "human_calibrated" or calibration.approved_at is None:
+        raise SFTSourceVerificationError(
+            "teacher rollout requires a recursively verified human-calibrated judge"
+        )
+    if fidelity.status != "approved" or fidelity.approved_at is None:
+        raise SFTSourceVerificationError("teacher rollout requires an approved fidelity report")
+    if judgment.rollout_id != rollout.rollout_id:
+        raise SFTSourceVerificationError("teacher judgment does not belong to the stored rollout")
+    if judgment.calibration_id != calibration.calibration_id:
+        raise SFTSourceVerificationError("teacher judgment uses a different stored calibration")
+    rubric, rubric_input = _read_json(
+        store,
+        artifact_id=calibration.rubric_id,
+        artifact_type="rubric",
+        relative_path="rubric.json",
+        model_type=Rubric,
+    )
+    if rubric.rubric_id != rubric_input.artifact_id:
+        raise SFTSourceVerificationError("teacher rubric has the wrong artifact identity")
+    if rubric.source_task_set_id != task_set_input.artifact_id:
+        raise SFTSourceVerificationError("teacher rubric belongs to a different task set")
+    if task_set_input not in rubric.inputs:
+        raise SFTSourceVerificationError("teacher rubric does not hash its canonical task set")
+    if judgment.rubric_id != rubric.rubric_id:
+        raise SFTSourceVerificationError("teacher judgment uses a different stored rubric")
+    if (
+        judgment.judge_model != calibration.judge_model
+        or judgment.judge_prompt_id != calibration.judge_prompt_id
+        or judgment.judge_prompt_sha256 != calibration.judge_prompt_sha256
+    ):
+        raise SFTSourceVerificationError(
+            "teacher judgment model or prompt does not match its stored calibration"
+        )
+    required_judgment_inputs = {rollout_input, rubric_input, calibration_input}
+    if not required_judgment_inputs.issubset(set(judgment.inputs)):
+        raise SFTSourceVerificationError(
+            "teacher judgment does not hash its rollout, rubric, and calibration artifacts"
+        )
+    score = _recompute_calibrated_score(judgment, rubric, calibration, rollout)
+    if score < rule.minimum_overall_score:
+        raise SFTSourceVerificationError("teacher judgment score does not meet acceptance policy")
+    if evidence.inputs != tuple(
+        sorted(
+            (
+                rollout_input,
+                task_set_input,
+                judgment_input,
+                calibration_input,
+                fidelity_input,
+                rule_input,
+            ),
+            key=lambda item: item.artifact_id,
+        )
+    ):
+        raise SFTSourceVerificationError("teacher evidence has noncanonical direct artifact inputs")
+    return score, rubric_input
+
+
+def _recompute_calibrated_score(
+    judgment: Judgment,
+    rubric: Rubric,
+    calibration: JudgeCalibration,
+    rollout: RolloutArtifact,
+) -> float:
+    """Recompute one authoritative equal-weight score from persisted raw scores and maps."""
+    rubric_ids = tuple(item.dimension_id for item in rubric.dimensions)
+    maps = {item.dimension_id: item for item in calibration.score_maps}
+    dimensions = {item.dimension_id: item for item in judgment.dimensions}
+    if set(maps) != set(rubric_ids) or set(dimensions) != set(rubric_ids):
+        raise SFTSourceVerificationError(
+            "teacher judgment, rubric, and calibration must cover the same dimensions"
+        )
+    known_span_ids = {span.span_id for span in rollout.spans}
+    calibrated_scores: list[float] = []
+    for dimension_id in rubric_ids:
+        dimension = dimensions[dimension_id]
+        if not set(dimension.evidence_span_ids).issubset(known_span_ids):
+            raise SFTSourceVerificationError(
+                "teacher judgment cites a span absent from its rollout"
+            )
+        expected = maps[dimension_id].apply(dimension.raw_score)
+        if not math.isclose(
+            dimension.calibrated_score,
+            expected,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise SFTSourceVerificationError(
+                "teacher judgment calibrated dimension does not match stored score map"
+            )
+        calibrated_scores.append(expected)
+    overall = sum(score / 5 for score in calibrated_scores) / len(calibrated_scores)
+    if not math.isclose(judgment.overall_score, overall, rel_tol=1e-12, abs_tol=1e-12):
+        raise SFTSourceVerificationError(
+            "teacher judgment overall score does not match authoritative calibrated dimensions"
+        )
+    return overall
+
+
+def _load_transcript(
+    store: ProjectStore,
+    *,
+    evidence_id: ArtifactId,
+    transcript_path: str,
+    transcript_sha256: Sha256,
+) -> SFTTranscript:
+    """Read and immediately verify canonical transcript bytes owned by accepted evidence."""
+    try:
+        payload = store.artifacts.read_bytes(evidence_id, transcript_path)
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTSourceVerificationError(
+            "accepted SFT transcript is unavailable or corrupt"
+        ) from exc
+    if hashlib.sha256(payload).hexdigest() != transcript_sha256:
+        raise SFTSourceVerificationError("accepted SFT transcript bytes do not match evidence")
+    try:
+        transcript = SFTTranscript.model_validate_json(payload)
+    except ValidationError as exc:
+        raise SFTSourceVerificationError(
+            "accepted SFT transcript is not a valid canonical record"
+        ) from exc
+    if canonical_json_bytes(transcript) != payload:
+        raise SFTSourceVerificationError("accepted SFT transcript bytes are not canonical")
+    return transcript
+
+
+def _read_json[ModelT: BaseModel](
+    store: ProjectStore,
+    *,
+    artifact_id: ArtifactId,
+    artifact_type: str,
+    relative_path: str,
+    model_type: type[ModelT],
+    expected_input: ArtifactInput | None = None,
+) -> tuple[ModelT, ArtifactInput]:
+    """Load one typed immutable record and normalize W6/project-store errors for SFT callers."""
+    try:
+        return read_artifact_json(
+            store,
+            artifact_id=artifact_id,
+            expected_artifact_type=artifact_type,
+            relative_path=relative_path,
+            model_type=model_type,
+            expected_input=expected_input,
+        )
+    except JudgingProvenanceError as exc:
+        raise SFTSourceVerificationError(
+            f"required {artifact_type} artifact is unavailable or does not match evidence"
+        ) from exc
+
+
+def _sorted_inputs(inputs: Iterable[ArtifactInput]) -> tuple[ArtifactInput, ...]:
+    """Return exact unique authoritative artifact inputs in stable identity order."""
+    by_id: dict[ArtifactId, ArtifactInput] = {}
+    for item in inputs:
+        existing = by_id.get(item.artifact_id)
+        if existing is not None and existing != item:
+            raise SFTSourceVerificationError(
+                f"verified source has conflicting hashes for artifact {item.artifact_id}"
+            )
+        by_id[item.artifact_id] = item
+    return tuple(by_id[item_id] for item_id in sorted(by_id))


### PR DESCRIPTION
## Summary
- add immutable, store-backed SFT dataset construction for production and teacher rollout sources
- preserve transcript, action, judgment, calibration, task-set, and trace-dataset provenance in frozen manifests
- render complete assistant and tool targets without turning ineligible actions into training targets

## Validation
- `uv run pytest -q` targeted W12, W5, W6, repository-boundary, and package-layout suite: 216 passed
- focused `uv run ty check wmo/optimize/model/sft wmo/common/traces`: passed
- focused Ruff formatting and full repository Ruff lint: passed
- targeted collection: 216 tests collected

## Known baseline gates
- whole-repository format and type checks remain blocked by pre-existing legacy docs and provider dependency errors
- full collection remains blocked by missing optional Harbor dependencies