### PR TITLE
W13: add offline Tinker SFT runner

### DIFF
--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -1,4 +1,4 @@
-"""Frozen, leakage-safe SFT dataset construction from accepted WMO evidence."""
+"""Frozen, leakage-safe SFT datasets and managed offline Tinker SFT behavior."""
 
 from wmo.optimize.model.sft.builder import (
     SFTBuildError,
@@ -32,6 +32,25 @@ from wmo.optimize.model.sft.rendering import (
     parse_rendered_turn,
     render_context_target,
 )
+from wmo.optimize.model.sft.tinker import (
+    TinkerSFTDatum,
+    TinkerSFTDependencyError,
+    TinkerTrainerBackend,
+    TinkerTrainerSession,
+    tinker_messages_from_example,
+)
+from wmo.optimize.model.sft.training import (
+    TinkerSFTBudgetExceeded,
+    TinkerSFTError,
+    TinkerSFTModelArtifact,
+    TinkerSFTOptimizer,
+    TinkerSFTResult,
+    TinkerSFTResumeError,
+    TinkerSFTRunManifest,
+    TinkerSFTSpec,
+    TrainerBackend,
+    train_tinker_sft,
+)
 
 __all__ = [
     "AssistantActionEvent",
@@ -52,12 +71,27 @@ __all__ = [
     "TeacherAcceptanceEvidence",
     "TeacherAcceptanceRule",
     "TeacherSFTSource",
+    "TinkerSFTBudgetExceeded",
+    "TinkerSFTDatum",
+    "TinkerSFTDependencyError",
+    "TinkerSFTError",
+    "TinkerSFTModelArtifact",
+    "TinkerSFTOptimizer",
+    "TinkerSFTResult",
+    "TinkerSFTRunManifest",
+    "TinkerSFTResumeError",
+    "TinkerSFTSpec",
+    "TinkerTrainerBackend",
+    "TinkerTrainerSession",
     "ToolEvent",
+    "TrainerBackend",
     "build_sft_dataset",
     "context_target_fingerprint",
     "ensure_no_cross_split_fingerprints",
     "load_sft_dataset",
     "parse_rendered_turn",
     "render_context_target",
+    "tinker_messages_from_example",
+    "train_tinker_sft",
     "write_sft_dataset",
 ]

--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -6,6 +6,7 @@ from wmo.optimize.model.sft.builder import (
     build_sft_dataset,
     ensure_no_cross_split_fingerprints,
     load_sft_dataset,
+    load_verified_sft_dataset,
     write_sft_dataset,
 )
 from wmo.optimize.model.sft.contracts import (
@@ -40,6 +41,7 @@ from wmo.optimize.model.sft.tinker import (
     tinker_messages_from_example,
 )
 from wmo.optimize.model.sft.training import (
+    TinkerSFTAmbiguousStepError,
     TinkerSFTBudgetExceeded,
     TinkerSFTError,
     TinkerSFTModelArtifact,
@@ -72,6 +74,7 @@ __all__ = [
     "TeacherAcceptanceRule",
     "TeacherSFTSource",
     "TinkerSFTBudgetExceeded",
+    "TinkerSFTAmbiguousStepError",
     "TinkerSFTDatum",
     "TinkerSFTDependencyError",
     "TinkerSFTError",
@@ -89,6 +92,7 @@ __all__ = [
     "context_target_fingerprint",
     "ensure_no_cross_split_fingerprints",
     "load_sft_dataset",
+    "load_verified_sft_dataset",
     "parse_rendered_turn",
     "render_context_target",
     "tinker_messages_from_example",

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -281,6 +281,8 @@ def write_sft_dataset(store: ProjectStore, artifact: SFTDatasetArtifact) -> SFTD
     Raises:
         SFTBuildError: Existing data conflicts or serialized rows violate dataset invariants.
     """
+    if artifact.build_spec is None:
+        raise SFTBuildError("new SFT datasets must persist their deterministic build spec")
     _validate_artifact_rows(artifact)
     files = {
         "dataset.json": artifact.metadata().model_dump(mode="json", exclude_none=False),
@@ -357,21 +359,43 @@ def load_sft_dataset(
     return artifact
 
 
-def load_verified_sft_dataset(store: ProjectStore, dataset_id: ArtifactId) -> SFTDatasetArtifact:
+def load_verified_sft_dataset(
+    store: ProjectStore,
+    dataset_id: ArtifactId,
+    *,
+    legacy_build_spec: SFTBuildSpec | None = None,
+) -> SFTDatasetArtifact:
     """Reload and rebuild one accepted dataset from its persisted W12 evidence chain.
 
     Args:
         store: Project-local store owning the dataset and every transitive source artifact.
         dataset_id: Stable ID of the previously persisted W12 dataset.
+        legacy_build_spec: Exact original W12 build settings when loading metadata that predates
+            persisted build specifications.
 
     Returns:
         The canonical dataset only when its stored bytes equal a fresh deterministic rebuild.
 
     Raises:
         SFTBuildError: Any dataset, source, evidence, input, partition, build, or fingerprint
-            invariant cannot be reproduced from the immutable project store.
+            invariant cannot be reproduced from the immutable project store. Legacy metadata
+            additionally requires its original build settings before it can be verified.
     """
     loaded = load_sft_dataset(store, dataset_id)
+    build_spec = loaded.build_spec
+    if build_spec is None:
+        if legacy_build_spec is None:
+            raise SFTBuildError(
+                f"frozen SFT dataset {dataset_id} predates persisted build specs; "
+                "provide legacy_build_spec with its original W12 settings"
+            )
+        build_spec = legacy_build_spec
+        loaded = loaded.model_copy(update={"build_spec": build_spec})
+    elif legacy_build_spec is not None:
+        raise SFTBuildError(
+            f"frozen SFT dataset {dataset_id} already persists its build spec; "
+            "legacy_build_spec is only valid for legacy metadata"
+        )
     production_sources = tuple(
         ProductionSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
         for source in loaded.sources
@@ -387,7 +411,7 @@ def load_verified_sft_dataset(store: ProjectStore, dataset_id: ArtifactId) -> SF
             store=store,
             production_sources=production_sources,
             teacher_sources=teacher_sources,
-            spec=loaded.build_spec,
+            spec=build_spec,
             created_at=loaded.dataset.created_at,
             code_revision=loaded.dataset.code_revision,
         )

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -9,12 +9,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
-from pydantic import Field, ValidationError
+from pydantic import ValidationError
 
 from wmo.common.core.artifacts import (
     ArtifactId,
     ArtifactInput,
-    ContractModel,
     Sha256,
     canonical_json_bytes,
     sha256_json,
@@ -30,6 +29,7 @@ from wmo.optimize.model.sft.contracts import (
     InfrastructureFailureEvent,
     PartitionedSFTExample,
     ProductionSFTSource,
+    SFTBuildSpec,
     SFTContextEvent,
     SFTDataset,
     SFTDatasetArtifact,
@@ -59,14 +59,6 @@ from wmo.optimize.model.sft.sources import (
 
 class SFTBuildError(ValueError):
     """Raised when SFT input provenance, partitioning, or artifact integrity is invalid."""
-
-
-class SFTBuildSpec(ContractModel):
-    """Deterministic controls for one frozen SFT dataset build."""
-
-    held_out_fraction: float = Field(default=0.20, gt=0, lt=1)
-    representative_sample_count: int = Field(default=3, ge=0)
-    split_salt: str = Field(default="wmo-sft-split-v1", min_length=1, max_length=256)
 
 
 @dataclass(frozen=True)
@@ -247,6 +239,7 @@ def build_sft_dataset(
         ),
     )
     return SFTDatasetArtifact(
+        build_spec=spec,
         dataset=dataset,
         sources=tuple(source_references),
         partitions=partitions,
@@ -346,6 +339,7 @@ def load_sft_dataset(
     except (ArtifactCorruptionError, ValidationError, ValueError) as exc:
         raise SFTBuildError(f"frozen SFT dataset {dataset_id} has invalid data files") from exc
     artifact = SFTDatasetArtifact(
+        build_spec=metadata.build_spec,
         dataset=metadata.dataset,
         sources=metadata.sources,
         partitions=metadata.partitions,
@@ -361,6 +355,53 @@ def load_sft_dataset(
             f"SFT dataset {dataset_id} is insufficient and cannot be consumed for training"
         )
     return artifact
+
+
+def load_verified_sft_dataset(store: ProjectStore, dataset_id: ArtifactId) -> SFTDatasetArtifact:
+    """Reload and rebuild one accepted dataset from its persisted W12 evidence chain.
+
+    Args:
+        store: Project-local store owning the dataset and every transitive source artifact.
+        dataset_id: Stable ID of the previously persisted W12 dataset.
+
+    Returns:
+        The canonical dataset only when its stored bytes equal a fresh deterministic rebuild.
+
+    Raises:
+        SFTBuildError: Any dataset, source, evidence, input, partition, build, or fingerprint
+            invariant cannot be reproduced from the immutable project store.
+    """
+    loaded = load_sft_dataset(store, dataset_id)
+    production_sources = tuple(
+        ProductionSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
+        for source in loaded.sources
+        if source.kind == "production_trace"
+    )
+    teacher_sources = tuple(
+        TeacherSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
+        for source in loaded.sources
+        if source.kind == "teacher_rollout"
+    )
+    try:
+        rebuilt = build_sft_dataset(
+            store=store,
+            production_sources=production_sources,
+            teacher_sources=teacher_sources,
+            spec=loaded.build_spec,
+            created_at=loaded.dataset.created_at,
+            code_revision=loaded.dataset.code_revision,
+        )
+    except SFTBuildError:
+        raise
+    except ValueError as exc:
+        raise SFTBuildError(
+            f"frozen SFT dataset {dataset_id} cannot reproduce its evidence chain"
+        ) from exc
+    if rebuilt != loaded:
+        raise SFTBuildError(
+            f"frozen SFT dataset {dataset_id} does not equal its canonical evidence rebuild"
+        )
+    return loaded
 
 
 def _scan_source_actions(

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -475,7 +475,7 @@ class SFTInspectionReport(ContractModel):
 class SFTDatasetMetadata(ContractModel):
     """All non-row frozen manifest data persisted beside canonical SFT JSONL examples."""
 
-    build_spec: SFTBuildSpec
+    build_spec: SFTBuildSpec | None = None
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]
@@ -486,7 +486,7 @@ class SFTDatasetMetadata(ContractModel):
 class SFTDatasetArtifact(ContractModel):
     """Materialized dataset rows plus the immutable metadata required to reload and inspect them."""
 
-    build_spec: SFTBuildSpec
+    build_spec: SFTBuildSpec | None = None
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -356,6 +356,14 @@ class SFTPartition(ContractModel):
         return value
 
 
+class SFTBuildSpec(ContractModel):
+    """Deterministic controls persisted with one frozen SFT dataset build."""
+
+    held_out_fraction: float = Field(default=0.20, gt=0, lt=1)
+    representative_sample_count: int = Field(default=3, ge=0)
+    split_salt: str = Field(default="wmo-sft-split-v1", min_length=1, max_length=256)
+
+
 class SFTSourceReference(ContractModel):
     """An auditable source and acceptance-evidence reference in a frozen dataset manifest."""
 
@@ -467,6 +475,7 @@ class SFTInspectionReport(ContractModel):
 class SFTDatasetMetadata(ContractModel):
     """All non-row frozen manifest data persisted beside canonical SFT JSONL examples."""
 
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]
@@ -477,6 +486,7 @@ class SFTDatasetMetadata(ContractModel):
 class SFTDatasetArtifact(ContractModel):
     """Materialized dataset rows plus the immutable metadata required to reload and inspect them."""
 
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]
@@ -487,6 +497,7 @@ class SFTDatasetArtifact(ContractModel):
     def metadata(self) -> SFTDatasetMetadata:
         """Return the immutable metadata file stored beside the canonical JSONL rows."""
         return SFTDatasetMetadata(
+            build_spec=self.build_spec,
             dataset=self.dataset,
             sources=self.sources,
             partitions=self.partitions,

--- a/wmo/optimize/model/sft/provider_resources.py
+++ b/wmo/optimize/model/sft/provider_resources.py
@@ -1,0 +1,39 @@
+"""Validation for opaque provider resource IDs persisted by offline SFT."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+from wmo.common.core.artifacts import SecretBoundaryError, assert_text_secret_free
+from wmo.optimize.model.sft.training_contracts import TinkerSFTError
+
+
+def validate_provider_resource_id(value: str, *, label: str) -> str:
+    """Reject URLs, credentials, and secret-like material before artifact persistence.
+
+    Args:
+        value: Provider-returned opaque resource identifier.
+        label: Human-readable resource kind for safe error messages.
+
+    Returns:
+        The unchanged validated opaque provider resource ID.
+
+    Raises:
+        TinkerSFTError: The value is a URL, malformed, or contains credential-like material.
+    """
+    if len(value) > 2048 or not value or any(character.isspace() for character in value):
+        raise TinkerSFTError(f"Tinker {label} is not a safe opaque provider resource ID")
+    parsed = urlsplit(value)
+    if parsed.scheme in {"http", "https", "ftp"} or not parsed.scheme:
+        raise TinkerSFTError(f"Tinker {label} must be an opaque provider resource ID, not a URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise TinkerSFTError(f"Tinker {label} must not contain URI user information")
+    if parsed.query or parsed.fragment or "@" in value:
+        raise TinkerSFTError(f"Tinker {label} must not contain URI query, fragment, or user info")
+    if not parsed.netloc and not parsed.path:
+        raise TinkerSFTError(f"Tinker {label} has no provider resource component")
+    try:
+        assert_text_secret_free(value)
+    except SecretBoundaryError as exc:
+        raise TinkerSFTError(f"Tinker {label} contains credential-like material") from exc
+    return value

--- a/wmo/optimize/model/sft/tinker.py
+++ b/wmo/optimize/model/sft/tinker.py
@@ -1,0 +1,312 @@
+"""Concrete managed Tinker cross-entropy adapter for the offline SFT runner.
+
+The adapter accepts a prebuilt ``tinker.ServiceClient``.  It never constructs a service client,
+reads an environment variable, or resolves a credential.  Application composition owns that
+authorization boundary, while tests inject the runner's in-memory ``TrainerBackend`` instead.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
+
+from wmo.common.core.artifacts import canonical_json_bytes
+from wmo.common.models import AssistantAction, ToolCall
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    SFTExample,
+    SFTMessage,
+    ToolEvent,
+)
+from wmo.optimize.model.sft.training import (
+    TinkerSFTError,
+    TinkerSFTSpec,
+    TrainerBatchResult,
+    TrainerDatum,
+    TrainerSession,
+)
+
+if TYPE_CHECKING:
+    import tinker
+    from tinker_cookbook.renderers import Message, Renderer
+
+_MISSING_TINKER_EXTRA = (
+    "Tinker SFT requires the optional distill dependencies; run `uv sync --extra distill` "
+    "or install `world-model-optimizer[distill]`"
+)
+
+
+class TinkerSFTDependencyError(TinkerSFTError):
+    """The concrete Tinker backend was requested without its optional local SDK dependencies."""
+
+
+class TinkerFunctionCall(TypedDict):
+    """The cookbook-compatible function payload of one complete assistant tool call."""
+
+    name: str
+    arguments: str
+
+
+class TinkerToolCall(TypedDict):
+    """The cookbook-compatible representation of one WMO assistant tool call."""
+
+    type: str
+    id: str
+    function: TinkerFunctionCall
+
+
+class TinkerConversationMessage(TypedDict):
+    """One cookbook-compatible text, assistant-tool, or tool-result message."""
+
+    role: str
+    content: str
+    tool_calls: NotRequired[list[TinkerToolCall]]
+    tool_call_id: NotRequired[str]
+    name: NotRequired[str]
+
+
+@dataclass(frozen=True)
+class TinkerSFTDatum:
+    """One immutable W12 example rendered as a pinned Tinker cross-entropy wire datum."""
+
+    example_id: str
+    supervised_token_count: int
+    datum: tinker.Datum
+
+
+class TinkerTrainerBackend:
+    """Create one concrete Tinker LoRA session from a caller-owned service client.
+
+    The supplied service client is intentionally already constructed.  This class has no API-key
+    parameter and no fallback constructor, which keeps environment and spend authorization outside
+    optimization code.
+    """
+
+    def __init__(self, service: tinker.ServiceClient) -> None:
+        """Bind a caller-owned service client without creating or configuring it.
+
+        Args:
+            service: Existing authorized Tinker service client.  No request occurs until ``open``.
+        """
+        self._service = service
+
+    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
+        """Create a managed LoRA client and restore a durable state before rendering any datum.
+
+        Args:
+            spec: Frozen LoRA and cross-entropy settings.
+            resume_state_path: Last recorded training-state handle, when continuing a prior run.
+
+        Returns:
+            A concrete session that renders W12 examples and performs managed cross-entropy steps.
+
+        Raises:
+            TinkerSFTDependencyError: The optional local SDK or cookbook package is unavailable.
+        """
+        _require_tinker_dependencies()
+        from tinker_cookbook.model_info import get_recommended_renderer_name
+        from tinker_cookbook.renderers import get_renderer
+
+        client = self._service.create_lora_training_client(spec.base_model, rank=spec.lora_rank)
+        if resume_state_path is not None:
+            # Tinker requires restore before a weight-affecting call.  In particular, renderer
+            # creation waits until this returns, so a resumed optimizer state is never replaced.
+            client.load_state_with_optimizer(resume_state_path).result()
+        renderer_name = get_recommended_renderer_name(spec.base_model)
+        renderer = get_renderer(
+            renderer_name,
+            client.get_tokenizer(),
+            model_name=spec.base_model,
+        )
+        return TinkerTrainerSession(client=client, renderer=renderer, spec=spec)
+
+
+class TinkerTrainerSession:
+    """One concrete Tinker training client using cookbook rendering and cross-entropy only."""
+
+    def __init__(
+        self,
+        *,
+        client: tinker.TrainingClient,
+        renderer: Renderer,
+        spec: TinkerSFTSpec,
+    ) -> None:
+        """Bind a managed client, its authoritative base-model renderer, and frozen settings.
+
+        Args:
+            client: Tinker client already created or restored by ``TinkerTrainerBackend``.
+            renderer: Cookbook renderer selected for the exact configured base model.
+            spec: Frozen datum length and optimizer settings.
+        """
+        self._client = client
+        self._renderer = renderer
+        self._spec = spec
+
+    def render_examples(self, examples: Sequence[SFTExample]) -> tuple[TrainerDatum, ...]:
+        """Render every complete target action into a cross-entropy datum in W12 row order.
+
+        Only the final assistant message is trainable because W12 expands each accepted assistant
+        action into a standalone row.  Previous assistant actions and tool events remain context.
+
+        Args:
+            examples: Ordered frozen train examples, never held-out rows.
+
+        Returns:
+            One labeled Tinker datum per input example, in exactly the same order.
+        """
+        _require_tinker_dependencies()
+        from tinker_cookbook.renderers import TrainOnWhat
+        from tinker_cookbook.supervised.data import conversation_to_datum
+
+        rendered: list[TrainerDatum] = []
+        for example in examples:
+            datum = conversation_to_datum(
+                cast("list[Message]", tinker_messages_from_example(example)),
+                self._renderer,
+                max_length=self._spec.maximum_datum_tokens,
+                train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+                reduction="none",
+            )
+            weights = datum.loss_fn_inputs.get("weights")
+            targets = datum.loss_fn_inputs.get("target_tokens")
+            if weights is None or targets is None:
+                raise TinkerSFTError("Tinker cookbook did not produce cross-entropy datum inputs")
+            if set(datum.loss_fn_inputs) != {"target_tokens", "weights"}:
+                raise TinkerSFTError(
+                    "Tinker SFT cross-entropy datum must contain only target_tokens and weights"
+                )
+            supervised_token_count = sum(weight != 0.0 for weight in weights.data)
+            if supervised_token_count <= 0:
+                raise TinkerSFTError(
+                    f"Tinker renderer left no supervised target tokens for {example.example_id}"
+                )
+            rendered.append(
+                TinkerSFTDatum(
+                    example_id=example.example_id,
+                    supervised_token_count=supervised_token_count,
+                    datum=datum,
+                )
+            )
+        return tuple(rendered)
+
+    def train_batch(
+        self, datums: Sequence[TrainerDatum], *, learning_rate: float
+    ) -> TrainerBatchResult:
+        """Run exactly one managed cross-entropy forward-backward and Adam update.
+
+        Args:
+            datums: Datums produced by this session's immutable W12 renderer.
+            learning_rate: Frozen Adam learning rate for the current batch.
+
+        Returns:
+            Only backend-reported loss and gradient metrics.  Tinker exposes no per-step monetary
+            meter on this API, so cost remains absent rather than estimated.
+
+        Raises:
+            TinkerSFTError: A datum did not originate from this concrete renderer.
+        """
+        _require_tinker_dependencies()
+        import tinker
+
+        tinker_datums: list[tinker.Datum] = []
+        for datum in datums:
+            if not isinstance(datum, TinkerSFTDatum):
+                raise TinkerSFTError("Tinker trainer received a datum from another backend")
+            tinker_datums.append(datum.datum)
+        forward_backward = self._client.forward_backward(tinker_datums, "cross_entropy").result()
+        optimizer = self._client.optim_step(tinker.AdamParams(learning_rate=learning_rate)).result()
+        return TrainerBatchResult(
+            loss=_named_metric(forward_backward.metrics, ("loss", "total_loss")),
+            gradient_norm=_named_metric(optimizer.metrics, ("grad_norm", "gradient_norm")),
+        )
+
+    def save_state(self, checkpoint_name: str) -> str:
+        """Persist one non-overwriting managed state and return Tinker's resume handle."""
+        response = self._client.save_state(checkpoint_name).result()
+        return response.path
+
+    def save_sampling_handle(self, model_name: str) -> str:
+        """Persist one completed sampler handle without deployment, serving, or catalog mutation."""
+        response = self._client.save_weights_for_sampler(model_name).result()
+        return response.path
+
+
+def tinker_messages_from_example(example: SFTExample) -> list[TinkerConversationMessage]:
+    """Convert one immutable W12 example into a complete cookbook supervised conversation.
+
+    The task is explicit initial context.  W12 observation events have no native cookbook role, so
+    they remain text-identical context under ``user``.  Tool call IDs, names, canonical arguments,
+    prior assistant actions, tool results, and the final complete target action are preserved.
+
+    Args:
+        example: One frozen W12 context and complete assistant-action target.
+
+    Returns:
+        Ordered messages whose final assistant message is the only supervised target.
+    """
+    messages: list[TinkerConversationMessage] = [
+        {"role": "system", "content": f"Task:\n{example.task}"}
+    ]
+    for event in example.history:
+        if isinstance(event, SFTMessage):
+            role = "user" if event.role == "observation" else event.role
+            messages.append({"role": role, "content": event.content})
+        elif isinstance(event, AssistantActionEvent):
+            messages.append(_assistant_message(event.action))
+        elif isinstance(event, ToolEvent):
+            tool_message: TinkerConversationMessage = {
+                "role": "tool",
+                "content": event.content,
+                "tool_call_id": event.tool_call_id,
+            }
+            if event.tool_name is not None:
+                tool_message["name"] = event.tool_name
+            messages.append(tool_message)
+        else:
+            raise TinkerSFTError("W12 training context contains an unsupported event")
+    messages.append(_assistant_message(example.target))
+    return messages
+
+
+def _assistant_message(action: AssistantAction) -> TinkerConversationMessage:
+    """Convert a complete typed assistant action without dropping text or ordered tool calls."""
+    message: TinkerConversationMessage = {"role": "assistant", "content": action.content or ""}
+    if action.tool_calls:
+        message["tool_calls"] = [_tool_call(call) for call in action.tool_calls]
+    return message
+
+
+def _tool_call(call: ToolCall) -> TinkerToolCall:
+    """Render one typed tool call through canonical JSON so argument bytes are deterministic."""
+    return {
+        "type": "function",
+        "id": call.call_id,
+        "function": {
+            "name": call.name,
+            "arguments": canonical_json_bytes(call.arguments).decode("utf-8"),
+        },
+    }
+
+
+def _named_metric(metrics: Mapping[str, float] | None, names: Sequence[str]) -> float | None:
+    """Extract one finite backend-reported metric by stable base name without inventing a value."""
+    if metrics is None:
+        return None
+    for key, value in metrics.items():
+        if key.split(":", 1)[0] in names:
+            numeric_value = float(value)
+            if not math.isfinite(numeric_value):
+                raise TinkerSFTError(f"Tinker reported a non-finite metric for {key}")
+            return numeric_value
+    return None
+
+
+def _require_tinker_dependencies() -> None:
+    """Fail clearly when the concrete backend is invoked without its optional local dependencies."""
+    try:
+        import tinker  # noqa: F401
+        import tinker_cookbook  # noqa: F401
+    except ImportError as exc:
+        raise TinkerSFTDependencyError(_MISSING_TINKER_EXTRA) from exc

--- a/wmo/optimize/model/sft/tinker.py
+++ b/wmo/optimize/model/sft/tinker.py
@@ -20,7 +20,7 @@ from wmo.optimize.model.sft.contracts import (
     SFTMessage,
     ToolEvent,
 )
-from wmo.optimize.model.sft.training import (
+from wmo.optimize.model.sft.training_contracts import (
     TinkerSFTError,
     TinkerSFTSpec,
     TrainerBatchResult,
@@ -92,6 +92,18 @@ class TinkerTrainerBackend:
         """
         self._service = service
 
+    def conservative_step_cost(self, spec: TinkerSFTSpec, *, batch_example_count: int) -> None:
+        """Return no cost bound because the pinned SDK exposes no supported estimator.
+
+        Args:
+            spec: Frozen training settings, unused because no SDK estimate exists.
+            batch_example_count: Planned row count, also insufficient for an SDK-backed bound.
+
+        Returns:
+            None. A run with ``maximum_cost_usd`` therefore fails before opening this backend.
+        """
+        return None
+
     def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
         """Create a managed LoRA client and restore a durable state before rendering any datum.
 
@@ -109,7 +121,11 @@ class TinkerTrainerBackend:
         from tinker_cookbook.model_info import get_recommended_renderer_name
         from tinker_cookbook.renderers import get_renderer
 
-        client = self._service.create_lora_training_client(spec.base_model, rank=spec.lora_rank)
+        client = self._service.create_lora_training_client(
+            spec.base_model,
+            rank=spec.lora_rank,
+            seed=spec.seed,
+        )
         if resume_state_path is not None:
             # Tinker requires restore before a weight-affecting call.  In particular, renderer
             # creation waits until this returns, so a resumed optimizer state is never replaced.
@@ -155,6 +171,10 @@ class TinkerTrainerSession:
 
         Returns:
             One labeled Tinker datum per input example, in exactly the same order.
+
+        Raises:
+            TinkerSFTError: Rendering omitted cross-entropy inputs, removed the complete target,
+                or left the target with no supervised tokens.
         """
         _require_tinker_dependencies()
         from tinker_cookbook.renderers import TrainOnWhat
@@ -165,9 +185,14 @@ class TinkerTrainerSession:
             datum = conversation_to_datum(
                 cast("list[Message]", tinker_messages_from_example(example)),
                 self._renderer,
-                max_length=self._spec.maximum_datum_tokens,
+                max_length=None,
                 train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE,
                 reduction="none",
+            )
+            datum = _truncate_context_only(
+                datum,
+                maximum_datum_tokens=self._spec.maximum_datum_tokens,
+                example_id=example.example_id,
             )
             weights = datum.loss_fn_inputs.get("weights")
             targets = datum.loss_fn_inputs.get("target_tokens")
@@ -223,12 +248,26 @@ class TinkerTrainerSession:
         )
 
     def save_state(self, checkpoint_name: str) -> str:
-        """Persist one non-overwriting managed state and return Tinker's resume handle."""
+        """Persist one non-overwriting managed optimizer state.
+
+        Args:
+            checkpoint_name: Unique immutable checkpoint name for the current run step.
+
+        Returns:
+            Tinker's opaque resume resource identifier.
+        """
         response = self._client.save_state(checkpoint_name).result()
         return response.path
 
     def save_sampling_handle(self, model_name: str) -> str:
-        """Persist one completed sampler handle without deployment, serving, or catalog mutation."""
+        """Persist one completed sampler handle without deploying or serving it.
+
+        Args:
+            model_name: Unique immutable resource name for the completed run.
+
+        Returns:
+            Tinker's opaque sampling resource identifier.
+        """
         response = self._client.save_weights_for_sampler(model_name).result()
         return response.path
 
@@ -245,6 +284,9 @@ def tinker_messages_from_example(example: SFTExample) -> list[TinkerConversation
 
     Returns:
         Ordered messages whose final assistant message is the only supervised target.
+
+    Raises:
+        TinkerSFTError: The frozen context contains an unsupported event type.
     """
     messages: list[TinkerConversationMessage] = [
         {"role": "system", "content": f"Task:\n{example.task}"}
@@ -301,6 +343,51 @@ def _named_metric(metrics: Mapping[str, float] | None, names: Sequence[str]) -> 
                 raise TinkerSFTError(f"Tinker reported a non-finite metric for {key}")
             return numeric_value
     return None
+
+
+def _truncate_context_only(
+    datum: tinker.Datum,
+    *,
+    maximum_datum_tokens: int | None,
+    example_id: str,
+) -> tinker.Datum:
+    """Trim only unsupervised prompt tokens while retaining the complete target suffix."""
+    if maximum_datum_tokens is None:
+        return datum
+    import tinker
+
+    model_tokens = datum.model_input.to_ints()
+    maximum_model_tokens = maximum_datum_tokens - 1
+    if len(model_tokens) <= maximum_model_tokens:
+        return datum
+    weights = datum.loss_fn_inputs["weights"].data
+    targets = datum.loss_fn_inputs["target_tokens"].data
+    weight_tensor = datum.loss_fn_inputs["weights"]
+    target_tensor = datum.loss_fn_inputs["target_tokens"]
+    first_supervised = next(
+        (index for index, weight in enumerate(weights) if weight != 0.0),
+        len(weights),
+    )
+    trim_count = len(model_tokens) - maximum_model_tokens
+    if trim_count > first_supervised:
+        raise TinkerSFTError(
+            f"maximum_datum_tokens cannot retain the complete supervised target for {example_id}"
+        )
+    return tinker.Datum(
+        model_input=tinker.ModelInput.from_ints(model_tokens[trim_count:]),
+        loss_fn_inputs={
+            "target_tokens": tinker.TensorData(
+                data=targets[trim_count:],
+                dtype=target_tensor.dtype,
+                shape=[len(targets) - trim_count],
+            ),
+            "weights": tinker.TensorData(
+                data=weights[trim_count:],
+                dtype=weight_tensor.dtype,
+                shape=[len(weights) - trim_count],
+            ),
+        },
+    )
 
 
 def _require_tinker_dependencies() -> None:

--- a/wmo/optimize/model/sft/tinker_test.py
+++ b/wmo/optimize/model/sft/tinker_test.py
@@ -24,7 +24,7 @@ from wmo.optimize.model.sft.tinker import (
     TinkerTrainerSession,
     tinker_messages_from_example,
 )
-from wmo.optimize.model.sft.training import TinkerSFTSpec
+from wmo.optimize.model.sft.training import TinkerSFTError, TinkerSFTSpec
 
 if TYPE_CHECKING:
     import tinker
@@ -257,9 +257,11 @@ class _Service:
     client: _ResumeClient
     calls: list[str]
 
-    def create_lora_training_client(self, base_model: str, rank: int) -> _ResumeClient:
+    def create_lora_training_client(
+        self, base_model: str, rank: int, seed: int | None = None
+    ) -> _ResumeClient:
         """Return the injected local client without constructing a Tinker service."""
-        self.calls.append(f"create:{base_model}:{rank}")
+        self.calls.append(f"create:{base_model}:{rank}:{seed}")
         return self.client
 
 
@@ -291,7 +293,37 @@ def test_backend_restores_before_renderer_setup_with_an_injected_local_service(
 
     assert isinstance(session, TinkerTrainerSession)
     assert calls == [
-        "create:Qwen/Qwen3-8B:8",
+        "create:Qwen/Qwen3-8B:8:0",
         "load:fake://state/checkpoint",
         "tokenizer",
     ]
+
+
+def test_context_truncation_retains_the_complete_two_token_target() -> None:
+    """A tight datum limit removes prompt context without dropping either target token."""
+    renderer = _DatumRenderer()
+    session = TinkerTrainerSession(
+        client=cast("tinker.TrainingClient", _TrainingClient()),
+        renderer=cast("Renderer", renderer),
+        spec=_spec().model_copy(update={"maximum_datum_tokens": 3}),
+    )
+
+    (datum,) = session.render_examples((_example(),))
+
+    assert isinstance(datum, TinkerSFTDatum)
+    assert datum.supervised_token_count == 2
+    assert datum.datum.model_input.to_ints() == [11, 12]
+    assert datum.datum.loss_fn_inputs["target_tokens"].data == [12, 13]
+    assert datum.datum.loss_fn_inputs["weights"].data == [1.0, 1.0]
+
+
+def test_datum_limit_rejects_instead_of_truncating_the_two_token_target() -> None:
+    """A limit too small for the complete target fails before any training dispatch."""
+    session = TinkerTrainerSession(
+        client=cast("tinker.TrainingClient", _TrainingClient()),
+        renderer=cast("Renderer", _DatumRenderer()),
+        spec=_spec().model_copy(update={"maximum_datum_tokens": 2}),
+    )
+
+    with pytest.raises(TinkerSFTError, match="complete supervised target"):
+        session.render_examples((_example(),))

--- a/wmo/optimize/model/sft/tinker_test.py
+++ b/wmo/optimize/model/sft/tinker_test.py
@@ -1,0 +1,297 @@
+"""Local Tinker datum and adapter tests that never construct a service client."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactInput
+from wmo.common.models import AssistantAction, ToolCall
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    SFTExample,
+    SFTMessage,
+    ToolEvent,
+    TraceExampleSource,
+)
+from wmo.optimize.model.sft.tinker import (
+    TinkerConversationMessage,
+    TinkerSFTDatum,
+    TinkerTrainerBackend,
+    TinkerTrainerSession,
+    tinker_messages_from_example,
+)
+from wmo.optimize.model.sft.training import TinkerSFTSpec
+
+if TYPE_CHECKING:
+    import tinker
+    import torch
+    from tinker_cookbook.renderers import Renderer, TrainOnWhat
+
+_DIGEST = "a" * 64
+
+
+def _spec() -> TinkerSFTSpec:
+    """Build one compact concrete Tinker specification for local adapter tests."""
+    return TinkerSFTSpec(
+        base_model="Qwen/Qwen3-8B",
+        lora_rank=8,
+        learning_rate=0.01,
+        batch_size=1,
+        epochs=1,
+        checkpoint_every_steps=1,
+        maximum_datum_tokens=32,
+    )
+
+
+def _example() -> SFTExample:
+    """Build one complete W12 target with prior and target tool calls for conversion checks."""
+    return SFTExample(
+        example_id="example-tinker",
+        leakage_group_id="lineage-tinker",
+        task="Resolve an account request.",
+        history=(
+            SFTMessage(role="system", content="Follow the support policy."),
+            SFTMessage(role="user", content="Please inspect my account."),
+            SFTMessage(role="observation", content="The account is active."),
+            AssistantActionEvent(
+                action=AssistantAction(
+                    content="I will inspect it.",
+                    tool_calls=(
+                        ToolCall(
+                            call_id="call-history",
+                            name="lookup_account",
+                            arguments={"account_id": "A-1"},
+                        ),
+                    ),
+                )
+            ),
+            ToolEvent(
+                tool_call_id="call-history",
+                tool_name="lookup_account",
+                content="Account A-1 is active.",
+            ),
+        ),
+        target=AssistantAction(
+            content="Your account is active.",
+            tool_calls=(
+                ToolCall(
+                    call_id="call-target",
+                    name="send_confirmation",
+                    arguments={"channel": "email", "priority": 1},
+                ),
+            ),
+        ),
+        source=TraceExampleSource(
+            trace_id="trace-tinker",
+            acceptance_evidence=ArtifactInput(artifact_id="acceptance-evidence", sha256=_DIGEST),
+        ),
+        source_step_index=2,
+    )
+
+
+def test_messages_preserve_complete_target_action_and_tool_context() -> None:
+    """The cookbook conversation retains every target and historical tool field in order."""
+    messages = tinker_messages_from_example(_example())
+
+    assert messages == [
+        {"role": "system", "content": "Task:\nResolve an account request."},
+        {"role": "system", "content": "Follow the support policy."},
+        {"role": "user", "content": "Please inspect my account."},
+        {"role": "user", "content": "The account is active."},
+        {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call-history",
+                    "function": {
+                        "name": "lookup_account",
+                        "arguments": '{"account_id":"A-1"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "Account A-1 is active.",
+            "tool_call_id": "call-history",
+            "name": "lookup_account",
+        },
+        {
+            "role": "assistant",
+            "content": "Your account is active.",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call-target",
+                    "function": {
+                        "name": "send_confirmation",
+                        "arguments": '{"channel":"email","priority":1}',
+                    },
+                }
+            ],
+        },
+    ]
+
+
+class _DatumRenderer:
+    """Return fixed local token and weight tensors without fetching a tokenizer or model."""
+
+    def __init__(self) -> None:
+        self.conversations: list[list[TinkerConversationMessage]] = []
+        self.train_on_what: list[TrainOnWhat] = []
+
+    def build_supervised_example(
+        self,
+        conversation: list[TinkerConversationMessage],
+        train_on_what: TrainOnWhat,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        """Build a deterministic input whose shifted CE layout is easy to inspect exactly."""
+        import tinker
+        import torch
+
+        self.conversations.append(conversation)
+        self.train_on_what.append(train_on_what)
+        return (
+            tinker.ModelInput(chunks=[tinker.EncodedTextChunk(tokens=[10, 11, 12, 13])]),
+            torch.tensor([0.0, 0.0, 1.0, 1.0]),
+        )
+
+
+class _Future[ValueT]:
+    """A synchronous local stand-in for the small Tinker future surface used by the adapter."""
+
+    def __init__(self, value: ValueT) -> None:
+        self._value = value
+
+    def result(self) -> ValueT:
+        """Return the prebuilt local SDK-shaped response."""
+        return self._value
+
+
+class _TrainingClient:
+    """Record local concrete training calls without creating a Tinker service session."""
+
+    def __init__(self) -> None:
+        self.forward_backward_calls: list[tuple[Sequence[tinker.Datum], str]] = []
+        self.optim_steps: list[tinker.AdamParams] = []
+
+    def forward_backward(
+        self, data: Sequence[tinker.Datum], loss_fn: str
+    ) -> _Future[tinker.ForwardBackwardOutput]:
+        """Return fixed locally constructed loss metrics."""
+        import tinker
+
+        self.forward_backward_calls.append((data, loss_fn))
+        return _Future(
+            tinker.ForwardBackwardOutput(
+                loss_fn_output_type="cross_entropy",
+                loss_fn_outputs=[],
+                metrics={"total_loss:mean": 1.25},
+            )
+        )
+
+    def optim_step(self, params: tinker.AdamParams) -> _Future[tinker.OptimStepResponse]:
+        """Return a fixed local gradient metric."""
+        import tinker
+
+        self.optim_steps.append(params)
+        return _Future(tinker.OptimStepResponse(metrics={"grad_norm:mean": 0.75}))
+
+
+def test_datum_fixture_is_shifted_cross_entropy_with_only_target_tokens_and_weights() -> None:
+    """The frozen local datum fixture pins cookbook conversion to the current CE wire contract."""
+    renderer = _DatumRenderer()
+    client = _TrainingClient()
+    session = TinkerTrainerSession(
+        client=cast("tinker.TrainingClient", client),
+        renderer=cast("Renderer", renderer),
+        spec=_spec(),
+    )
+
+    (datum,) = session.render_examples((_example(),))
+
+    assert isinstance(datum, TinkerSFTDatum)
+    assert datum.example_id == "example-tinker"
+    assert datum.supervised_token_count == 2
+    assert datum.datum.model_input.to_ints() == [10, 11, 12]
+    assert datum.datum.loss_fn_inputs["target_tokens"].data == [11, 12, 13]
+    assert datum.datum.loss_fn_inputs["weights"].data == [0.0, 1.0, 1.0]
+    assert set(datum.datum.loss_fn_inputs) == {"target_tokens", "weights"}
+    assert renderer.train_on_what[0].value == "last_assistant_message"
+
+    result = session.train_batch((datum,), learning_rate=0.02)
+
+    assert result.loss == 1.25
+    assert result.gradient_norm == 0.75
+    assert client.forward_backward_calls[0][1] == "cross_entropy"
+    assert client.optim_steps[0].learning_rate == 0.02
+
+
+@dataclass
+class _ResumeClient:
+    """Record ordering around the concrete backend's restore and renderer setup calls."""
+
+    calls: list[str]
+
+    def load_state_with_optimizer(self, path: str) -> _Future[None]:
+        """Record a local restore with no provider communication."""
+        self.calls.append(f"load:{path}")
+        return _Future(None)
+
+    def get_tokenizer(self) -> str:
+        """Return a marker token source after recording its position in the call sequence."""
+        self.calls.append("tokenizer")
+        return "local-tokenizer"
+
+
+@dataclass
+class _Service:
+    """Expose just the prebuilt service-client creation call used by the concrete backend."""
+
+    client: _ResumeClient
+    calls: list[str]
+
+    def create_lora_training_client(self, base_model: str, rank: int) -> _ResumeClient:
+        """Return the injected local client without constructing a Tinker service."""
+        self.calls.append(f"create:{base_model}:{rank}")
+        return self.client
+
+
+def test_backend_restores_before_renderer_setup_with_an_injected_local_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The backend restores state before tokenizer or renderer access, with no real client."""
+    import tinker_cookbook.model_info
+    import tinker_cookbook.renderers
+
+    calls: list[str] = []
+    client = _ResumeClient(calls)
+    service = _Service(client, calls)
+    renderer = _DatumRenderer()
+    monkeypatch.setattr(
+        tinker_cookbook.model_info,
+        "get_recommended_renderer_name",
+        lambda model: "local-renderer",
+    )
+    monkeypatch.setattr(
+        tinker_cookbook.renderers,
+        "get_renderer",
+        lambda name, tokenizer, model_name: renderer,
+    )
+
+    session = TinkerTrainerBackend(cast("tinker.ServiceClient", service)).open(
+        _spec(), "fake://state/checkpoint"
+    )
+
+    assert isinstance(session, TinkerTrainerSession)
+    assert calls == [
+        "create:Qwen/Qwen3-8B:8",
+        "load:fake://state/checkpoint",
+        "tokenizer",
+    ]

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -1,0 +1,994 @@
+"""Append-only offline Tinker SFT orchestration over immutable W12 datasets."""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Literal, Protocol
+
+from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    assert_secret_free,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.core.files import write_bytes_atomic
+from wmo.common.core.locks import file_write_lock
+from wmo.common.models import NumericMeasurement, Usage
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+
+_MANIFEST_FILE = "manifest.json"
+_EVENTS_FILE = "events.jsonl"
+_MODEL_FILE = "model.json"
+_MODEL_INTENT_FILE = "model-intent.json"
+_RESULT_FILE = "result.json"
+
+
+class TinkerSFTError(RuntimeError):
+    """The frozen dataset or append-only local SFT run cannot proceed safely."""
+
+
+class TinkerSFTResumeError(TinkerSFTError):
+    """An existing run directory cannot be resumed without mixing immutable state."""
+
+
+class TinkerSFTBudgetExceeded(TinkerSFTError):
+    """Observed or required spend accounting prevents another managed training step."""
+
+
+class TinkerSFTSpec(ContractModel):
+    """Frozen base-model, LoRA, batch, checkpoint, and managed-spend settings."""
+
+    base_model: str = Field(min_length=1, max_length=512)
+    lora_rank: int = Field(default=32, gt=0, le=4096)
+    learning_rate: float = Field(gt=0)
+    batch_size: int = Field(gt=0)
+    epochs: int = Field(gt=0)
+    checkpoint_every_steps: int = Field(gt=0)
+    maximum_steps: int | None = Field(default=None, gt=0)
+    maximum_datum_tokens: int | None = Field(default=None, gt=0)
+    maximum_cost_usd: float | None = Field(default=None, gt=0)
+
+    @field_validator("learning_rate", "maximum_cost_usd")
+    @classmethod
+    def _require_finite_float(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT numeric settings must be finite")
+        return value
+
+
+class TrainerBatchResult(ContractModel):
+    """Metrics returned by one backend-managed cross-entropy update, without fabrication."""
+
+    loss: float | None = None
+    gradient_norm: float | None = None
+    usage: Usage | None = None
+    cost_usd: NumericMeasurement | None = None
+
+    @field_validator("loss", "gradient_norm")
+    @classmethod
+    def _require_finite_metric(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT backend metrics must be finite")
+        return value
+
+
+class TrainerDatum(Protocol):
+    """The tiny datum identity slice retained after a backend renders frozen examples."""
+
+    @property
+    def example_id(self) -> str:
+        """Return the exact frozen W12 example identifier rendered into this datum."""
+        ...
+
+    @property
+    def supervised_token_count(self) -> int:
+        """Return the non-zero cross-entropy token count after renderer truncation."""
+        ...
+
+
+class TrainerSession(Protocol):
+    """One managed training client already created or restored by its backend."""
+
+    def render_examples(self, examples: Sequence[SFTExample]) -> tuple[TrainerDatum, ...]:
+        """Render complete frozen assistant-action targets into cross-entropy datums."""
+        ...
+
+    def train_batch(
+        self, datums: Sequence[TrainerDatum], *, learning_rate: float
+    ) -> TrainerBatchResult:
+        """Accumulate and apply one managed cross-entropy batch."""
+        ...
+
+    def save_state(self, checkpoint_name: str) -> str:
+        """Persist a resumable managed state and return its non-secret provider handle."""
+        ...
+
+    def save_sampling_handle(self, model_name: str) -> str:
+        """Persist completed weights for later sampling and return the non-secret handle."""
+        ...
+
+
+class TrainerBackend(Protocol):
+    """The injection boundary for the concrete Tinker SDK adapter or a test fake."""
+
+    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
+        """Create an uninitialized session, restoring state before renderer work when set."""
+        ...
+
+
+class TinkerSFTRunManifest(ArtifactEnvelope):
+    """Immutable local identity for one append-only run directory."""
+
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    dataset_examples_sha256: Sha256
+    spec: TinkerSFTSpec
+    spec_sha256: Sha256
+
+    @model_validator(mode="after")
+    def _require_exact_dataset_and_spec_bindings(self) -> TinkerSFTRunManifest:
+        expected_inputs = (
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT manifests must name exactly their frozen dataset build")
+        if self.spec_sha256 != sha256_json(self.spec):
+            raise ValueError("Tinker SFT manifest spec digest does not match settings")
+        return self
+
+
+class TinkerSFTMetric(ContractModel):
+    """One observed managed training batch, without a task-behavior or quality claim."""
+
+    record_type: Literal["metric"] = "metric"
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    epoch: int = Field(ge=1)
+    batch_index: int = Field(ge=1)
+    batch_example_count: int = Field(gt=0)
+    supervised_token_count: int = Field(gt=0)
+    loss: float | None = None
+    gradient_norm: float | None = None
+    usage: Usage | None = None
+    cost_usd: NumericMeasurement | None = None
+    cumulative_cost_usd: NumericMeasurement | None = None
+
+    @field_validator("loss", "gradient_norm")
+    @classmethod
+    def _require_finite_metric(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT metrics must be finite")
+        return value
+
+
+class TinkerSFTCheckpoint(ContractModel):
+    """One durable provider state tied to a completed prefix of frozen training batches."""
+
+    record_type: Literal["checkpoint"] = "checkpoint"
+    checkpoint_id: ArtifactId
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    state_path: str = Field(min_length=1, max_length=2048)
+    metric_count: int = Field(gt=0)
+    cumulative_cost_usd: NumericMeasurement | None = None
+
+
+class TinkerSFTResumeEvent(ContractModel):
+    """An append-only record that a new attempt starts from a durable earlier checkpoint."""
+
+    record_type: Literal["resume"] = "resume"
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=2)
+    checkpoint_id: ArtifactId
+    resumed_from_step: int = Field(ge=1)
+
+
+class TinkerSFTCheckpointIntent(ContractModel):
+    """A durable pre-call marker that prevents an ambiguous checkpoint save from being repeated."""
+
+    run_id: ArtifactId
+    checkpoint_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    checkpoint_name: str = Field(min_length=1, max_length=512)
+
+
+class TinkerSFTModelIntent(ContractModel):
+    """A durable pre-call marker for the non-idempotent terminal sampling-handle save."""
+
+    run_id: ArtifactId
+    model_name: str = Field(min_length=1, max_length=512)
+    checkpoint_id: ArtifactId
+
+
+class TinkerSFTModelArtifact(ArtifactEnvelope):
+    """Completed sampling handle plus the frozen dataset and durable checkpoint that produced it."""
+
+    model_id: ArtifactId
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    final_checkpoint_id: ArtifactId
+    final_checkpoint_state_path: str = Field(min_length=1, max_length=2048)
+    sampling_handle: str = Field(min_length=1, max_length=2048)
+    training_step_count: int = Field(gt=0)
+    training_metric_count: int = Field(gt=0)
+    total_cost_usd: NumericMeasurement | None = None
+
+    @model_validator(mode="after")
+    def _require_exact_dataset_binding(self) -> TinkerSFTModelArtifact:
+        expected_inputs = (
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT models must name exactly their frozen dataset build")
+        return self
+
+
+class TinkerSFTResult(ArtifactEnvelope):
+    """Terminal local result that names the completed handle artifact and training facts."""
+
+    result_id: ArtifactId
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    model_id: ArtifactId
+    model_sha256: Sha256
+    training_step_count: int = Field(gt=0)
+    training_metric_count: int = Field(gt=0)
+    checkpoint_count: int = Field(gt=0)
+    total_cost_usd: NumericMeasurement | None = None
+
+    @model_validator(mode="after")
+    def _require_exact_terminal_inputs(self) -> TinkerSFTResult:
+        expected_inputs = tuple(
+            sorted(
+                (
+                    ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+                    ArtifactInput(artifact_id=self.model_id, sha256=self.model_sha256),
+                ),
+                key=lambda item: item.artifact_id,
+            )
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT results must name their dataset and terminal model")
+        return self
+
+
+type TinkerSFTEvent = Annotated[
+    TinkerSFTMetric | TinkerSFTCheckpoint | TinkerSFTResumeEvent,
+    Field(discriminator="record_type"),
+]
+_EVENT_ADAPTER = TypeAdapter(TinkerSFTEvent)
+
+
+class TinkerSFTOptimizer:
+    """Concrete offline SFT optimizer composed with one injected Tinker-capable backend."""
+
+    def __init__(self, backend: TrainerBackend) -> None:
+        """Bind one caller-composed concrete adapter or deterministic test fake."""
+        self._backend = backend
+
+    def optimize(
+        self,
+        *,
+        dataset: SFTDatasetArtifact,
+        spec: TinkerSFTSpec,
+        output_dir: Path,
+        created_at: datetime,
+        code_revision: str,
+    ) -> TinkerSFTResult:
+        """Train from one frozen dataset without changing router, catalog, or serving state."""
+        return train_tinker_sft(
+            dataset,
+            spec,
+            output_dir,
+            backend=self._backend,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+
+
+def train_tinker_sft(
+    dataset: SFTDatasetArtifact,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    *,
+    backend: TrainerBackend,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTResult:
+    """Train a managed LoRA from frozen W12 examples with append-only local provenance.
+
+    Args:
+        dataset: W12 immutable artifact with accepted train and held-out example rows.
+        spec: Base model, LoRA, optimization, budget, and checkpoint settings.
+        output_dir: Append-only local run directory.
+        backend: Concrete Tinker SDK adapter or a deterministic injected fake.
+        created_at: Time recorded when this output directory is first initialized.
+        code_revision: Exact revision recorded when this output directory is first initialized.
+
+    Returns:
+        Completed model-handle and result artifacts containing only training and checkpoint facts.
+
+    Raises:
+        TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
+    """
+    _validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
+    manifest_path = output_dir / _MANIFEST_FILE
+    with file_write_lock(manifest_path, what="the Tinker SFT run"):
+        return _train_locked(
+            dataset=dataset,
+            spec=spec,
+            output_dir=output_dir,
+            backend=backend,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+
+
+def _train_locked(
+    *,
+    dataset: SFTDatasetArtifact,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    backend: TrainerBackend,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTResult:
+    manifest = _load_or_create_manifest(
+        dataset=dataset,
+        spec=spec,
+        output_dir=output_dir,
+        created_at=created_at,
+        code_revision=code_revision,
+    )
+    completed = _load_completed_result(output_dir, manifest)
+    if completed is not None:
+        return completed
+    events = _read_events(output_dir, manifest.run_id)
+    _assert_no_ambiguous_checkpoint_intent(output_dir, manifest.run_id, events)
+    existing_model = _load_model(output_dir, manifest)
+    if existing_model is not None:
+        return _write_terminal_result(
+            output_dir=output_dir,
+            manifest=manifest,
+            model=existing_model,
+            events=events,
+        )
+    latest_checkpoint = _latest_checkpoint(events)
+    durable_metrics = _metrics_at_checkpoint(events, latest_checkpoint)
+    durable_cost = _total_cost(durable_metrics)
+    _require_budget_can_continue(spec, durable_metrics, durable_cost)
+
+    train_examples = tuple(row.example for row in dataset.rows if row.partition == "train")
+    session = backend.open(
+        spec,
+        latest_checkpoint.state_path if latest_checkpoint is not None else None,
+    )
+    attempt_id = _next_attempt_id(events)
+    if latest_checkpoint is not None:
+        _append_event(
+            output_dir,
+            TinkerSFTResumeEvent(
+                run_id=manifest.run_id,
+                attempt_id=attempt_id,
+                checkpoint_id=latest_checkpoint.checkpoint_id,
+                resumed_from_step=latest_checkpoint.step,
+            ),
+        )
+        events = (*events, _read_last_event(output_dir))
+    datums = session.render_examples(train_examples)
+    _validate_rendered_datums(datums, train_examples)
+    schedule = _build_schedule(datums, spec)
+    start_step = latest_checkpoint.step if latest_checkpoint is not None else 0
+    if start_step > len(schedule):
+        raise TinkerSFTResumeError(
+            "the latest Tinker SFT checkpoint is beyond this frozen training schedule"
+        )
+    current_cost = durable_cost
+    for step, batch in enumerate(schedule[start_step:], start=start_step + 1):
+        batch_result = session.train_batch(batch.datums, learning_rate=spec.learning_rate)
+        current_cost = _add_cost(current_cost, batch_result.cost_usd, has_prior_metrics=step > 1)
+        metric = TinkerSFTMetric(
+            run_id=manifest.run_id,
+            attempt_id=attempt_id,
+            step=step,
+            epoch=batch.epoch,
+            batch_index=batch.batch_index,
+            batch_example_count=len(batch.datums),
+            supervised_token_count=sum(datum.supervised_token_count for datum in batch.datums),
+            loss=batch_result.loss,
+            gradient_norm=batch_result.gradient_norm,
+            usage=batch_result.usage,
+            cost_usd=batch_result.cost_usd,
+            cumulative_cost_usd=current_cost,
+        )
+        _append_event(output_dir, metric)
+        events = (*events, metric)
+        must_checkpoint = step % spec.checkpoint_every_steps == 0 or step == len(schedule)
+        if spec.maximum_cost_usd is not None:
+            if current_cost is None:
+                checkpoint = _save_checkpoint(
+                    session=session,
+                    output_dir=output_dir,
+                    manifest=manifest,
+                    events=events,
+                    attempt_id=attempt_id,
+                    step=step,
+                    cumulative_cost_usd=current_cost,
+                )
+                events = (*events, checkpoint)
+                raise TinkerSFTBudgetExceeded(
+                    "maximum_cost_usd requires every completed Tinker SFT batch to report cost"
+                )
+            if current_cost.value >= spec.maximum_cost_usd:
+                checkpoint = _save_checkpoint(
+                    session=session,
+                    output_dir=output_dir,
+                    manifest=manifest,
+                    events=events,
+                    attempt_id=attempt_id,
+                    step=step,
+                    cumulative_cost_usd=current_cost,
+                )
+                events = (*events, checkpoint)
+                raise TinkerSFTBudgetExceeded(
+                    "observed Tinker SFT spend reached maximum_cost_usd; resume requires a larger "
+                    "explicit budget"
+                )
+        if must_checkpoint:
+            checkpoint = _save_checkpoint(
+                session=session,
+                output_dir=output_dir,
+                manifest=manifest,
+                events=events,
+                attempt_id=attempt_id,
+                step=step,
+                cumulative_cost_usd=current_cost,
+            )
+            events = (*events, checkpoint)
+    final_checkpoint = _latest_checkpoint(events)
+    if final_checkpoint is None or final_checkpoint.step != len(schedule):
+        raise TinkerSFTError("completed Tinker SFT training has no final durable checkpoint")
+    model = _save_or_load_terminal_model(
+        session=session,
+        output_dir=output_dir,
+        manifest=manifest,
+        final_checkpoint=final_checkpoint,
+        events=events,
+    )
+    return _write_terminal_result(
+        output_dir=output_dir,
+        manifest=manifest,
+        model=model,
+        events=events,
+    )
+
+
+def _validate_run_inputs(
+    dataset: SFTDatasetArtifact, *, created_at: datetime, code_revision: str
+) -> None:
+    if created_at.tzinfo is None or created_at.utcoffset() is None:
+        raise TinkerSFTError("Tinker SFT creation time must include a timezone")
+    if not code_revision:
+        raise TinkerSFTError("Tinker SFT code_revision must be non-empty")
+    if dataset.dataset.status != "accepted":
+        raise TinkerSFTError("Tinker SFT only accepts an accepted frozen W12 dataset")
+    if dataset.dataset.examples_sha256 != partitioned_rows_sha256(dataset.rows):
+        raise TinkerSFTError("Tinker SFT dataset rows do not match the W12 examples digest")
+    train_rows = tuple(row for row in dataset.rows if row.partition == "train")
+    held_out_rows = tuple(row for row in dataset.rows if row.partition == "held_out")
+    if not train_rows:
+        raise TinkerSFTError("an accepted W12 dataset needs at least one train example")
+    if dataset.dataset.train_example_ids != tuple(
+        sorted(row.example.example_id for row in train_rows)
+    ):
+        raise TinkerSFTError("Tinker SFT train rows do not match the W12 manifest")
+    if dataset.dataset.held_out_example_ids != tuple(
+        sorted(row.example.example_id for row in held_out_rows)
+    ):
+        raise TinkerSFTError("Tinker SFT held-out rows do not match the W12 manifest")
+
+
+def _load_or_create_manifest(
+    *,
+    dataset: SFTDatasetArtifact,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTRunManifest:
+    path = output_dir / _MANIFEST_FILE
+    if path.exists():
+        manifest = _read_model(path, TinkerSFTRunManifest, "Tinker SFT manifest")
+        _validate_manifest(manifest, dataset=dataset, spec=spec, code_revision=code_revision)
+        return manifest
+    dataset_input = ArtifactInput(
+        artifact_id=dataset.dataset.dataset_id,
+        sha256=dataset.dataset.build_sha256,
+    )
+    spec_sha256 = sha256_json(spec)
+    run_id = stable_id(
+        "tinker-sft-run",
+        {
+            "dataset_id": dataset.dataset.dataset_id,
+            "dataset_build_sha256": dataset.dataset.build_sha256,
+            "dataset_examples_sha256": dataset.dataset.examples_sha256,
+            "spec_sha256": spec_sha256,
+        },
+    )
+    manifest = TinkerSFTRunManifest(
+        schema_version=1,
+        created_at=created_at,
+        inputs=(dataset_input,),
+        code_revision=code_revision,
+        run_id=run_id,
+        dataset_id=dataset.dataset.dataset_id,
+        dataset_build_sha256=dataset.dataset.build_sha256,
+        dataset_examples_sha256=dataset.dataset.examples_sha256,
+        spec=spec,
+        spec_sha256=spec_sha256,
+    )
+    _write_new_json(path, manifest, "Tinker SFT manifest")
+    return manifest
+
+
+def _validate_manifest(
+    manifest: TinkerSFTRunManifest,
+    *,
+    dataset: SFTDatasetArtifact,
+    spec: TinkerSFTSpec,
+    code_revision: str,
+) -> None:
+    if manifest.dataset_id != dataset.dataset.dataset_id:
+        raise TinkerSFTResumeError("existing Tinker SFT run belongs to a different W12 dataset")
+    if manifest.dataset_build_sha256 != dataset.dataset.build_sha256:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different W12 dataset build")
+    if manifest.dataset_examples_sha256 != dataset.dataset.examples_sha256:
+        raise TinkerSFTResumeError("existing Tinker SFT run has different W12 example rows")
+    if manifest.spec != spec:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different training spec")
+    if manifest.code_revision != code_revision:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different code revision")
+
+
+def _read_events(output_dir: Path, run_id: ArtifactId) -> tuple[TinkerSFTEvent, ...]:
+    path = output_dir / _EVENTS_FILE
+    if not path.exists():
+        return ()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise TinkerSFTResumeError(f"cannot read Tinker SFT events at {path}: {exc}") from exc
+    events: list[TinkerSFTEvent] = []
+    for number, line in enumerate(lines, start=1):
+        if not line:
+            raise TinkerSFTResumeError(f"Tinker SFT event log has an empty line at {number}")
+        try:
+            event = _EVENT_ADAPTER.validate_json(line)
+        except ValueError as exc:
+            raise TinkerSFTResumeError(
+                f"Tinker SFT event log has an invalid record at line {number}: {exc}"
+            ) from exc
+        if event.run_id != run_id:
+            raise TinkerSFTResumeError("Tinker SFT event log names a different run")
+        events.append(event)
+    _validate_event_history(tuple(events))
+    return tuple(events)
+
+
+def _validate_event_history(events: tuple[TinkerSFTEvent, ...]) -> None:
+    checkpoints: dict[str, TinkerSFTCheckpoint] = {}
+    seen_attempts: set[int] = set()
+    for event in events:
+        if isinstance(event, TinkerSFTCheckpoint):
+            if event.checkpoint_id in checkpoints:
+                raise TinkerSFTResumeError("Tinker SFT event log repeats a checkpoint identifier")
+            checkpoints[event.checkpoint_id] = event
+            seen_attempts.add(event.attempt_id)
+        elif isinstance(event, TinkerSFTResumeEvent):
+            checkpoint = checkpoints.get(event.checkpoint_id)
+            if checkpoint is None:
+                raise TinkerSFTResumeError("Tinker SFT resume event names an unknown checkpoint")
+            if checkpoint.step != event.resumed_from_step:
+                raise TinkerSFTResumeError("Tinker SFT resume event has the wrong checkpoint step")
+            if event.attempt_id in seen_attempts:
+                raise TinkerSFTResumeError("Tinker SFT event log reuses an attempt identifier")
+            seen_attempts.add(event.attempt_id)
+        else:
+            seen_attempts.add(event.attempt_id)
+
+
+def _latest_checkpoint(events: Sequence[TinkerSFTEvent]) -> TinkerSFTCheckpoint | None:
+    checkpoints = [event for event in events if isinstance(event, TinkerSFTCheckpoint)]
+    return checkpoints[-1] if checkpoints else None
+
+
+def _metrics_at_checkpoint(
+    events: Sequence[TinkerSFTEvent], checkpoint: TinkerSFTCheckpoint | None
+) -> tuple[TinkerSFTMetric, ...]:
+    if checkpoint is None:
+        return ()
+    checkpoints = {
+        event.checkpoint_id: event for event in events if isinstance(event, TinkerSFTCheckpoint)
+    }
+    resume_events = {
+        event.attempt_id: event for event in events if isinstance(event, TinkerSFTResumeEvent)
+    }
+    metrics_by_attempt: dict[int, list[TinkerSFTMetric]] = {}
+    for event in events:
+        if isinstance(event, TinkerSFTMetric):
+            metrics_by_attempt.setdefault(event.attempt_id, []).append(event)
+
+    def collect(attempt_id: int, through_step: int) -> tuple[TinkerSFTMetric, ...]:
+        resume = resume_events.get(attempt_id)
+        start_step = 0
+        inherited: tuple[TinkerSFTMetric, ...] = ()
+        if resume is not None:
+            parent = checkpoints[resume.checkpoint_id]
+            start_step = parent.step
+            inherited = collect(parent.attempt_id, parent.step)
+        local = tuple(
+            metric
+            for metric in metrics_by_attempt.get(attempt_id, [])
+            if start_step < metric.step <= through_step
+        )
+        expected_steps = tuple(range(start_step + 1, through_step + 1))
+        if tuple(metric.step for metric in local) != expected_steps:
+            raise TinkerSFTResumeError(
+                "Tinker SFT checkpoint lacks a complete metric lineage for its durable state"
+            )
+        return (*inherited, *local)
+
+    return collect(checkpoint.attempt_id, checkpoint.step)
+
+
+def _next_attempt_id(events: Sequence[TinkerSFTEvent]) -> int:
+    return max((event.attempt_id for event in events), default=0) + 1
+
+
+def _build_schedule(
+    datums: tuple[TrainerDatum, ...], spec: TinkerSFTSpec
+) -> tuple[_ScheduledBatch, ...]:
+    one_epoch = tuple(
+        datums[index : index + spec.batch_size] for index in range(0, len(datums), spec.batch_size)
+    )
+    schedule = tuple(
+        _ScheduledBatch(epoch=epoch, batch_index=batch_index, datums=batch)
+        for epoch in range(1, spec.epochs + 1)
+        for batch_index, batch in enumerate(one_epoch, start=1)
+    )
+    if spec.maximum_steps is not None:
+        schedule = schedule[: spec.maximum_steps]
+    if not schedule:
+        raise TinkerSFTError("Tinker SFT schedule has no managed training batches")
+    return schedule
+
+
+class _ScheduledBatch:
+    def __init__(self, *, epoch: int, batch_index: int, datums: Sequence[TrainerDatum]) -> None:
+        self.epoch = epoch
+        self.batch_index = batch_index
+        self.datums = tuple(datums)
+
+
+def _validate_rendered_datums(
+    datums: tuple[TrainerDatum, ...], examples: Sequence[SFTExample]
+) -> None:
+    example_ids = tuple(example.example_id for example in examples)
+    datum_ids = tuple(datum.example_id for datum in datums)
+    if datum_ids != example_ids:
+        raise TinkerSFTError("Tinker SFT backend rendered a different ordered train-example set")
+    if any(datum.supervised_token_count <= 0 for datum in datums):
+        raise TinkerSFTError("Tinker SFT backend produced a datum without supervised target tokens")
+
+
+def _add_cost(
+    current: NumericMeasurement | None,
+    added: NumericMeasurement | None,
+    *,
+    has_prior_metrics: bool,
+) -> NumericMeasurement | None:
+    if added is None:
+        return None
+    if current is None:
+        if has_prior_metrics:
+            return None
+        return added
+    provenance: Literal["observed", "estimated"] = (
+        "observed"
+        if current.provenance == "observed" and added.provenance == "observed"
+        else "estimated"
+    )
+    return NumericMeasurement(value=current.value + added.value, provenance=provenance)
+
+
+def _total_cost(metrics: Sequence[TinkerSFTMetric]) -> NumericMeasurement | None:
+    if not metrics:
+        return None
+    total: NumericMeasurement | None = None
+    for index, metric in enumerate(metrics):
+        total = _add_cost(total, metric.cost_usd, has_prior_metrics=index > 0)
+        if total is None:
+            return None
+    return total
+
+
+def _require_budget_can_continue(
+    spec: TinkerSFTSpec,
+    metrics: Sequence[TinkerSFTMetric],
+    cost: NumericMeasurement | None,
+) -> None:
+    if spec.maximum_cost_usd is None:
+        return
+    if metrics and cost is None:
+        raise TinkerSFTBudgetExceeded(
+            "maximum_cost_usd cannot resume because a prior completed Tinker SFT batch lacked cost"
+        )
+    if cost is not None and cost.value >= spec.maximum_cost_usd:
+        raise TinkerSFTBudgetExceeded(
+            "observed Tinker SFT spend already reached maximum_cost_usd; no further provider call "
+            "was made"
+        )
+
+
+def _save_checkpoint(
+    *,
+    session: TrainerSession,
+    output_dir: Path,
+    manifest: TinkerSFTRunManifest,
+    events: Sequence[TinkerSFTEvent],
+    attempt_id: int,
+    step: int,
+    cumulative_cost_usd: NumericMeasurement | None,
+) -> TinkerSFTCheckpoint:
+    checkpoint_id = stable_id(
+        "tinker-sft-checkpoint",
+        {"run_id": manifest.run_id, "attempt_id": attempt_id, "step": step},
+    )
+    checkpoint_name = f"{manifest.run_id}-attempt-{attempt_id}-step-{step}"
+    intent = TinkerSFTCheckpointIntent(
+        run_id=manifest.run_id,
+        checkpoint_id=checkpoint_id,
+        attempt_id=attempt_id,
+        step=step,
+        checkpoint_name=checkpoint_name,
+    )
+    _write_new_json(
+        _checkpoint_intent_path(output_dir, checkpoint_id), intent, "Tinker SFT checkpoint intent"
+    )
+    state_path = session.save_state(checkpoint_name)
+    checkpoint = TinkerSFTCheckpoint(
+        checkpoint_id=checkpoint_id,
+        run_id=manifest.run_id,
+        attempt_id=attempt_id,
+        step=step,
+        state_path=state_path,
+        metric_count=step,
+        cumulative_cost_usd=cumulative_cost_usd,
+    )
+    _append_event(output_dir, checkpoint)
+    return checkpoint
+
+
+def _save_or_load_terminal_model(
+    *,
+    session: TrainerSession,
+    output_dir: Path,
+    manifest: TinkerSFTRunManifest,
+    final_checkpoint: TinkerSFTCheckpoint,
+    events: Sequence[TinkerSFTEvent],
+) -> TinkerSFTModelArtifact:
+    existing_model = _load_model(output_dir, manifest)
+    if existing_model is not None:
+        return existing_model
+    intent_path = output_dir / _MODEL_INTENT_FILE
+    if intent_path.exists():
+        intent = _read_model(intent_path, TinkerSFTModelIntent, "Tinker SFT model intent")
+        if intent.run_id != manifest.run_id:
+            raise TinkerSFTResumeError("Tinker SFT model intent names a different run")
+        raise TinkerSFTResumeError(
+            "a prior terminal Tinker sampling-handle save may have completed without a local model "
+            "artifact; inspect the provider before retrying"
+        )
+    model_name = f"{manifest.run_id}-final"
+    _write_new_json(
+        intent_path,
+        TinkerSFTModelIntent(
+            run_id=manifest.run_id,
+            model_name=model_name,
+            checkpoint_id=final_checkpoint.checkpoint_id,
+        ),
+        "Tinker SFT model intent",
+    )
+    sampling_handle = session.save_sampling_handle(model_name)
+    effective_metrics = _metrics_at_checkpoint(events, final_checkpoint)
+    model_id = stable_id(
+        "tinker-sft-model",
+        {
+            "run_id": manifest.run_id,
+            "checkpoint_id": final_checkpoint.checkpoint_id,
+            "sampling_handle": sampling_handle,
+        },
+    )
+    model = TinkerSFTModelArtifact(
+        schema_version=1,
+        created_at=manifest.created_at,
+        inputs=(
+            ArtifactInput(
+                artifact_id=manifest.dataset_id,
+                sha256=manifest.dataset_build_sha256,
+            ),
+        ),
+        code_revision=manifest.code_revision,
+        model_id=model_id,
+        run_id=manifest.run_id,
+        dataset_id=manifest.dataset_id,
+        dataset_build_sha256=manifest.dataset_build_sha256,
+        final_checkpoint_id=final_checkpoint.checkpoint_id,
+        final_checkpoint_state_path=final_checkpoint.state_path,
+        sampling_handle=sampling_handle,
+        training_step_count=final_checkpoint.step,
+        training_metric_count=len(effective_metrics),
+        total_cost_usd=_total_cost(effective_metrics),
+    )
+    _write_new_json(output_dir / _MODEL_FILE, model, "Tinker SFT model artifact")
+    return model
+
+
+def _write_terminal_result(
+    *,
+    output_dir: Path,
+    manifest: TinkerSFTRunManifest,
+    model: TinkerSFTModelArtifact,
+    events: Sequence[TinkerSFTEvent],
+) -> TinkerSFTResult:
+    existing = _load_completed_result(output_dir, manifest)
+    if existing is not None:
+        return existing
+    final_checkpoint = _latest_checkpoint(events)
+    if final_checkpoint is None:
+        raise TinkerSFTResumeError("Tinker SFT model artifact has no checkpoint event")
+    effective_metrics = _metrics_at_checkpoint(events, final_checkpoint)
+    model_sha256 = sha256_json(model)
+    result = TinkerSFTResult(
+        schema_version=1,
+        created_at=manifest.created_at,
+        inputs=tuple(
+            sorted(
+                (
+                    ArtifactInput(
+                        artifact_id=manifest.dataset_id,
+                        sha256=manifest.dataset_build_sha256,
+                    ),
+                    ArtifactInput(artifact_id=model.model_id, sha256=model_sha256),
+                ),
+                key=lambda item: item.artifact_id,
+            )
+        ),
+        code_revision=manifest.code_revision,
+        result_id=stable_id(
+            "tinker-sft-result",
+            {"run_id": manifest.run_id, "model_sha256": model_sha256},
+        ),
+        run_id=manifest.run_id,
+        dataset_id=manifest.dataset_id,
+        dataset_build_sha256=manifest.dataset_build_sha256,
+        model_id=model.model_id,
+        model_sha256=model_sha256,
+        training_step_count=final_checkpoint.step,
+        training_metric_count=len(effective_metrics),
+        checkpoint_count=sum(isinstance(event, TinkerSFTCheckpoint) for event in events),
+        total_cost_usd=_total_cost(effective_metrics),
+    )
+    _write_new_json(output_dir / _RESULT_FILE, result, "Tinker SFT result")
+    return result
+
+
+def _load_completed_result(
+    output_dir: Path, manifest: TinkerSFTRunManifest
+) -> TinkerSFTResult | None:
+    path = output_dir / _RESULT_FILE
+    if not path.exists():
+        return None
+    result = _read_model(path, TinkerSFTResult, "Tinker SFT result")
+    if result.run_id != manifest.run_id:
+        raise TinkerSFTResumeError("Tinker SFT result names a different run")
+    if result.dataset_id != manifest.dataset_id:
+        raise TinkerSFTResumeError("Tinker SFT result names a different dataset")
+    model = _load_model(output_dir, manifest)
+    if model is None:
+        raise TinkerSFTResumeError("Tinker SFT result exists without its model artifact")
+    if result.model_id != model.model_id or result.model_sha256 != sha256_json(model):
+        raise TinkerSFTResumeError("Tinker SFT result does not match its model artifact")
+    return result
+
+
+def _load_model(output_dir: Path, manifest: TinkerSFTRunManifest) -> TinkerSFTModelArtifact | None:
+    path = output_dir / _MODEL_FILE
+    if not path.exists():
+        return None
+    model = _read_model(path, TinkerSFTModelArtifact, "Tinker SFT model artifact")
+    if model.run_id != manifest.run_id:
+        raise TinkerSFTResumeError("Tinker SFT model artifact names a different run")
+    if model.dataset_id != manifest.dataset_id:
+        raise TinkerSFTResumeError("Tinker SFT model artifact names a different dataset")
+    if model.dataset_build_sha256 != manifest.dataset_build_sha256:
+        raise TinkerSFTResumeError("Tinker SFT model artifact has a different dataset build")
+    return model
+
+
+def _assert_no_ambiguous_checkpoint_intent(
+    output_dir: Path, run_id: ArtifactId, events: Sequence[TinkerSFTEvent]
+) -> None:
+    checkpoint_ids = {
+        event.checkpoint_id for event in events if isinstance(event, TinkerSFTCheckpoint)
+    }
+    for path in output_dir.glob("*.checkpoint-intent.json"):
+        intent = _read_model(path, TinkerSFTCheckpointIntent, "Tinker SFT checkpoint intent")
+        if intent.run_id != run_id:
+            raise TinkerSFTResumeError("Tinker SFT checkpoint intent names a different run")
+        if intent.checkpoint_id not in checkpoint_ids:
+            raise TinkerSFTResumeError(
+                "a prior Tinker checkpoint save may have completed without an event record; "
+                "inspect the provider before retrying"
+            )
+
+
+def _checkpoint_intent_path(output_dir: Path, checkpoint_id: ArtifactId) -> Path:
+    return output_dir / f"{checkpoint_id}.checkpoint-intent.json"
+
+
+def _append_event(output_dir: Path, event: TinkerSFTEvent) -> None:
+    assert_secret_free(event)
+    path = output_dir / _EVENTS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = canonical_json_bytes(event) + b"\n"
+    with path.open("ab") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _read_last_event(output_dir: Path) -> TinkerSFTEvent:
+    events = _read_events(
+        output_dir,
+        _read_model(
+            output_dir / _MANIFEST_FILE, TinkerSFTRunManifest, "Tinker SFT manifest"
+        ).run_id,
+    )
+    if not events:
+        raise TinkerSFTResumeError("Tinker SFT resume event was not persisted")
+    return events[-1]
+
+
+def _write_new_json(path: Path, value: BaseModel, label: str) -> None:
+    if path.exists():
+        raise TinkerSFTResumeError(
+            f"{label} already exists at {path}; append-only runs do not replace it"
+        )
+    assert_secret_free(value)
+    write_bytes_atomic(path, canonical_json_bytes(value) + b"\n")
+
+
+def _read_model[ModelT: BaseModel](path: Path, model_type: type[ModelT], label: str) -> ModelT:
+    try:
+        return model_type.model_validate_json(path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise TinkerSFTResumeError(f"cannot read {label} at {path}: {exc}") from exc

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -23,7 +23,7 @@ from wmo.common.core.locks import file_write_lock
 from wmo.common.models import NumericMeasurement
 from wmo.common.project import ArtifactCorruptionError, ProjectStore, artifact_input
 from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
-from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
+from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
 from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
 from wmo.optimize.model.sft.training_contracts import (
@@ -82,6 +82,7 @@ class TinkerSFTOptimizer:
         output_dir: Path,
         created_at: datetime,
         code_revision: str,
+        legacy_build_spec: SFTBuildSpec | None = None,
     ) -> TinkerSFTResult:
         """Train from one persisted dataset without changing catalog, router, or serving state."""
         return train_tinker_sft(
@@ -92,6 +93,7 @@ class TinkerSFTOptimizer:
             backend=self._backend,
             created_at=created_at,
             code_revision=code_revision,
+            legacy_build_spec=legacy_build_spec,
         )
 
 
@@ -104,6 +106,7 @@ def train_tinker_sft(
     backend: TrainerBackend,
     created_at: datetime,
     code_revision: str,
+    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Train a managed LoRA from frozen W12 examples with append-only local provenance.
 
@@ -115,6 +118,8 @@ def train_tinker_sft(
         backend: Concrete Tinker SDK adapter or a deterministic injected fake.
         created_at: Time recorded when this output directory is first initialized.
         code_revision: Exact revision recorded when this output directory is first initialized.
+        legacy_build_spec: Original W12 build settings for a dataset that predates persisted
+            build specifications. The runner rebuilds and verifies the legacy evidence chain.
 
     Returns:
         Completed model-handle and result artifacts containing only training and checkpoint facts.
@@ -123,7 +128,11 @@ def train_tinker_sft(
         TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
     """
     try:
-        dataset = load_verified_sft_dataset(store, dataset_id)
+        dataset = load_verified_sft_dataset(
+            store,
+            dataset_id,
+            legacy_build_spec=legacy_build_spec,
+        )
         dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
     except (ArtifactCorruptionError, SFTBuildError) as exc:
         raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -2,21 +2,18 @@
 
 from __future__ import annotations
 
-import math
+import hashlib
 import os
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Literal, Protocol
+from typing import Literal
 
-from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
+from pydantic import BaseModel
 
 from wmo.common.core.artifacts import (
-    ArtifactEnvelope,
     ArtifactId,
     ArtifactInput,
-    ContractModel,
-    Sha256,
     assert_secret_free,
     canonical_json_bytes,
     sha256_json,
@@ -24,257 +21,39 @@ from wmo.common.core.artifacts import (
 )
 from wmo.common.core.files import write_bytes_atomic
 from wmo.common.core.locks import file_write_lock
-from wmo.common.models import NumericMeasurement, Usage
+from wmo.common.models import NumericMeasurement
+from wmo.common.project import ProjectStore
+from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
 from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
 from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+from wmo.optimize.model.sft.training_contracts import (
+    TINKER_SFT_EVENT_ADAPTER,
+    TinkerSFTAmbiguousStepError,
+    TinkerSFTBudgetExceeded,
+    TinkerSFTCheckpoint,
+    TinkerSFTCheckpointIntent,
+    TinkerSFTError,
+    TinkerSFTEvent,
+    TinkerSFTMetric,
+    TinkerSFTModelArtifact,
+    TinkerSFTModelIntent,
+    TinkerSFTResult,
+    TinkerSFTResumeError,
+    TinkerSFTResumeEvent,
+    TinkerSFTRunManifest,
+    TinkerSFTSpec,
+    TinkerSFTStepIntent,
+    TrainerBackend,
+    TrainerDatum,
+    TrainerSession,
+)
 
 _MANIFEST_FILE = "manifest.json"
 _EVENTS_FILE = "events.jsonl"
 _MODEL_FILE = "model.json"
 _MODEL_INTENT_FILE = "model-intent.json"
 _RESULT_FILE = "result.json"
-
-
-class TinkerSFTError(RuntimeError):
-    """The frozen dataset or append-only local SFT run cannot proceed safely."""
-
-
-class TinkerSFTResumeError(TinkerSFTError):
-    """An existing run directory cannot be resumed without mixing immutable state."""
-
-
-class TinkerSFTBudgetExceeded(TinkerSFTError):
-    """Observed or required spend accounting prevents another managed training step."""
-
-
-class TinkerSFTSpec(ContractModel):
-    """Frozen base-model, LoRA, batch, checkpoint, and managed-spend settings."""
-
-    base_model: str = Field(min_length=1, max_length=512)
-    lora_rank: int = Field(default=32, gt=0, le=4096)
-    learning_rate: float = Field(gt=0)
-    batch_size: int = Field(gt=0)
-    epochs: int = Field(gt=0)
-    checkpoint_every_steps: int = Field(gt=0)
-    maximum_steps: int | None = Field(default=None, gt=0)
-    maximum_datum_tokens: int | None = Field(default=None, gt=0)
-    maximum_cost_usd: float | None = Field(default=None, gt=0)
-
-    @field_validator("learning_rate", "maximum_cost_usd")
-    @classmethod
-    def _require_finite_float(cls, value: float | None) -> float | None:
-        if value is not None and not math.isfinite(value):
-            raise ValueError("Tinker SFT numeric settings must be finite")
-        return value
-
-
-class TrainerBatchResult(ContractModel):
-    """Metrics returned by one backend-managed cross-entropy update, without fabrication."""
-
-    loss: float | None = None
-    gradient_norm: float | None = None
-    usage: Usage | None = None
-    cost_usd: NumericMeasurement | None = None
-
-    @field_validator("loss", "gradient_norm")
-    @classmethod
-    def _require_finite_metric(cls, value: float | None) -> float | None:
-        if value is not None and not math.isfinite(value):
-            raise ValueError("Tinker SFT backend metrics must be finite")
-        return value
-
-
-class TrainerDatum(Protocol):
-    """The tiny datum identity slice retained after a backend renders frozen examples."""
-
-    @property
-    def example_id(self) -> str:
-        """Return the exact frozen W12 example identifier rendered into this datum."""
-        ...
-
-    @property
-    def supervised_token_count(self) -> int:
-        """Return the non-zero cross-entropy token count after renderer truncation."""
-        ...
-
-
-class TrainerSession(Protocol):
-    """One managed training client already created or restored by its backend."""
-
-    def render_examples(self, examples: Sequence[SFTExample]) -> tuple[TrainerDatum, ...]:
-        """Render complete frozen assistant-action targets into cross-entropy datums."""
-        ...
-
-    def train_batch(
-        self, datums: Sequence[TrainerDatum], *, learning_rate: float
-    ) -> TrainerBatchResult:
-        """Accumulate and apply one managed cross-entropy batch."""
-        ...
-
-    def save_state(self, checkpoint_name: str) -> str:
-        """Persist a resumable managed state and return its non-secret provider handle."""
-        ...
-
-    def save_sampling_handle(self, model_name: str) -> str:
-        """Persist completed weights for later sampling and return the non-secret handle."""
-        ...
-
-
-class TrainerBackend(Protocol):
-    """The injection boundary for the concrete Tinker SDK adapter or a test fake."""
-
-    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
-        """Create an uninitialized session, restoring state before renderer work when set."""
-        ...
-
-
-class TinkerSFTRunManifest(ArtifactEnvelope):
-    """Immutable local identity for one append-only run directory."""
-
-    run_id: ArtifactId
-    dataset_id: ArtifactId
-    dataset_build_sha256: Sha256
-    dataset_examples_sha256: Sha256
-    spec: TinkerSFTSpec
-    spec_sha256: Sha256
-
-    @model_validator(mode="after")
-    def _require_exact_dataset_and_spec_bindings(self) -> TinkerSFTRunManifest:
-        expected_inputs = (
-            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
-        )
-        if self.inputs != expected_inputs:
-            raise ValueError("Tinker SFT manifests must name exactly their frozen dataset build")
-        if self.spec_sha256 != sha256_json(self.spec):
-            raise ValueError("Tinker SFT manifest spec digest does not match settings")
-        return self
-
-
-class TinkerSFTMetric(ContractModel):
-    """One observed managed training batch, without a task-behavior or quality claim."""
-
-    record_type: Literal["metric"] = "metric"
-    run_id: ArtifactId
-    attempt_id: int = Field(ge=1)
-    step: int = Field(ge=1)
-    epoch: int = Field(ge=1)
-    batch_index: int = Field(ge=1)
-    batch_example_count: int = Field(gt=0)
-    supervised_token_count: int = Field(gt=0)
-    loss: float | None = None
-    gradient_norm: float | None = None
-    usage: Usage | None = None
-    cost_usd: NumericMeasurement | None = None
-    cumulative_cost_usd: NumericMeasurement | None = None
-
-    @field_validator("loss", "gradient_norm")
-    @classmethod
-    def _require_finite_metric(cls, value: float | None) -> float | None:
-        if value is not None and not math.isfinite(value):
-            raise ValueError("Tinker SFT metrics must be finite")
-        return value
-
-
-class TinkerSFTCheckpoint(ContractModel):
-    """One durable provider state tied to a completed prefix of frozen training batches."""
-
-    record_type: Literal["checkpoint"] = "checkpoint"
-    checkpoint_id: ArtifactId
-    run_id: ArtifactId
-    attempt_id: int = Field(ge=1)
-    step: int = Field(ge=1)
-    state_path: str = Field(min_length=1, max_length=2048)
-    metric_count: int = Field(gt=0)
-    cumulative_cost_usd: NumericMeasurement | None = None
-
-
-class TinkerSFTResumeEvent(ContractModel):
-    """An append-only record that a new attempt starts from a durable earlier checkpoint."""
-
-    record_type: Literal["resume"] = "resume"
-    run_id: ArtifactId
-    attempt_id: int = Field(ge=2)
-    checkpoint_id: ArtifactId
-    resumed_from_step: int = Field(ge=1)
-
-
-class TinkerSFTCheckpointIntent(ContractModel):
-    """A durable pre-call marker that prevents an ambiguous checkpoint save from being repeated."""
-
-    run_id: ArtifactId
-    checkpoint_id: ArtifactId
-    attempt_id: int = Field(ge=1)
-    step: int = Field(ge=1)
-    checkpoint_name: str = Field(min_length=1, max_length=512)
-
-
-class TinkerSFTModelIntent(ContractModel):
-    """A durable pre-call marker for the non-idempotent terminal sampling-handle save."""
-
-    run_id: ArtifactId
-    model_name: str = Field(min_length=1, max_length=512)
-    checkpoint_id: ArtifactId
-
-
-class TinkerSFTModelArtifact(ArtifactEnvelope):
-    """Completed sampling handle plus the frozen dataset and durable checkpoint that produced it."""
-
-    model_id: ArtifactId
-    run_id: ArtifactId
-    dataset_id: ArtifactId
-    dataset_build_sha256: Sha256
-    final_checkpoint_id: ArtifactId
-    final_checkpoint_state_path: str = Field(min_length=1, max_length=2048)
-    sampling_handle: str = Field(min_length=1, max_length=2048)
-    training_step_count: int = Field(gt=0)
-    training_metric_count: int = Field(gt=0)
-    total_cost_usd: NumericMeasurement | None = None
-
-    @model_validator(mode="after")
-    def _require_exact_dataset_binding(self) -> TinkerSFTModelArtifact:
-        expected_inputs = (
-            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
-        )
-        if self.inputs != expected_inputs:
-            raise ValueError("Tinker SFT models must name exactly their frozen dataset build")
-        return self
-
-
-class TinkerSFTResult(ArtifactEnvelope):
-    """Terminal local result that names the completed handle artifact and training facts."""
-
-    result_id: ArtifactId
-    run_id: ArtifactId
-    dataset_id: ArtifactId
-    dataset_build_sha256: Sha256
-    model_id: ArtifactId
-    model_sha256: Sha256
-    training_step_count: int = Field(gt=0)
-    training_metric_count: int = Field(gt=0)
-    checkpoint_count: int = Field(gt=0)
-    total_cost_usd: NumericMeasurement | None = None
-
-    @model_validator(mode="after")
-    def _require_exact_terminal_inputs(self) -> TinkerSFTResult:
-        expected_inputs = tuple(
-            sorted(
-                (
-                    ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
-                    ArtifactInput(artifact_id=self.model_id, sha256=self.model_sha256),
-                ),
-                key=lambda item: item.artifact_id,
-            )
-        )
-        if self.inputs != expected_inputs:
-            raise ValueError("Tinker SFT results must name their dataset and terminal model")
-        return self
-
-
-type TinkerSFTEvent = Annotated[
-    TinkerSFTMetric | TinkerSFTCheckpoint | TinkerSFTResumeEvent,
-    Field(discriminator="record_type"),
-]
-_EVENT_ADAPTER = TypeAdapter(TinkerSFTEvent)
 
 
 class TinkerSFTOptimizer:
@@ -287,15 +66,17 @@ class TinkerSFTOptimizer:
     def optimize(
         self,
         *,
-        dataset: SFTDatasetArtifact,
+        store: ProjectStore,
+        dataset_id: ArtifactId,
         spec: TinkerSFTSpec,
         output_dir: Path,
         created_at: datetime,
         code_revision: str,
     ) -> TinkerSFTResult:
-        """Train from one frozen dataset without changing router, catalog, or serving state."""
+        """Train from one persisted dataset without changing catalog, router, or serving state."""
         return train_tinker_sft(
-            dataset,
+            store,
+            dataset_id,
             spec,
             output_dir,
             backend=self._backend,
@@ -305,7 +86,8 @@ class TinkerSFTOptimizer:
 
 
 def train_tinker_sft(
-    dataset: SFTDatasetArtifact,
+    store: ProjectStore,
+    dataset_id: ArtifactId,
     spec: TinkerSFTSpec,
     output_dir: Path,
     *,
@@ -316,7 +98,8 @@ def train_tinker_sft(
     """Train a managed LoRA from frozen W12 examples with append-only local provenance.
 
     Args:
-        dataset: W12 immutable artifact with accepted train and held-out example rows.
+        store: Project store owning the dataset and every transitive acceptance artifact.
+        dataset_id: Persisted W12 dataset ID. Caller-constructed rows are never authoritative.
         spec: Base model, LoRA, optimization, budget, and checkpoint settings.
         output_dir: Append-only local run directory.
         backend: Concrete Tinker SDK adapter or a deterministic injected fake.
@@ -329,6 +112,10 @@ def train_tinker_sft(
     Raises:
         TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
     """
+    try:
+        dataset = load_verified_sft_dataset(store, dataset_id)
+    except SFTBuildError as exc:
+        raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc
     _validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
     manifest_path = output_dir / _MANIFEST_FILE
     with file_write_lock(manifest_path, what="the Tinker SFT run"):
@@ -358,13 +145,16 @@ def _train_locked(
         created_at=created_at,
         code_revision=code_revision,
     )
-    completed = _load_completed_result(output_dir, manifest)
+    events = _read_events(output_dir, manifest.run_id)
+    _assert_no_ambiguous_step_intent(output_dir, manifest.run_id, events)
+    _assert_no_ambiguous_checkpoint_intent(output_dir, manifest.run_id, events)
+    _assert_no_uncheckpointed_completed_steps(events)
+    completed = _load_completed_result(output_dir, manifest, events)
     if completed is not None:
         return completed
-    events = _read_events(output_dir, manifest.run_id)
-    _assert_no_ambiguous_checkpoint_intent(output_dir, manifest.run_id, events)
     existing_model = _load_model(output_dir, manifest)
     if existing_model is not None:
+        _validate_model_lineage(output_dir, existing_model, events)
         return _write_terminal_result(
             output_dir=output_dir,
             manifest=manifest,
@@ -377,6 +167,19 @@ def _train_locked(
     _require_budget_can_continue(spec, durable_metrics, durable_cost)
 
     train_examples = tuple(row.example for row in dataset.rows if row.partition == "train")
+    schedule_counts = _schedule_batch_counts(len(train_examples), spec)
+    start_step = latest_checkpoint.step if latest_checkpoint is not None else 0
+    if start_step > len(schedule_counts):
+        raise TinkerSFTResumeError(
+            "the latest Tinker SFT checkpoint is beyond this frozen training schedule"
+        )
+    if start_step < len(schedule_counts):
+        _require_step_budget(
+            backend=backend,
+            spec=spec,
+            batch_example_count=schedule_counts[start_step],
+            current_cost=durable_cost,
+        )
     session = backend.open(
         spec,
         latest_checkpoint.state_path if latest_checkpoint is not None else None,
@@ -396,13 +199,27 @@ def _train_locked(
     datums = session.render_examples(train_examples)
     _validate_rendered_datums(datums, train_examples)
     schedule = _build_schedule(datums, spec)
-    start_step = latest_checkpoint.step if latest_checkpoint is not None else 0
-    if start_step > len(schedule):
-        raise TinkerSFTResumeError(
-            "the latest Tinker SFT checkpoint is beyond this frozen training schedule"
-        )
     current_cost = durable_cost
     for step, batch in enumerate(schedule[start_step:], start=start_step + 1):
+        upper_bound = _require_step_budget(
+            backend=backend,
+            spec=spec,
+            batch_example_count=len(batch.datums),
+            current_cost=current_cost,
+        )
+        _write_new_json(
+            _step_intent_path(output_dir, attempt_id, step),
+            TinkerSFTStepIntent(
+                run_id=manifest.run_id,
+                attempt_id=attempt_id,
+                step=step,
+                epoch=batch.epoch,
+                batch_index=batch.batch_index,
+                example_ids=tuple(datum.example_id for datum in batch.datums),
+                conservative_cost_upper_bound_usd=upper_bound,
+            ),
+            "Tinker SFT optimizer-step intent",
+        )
         batch_result = session.train_batch(batch.datums, learning_rate=spec.learning_rate)
         current_cost = _add_cost(current_cost, batch_result.cost_usd, has_prior_metrics=step > 1)
         metric = TinkerSFTMetric(
@@ -412,6 +229,7 @@ def _train_locked(
             epoch=batch.epoch,
             batch_index=batch.batch_index,
             batch_example_count=len(batch.datums),
+            example_ids=tuple(datum.example_id for datum in batch.datums),
             supervised_token_count=sum(datum.supervised_token_count for datum in batch.datums),
             loss=batch_result.loss,
             gradient_norm=batch_result.gradient_norm,
@@ -421,37 +239,17 @@ def _train_locked(
         )
         _append_event(output_dir, metric)
         events = (*events, metric)
+        if upper_bound is not None and batch_result.cost_usd is not None:
+            if batch_result.cost_usd.value > upper_bound.value:
+                raise TinkerSFTBudgetExceeded(
+                    "backend-reported step cost exceeded its conservative pre-dispatch bound; "
+                    "the completed step is not replayable and requires manual review"
+                )
         must_checkpoint = step % spec.checkpoint_every_steps == 0 or step == len(schedule)
-        if spec.maximum_cost_usd is not None:
-            if current_cost is None:
-                checkpoint = _save_checkpoint(
-                    session=session,
-                    output_dir=output_dir,
-                    manifest=manifest,
-                    events=events,
-                    attempt_id=attempt_id,
-                    step=step,
-                    cumulative_cost_usd=current_cost,
-                )
-                events = (*events, checkpoint)
-                raise TinkerSFTBudgetExceeded(
-                    "maximum_cost_usd requires every completed Tinker SFT batch to report cost"
-                )
-            if current_cost.value >= spec.maximum_cost_usd:
-                checkpoint = _save_checkpoint(
-                    session=session,
-                    output_dir=output_dir,
-                    manifest=manifest,
-                    events=events,
-                    attempt_id=attempt_id,
-                    step=step,
-                    cumulative_cost_usd=current_cost,
-                )
-                events = (*events, checkpoint)
-                raise TinkerSFTBudgetExceeded(
-                    "observed Tinker SFT spend reached maximum_cost_usd; resume requires a larger "
-                    "explicit budget"
-                )
+        if spec.maximum_cost_usd is not None and current_cost is None:
+            raise TinkerSFTBudgetExceeded(
+                "a completed Tinker SFT step did not report exact cost; no later step may dispatch"
+            )
         if must_checkpoint:
             checkpoint = _save_checkpoint(
                 session=session,
@@ -581,13 +379,20 @@ def _read_events(output_dir: Path, run_id: ArtifactId) -> tuple[TinkerSFTEvent, 
         if not line:
             raise TinkerSFTResumeError(f"Tinker SFT event log has an empty line at {number}")
         try:
-            event = _EVENT_ADAPTER.validate_json(line)
+            event = TINKER_SFT_EVENT_ADAPTER.validate_json(line)
         except ValueError as exc:
             raise TinkerSFTResumeError(
                 f"Tinker SFT event log has an invalid record at line {number}: {exc}"
             ) from exc
         if event.run_id != run_id:
             raise TinkerSFTResumeError("Tinker SFT event log names a different run")
+        if isinstance(event, TinkerSFTCheckpoint):
+            try:
+                validate_provider_resource_id(event.state_path, label="checkpoint state")
+            except TinkerSFTError as exc:
+                raise TinkerSFTResumeError(
+                    "Tinker SFT checkpoint has an unsafe resource ID"
+                ) from exc
         events.append(event)
     _validate_event_history(tuple(events))
     return tuple(events)
@@ -595,6 +400,7 @@ def _read_events(output_dir: Path, run_id: ArtifactId) -> tuple[TinkerSFTEvent, 
 
 def _validate_event_history(events: tuple[TinkerSFTEvent, ...]) -> None:
     checkpoints: dict[str, TinkerSFTCheckpoint] = {}
+    metric_keys: set[tuple[int, int]] = set()
     seen_attempts: set[int] = set()
     for event in events:
         if isinstance(event, TinkerSFTCheckpoint):
@@ -612,12 +418,28 @@ def _validate_event_history(events: tuple[TinkerSFTEvent, ...]) -> None:
                 raise TinkerSFTResumeError("Tinker SFT event log reuses an attempt identifier")
             seen_attempts.add(event.attempt_id)
         else:
+            metric_key = (event.attempt_id, event.step)
+            if metric_key in metric_keys:
+                raise TinkerSFTResumeError("Tinker SFT event log repeats a completed step")
+            if event.batch_example_count != len(event.example_ids):
+                raise TinkerSFTResumeError("Tinker SFT metric has an inconsistent batch size")
+            metric_keys.add(metric_key)
             seen_attempts.add(event.attempt_id)
 
 
 def _latest_checkpoint(events: Sequence[TinkerSFTEvent]) -> TinkerSFTCheckpoint | None:
     checkpoints = [event for event in events if isinstance(event, TinkerSFTCheckpoint)]
     return checkpoints[-1] if checkpoints else None
+
+
+def _assert_no_uncheckpointed_completed_steps(events: Sequence[TinkerSFTEvent]) -> None:
+    checkpoint = _latest_checkpoint(events)
+    durable_step = 0 if checkpoint is None else checkpoint.step
+    if any(isinstance(event, TinkerSFTMetric) and event.step > durable_step for event in events):
+        raise TinkerSFTAmbiguousStepError(
+            "a completed optimizer step has no durable checkpoint state; replay would duplicate "
+            "remote work and spend, so manual recovery or a new run is required"
+        )
 
 
 def _metrics_at_checkpoint(
@@ -666,19 +488,39 @@ def _next_attempt_id(events: Sequence[TinkerSFTEvent]) -> int:
 def _build_schedule(
     datums: tuple[TrainerDatum, ...], spec: TinkerSFTSpec
 ) -> tuple[_ScheduledBatch, ...]:
-    one_epoch = tuple(
-        datums[index : index + spec.batch_size] for index in range(0, len(datums), spec.batch_size)
-    )
-    schedule = tuple(
-        _ScheduledBatch(epoch=epoch, batch_index=batch_index, datums=batch)
-        for epoch in range(1, spec.epochs + 1)
-        for batch_index, batch in enumerate(one_epoch, start=1)
-    )
+    schedule_items: list[_ScheduledBatch] = []
+    for epoch in range(1, spec.epochs + 1):
+        shuffled = tuple(
+            sorted(
+                datums,
+                key=lambda datum: hashlib.sha256(
+                    f"{spec.seed}:{epoch}:{datum.example_id}".encode()
+                ).hexdigest(),
+            )
+        )
+        batches = tuple(
+            shuffled[index : index + spec.batch_size]
+            for index in range(0, len(shuffled), spec.batch_size)
+        )
+        schedule_items.extend(
+            _ScheduledBatch(epoch=epoch, batch_index=batch_index, datums=batch)
+            for batch_index, batch in enumerate(batches, start=1)
+        )
+    schedule = tuple(schedule_items)
     if spec.maximum_steps is not None:
         schedule = schedule[: spec.maximum_steps]
     if not schedule:
         raise TinkerSFTError("Tinker SFT schedule has no managed training batches")
     return schedule
+
+
+def _schedule_batch_counts(example_count: int, spec: TinkerSFTSpec) -> tuple[int, ...]:
+    one_epoch = tuple(
+        min(spec.batch_size, example_count - index)
+        for index in range(0, example_count, spec.batch_size)
+    )
+    counts = one_epoch * spec.epochs
+    return counts[: spec.maximum_steps] if spec.maximum_steps is not None else counts
 
 
 class _ScheduledBatch:
@@ -748,6 +590,34 @@ def _require_budget_can_continue(
         )
 
 
+def _require_step_budget(
+    *,
+    backend: TrainerBackend,
+    spec: TinkerSFTSpec,
+    batch_example_count: int,
+    current_cost: NumericMeasurement | None,
+) -> NumericMeasurement | None:
+    upper_bound = backend.conservative_step_cost(
+        spec,
+        batch_example_count=batch_example_count,
+    )
+    if upper_bound is not None and upper_bound.value < 0:
+        raise TinkerSFTBudgetExceeded("backend cost upper bounds must be nonnegative")
+    if spec.maximum_cost_usd is None:
+        return upper_bound
+    if upper_bound is None:
+        raise TinkerSFTBudgetExceeded(
+            "maximum_cost_usd requires a backend-proven conservative step cost before dispatch"
+        )
+    spent = 0.0 if current_cost is None else current_cost.value
+    if spent + upper_bound.value > spec.maximum_cost_usd:
+        raise TinkerSFTBudgetExceeded(
+            "the next Tinker SFT step's conservative cost bound exceeds the remaining budget; "
+            "no optimizer call was dispatched"
+        )
+    return upper_bound
+
+
 def _save_checkpoint(
     *,
     session: TrainerSession,
@@ -773,7 +643,9 @@ def _save_checkpoint(
     _write_new_json(
         _checkpoint_intent_path(output_dir, checkpoint_id), intent, "Tinker SFT checkpoint intent"
     )
-    state_path = session.save_state(checkpoint_name)
+    state_path = validate_provider_resource_id(
+        session.save_state(checkpoint_name), label="checkpoint state"
+    )
     checkpoint = TinkerSFTCheckpoint(
         checkpoint_id=checkpoint_id,
         run_id=manifest.run_id,
@@ -817,7 +689,9 @@ def _save_or_load_terminal_model(
         ),
         "Tinker SFT model intent",
     )
-    sampling_handle = session.save_sampling_handle(model_name)
+    sampling_handle = validate_provider_resource_id(
+        session.save_sampling_handle(model_name), label="sampling handle"
+    )
     effective_metrics = _metrics_at_checkpoint(events, final_checkpoint)
     model_id = stable_id(
         "tinker-sft-model",
@@ -841,6 +715,7 @@ def _save_or_load_terminal_model(
         run_id=manifest.run_id,
         dataset_id=manifest.dataset_id,
         dataset_build_sha256=manifest.dataset_build_sha256,
+        events_sha256=_events_sha256(output_dir),
         final_checkpoint_id=final_checkpoint.checkpoint_id,
         final_checkpoint_state_path=final_checkpoint.state_path,
         sampling_handle=sampling_handle,
@@ -859,7 +734,7 @@ def _write_terminal_result(
     model: TinkerSFTModelArtifact,
     events: Sequence[TinkerSFTEvent],
 ) -> TinkerSFTResult:
-    existing = _load_completed_result(output_dir, manifest)
+    existing = _load_completed_result(output_dir, manifest, events)
     if existing is not None:
         return existing
     final_checkpoint = _latest_checkpoint(events)
@@ -892,6 +767,8 @@ def _write_terminal_result(
         dataset_build_sha256=manifest.dataset_build_sha256,
         model_id=model.model_id,
         model_sha256=model_sha256,
+        events_sha256=_events_sha256(output_dir),
+        final_checkpoint_id=final_checkpoint.checkpoint_id,
         training_step_count=final_checkpoint.step,
         training_metric_count=len(effective_metrics),
         checkpoint_count=sum(isinstance(event, TinkerSFTCheckpoint) for event in events),
@@ -902,7 +779,9 @@ def _write_terminal_result(
 
 
 def _load_completed_result(
-    output_dir: Path, manifest: TinkerSFTRunManifest
+    output_dir: Path,
+    manifest: TinkerSFTRunManifest,
+    events: Sequence[TinkerSFTEvent],
 ) -> TinkerSFTResult | None:
     path = output_dir / _RESULT_FILE
     if not path.exists():
@@ -917,6 +796,23 @@ def _load_completed_result(
         raise TinkerSFTResumeError("Tinker SFT result exists without its model artifact")
     if result.model_id != model.model_id or result.model_sha256 != sha256_json(model):
         raise TinkerSFTResumeError("Tinker SFT result does not match its model artifact")
+    _validate_model_lineage(output_dir, model, events)
+    final_checkpoint = _latest_checkpoint(events)
+    if final_checkpoint is None or result.final_checkpoint_id != final_checkpoint.checkpoint_id:
+        raise TinkerSFTResumeError("Tinker SFT result does not match its final checkpoint event")
+    effective_metrics = _metrics_at_checkpoint(events, final_checkpoint)
+    if result.events_sha256 != _events_sha256(output_dir):
+        raise TinkerSFTResumeError("Tinker SFT result does not hash the current event log")
+    if result.events_sha256 != model.events_sha256:
+        raise TinkerSFTResumeError("Tinker SFT result and model name different event logs")
+    if result.training_step_count != final_checkpoint.step:
+        raise TinkerSFTResumeError("Tinker SFT result has the wrong durable step count")
+    if result.training_metric_count != len(effective_metrics):
+        raise TinkerSFTResumeError("Tinker SFT result has the wrong durable metric count")
+    if result.total_cost_usd != _total_cost(effective_metrics):
+        raise TinkerSFTResumeError("Tinker SFT result has the wrong durable cost facts")
+    if result.checkpoint_count != sum(isinstance(event, TinkerSFTCheckpoint) for event in events):
+        raise TinkerSFTResumeError("Tinker SFT result has the wrong checkpoint count")
     return result
 
 
@@ -931,7 +827,46 @@ def _load_model(output_dir: Path, manifest: TinkerSFTRunManifest) -> TinkerSFTMo
         raise TinkerSFTResumeError("Tinker SFT model artifact names a different dataset")
     if model.dataset_build_sha256 != manifest.dataset_build_sha256:
         raise TinkerSFTResumeError("Tinker SFT model artifact has a different dataset build")
+    try:
+        validate_provider_resource_id(model.sampling_handle, label="sampling handle")
+        validate_provider_resource_id(model.final_checkpoint_state_path, label="checkpoint state")
+    except TinkerSFTError as exc:
+        raise TinkerSFTResumeError("Tinker SFT model artifact has an unsafe resource ID") from exc
     return model
+
+
+def _validate_model_lineage(
+    output_dir: Path,
+    model: TinkerSFTModelArtifact,
+    events: Sequence[TinkerSFTEvent],
+) -> None:
+    final_checkpoint = _latest_checkpoint(events)
+    if final_checkpoint is None:
+        raise TinkerSFTResumeError("Tinker SFT model artifact has no durable checkpoint event")
+    if model.events_sha256 != _events_sha256(output_dir):
+        raise TinkerSFTResumeError("Tinker SFT model artifact does not hash the current event log")
+    if model.final_checkpoint_id != final_checkpoint.checkpoint_id:
+        raise TinkerSFTResumeError("Tinker SFT model artifact names a different final checkpoint")
+    if model.final_checkpoint_state_path != final_checkpoint.state_path:
+        raise TinkerSFTResumeError("Tinker SFT model artifact has a different checkpoint resource")
+    metrics = _metrics_at_checkpoint(events, final_checkpoint)
+    if model.training_step_count != final_checkpoint.step or model.training_metric_count != len(
+        metrics
+    ):
+        raise TinkerSFTResumeError("Tinker SFT model artifact has inconsistent training counts")
+    if model.total_cost_usd != _total_cost(metrics):
+        raise TinkerSFTResumeError("Tinker SFT model artifact has inconsistent durable cost facts")
+
+
+def _events_sha256(output_dir: Path) -> str:
+    path = output_dir / _EVENTS_FILE
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise TinkerSFTResumeError(f"Tinker SFT event log is required at {path}: {exc}") from exc
+    if not payload:
+        raise TinkerSFTResumeError("Tinker SFT event log is empty")
+    return hashlib.sha256(payload).hexdigest()
 
 
 def _assert_no_ambiguous_checkpoint_intent(
@@ -940,6 +875,7 @@ def _assert_no_ambiguous_checkpoint_intent(
     checkpoint_ids = {
         event.checkpoint_id for event in events if isinstance(event, TinkerSFTCheckpoint)
     }
+    intent_ids: set[ArtifactId] = set()
     for path in output_dir.glob("*.checkpoint-intent.json"):
         intent = _read_model(path, TinkerSFTCheckpointIntent, "Tinker SFT checkpoint intent")
         if intent.run_id != run_id:
@@ -949,6 +885,42 @@ def _assert_no_ambiguous_checkpoint_intent(
                 "a prior Tinker checkpoint save may have completed without an event record; "
                 "inspect the provider before retrying"
             )
+        intent_ids.add(intent.checkpoint_id)
+    if checkpoint_ids != intent_ids:
+        raise TinkerSFTResumeError("Tinker SFT checkpoint event is missing its pre-call intent")
+
+
+def _assert_no_ambiguous_step_intent(
+    output_dir: Path, run_id: ArtifactId, events: Sequence[TinkerSFTEvent]
+) -> None:
+    metrics = {
+        (event.attempt_id, event.step): event
+        for event in events
+        if isinstance(event, TinkerSFTMetric)
+    }
+    intent_keys: set[tuple[int, int]] = set()
+    for path in output_dir.glob("*.step-intent.json"):
+        intent = _read_model(path, TinkerSFTStepIntent, "Tinker SFT optimizer-step intent")
+        if intent.run_id != run_id:
+            raise TinkerSFTResumeError("Tinker SFT optimizer-step intent names a different run")
+        metric = metrics.get((intent.attempt_id, intent.step))
+        if metric is None:
+            raise TinkerSFTAmbiguousStepError(
+                "a prior Tinker optimizer step was durably marked before dispatch but has no "
+                "completion event; remote completion and spend are unknown, so the step will "
+                "not be replayed. Manual provider inspection or a new run is required"
+            )
+        if metric.example_ids != intent.example_ids:
+            raise TinkerSFTResumeError(
+                "Tinker SFT optimizer-step intent does not match its completed metric batch"
+            )
+        intent_keys.add((intent.attempt_id, intent.step))
+    if set(metrics) != intent_keys:
+        raise TinkerSFTResumeError("Tinker SFT completed metric is missing its pre-dispatch intent")
+
+
+def _step_intent_path(output_dir: Path, attempt_id: int, step: int) -> Path:
+    return output_dir / f"attempt-{attempt_id}-step-{step}.step-intent.json"
 
 
 def _checkpoint_intent_path(output_dir: Path, checkpoint_id: ArtifactId) -> Path:

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -7,7 +7,6 @@ import os
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
 
 from pydantic import BaseModel
 
@@ -22,9 +21,9 @@ from wmo.common.core.artifacts import (
 from wmo.common.core.files import write_bytes_atomic
 from wmo.common.core.locks import file_write_lock
 from wmo.common.models import NumericMeasurement
-from wmo.common.project import ProjectStore
+from wmo.common.project import ArtifactCorruptionError, ProjectStore, artifact_input
 from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
-from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
 from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
 from wmo.optimize.model.sft.training_contracts import (
@@ -45,8 +44,19 @@ from wmo.optimize.model.sft.training_contracts import (
     TinkerSFTSpec,
     TinkerSFTStepIntent,
     TrainerBackend,
-    TrainerDatum,
     TrainerSession,
+)
+from wmo.optimize.model.sft.training_runtime import (
+    _add_cost,
+    _build_schedule,
+    _expected_schedule,
+    _ExpectedBatch,
+    _require_budget_can_continue,
+    _require_step_budget,
+    _schedule_batch_counts,
+    _total_cost,
+    _validate_event_schedule,
+    _validate_rendered_datums,
 )
 
 _MANIFEST_FILE = "manifest.json"
@@ -114,13 +124,15 @@ def train_tinker_sft(
     """
     try:
         dataset = load_verified_sft_dataset(store, dataset_id)
-    except SFTBuildError as exc:
+        dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
+    except (ArtifactCorruptionError, SFTBuildError) as exc:
         raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc
     _validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
     manifest_path = output_dir / _MANIFEST_FILE
     with file_write_lock(manifest_path, what="the Tinker SFT run"):
         return _train_locked(
             dataset=dataset,
+            dataset_input=dataset_input,
             spec=spec,
             output_dir=output_dir,
             backend=backend,
@@ -132,6 +144,7 @@ def train_tinker_sft(
 def _train_locked(
     *,
     dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
     spec: TinkerSFTSpec,
     output_dir: Path,
     backend: TrainerBackend,
@@ -140,6 +153,7 @@ def _train_locked(
 ) -> TinkerSFTResult:
     manifest = _load_or_create_manifest(
         dataset=dataset,
+        dataset_input=dataset_input,
         spec=spec,
         output_dir=output_dir,
         created_at=created_at,
@@ -149,24 +163,44 @@ def _train_locked(
     _assert_no_ambiguous_step_intent(output_dir, manifest.run_id, events)
     _assert_no_ambiguous_checkpoint_intent(output_dir, manifest.run_id, events)
     _assert_no_uncheckpointed_completed_steps(events)
-    completed = _load_completed_result(output_dir, manifest, events)
+    train_examples = tuple(row.example for row in dataset.rows if row.partition == "train")
+    expected_schedule = _expected_schedule(train_examples, spec)
+    _validate_event_schedule(events, expected_schedule)
+    completed = _load_completed_result(
+        output_dir,
+        manifest,
+        events,
+        dataset=dataset,
+        dataset_input=dataset_input,
+        expected_schedule=expected_schedule,
+    )
     if completed is not None:
         return completed
     existing_model = _load_model(output_dir, manifest)
     if existing_model is not None:
-        _validate_model_lineage(output_dir, existing_model, events)
+        _validate_model_lineage(
+            output_dir,
+            existing_model,
+            events,
+            manifest=manifest,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            expected_schedule=expected_schedule,
+        )
         return _write_terminal_result(
             output_dir=output_dir,
             manifest=manifest,
             model=existing_model,
             events=events,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            expected_schedule=expected_schedule,
         )
     latest_checkpoint = _latest_checkpoint(events)
     durable_metrics = _metrics_at_checkpoint(events, latest_checkpoint)
     durable_cost = _total_cost(durable_metrics)
     _require_budget_can_continue(spec, durable_metrics, durable_cost)
 
-    train_examples = tuple(row.example for row in dataset.rows if row.partition == "train")
     schedule_counts = _schedule_batch_counts(len(train_examples), spec)
     start_step = latest_checkpoint.step if latest_checkpoint is not None else 0
     if start_step > len(schedule_counts):
@@ -270,12 +304,18 @@ def _train_locked(
         manifest=manifest,
         final_checkpoint=final_checkpoint,
         events=events,
+        dataset=dataset,
+        dataset_input=dataset_input,
+        expected_schedule=expected_schedule,
     )
     return _write_terminal_result(
         output_dir=output_dir,
         manifest=manifest,
         model=model,
         events=events,
+        dataset=dataset,
+        dataset_input=dataset_input,
+        expected_schedule=expected_schedule,
     )
 
 
@@ -307,6 +347,7 @@ def _validate_run_inputs(
 def _load_or_create_manifest(
     *,
     dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
     spec: TinkerSFTSpec,
     output_dir: Path,
     created_at: datetime,
@@ -315,17 +356,22 @@ def _load_or_create_manifest(
     path = output_dir / _MANIFEST_FILE
     if path.exists():
         manifest = _read_model(path, TinkerSFTRunManifest, "Tinker SFT manifest")
-        _validate_manifest(manifest, dataset=dataset, spec=spec, code_revision=code_revision)
+        _validate_manifest(
+            manifest,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            spec=spec,
+            code_revision=code_revision,
+        )
         return manifest
-    dataset_input = ArtifactInput(
-        artifact_id=dataset.dataset.dataset_id,
-        sha256=dataset.dataset.build_sha256,
-    )
+    if dataset_input.artifact_id != dataset.dataset.dataset_id:
+        raise TinkerSFTError("canonical W12 manifest names a different dataset")
     spec_sha256 = sha256_json(spec)
     run_id = stable_id(
         "tinker-sft-run",
         {
             "dataset_id": dataset.dataset.dataset_id,
+            "dataset_manifest_sha256": dataset_input.sha256,
             "dataset_build_sha256": dataset.dataset.build_sha256,
             "dataset_examples_sha256": dataset.dataset.examples_sha256,
             "spec_sha256": spec_sha256,
@@ -338,6 +384,7 @@ def _load_or_create_manifest(
         code_revision=code_revision,
         run_id=run_id,
         dataset_id=dataset.dataset.dataset_id,
+        dataset_manifest_sha256=dataset_input.sha256,
         dataset_build_sha256=dataset.dataset.build_sha256,
         dataset_examples_sha256=dataset.dataset.examples_sha256,
         spec=spec,
@@ -351,11 +398,20 @@ def _validate_manifest(
     manifest: TinkerSFTRunManifest,
     *,
     dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
     spec: TinkerSFTSpec,
     code_revision: str,
 ) -> None:
     if manifest.dataset_id != dataset.dataset.dataset_id:
         raise TinkerSFTResumeError("existing Tinker SFT run belongs to a different W12 dataset")
+    if manifest.inputs != (dataset_input,):
+        raise TinkerSFTResumeError(
+            "existing Tinker SFT run does not name the canonical W12 artifact manifest"
+        )
+    if manifest.dataset_manifest_sha256 != dataset_input.sha256:
+        raise TinkerSFTResumeError(
+            "existing Tinker SFT run has a different W12 artifact manifest digest"
+        )
     if manifest.dataset_build_sha256 != dataset.dataset.build_sha256:
         raise TinkerSFTResumeError("existing Tinker SFT run has a different W12 dataset build")
     if manifest.dataset_examples_sha256 != dataset.dataset.examples_sha256:
@@ -485,139 +541,6 @@ def _next_attempt_id(events: Sequence[TinkerSFTEvent]) -> int:
     return max((event.attempt_id for event in events), default=0) + 1
 
 
-def _build_schedule(
-    datums: tuple[TrainerDatum, ...], spec: TinkerSFTSpec
-) -> tuple[_ScheduledBatch, ...]:
-    schedule_items: list[_ScheduledBatch] = []
-    for epoch in range(1, spec.epochs + 1):
-        shuffled = tuple(
-            sorted(
-                datums,
-                key=lambda datum: hashlib.sha256(
-                    f"{spec.seed}:{epoch}:{datum.example_id}".encode()
-                ).hexdigest(),
-            )
-        )
-        batches = tuple(
-            shuffled[index : index + spec.batch_size]
-            for index in range(0, len(shuffled), spec.batch_size)
-        )
-        schedule_items.extend(
-            _ScheduledBatch(epoch=epoch, batch_index=batch_index, datums=batch)
-            for batch_index, batch in enumerate(batches, start=1)
-        )
-    schedule = tuple(schedule_items)
-    if spec.maximum_steps is not None:
-        schedule = schedule[: spec.maximum_steps]
-    if not schedule:
-        raise TinkerSFTError("Tinker SFT schedule has no managed training batches")
-    return schedule
-
-
-def _schedule_batch_counts(example_count: int, spec: TinkerSFTSpec) -> tuple[int, ...]:
-    one_epoch = tuple(
-        min(spec.batch_size, example_count - index)
-        for index in range(0, example_count, spec.batch_size)
-    )
-    counts = one_epoch * spec.epochs
-    return counts[: spec.maximum_steps] if spec.maximum_steps is not None else counts
-
-
-class _ScheduledBatch:
-    def __init__(self, *, epoch: int, batch_index: int, datums: Sequence[TrainerDatum]) -> None:
-        self.epoch = epoch
-        self.batch_index = batch_index
-        self.datums = tuple(datums)
-
-
-def _validate_rendered_datums(
-    datums: tuple[TrainerDatum, ...], examples: Sequence[SFTExample]
-) -> None:
-    example_ids = tuple(example.example_id for example in examples)
-    datum_ids = tuple(datum.example_id for datum in datums)
-    if datum_ids != example_ids:
-        raise TinkerSFTError("Tinker SFT backend rendered a different ordered train-example set")
-    if any(datum.supervised_token_count <= 0 for datum in datums):
-        raise TinkerSFTError("Tinker SFT backend produced a datum without supervised target tokens")
-
-
-def _add_cost(
-    current: NumericMeasurement | None,
-    added: NumericMeasurement | None,
-    *,
-    has_prior_metrics: bool,
-) -> NumericMeasurement | None:
-    if added is None:
-        return None
-    if current is None:
-        if has_prior_metrics:
-            return None
-        return added
-    provenance: Literal["observed", "estimated"] = (
-        "observed"
-        if current.provenance == "observed" and added.provenance == "observed"
-        else "estimated"
-    )
-    return NumericMeasurement(value=current.value + added.value, provenance=provenance)
-
-
-def _total_cost(metrics: Sequence[TinkerSFTMetric]) -> NumericMeasurement | None:
-    if not metrics:
-        return None
-    total: NumericMeasurement | None = None
-    for index, metric in enumerate(metrics):
-        total = _add_cost(total, metric.cost_usd, has_prior_metrics=index > 0)
-        if total is None:
-            return None
-    return total
-
-
-def _require_budget_can_continue(
-    spec: TinkerSFTSpec,
-    metrics: Sequence[TinkerSFTMetric],
-    cost: NumericMeasurement | None,
-) -> None:
-    if spec.maximum_cost_usd is None:
-        return
-    if metrics and cost is None:
-        raise TinkerSFTBudgetExceeded(
-            "maximum_cost_usd cannot resume because a prior completed Tinker SFT batch lacked cost"
-        )
-    if cost is not None and cost.value >= spec.maximum_cost_usd:
-        raise TinkerSFTBudgetExceeded(
-            "observed Tinker SFT spend already reached maximum_cost_usd; no further provider call "
-            "was made"
-        )
-
-
-def _require_step_budget(
-    *,
-    backend: TrainerBackend,
-    spec: TinkerSFTSpec,
-    batch_example_count: int,
-    current_cost: NumericMeasurement | None,
-) -> NumericMeasurement | None:
-    upper_bound = backend.conservative_step_cost(
-        spec,
-        batch_example_count=batch_example_count,
-    )
-    if upper_bound is not None and upper_bound.value < 0:
-        raise TinkerSFTBudgetExceeded("backend cost upper bounds must be nonnegative")
-    if spec.maximum_cost_usd is None:
-        return upper_bound
-    if upper_bound is None:
-        raise TinkerSFTBudgetExceeded(
-            "maximum_cost_usd requires a backend-proven conservative step cost before dispatch"
-        )
-    spent = 0.0 if current_cost is None else current_cost.value
-    if spent + upper_bound.value > spec.maximum_cost_usd:
-        raise TinkerSFTBudgetExceeded(
-            "the next Tinker SFT step's conservative cost bound exceeds the remaining budget; "
-            "no optimizer call was dispatched"
-        )
-    return upper_bound
-
-
 def _save_checkpoint(
     *,
     session: TrainerSession,
@@ -666,9 +589,21 @@ def _save_or_load_terminal_model(
     manifest: TinkerSFTRunManifest,
     final_checkpoint: TinkerSFTCheckpoint,
     events: Sequence[TinkerSFTEvent],
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    expected_schedule: Sequence[_ExpectedBatch],
 ) -> TinkerSFTModelArtifact:
     existing_model = _load_model(output_dir, manifest)
     if existing_model is not None:
+        _validate_model_lineage(
+            output_dir,
+            existing_model,
+            events,
+            manifest=manifest,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            expected_schedule=expected_schedule,
+        )
         return existing_model
     intent_path = output_dir / _MODEL_INTENT_FILE
     if intent_path.exists():
@@ -704,16 +639,12 @@ def _save_or_load_terminal_model(
     model = TinkerSFTModelArtifact(
         schema_version=1,
         created_at=manifest.created_at,
-        inputs=(
-            ArtifactInput(
-                artifact_id=manifest.dataset_id,
-                sha256=manifest.dataset_build_sha256,
-            ),
-        ),
+        inputs=(dataset_input,),
         code_revision=manifest.code_revision,
         model_id=model_id,
         run_id=manifest.run_id,
         dataset_id=manifest.dataset_id,
+        dataset_manifest_sha256=dataset_input.sha256,
         dataset_build_sha256=manifest.dataset_build_sha256,
         events_sha256=_events_sha256(output_dir),
         final_checkpoint_id=final_checkpoint.checkpoint_id,
@@ -733,8 +664,18 @@ def _write_terminal_result(
     manifest: TinkerSFTRunManifest,
     model: TinkerSFTModelArtifact,
     events: Sequence[TinkerSFTEvent],
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    expected_schedule: Sequence[_ExpectedBatch],
 ) -> TinkerSFTResult:
-    existing = _load_completed_result(output_dir, manifest, events)
+    existing = _load_completed_result(
+        output_dir,
+        manifest,
+        events,
+        dataset=dataset,
+        dataset_input=dataset_input,
+        expected_schedule=expected_schedule,
+    )
     if existing is not None:
         return existing
     final_checkpoint = _latest_checkpoint(events)
@@ -750,7 +691,7 @@ def _write_terminal_result(
                 (
                     ArtifactInput(
                         artifact_id=manifest.dataset_id,
-                        sha256=manifest.dataset_build_sha256,
+                        sha256=dataset_input.sha256,
                     ),
                     ArtifactInput(artifact_id=model.model_id, sha256=model_sha256),
                 ),
@@ -764,6 +705,7 @@ def _write_terminal_result(
         ),
         run_id=manifest.run_id,
         dataset_id=manifest.dataset_id,
+        dataset_manifest_sha256=dataset_input.sha256,
         dataset_build_sha256=manifest.dataset_build_sha256,
         model_id=model.model_id,
         model_sha256=model_sha256,
@@ -782,6 +724,10 @@ def _load_completed_result(
     output_dir: Path,
     manifest: TinkerSFTRunManifest,
     events: Sequence[TinkerSFTEvent],
+    *,
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    expected_schedule: Sequence[_ExpectedBatch],
 ) -> TinkerSFTResult | None:
     path = output_dir / _RESULT_FILE
     if not path.exists():
@@ -791,12 +737,30 @@ def _load_completed_result(
         raise TinkerSFTResumeError("Tinker SFT result names a different run")
     if result.dataset_id != manifest.dataset_id:
         raise TinkerSFTResumeError("Tinker SFT result names a different dataset")
+    _validate_dataset_lineage(
+        label="result",
+        dataset_id=result.dataset_id,
+        dataset_manifest_sha256=result.dataset_manifest_sha256,
+        dataset_build_sha256=result.dataset_build_sha256,
+        inputs=result.inputs,
+        manifest=manifest,
+        dataset=dataset,
+        dataset_input=dataset_input,
+    )
     model = _load_model(output_dir, manifest)
     if model is None:
         raise TinkerSFTResumeError("Tinker SFT result exists without its model artifact")
     if result.model_id != model.model_id or result.model_sha256 != sha256_json(model):
         raise TinkerSFTResumeError("Tinker SFT result does not match its model artifact")
-    _validate_model_lineage(output_dir, model, events)
+    _validate_model_lineage(
+        output_dir,
+        model,
+        events,
+        manifest=manifest,
+        dataset=dataset,
+        dataset_input=dataset_input,
+        expected_schedule=expected_schedule,
+    )
     final_checkpoint = _latest_checkpoint(events)
     if final_checkpoint is None or result.final_checkpoint_id != final_checkpoint.checkpoint_id:
         raise TinkerSFTResumeError("Tinker SFT result does not match its final checkpoint event")
@@ -813,6 +777,8 @@ def _load_completed_result(
         raise TinkerSFTResumeError("Tinker SFT result has the wrong durable cost facts")
     if result.checkpoint_count != sum(isinstance(event, TinkerSFTCheckpoint) for event in events):
         raise TinkerSFTResumeError("Tinker SFT result has the wrong checkpoint count")
+    if result.training_step_count != len(expected_schedule):
+        raise TinkerSFTResumeError("Tinker SFT result does not complete the frozen schedule")
     return result
 
 
@@ -835,11 +801,58 @@ def _load_model(output_dir: Path, manifest: TinkerSFTRunManifest) -> TinkerSFTMo
     return model
 
 
+def _validate_dataset_lineage(
+    *,
+    label: str,
+    dataset_id: ArtifactId,
+    dataset_manifest_sha256: str,
+    dataset_build_sha256: str,
+    inputs: Sequence[ArtifactInput],
+    manifest: TinkerSFTRunManifest,
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+) -> None:
+    if dataset_id != dataset.dataset.dataset_id or dataset_id != manifest.dataset_id:
+        raise TinkerSFTResumeError(f"Tinker SFT {label} has a different canonical dataset ID")
+    if (
+        dataset_manifest_sha256 != dataset_input.sha256
+        or dataset_manifest_sha256 != manifest.dataset_manifest_sha256
+    ):
+        raise TinkerSFTResumeError(
+            f"Tinker SFT {label} has a different canonical dataset manifest digest"
+        )
+    if (
+        dataset_build_sha256 != dataset.dataset.build_sha256
+        or dataset_build_sha256 != manifest.dataset_build_sha256
+    ):
+        raise TinkerSFTResumeError(f"Tinker SFT {label} has a different dataset build digest")
+    matching_inputs = tuple(item for item in inputs if item.artifact_id == dataset_id)
+    if matching_inputs != (dataset_input,):
+        raise TinkerSFTResumeError(
+            f"Tinker SFT {label} does not input the canonical W12 artifact manifest"
+        )
+
+
 def _validate_model_lineage(
     output_dir: Path,
     model: TinkerSFTModelArtifact,
     events: Sequence[TinkerSFTEvent],
+    *,
+    manifest: TinkerSFTRunManifest,
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    expected_schedule: Sequence[_ExpectedBatch],
 ) -> None:
+    _validate_dataset_lineage(
+        label="model",
+        dataset_id=model.dataset_id,
+        dataset_manifest_sha256=model.dataset_manifest_sha256,
+        dataset_build_sha256=model.dataset_build_sha256,
+        inputs=model.inputs,
+        manifest=manifest,
+        dataset=dataset,
+        dataset_input=dataset_input,
+    )
     final_checkpoint = _latest_checkpoint(events)
     if final_checkpoint is None:
         raise TinkerSFTResumeError("Tinker SFT model artifact has no durable checkpoint event")
@@ -856,6 +869,13 @@ def _validate_model_lineage(
         raise TinkerSFTResumeError("Tinker SFT model artifact has inconsistent training counts")
     if model.total_cost_usd != _total_cost(metrics):
         raise TinkerSFTResumeError("Tinker SFT model artifact has inconsistent durable cost facts")
+    if final_checkpoint.step != len(expected_schedule) or len(metrics) != len(expected_schedule):
+        raise TinkerSFTResumeError("Tinker SFT model does not complete the frozen schedule")
+    all_metrics = tuple(event for event in events if isinstance(event, TinkerSFTMetric))
+    if len(all_metrics) != len(expected_schedule) or tuple(
+        sorted(metric.step for metric in all_metrics)
+    ) != tuple(range(1, len(expected_schedule) + 1)):
+        raise TinkerSFTResumeError("Tinker SFT event chain does not exactly complete the schedule")
 
 
 def _events_sha256(output_dir: Path) -> str:

--- a/wmo/optimize/model/sft/training_contracts.py
+++ b/wmo/optimize/model/sft/training_contracts.py
@@ -1,0 +1,289 @@
+"""Typed contracts for append-only managed offline Tinker SFT runs."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Annotated, Literal, Protocol
+
+from pydantic import Field, TypeAdapter, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    sha256_json,
+)
+from wmo.common.models import NumericMeasurement, Usage
+from wmo.optimize.model.sft.contracts import SFTExample
+
+
+class TinkerSFTError(RuntimeError):
+    """The frozen dataset or append-only local SFT run cannot proceed safely."""
+
+
+class TinkerSFTResumeError(TinkerSFTError):
+    """An existing run directory cannot be resumed without mixing immutable state."""
+
+
+class TinkerSFTAmbiguousStepError(TinkerSFTResumeError):
+    """A remote optimizer step may have run and cannot safely be replayed."""
+
+
+class TinkerSFTBudgetExceeded(TinkerSFTError):
+    """Conservative spend accounting prevents another managed training step."""
+
+
+class TinkerSFTSpec(ContractModel):
+    """Frozen base-model, LoRA, schedule, checkpoint, and managed-spend settings."""
+
+    base_model: str = Field(min_length=1, max_length=512)
+    lora_rank: int = Field(default=32, gt=0, le=4096)
+    learning_rate: float = Field(gt=0)
+    batch_size: int = Field(gt=0)
+    epochs: int = Field(gt=0)
+    seed: int = Field(default=0, ge=0, le=2**32 - 1)
+    checkpoint_every_steps: int = Field(gt=0)
+    maximum_steps: int | None = Field(default=None, gt=0)
+    maximum_datum_tokens: int | None = Field(default=None, gt=1)
+    maximum_cost_usd: float | None = Field(default=None, gt=0)
+
+    @field_validator("learning_rate", "maximum_cost_usd")
+    @classmethod
+    def _require_finite_float(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT numeric settings must be finite")
+        return value
+
+
+class TrainerBatchResult(ContractModel):
+    """Facts returned by one completed backend-managed cross-entropy update."""
+
+    loss: float | None = None
+    gradient_norm: float | None = None
+    usage: Usage | None = None
+    cost_usd: NumericMeasurement | None = None
+
+    @field_validator("loss", "gradient_norm")
+    @classmethod
+    def _require_finite_metric(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT backend metrics must be finite")
+        return value
+
+
+class TrainerDatum(Protocol):
+    """The datum identity retained after a backend renders one frozen example."""
+
+    @property
+    def example_id(self) -> str:
+        """Return the exact frozen W12 example identifier rendered into this datum."""
+        ...
+
+    @property
+    def supervised_token_count(self) -> int:
+        """Return the nonzero cross-entropy token count after context-only truncation."""
+        ...
+
+
+class TrainerSession(Protocol):
+    """One managed training client already created or restored by its backend."""
+
+    def render_examples(self, examples: Sequence[SFTExample]) -> tuple[TrainerDatum, ...]:
+        """Render complete frozen assistant-action targets into cross-entropy datums."""
+        ...
+
+    def train_batch(
+        self, datums: Sequence[TrainerDatum], *, learning_rate: float
+    ) -> TrainerBatchResult:
+        """Dispatch and complete one managed cross-entropy optimizer update."""
+        ...
+
+    def save_state(self, checkpoint_name: str) -> str:
+        """Persist a resumable managed state and return its provider resource ID."""
+        ...
+
+    def save_sampling_handle(self, model_name: str) -> str:
+        """Persist completed weights and return their non-secret provider resource ID."""
+        ...
+
+
+class TrainerBackend(Protocol):
+    """The narrow seam for the concrete Tinker adapter or deterministic test fake."""
+
+    def conservative_step_cost(
+        self, spec: TinkerSFTSpec, *, batch_example_count: int
+    ) -> NumericMeasurement | None:
+        """Return a pre-client upper cost bound, or None when the backend cannot prove one."""
+        ...
+
+    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
+        """Create a session, restoring state before renderer or training work when set."""
+        ...
+
+
+class TinkerSFTRunManifest(ArtifactEnvelope):
+    """Immutable local identity for one append-only run directory."""
+
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    dataset_examples_sha256: Sha256
+    spec: TinkerSFTSpec
+    spec_sha256: Sha256
+
+    @model_validator(mode="after")
+    def _require_exact_dataset_and_spec_bindings(self) -> TinkerSFTRunManifest:
+        expected_inputs = (
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT manifests must name exactly their frozen dataset build")
+        if self.spec_sha256 != sha256_json(self.spec):
+            raise ValueError("Tinker SFT manifest spec digest does not match settings")
+        return self
+
+
+class TinkerSFTMetric(ContractModel):
+    """One observed managed batch without a task-behavior or quality claim."""
+
+    record_type: Literal["metric"] = "metric"
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    epoch: int = Field(ge=1)
+    batch_index: int = Field(ge=1)
+    batch_example_count: int = Field(gt=0)
+    example_ids: tuple[ArtifactId, ...] = Field(min_length=1)
+    supervised_token_count: int = Field(gt=0)
+    loss: float | None = None
+    gradient_norm: float | None = None
+    usage: Usage | None = None
+    cost_usd: NumericMeasurement | None = None
+    cumulative_cost_usd: NumericMeasurement | None = None
+
+    @field_validator("loss", "gradient_norm")
+    @classmethod
+    def _require_finite_metric(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("Tinker SFT metrics must be finite")
+        return value
+
+
+class TinkerSFTCheckpoint(ContractModel):
+    """One durable provider state tied to a completed prefix of training batches."""
+
+    record_type: Literal["checkpoint"] = "checkpoint"
+    checkpoint_id: ArtifactId
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    state_path: str = Field(min_length=1, max_length=2048)
+    metric_count: int = Field(gt=0)
+    cumulative_cost_usd: NumericMeasurement | None = None
+
+
+class TinkerSFTResumeEvent(ContractModel):
+    """An append-only record that a new attempt starts from a durable checkpoint."""
+
+    record_type: Literal["resume"] = "resume"
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=2)
+    checkpoint_id: ArtifactId
+    resumed_from_step: int = Field(ge=1)
+
+
+class TinkerSFTStepIntent(ContractModel):
+    """Durable proof that one non-idempotent optimizer update is about to dispatch."""
+
+    run_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    epoch: int = Field(ge=1)
+    batch_index: int = Field(ge=1)
+    example_ids: tuple[ArtifactId, ...] = Field(min_length=1)
+    conservative_cost_upper_bound_usd: NumericMeasurement | None = None
+
+
+class TinkerSFTCheckpointIntent(ContractModel):
+    """A pre-call marker preventing an ambiguous checkpoint save from being repeated."""
+
+    run_id: ArtifactId
+    checkpoint_id: ArtifactId
+    attempt_id: int = Field(ge=1)
+    step: int = Field(ge=1)
+    checkpoint_name: str = Field(min_length=1, max_length=512)
+
+
+class TinkerSFTModelIntent(ContractModel):
+    """A pre-call marker for the non-idempotent terminal sampling-handle save."""
+
+    run_id: ArtifactId
+    model_name: str = Field(min_length=1, max_length=512)
+    checkpoint_id: ArtifactId
+
+
+class TinkerSFTModelArtifact(ArtifactEnvelope):
+    """Completed handle plus its exact dataset, event log, and checkpoint lineage."""
+
+    model_id: ArtifactId
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    events_sha256: Sha256
+    final_checkpoint_id: ArtifactId
+    final_checkpoint_state_path: str = Field(min_length=1, max_length=2048)
+    sampling_handle: str = Field(min_length=1, max_length=2048)
+    training_step_count: int = Field(gt=0)
+    training_metric_count: int = Field(gt=0)
+    total_cost_usd: NumericMeasurement | None = None
+
+    @model_validator(mode="after")
+    def _require_exact_dataset_binding(self) -> TinkerSFTModelArtifact:
+        expected_inputs = (
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT models must name exactly their frozen dataset build")
+        return self
+
+
+class TinkerSFTResult(ArtifactEnvelope):
+    """Terminal result naming the exact model, event log, and training facts."""
+
+    result_id: ArtifactId
+    run_id: ArtifactId
+    dataset_id: ArtifactId
+    dataset_build_sha256: Sha256
+    model_id: ArtifactId
+    model_sha256: Sha256
+    events_sha256: Sha256
+    final_checkpoint_id: ArtifactId
+    training_step_count: int = Field(gt=0)
+    training_metric_count: int = Field(gt=0)
+    checkpoint_count: int = Field(gt=0)
+    total_cost_usd: NumericMeasurement | None = None
+
+    @model_validator(mode="after")
+    def _require_exact_terminal_inputs(self) -> TinkerSFTResult:
+        expected_inputs = tuple(
+            sorted(
+                (
+                    ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+                    ArtifactInput(artifact_id=self.model_id, sha256=self.model_sha256),
+                ),
+                key=lambda item: item.artifact_id,
+            )
+        )
+        if self.inputs != expected_inputs:
+            raise ValueError("Tinker SFT results must name their dataset and terminal model")
+        return self
+
+
+type TinkerSFTEvent = Annotated[
+    TinkerSFTMetric | TinkerSFTCheckpoint | TinkerSFTResumeEvent,
+    Field(discriminator="record_type"),
+]
+TINKER_SFT_EVENT_ADAPTER = TypeAdapter(TinkerSFTEvent)

--- a/wmo/optimize/model/sft/training_contracts.py
+++ b/wmo/optimize/model/sft/training_contracts.py
@@ -15,6 +15,7 @@ from wmo.common.core.artifacts import (
     ContractModel,
     Sha256,
     sha256_json,
+    stable_id,
 )
 from wmo.common.models import NumericMeasurement, Usage
 from wmo.optimize.model.sft.contracts import SFTExample
@@ -129,6 +130,7 @@ class TinkerSFTRunManifest(ArtifactEnvelope):
 
     run_id: ArtifactId
     dataset_id: ArtifactId
+    dataset_manifest_sha256: Sha256
     dataset_build_sha256: Sha256
     dataset_examples_sha256: Sha256
     spec: TinkerSFTSpec
@@ -137,12 +139,24 @@ class TinkerSFTRunManifest(ArtifactEnvelope):
     @model_validator(mode="after")
     def _require_exact_dataset_and_spec_bindings(self) -> TinkerSFTRunManifest:
         expected_inputs = (
-            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_manifest_sha256),
         )
         if self.inputs != expected_inputs:
             raise ValueError("Tinker SFT manifests must name exactly their frozen dataset build")
         if self.spec_sha256 != sha256_json(self.spec):
             raise ValueError("Tinker SFT manifest spec digest does not match settings")
+        expected_run_id = stable_id(
+            "tinker-sft-run",
+            {
+                "dataset_id": self.dataset_id,
+                "dataset_manifest_sha256": self.dataset_manifest_sha256,
+                "dataset_build_sha256": self.dataset_build_sha256,
+                "dataset_examples_sha256": self.dataset_examples_sha256,
+                "spec_sha256": self.spec_sha256,
+            },
+        )
+        if self.run_id != expected_run_id:
+            raise ValueError("Tinker SFT manifest run ID is not content-addressed")
         return self
 
 
@@ -231,6 +245,7 @@ class TinkerSFTModelArtifact(ArtifactEnvelope):
     model_id: ArtifactId
     run_id: ArtifactId
     dataset_id: ArtifactId
+    dataset_manifest_sha256: Sha256
     dataset_build_sha256: Sha256
     events_sha256: Sha256
     final_checkpoint_id: ArtifactId
@@ -243,10 +258,20 @@ class TinkerSFTModelArtifact(ArtifactEnvelope):
     @model_validator(mode="after")
     def _require_exact_dataset_binding(self) -> TinkerSFTModelArtifact:
         expected_inputs = (
-            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+            ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_manifest_sha256),
         )
         if self.inputs != expected_inputs:
             raise ValueError("Tinker SFT models must name exactly their frozen dataset build")
+        expected_model_id = stable_id(
+            "tinker-sft-model",
+            {
+                "run_id": self.run_id,
+                "checkpoint_id": self.final_checkpoint_id,
+                "sampling_handle": self.sampling_handle,
+            },
+        )
+        if self.model_id != expected_model_id:
+            raise ValueError("Tinker SFT model ID is not content-addressed")
         return self
 
 
@@ -256,6 +281,7 @@ class TinkerSFTResult(ArtifactEnvelope):
     result_id: ArtifactId
     run_id: ArtifactId
     dataset_id: ArtifactId
+    dataset_manifest_sha256: Sha256
     dataset_build_sha256: Sha256
     model_id: ArtifactId
     model_sha256: Sha256
@@ -271,7 +297,10 @@ class TinkerSFTResult(ArtifactEnvelope):
         expected_inputs = tuple(
             sorted(
                 (
-                    ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_build_sha256),
+                    ArtifactInput(
+                        artifact_id=self.dataset_id,
+                        sha256=self.dataset_manifest_sha256,
+                    ),
                     ArtifactInput(artifact_id=self.model_id, sha256=self.model_sha256),
                 ),
                 key=lambda item: item.artifact_id,
@@ -279,6 +308,12 @@ class TinkerSFTResult(ArtifactEnvelope):
         )
         if self.inputs != expected_inputs:
             raise ValueError("Tinker SFT results must name their dataset and terminal model")
+        expected_result_id = stable_id(
+            "tinker-sft-result",
+            {"run_id": self.run_id, "model_sha256": self.model_sha256},
+        )
+        if self.result_id != expected_result_id:
+            raise ValueError("Tinker SFT result ID is not content-addressed")
         return self
 
 

--- a/wmo/optimize/model/sft/training_runtime.py
+++ b/wmo/optimize/model/sft/training_runtime.py
@@ -1,0 +1,221 @@
+"""Deterministic scheduling and conservative cost helpers for offline SFT."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from typing import Literal
+
+from wmo.common.core.artifacts import ArtifactId, stable_id
+from wmo.common.models import NumericMeasurement
+from wmo.optimize.model.sft.contracts import SFTExample
+from wmo.optimize.model.sft.training_contracts import (
+    TinkerSFTBudgetExceeded,
+    TinkerSFTCheckpoint,
+    TinkerSFTError,
+    TinkerSFTEvent,
+    TinkerSFTMetric,
+    TinkerSFTResumeError,
+    TinkerSFTSpec,
+    TrainerBackend,
+    TrainerDatum,
+)
+
+
+class _ScheduledBatch:
+    def __init__(self, *, epoch: int, batch_index: int, datums: Sequence[TrainerDatum]) -> None:
+        self.epoch = epoch
+        self.batch_index = batch_index
+        self.datums = tuple(datums)
+
+
+class _ExpectedBatch:
+    def __init__(self, *, epoch: int, batch_index: int, example_ids: Sequence[ArtifactId]) -> None:
+        self.epoch = epoch
+        self.batch_index = batch_index
+        self.example_ids = tuple(example_ids)
+
+
+def _build_schedule(
+    datums: tuple[TrainerDatum, ...], spec: TinkerSFTSpec
+) -> tuple[_ScheduledBatch, ...]:
+    schedule_items: list[_ScheduledBatch] = []
+    for epoch in range(1, spec.epochs + 1):
+        shuffled = tuple(
+            sorted(
+                datums,
+                key=lambda datum: hashlib.sha256(
+                    f"{spec.seed}:{epoch}:{datum.example_id}".encode()
+                ).hexdigest(),
+            )
+        )
+        batches = tuple(
+            shuffled[index : index + spec.batch_size]
+            for index in range(0, len(shuffled), spec.batch_size)
+        )
+        schedule_items.extend(
+            _ScheduledBatch(epoch=epoch, batch_index=batch_index, datums=batch)
+            for batch_index, batch in enumerate(batches, start=1)
+        )
+    schedule = tuple(schedule_items)
+    if spec.maximum_steps is not None:
+        schedule = schedule[: spec.maximum_steps]
+    if not schedule:
+        raise TinkerSFTError("Tinker SFT schedule has no managed training batches")
+    return schedule
+
+
+def _expected_schedule(
+    examples: Sequence[SFTExample], spec: TinkerSFTSpec
+) -> tuple[_ExpectedBatch, ...]:
+    schedule: list[_ExpectedBatch] = []
+    for epoch in range(1, spec.epochs + 1):
+        shuffled_ids = tuple(
+            sorted(
+                (example.example_id for example in examples),
+                key=lambda example_id: hashlib.sha256(
+                    f"{spec.seed}:{epoch}:{example_id}".encode()
+                ).hexdigest(),
+            )
+        )
+        batches = tuple(
+            shuffled_ids[index : index + spec.batch_size]
+            for index in range(0, len(shuffled_ids), spec.batch_size)
+        )
+        schedule.extend(
+            _ExpectedBatch(epoch=epoch, batch_index=batch_index, example_ids=batch)
+            for batch_index, batch in enumerate(batches, start=1)
+        )
+    expected = tuple(schedule)
+    if spec.maximum_steps is not None:
+        expected = expected[: spec.maximum_steps]
+    if not expected:
+        raise TinkerSFTError("Tinker SFT schedule has no managed training batches")
+    return expected
+
+
+def _validate_event_schedule(
+    events: Sequence[TinkerSFTEvent], expected_schedule: Sequence[_ExpectedBatch]
+) -> None:
+    for event in events:
+        if isinstance(event, TinkerSFTMetric):
+            if event.step > len(expected_schedule):
+                raise TinkerSFTResumeError("Tinker SFT metric is beyond the frozen schedule")
+            expected = expected_schedule[event.step - 1]
+            if (
+                event.epoch != expected.epoch
+                or event.batch_index != expected.batch_index
+                or event.example_ids != expected.example_ids
+                or event.batch_example_count != len(expected.example_ids)
+            ):
+                raise TinkerSFTResumeError(
+                    "Tinker SFT metric does not match its frozen scheduled batch"
+                )
+        elif isinstance(event, TinkerSFTCheckpoint):
+            expected_checkpoint_id = stable_id(
+                "tinker-sft-checkpoint",
+                {"run_id": event.run_id, "attempt_id": event.attempt_id, "step": event.step},
+            )
+            if event.checkpoint_id != expected_checkpoint_id:
+                raise TinkerSFTResumeError("Tinker SFT checkpoint ID is not content-addressed")
+            if event.step > len(expected_schedule) or event.metric_count != event.step:
+                raise TinkerSFTResumeError(
+                    "Tinker SFT checkpoint does not match the frozen schedule prefix"
+                )
+
+
+def _schedule_batch_counts(example_count: int, spec: TinkerSFTSpec) -> tuple[int, ...]:
+    one_epoch = tuple(
+        min(spec.batch_size, example_count - index)
+        for index in range(0, example_count, spec.batch_size)
+    )
+    counts = one_epoch * spec.epochs
+    return counts[: spec.maximum_steps] if spec.maximum_steps is not None else counts
+
+
+def _validate_rendered_datums(
+    datums: tuple[TrainerDatum, ...], examples: Sequence[SFTExample]
+) -> None:
+    example_ids = tuple(example.example_id for example in examples)
+    datum_ids = tuple(datum.example_id for datum in datums)
+    if datum_ids != example_ids:
+        raise TinkerSFTError("Tinker SFT backend rendered a different ordered train-example set")
+    if any(datum.supervised_token_count <= 0 for datum in datums):
+        raise TinkerSFTError("Tinker SFT backend produced a datum without supervised target tokens")
+
+
+def _add_cost(
+    current: NumericMeasurement | None,
+    added: NumericMeasurement | None,
+    *,
+    has_prior_metrics: bool,
+) -> NumericMeasurement | None:
+    if added is None:
+        return None
+    if current is None:
+        if has_prior_metrics:
+            return None
+        return added
+    provenance: Literal["observed", "estimated"] = (
+        "observed"
+        if current.provenance == "observed" and added.provenance == "observed"
+        else "estimated"
+    )
+    return NumericMeasurement(value=current.value + added.value, provenance=provenance)
+
+
+def _total_cost(metrics: Sequence[TinkerSFTMetric]) -> NumericMeasurement | None:
+    if not metrics:
+        return None
+    total: NumericMeasurement | None = None
+    for index, metric in enumerate(metrics):
+        total = _add_cost(total, metric.cost_usd, has_prior_metrics=index > 0)
+        if total is None:
+            return None
+    return total
+
+
+def _require_budget_can_continue(
+    spec: TinkerSFTSpec,
+    metrics: Sequence[TinkerSFTMetric],
+    cost: NumericMeasurement | None,
+) -> None:
+    if spec.maximum_cost_usd is None:
+        return
+    if metrics and cost is None:
+        raise TinkerSFTBudgetExceeded(
+            "maximum_cost_usd cannot resume because a prior completed Tinker SFT batch lacked cost"
+        )
+    if cost is not None and cost.value >= spec.maximum_cost_usd:
+        raise TinkerSFTBudgetExceeded(
+            "observed Tinker SFT spend already reached maximum_cost_usd; no further provider call "
+            "was made"
+        )
+
+
+def _require_step_budget(
+    *,
+    backend: TrainerBackend,
+    spec: TinkerSFTSpec,
+    batch_example_count: int,
+    current_cost: NumericMeasurement | None,
+) -> NumericMeasurement | None:
+    upper_bound = backend.conservative_step_cost(
+        spec,
+        batch_example_count=batch_example_count,
+    )
+    if upper_bound is not None and upper_bound.value < 0:
+        raise TinkerSFTBudgetExceeded("backend cost upper bounds must be nonnegative")
+    if spec.maximum_cost_usd is None:
+        return upper_bound
+    if upper_bound is None:
+        raise TinkerSFTBudgetExceeded(
+            "maximum_cost_usd requires a backend-proven conservative step cost before dispatch"
+        )
+    spent = 0.0 if current_cost is None else current_cost.value
+    if spent + upper_bound.value > spec.maximum_cost_usd:
+        raise TinkerSFTBudgetExceeded(
+            "the next Tinker SFT step's conservative cost bound exceeds the remaining budget; "
+            "no optimizer call was dispatched"
+        )
+    return upper_bound

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -24,7 +24,7 @@ from wmo.optimize.model.sft.builder_test import (
 from wmo.optimize.model.sft.builder_test import (
     _write_production_source,
 )
-from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact, SFTExample
 from wmo.optimize.model.sft.rendering import (
     canonical_partitioned_rows_jsonl,
     partitioned_rows_sha256,
@@ -158,6 +158,28 @@ def _persisted_dataset(tmp_path: Path) -> _PersistedDataset:
     return _PersistedDataset(store=store, artifact=artifact)
 
 
+def _legacy_w12_dataset(tmp_path: Path) -> _PersistedDataset:
+    """Persist the exact W12 metadata shape that predates the build-spec field."""
+    store = _fixture_store(tmp_path / "project")
+    sources = (
+        _write_production_source(store, "train-source-a"),
+        _write_production_source(store, "train-source-b"),
+    )
+    artifact = _build_fixture_dataset(store, production=sources)
+    metadata = artifact.metadata().model_dump(mode="json", exclude_none=False)
+    metadata.pop("build_spec")
+    store.artifacts.write(
+        artifact_id=artifact.dataset.dataset_id,
+        artifact_type="sft-dataset",
+        envelope=artifact.dataset,
+        files={
+            "dataset.json": canonical_json_bytes(metadata),
+            "examples.jsonl": canonical_partitioned_rows_jsonl(artifact.rows),
+        },
+    )
+    return _PersistedDataset(store=store, artifact=artifact)
+
+
 def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
     """Return one small deterministic training specification."""
     fields: dict[str, int | float | str | None] = {
@@ -180,6 +202,7 @@ def _run(
     backend: _FakeBackend,
     *,
     spec: TinkerSFTSpec | None = None,
+    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Run the public operation with immutable test provenance."""
     return train_tinker_sft(
@@ -190,6 +213,7 @@ def _run(
         backend=backend,
         created_at=_TIME,
         code_revision="w13-test",
+        legacy_build_spec=legacy_build_spec,
     )
 
 
@@ -233,6 +257,52 @@ def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
         "checkpoint",
     ]
     assert "quality" not in json.dumps(terminal)
+
+
+def test_legacy_w12_dataset_requires_and_verifies_its_original_build_spec(
+    tmp_path: Path,
+) -> None:
+    """Legacy W12 metadata trains only after its original build settings reproduce it."""
+    fixture = _legacy_w12_dataset(tmp_path)
+    missing_backend = _FakeBackend()
+
+    with pytest.raises(TinkerSFTError, match="legacy_build_spec"):
+        _run(fixture, tmp_path / "missing-spec", missing_backend)
+
+    assert missing_backend.open_resume_paths == []
+    assert fixture.artifact.build_spec is not None
+    backend = _FakeBackend()
+
+    result = _run(
+        fixture,
+        tmp_path / "migrated-run",
+        backend,
+        legacy_build_spec=fixture.artifact.build_spec,
+    )
+
+    assert result.dataset_id == fixture.artifact.dataset.dataset_id
+    assert backend.open_resume_paths == [None]
+
+
+def test_legacy_w12_dataset_rejects_a_nonmatching_migration_build_spec(
+    tmp_path: Path,
+) -> None:
+    """A caller-supplied legacy spec cannot rewrite the frozen W12 evidence chain."""
+    fixture = _legacy_w12_dataset(tmp_path)
+    backend = _FakeBackend()
+
+    with pytest.raises(TinkerSFTError, match="does not equal its canonical evidence rebuild"):
+        _run(
+            fixture,
+            tmp_path / "wrong-spec",
+            backend,
+            legacy_build_spec=SFTBuildSpec(
+                held_out_fraction=0.2,
+                representative_sample_count=2,
+            ),
+        )
+
+    assert backend.open_resume_paths == []
 
 
 def test_resume_uses_last_durable_checkpoint_without_replaying_completed_batch(

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -2,42 +2,46 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
 
 import pytest
 
-from wmo.common.core.artifacts import ArtifactInput
-from wmo.common.models import AssistantAction, NumericMeasurement
-from wmo.optimize.model.sft.contracts import (
-    AssistantActionEvent,
-    PartitionedSFTExample,
-    SFTDataset,
-    SFTDatasetArtifact,
-    SFTExample,
-    SFTInspectionReport,
-    SFTMessage,
-    TraceExampleSource,
+from wmo.common.core.artifacts import canonical_json_bytes
+from wmo.common.models import NumericMeasurement
+from wmo.common.project import ProjectStore
+from wmo.optimize.model.sft.builder import write_sft_dataset
+from wmo.optimize.model.sft.builder_test import (
+    _build as _build_fixture_dataset,
 )
-from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+from wmo.optimize.model.sft.builder_test import (
+    _store as _fixture_store,
+)
+from wmo.optimize.model.sft.builder_test import (
+    _write_production_source,
+)
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.rendering import (
+    canonical_partitioned_rows_jsonl,
+    partitioned_rows_sha256,
+)
 from wmo.optimize.model.sft.training import (
+    TinkerSFTAmbiguousStepError,
     TinkerSFTBudgetExceeded,
+    TinkerSFTError,
     TinkerSFTOptimizer,
     TinkerSFTResult,
     TinkerSFTResumeError,
     TinkerSFTSpec,
-    TrainerBatchResult,
     TrainerDatum,
     train_tinker_sft,
 )
+from wmo.optimize.model.sft.training_contracts import TrainerBatchResult
 
 _TIME = datetime(2026, 8, 12, tzinfo=UTC)
-_DIGEST = "d" * 64
 
 
 @dataclass(frozen=True)
@@ -68,7 +72,7 @@ class _FakeSession:
         if self._backend.fail_on_train_call == self._backend.train_calls:
             raise RuntimeError("injected training failure")
         self._backend.trained_example_ids.extend(datum.example_id for datum in datums)
-        return TrainerBatchResult(
+        result = TrainerBatchResult(
             loss=1.0 / self._backend.train_calls,
             gradient_norm=0.5,
             cost_usd=NumericMeasurement(
@@ -76,10 +80,13 @@ class _FakeSession:
                 provenance="observed",
             ),
         )
+        if self._backend.fail_after_train_call == self._backend.train_calls:
+            raise RuntimeError("injected failure after optimizer dispatch")
+        return result
 
     def save_state(self, checkpoint_name: str) -> str:
         self._backend.saved_state_names.append(checkpoint_name)
-        return f"fake://state/{checkpoint_name}"
+        return self._backend.state_resource or f"fake://state/{checkpoint_name}"
 
     def save_sampling_handle(self, model_name: str) -> str:
         self._backend.saved_model_names.append(model_name)
@@ -93,99 +100,62 @@ class _FakeBackend:
         self,
         *,
         cost_per_batch: float = 0.10,
+        conservative_cost_per_batch: float | None = 0.10,
         fail_on_train_call: int | None = None,
+        fail_after_train_call: int | None = None,
+        fail_on_cost_call: int | None = None,
+        state_resource: str | None = None,
     ) -> None:
         self.cost_per_batch = cost_per_batch
+        self.conservative_cost_per_batch = conservative_cost_per_batch
         self.fail_on_train_call = fail_on_train_call
+        self.fail_after_train_call = fail_after_train_call
+        self.fail_on_cost_call = fail_on_cost_call
+        self.state_resource = state_resource
         self.open_resume_paths: list[str | None] = []
         self.rendered_example_ids: list[str] = []
         self.trained_example_ids: list[str] = []
         self.saved_state_names: list[str] = []
         self.saved_model_names: list[str] = []
         self.train_calls = 0
+        self.cost_calls = 0
+
+    def conservative_step_cost(
+        self, spec: TinkerSFTSpec, *, batch_example_count: int
+    ) -> NumericMeasurement | None:
+        self.cost_calls += 1
+        if self.fail_on_cost_call == self.cost_calls:
+            raise RuntimeError("injected pre-dispatch planning failure")
+        if self.conservative_cost_per_batch is None:
+            return None
+        return NumericMeasurement(
+            value=self.conservative_cost_per_batch,
+            provenance="estimated",
+        )
 
     def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> _FakeSession:
         self.open_resume_paths.append(resume_state_path)
         return _FakeSession(self)
 
 
-def _example(name: str, partition: Literal["train", "held_out"]) -> PartitionedSFTExample:
-    """Build one immutable W12-shaped SFT row for a deterministic training test."""
-    return PartitionedSFTExample(
-        partition=partition,
-        fingerprint=hashlib.sha256(name.encode("utf-8")).hexdigest(),
-        example=SFTExample(
-            example_id=f"example-{name}",
-            leakage_group_id=f"lineage-{name}",
-            task=f"Resolve request {name}.",
-            history=(
-                SFTMessage(role="system", content="Follow the support policy."),
-                SFTMessage(role="user", content=f"Customer request {name}."),
-                AssistantActionEvent(action=AssistantAction(content="I will investigate.")),
-            ),
-            target=AssistantAction(content=f"Resolved {name}."),
-            source=TraceExampleSource(
-                trace_id=f"trace-{name}",
-                acceptance_evidence=ArtifactInput(
-                    artifact_id="acceptance-evidence", sha256=_DIGEST
-                ),
-            ),
-            source_step_index=1,
-        ),
-    )
+@dataclass(frozen=True)
+class _PersistedDataset:
+    """Canonical persisted W12 fixture used through the public W13 entry boundary."""
+
+    store: ProjectStore
+    artifact: SFTDatasetArtifact
 
 
-def _dataset() -> SFTDatasetArtifact:
-    """Build one accepted frozen dataset with two train rows and one held-out row."""
-    rows = (
-        _example("train-a", "train"),
-        _example("train-b", "train"),
-        _example("held-out", "held_out"),
+def _persisted_dataset(tmp_path: Path) -> _PersistedDataset:
+    """Build and persist two verified production lineages through W12 services."""
+    store = _fixture_store(tmp_path / "project")
+    sources = (
+        _write_production_source(store, "train-source-a"),
+        _write_production_source(store, "train-source-b"),
     )
-    train_rows = tuple(row for row in rows if row.partition == "train")
-    held_out_rows = tuple(row for row in rows if row.partition == "held_out")
-    dataset = SFTDataset(
-        schema_version=1,
-        created_at=_TIME,
-        inputs=(ArtifactInput(artifact_id="acceptance-evidence", sha256=_DIGEST),),
-        code_revision="w12-fixture",
-        dataset_id="sft-dataset-fixture",
-        build_sha256="b" * 64,
-        status="accepted",
-        acceptance_rule_ids=("acceptance-rule",),
-        acceptance_evidence_ids=("acceptance-evidence",),
-        train_leakage_group_ids=tuple(sorted(row.example.leakage_group_id for row in train_rows)),
-        held_out_leakage_group_ids=tuple(
-            sorted(row.example.leakage_group_id for row in held_out_rows)
-        ),
-        train_example_ids=tuple(sorted(row.example.example_id for row in train_rows)),
-        held_out_example_ids=tuple(sorted(row.example.example_id for row in held_out_rows)),
-        examples_path="examples.jsonl",
-        examples_sha256=partitioned_rows_sha256(rows),
-    )
-    inspection = SFTInspectionReport(
-        report_id="sft-inspection-fixture",
-        dataset_id=dataset.dataset_id,
-        build_sha256=dataset.build_sha256,
-        source_count=1,
-        accepted_source_count=1,
-        eligible_action_count=len(rows),
-        fingerprint_count=len(rows),
-        connected_component_count=len(rows),
-        train_example_count=len(train_rows),
-        held_out_example_count=len(held_out_rows),
-        exclusions=(),
-        representative_train_example_ids=tuple(row.example.example_id for row in train_rows),
-        representative_held_out_example_ids=tuple(row.example.example_id for row in held_out_rows),
-    )
-    return SFTDatasetArtifact(
-        dataset=dataset,
-        sources=(),
-        partitions=(),
-        inspection=inspection,
-        representative_samples=rows,
-        rows=rows,
-    )
+    artifact = _build_fixture_dataset(store, production=sources)
+    write_sft_dataset(store, artifact)
+    return _PersistedDataset(store=store, artifact=artifact)
 
 
 def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
@@ -205,6 +175,7 @@ def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
 
 
 def _run(
+    fixture: _PersistedDataset,
     output_dir: Path,
     backend: _FakeBackend,
     *,
@@ -212,7 +183,8 @@ def _run(
 ) -> TinkerSFTResult:
     """Run the public operation with immutable test provenance."""
     return train_tinker_sft(
-        _dataset(),
+        fixture.store,
+        fixture.artifact.dataset.dataset_id,
         spec or _spec(),
         output_dir,
         backend=backend,
@@ -225,22 +197,26 @@ def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
     tmp_path: Path,
 ) -> None:
     """The injected fake completes without a service client, credentials, or network call."""
+    fixture = _persisted_dataset(tmp_path)
     backend = _FakeBackend()
+    train_ids = tuple(
+        row.example.example_id for row in fixture.artifact.rows if row.partition == "train"
+    )
 
-    result = _run(tmp_path / "run", backend)
+    result = _run(fixture, tmp_path / "run", backend)
 
     assert backend.open_resume_paths == [None]
-    assert backend.rendered_example_ids == ["example-train-a", "example-train-b"]
-    assert backend.trained_example_ids == ["example-train-a", "example-train-b"]
-    assert result.dataset_id == "sft-dataset-fixture"
+    assert backend.rendered_example_ids == list(train_ids)
+    assert sorted(backend.trained_example_ids) == sorted(train_ids)
+    assert result.dataset_id == fixture.artifact.dataset.dataset_id
     assert result.training_step_count == 2
     assert result.total_cost_usd == NumericMeasurement(value=0.20, provenance="observed")
     manifest = json.loads((tmp_path / "run" / "manifest.json").read_text(encoding="utf-8"))
     model = json.loads((tmp_path / "run" / "model.json").read_text(encoding="utf-8"))
     terminal = json.loads((tmp_path / "run" / "result.json").read_text(encoding="utf-8"))
     metrics = (tmp_path / "run" / "events.jsonl").read_text(encoding="utf-8").splitlines()
-    assert manifest["dataset_build_sha256"] == "b" * 64
-    assert manifest["dataset_examples_sha256"] == _dataset().dataset.examples_sha256
+    assert manifest["dataset_build_sha256"] == fixture.artifact.dataset.build_sha256
+    assert manifest["dataset_examples_sha256"] == fixture.artifact.dataset.examples_sha256
     assert model["sampling_handle"].startswith("fake://model/")
     assert terminal["model_id"] == model["model_id"]
     assert [json.loads(line)["record_type"] for line in metrics] == [
@@ -256,18 +232,20 @@ def test_resume_uses_last_durable_checkpoint_without_replaying_completed_batch(
     tmp_path: Path,
 ) -> None:
     """A retry restores the recorded state before training only the remaining batch."""
-    backend = _FakeBackend(fail_on_train_call=2)
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend(fail_on_cost_call=3)
     output_dir = tmp_path / "run"
 
-    with pytest.raises(RuntimeError, match="injected training failure"):
-        _run(output_dir, backend)
+    with pytest.raises(RuntimeError, match="planning failure"):
+        _run(fixture, output_dir, backend)
 
     saved_state = f"fake://state/{backend.saved_state_names[-1]}"
-    backend.fail_on_train_call = None
-    result = _run(output_dir, backend)
+    backend.fail_on_cost_call = None
+    result = _run(fixture, output_dir, backend)
 
     assert backend.open_resume_paths == [None, saved_state]
-    assert backend.trained_example_ids == ["example-train-a", "example-train-b"]
+    assert len(backend.trained_example_ids) == 2
+    assert len(set(backend.trained_example_ids)) == 2
     assert result.training_step_count == 2
     records = [
         json.loads(line)
@@ -282,90 +260,86 @@ def test_resume_uses_last_durable_checkpoint_without_replaying_completed_batch(
     ]
 
 
-def test_retry_after_an_uncheckpointed_metric_starts_a_new_base_attempt(tmp_path: Path) -> None:
-    """Abandoned pre-checkpoint metrics never become a later checkpoint's durable lineage."""
-    backend = _FakeBackend(fail_on_train_call=2)
+def test_crash_after_optimizer_dispatch_never_replays_and_reports_unknown_spend(
+    tmp_path: Path,
+) -> None:
+    """An unmatched pre-dispatch intent is an honest terminal ambiguity, never a retry cue."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend(fail_after_train_call=1)
     output_dir = tmp_path / "run"
-    spec = _spec(checkpoint_every_steps=2)
 
-    with pytest.raises(RuntimeError, match="injected training failure"):
-        _run(output_dir, backend, spec=spec)
+    with pytest.raises(RuntimeError, match="after optimizer dispatch"):
+        _run(fixture, output_dir, backend)
 
+    assert backend.train_calls == 1
     assert backend.saved_state_names == []
-    backend.fail_on_train_call = None
-    result = _run(output_dir, backend, spec=spec)
-
-    assert backend.open_resume_paths == [None, None]
-    assert backend.trained_example_ids == [
-        "example-train-a",
-        "example-train-a",
-        "example-train-b",
-    ]
-    records = [
-        json.loads(line)
-        for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
-    ]
-    assert [(record["record_type"], record["attempt_id"]) for record in records] == [
-        ("metric", 1),
-        ("metric", 2),
-        ("metric", 2),
-        ("checkpoint", 2),
-    ]
-    assert result.training_metric_count == 2
-    assert result.total_cost_usd == NumericMeasurement(value=0.20, provenance="observed")
+    backend.fail_after_train_call = None
+    with pytest.raises(TinkerSFTAmbiguousStepError, match="spend are unknown"):
+        _run(fixture, output_dir, backend)
+    assert backend.train_calls == 1
+    assert backend.open_resume_paths == [None]
 
 
 def test_completed_run_is_idempotent_and_does_not_open_another_trainer(tmp_path: Path) -> None:
     """A completed terminal result is returned from local provenance before backend composition."""
+    fixture = _persisted_dataset(tmp_path)
     backend = _FakeBackend()
     output_dir = tmp_path / "run"
 
-    first = _run(output_dir, backend)
-    second = _run(output_dir, backend)
+    first = _run(fixture, output_dir, backend)
+    second = _run(fixture, output_dir, backend)
 
     assert second == first
     assert backend.open_resume_paths == [None]
 
 
-def test_budget_exhaustion_persists_a_checkpoint_and_refuses_further_spend(
+def test_budget_refuses_a_step_whose_upper_bound_exceeds_remaining_spend(
     tmp_path: Path,
 ) -> None:
-    """Observed spend over the cap leaves a resumable checkpoint but no terminal model."""
-    backend = _FakeBackend(cost_per_batch=0.20)
+    """A $0.10 cap against a $0.20 bound dispatches no trainer or optimizer call."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend(cost_per_batch=0.20, conservative_cost_per_batch=0.20)
     output_dir = tmp_path / "run"
 
-    with pytest.raises(TinkerSFTBudgetExceeded, match="maximum_cost_usd"):
-        _run(output_dir, backend, spec=_spec(maximum_cost_usd=0.30, checkpoint_every_steps=10))
+    with pytest.raises(TinkerSFTBudgetExceeded, match="remaining budget"):
+        _run(fixture, output_dir, backend, spec=_spec(maximum_cost_usd=0.10))
 
-    records = [
-        json.loads(line)
-        for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
-    ]
-    assert [record["record_type"] for record in records] == ["metric", "metric", "checkpoint"]
-    assert not (output_dir / "model.json").exists()
-    opens_before_retry = list(backend.open_resume_paths)
-    with pytest.raises(TinkerSFTBudgetExceeded, match="already reached"):
-        _run(output_dir, backend, spec=_spec(maximum_cost_usd=0.30, checkpoint_every_steps=10))
-    assert backend.open_resume_paths == opens_before_retry
+    assert backend.open_resume_paths == []
+    assert backend.train_calls == 0
+
+
+def test_unknown_cost_refuses_before_open_or_optimizer_dispatch(tmp_path: Path) -> None:
+    """A budgeted concrete-style backend with no supported bound performs zero remote work."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend(conservative_cost_per_batch=None)
+
+    with pytest.raises(TinkerSFTBudgetExceeded, match="backend-proven"):
+        _run(fixture, tmp_path / "run", backend, spec=_spec(maximum_cost_usd=1.0))
+
+    assert backend.open_resume_paths == []
+    assert backend.train_calls == 0
 
 
 def test_changed_spec_cannot_reuse_an_append_only_run_directory(tmp_path: Path) -> None:
     """A run directory remains tied to its original frozen dataset and optimization settings."""
+    fixture = _persisted_dataset(tmp_path)
     backend = _FakeBackend()
     output_dir = tmp_path / "run"
-    _run(output_dir, backend)
+    _run(fixture, output_dir, backend)
 
     with pytest.raises(TinkerSFTResumeError, match="training spec"):
-        _run(output_dir, backend, spec=_spec(learning_rate=0.02))
+        _run(fixture, output_dir, backend, spec=_spec(learning_rate=0.02))
 
 
 def test_optimizer_delegates_to_the_same_injected_backend(tmp_path: Path) -> None:
     """The narrow optimizer seam adds no registry or alternate training implementation."""
+    fixture = _persisted_dataset(tmp_path)
     backend = _FakeBackend()
     optimizer = TinkerSFTOptimizer(backend)
 
     result = optimizer.optimize(
-        dataset=_dataset(),
+        store=fixture.store,
+        dataset_id=fixture.artifact.dataset.dataset_id,
         spec=_spec(),
         output_dir=tmp_path / "run",
         created_at=_TIME,
@@ -374,3 +348,99 @@ def test_optimizer_delegates_to_the_same_injected_backend(tmp_path: Path) -> Non
 
     assert result.training_step_count == 2
     assert backend.open_resume_paths == [None]
+
+
+def test_seed_deterministically_controls_schedule_order(tmp_path: Path) -> None:
+    """The same seed repeats exact batch order while a selected alternate seed changes it."""
+    fixture = _persisted_dataset(tmp_path)
+    first = _FakeBackend()
+    repeat = _FakeBackend()
+    alternate = _FakeBackend()
+
+    _run(fixture, tmp_path / "first", first, spec=_spec(seed=7))
+    _run(fixture, tmp_path / "repeat", repeat, spec=_spec(seed=7))
+    _run(fixture, tmp_path / "alternate", alternate, spec=_spec(seed=11))
+
+    assert first.trained_example_ids == repeat.trained_example_ids
+    assert first.trained_example_ids != alternate.trained_example_ids
+
+
+def test_forged_cross_split_persisted_input_never_opens_training(tmp_path: Path) -> None:
+    """Even manifest-digested forged rows fail W12 invariants before backend composition."""
+    fixture = _persisted_dataset(tmp_path)
+    original = fixture.artifact
+    held_out = next(row for row in original.rows if row.partition == "held_out")
+    forged_row = held_out.model_copy(
+        update={
+            "partition": "train",
+            "example": held_out.example.model_copy(update={"example_id": "forged-example"}),
+        }
+    )
+    rows = (*original.rows, forged_row)
+    dataset = original.dataset.model_copy(
+        update={
+            "dataset_id": "forged-cross-split",
+            "build_sha256": "f" * 64,
+            "train_example_ids": tuple(
+                sorted((*original.dataset.train_example_ids, forged_row.example.example_id))
+            ),
+            "examples_sha256": partitioned_rows_sha256(rows),
+        }
+    )
+    inspection = original.inspection.model_copy(
+        update={
+            "dataset_id": dataset.dataset_id,
+            "build_sha256": dataset.build_sha256,
+            "train_example_count": original.inspection.train_example_count + 1,
+        }
+    )
+    forged = original.model_copy(
+        update={"dataset": dataset, "inspection": inspection, "rows": rows}
+    )
+    fixture.store.artifacts.write(
+        artifact_id=dataset.dataset_id,
+        artifact_type="sft-dataset",
+        envelope=dataset,
+        files={
+            "dataset.json": canonical_json_bytes(forged.metadata()),
+            "examples.jsonl": canonical_partitioned_rows_jsonl(rows),
+        },
+    )
+    backend = _FakeBackend()
+
+    with pytest.raises(TinkerSFTError, match="not safe for training"):
+        train_tinker_sft(
+            fixture.store,
+            dataset.dataset_id,
+            _spec(),
+            tmp_path / "forged-run",
+            backend=backend,
+            created_at=_TIME,
+            code_revision="w13-test",
+        )
+
+    assert backend.open_resume_paths == []
+    assert backend.train_calls == 0
+
+
+def test_completed_reuse_refuses_when_event_log_is_deleted(tmp_path: Path) -> None:
+    """A terminal result is not trusted without its hash-bound checkpoint event lineage."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend()
+    output_dir = tmp_path / "run"
+    _run(fixture, output_dir, backend)
+    (output_dir / "events.jsonl").unlink()
+
+    with pytest.raises(TinkerSFTResumeError):
+        _run(fixture, output_dir, backend)
+
+
+def test_provider_token_url_is_rejected_before_checkpoint_persistence(tmp_path: Path) -> None:
+    """Provider resource strings with token query material never enter local artifacts."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend(state_resource="https://provider.test/state?token=secret-value")
+
+    with pytest.raises(TinkerSFTError, match="opaque provider resource ID"):
+        _run(fixture, tmp_path / "run", backend)
+
+    assert not (tmp_path / "run" / "result.json").exists()

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -1,0 +1,376 @@
+"""Deterministic offline SFT-run tests with an injected no-network trainer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactInput
+from wmo.common.models import AssistantAction, NumericMeasurement
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    PartitionedSFTExample,
+    SFTDataset,
+    SFTDatasetArtifact,
+    SFTExample,
+    SFTInspectionReport,
+    SFTMessage,
+    TraceExampleSource,
+)
+from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+from wmo.optimize.model.sft.training import (
+    TinkerSFTBudgetExceeded,
+    TinkerSFTOptimizer,
+    TinkerSFTResult,
+    TinkerSFTResumeError,
+    TinkerSFTSpec,
+    TrainerBatchResult,
+    TrainerDatum,
+    train_tinker_sft,
+)
+
+_TIME = datetime(2026, 8, 12, tzinfo=UTC)
+_DIGEST = "d" * 64
+
+
+@dataclass(frozen=True)
+class _FakeDatum:
+    """One rendered datum returned by the fake trainer without an SDK dependency."""
+
+    example_id: str
+    supervised_token_count: int
+
+
+class _FakeSession:
+    """Record deterministic training calls without creating a Tinker client."""
+
+    def __init__(self, backend: _FakeBackend) -> None:
+        self._backend = backend
+
+    def render_examples(self, examples: Sequence[SFTExample]) -> tuple[_FakeDatum, ...]:
+        self._backend.rendered_example_ids.extend(example.example_id for example in examples)
+        return tuple(
+            _FakeDatum(example_id=example.example_id, supervised_token_count=index + 3)
+            for index, example in enumerate(examples)
+        )
+
+    def train_batch(
+        self, datums: Sequence[TrainerDatum], *, learning_rate: float
+    ) -> TrainerBatchResult:
+        self._backend.train_calls += 1
+        if self._backend.fail_on_train_call == self._backend.train_calls:
+            raise RuntimeError("injected training failure")
+        self._backend.trained_example_ids.extend(datum.example_id for datum in datums)
+        return TrainerBatchResult(
+            loss=1.0 / self._backend.train_calls,
+            gradient_norm=0.5,
+            cost_usd=NumericMeasurement(
+                value=self._backend.cost_per_batch,
+                provenance="observed",
+            ),
+        )
+
+    def save_state(self, checkpoint_name: str) -> str:
+        self._backend.saved_state_names.append(checkpoint_name)
+        return f"fake://state/{checkpoint_name}"
+
+    def save_sampling_handle(self, model_name: str) -> str:
+        self._backend.saved_model_names.append(model_name)
+        return f"fake://model/{model_name}"
+
+
+class _FakeBackend:
+    """A complete backend double proving the runner needs neither credentials nor a network."""
+
+    def __init__(
+        self,
+        *,
+        cost_per_batch: float = 0.10,
+        fail_on_train_call: int | None = None,
+    ) -> None:
+        self.cost_per_batch = cost_per_batch
+        self.fail_on_train_call = fail_on_train_call
+        self.open_resume_paths: list[str | None] = []
+        self.rendered_example_ids: list[str] = []
+        self.trained_example_ids: list[str] = []
+        self.saved_state_names: list[str] = []
+        self.saved_model_names: list[str] = []
+        self.train_calls = 0
+
+    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> _FakeSession:
+        self.open_resume_paths.append(resume_state_path)
+        return _FakeSession(self)
+
+
+def _example(name: str, partition: Literal["train", "held_out"]) -> PartitionedSFTExample:
+    """Build one immutable W12-shaped SFT row for a deterministic training test."""
+    return PartitionedSFTExample(
+        partition=partition,
+        fingerprint=hashlib.sha256(name.encode("utf-8")).hexdigest(),
+        example=SFTExample(
+            example_id=f"example-{name}",
+            leakage_group_id=f"lineage-{name}",
+            task=f"Resolve request {name}.",
+            history=(
+                SFTMessage(role="system", content="Follow the support policy."),
+                SFTMessage(role="user", content=f"Customer request {name}."),
+                AssistantActionEvent(action=AssistantAction(content="I will investigate.")),
+            ),
+            target=AssistantAction(content=f"Resolved {name}."),
+            source=TraceExampleSource(
+                trace_id=f"trace-{name}",
+                acceptance_evidence=ArtifactInput(
+                    artifact_id="acceptance-evidence", sha256=_DIGEST
+                ),
+            ),
+            source_step_index=1,
+        ),
+    )
+
+
+def _dataset() -> SFTDatasetArtifact:
+    """Build one accepted frozen dataset with two train rows and one held-out row."""
+    rows = (
+        _example("train-a", "train"),
+        _example("train-b", "train"),
+        _example("held-out", "held_out"),
+    )
+    train_rows = tuple(row for row in rows if row.partition == "train")
+    held_out_rows = tuple(row for row in rows if row.partition == "held_out")
+    dataset = SFTDataset(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(ArtifactInput(artifact_id="acceptance-evidence", sha256=_DIGEST),),
+        code_revision="w12-fixture",
+        dataset_id="sft-dataset-fixture",
+        build_sha256="b" * 64,
+        status="accepted",
+        acceptance_rule_ids=("acceptance-rule",),
+        acceptance_evidence_ids=("acceptance-evidence",),
+        train_leakage_group_ids=tuple(sorted(row.example.leakage_group_id for row in train_rows)),
+        held_out_leakage_group_ids=tuple(
+            sorted(row.example.leakage_group_id for row in held_out_rows)
+        ),
+        train_example_ids=tuple(sorted(row.example.example_id for row in train_rows)),
+        held_out_example_ids=tuple(sorted(row.example.example_id for row in held_out_rows)),
+        examples_path="examples.jsonl",
+        examples_sha256=partitioned_rows_sha256(rows),
+    )
+    inspection = SFTInspectionReport(
+        report_id="sft-inspection-fixture",
+        dataset_id=dataset.dataset_id,
+        build_sha256=dataset.build_sha256,
+        source_count=1,
+        accepted_source_count=1,
+        eligible_action_count=len(rows),
+        fingerprint_count=len(rows),
+        connected_component_count=len(rows),
+        train_example_count=len(train_rows),
+        held_out_example_count=len(held_out_rows),
+        exclusions=(),
+        representative_train_example_ids=tuple(row.example.example_id for row in train_rows),
+        representative_held_out_example_ids=tuple(row.example.example_id for row in held_out_rows),
+    )
+    return SFTDatasetArtifact(
+        dataset=dataset,
+        sources=(),
+        partitions=(),
+        inspection=inspection,
+        representative_samples=rows,
+        rows=rows,
+    )
+
+
+def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
+    """Return one small deterministic training specification."""
+    fields: dict[str, int | float | str | None] = {
+        "base_model": "test-base-model",
+        "lora_rank": 8,
+        "learning_rate": 0.01,
+        "batch_size": 1,
+        "epochs": 1,
+        "checkpoint_every_steps": 1,
+        "maximum_steps": None,
+        "maximum_datum_tokens": 128,
+        "maximum_cost_usd": None,
+    }
+    return TinkerSFTSpec.model_validate(fields | overrides)
+
+
+def _run(
+    output_dir: Path,
+    backend: _FakeBackend,
+    *,
+    spec: TinkerSFTSpec | None = None,
+) -> TinkerSFTResult:
+    """Run the public operation with immutable test provenance."""
+    return train_tinker_sft(
+        _dataset(),
+        spec or _spec(),
+        output_dir,
+        backend=backend,
+        created_at=_TIME,
+        code_revision="w13-test",
+    )
+
+
+def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
+    tmp_path: Path,
+) -> None:
+    """The injected fake completes without a service client, credentials, or network call."""
+    backend = _FakeBackend()
+
+    result = _run(tmp_path / "run", backend)
+
+    assert backend.open_resume_paths == [None]
+    assert backend.rendered_example_ids == ["example-train-a", "example-train-b"]
+    assert backend.trained_example_ids == ["example-train-a", "example-train-b"]
+    assert result.dataset_id == "sft-dataset-fixture"
+    assert result.training_step_count == 2
+    assert result.total_cost_usd == NumericMeasurement(value=0.20, provenance="observed")
+    manifest = json.loads((tmp_path / "run" / "manifest.json").read_text(encoding="utf-8"))
+    model = json.loads((tmp_path / "run" / "model.json").read_text(encoding="utf-8"))
+    terminal = json.loads((tmp_path / "run" / "result.json").read_text(encoding="utf-8"))
+    metrics = (tmp_path / "run" / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    assert manifest["dataset_build_sha256"] == "b" * 64
+    assert manifest["dataset_examples_sha256"] == _dataset().dataset.examples_sha256
+    assert model["sampling_handle"].startswith("fake://model/")
+    assert terminal["model_id"] == model["model_id"]
+    assert [json.loads(line)["record_type"] for line in metrics] == [
+        "metric",
+        "checkpoint",
+        "metric",
+        "checkpoint",
+    ]
+    assert "quality" not in json.dumps(terminal)
+
+
+def test_resume_uses_last_durable_checkpoint_without_replaying_completed_batch(
+    tmp_path: Path,
+) -> None:
+    """A retry restores the recorded state before training only the remaining batch."""
+    backend = _FakeBackend(fail_on_train_call=2)
+    output_dir = tmp_path / "run"
+
+    with pytest.raises(RuntimeError, match="injected training failure"):
+        _run(output_dir, backend)
+
+    saved_state = f"fake://state/{backend.saved_state_names[-1]}"
+    backend.fail_on_train_call = None
+    result = _run(output_dir, backend)
+
+    assert backend.open_resume_paths == [None, saved_state]
+    assert backend.trained_example_ids == ["example-train-a", "example-train-b"]
+    assert result.training_step_count == 2
+    records = [
+        json.loads(line)
+        for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["record_type"] for record in records] == [
+        "metric",
+        "checkpoint",
+        "resume",
+        "metric",
+        "checkpoint",
+    ]
+
+
+def test_retry_after_an_uncheckpointed_metric_starts_a_new_base_attempt(tmp_path: Path) -> None:
+    """Abandoned pre-checkpoint metrics never become a later checkpoint's durable lineage."""
+    backend = _FakeBackend(fail_on_train_call=2)
+    output_dir = tmp_path / "run"
+    spec = _spec(checkpoint_every_steps=2)
+
+    with pytest.raises(RuntimeError, match="injected training failure"):
+        _run(output_dir, backend, spec=spec)
+
+    assert backend.saved_state_names == []
+    backend.fail_on_train_call = None
+    result = _run(output_dir, backend, spec=spec)
+
+    assert backend.open_resume_paths == [None, None]
+    assert backend.trained_example_ids == [
+        "example-train-a",
+        "example-train-a",
+        "example-train-b",
+    ]
+    records = [
+        json.loads(line)
+        for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [(record["record_type"], record["attempt_id"]) for record in records] == [
+        ("metric", 1),
+        ("metric", 2),
+        ("metric", 2),
+        ("checkpoint", 2),
+    ]
+    assert result.training_metric_count == 2
+    assert result.total_cost_usd == NumericMeasurement(value=0.20, provenance="observed")
+
+
+def test_completed_run_is_idempotent_and_does_not_open_another_trainer(tmp_path: Path) -> None:
+    """A completed terminal result is returned from local provenance before backend composition."""
+    backend = _FakeBackend()
+    output_dir = tmp_path / "run"
+
+    first = _run(output_dir, backend)
+    second = _run(output_dir, backend)
+
+    assert second == first
+    assert backend.open_resume_paths == [None]
+
+
+def test_budget_exhaustion_persists_a_checkpoint_and_refuses_further_spend(
+    tmp_path: Path,
+) -> None:
+    """Observed spend over the cap leaves a resumable checkpoint but no terminal model."""
+    backend = _FakeBackend(cost_per_batch=0.20)
+    output_dir = tmp_path / "run"
+
+    with pytest.raises(TinkerSFTBudgetExceeded, match="maximum_cost_usd"):
+        _run(output_dir, backend, spec=_spec(maximum_cost_usd=0.30, checkpoint_every_steps=10))
+
+    records = [
+        json.loads(line)
+        for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["record_type"] for record in records] == ["metric", "metric", "checkpoint"]
+    assert not (output_dir / "model.json").exists()
+    opens_before_retry = list(backend.open_resume_paths)
+    with pytest.raises(TinkerSFTBudgetExceeded, match="already reached"):
+        _run(output_dir, backend, spec=_spec(maximum_cost_usd=0.30, checkpoint_every_steps=10))
+    assert backend.open_resume_paths == opens_before_retry
+
+
+def test_changed_spec_cannot_reuse_an_append_only_run_directory(tmp_path: Path) -> None:
+    """A run directory remains tied to its original frozen dataset and optimization settings."""
+    backend = _FakeBackend()
+    output_dir = tmp_path / "run"
+    _run(output_dir, backend)
+
+    with pytest.raises(TinkerSFTResumeError, match="training spec"):
+        _run(output_dir, backend, spec=_spec(learning_rate=0.02))
+
+
+def test_optimizer_delegates_to_the_same_injected_backend(tmp_path: Path) -> None:
+    """The narrow optimizer seam adds no registry or alternate training implementation."""
+    backend = _FakeBackend()
+    optimizer = TinkerSFTOptimizer(backend)
+
+    result = optimizer.optimize(
+        dataset=_dataset(),
+        spec=_spec(),
+        output_dir=tmp_path / "run",
+        created_at=_TIME,
+        code_revision="w13-test",
+    )
+
+    assert result.training_step_count == 2
+    assert backend.open_resume_paths == [None]

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -10,9 +11,9 @@ from pathlib import Path
 
 import pytest
 
-from wmo.common.core.artifacts import canonical_json_bytes
+from wmo.common.core.artifacts import canonical_json_bytes, sha256_json, stable_id
 from wmo.common.models import NumericMeasurement
-from wmo.common.project import ProjectStore
+from wmo.common.project import ProjectStore, artifact_input
 from wmo.optimize.model.sft.builder import write_sft_dataset
 from wmo.optimize.model.sft.builder_test import (
     _build as _build_fixture_dataset,
@@ -36,10 +37,9 @@ from wmo.optimize.model.sft.training import (
     TinkerSFTResult,
     TinkerSFTResumeError,
     TinkerSFTSpec,
-    TrainerDatum,
     train_tinker_sft,
 )
-from wmo.optimize.model.sft.training_contracts import TrainerBatchResult
+from wmo.optimize.model.sft.training_contracts import TrainerBatchResult, TrainerDatum
 
 _TIME = datetime(2026, 8, 12, tzinfo=UTC)
 
@@ -216,6 +216,13 @@ def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
     terminal = json.loads((tmp_path / "run" / "result.json").read_text(encoding="utf-8"))
     metrics = (tmp_path / "run" / "events.jsonl").read_text(encoding="utf-8").splitlines()
     assert manifest["dataset_build_sha256"] == fixture.artifact.dataset.build_sha256
+    expected_dataset_input = artifact_input(
+        fixture.store.artifacts.read(fixture.artifact.dataset.dataset_id).manifest
+    )
+    assert manifest["dataset_manifest_sha256"] == expected_dataset_input.sha256
+    assert manifest["inputs"] == [expected_dataset_input.model_dump(mode="json")]
+    assert model["inputs"] == [expected_dataset_input.model_dump(mode="json")]
+    assert expected_dataset_input.model_dump(mode="json") in terminal["inputs"]
     assert manifest["dataset_examples_sha256"] == fixture.artifact.dataset.examples_sha256
     assert model["sampling_handle"].startswith("fake://model/")
     assert terminal["model_id"] == model["model_id"]
@@ -433,6 +440,103 @@ def test_completed_reuse_refuses_when_event_log_is_deleted(tmp_path: Path) -> No
 
     with pytest.raises(TinkerSFTResumeError):
         _run(fixture, output_dir, backend)
+
+
+def test_completed_reuse_rejects_coherent_result_dataset_build_input_edit(
+    tmp_path: Path,
+) -> None:
+    """A self-consistent mutable result cannot replace the canonical W12 manifest binding."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend()
+    output_dir = tmp_path / "run"
+    _run(fixture, output_dir, backend)
+    result_path = output_dir / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    forged_build = "0" * 64
+    result["dataset_build_sha256"] = forged_build
+    for input_item in result["inputs"]:
+        if input_item["artifact_id"] == fixture.artifact.dataset.dataset_id:
+            input_item["sha256"] = forged_build
+    result_path.write_bytes(canonical_json_bytes(result) + b"\n")
+
+    with pytest.raises(TinkerSFTResumeError):
+        _run(fixture, output_dir, backend)
+
+
+def test_completed_reuse_rejects_coherently_truncated_schedule(tmp_path: Path) -> None:
+    """A hash-consistent one-step terminal history cannot complete a frozen two-step run."""
+    fixture = _persisted_dataset(tmp_path)
+    backend = _FakeBackend()
+    output_dir = tmp_path / "run"
+    _run(fixture, output_dir, backend)
+
+    event_path = output_dir / "events.jsonl"
+    events = [json.loads(line) for line in event_path.read_text(encoding="utf-8").splitlines()]
+    first_events = [event for event in events if event.get("step") == 1]
+    first_checkpoint = next(event for event in first_events if event["record_type"] == "checkpoint")
+    first_metric = next(event for event in first_events if event["record_type"] == "metric")
+    event_payload = b"".join(canonical_json_bytes(event) + b"\n" for event in first_events)
+    event_path.write_bytes(event_payload)
+    events_sha256 = hashlib.sha256(event_payload).hexdigest()
+
+    for path in output_dir.glob("*step-2.step-intent.json"):
+        path.unlink()
+    second_checkpoint = next(
+        event for event in events if event["record_type"] == "checkpoint" and event["step"] == 2
+    )
+    (output_dir / f"{second_checkpoint['checkpoint_id']}.checkpoint-intent.json").unlink()
+    (output_dir / "model-intent.json").unlink()
+
+    model_path = output_dir / "model.json"
+    model = json.loads(model_path.read_text(encoding="utf-8"))
+    model.update(
+        {
+            "events_sha256": events_sha256,
+            "final_checkpoint_id": first_checkpoint["checkpoint_id"],
+            "final_checkpoint_state_path": first_checkpoint["state_path"],
+            "training_step_count": 1,
+            "training_metric_count": 1,
+            "total_cost_usd": first_metric["cumulative_cost_usd"],
+        }
+    )
+    model["model_id"] = stable_id(
+        "tinker-sft-model",
+        {
+            "run_id": model["run_id"],
+            "checkpoint_id": model["final_checkpoint_id"],
+            "sampling_handle": model["sampling_handle"],
+        },
+    )
+    model_path.write_bytes(canonical_json_bytes(model) + b"\n")
+    model_sha256 = sha256_json(model)
+
+    result_path = output_dir / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    result.update(
+        {
+            "events_sha256": events_sha256,
+            "final_checkpoint_id": first_checkpoint["checkpoint_id"],
+            "model_id": model["model_id"],
+            "model_sha256": model_sha256,
+            "training_step_count": 1,
+            "training_metric_count": 1,
+            "checkpoint_count": 1,
+            "total_cost_usd": first_metric["cumulative_cost_usd"],
+        }
+    )
+    for input_item in result["inputs"]:
+        if input_item["artifact_id"] != fixture.artifact.dataset.dataset_id:
+            input_item.update({"artifact_id": model["model_id"], "sha256": model_sha256})
+    result["inputs"] = sorted(result["inputs"], key=lambda item: item["artifact_id"])
+    result["result_id"] = stable_id(
+        "tinker-sft-result",
+        {"run_id": result["run_id"], "model_sha256": model_sha256},
+    )
+    result_path.write_bytes(canonical_json_bytes(result) + b"\n")
+
+    with pytest.raises(TinkerSFTResumeError, match="frozen schedule"):
+        _run(fixture, output_dir, backend)
+    assert backend.open_resume_paths == [None]
 
 
 def test_provider_token_url_is_rejected_before_checkpoint_persistence(tmp_path: Path) -> None:

--- a/wmo/simulation/package_layout_test.py
+++ b/wmo/simulation/package_layout_test.py
@@ -13,7 +13,6 @@ def test_simulation_domains_are_nested() -> None:
         "ingest",
         "model",
         "retrieval",
-        "scenarios",
         "serving",
     }
     missing_dirs = sorted(name for name in expected_dirs if not (SIMULATION_DIR / name).is_dir())


### PR DESCRIPTION
Restacks the approved W13 offline Tinker SFT runner onto W8. The W13 patch range is unchanged from reviewed commit 0af2dace80ce2644eda65ce5b03dcf256c49d5c2. Includes one required W1 bookkeeping deletion for the obsolete simulation scenarios directory requirement. Validation: offline W12/W13 and W8 artifact suites, exact CI guard suite, full Ruff and ty, CLI help, and wheel smoke all pass. The known full pytest failures are byte-identical W8-base CLI seams and are intentionally not changed.