### PR TITLE
W7: local review workbench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ state, not a permanent exemption, and must be empty by the final release audit.
    not return domain packages or production modules to the flat `wmo/` namespace.
 
 5. **The top level is a closed allowlist.** The tracked top-level directories are exactly: `wmo/`,
-   `docs/`, `assets/`, `.claude/`, `.github/`. That list is closed.
+   `docs/`, `assets/`, `web/`, `.claude/`, `.github/`. That list is closed.
 
    `.agents/` is the one sanctioned scratchpad: a local, gitignored working directory for agent
    sessions (notes, probe scripts, run outputs). It is never tracked, never part of a PR, and
@@ -226,6 +226,8 @@ state, not a permanent exemption, and must be empty by the final release audit.
      area under the rule 4 hierarchy. `wmo/common/vendor/` holds self-contained building blocks
      with no import back into WMO product domains, including the waterfall chain and its MIT
      `LICENSE`.
+   - `web/` is the local-only TypeScript review workbench. It proxies only to the loopback WMO
+     review adapter and must not add provider, credential, tenant, or deployment integrations.
    - `assets/` — media referenced by README/docs (demo GIFs, logos).
    - `.claude/` — checked-in agent skills (e.g. `/ready-for-merge`); local files
      (`settings.local.json`, locks) stay gitignored.

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+coverage/
+*.tsbuildinfo

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes: APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev`; verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,69 @@
+@import "tailwindcss";
+@config "../tailwind.config.ts";
+
+:root {
+  --background: #fafafa;
+  --foreground: #0a0a0a;
+  --surface: #ffffff;
+  --surface-subtle: #f5f5f5;
+  --ink: #0a0a0a;
+  --muted: #737373;
+  --muted-2: #a3a3a3;
+  --line: #ededed;
+  --line-strong: #e0e0e0;
+  --success: #22a050;
+  --success-soft: #f0fdf4;
+  --danger: #dc3c3c;
+  --danger-soft: #fef2f2;
+  --warning: #b45309;
+  --warning-soft: #fff9ea;
+  --purple: #7850c8;
+  --purple-soft: #faf5ff;
+  --accent: #6366f1;
+  --hover: #efefef;
+  --active: #f1f1f1;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--ink);
+  font-family: var(--font-geist-sans), system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { Geist, Geist_Mono } from "next/font/google";
+
+import "./globals.css";
+
+const geistSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist-sans",
+  display: "swap"
+});
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+  display: "swap"
+});
+
+export const metadata: Metadata = {
+  title: "WMO local review",
+  description: "Review representative tasks, rubrics, and judge calibration locally."
+};
+
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+      <body className="flex min-h-dvh w-full flex-col bg-background">{children}</body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { ReviewWorkbench } from "@/components/review-workbench";
+
+export default function ReviewPage() {
+  return <ReviewWorkbench />;
+}

--- a/web/app/review-api/[...path]/route.ts
+++ b/web/app/review-api/[...path]/route.ts
@@ -1,0 +1,27 @@
+import { LocalProxyError, proxyLocalReview } from "@/lib/review-proxy";
+
+type RouteContext = { params: Promise<{ path: string[] }> };
+
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
+  return handle(request, context, "GET");
+}
+
+export async function POST(request: Request, context: RouteContext): Promise<Response> {
+  return handle(request, context, "POST");
+}
+
+async function handle(
+  request: Request,
+  context: RouteContext,
+  method: "GET" | "POST"
+): Promise<Response> {
+  try {
+    const { path } = await context.params;
+    return await proxyLocalReview(request, path, method);
+  } catch (reason) {
+    if (reason instanceof LocalProxyError) {
+      return Response.json({ detail: reason.message }, { status: 400 });
+    }
+    return Response.json({ detail: "The local review adapter is unavailable." }, { status: 502 });
+  }
+}

--- a/web/components/calibration-review.tsx
+++ b/web/components/calibration-review.tsx
@@ -1,0 +1,178 @@
+import { AlertTriangle, BarChart3, CheckCircle2, History } from "lucide-react";
+
+import { Card, Chip, EmptyState } from "@/components/ui";
+import type { CalibrationReport, HumanScore, RubricDimension } from "@/lib/review-types";
+
+export function CalibrationReview({
+  dimensions,
+  reports,
+  scores
+}: {
+  dimensions: RubricDimension[];
+  reports: CalibrationReport[];
+  scores: HumanScore[];
+}) {
+  const latest = reports.at(-1);
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Calibration review</p>
+            <h2 className="mb-0 mt-2 text-xl font-semibold tracking-tight text-ink">Review disagreement before trusting a judge</h2>
+            <p className="mb-0 mt-2 max-w-2xl text-sm leading-relaxed text-muted">
+              Human score corrections remain append-only. When an eligible local report exists, the adapter
+              rebuilds it from its frozen split and verified observations.
+            </p>
+          </div>
+          <Chip label={`${scores.length} score events`} tone={scores.length === 0 ? "neutral" : "purple"} />
+        </div>
+      </Card>
+
+      {latest ? (
+        <>
+          <Metrics report={latest} dimensions={dimensions} />
+          <Disagreements report={latest} dimensions={dimensions} />
+        </>
+      ) : (
+        <EmptyState
+          body="Finalize a rubric, attach judged rollout evidence, and record local human scores. A calibration report appears only when W6 has a verified frozen split."
+          title="No calibration report yet"
+        />
+      )}
+      <ScoreHistory scores={scores} />
+    </div>
+  );
+}
+
+function Metrics({ dimensions, report }: { dimensions: RubricDimension[]; report: CalibrationReport }) {
+  const tone =
+    report.status === "ready_for_approval"
+      ? "success"
+      : report.status === "insufficient"
+        ? "warning"
+        : "purple";
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <BarChart3 aria-hidden="true" className="size-4 text-muted" />
+          <h3 className="m-0 text-sm font-semibold text-ink">Latest local calibration</h3>
+        </div>
+        <Chip label={report.status.replaceAll("_", " ")} tone={tone} />
+      </div>
+      <dl className="mt-4 grid gap-4 border-y border-line py-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Metric label="Eligible labels" value={String(report.eligible_label_count)} />
+        <Metric label="Recommended labels" value={String(report.recommended_label_count)} />
+        <Metric label="Report" value={report.report_id} />
+      </dl>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full min-w-[560px] border-separate border-spacing-0 text-left text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-[0.08em] text-muted">
+              <th className="border-b border-line pb-3 font-medium">Dimension</th>
+              <th className="border-b border-line pb-3 font-medium">MAE</th>
+              <th className="border-b border-line pb-3 font-medium">Rank agreement</th>
+              <th className="border-b border-line pb-3 font-medium">Mean optimistic error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.dimension_metrics.map((metric) => (
+              <tr key={metric.dimension_id}>
+                <td className="border-b border-line py-3 text-[#363636]">
+                  {dimensions.find((item) => item.dimension_id === metric.dimension_id)?.name ?? metric.dimension_id}
+                </td>
+                <td className="border-b border-line py-3 font-mono text-muted">{metricValue(metric.mae)}</td>
+                <td className="border-b border-line py-3 font-mono text-muted">{metricValue(metric.rank_agreement)}</td>
+                <td className="border-b border-line py-3 font-mono text-muted">
+                  {metricValue(metric.mean_optimistic_error)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+function Disagreements({ dimensions, report }: { dimensions: RubricDimension[]; report: CalibrationReport }) {
+  return (
+    <Card>
+      <div className="flex items-center gap-2">
+        <AlertTriangle aria-hidden="true" className="size-4 text-warning" />
+        <h3 className="m-0 text-sm font-semibold text-ink">Worst disagreements</h3>
+      </div>
+      {report.worst_disagreements.length === 0 ? (
+        <p className="mb-0 mt-3 text-sm text-muted">No disagreement rows were stored in this report.</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {report.worst_disagreements.map((item) => {
+            const prediction = item.prediction;
+            const name = dimensions.find((dimension) => dimension.dimension_id === prediction.dimension_id)?.name;
+            return (
+              <article className="rounded-[var(--radius-md)] bg-warning-soft p-4" key={`${prediction.rollout_id}-${prediction.dimension_id}`}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="m-0 text-sm font-semibold text-[#363636]">{name ?? prediction.dimension_id}</p>
+                    <p className="mb-0 mt-1 font-mono text-xs text-muted">
+                      rollout {prediction.rollout_id} · lineage {prediction.lineage_id}
+                    </p>
+                  </div>
+                  <Chip label={item.direction} tone="warning" />
+                </div>
+                <div className="mt-3 grid gap-3 text-sm sm:grid-cols-4">
+                  <Metric label="Judge raw" value={String(prediction.raw_score)} />
+                  <Metric label="Human" value={String(prediction.human_score)} />
+                  <Metric label="Calibrated" value={prediction.calibrated_score.toFixed(1)} />
+                  <Metric label="Absolute error" value={prediction.absolute_error.toFixed(1)} />
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ScoreHistory({ scores }: { scores: HumanScore[] }) {
+  return (
+    <Card>
+      <div className="flex items-center gap-2">
+        <History aria-hidden="true" className="size-4 text-muted" />
+        <h3 className="m-0 text-sm font-semibold text-ink">Local score history</h3>
+      </div>
+      {scores.length === 0 ? (
+        <p className="mb-0 mt-3 text-sm text-muted">No human score corrections have been recorded.</p>
+      ) : (
+        <ol className="mt-4 space-y-2">
+          {scores.map((score) => (
+            <li className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-md)] bg-surface-subtle px-3 py-2" key={score.label_id}>
+              <span className="text-sm text-[#474747]">
+                {score.rollout_id} · {score.dimension_id}
+              </span>
+              <span className="flex items-center gap-2 font-mono text-xs text-muted">
+                {score.supersedes_label_id ? <CheckCircle2 aria-label="Correction" className="size-3 text-success" /> : null}
+                score {score.score}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Card>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[11px] uppercase tracking-[0.09em] text-muted">{label}</dt>
+      <dd className="mb-0 mt-1 break-words text-sm font-medium text-[#363636]">{value}</dd>
+    </div>
+  );
+}
+
+function metricValue(value: number | null): string {
+  return value === null ? "Not available" : value.toFixed(2);
+}

--- a/web/components/calibration-review.tsx
+++ b/web/components/calibration-review.tsx
@@ -1,18 +1,39 @@
 import { AlertTriangle, BarChart3, CheckCircle2, History } from "lucide-react";
+import { useState } from "react";
 
-import { Card, Chip, EmptyState } from "@/components/ui";
-import type { CalibrationReport, HumanScore, RubricDimension } from "@/lib/review-types";
+import { Button, Card, Chip, Dialog, EmptyState } from "@/components/ui";
+import type {
+  CalibrationApproval,
+  CalibrationReport,
+  HumanScore,
+  JudgeCalibration,
+  RubricDimension
+} from "@/lib/review-types";
 
 export function CalibrationReview({
+  busy,
+  calibrations,
   dimensions,
+  onApprove,
   reports,
   scores
 }: {
+  busy: boolean;
+  calibrations: JudgeCalibration[];
   dimensions: RubricDimension[];
+  onApprove: (reportId: string, approval: CalibrationApproval) => void;
   reports: CalibrationReport[];
   scores: HumanScore[];
 }) {
   const latest = reports.at(-1);
+  const approved = latest
+    ? calibrations.find(
+        (item) =>
+          item.out_of_fold_report_id === latest.report_id && item.status === "human_calibrated"
+      )
+    : undefined;
+  const [confirming, setConfirming] = useState(false);
+  const [acceptingRisk, setAcceptingRisk] = useState(false);
   return (
     <div className="space-y-4">
       <Card>
@@ -33,6 +54,12 @@ export function CalibrationReview({
         <>
           <Metrics report={latest} dimensions={dimensions} />
           <Disagreements report={latest} dimensions={dimensions} />
+          <ApprovalCard
+            approved={approved}
+            busy={busy}
+            onReview={() => setConfirming(true)}
+            report={latest}
+          />
         </>
       ) : (
         <EmptyState
@@ -41,7 +68,96 @@ export function CalibrationReview({
         />
       )}
       <ScoreHistory scores={scores} />
+      {latest && confirming ? (
+        <Dialog onClose={() => setConfirming(false)} title="Approve this judge calibration?">
+          <p className="mt-0 text-sm leading-relaxed text-muted">
+            This writes a human-calibrated judge artifact bound to report {latest.report_id}.
+            Approval cannot be inferred from viewing the report.
+          </p>
+          {latest.status === "insufficient" ? (
+            <label className="mt-4 flex items-start gap-3 rounded-[var(--radius-md)] bg-warning-soft p-3 text-sm text-warning">
+              <input
+                checked={acceptingRisk}
+                className="mt-0.5"
+                onChange={(event) => setAcceptingRisk(event.target.checked)}
+                type="checkbox"
+              />
+              I explicitly accept the calibration risk from fewer than ten eligible rollouts.
+            </label>
+          ) : null}
+          <div className="mt-5 flex justify-end gap-2">
+            <Button onClick={() => setConfirming(false)} type="button">
+              Cancel
+            </Button>
+            <Button
+              disabled={busy || (latest.status === "insufficient" && !acceptingRisk)}
+              onClick={() => {
+                onApprove(latest.report_id, {
+                  confirmed: true,
+                  accept_insufficient_risk: latest.status === "insufficient" && acceptingRisk
+                });
+                setConfirming(false);
+              }}
+              type="button"
+              variant="primary"
+            >
+              Confirm calibration approval
+            </Button>
+          </div>
+        </Dialog>
+      ) : null}
     </div>
+  );
+}
+
+function ApprovalCard({
+  approved,
+  busy,
+  onReview,
+  report
+}: {
+  approved?: JudgeCalibration;
+  busy: boolean;
+  onReview: () => void;
+  report: CalibrationReport;
+}) {
+  if (approved) {
+    return (
+      <Card>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="m-0 text-sm font-semibold text-ink">Human-calibrated artifact</h3>
+            <p className="mb-0 mt-2 break-all font-mono text-xs text-muted">
+              {approved.calibration_id}
+            </p>
+          </div>
+          <Chip label="human calibrated" tone="success" />
+        </div>
+        {approved.risk_acceptance ? (
+          <p className="mb-0 mt-3 text-sm text-warning">
+            Low-sample risk acceptance: {approved.risk_acceptance.artifact_id}
+          </p>
+        ) : null}
+      </Card>
+    );
+  }
+  const approvable = report.status === "ready_for_approval" || report.status === "insufficient";
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h3 className="m-0 text-sm font-semibold text-ink">Calibration approval</h3>
+          <p className="mb-0 mt-1 text-sm text-muted">
+            {approvable
+              ? "Review the exact persisted report before writing a human-calibrated artifact."
+              : "A provisional zero-label report cannot be human approved."}
+          </p>
+        </div>
+        <Button disabled={busy || !approvable} onClick={onReview} type="button" variant="primary">
+          {report.status === "insufficient" ? "Review low-sample approval" : "Approve calibration"}
+        </Button>
+      </div>
+    </Card>
   );
 }
 

--- a/web/components/review-workbench.test.tsx
+++ b/web/components/review-workbench.test.tsx
@@ -138,6 +138,86 @@ describe("ReviewWorkbench", () => {
     );
   });
 
+  it("blocks background proposal shortcuts while a modal is open", async () => {
+    const mutateRubric = vi.fn(async () => draftReviewSnapshot);
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => draftReviewSnapshot),
+      mutateRubric,
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Rubric scales" }));
+    const proposal = screen.getByRole("article", { name: "Task success proposal" });
+    fireEvent.click(screen.getByRole("button", { name: "Design replacement set" }));
+    await screen.findByRole("dialog", { name: "Design the complete replacement set" });
+    fireEvent.keyDown(proposal, { key: "a" });
+
+    expect(mutateRubric).not.toHaveBeenCalled();
+  });
+
+  it("dismisses rubric finalization with Escape without finalizing", async () => {
+    const snapshot: ReviewSnapshot = {
+      ...draftReviewSnapshot,
+      rubric_review: {
+        ...draftReviewSnapshot.rubric_review,
+        dimensions: [taskSuccessDimension]
+      }
+    };
+    const mutateRubric = vi.fn(async () => snapshot);
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => snapshot),
+      mutateRubric,
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Rubric scales" }));
+    const finalize = screen.getByRole("button", { name: "Finalize rubric" });
+    finalize.focus();
+    fireEvent.click(finalize);
+    fireEvent.keyDown(screen.getByRole("dialog", { name: "Finalize this rubric?" }), {
+      key: "Escape"
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(finalize).toHaveFocus();
+    expect(mutateRubric).not.toHaveBeenCalled();
+  });
+
+  it("disables reorder controls at the first and last boundaries", async () => {
+    const snapshot: ReviewSnapshot = {
+      ...draftReviewSnapshot,
+      rubric_review: {
+        ...draftReviewSnapshot.rubric_review,
+        dimensions: [taskSuccessDimension, clarityDimension]
+      }
+    };
+    const mutateRubric = vi.fn(async () => snapshot);
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => snapshot),
+      mutateRubric,
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Rubric scales" }));
+
+    expect(screen.getByRole("button", { name: "Move Task success up" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move Task success down" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Move Customer clarity up" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Move Customer clarity down" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Move Task success up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move Customer clarity down" }));
+    expect(mutateRubric).not.toHaveBeenCalled();
+  });
+
   it("requires low-sample risk confirmation and renders the written calibration", async () => {
     const insufficientSnapshot: ReviewSnapshot = {
       ...finalizedReviewSnapshot,
@@ -186,6 +266,36 @@ describe("ReviewWorkbench", () => {
     );
     expect(await screen.findByText("Human-calibrated artifact")).toBeInTheDocument();
     expect(screen.getByText(/risk-fixture/)).toBeInTheDocument();
+  });
+
+  it("dismisses calibration approval with Escape without approving", async () => {
+    const insufficientSnapshot: ReviewSnapshot = {
+      ...finalizedReviewSnapshot,
+      calibration_reports: finalizedReviewSnapshot.calibration_reports.map((report) => ({
+        ...report,
+        status: "insufficient"
+      }))
+    };
+    const approveCalibration = vi.fn();
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => insufficientSnapshot),
+      mutateRubric: vi.fn(),
+      overrideScore: vi.fn(),
+      approveCalibration
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Calibration" }));
+    const reviewApproval = screen.getByRole("button", { name: "Review low-sample approval" });
+    reviewApproval.focus();
+    fireEvent.click(reviewApproval);
+    const dialog = screen.getByRole("dialog", { name: "Approve this judge calibration?" });
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(reviewApproval).toHaveFocus();
+    expect(approveCalibration).not.toHaveBeenCalled();
   });
 });
 

--- a/web/components/review-workbench.test.tsx
+++ b/web/components/review-workbench.test.tsx
@@ -73,7 +73,8 @@ describe("ReviewWorkbench", () => {
         rollout_id: "rollout-refund",
         lineage_id: "lineage-refund",
         dimension_id: "task-success",
-        score: 4
+        score: 4,
+        submission_id: expect.any(String)
       })
     );
     expect(await screen.findByText("Score saved locally.")).toBeInTheDocument();

--- a/web/components/review-workbench.test.tsx
+++ b/web/components/review-workbench.test.tsx
@@ -6,6 +6,13 @@ import { draftReviewSnapshot, finalizedReviewSnapshot, taskSuccessDimension } fr
 import type { ReviewApi } from "@/lib/review-api";
 import type { ReviewMutationResponse, ReviewSnapshot } from "@/lib/review-types";
 
+const clarityDimension = {
+  ...taskSuccessDimension,
+  dimension_id: "customer-clarity",
+  name: "Customer clarity",
+  description: "Whether the response gives the customer a clear next step."
+};
+
 describe("ReviewWorkbench", () => {
   afterEach(() => cleanup());
 
@@ -26,7 +33,8 @@ describe("ReviewWorkbench", () => {
     const api: ReviewApi = {
       getSnapshot: vi.fn(async () => state),
       mutateRubric,
-      overrideScore: vi.fn()
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
     };
 
     render(<ReviewWorkbench api={api} />);
@@ -51,7 +59,8 @@ describe("ReviewWorkbench", () => {
     const api: ReviewApi = {
       getSnapshot: vi.fn(async () => finalizedReviewSnapshot),
       mutateRubric: vi.fn(),
-      overrideScore
+      overrideScore,
+      approveCalibration: vi.fn()
     };
 
     render(<ReviewWorkbench api={api} />);
@@ -74,7 +83,8 @@ describe("ReviewWorkbench", () => {
     const api: ReviewApi = {
       getSnapshot: vi.fn(async () => draftReviewSnapshot),
       mutateRubric: vi.fn(),
-      overrideScore: vi.fn()
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
     };
 
     render(<ReviewWorkbench api={api} />);
@@ -85,6 +95,97 @@ describe("ReviewWorkbench", () => {
     expect(screen.getByRole("option", { selected: true })).toHaveTextContent(
       "Explain a delayed shipment and give the customer a verified next step."
     );
+  });
+
+  it("submits the exact selected complete replacement set", async () => {
+    const snapshot: ReviewSnapshot = {
+      ...draftReviewSnapshot,
+      rubric_review: {
+        ...draftReviewSnapshot.rubric_review,
+        dimensions: [taskSuccessDimension],
+        proposals: [
+          {
+            ...draftReviewSnapshot.rubric_review.proposals[0],
+            dimensions: [
+              {
+                ...draftReviewSnapshot.rubric_review.proposals[0].dimensions[0],
+                dimension: clarityDimension
+              }
+            ]
+          }
+        ]
+      }
+    };
+    const mutateRubric = vi.fn(async () => snapshot);
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => snapshot),
+      mutateRubric,
+      overrideScore: vi.fn(),
+      approveCalibration: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Rubric scales" }));
+    fireEvent.click(screen.getByRole("button", { name: "Design replacement set" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Customer clarity/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Replace all scales" }));
+
+    await waitFor(() =>
+      expect(mutateRubric).toHaveBeenCalledWith("replace_all", {
+        dimensions: [clarityDimension]
+      })
+    );
+  });
+
+  it("requires low-sample risk confirmation and renders the written calibration", async () => {
+    const insufficientSnapshot: ReviewSnapshot = {
+      ...finalizedReviewSnapshot,
+      calibration_reports: finalizedReviewSnapshot.calibration_reports.map((report) => ({
+        ...report,
+        status: "insufficient"
+      }))
+    };
+    const approvedSnapshot: ReviewSnapshot = {
+      ...insufficientSnapshot,
+      calibrations: [
+        {
+          calibration_id: "human-calibration-fixture",
+          rubric_id: "rubric-fixture",
+          out_of_fold_report_id: "calibration-fixture",
+          label_count: 2,
+          recommended_label_count: 8,
+          status: "human_calibrated",
+          approved_at: "2026-08-12T00:00:00Z",
+          risk_acceptance: { artifact_id: "risk-fixture", sha256: "a".repeat(64) }
+        }
+      ]
+    };
+    const approveCalibration = vi.fn(async () => scoreResponse(approvedSnapshot));
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => insufficientSnapshot),
+      mutateRubric: vi.fn(),
+      overrideScore: vi.fn(),
+      approveCalibration
+    };
+
+    render(<ReviewWorkbench api={api} />);
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Calibration" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review low-sample approval" }));
+    const confirm = screen.getByRole("button", { name: "Confirm calibration approval" });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(screen.getByRole("checkbox", { name: /explicitly accept/ }));
+    fireEvent.click(confirm);
+
+    await waitFor(() =>
+      expect(approveCalibration).toHaveBeenCalledWith("calibration-fixture", {
+        confirmed: true,
+        accept_insufficient_risk: true
+      })
+    );
+    expect(await screen.findByText("Human-calibrated artifact")).toBeInTheDocument();
+    expect(screen.getByText(/risk-fixture/)).toBeInTheDocument();
   });
 });
 

--- a/web/components/review-workbench.test.tsx
+++ b/web/components/review-workbench.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ReviewWorkbench } from "@/components/review-workbench";
+import { draftReviewSnapshot, finalizedReviewSnapshot, taskSuccessDimension } from "@/lib/review-fixture";
+import type { ReviewApi } from "@/lib/review-api";
+import type { ReviewMutationResponse, ReviewSnapshot } from "@/lib/review-types";
+
+describe("ReviewWorkbench", () => {
+  afterEach(() => cleanup());
+
+  it("delegates proposal acceptance and confirmed finalization to the local adapter", async () => {
+    let state = draftReviewSnapshot;
+    const mutateRubric = vi.fn(async (action: string) => {
+      if (action === "accept") {
+        state = {
+          ...state,
+          rubric_review: { ...state.rubric_review, dimensions: [taskSuccessDimension] }
+        };
+      }
+      if (action === "finalize") {
+        state = finalizedReviewSnapshot;
+      }
+      return state;
+    });
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => state),
+      mutateRubric,
+      overrideScore: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+
+    await screen.findAllByText("Resolve a customer refund request after a duplicate subscription charge.");
+    fireEvent.click(screen.getByRole("button", { name: "Rubric scales" }));
+    fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() =>
+      expect(mutateRubric).toHaveBeenCalledWith("accept", { dimension_id: "task-success" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Finalize rubric" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Finalize this rubric?");
+    fireEvent.click(screen.getByRole("button", { name: "Confirm finalization" }));
+
+    await waitFor(() => expect(mutateRubric).toHaveBeenCalledWith("finalize", { confirmed: true }));
+    expect(await screen.findByText("Finalized scales")).toBeInTheDocument();
+  });
+
+  it("records a zero-to-five score override against selected rollout evidence", async () => {
+    const overrideScore = vi.fn(async () => scoreResponse(finalizedReviewSnapshot));
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => finalizedReviewSnapshot),
+      mutateRubric: vi.fn(),
+      overrideScore
+    };
+
+    render(<ReviewWorkbench api={api} />);
+
+    await screen.findByText("Rollout evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Set Task success score to 4" }));
+
+    await waitFor(() =>
+      expect(overrideScore).toHaveBeenCalledWith({
+        rollout_id: "rollout-refund",
+        lineage_id: "lineage-refund",
+        dimension_id: "task-success",
+        score: 4
+      })
+    );
+    expect(await screen.findByText("Score saved locally.")).toBeInTheDocument();
+  });
+
+  it("moves selected tasks with keyboard arrows outside an input", async () => {
+    const api: ReviewApi = {
+      getSnapshot: vi.fn(async () => draftReviewSnapshot),
+      mutateRubric: vi.fn(),
+      overrideScore: vi.fn()
+    };
+
+    render(<ReviewWorkbench api={api} />);
+
+    await screen.findAllByText("Resolve a customer refund request after a duplicate subscription charge.");
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+
+    expect(screen.getByRole("option", { selected: true })).toHaveTextContent(
+      "Explain a delayed shipment and give the customer a verified next step."
+    );
+  });
+});
+
+function scoreResponse(snapshot: ReviewSnapshot): ReviewMutationResponse {
+  return { notice: "Score saved locally.", snapshot };
+}

--- a/web/components/review-workbench.tsx
+++ b/web/components/review-workbench.tsx
@@ -8,7 +8,12 @@ import { RubricReview } from "@/components/rubric-review";
 import { TaskReview } from "@/components/task-review";
 import { Button, Card, Chip, EmptyState } from "@/components/ui";
 import { localReviewApi, type ReviewApi } from "@/lib/review-api";
-import type { ReviewSnapshot, RubricAction, ScoreOverride } from "@/lib/review-types";
+import type {
+  CalibrationApproval,
+  ReviewSnapshot,
+  RubricAction,
+  ScoreOverride
+} from "@/lib/review-types";
 
 type ReviewTab = "tasks" | "rubric" | "calibration";
 
@@ -91,6 +96,14 @@ export function ReviewWorkbench({ api = localReviewApi }: { api?: ReviewApi }) {
     });
   };
 
+  const approveCalibration = (reportId: string, input: CalibrationApproval) => {
+    void perform(async () => {
+      const response = await api.approveCalibration(reportId, input);
+      setSnapshot(response.snapshot);
+      setNotice(response.notice);
+    });
+  };
+
   async function perform(operation: () => Promise<void>) {
     setBusy(true);
     setError("");
@@ -165,7 +178,10 @@ export function ReviewWorkbench({ api = localReviewApi }: { api?: ReviewApi }) {
         ) : null}
         {snapshot && tab === "calibration" ? (
           <CalibrationReview
+            busy={busy}
+            calibrations={snapshot.calibrations}
             dimensions={activeDimensions}
+            onApprove={approveCalibration}
             reports={snapshot.calibration_reports}
             scores={snapshot.human_score_history.scores}
           />

--- a/web/components/review-workbench.tsx
+++ b/web/components/review-workbench.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { ChevronRight, Database, Gauge, ListChecks, RefreshCw, Scale } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { CalibrationReview } from "@/components/calibration-review";
+import { RubricReview } from "@/components/rubric-review";
+import { TaskReview } from "@/components/task-review";
+import { Button, Card, Chip, EmptyState } from "@/components/ui";
+import { localReviewApi, type ReviewApi } from "@/lib/review-api";
+import type { ReviewSnapshot, RubricAction, ScoreOverride } from "@/lib/review-types";
+
+type ReviewTab = "tasks" | "rubric" | "calibration";
+
+const tabs: Array<{ id: ReviewTab; label: string; icon: typeof ListChecks }> = [
+  { id: "tasks", label: "Task review", icon: ListChecks },
+  { id: "rubric", label: "Rubric scales", icon: Scale },
+  { id: "calibration", label: "Calibration", icon: Gauge }
+];
+
+export function ReviewWorkbench({ api = localReviewApi }: { api?: ReviewApi }) {
+  const [snapshot, setSnapshot] = useState<ReviewSnapshot | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState("");
+  const [tab, setTab] = useState<ReviewTab>("tasks");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setBusy(true);
+    setError("");
+    try {
+      const next = await api.getSnapshot();
+      setSnapshot(next);
+      setSelectedTaskId((current) => current || next.task_set.tasks[0]?.task_id || "");
+    } catch (reason) {
+      setError(messageFor(reason));
+    } finally {
+      setBusy(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (tab !== "tasks" || !snapshot) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        ["INPUT", "TEXTAREA", "SELECT", "BUTTON"].includes(target.tagName)
+      ) {
+        return;
+      }
+      const currentIndex = snapshot.task_set.tasks.findIndex((task) => task.task_id === selectedTaskId);
+      if (event.key === "ArrowDown" && currentIndex < snapshot.task_set.tasks.length - 1) {
+        event.preventDefault();
+        setSelectedTaskId(snapshot.task_set.tasks[currentIndex + 1].task_id);
+      }
+      if (event.key === "ArrowUp" && currentIndex > 0) {
+        event.preventDefault();
+        setSelectedTaskId(snapshot.task_set.tasks[currentIndex - 1].task_id);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selectedTaskId, snapshot, tab]);
+
+  const activeDimensions = useMemo(
+    () => snapshot?.rubric_review.finalized_rubric?.dimensions ?? snapshot?.rubric_review.dimensions ?? [],
+    [snapshot]
+  );
+
+  const mutateRubric = (action: RubricAction, payload: Record<string, unknown>) => {
+    void perform(async () => {
+      const next = await api.mutateRubric(action, payload);
+      setSnapshot(next);
+      setNotice(action === "finalize" ? "Rubric finalized locally." : "Rubric draft saved locally.");
+    });
+  };
+
+  const overrideScore = (input: ScoreOverride) => {
+    void perform(async () => {
+      const response = await api.overrideScore(input);
+      setSnapshot(response.snapshot);
+      setNotice(response.notice);
+    });
+  };
+
+  async function perform(operation: () => Promise<void>) {
+    setBusy(true);
+    setError("");
+    try {
+      await operation();
+    } catch (reason) {
+      setError(messageFor(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen max-w-[1440px] px-4 py-5 sm:px-6 lg:px-8">
+      <Header busy={busy} notice={notice} onRefresh={() => void refresh()} snapshot={snapshot} />
+      <nav aria-label="Local review sections" className="mt-5 flex overflow-x-auto border-b border-line">
+        {tabs.map((item) => {
+          const Icon = item.icon;
+          const selected = tab === item.id;
+          return (
+            <button
+              aria-current={selected ? "page" : undefined}
+              className={`inline-flex shrink-0 items-center gap-2 border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                selected
+                  ? "border-ink text-ink"
+                  : "border-transparent text-muted hover:border-line-strong hover:text-ink"
+              }`}
+              key={item.id}
+              onClick={() => setTab(item.id)}
+              type="button"
+            >
+              <Icon aria-hidden="true" className="size-4" />
+              {item.label}
+            </button>
+          );
+        })}
+      </nav>
+      {error ? (
+        <div className="mt-4 rounded-[var(--radius-md)] border border-danger bg-danger-soft px-4 py-3 text-sm text-danger" role="alert">
+          {error}
+        </div>
+      ) : null}
+      <section className="mt-5" aria-live="polite">
+        {!snapshot && busy ? <LoadingState /> : null}
+        {!snapshot && !busy ? (
+          <EmptyState
+            body="Start local review with npm run review after wmo build has created the project artifacts."
+            title="Local review could not load"
+          />
+        ) : null}
+        {snapshot && tab === "tasks" ? (
+          <TaskReview
+            activeDimensions={activeDimensions}
+            coverage={snapshot.coverage?.selections ?? []}
+            humanScores={snapshot.human_score_history.scores}
+            onScore={({ dimensionId, lineageId, rolloutId, score }) =>
+              overrideScore({
+                dimension_id: dimensionId,
+                lineage_id: lineageId,
+                rollout_id: rolloutId,
+                score
+              })
+            }
+            onSelectTask={setSelectedTaskId}
+            rollouts={snapshot.rollouts}
+            selectedTaskId={selectedTaskId}
+            tasks={snapshot.task_set.tasks}
+          />
+        ) : null}
+        {snapshot && tab === "rubric" ? (
+          <RubricReview busy={busy} onMutation={mutateRubric} snapshot={snapshot} />
+        ) : null}
+        {snapshot && tab === "calibration" ? (
+          <CalibrationReview
+            dimensions={activeDimensions}
+            reports={snapshot.calibration_reports}
+            scores={snapshot.human_score_history.scores}
+          />
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+function Header({
+  busy,
+  notice,
+  onRefresh,
+  snapshot
+}: {
+  busy: boolean;
+  notice: string;
+  onRefresh: () => void;
+  snapshot: ReviewSnapshot | null;
+}) {
+  return (
+    <Card className="bg-surface p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-5">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Chip label="Local only" tone="purple" />
+            <span className="font-mono text-xs text-muted">{snapshot?.project_id ?? "loading project"}</span>
+          </div>
+          <h1 className="mb-0 mt-3 text-2xl font-semibold tracking-tight text-ink sm:text-3xl">Judgment review</h1>
+          <p className="mb-0 mt-2 max-w-3xl text-sm leading-relaxed text-muted">
+            Inspect selected tasks, rollout evidence, rubric scales, and judge disagreement without leaving
+            this machine.
+          </p>
+        </div>
+        <Button disabled={busy} onClick={onRefresh} type="button">
+          <RefreshCw aria-hidden="true" className={`size-4 ${busy ? "animate-spin" : ""}`} />
+          Refresh local data
+        </Button>
+      </div>
+      <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-line pt-4 text-sm text-muted">
+        <Database aria-hidden="true" className="size-4" />
+        <span>{snapshot?.local_data_notice ?? "Reading only the local project store."}</span>
+      </div>
+      {notice ? (
+        <div className="mt-3 flex items-center gap-2 rounded-[var(--radius-md)] bg-success-soft px-3 py-2 text-sm text-success">
+          <ChevronRight aria-hidden="true" className="size-4" />
+          {notice}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="grid min-h-[340px] place-items-center">
+      <div className="text-center">
+        <div className="mx-auto size-7 animate-spin rounded-full border-2 border-line-strong border-t-ink" />
+        <p className="mb-0 mt-3 text-sm text-muted">Reading local review artifacts…</p>
+      </div>
+    </div>
+  );
+}
+
+function messageFor(reason: unknown): string {
+  return reason instanceof Error ? reason.message : "The local review adapter returned an unknown error.";
+}

--- a/web/components/review-workbench.tsx
+++ b/web/components/review-workbench.tsx
@@ -164,7 +164,8 @@ export function ReviewWorkbench({ api = localReviewApi }: { api?: ReviewApi }) {
                 dimension_id: dimensionId,
                 lineage_id: lineageId,
                 rollout_id: rolloutId,
-                score
+                score,
+                submission_id: crypto.randomUUID()
               })
             }
             onSelectTask={setSelectedTaskId}

--- a/web/components/rubric-review.tsx
+++ b/web/components/rubric-review.tsx
@@ -1,0 +1,449 @@
+import { Check, GripVertical, Pencil, Plus, Replace, ShieldCheck, X } from "lucide-react";
+import { useState, type FormEvent } from "react";
+
+import { Button, Card, Chip, Dialog, EmptyState } from "@/components/ui";
+import type {
+  ProposedDimension,
+  ReviewSnapshot,
+  RubricAction,
+  RubricDimension,
+  Score,
+  ScoreAnchor
+} from "@/lib/review-types";
+
+type RubricReviewProps = {
+  busy: boolean;
+  onMutation: (action: RubricAction, payload: Record<string, unknown>) => void;
+  snapshot: ReviewSnapshot;
+};
+
+type EditingScale = {
+  initial?: RubricDimension;
+  proposalDimensionId?: string;
+};
+
+export function RubricReview({ busy, onMutation, snapshot }: RubricReviewProps) {
+  const { rubric_review: review } = snapshot;
+  const activeDimensions = review.finalized_rubric?.dimensions ?? review.dimensions;
+  const [editingScale, setEditingScale] = useState<EditingScale | null>(null);
+  const [confirmingFinalization, setConfirmingFinalization] = useState(false);
+  const [swipeStart, setSwipeStart] = useState<number | null>(null);
+
+  const mutate = (action: RubricAction, payload: Record<string, unknown>) => {
+    if (!busy) {
+      onMutation(action, payload);
+    }
+  };
+
+  const acceptedIds = new Set(activeDimensions.map((item) => item.dimension_id));
+  const rejectedIds = new Set(review.rejected_dimension_ids);
+  const finalized = review.status === "finalized";
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Rubric scale review</p>
+            <h2 className="mb-0 mt-2 text-xl font-semibold tracking-tight text-ink">Keep the judgment scale legible</h2>
+            <p className="mb-0 mt-2 max-w-2xl text-sm leading-relaxed text-muted">
+              Accept, reject, or edit model proposals before finalization. Every change is delegated to the
+              local W6 review draft.
+            </p>
+          </div>
+          <Chip label={finalized ? "human approved" : "draft"} tone={finalized ? "success" : "warning"} />
+        </div>
+        <div className="mt-5 flex flex-wrap gap-2 border-t border-line pt-4">
+          <Button disabled={busy || finalized} onClick={() => setEditingScale({})} type="button" variant="primary">
+            <Plus aria-hidden="true" className="size-4" />
+            Add scale
+          </Button>
+          <Button
+            disabled={busy || finalized || activeDimensions.length === 0}
+            onClick={() => mutate("replace_all", { dimensions: activeDimensions })}
+            type="button"
+          >
+            <Replace aria-hidden="true" className="size-4" />
+            Replace all with active scales
+          </Button>
+          <Button
+            disabled={busy || finalized || activeDimensions.length === 0}
+            onClick={() => setConfirmingFinalization(true)}
+            type="button"
+            variant="primary"
+          >
+            <ShieldCheck aria-hidden="true" className="size-4" />
+            Finalize rubric
+          </Button>
+        </div>
+      </Card>
+
+      <section aria-labelledby="proposals-heading">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="m-0 text-sm font-semibold text-ink" id="proposals-heading">
+            Proposed scales
+          </h2>
+          <p className="m-0 text-xs text-muted">Focus a card, then use A, R, or E.</p>
+        </div>
+        {review.proposals.length === 0 ? (
+          <EmptyState body="No proposal artifacts are available in this local project." title="No proposed scales" />
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {review.proposals.flatMap((proposal) =>
+              proposal.dimensions.map((proposed) => {
+                const dimensionId = proposed.dimension.dimension_id;
+                const accepted = acceptedIds.has(dimensionId);
+                const rejected = rejectedIds.has(dimensionId);
+                return (
+                  <ProposalCard
+                    accepted={accepted}
+                    busy={busy || finalized}
+                    key={`${proposal.proposal_id}-${dimensionId}`}
+                    onAccept={() => mutate("accept", { dimension_id: dimensionId })}
+                    onEdit={() => setEditingScale({ initial: proposed.dimension, proposalDimensionId: dimensionId })}
+                    onReject={() => mutate("reject", { dimension_id: dimensionId })}
+                    onSwipeEnd={(delta) => {
+                      if (delta > 48) {
+                        mutate("accept", { dimension_id: dimensionId });
+                      }
+                      if (delta < -48) {
+                        mutate("reject", { dimension_id: dimensionId });
+                      }
+                    }}
+                    onSwipeStart={setSwipeStart}
+                    proposed={proposed}
+                    rejected={rejected}
+                    swipeStart={swipeStart}
+                  />
+                );
+              })
+            )}
+          </div>
+        )}
+      </section>
+
+      <section aria-labelledby="active-scales-heading">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="m-0 text-sm font-semibold text-ink" id="active-scales-heading">
+            {finalized ? "Finalized scales" : "Active scales"}
+          </h2>
+          <span className="font-mono text-xs text-muted">{activeDimensions.length}</span>
+        </div>
+        {activeDimensions.length === 0 ? (
+          <EmptyState
+            body="Accept a proposal or add a human-authored scale. Finalization remains unavailable until at least one scale is active."
+            title="No active scales"
+          />
+        ) : (
+          <div className="space-y-3">
+            {activeDimensions.map((dimension, index) => (
+              <ActiveScaleCard
+                canEdit={!finalized && !busy}
+                dimension={dimension}
+                index={index}
+                key={dimension.dimension_id}
+                onEdit={() => setEditingScale({ initial: dimension, proposalDimensionId: dimension.dimension_id })}
+                onMove={(direction) => {
+                  const target = index + direction;
+                  if (target < 0 || target >= activeDimensions.length) {
+                    return;
+                  }
+                  const reordered = [...activeDimensions];
+                  [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+                  mutate("order", { dimension_ids: reordered.map((item) => item.dimension_id) });
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {editingScale ? (
+        <ScaleEditorDialog
+          initial={editingScale.initial}
+          onClose={() => setEditingScale(null)}
+          onSave={(dimension) => {
+            if (editingScale.proposalDimensionId) {
+              mutate("edit", {
+                dimension_id: editingScale.proposalDimensionId,
+                name: dimension.name,
+                description: dimension.description,
+                anchors: dimension.anchors
+              });
+            } else {
+              mutate("add", { dimension });
+            }
+            setEditingScale(null);
+          }}
+        />
+      ) : null}
+      {confirmingFinalization ? (
+        <Dialog onClose={() => setConfirmingFinalization(false)} title="Finalize this rubric?">
+          <p className="mt-0 text-sm leading-relaxed text-muted">
+            Finalization writes the immutable human-approved rubric. It cannot be reopened from this local
+            review flow.
+          </p>
+          <div className="mt-5 flex justify-end gap-2">
+            <Button onClick={() => setConfirmingFinalization(false)} type="button">
+              Keep editing
+            </Button>
+            <Button
+              onClick={() => {
+                mutate("finalize", { confirmed: true });
+                setConfirmingFinalization(false);
+              }}
+              type="button"
+              variant="primary"
+            >
+              Confirm finalization
+            </Button>
+          </div>
+        </Dialog>
+      ) : null}
+    </div>
+  );
+}
+
+function ProposalCard({
+  accepted,
+  busy,
+  onAccept,
+  onEdit,
+  onReject,
+  onSwipeEnd,
+  onSwipeStart,
+  proposed,
+  rejected,
+  swipeStart
+}: {
+  accepted: boolean;
+  busy: boolean;
+  onAccept: () => void;
+  onEdit: () => void;
+  onReject: () => void;
+  onSwipeEnd: (delta: number) => void;
+  onSwipeStart: (position: number | null) => void;
+  proposed: ProposedDimension;
+  rejected: boolean;
+  swipeStart: number | null;
+}) {
+  const status = accepted ? "accepted" : rejected ? "rejected" : "needs review";
+  const tone = accepted ? "success" : rejected ? "danger" : "warning";
+  return (
+    <Card className="relative overflow-hidden">
+      <article
+        aria-label={`${proposed.dimension.name} proposal`}
+        className="outline-none"
+        onKeyDown={(event) => {
+          if (event.currentTarget !== event.target || busy) {
+            return;
+          }
+          const command = event.key.toLowerCase();
+          if (command === "a") {
+            event.preventDefault();
+            onAccept();
+          }
+          if (command === "r") {
+            event.preventDefault();
+            onReject();
+          }
+          if (command === "e") {
+            event.preventDefault();
+            onEdit();
+          }
+        }}
+        onPointerDown={(event) => onSwipeStart(event.clientX)}
+        onPointerUp={(event) => {
+          if (swipeStart !== null) {
+            onSwipeEnd(event.clientX - swipeStart);
+          }
+          onSwipeStart(null);
+        }}
+        tabIndex={0}
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Proposal</p>
+            <h3 className="mb-0 mt-2 text-base font-semibold text-ink">{proposed.dimension.name}</h3>
+          </div>
+          <Chip label={status} tone={tone} />
+        </div>
+        <p className="mb-0 mt-3 text-sm leading-relaxed text-muted">{proposed.dimension.description}</p>
+        <AnchorList anchors={proposed.dimension.anchors} />
+        <p className="mb-0 mt-4 text-xs leading-relaxed text-muted">
+          Evidence: {proposed.source_rollout_ids.join(", ")} · spans {proposed.evidence_span_ids.join(", ")}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2 border-t border-line pt-4">
+          <Button disabled={busy || accepted || rejected} onClick={onAccept} type="button" variant="primary">
+            <Check aria-hidden="true" className="size-4" />
+            Accept
+          </Button>
+          <Button disabled={busy || accepted || rejected} onClick={onReject} type="button" variant="danger">
+            <X aria-hidden="true" className="size-4" />
+            Reject
+          </Button>
+          <Button disabled={busy || rejected} onClick={onEdit} type="button">
+            <Pencil aria-hidden="true" className="size-4" />
+            Edit
+          </Button>
+        </div>
+      </article>
+    </Card>
+  );
+}
+
+function ActiveScaleCard({
+  canEdit,
+  dimension,
+  index,
+  onEdit,
+  onMove
+}: {
+  canEdit: boolean;
+  dimension: RubricDimension;
+  index: number;
+  onEdit: () => void;
+  onMove: (direction: -1 | 1) => void;
+}) {
+  return (
+    <Card className="p-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex gap-3">
+          <GripVertical aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-muted-2" />
+          <div>
+            <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Scale {index + 1}</p>
+            <h3 className="mb-0 mt-1 text-base font-semibold text-ink">{dimension.name}</h3>
+            <p className="mb-0 mt-1 text-sm leading-relaxed text-muted">{dimension.description}</p>
+          </div>
+        </div>
+        {canEdit ? (
+          <div className="flex gap-2">
+            <Button aria-label={`Move ${dimension.name} up`} className="min-h-8 px-2" onClick={() => onMove(-1)} type="button">
+              ↑
+            </Button>
+            <Button aria-label={`Move ${dimension.name} down`} className="min-h-8 px-2" onClick={() => onMove(1)} type="button">
+              ↓
+            </Button>
+            <Button onClick={onEdit} type="button">
+              <Pencil aria-hidden="true" className="size-4" />
+              Edit
+            </Button>
+          </div>
+        ) : null}
+      </div>
+      <AnchorList anchors={dimension.anchors} />
+    </Card>
+  );
+}
+
+function AnchorList({ anchors }: { anchors: ScoreAnchor[] }) {
+  return (
+    <ol className="mt-4 grid gap-2 border-t border-line pt-4 sm:grid-cols-2 lg:grid-cols-3">
+      {anchors.map((anchor) => (
+        <li className="flex gap-2 text-sm leading-relaxed text-muted" key={anchor.score}>
+          <span className="grid size-5 shrink-0 place-items-center rounded-full bg-surface-subtle font-mono text-[11px] text-[#474747]">
+            {anchor.score}
+          </span>
+          {anchor.description}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function ScaleEditorDialog({
+  initial,
+  onClose,
+  onSave
+}: {
+  initial?: RubricDimension;
+  onClose: () => void;
+  onSave: (dimension: RubricDimension) => void;
+}) {
+  const [dimensionId, setDimensionId] = useState(initial?.dimension_id ?? "");
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [anchorDescriptions, setAnchorDescriptions] = useState<string[]>(
+    initial?.anchors.map((anchor) => anchor.description) ?? Array.from({ length: 6 }, () => "")
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedId = (dimensionId || name)
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, "-")
+      .replaceAll(/^-|-$/g, "");
+    onSave({
+      dimension_id: normalizedId || "human-scale",
+      name: name.trim(),
+      description: description.trim(),
+      anchors: anchorDescriptions.map((item, index) => ({
+        score: index as Score,
+        description: item.trim()
+      }))
+    });
+  };
+
+  return (
+    <Dialog onClose={onClose} title={initial ? `Edit ${initial.name}` : "Add a rubric scale"}>
+      <form className="space-y-4" onSubmit={submit}>
+        <label className="block text-sm font-medium text-[#363636]">
+          Scale name
+          <input
+            className="mt-1.5 block w-full rounded-[var(--radius-md)] border border-line-strong bg-surface px-3 py-2 text-sm"
+            onChange={(event) => setName(event.target.value)}
+            required
+            value={name}
+          />
+        </label>
+        <label className="block text-sm font-medium text-[#363636]">
+          Stable identifier
+          <input
+            className="mt-1.5 block w-full rounded-[var(--radius-md)] border border-line-strong bg-surface px-3 py-2 font-mono text-sm"
+            onChange={(event) => setDimensionId(event.target.value)}
+            placeholder="task-success"
+            value={dimensionId}
+          />
+        </label>
+        <label className="block text-sm font-medium text-[#363636]">
+          What does this scale measure?
+          <textarea
+            className="mt-1.5 block min-h-20 w-full rounded-[var(--radius-md)] border border-line-strong bg-surface px-3 py-2 text-sm"
+            onChange={(event) => setDescription(event.target.value)}
+            required
+            value={description}
+          />
+        </label>
+        <fieldset className="border-t border-line pt-4">
+          <legend className="text-sm font-medium text-[#363636]">Zero-to-five anchors</legend>
+          <div className="mt-3 grid gap-3">
+            {anchorDescriptions.map((anchor, index) => (
+              <label className="grid grid-cols-[24px_minmax(0,1fr)] items-center gap-2 text-sm text-muted" key={index}>
+                <span className="font-mono text-xs">{index}</span>
+                <input
+                  className="w-full rounded-[var(--radius-md)] border border-line-strong bg-surface px-3 py-2 text-sm text-ink"
+                  onChange={(event) => {
+                    setAnchorDescriptions((previous) =>
+                      previous.map((item, itemIndex) => (itemIndex === index ? event.target.value : item))
+                    );
+                  }}
+                  required
+                  value={anchor}
+                />
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        <div className="flex justify-end gap-2 border-t border-line pt-4">
+          <Button onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary">
+            Save scale
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/web/components/rubric-review.tsx
+++ b/web/components/rubric-review.tsx
@@ -145,6 +145,8 @@ export function RubricReview({ busy, onMutation, snapshot }: RubricReviewProps) 
             {activeDimensions.map((dimension, index) => (
               <ActiveScaleCard
                 canEdit={!finalized && !busy}
+                canMoveDown={index < activeDimensions.length - 1}
+                canMoveUp={index > 0}
                 dimension={dimension}
                 index={index}
                 key={dimension.dimension_id}
@@ -408,12 +410,16 @@ function ProposalCard({
 
 function ActiveScaleCard({
   canEdit,
+  canMoveDown,
+  canMoveUp,
   dimension,
   index,
   onEdit,
   onMove
 }: {
   canEdit: boolean;
+  canMoveDown: boolean;
+  canMoveUp: boolean;
   dimension: RubricDimension;
   index: number;
   onEdit: () => void;
@@ -432,10 +438,22 @@ function ActiveScaleCard({
         </div>
         {canEdit ? (
           <div className="flex gap-2">
-            <Button aria-label={`Move ${dimension.name} up`} className="min-h-8 px-2" onClick={() => onMove(-1)} type="button">
+            <Button
+              aria-label={`Move ${dimension.name} up`}
+              className="min-h-8 px-2"
+              disabled={!canMoveUp}
+              onClick={() => onMove(-1)}
+              type="button"
+            >
               ↑
             </Button>
-            <Button aria-label={`Move ${dimension.name} down`} className="min-h-8 px-2" onClick={() => onMove(1)} type="button">
+            <Button
+              aria-label={`Move ${dimension.name} down`}
+              className="min-h-8 px-2"
+              disabled={!canMoveDown}
+              onClick={() => onMove(1)}
+              type="button"
+            >
               ↓
             </Button>
             <Button onClick={onEdit} type="button">

--- a/web/components/rubric-review.tsx
+++ b/web/components/rubric-review.tsx
@@ -27,6 +27,9 @@ export function RubricReview({ busy, onMutation, snapshot }: RubricReviewProps) 
   const activeDimensions = review.finalized_rubric?.dimensions ?? review.dimensions;
   const [editingScale, setEditingScale] = useState<EditingScale | null>(null);
   const [confirmingFinalization, setConfirmingFinalization] = useState(false);
+  const [replacingAll, setReplacingAll] = useState(false);
+  const [authoringReplacement, setAuthoringReplacement] = useState(false);
+  const [replacementDimensions, setReplacementDimensions] = useState<RubricDimension[]>([]);
   const [swipeStart, setSwipeStart] = useState<number | null>(null);
 
   const mutate = (action: RubricAction, payload: Record<string, unknown>) => {
@@ -59,12 +62,15 @@ export function RubricReview({ busy, onMutation, snapshot }: RubricReviewProps) 
             Add scale
           </Button>
           <Button
-            disabled={busy || finalized || activeDimensions.length === 0}
-            onClick={() => mutate("replace_all", { dimensions: activeDimensions })}
+            disabled={busy || finalized}
+            onClick={() => {
+              setReplacementDimensions([]);
+              setReplacingAll(true);
+            }}
             type="button"
           >
             <Replace aria-hidden="true" className="size-4" />
-            Replace all with active scales
+            Design replacement set
           </Button>
           <Button
             disabled={busy || finalized || activeDimensions.length === 0}
@@ -200,7 +206,115 @@ export function RubricReview({ busy, onMutation, snapshot }: RubricReviewProps) 
           </div>
         </Dialog>
       ) : null}
+      {replacingAll && !authoringReplacement ? (
+        <ReplaceAllDialog
+          activeDimensions={activeDimensions}
+          onAuthor={() => setAuthoringReplacement(true)}
+          onClose={() => setReplacingAll(false)}
+          onSubmit={() => {
+            mutate("replace_all", { dimensions: replacementDimensions });
+            setReplacingAll(false);
+          }}
+          proposals={review.proposals.flatMap((proposal) =>
+            proposal.dimensions.map((item) => item.dimension)
+          )}
+          selected={replacementDimensions}
+          setSelected={setReplacementDimensions}
+        />
+      ) : null}
+      {authoringReplacement ? (
+        <ScaleEditorDialog
+          onClose={() => setAuthoringReplacement(false)}
+          onSave={(dimension) => {
+            setReplacementDimensions((current) => [
+              ...current.filter((item) => item.dimension_id !== dimension.dimension_id),
+              dimension
+            ]);
+            setAuthoringReplacement(false);
+          }}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function ReplaceAllDialog({
+  activeDimensions,
+  onAuthor,
+  onClose,
+  onSubmit,
+  proposals,
+  selected,
+  setSelected
+}: {
+  activeDimensions: RubricDimension[];
+  onAuthor: () => void;
+  onClose: () => void;
+  onSubmit: () => void;
+  proposals: RubricDimension[];
+  selected: RubricDimension[];
+  setSelected: (dimensions: RubricDimension[]) => void;
+}) {
+  const candidates = [...activeDimensions, ...proposals].filter(
+    (dimension, index, all) =>
+      all.findIndex((item) => item.dimension_id === dimension.dimension_id) === index
+  );
+  const selectedIds = new Set(selected.map((item) => item.dimension_id));
+  return (
+    <Dialog onClose={onClose} title="Design the complete replacement set">
+      <p className="mt-0 text-sm leading-relaxed text-muted">
+        Select existing or proposed scales, or author a new scale. Submission replaces every
+        active scale with this exact ordered set.
+      </p>
+      <div className="mt-4 space-y-2">
+        {candidates.map((dimension) => (
+          <label
+            className="flex items-start gap-3 rounded-[var(--radius-md)] border border-line p-3"
+            key={dimension.dimension_id}
+          >
+            <input
+              checked={selectedIds.has(dimension.dimension_id)}
+              className="mt-1"
+              onChange={(event) =>
+                setSelected(
+                  event.target.checked
+                    ? [...selected, dimension]
+                    : selected.filter((item) => item.dimension_id !== dimension.dimension_id)
+                )
+              }
+              type="checkbox"
+            />
+            <span>
+              <span className="block text-sm font-semibold text-ink">{dimension.name}</span>
+              <span className="mt-1 block text-xs leading-relaxed text-muted">
+                {dimension.description}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+      {selected.length > 0 ? (
+        <ol className="mt-4 rounded-[var(--radius-md)] bg-surface-subtle p-3 text-sm text-muted">
+          {selected.map((dimension, index) => (
+            <li key={dimension.dimension_id}>
+              {index + 1}. {dimension.name}
+            </li>
+          ))}
+        </ol>
+      ) : null}
+      <div className="mt-5 flex flex-wrap justify-end gap-2 border-t border-line pt-4">
+        <Button onClick={onClose} type="button">
+          Cancel
+        </Button>
+        <Button onClick={onAuthor} type="button">
+          <Plus aria-hidden="true" className="size-4" />
+          Author replacement scale
+        </Button>
+        <Button disabled={selected.length === 0} onClick={onSubmit} type="button" variant="primary">
+          Replace all scales
+        </Button>
+      </div>
+    </Dialog>
   );
 }
 

--- a/web/components/task-review.tsx
+++ b/web/components/task-review.tsx
@@ -1,0 +1,304 @@
+import { ArrowDown, ArrowUp, CheckCircle2, CircleAlert, Layers3 } from "lucide-react";
+
+import { Button, Card, Chip, EmptyState } from "@/components/ui";
+import type {
+  HumanScore,
+  ReviewRollout,
+  RubricDimension,
+  Score,
+  SelectionCoverage,
+  Task
+} from "@/lib/review-types";
+
+type TaskReviewProps = {
+  activeDimensions: RubricDimension[];
+  coverage: SelectionCoverage[];
+  humanScores: HumanScore[];
+  onScore: (input: {
+    rolloutId: string;
+    lineageId: string;
+    dimensionId: string;
+    score: Score;
+  }) => void;
+  onSelectTask: (taskId: string) => void;
+  rollouts: ReviewRollout[];
+  selectedTaskId: string;
+  tasks: Task[];
+};
+
+export function TaskReview({
+  activeDimensions,
+  coverage,
+  humanScores,
+  onScore,
+  onSelectTask,
+  rollouts,
+  selectedTaskId,
+  tasks
+}: TaskReviewProps) {
+  const selectedTask = tasks.find((task) => task.task_id === selectedTaskId) ?? tasks[0];
+  const selectedCoverage = coverage.find((item) => item.task_id === selectedTask?.task_id);
+  const taskRollouts = rollouts.filter((item) => item.rollout.task_id === selectedTask?.task_id);
+
+  if (!selectedTask) {
+    return <EmptyState title="No selected tasks" body="Run wmo build for this project, then reopen local review." />;
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[290px_minmax(0,1fr)]">
+      <Card className="h-fit p-2">
+        <div className="flex items-center justify-between px-2 py-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.1em] text-muted">Task set</span>
+          <span className="font-mono text-xs text-muted">{tasks.length}</span>
+        </div>
+        <div aria-label="Task list" className="space-y-1" role="listbox">
+          {tasks.map((task, index) => {
+            const selected = task.task_id === selectedTask.task_id;
+            return (
+              <button
+                aria-selected={selected}
+                className={`w-full rounded-[var(--radius-md)] px-3 py-3 text-left transition-colors ${
+                  selected ? "bg-active text-ink" : "text-[#474747] hover:bg-hover"
+                }`}
+                key={task.task_id}
+                onClick={() => onSelectTask(task.task_id)}
+                role="option"
+                type="button"
+              >
+                <span className="mb-2 flex items-center justify-between gap-3">
+                  <span className="font-mono text-[11px] text-muted">{String(index + 1).padStart(2, "0")}</span>
+                  <Chip label={task.partition === "held_out" ? "held out" : "fit"} tone="neutral" />
+                </span>
+                <span className="line-clamp-3 block text-sm font-medium leading-snug">{task.instruction}</span>
+              </button>
+            );
+          })}
+        </div>
+        <p className="mb-1 mt-3 px-2 text-xs leading-relaxed text-muted">
+          <ArrowUp aria-hidden="true" className="mr-1 inline size-3" />
+          <ArrowDown aria-hidden="true" className="mr-1 inline size-3" />
+          Use arrow keys outside a field to move between tasks.
+        </p>
+      </Card>
+
+      <div className="space-y-4">
+        <TaskContext coverage={selectedCoverage} task={selectedTask} />
+        {taskRollouts.length === 0 ? (
+          <EmptyState
+            body="This selected task has no stored rollout evidence yet. The task and coverage provenance remain reviewable."
+            title="No rollout evidence for this task"
+          />
+        ) : (
+          taskRollouts.map((item) => (
+            <RolloutEvidence
+              activeDimensions={activeDimensions}
+              humanScores={humanScores}
+              key={item.rollout.rollout_id}
+              onScore={onScore}
+              reviewRollout={item}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TaskContext({ coverage, task }: { coverage?: SelectionCoverage; task: Task }) {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Selected task</p>
+          <h2 className="mb-0 mt-2 max-w-3xl text-xl font-semibold tracking-tight text-ink">
+            {task.instruction}
+          </h2>
+        </div>
+        <Chip label={task.partition === "held_out" ? "held-out evidence" : "fit evidence"} tone="purple" />
+      </div>
+      <dl className="mt-5 grid gap-4 border-t border-line pt-4 sm:grid-cols-3">
+        <Definition label="Lineage" value={task.lineage_group_id} />
+        <Definition label="Workload weight" value={`${Math.round(task.workload_weight * 100)}%`} />
+        <Definition label="Source traces" value={task.source_trace_ids.join(", ")} />
+      </dl>
+      {coverage ? (
+        <div className="mt-4 rounded-[var(--radius-md)] bg-surface-subtle p-3">
+          <p className="m-0 flex items-center gap-2 text-sm font-medium text-[#363636]">
+            <Layers3 aria-hidden="true" className="size-4 text-muted" />
+            Coverage selection
+          </p>
+          <p className="mb-0 mt-1 text-sm leading-relaxed text-muted">
+            {coverage.selection_reasons.join(" · ")} · representative trace {coverage.representative_trace_id}
+          </p>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function RolloutEvidence({
+  activeDimensions,
+  humanScores,
+  onScore,
+  reviewRollout
+}: {
+  activeDimensions: RubricDimension[];
+  humanScores: HumanScore[];
+  onScore: TaskReviewProps["onScore"];
+  reviewRollout: ReviewRollout;
+}) {
+  const { judgment, lineage_id: lineageId, rollout } = reviewRollout;
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="m-0 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">Rollout evidence</p>
+          <h2 className="mb-0 mt-2 text-base font-semibold text-ink">{rollout.candidate.model_id}</h2>
+          <p className="mb-0 mt-1 text-sm text-muted">
+            {rollout.evidence_source.replaceAll("_", " ")} · stopped {rollout.stop_reason.replaceAll("_", " ")}
+          </p>
+        </div>
+        {rollout.failure ? (
+          <Chip label="Failure captured" tone="danger" />
+        ) : (
+          <Chip label="Completed" tone="success" />
+        )}
+      </div>
+      <div className="mt-5 space-y-3 border-t border-line pt-4">
+        {rollout.spans.map((span, index) => (
+          <article className="grid gap-2 sm:grid-cols-[28px_minmax(0,1fr)]" key={span.span_id}>
+            <span className="font-mono text-xs text-muted">{String(index + 1).padStart(2, "0")}</span>
+            <div className="rounded-[var(--radius-md)] border border-line bg-[#fcfcfc] p-3">
+              <p className="m-0 flex flex-wrap items-center gap-2 text-sm font-semibold text-[#363636]">
+                {span.kind.replaceAll("_", " ")}
+                {span.tool_name ? <Chip label={span.tool_name} tone="blue" /> : null}
+              </p>
+              <pre className="mb-0 mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs leading-relaxed text-muted">
+                {JSON.stringify(span.payload, null, 2)}
+              </pre>
+              {span.failure ? <p className="mb-0 mt-2 text-sm text-danger">{span.failure.message}</p> : null}
+            </div>
+          </article>
+        ))}
+      </div>
+      {rollout.final_output ? (
+        <div className="mt-4 rounded-[var(--radius-md)] border border-line bg-surface p-3">
+          <p className="m-0 text-xs font-semibold uppercase tracking-[0.1em] text-muted">Final output</p>
+          <pre className="mb-0 mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs leading-relaxed text-[#474747]">
+            {JSON.stringify(rollout.final_output, null, 2)}
+          </pre>
+        </div>
+      ) : null}
+      <JudgmentReview
+        activeDimensions={activeDimensions}
+        humanScores={humanScores}
+        judgment={judgment}
+        lineageId={lineageId}
+        onScore={onScore}
+        rolloutId={rollout.rollout_id}
+      />
+    </Card>
+  );
+}
+
+function JudgmentReview({
+  activeDimensions,
+  humanScores,
+  judgment,
+  lineageId,
+  onScore,
+  rolloutId
+}: {
+  activeDimensions: RubricDimension[];
+  humanScores: HumanScore[];
+  judgment: ReviewRollout["judgment"];
+  lineageId: string | null;
+  onScore: TaskReviewProps["onScore"];
+  rolloutId: string;
+}) {
+  if (!judgment) {
+    return (
+      <div className="mt-5 rounded-[var(--radius-md)] bg-warning-soft p-3 text-sm text-warning">
+        No stored judgment is attached to this rollout yet.
+      </div>
+    );
+  }
+  return (
+    <div className="mt-5 border-t border-line pt-4">
+      <div className="flex items-center gap-2">
+        <CheckCircle2 aria-hidden="true" className="size-4 text-success" />
+        <h3 className="m-0 text-sm font-semibold text-ink">Judgment review</h3>
+      </div>
+      <div className="mt-3 space-y-3">
+        {judgment.dimensions.map((dimension) => {
+          const rubricDimension = activeDimensions.find(
+            (item) => item.dimension_id === dimension.dimension_id
+          );
+          const activeHumanScore = humanScores
+            .filter(
+              (item) =>
+                item.rollout_id === rolloutId &&
+                item.dimension_id === dimension.dimension_id &&
+                item.lineage_id === lineageId
+            )
+            .at(-1);
+          return (
+            <div className="rounded-[var(--radius-md)] bg-surface-subtle p-3" key={dimension.dimension_id}>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="m-0 text-sm font-semibold text-[#363636]">
+                    {rubricDimension?.name ?? dimension.dimension_id}
+                  </p>
+                  <p className="mb-0 mt-1 text-sm leading-relaxed text-muted">{dimension.feedback}</p>
+                </div>
+                <span className="font-mono text-xs text-muted">
+                  raw {dimension.raw_score} · calibrated {dimension.calibrated_score.toFixed(1)}
+                </span>
+              </div>
+              {activeDimensions.some((item) => item.dimension_id === dimension.dimension_id) && lineageId ? (
+                <div className="mt-3 flex flex-wrap items-center gap-2" aria-label={`Set ${rubricDimension?.name ?? dimension.dimension_id} score`}>
+                  <span className="mr-1 text-xs text-muted">
+                    Human {activeHumanScore ? `override: ${activeHumanScore.score}` : "score"}
+                  </span>
+                  {([0, 1, 2, 3, 4, 5] as Score[]).map((score) => (
+                    <Button
+                      aria-label={`Set ${rubricDimension?.name ?? dimension.dimension_id} score to ${score}`}
+                      className="min-h-8 min-w-8 px-2 font-mono text-xs"
+                      key={score}
+                      onClick={() =>
+                        onScore({
+                          rolloutId,
+                          lineageId,
+                          dimensionId: dimension.dimension_id,
+                          score
+                        })
+                      }
+                      type="button"
+                      variant={activeHumanScore?.score === score ? "primary" : "default"}
+                    >
+                      {score}
+                    </Button>
+                  ))}
+                </div>
+              ) : (
+                <p className="mb-0 mt-3 flex items-center gap-2 text-xs text-muted">
+                  <CircleAlert aria-hidden="true" className="size-3" />
+                  Finalize this rubric before recording a human score.
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Definition({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted">{label}</dt>
+      <dd className="mb-0 mt-1 break-words text-sm text-[#474747]">{value}</dd>
+    </div>
+  );
+}

--- a/web/components/ui.test.tsx
+++ b/web/components/ui.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { Button, Dialog } from "@/components/ui";
+
+describe("Dialog", () => {
+  afterEach(() => cleanup());
+
+  it("enters and traps focus in both directions, then Escape restores prior focus", async () => {
+    render(<DialogHarness />);
+    const opener = screen.getByRole("button", { name: "Open dialog" });
+    opener.focus();
+    fireEvent.click(opener);
+
+    const dialog = screen.getByRole("dialog", { name: "Confirm local action" });
+    const close = screen.getByRole("button", { name: "Close dialog" });
+    const confirm = screen.getByRole("button", { name: "Confirm action" });
+    await waitFor(() => expect(close).toHaveFocus());
+    expect(document.getElementById(dialog.getAttribute("aria-labelledby") ?? "")).toHaveTextContent(
+      "Confirm local action"
+    );
+
+    confirm.focus();
+    fireEvent.keyDown(confirm, { key: "Tab" });
+    expect(close).toHaveFocus();
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
+    expect(confirm).toHaveFocus();
+    fireEvent.keyDown(confirm, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+
+  it("makes the background inert and blocks background pointer and keyboard actions", async () => {
+    const backgroundAction = vi.fn();
+    render(<DialogHarness onBackgroundAction={backgroundAction} />);
+    const opener = screen.getByRole("button", { name: "Open dialog" });
+    const background = screen.getByRole("button", { name: "Background action" });
+    fireEvent.click(opener);
+    await screen.findByRole("dialog");
+    const applicationRoot = opener.closest("[aria-hidden='true']");
+
+    expect(applicationRoot).toHaveAttribute("aria-hidden", "true");
+    expect(applicationRoot).toHaveProperty("inert", true);
+    fireEvent.click(background);
+    fireEvent.keyDown(background, { key: "a" });
+    expect(backgroundAction).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(applicationRoot).not.toHaveAttribute("aria-hidden");
+    expect((applicationRoot as HTMLElement | null)?.inert).toBeFalsy();
+  });
+});
+
+function DialogHarness({ onBackgroundAction = () => undefined }: { onBackgroundAction?: () => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)} type="button">
+        Open dialog
+      </Button>
+      <Button onClick={onBackgroundAction} onKeyDown={onBackgroundAction} type="button">
+        Background action
+      </Button>
+      {open ? (
+        <Dialog onClose={() => setOpen(false)} title="Confirm local action">
+          <Button type="button">Confirm action</Button>
+        </Dialog>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/ui.tsx
+++ b/web/components/ui.tsx
@@ -1,0 +1,118 @@
+import { useId, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { clsx } from "clsx";
+
+type ButtonVariant = "default" | "primary" | "danger" | "quiet";
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+  variant?: ButtonVariant;
+};
+
+export function buttonClassName(variant: ButtonVariant = "default", className?: string): string {
+  return clsx(
+    "inline-flex min-h-[38px] items-center justify-center gap-2 rounded-[var(--radius-md)] px-4 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-55",
+    variant === "primary" && "border border-ink bg-ink text-white hover:bg-[#252525]",
+    variant === "danger" && "border border-danger bg-danger text-white hover:bg-[#bd2d2d]",
+    variant === "quiet" && "border border-transparent bg-transparent text-muted hover:bg-hover hover:text-ink",
+    variant === "default" && "border border-line-strong bg-surface text-ink hover:bg-hover",
+    className
+  );
+}
+
+export function Button({ children, className, variant = "default", ...props }: ButtonProps) {
+  return (
+    <button className={buttonClassName(variant, className)} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export function Card({
+  children,
+  className
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={clsx("rounded-[var(--radius-lg)] border border-line bg-surface p-[18px]", className)}>
+      {children}
+    </section>
+  );
+}
+
+type ChipTone = "neutral" | "success" | "warning" | "danger" | "purple" | "blue";
+
+const chipTone: Record<ChipTone, string> = {
+  neutral: "bg-surface-subtle text-muted",
+  success: "bg-success-soft text-success",
+  warning: "bg-warning-soft text-warning",
+  danger: "bg-danger-soft text-danger",
+  purple: "bg-purple-soft text-purple",
+  blue: "bg-blue-50 text-blue-700"
+};
+
+export function Chip({ label, tone = "neutral" }: { label: string; tone?: ChipTone }) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full px-[9px] py-[5px] font-mono text-[11px] font-semibold uppercase",
+        chipTone[tone]
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="grid min-h-[220px] place-items-center rounded-[var(--radius-lg)] border border-dashed border-line-strong px-5 text-center">
+      <div>
+        <h2 className="m-0 text-sm font-medium text-[#474747]">{title}</h2>
+        <p className="mt-2 max-w-xl text-[13px] leading-relaxed text-muted">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+export function Dialog({
+  title,
+  children,
+  onClose
+}: {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  const titleId = useId();
+  return (
+    <div
+      aria-labelledby={titleId}
+      aria-modal="true"
+      className="fixed inset-0 z-50 grid place-items-center bg-ink/20 p-4"
+      onMouseDown={onClose}
+      role="dialog"
+    >
+      <section
+        className="w-full max-w-xl rounded-[var(--radius-lg)] border border-line bg-surface p-5 shadow-xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <h2 className="m-0 text-base font-semibold text-ink" id={titleId}>
+            {title}
+          </h2>
+          <button
+            aria-label="Close dialog"
+            className="rounded-[var(--radius-sm)] border-0 bg-transparent px-2 py-1 text-lg leading-none text-muted hover:bg-hover hover:text-ink"
+            onClick={onClose}
+            type="button"
+          >
+            ×
+          </button>
+        </div>
+        {children}
+      </section>
+    </div>
+  );
+}

--- a/web/components/ui.tsx
+++ b/web/components/ui.tsx
@@ -1,5 +1,6 @@
-import { useId, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { clsx } from "clsx";
+import { useEffect, useId, useRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 type ButtonVariant = "default" | "primary" | "danger" | "quiet";
 
@@ -79,40 +80,155 @@ export function EmptyState({ title, body }: { title: string; body: string }) {
 export function Dialog({
   title,
   children,
-  onClose
+  onClose,
+  dismissible = true
 }: {
   title: string;
   children: ReactNode;
   onClose: () => void;
+  dismissible?: boolean;
 }) {
   const titleId = useId();
-  return (
+  const dialogId = useId();
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const overlay = overlayRef.current;
+    const dialog = dialogRef.current;
+    if (!overlay || !dialog) {
+      return;
+    }
+    const priorFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const background = Array.from(document.body.children).filter((item) => item !== overlay);
+    const priorBackground = background.map((item) => ({
+      element: item as HTMLElement,
+      ariaHidden: item.getAttribute("aria-hidden"),
+      inert: (item as HTMLElement).inert
+    }));
+    for (const item of priorBackground) {
+      item.element.inert = true;
+      item.element.setAttribute("aria-hidden", "true");
+    }
+
+    const controls = focusableControls(dialog);
+    (controls[0] ?? dialog).focus();
+
+    const protectModal = (event: Event) => {
+      if (event.target instanceof Node && !overlay.contains(event.target)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && dismissible) {
+        event.preventDefault();
+        event.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      const currentControls = focusableControls(dialog);
+      if (!(event.target instanceof Node) || !overlay.contains(event.target)) {
+        protectModal(event);
+        if (event.key === "Tab") {
+          const boundary = event.shiftKey ? currentControls.at(-1) : currentControls[0];
+          (boundary ?? dialog).focus();
+        }
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      if (currentControls.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = currentControls[0];
+      const last = currentControls.at(-1) ?? first;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!dialog.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("pointerdown", protectModal, true);
+    document.addEventListener("click", protectModal, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("pointerdown", protectModal, true);
+      document.removeEventListener("click", protectModal, true);
+      for (const item of priorBackground) {
+        item.element.inert = item.inert;
+        if (item.ariaHidden === null) {
+          item.element.removeAttribute("aria-hidden");
+        } else {
+          item.element.setAttribute("aria-hidden", item.ariaHidden);
+        }
+      }
+      if (priorFocus?.isConnected) {
+        priorFocus.focus();
+      }
+    };
+  }, [dismissible]);
+
+  return createPortal(
     <div
-      aria-labelledby={titleId}
-      aria-modal="true"
       className="fixed inset-0 z-50 grid place-items-center bg-ink/20 p-4"
-      onMouseDown={onClose}
-      role="dialog"
+      onMouseDown={(event) => {
+        if (dismissible && event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+      ref={overlayRef}
     >
       <section
+        aria-labelledby={titleId}
+        aria-modal="true"
         className="w-full max-w-xl rounded-[var(--radius-lg)] border border-line bg-surface p-5 shadow-xl"
-        onMouseDown={(event) => event.stopPropagation()}
+        id={dialogId}
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
       >
         <div className="mb-4 flex items-start justify-between gap-4">
           <h2 className="m-0 text-base font-semibold text-ink" id={titleId}>
             {title}
           </h2>
-          <button
-            aria-label="Close dialog"
-            className="rounded-[var(--radius-sm)] border-0 bg-transparent px-2 py-1 text-lg leading-none text-muted hover:bg-hover hover:text-ink"
-            onClick={onClose}
-            type="button"
-          >
-            ×
-          </button>
+          {dismissible ? (
+            <button
+              aria-label="Close dialog"
+              className="rounded-[var(--radius-sm)] border-0 bg-transparent px-2 py-1 text-lg leading-none text-muted hover:bg-hover hover:text-ink"
+              onClick={onClose}
+              type="button"
+            >
+              ×
+            </button>
+          ) : null}
         </div>
         {children}
       </section>
-    </div>
+    </div>,
+    document.body
   );
+}
+
+function focusableControls(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((item) => item.getAttribute("aria-hidden") !== "true");
 }

--- a/web/lib/review-api.test.ts
+++ b/web/lib/review-api.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { localReviewApi } from "@/lib/review-api";
+
+describe("localReviewApi", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the loopback proxy routes and surfaces the adapter error detail", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ project_id: "support" }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await localReviewApi.getSnapshot();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/review-api/api/review",
+      expect.objectContaining({ headers: { "Content-Type": "application/json" } })
+    );
+  });
+
+  it("returns the local validation reason instead of replacing it in the UI", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "finalization needs confirmation" }), { status: 400 })
+      )
+    );
+
+    await expect(localReviewApi.mutateRubric("finalize", { confirmed: false })).rejects.toThrow(
+      "finalization needs confirmation"
+    );
+  });
+});

--- a/web/lib/review-api.ts
+++ b/web/lib/review-api.ts
@@ -1,4 +1,5 @@
 import type {
+  CalibrationApproval,
   ReviewMutationResponse,
   ReviewSnapshot,
   RubricAction,
@@ -9,6 +10,10 @@ export type ReviewApi = {
   getSnapshot: () => Promise<ReviewSnapshot>;
   mutateRubric: (action: RubricAction, payload: Record<string, unknown>) => Promise<ReviewSnapshot>;
   overrideScore: (payload: ScoreOverride) => Promise<ReviewMutationResponse>;
+  approveCalibration: (
+    reportId: string,
+    payload: CalibrationApproval
+  ) => Promise<ReviewMutationResponse>;
 };
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -39,6 +44,11 @@ export const localReviewApi: ReviewApi = {
     }),
   overrideScore: (payload) =>
     request<ReviewMutationResponse>("/api/review/score", {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }),
+  approveCalibration: (reportId, payload) =>
+    request<ReviewMutationResponse>(`/api/review/calibration/${reportId}/approve`, {
       method: "POST",
       body: JSON.stringify(payload)
     })

--- a/web/lib/review-api.ts
+++ b/web/lib/review-api.ts
@@ -1,0 +1,45 @@
+import type {
+  ReviewMutationResponse,
+  ReviewSnapshot,
+  RubricAction,
+  ScoreOverride
+} from "@/lib/review-types";
+
+export type ReviewApi = {
+  getSnapshot: () => Promise<ReviewSnapshot>;
+  mutateRubric: (action: RubricAction, payload: Record<string, unknown>) => Promise<ReviewSnapshot>;
+  overrideScore: (payload: ScoreOverride) => Promise<ReviewMutationResponse>;
+};
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`/review-api${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers
+    }
+  });
+  if (!response.ok) {
+    const body: unknown = await response.json().catch(() => null);
+    const detail =
+      typeof body === "object" && body !== null && "detail" in body && typeof body.detail === "string"
+        ? body.detail
+        : `Local review request failed with ${response.status}.`;
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+export const localReviewApi: ReviewApi = {
+  getSnapshot: () => request<ReviewSnapshot>("/api/review"),
+  mutateRubric: (action, payload) =>
+    request<ReviewSnapshot>(`/api/review/rubric/${action}`, {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }),
+  overrideScore: (payload) =>
+    request<ReviewMutationResponse>("/api/review/score", {
+      method: "POST",
+      body: JSON.stringify(payload)
+    })
+};

--- a/web/lib/review-fixture.ts
+++ b/web/lib/review-fixture.ts
@@ -200,7 +200,8 @@ const baseSnapshot: ReviewSnapshot = {
       }
     }
   ],
-  calibration_reports: []
+  calibration_reports: [],
+  calibrations: []
 };
 
 export const draftReviewSnapshot: ReviewSnapshot = baseSnapshot;
@@ -246,5 +247,6 @@ export const finalizedReviewSnapshot: ReviewSnapshot = {
         }
       ]
     }
-  ]
+  ],
+  calibrations: []
 };

--- a/web/lib/review-fixture.ts
+++ b/web/lib/review-fixture.ts
@@ -1,0 +1,250 @@
+import type { ReviewSnapshot, RubricDimension, ScoreAnchor } from "@/lib/review-types";
+
+const anchors: ScoreAnchor[] = [
+  { score: 0, description: "The requested outcome is absent or harmful." },
+  { score: 1, description: "The response misses the core request." },
+  { score: 2, description: "The response makes limited, incomplete progress." },
+  { score: 3, description: "The response resolves the request with material gaps." },
+  { score: 4, description: "The response resolves the request clearly and correctly." },
+  { score: 5, description: "The response resolves the request with excellent evidence and care." }
+];
+
+export const taskSuccessDimension: RubricDimension = {
+  dimension_id: "task-success",
+  name: "Task success",
+  description: "Whether the customer received the requested outcome.",
+  anchors
+};
+
+const baseSnapshot: ReviewSnapshot = {
+  project_id: "support",
+  local_data_notice:
+    "This review stays on this machine. WMO reads local artifacts and writes only the project review draft plus immutable approved artifacts. Browser restarts resume review.json; remove the local project directory yourself to clear all project data.",
+  task_set: {
+    task_set: { task_set_id: "task-set-fixture", code_revision: "fixture" },
+    tasks: [
+      {
+        task_id: "task-refund",
+        lineage_group_id: "lineage-refund",
+        partition: "fit",
+        instruction: "Resolve a customer refund request after a duplicate subscription charge.",
+        initial_context: { channel: "email", account_tier: "standard" },
+        tools: [
+          {
+            name: "billing_lookup",
+            description: "Find a subscription charge by account and invoice.",
+            input_schema: { type: "object", required: ["account_id"] }
+          }
+        ],
+        workload_weight: 0.62,
+        source_trace_ids: ["trace-refund-01", "trace-refund-07"]
+      },
+      {
+        task_id: "task-shipping",
+        lineage_group_id: "lineage-shipping",
+        partition: "held_out",
+        instruction: "Explain a delayed shipment and give the customer a verified next step.",
+        initial_context: { channel: "chat", locale: "en-US" },
+        tools: [
+          {
+            name: "shipment_lookup",
+            description: "Retrieve a shipment status and carrier event history.",
+            input_schema: { type: "object", required: ["order_id"] }
+          }
+        ],
+        workload_weight: 0.38,
+        source_trace_ids: ["trace-shipping-03"]
+      }
+    ]
+  },
+  coverage: {
+    input_trace_count: 8,
+    invalid_trace_count: 0,
+    eligible_trace_count: 8,
+    duplicate_trace_count: 1,
+    selected_task_count: 2,
+    split_separation_verified: true,
+    selections: [
+      {
+        task_id: "task-refund",
+        representative_trace_id: "trace-refund-01",
+        partition: "fit",
+        lineage_group_id: "lineage-refund",
+        cluster_id: 0,
+        selection_reasons: ["coverage representative", "high workload mass"],
+        source_trace_ids: ["trace-refund-01", "trace-refund-07"],
+        workload_mass: 0.62,
+        workload_weight: 0.62
+      },
+      {
+        task_id: "task-shipping",
+        representative_trace_id: "trace-shipping-03",
+        partition: "held_out",
+        lineage_group_id: "lineage-shipping",
+        cluster_id: 1,
+        selection_reasons: ["held-out lineage", "coverage representative"],
+        source_trace_ids: ["trace-shipping-03"],
+        workload_mass: 0.38,
+        workload_weight: 0.38
+      }
+    ]
+  },
+  rubric_review: {
+    source_task_set_id: "task-set-fixture",
+    proposals: [
+      {
+        proposal_id: "proposal-task-success",
+        successful_rollout_ids: ["rollout-refund"],
+        failed_rollout_ids: ["rollout-shipping"],
+        dimensions: [
+          {
+            dimension: taskSuccessDimension,
+            source_rollout_ids: ["rollout-refund", "rollout-shipping"],
+            evidence_span_ids: ["span-refund-answer", "span-shipping-answer"],
+            overlap_with_dimension_ids: []
+          }
+        ]
+      }
+    ],
+    dimensions: [],
+    rejected_dimension_ids: [],
+    status: "draft",
+    finalized_rubric: null
+  },
+  human_score_history: { scores: [] },
+  rollouts: [
+    {
+      lineage_id: "lineage-refund",
+      rollout: {
+        rollout_id: "rollout-refund",
+        task_id: "task-refund",
+        evidence_source: "world_model",
+        candidate: { model_id: "candidate-a" },
+        stop_reason: "completed",
+        final_output: { message: "The duplicate charge was refunded and confirmation was sent." },
+        failure: null,
+        spans: [
+          {
+            span_id: "span-refund-lookup",
+            kind: "tool_call",
+            payload: { account_id: "acct_104", invoice: "inv_900" },
+            tool_name: "billing_lookup",
+            failure: null
+          },
+          {
+            span_id: "span-refund-answer",
+            kind: "agent_message",
+            payload: { text: "I found the duplicate charge and submitted the refund." },
+            tool_name: null,
+            failure: null
+          }
+        ]
+      },
+      judgment: {
+        judgment_id: "judgment-refund",
+        rollout_id: "rollout-refund",
+        rubric_id: "rubric-fixture",
+        dimensions: [
+          {
+            dimension_id: "task-success",
+            raw_score: 3,
+            calibrated_score: 3.2,
+            evidence_span_ids: ["span-refund-answer"],
+            feedback: "The refund is completed but the confirmation timing is not explicit."
+          }
+        ],
+        overall_score: 0.64
+      }
+    },
+    {
+      lineage_id: "lineage-shipping",
+      rollout: {
+        rollout_id: "rollout-shipping",
+        task_id: "task-shipping",
+        evidence_source: "world_model",
+        candidate: { model_id: "candidate-a" },
+        stop_reason: "completed",
+        final_output: { message: "The package is delayed. Please wait." },
+        failure: null,
+        spans: [
+          {
+            span_id: "span-shipping-lookup",
+            kind: "tool_call",
+            payload: { order_id: "order_233" },
+            tool_name: "shipment_lookup",
+            failure: null
+          },
+          {
+            span_id: "span-shipping-answer",
+            kind: "agent_message",
+            payload: { text: "The package is delayed. Please wait." },
+            tool_name: null,
+            failure: null
+          }
+        ]
+      },
+      judgment: {
+        judgment_id: "judgment-shipping",
+        rollout_id: "rollout-shipping",
+        rubric_id: "rubric-fixture",
+        dimensions: [
+          {
+            dimension_id: "task-success",
+            raw_score: 1,
+            calibrated_score: 1.1,
+            evidence_span_ids: ["span-shipping-answer"],
+            feedback: "The response gives no verified carrier event or usable next step."
+          }
+        ],
+        overall_score: 0.22
+      }
+    }
+  ],
+  calibration_reports: []
+};
+
+export const draftReviewSnapshot: ReviewSnapshot = baseSnapshot;
+
+export const finalizedReviewSnapshot: ReviewSnapshot = {
+  ...baseSnapshot,
+  rubric_review: {
+    ...baseSnapshot.rubric_review,
+    dimensions: [taskSuccessDimension],
+    status: "finalized",
+    finalized_rubric: {
+      rubric_id: "rubric-fixture",
+      dimensions: [taskSuccessDimension],
+      status: "human_approved"
+    }
+  },
+  calibration_reports: [
+    {
+      report_id: "calibration-fixture",
+      status: "provisional",
+      eligible_label_count: 2,
+      recommended_label_count: 8,
+      dimension_metrics: [
+        {
+          dimension_id: "task-success",
+          mae: 0.8,
+          rank_agreement: 0.5,
+          mean_optimistic_error: 0.6
+        }
+      ],
+      worst_disagreements: [
+        {
+          direction: "optimistic",
+          prediction: {
+            rollout_id: "rollout-shipping",
+            lineage_id: "lineage-shipping",
+            dimension_id: "task-success",
+            raw_score: 3,
+            human_score: 1,
+            calibrated_score: 2.5,
+            absolute_error: 2
+          }
+        }
+      ]
+    }
+  ]
+};

--- a/web/lib/review-proxy.test.ts
+++ b/web/lib/review-proxy.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LocalProxyError, proxyLocalReview, validateLocalWebRequest } from "@/lib/review-proxy";
+
+describe("local review proxy boundary", () => {
+  const originalApiUrl = process.env.WMO_REVIEW_API_URL;
+  const originalWebPort = process.env.WMO_REVIEW_WEB_PORT;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreEnv("WMO_REVIEW_API_URL", originalApiUrl);
+    restoreEnv("WMO_REVIEW_WEB_PORT", originalWebPort);
+  });
+
+  it("accepts only the exact loopback Host and same-origin browser headers", () => {
+    expect(() =>
+      validateLocalWebRequest(
+        request({
+          host: "127.0.0.1:3000",
+          origin: "http://127.0.0.1:3000",
+          referer: "http://127.0.0.1:3000/review"
+        }),
+        3000
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateLocalWebRequest(
+        request({ host: "[::1]:3000", origin: "http://[::1]:3000" }),
+        3000
+      )
+    ).not.toThrow();
+
+    const rejectedHeaders: Array<Record<string, string>> = [
+      { host: "evil.example:3000" },
+      { host: "192.168.1.20:3000" },
+      { host: "127.0.0.1:3001" },
+      { host: "127.0.0.1:3000", origin: "http://evil.example:3000" },
+      { host: "127.0.0.1:3000", origin: "http://localhost:3000" },
+      { host: "127.0.0.1:3000", referer: "http://127.0.0.1:3001/review" }
+    ];
+    for (const headers of rejectedHeaders) {
+      expect(() => validateLocalWebRequest(request(headers), 3000)).toThrow(LocalProxyError);
+    }
+  });
+
+  it("proxies only allowlisted paths to a configured loopback API without forwarding origin", async () => {
+    process.env.WMO_REVIEW_API_URL = "http://127.0.0.1:8017";
+    process.env.WMO_REVIEW_WEB_PORT = "3000";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ project_id: "support" }), {
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await proxyLocalReview(
+      request({ host: "127.0.0.1:3000", origin: "http://127.0.0.1:3000" }),
+      ["api", "review", "calibration", "report-1", "approve"],
+      "POST"
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [target, init] = fetchMock.mock.calls[0];
+    expect(String(target)).toBe("http://127.0.0.1:8017/api/review/calibration/report-1/approve");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+    await expect(
+      proxyLocalReview(
+        request({ host: "127.0.0.1:3000" }),
+        ["api", "review", "../../raw"],
+        "GET"
+      )
+    ).rejects.toThrow("not allowed");
+  });
+
+  it("hard-codes Next development and start commands to loopback", () => {
+    const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8"));
+    expect(packageJson.scripts.dev).toBe("node scripts/next-local.mjs dev");
+    expect(packageJson.scripts.start).toBe("node scripts/next-local.mjs start");
+    const launcher = readFileSync(resolve(process.cwd(), "scripts/next-local.mjs"), "utf8");
+    expect(launcher).toContain('"--hostname", "127.0.0.1"');
+    const lanBind = spawnSync(
+      process.execPath,
+      ["scripts/next-local.mjs", "dev", "--hostname", "0.0.0.0"],
+      { cwd: process.cwd(), encoding: "utf8" }
+    );
+    expect(lanBind.status).toBe(2);
+    expect(lanBind.stderr).toContain("cannot be overridden");
+  });
+});
+
+function request(headers: Record<string, string>): Request {
+  return new Request("http://127.0.0.1:3000/review-api/api/review", {
+    headers,
+    method: "POST"
+  });
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/web/lib/review-proxy.ts
+++ b/web/lib/review-proxy.ts
@@ -1,0 +1,135 @@
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
+const RUBRIC_ACTIONS = new Set([
+  "accept",
+  "reject",
+  "edit",
+  "add",
+  "replace_all",
+  "order",
+  "finalize"
+]);
+
+export class LocalProxyError extends Error {}
+
+export function configuredWebPort(): number {
+  return configuredPort("WMO_REVIEW_WEB_PORT", 3000);
+}
+
+export function validateLocalWebRequest(request: Request, expectedPort: number): void {
+  const host = request.headers.get("host");
+  if (!host) {
+    throw new LocalProxyError("Local review requires a Host header.");
+  }
+  const expected = parseOrigin(`http://${host}`, "Host");
+  if (!LOOPBACK_HOSTS.has(expected.hostname) || expected.port !== expectedPort) {
+    throw new LocalProxyError("Local review Host must be loopback with the expected port.");
+  }
+  for (const headerName of ["origin", "referer"] as const) {
+    const value = request.headers.get(headerName);
+    if (value && !sameOrigin(parseOrigin(value, headerName), expected)) {
+      throw new LocalProxyError(`Local review ${headerName} must match the Host origin.`);
+    }
+  }
+}
+
+export async function proxyLocalReview(
+  request: Request,
+  path: string[],
+  method: "GET" | "POST"
+): Promise<Response> {
+  const webPort = configuredWebPort();
+  validateLocalWebRequest(request, webPort);
+  const apiUrl = configuredApiUrl();
+  const targetPath = allowedTargetPath(path, method);
+  const body = method === "POST" ? await request.text() : undefined;
+  const response = await fetch(new URL(targetPath, apiUrl), {
+    method,
+    body,
+    cache: "no-store",
+    headers: method === "POST" ? { "Content-Type": "application/json" } : undefined
+  });
+  return new Response(response.body, {
+    status: response.status,
+    headers: { "Content-Type": response.headers.get("content-type") ?? "application/json" }
+  });
+}
+
+function configuredApiUrl(): URL {
+  const value = process.env.WMO_REVIEW_API_URL ?? "http://127.0.0.1:8017";
+  const url = new URL(value);
+  if (
+    url.protocol !== "http:" ||
+    !LOOPBACK_HOSTS.has(url.hostname) ||
+    !url.port ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new LocalProxyError("WMO_REVIEW_API_URL must be an explicit loopback HTTP origin.");
+  }
+  return url;
+}
+
+function configuredPort(name: string, fallback: number): number {
+  const value = process.env[name];
+  const port = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new LocalProxyError(`${name} must be an integer from 1 through 65535.`);
+  }
+  return port;
+}
+
+function allowedTargetPath(path: string[], method: "GET" | "POST"): string {
+  if (method === "GET" && path.join("/") === "api/review") {
+    return "/api/review";
+  }
+  if (method === "POST" && path.join("/") === "api/review/score") {
+    return "/api/review/score";
+  }
+  if (
+    method === "POST" &&
+    path.length === 4 &&
+    path[0] === "api" &&
+    path[1] === "review" &&
+    path[2] === "rubric" &&
+    RUBRIC_ACTIONS.has(path[3])
+  ) {
+    return `/api/review/rubric/${path[3]}`;
+  }
+  if (
+    method === "POST" &&
+    path.length === 5 &&
+    path[0] === "api" &&
+    path[1] === "review" &&
+    path[2] === "calibration" &&
+    /^[a-z0-9][a-z0-9._-]*$/.test(path[3]) &&
+    path[4] === "approve"
+  ) {
+    return `/api/review/calibration/${path[3]}/approve`;
+  }
+  throw new LocalProxyError("This local review proxy path is not allowed.");
+}
+
+function parseOrigin(value: string, label: string): { hostname: string; port: number; protocol: string } {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new LocalProxyError(`Local review ${label} is not a valid URL.`);
+  }
+  if (url.protocol !== "http:" || !url.hostname || !url.port || url.username || url.password) {
+    throw new LocalProxyError(`Local review ${label} must be an explicit HTTP origin.`);
+  }
+  return { hostname: url.hostname.toLowerCase(), port: Number(url.port), protocol: url.protocol };
+}
+
+function sameOrigin(
+  left: { hostname: string; port: number; protocol: string },
+  right: { hostname: string; port: number; protocol: string }
+): boolean {
+  return (
+    left.protocol === right.protocol && left.hostname === right.hostname && left.port === right.port
+  );
+}

--- a/web/lib/review-types.ts
+++ b/web/lib/review-types.ts
@@ -152,6 +152,17 @@ export type CalibrationReport = {
   worst_disagreements: WorstDisagreement[];
 };
 
+export type JudgeCalibration = {
+  calibration_id: string;
+  rubric_id: string;
+  out_of_fold_report_id: string;
+  label_count: number;
+  recommended_label_count: number;
+  status: "provisional" | "insufficient" | "human_calibrated";
+  approved_at: string | null;
+  risk_acceptance: { artifact_id: string; sha256: string } | null;
+};
+
 export type HumanScore = {
   label_id: string;
   rubric_id: string;
@@ -174,6 +185,7 @@ export type ReviewSnapshot = {
   human_score_history: { scores: HumanScore[] };
   rollouts: ReviewRollout[];
   calibration_reports: CalibrationReport[];
+  calibrations: JudgeCalibration[];
 };
 
 export type ReviewMutationResponse = {
@@ -186,4 +198,9 @@ export type ScoreOverride = {
   lineage_id: string;
   dimension_id: string;
   score: Score;
+};
+
+export type CalibrationApproval = {
+  confirmed: boolean;
+  accept_insufficient_risk: boolean;
 };

--- a/web/lib/review-types.ts
+++ b/web/lib/review-types.ts
@@ -198,6 +198,7 @@ export type ScoreOverride = {
   lineage_id: string;
   dimension_id: string;
   score: Score;
+  submission_id: string;
 };
 
 export type CalibrationApproval = {

--- a/web/lib/review-types.ts
+++ b/web/lib/review-types.ts
@@ -1,0 +1,189 @@
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export type Score = 0 | 1 | 2 | 3 | 4 | 5;
+export type RubricAction =
+  | "accept"
+  | "reject"
+  | "edit"
+  | "add"
+  | "replace_all"
+  | "order"
+  | "finalize";
+
+export type ScoreAnchor = {
+  score: Score;
+  description: string;
+};
+
+export type RubricDimension = {
+  dimension_id: string;
+  name: string;
+  description: string;
+  anchors: ScoreAnchor[];
+};
+
+export type ProposedDimension = {
+  dimension: RubricDimension;
+  source_rollout_ids: string[];
+  evidence_span_ids: string[];
+  overlap_with_dimension_ids: string[];
+};
+
+export type RubricProposal = {
+  proposal_id: string;
+  dimensions: ProposedDimension[];
+  successful_rollout_ids: string[];
+  failed_rollout_ids: string[];
+};
+
+export type RubricReview = {
+  source_task_set_id: string;
+  proposals: RubricProposal[];
+  dimensions: RubricDimension[];
+  rejected_dimension_ids: string[];
+  status: "draft" | "finalized";
+  finalized_rubric: {
+    rubric_id: string;
+    dimensions: RubricDimension[];
+    status: "provisional" | "human_approved";
+  } | null;
+};
+
+export type Task = {
+  task_id: string;
+  lineage_group_id: string;
+  partition: "fit" | "held_out";
+  instruction: string;
+  initial_context: JsonObject;
+  tools: Array<{ name: string; description: string; input_schema: JsonObject }>;
+  workload_weight: number;
+  source_trace_ids: string[];
+};
+
+export type SelectionCoverage = {
+  task_id: string;
+  representative_trace_id: string;
+  partition: "fit" | "held_out";
+  lineage_group_id: string;
+  cluster_id: number;
+  selection_reasons: string[];
+  source_trace_ids: string[];
+  workload_mass: number;
+  workload_weight: number;
+};
+
+export type CoverageReport = {
+  input_trace_count: number;
+  invalid_trace_count: number;
+  eligible_trace_count: number;
+  duplicate_trace_count: number;
+  selected_task_count: number;
+  split_separation_verified: boolean;
+  selections: SelectionCoverage[];
+};
+
+export type RolloutSpan = {
+  span_id: string;
+  kind: string;
+  payload: JsonObject;
+  tool_name: string | null;
+  failure: { message: string } | null;
+};
+
+export type Rollout = {
+  rollout_id: string;
+  task_id: string;
+  evidence_source: "production" | "world_model" | "sandbox";
+  candidate: { model_id: string };
+  stop_reason: string;
+  final_output: JsonObject | null;
+  failure: { message: string } | null;
+  spans: RolloutSpan[];
+};
+
+export type DimensionJudgment = {
+  dimension_id: string;
+  raw_score: Score;
+  calibrated_score: number;
+  evidence_span_ids: string[];
+  feedback: string;
+};
+
+export type Judgment = {
+  judgment_id: string;
+  rollout_id: string;
+  rubric_id: string;
+  dimensions: DimensionJudgment[];
+  overall_score: number;
+};
+
+export type ReviewRollout = {
+  rollout: Rollout;
+  lineage_id: string | null;
+  judgment: Judgment | null;
+};
+
+export type WorstDisagreement = {
+  direction: "optimistic" | "pessimistic" | "exact";
+  prediction: {
+    rollout_id: string;
+    lineage_id: string;
+    dimension_id: string;
+    raw_score: Score;
+    human_score: Score;
+    calibrated_score: number;
+    absolute_error: number;
+  };
+};
+
+export type CalibrationReport = {
+  report_id: string;
+  status: "provisional" | "insufficient" | "ready_for_approval";
+  eligible_label_count: number;
+  recommended_label_count: number;
+  dimension_metrics: Array<{
+    dimension_id: string;
+    mae: number | null;
+    rank_agreement: number | null;
+    mean_optimistic_error: number | null;
+  }>;
+  worst_disagreements: WorstDisagreement[];
+};
+
+export type HumanScore = {
+  label_id: string;
+  rubric_id: string;
+  rollout_id: string;
+  lineage_id: string;
+  dimension_id: string;
+  score: Score;
+  supersedes_label_id: string | null;
+};
+
+export type ReviewSnapshot = {
+  project_id: string;
+  local_data_notice: string;
+  task_set: {
+    task_set: { task_set_id: string; code_revision: string };
+    tasks: Task[];
+  };
+  coverage: CoverageReport | null;
+  rubric_review: RubricReview;
+  human_score_history: { scores: HumanScore[] };
+  rollouts: ReviewRollout[];
+  calibration_reports: CalibrationReport[];
+};
+
+export type ReviewMutationResponse = {
+  snapshot: ReviewSnapshot;
+  notice: string;
+};
+
+export type ScoreOverride = {
+  rollout_id: string;
+  lineage_id: string;
+  dimension_id: string;
+  score: Score;
+};

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,0 +1,21 @@
+import type { NextConfig } from "next";
+
+const reviewApiUrl = process.env.WMO_REVIEW_API_URL ?? "http://127.0.0.1:8017";
+const reviewApiHost = new URL(reviewApiUrl).hostname;
+
+if (!["127.0.0.1", "::1", "localhost"].includes(reviewApiHost)) {
+  throw new Error("WMO_REVIEW_API_URL must point to a loopback local review adapter.");
+}
+
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: "/review-api/:path*",
+        destination: `${reviewApiUrl}/:path*`
+      }
+    ];
+  }
+};
+
+export default nextConfig;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,21 +1,5 @@
 import type { NextConfig } from "next";
 
-const reviewApiUrl = process.env.WMO_REVIEW_API_URL ?? "http://127.0.0.1:8017";
-const reviewApiHost = new URL(reviewApiUrl).hostname;
-
-if (!["127.0.0.1", "::1", "localhost"].includes(reviewApiHost)) {
-  throw new Error("WMO_REVIEW_API_URL must point to a loopback local review adapter.");
-}
-
-const nextConfig: NextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: "/review-api/:path*",
-        destination: `${reviewApiUrl}/:path*`
-      }
-    ];
-  }
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,4582 @@
+{
+  "name": "@wmo/local-review",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wmo/local-review",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tailwindcss/postcss": "^4.1.18",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.468.0",
+        "next": "^16.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwindcss": "^4.1.18"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.0",
+        "@testing-library/react": "^16.1.0",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "jsdom": "^25.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.3.0",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.5.23",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@wmo/local-review",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "npm@10.9.8",
+  "scripts": {
+    "dev": "next dev",
+    "review": "node scripts/review.mjs",
+    "build": "next build",
+    "lint": "tsc --noEmit --project tsconfig.json",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.1.18"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "packageManager": "npm@10.9.8",
   "scripts": {
-    "dev": "next dev",
+    "dev": "node scripts/next-local.mjs dev",
     "review": "node scripts/review.mjs",
     "build": "next build",
+    "start": "node scripts/next-local.mjs start",
     "lint": "tsc --noEmit --project tsconfig.json",
     "test": "vitest run --config vitest.config.ts"
   },

--- a/web/postcss.config.mjs
+++ b/web/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {}
+  }
+};

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { configuredWebPort, LocalProxyError, validateLocalWebRequest } from "@/lib/review-proxy";
+
+export function proxy(request: NextRequest): NextResponse {
+  try {
+    validateLocalWebRequest(request, configuredWebPort());
+  } catch (error) {
+    if (error instanceof LocalProxyError) {
+      return NextResponse.json({ detail: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ detail: "Local review request validation failed." }, { status: 400 });
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*"
+};

--- a/web/scripts/next-local.mjs
+++ b/web/scripts/next-local.mjs
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const [mode, ...arguments_] = process.argv.slice(2);
+if (!new Set(["dev", "start"]).has(mode)) {
+  fail("Usage: next-local.mjs <dev|start> [Next options]");
+}
+if (
+  arguments_.some(
+    (value) =>
+      value === "--hostname" ||
+      value.startsWith("--hostname=") ||
+      value === "-H" ||
+      value.startsWith("-H=")
+  )
+) {
+  fail("The local review hostname is fixed to 127.0.0.1 and cannot be overridden.");
+}
+
+const next = spawn(
+  process.execPath,
+  ["node_modules/next/dist/bin/next", mode, ...arguments_, "--hostname", "127.0.0.1"],
+  { stdio: "inherit" }
+);
+next.once("error", (error) => fail(error.message));
+next.once("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 1);
+  }
+});
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(2);
+}

--- a/web/scripts/review.mjs
+++ b/web/scripts/review.mjs
@@ -7,27 +7,31 @@ const repositoryDir = path.resolve(webDir, "..");
 const options = parseOptions(process.argv.slice(2));
 const adapterUrl = `http://127.0.0.1:${options.apiPort}`;
 
-const adapter = spawn(
-  "uv",
-  [
-    "run",
-    "python",
-    "-m",
-    "wmo.review_server",
-    "--root",
-    options.root,
-    "--project",
-    options.project,
-    "--host",
-    "127.0.0.1",
-    "--port",
-    String(options.apiPort)
-  ],
-  { cwd: repositoryDir, stdio: "inherit" }
-);
+const adapterArguments = [
+  "run",
+  "python",
+  "-m",
+  "wmo.review_server",
+  "--root",
+  options.root,
+  "--project",
+  options.project,
+  "--host",
+  "127.0.0.1",
+  "--port",
+  String(options.apiPort)
+];
+if (options.taskSet) {
+  adapterArguments.push("--task-set", options.taskSet);
+}
+const adapter = spawn("uv", adapterArguments, { cwd: repositoryDir, stdio: "inherit" });
 const web = spawn("npm", ["run", "dev", "--", "--port", String(options.port)], {
   cwd: webDir,
-  env: { ...process.env, WMO_REVIEW_API_URL: adapterUrl },
+  env: {
+    ...process.env,
+    WMO_REVIEW_API_URL: adapterUrl,
+    WMO_REVIEW_WEB_PORT: String(options.port)
+  },
   stdio: "inherit"
 });
 
@@ -62,6 +66,7 @@ function parseOptions(args) {
   const options = {
     root: path.join(repositoryDir, ".wmo"),
     project: "default",
+    taskSet: null,
     apiPort: 8017,
     port: 3000
   };
@@ -71,6 +76,8 @@ function parseOptions(args) {
       options.root = requiredValue(args, ++index, value);
     } else if (value === "--project") {
       options.project = requiredValue(args, ++index, value);
+    } else if (value === "--task-set") {
+      options.taskSet = requiredValue(args, ++index, value);
     } else if (value === "--api-port") {
       options.apiPort = portValue(requiredValue(args, ++index, value), value);
     } else if (value === "--port") {

--- a/web/scripts/review.mjs
+++ b/web/scripts/review.mjs
@@ -1,0 +1,99 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const webDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryDir = path.resolve(webDir, "..");
+const options = parseOptions(process.argv.slice(2));
+const adapterUrl = `http://127.0.0.1:${options.apiPort}`;
+
+const adapter = spawn(
+  "uv",
+  [
+    "run",
+    "python",
+    "-m",
+    "wmo.review_server",
+    "--root",
+    options.root,
+    "--project",
+    options.project,
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(options.apiPort)
+  ],
+  { cwd: repositoryDir, stdio: "inherit" }
+);
+const web = spawn("npm", ["run", "dev", "--", "--port", String(options.port)], {
+  cwd: webDir,
+  env: { ...process.env, WMO_REVIEW_API_URL: adapterUrl },
+  stdio: "inherit"
+});
+
+let stopping = false;
+
+function stop(exitCode = 0) {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
+  adapter.kill("SIGTERM");
+  web.kill("SIGTERM");
+  process.exitCode = exitCode;
+}
+
+adapter.once("error", () => stop(1));
+web.once("error", () => stop(1));
+adapter.once("exit", (code) => {
+  if (!stopping) {
+    stop(code ?? 1);
+  }
+});
+web.once("exit", (code) => {
+  if (!stopping) {
+    stop(code ?? 1);
+  }
+});
+process.once("SIGINT", () => stop());
+process.once("SIGTERM", () => stop());
+
+function parseOptions(args) {
+  const options = {
+    root: path.join(repositoryDir, ".wmo"),
+    project: "default",
+    apiPort: 8017,
+    port: 3000
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value === "--root") {
+      options.root = requiredValue(args, ++index, value);
+    } else if (value === "--project") {
+      options.project = requiredValue(args, ++index, value);
+    } else if (value === "--api-port") {
+      options.apiPort = portValue(requiredValue(args, ++index, value), value);
+    } else if (value === "--port") {
+      options.port = portValue(requiredValue(args, ++index, value), value);
+    } else {
+      throw new Error(`Unknown option: ${value}`);
+    }
+  }
+  return options;
+}
+
+function requiredValue(args, index, option) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function portValue(value, option) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${option} must be an integer from 1 through 65535`);
+  }
+  return port;
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,57 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        surface: {
+          DEFAULT: "var(--surface)",
+          subtle: "var(--surface-subtle)"
+        },
+        ink: "var(--ink)",
+        muted: {
+          DEFAULT: "var(--muted)",
+          2: "var(--muted-2)"
+        },
+        line: {
+          DEFAULT: "var(--line)",
+          strong: "var(--line-strong)"
+        },
+        success: {
+          DEFAULT: "var(--success)",
+          soft: "var(--success-soft)"
+        },
+        warning: {
+          DEFAULT: "var(--warning)",
+          soft: "var(--warning-soft)"
+        },
+        danger: {
+          DEFAULT: "var(--danger)",
+          soft: "var(--danger-soft)"
+        },
+        purple: {
+          DEFAULT: "var(--purple)",
+          soft: "var(--purple-soft)"
+        },
+        accent: "var(--accent)",
+        hover: "var(--hover)",
+        active: "var(--active)"
+      },
+      fontFamily: {
+        sans: ["var(--font-geist-sans)", "system-ui", "-apple-system", "sans-serif"],
+        mono: ["var(--font-geist-mono)", "monospace"]
+      },
+      borderRadius: {
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["**/*.test.ts", "**/*.test.tsx"]
+  },
+  resolve: {
+    alias: {
+      "@": new URL("./", import.meta.url).pathname
+    }
+  }
+});

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -88,6 +88,7 @@ def build(
             created_at=datetime.now(UTC),
             code_revision=_current_revision(),
         )
+        _ensure_review_draft(store)
     except (ArtifactStoreError, ProjectStoreError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from None
     _capture_local_build_telemetry(
@@ -139,6 +140,17 @@ def _project_store(root: Path, project_id: str) -> ProjectStore:
     else:
         store.initialize(ProjectConfig(project_id=project_id))
     return store
+
+
+def _ensure_review_draft(store: ProjectStore) -> None:
+    """Create the shared mutable review root once without replacing an existing draft.
+
+    The optional local web review owns its namespaced state beneath this exact review.json file.
+    Creating an empty root here lets a later browser session resume the build's project without a
+    second store or artifact path.
+    """
+    if store.read_review() is None:
+        store.write_review({})
 
 
 def _current_revision() -> str:

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -149,8 +149,7 @@ def _ensure_review_draft(store: ProjectStore) -> None:
     Creating an empty root here lets a later browser session resume the build's project without a
     second store or artifact path.
     """
-    if store.read_review() is None:
-        store.write_review({})
+    store.update_review(lambda current: {} if current is None else current)
 
 
 def _current_revision() -> str:

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -156,6 +156,7 @@ def test_build_reads_the_raw_otlp_file_once_and_persists_the_immutable_boundary(
     task_records = tuple(line for line in tasks.decode("utf-8").splitlines() if line)
     assert sum('"partition":"fit"' in line for line in task_records) == 50
     assert sum('"partition":"held_out"' in line for line in task_records) == 20
+    assert ProjectStore(root, "support").read_review() == {}
     assert len(captured) == 1
     stats = captured[0]
     assert stats.input_trace_count == 100

--- a/wmo/common/judging/labels.py
+++ b/wmo/common/judging/labels.py
@@ -223,9 +223,10 @@ class HumanScoreReview:
         lineage_id: ArtifactId,
         dimension_id: ArtifactId,
         score: Literal[0, 1, 2, 3, 4, 5],
+        submission_id: str,
         created_at: datetime,
     ) -> HumanScore:
-        """Append or correct one score after reloading its active predecessor under the lock.
+        """Append or correct one score with a stable client delivery identity under the lock.
 
         Args:
             rubric_id: Immutable finalized rubric that owns the score.
@@ -233,19 +234,42 @@ class HumanScoreReview:
             lineage_id: Frozen task lineage retained for calibration.
             dimension_id: Rubric dimension receiving the zero-to-five score.
             score: Human score on the finalized dimension scale.
+            submission_id: Stable identifier for this one UI submission and all of its retries.
             created_at: Time at which the local human decision is recorded.
 
         Returns:
             The stored original score, immutable correction, or existing identical score.
 
         Raises:
-            ValueError: The supplied score timestamp has no timezone.
+            ValueError: The supplied submission identity is empty, or score timestamp has no
+                timezone.
         """
         if created_at.tzinfo is None or created_at.utcoffset() is None:
             raise ValueError("human score timestamps must include a timezone")
+        if not submission_id.strip():
+            raise ValueError("human score submission IDs must be nonempty")
         result: list[HumanScore] = []
 
-        def transition(history: HumanScoreHistory) -> HumanScoreHistory:
+        def update(current: JsonValue | None) -> JsonObject:
+            root = _root_review_from_value(current)
+            history = _history_from_root(root)
+            submissions = _score_submissions_from_root(root)
+            target = (rubric_id, rollout_id, lineage_id, dimension_id)
+            saved_label_id = submissions.get(submission_id)
+            if saved_label_id is not None:
+                saved = next(
+                    (item for item in history.scores if item.label_id == saved_label_id),
+                    None,
+                )
+                if saved is None:
+                    raise ValueError("human score submission refers to a missing label")
+                if _target_key(saved) != target or saved.score != score:
+                    raise ValueError(
+                        "human score submission IDs cannot be reused for a different decision"
+                    )
+                result.append(saved)
+                selected.append((root, history))
+                return root
             existing = next(
                 (
                     item
@@ -261,32 +285,40 @@ class HumanScoreReview:
                 None,
             )
             if existing is not None and existing.score == score:
-                result.append(existing)
-                return history
-            label = HumanScore(
-                label_id=stable_id(
-                    "human-score",
-                    {
-                        "rubric_id": rubric_id,
-                        "rollout_id": rollout_id,
-                        "lineage_id": lineage_id,
-                        "dimension_id": dimension_id,
-                        "score": score,
-                        "sequence": len(history.scores),
-                    },
-                ),
-                rubric_id=rubric_id,
-                rollout_id=rollout_id,
-                lineage_id=lineage_id,
-                dimension_id=dimension_id,
-                score=score,
-                created_at=created_at,
-                supersedes_label_id=None if existing is None else existing.label_id,
-            )
+                label = existing
+                next_history = history
+            else:
+                label = HumanScore(
+                    label_id=stable_id(
+                        "human-score",
+                        {
+                            "rubric_id": rubric_id,
+                            "rollout_id": rollout_id,
+                            "lineage_id": lineage_id,
+                            "dimension_id": dimension_id,
+                            "score": score,
+                            "sequence": len(history.scores),
+                        },
+                    ),
+                    rubric_id=rubric_id,
+                    rollout_id=rollout_id,
+                    lineage_id=lineage_id,
+                    dimension_id=dimension_id,
+                    score=score,
+                    created_at=created_at,
+                    supersedes_label_id=None if existing is None else existing.label_id,
+                )
+                next_history = history.append(label) if existing is None else history.correct(label)
+            submissions[submission_id] = label.label_id
             result.append(label)
-            return history.append(label) if existing is None else history.correct(label)
+            root["human_score_history"] = next_history.model_dump(mode="json")
+            root["human_score_submissions"] = submissions
+            selected.append((root, next_history))
+            return root
 
-        self._mutate(transition)
+        selected: list[tuple[JsonObject, HumanScoreHistory]] = []
+        self._store.update_review(update)
+        self._root_review, self._history = selected[0]
         return result[0]
 
     def finalize(
@@ -440,6 +472,22 @@ def _history_from_root(root: JsonObject) -> HumanScoreHistory:
         return HumanScoreHistory.model_validate(saved)
     except ValueError as exc:
         raise ValueError("review.json contains an invalid human score history") from exc
+
+
+def _score_submissions_from_root(root: JsonObject) -> dict[str, str]:
+    """Validate the local retry map from a locked review root."""
+    saved = root.get("human_score_submissions")
+    if saved is None:
+        return {}
+    if not isinstance(saved, dict) or any(
+        not isinstance(submission_id, str)
+        or not submission_id
+        or not isinstance(label_id, str)
+        or not label_id
+        for submission_id, label_id in saved.items()
+    ):
+        raise ValueError("review.json contains an invalid human score submission map")
+    return dict(saved)
 
 
 def _same_label_set_identity(left: HumanLabelSet, right: HumanLabelSet) -> bool:

--- a/wmo/common/judging/labels.py
+++ b/wmo/common/judging/labels.py
@@ -236,7 +236,7 @@ class HumanScoreReview:
             created_at: Time at which the local human decision is recorded.
 
         Returns:
-            The newly persisted original score or immutable correction.
+            The stored original score, immutable correction, or existing identical score.
 
         Raises:
             ValueError: The supplied score timestamp has no timezone.
@@ -260,6 +260,9 @@ class HumanScoreReview:
                 ),
                 None,
             )
+            if existing is not None and existing.score == score:
+                result.append(existing)
+                return history
             label = HumanScore(
                 label_id=stable_id(
                     "human-score",

--- a/wmo/common/judging/labels.py
+++ b/wmo/common/judging/labels.py
@@ -225,7 +225,22 @@ class HumanScoreReview:
         score: Literal[0, 1, 2, 3, 4, 5],
         created_at: datetime,
     ) -> HumanScore:
-        """Append or correct one score after reloading its active predecessor under the lock."""
+        """Append or correct one score after reloading its active predecessor under the lock.
+
+        Args:
+            rubric_id: Immutable finalized rubric that owns the score.
+            rollout_id: Persisted rollout receiving the score.
+            lineage_id: Frozen task lineage retained for calibration.
+            dimension_id: Rubric dimension receiving the zero-to-five score.
+            score: Human score on the finalized dimension scale.
+            created_at: Time at which the local human decision is recorded.
+
+        Returns:
+            The newly persisted original score or immutable correction.
+
+        Raises:
+            ValueError: The supplied score timestamp has no timezone.
+        """
         if created_at.tzinfo is None or created_at.utcoffset() is None:
             raise ValueError("human score timestamps must include a timezone")
         result: list[HumanScore] = []
@@ -278,7 +293,16 @@ class HumanScoreReview:
         code_revision: str,
         created_at: datetime,
     ) -> HumanLabelSet:
-        """Freeze the latest locked score history as an immutable calibration input."""
+        """Freeze the latest locked score history as an immutable calibration input.
+
+        Args:
+            rubric_id: Immutable finalized rubric whose labels are being frozen.
+            code_revision: Exact code revision producing the label-set artifact.
+            created_at: Time at which the frozen label set is materialized.
+
+        Returns:
+            The immutable label set containing the complete correction history.
+        """
         result: list[HumanLabelSet] = []
 
         def transition(history: HumanScoreHistory) -> HumanScoreHistory:

--- a/wmo/common/judging/labels.py
+++ b/wmo/common/judging/labels.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
 from typing import Literal
 
@@ -180,18 +181,18 @@ class HumanScoreReview:
         Raises:
             ValueError: The saved review data is not a valid JSON object or score history.
         """
-        root_review = _read_root_review(store)
-        saved = root_review.get("human_score_history")
-        if saved is None:
-            history = HumanScoreHistory()
-        else:
-            try:
-                history = HumanScoreHistory.model_validate(saved)
-            except ValueError as exc:
-                raise ValueError("review.json contains an invalid human score history") from exc
-        review = cls(store, root_review, history)
-        review._save()
-        return review
+        selected: list[tuple[JsonObject, HumanScoreHistory]] = []
+
+        def initialize(current: JsonValue | None) -> JsonObject:
+            root = _root_review_from_value(current)
+            history = _history_from_root(root)
+            root["human_score_history"] = history.model_dump(mode="json")
+            selected.append((root, history))
+            return root
+
+        store.update_review(initialize)
+        root, history = selected[0]
+        return cls(store, root, history)
 
     @property
     def history(self) -> HumanScoreHistory:
@@ -204,8 +205,7 @@ class HumanScoreReview:
         Args:
             score: New score with no correction predecessor.
         """
-        self._history = self._history.append(score)
-        self._save()
+        self._mutate(lambda history: history.append(score))
 
     def correct(self, score: HumanScore) -> None:
         """Persist one correction while retaining its superseded historical label.
@@ -213,10 +213,89 @@ class HumanScoreReview:
         Args:
             score: New score that names the earlier label it supersedes.
         """
-        self._history = self._history.correct(score)
-        self._save()
+        self._mutate(lambda history: history.correct(score))
+
+    def upsert(
+        self,
+        *,
+        rubric_id: ArtifactId,
+        rollout_id: ArtifactId,
+        lineage_id: ArtifactId,
+        dimension_id: ArtifactId,
+        score: Literal[0, 1, 2, 3, 4, 5],
+        created_at: datetime,
+    ) -> HumanScore:
+        """Append or correct one score after reloading its active predecessor under the lock."""
+        if created_at.tzinfo is None or created_at.utcoffset() is None:
+            raise ValueError("human score timestamps must include a timezone")
+        result: list[HumanScore] = []
+
+        def transition(history: HumanScoreHistory) -> HumanScoreHistory:
+            existing = next(
+                (
+                    item
+                    for item in history.active_scores()
+                    if (
+                        item.rubric_id,
+                        item.rollout_id,
+                        item.lineage_id,
+                        item.dimension_id,
+                    )
+                    == (rubric_id, rollout_id, lineage_id, dimension_id)
+                ),
+                None,
+            )
+            label = HumanScore(
+                label_id=stable_id(
+                    "human-score",
+                    {
+                        "rubric_id": rubric_id,
+                        "rollout_id": rollout_id,
+                        "lineage_id": lineage_id,
+                        "dimension_id": dimension_id,
+                        "score": score,
+                        "sequence": len(history.scores),
+                    },
+                ),
+                rubric_id=rubric_id,
+                rollout_id=rollout_id,
+                lineage_id=lineage_id,
+                dimension_id=dimension_id,
+                score=score,
+                created_at=created_at,
+                supersedes_label_id=None if existing is None else existing.label_id,
+            )
+            result.append(label)
+            return history.append(label) if existing is None else history.correct(label)
+
+        self._mutate(transition)
+        return result[0]
 
     def finalize(
+        self,
+        *,
+        rubric_id: ArtifactId,
+        code_revision: str,
+        created_at: datetime,
+    ) -> HumanLabelSet:
+        """Freeze the latest locked score history as an immutable calibration input."""
+        result: list[HumanLabelSet] = []
+
+        def transition(history: HumanScoreHistory) -> HumanScoreHistory:
+            self._history = history
+            result.append(
+                self._finalize(
+                    rubric_id=rubric_id,
+                    code_revision=code_revision,
+                    created_at=created_at,
+                )
+            )
+            return history
+
+        self._mutate(transition)
+        return result[0]
+
+    def _finalize(
         self,
         *,
         rubric_id: ArtifactId,
@@ -293,15 +372,26 @@ class HumanScoreReview:
             label_set = stored
         return label_set
 
-    def _save(self) -> None:
-        """Persist this namespace while preserving rubric and future review state."""
-        self._root_review["human_score_history"] = self._history.model_dump(mode="json")
-        self._store.write_review(self._root_review)
+    def _mutate(
+        self,
+        transition: Callable[[HumanScoreHistory], HumanScoreHistory],
+    ) -> None:
+        """Reload and apply one score-history transition while the review lock is held."""
+        selected: list[tuple[JsonObject, HumanScoreHistory]] = []
+
+        def update(current: JsonValue | None) -> JsonObject:
+            root = _root_review_from_value(current)
+            history = transition(_history_from_root(root))
+            root["human_score_history"] = history.model_dump(mode="json")
+            selected.append((root, history))
+            return root
+
+        self._store.update_review(update)
+        self._root_review, self._history = selected[0]
 
 
-def _read_root_review(store: ProjectStore) -> JsonObject:
-    """Read the mutable review root as a JSON object for namespace-preserving writes."""
-    review: JsonValue | None = store.read_review()
+def _root_review_from_value(review: JsonValue | None) -> JsonObject:
+    """Validate one locked review value as an object for namespace-preserving updates."""
     if review is None:
         return {}
     if not isinstance(review, dict):
@@ -312,6 +402,17 @@ def _read_root_review(store: ProjectStore) -> JsonObject:
             raise ValueError("review.json must use string field names")
         root[key] = value
     return root
+
+
+def _history_from_root(root: JsonObject) -> HumanScoreHistory:
+    """Validate the score namespace from the latest locked review root."""
+    saved = root.get("human_score_history")
+    if saved is None:
+        return HumanScoreHistory()
+    try:
+        return HumanScoreHistory.model_validate(saved)
+    except ValueError as exc:
+        raise ValueError("review.json contains an invalid human score history") from exc
 
 
 def _same_label_set_identity(left: HumanLabelSet, right: HumanLabelSet) -> bool:

--- a/wmo/common/judging/labels_test.py
+++ b/wmo/common/judging/labels_test.py
@@ -134,6 +134,33 @@ def test_human_score_review_persists_history_without_overwriting_other_review_st
     assert saved["other_review"] == {"status": "draft"}
 
 
+def test_human_score_review_upsert_is_idempotent_for_duplicate_delivery(tmp_path: Path) -> None:
+    """An identical retried score returns the active label without recording a correction."""
+    store = _store(tmp_path)
+    first = HumanScoreReview.open(store).upsert(
+        rubric_id="rubric-1",
+        rollout_id="rollout-1",
+        lineage_id="lineage-fit-1",
+        dimension_id="task-success",
+        score=3,
+        created_at=_TIME,
+    )
+    duplicate = HumanScoreReview.open(store).upsert(
+        rubric_id="rubric-1",
+        rollout_id="rollout-1",
+        lineage_id="lineage-fit-1",
+        dimension_id="task-success",
+        score=3,
+        created_at=_TIME + timedelta(seconds=1),
+    )
+
+    resumed = HumanScoreReview.open(store)
+
+    assert duplicate == first
+    assert resumed.history.scores == (first,)
+    assert resumed.history.active_scores() == (first,)
+
+
 def test_human_score_review_finalizes_an_idempotent_immutable_label_set(tmp_path: Path) -> None:
     """Finalized labels retain corrections and can safely resume without a second artifact."""
     store = _store(tmp_path)

--- a/wmo/common/judging/labels_test.py
+++ b/wmo/common/judging/labels_test.py
@@ -135,7 +135,7 @@ def test_human_score_review_persists_history_without_overwriting_other_review_st
 
 
 def test_human_score_review_upsert_is_idempotent_for_duplicate_delivery(tmp_path: Path) -> None:
-    """An identical retried score returns the active label without recording a correction."""
+    """A retried score submission returns its original label without recording a correction."""
     store = _store(tmp_path)
     first = HumanScoreReview.open(store).upsert(
         rubric_id="rubric-1",
@@ -143,6 +143,7 @@ def test_human_score_review_upsert_is_idempotent_for_duplicate_delivery(tmp_path
         lineage_id="lineage-fit-1",
         dimension_id="task-success",
         score=3,
+        submission_id="submission-1",
         created_at=_TIME,
     )
     duplicate = HumanScoreReview.open(store).upsert(
@@ -151,6 +152,7 @@ def test_human_score_review_upsert_is_idempotent_for_duplicate_delivery(tmp_path
         lineage_id="lineage-fit-1",
         dimension_id="task-success",
         score=3,
+        submission_id="submission-1",
         created_at=_TIME + timedelta(seconds=1),
     )
 
@@ -159,6 +161,46 @@ def test_human_score_review_upsert_is_idempotent_for_duplicate_delivery(tmp_path
     assert duplicate == first
     assert resumed.history.scores == (first,)
     assert resumed.history.active_scores() == (first,)
+
+
+def test_human_score_review_keeps_a_delayed_retry_from_reverting_a_correction(
+    tmp_path: Path,
+) -> None:
+    """A repeated delivery returns its original label after a newer correction is active."""
+    store = _store(tmp_path)
+    first = HumanScoreReview.open(store).upsert(
+        rubric_id="rubric-1",
+        rollout_id="rollout-1",
+        lineage_id="lineage-fit-1",
+        dimension_id="task-success",
+        score=2,
+        submission_id="submission-1",
+        created_at=_TIME,
+    )
+    corrected = HumanScoreReview.open(store).upsert(
+        rubric_id="rubric-1",
+        rollout_id="rollout-1",
+        lineage_id="lineage-fit-1",
+        dimension_id="task-success",
+        score=4,
+        submission_id="submission-2",
+        created_at=_TIME + timedelta(seconds=1),
+    )
+    delayed = HumanScoreReview.open(store).upsert(
+        rubric_id="rubric-1",
+        rollout_id="rollout-1",
+        lineage_id="lineage-fit-1",
+        dimension_id="task-success",
+        score=2,
+        submission_id="submission-1",
+        created_at=_TIME + timedelta(seconds=2),
+    )
+
+    resumed = HumanScoreReview.open(store)
+
+    assert delayed == first
+    assert resumed.history.scores == (first, corrected)
+    assert resumed.history.active_scores() == (corrected,)
 
 
 def test_human_score_review_finalizes_an_idempotent_immutable_label_set(tmp_path: Path) -> None:

--- a/wmo/common/judging/review.py
+++ b/wmo/common/judging/review.py
@@ -179,7 +179,11 @@ class RubricReview:
         return self._draft
 
     def accept(self, dimension_id: ArtifactId) -> None:
-        """Accept one proposed rubric card in a locked review transaction."""
+        """Accept one proposed rubric card in a locked review transaction.
+
+        Args:
+            dimension_id: Proposed rubric card to add to the human-owned draft.
+        """
         self._mutate(lambda review: review._accept(dimension_id))
 
     def _accept(self, dimension_id: ArtifactId) -> None:
@@ -205,7 +209,11 @@ class RubricReview:
         )
 
     def reject(self, dimension_id: ArtifactId) -> None:
-        """Reject one proposed rubric card in a locked review transaction."""
+        """Reject one proposed rubric card in a locked review transaction.
+
+        Args:
+            dimension_id: Proposed rubric card to remove from the editable draft.
+        """
         self._mutate(lambda review: review._reject(dimension_id))
 
     def _reject(self, dimension_id: ArtifactId) -> None:
@@ -241,7 +249,14 @@ class RubricReview:
         description: str | None = None,
         anchors: tuple[ScoreAnchor, ...] | None = None,
     ) -> None:
-        """Edit one rubric card in a locked review transaction."""
+        """Edit one rubric card in a locked review transaction.
+
+        Args:
+            dimension_id: Active or proposed rubric card to change.
+            name: Optional replacement display name.
+            description: Optional replacement customer-facing definition.
+            anchors: Optional complete ordered zero-to-five anchor replacement.
+        """
         self._mutate(
             lambda review: review._edit(
                 dimension_id,
@@ -301,7 +316,11 @@ class RubricReview:
         )
 
     def add(self, dimension: RubricDimension) -> None:
-        """Add one human-authored scale in a locked review transaction."""
+        """Add one human-authored scale in a locked review transaction.
+
+        Args:
+            dimension: Complete zero-to-five rubric dimension to append.
+        """
         self._mutate(lambda review: review._add(dimension))
 
     def _add(self, dimension: RubricDimension) -> None:
@@ -323,7 +342,11 @@ class RubricReview:
         )
 
     def replace_all(self, dimensions: Sequence[RubricDimension]) -> None:
-        """Replace every active scale in a locked review transaction."""
+        """Replace every active scale in a locked review transaction.
+
+        Args:
+            dimensions: Complete ordered non-empty set of replacement scales.
+        """
         replacement = tuple(dimensions)
         self._mutate(lambda review: review._replace_all(replacement))
 
@@ -349,7 +372,11 @@ class RubricReview:
         )
 
     def order(self, dimension_ids: Sequence[ArtifactId]) -> None:
-        """Reorder every active scale in a locked review transaction."""
+        """Reorder every active scale in a locked review transaction.
+
+        Args:
+            dimension_ids: Every active dimension ID once, in the desired output order.
+        """
         requested = tuple(dimension_ids)
         self._mutate(lambda review: review._order(requested))
 
@@ -374,7 +401,11 @@ class RubricReview:
         )
 
     def finalize(self) -> Rubric:
-        """Finalize the current draft inside one locked review transaction."""
+        """Finalize the current draft inside one locked review transaction.
+
+        Returns:
+            The immutable approved rubric produced from the locked review draft.
+        """
         finalized: list[Rubric] = []
 
         def transition(review: RubricReview) -> None:

--- a/wmo/common/judging/review.py
+++ b/wmo/common/judging/review.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from typing import Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, JsonValue, field_validator, model_validator
 
 from wmo.common.core.artifacts import ArtifactId, ContractModel, JsonObject, stable_id
 from wmo.common.judging.proposal import (
@@ -111,13 +111,15 @@ class RubricReview:
         self,
         store: ProjectStore,
         draft: RubricReviewDraft,
-        root_review: JsonObject,
+        proposals: tuple[RubricProposal, ...],
+        producer_revision: str,
         clock: Callable[[], datetime],
     ) -> None:
         """Construct a review service from validated persisted draft state."""
         self._store = store
         self._draft = draft
-        self._root_review = root_review
+        self._proposals = proposals
+        self._producer_revision = producer_revision
         self._clock = clock
 
     @classmethod
@@ -135,7 +137,7 @@ class RubricReview:
         Args:
             store: Project-local storage containing the sole mutable review file.
             source_task_set_id: Task set whose representative evidence seeded this review.
-            code_revision: Exact code revision recorded in the finalized rubric artifact.
+            code_revision: Exact current producer revision for any new artifact.
             proposals: Optional model-proposed cards used when creating a new draft.
             clock: Injectable wall clock for deterministic callers and tests.
 
@@ -146,29 +148,30 @@ class RubricReview:
             RubricReviewError: Existing draft state belongs to another task set or proposal set.
         """
         now = _utc_now if clock is None else clock
-        root_review = _read_root_review(store)
-        saved = root_review.get("rubric_review")
-        if saved is None:
-            draft = RubricReviewDraft(
-                source_task_set_id=source_task_set_id,
-                code_revision=code_revision,
-                proposals=tuple(proposals),
-            )
-            review = cls(store, draft, root_review, now)
-            review._save()
-            return review
-        try:
-            draft = RubricReviewDraft.model_validate(saved)
-        except ValueError as exc:
-            raise RubricReviewError("review.json contains an invalid rubric review draft") from exc
-        if draft.source_task_set_id != source_task_set_id:
-            raise RubricReviewError("existing rubric review belongs to another task set")
-        if draft.code_revision != code_revision:
-            raise RubricReviewError("existing rubric review belongs to another code revision")
         supplied_proposals = tuple(proposals)
-        if supplied_proposals and supplied_proposals != draft.proposals:
-            raise RubricReviewError("existing rubric review has a different proposal set")
-        return cls(store, draft, root_review, now)
+        selected: list[RubricReviewDraft] = []
+
+        def initialize(current: JsonValue | None) -> JsonObject:
+            root = _root_review_from_value(current)
+            saved = root.get("rubric_review")
+            if saved is None:
+                draft = RubricReviewDraft(
+                    source_task_set_id=source_task_set_id,
+                    code_revision=code_revision,
+                    proposals=supplied_proposals,
+                )
+            else:
+                draft = _validated_draft(
+                    saved,
+                    source_task_set_id=source_task_set_id,
+                    proposals=supplied_proposals,
+                )
+            root["rubric_review"] = draft.model_dump(mode="json")
+            selected.append(draft)
+            return root
+
+        store.update_review(initialize)
+        return cls(store, selected[0], supplied_proposals, code_revision, now)
 
     @property
     def draft(self) -> RubricReviewDraft:
@@ -176,6 +179,10 @@ class RubricReview:
         return self._draft
 
     def accept(self, dimension_id: ArtifactId) -> None:
+        """Accept one proposed rubric card in a locked review transaction."""
+        self._mutate(lambda review: review._accept(dimension_id))
+
+    def _accept(self, dimension_id: ArtifactId) -> None:
         """Accept one proposed rubric card into the editable review order.
 
         Args:
@@ -198,6 +205,10 @@ class RubricReview:
         )
 
     def reject(self, dimension_id: ArtifactId) -> None:
+        """Reject one proposed rubric card in a locked review transaction."""
+        self._mutate(lambda review: review._reject(dimension_id))
+
+    def _reject(self, dimension_id: ArtifactId) -> None:
         """Reject one proposed card and remove it from the editable rubric if needed.
 
         Args:
@@ -223,6 +234,24 @@ class RubricReview:
         )
 
     def edit(
+        self,
+        dimension_id: ArtifactId,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        anchors: tuple[ScoreAnchor, ...] | None = None,
+    ) -> None:
+        """Edit one rubric card in a locked review transaction."""
+        self._mutate(
+            lambda review: review._edit(
+                dimension_id,
+                name=name,
+                description=description,
+                anchors=anchors,
+            )
+        )
+
+    def _edit(
         self,
         dimension_id: ArtifactId,
         *,
@@ -272,6 +301,10 @@ class RubricReview:
         )
 
     def add(self, dimension: RubricDimension) -> None:
+        """Add one human-authored scale in a locked review transaction."""
+        self._mutate(lambda review: review._add(dimension))
+
+    def _add(self, dimension: RubricDimension) -> None:
         """Add one human-authored zero-to-five rubric dimension.
 
         Args:
@@ -290,6 +323,11 @@ class RubricReview:
         )
 
     def replace_all(self, dimensions: Sequence[RubricDimension]) -> None:
+        """Replace every active scale in a locked review transaction."""
+        replacement = tuple(dimensions)
+        self._mutate(lambda review: review._replace_all(replacement))
+
+    def _replace_all(self, dimensions: Sequence[RubricDimension]) -> None:
         """Replace the editable scale set with a complete human-owned ordering.
 
         Args:
@@ -311,6 +349,11 @@ class RubricReview:
         )
 
     def order(self, dimension_ids: Sequence[ArtifactId]) -> None:
+        """Reorder every active scale in a locked review transaction."""
+        requested = tuple(dimension_ids)
+        self._mutate(lambda review: review._order(requested))
+
+    def _order(self, dimension_ids: Sequence[ArtifactId]) -> None:
         """Set the complete visible order of already accepted rubric dimensions.
 
         Args:
@@ -331,6 +374,16 @@ class RubricReview:
         )
 
     def finalize(self) -> Rubric:
+        """Finalize the current draft inside one locked review transaction."""
+        finalized: list[Rubric] = []
+
+        def transition(review: RubricReview) -> None:
+            finalized.append(review._finalize())
+
+        self._mutate(transition)
+        return finalized[0]
+
+    def _finalize(self) -> Rubric:
         """Write one immutable approved rubric artifact and lock the review draft.
 
         Returns:
@@ -371,7 +424,7 @@ class RubricReview:
                         self._store,
                         proposal=proposal,
                         source_task_set_input=task_set_input,
-                        code_revision=self._draft.code_revision,
+                        code_revision=self._producer_revision,
                         created_at=created_at,
                     ).proposal_evidence_id
                     for proposal in accepted_proposals
@@ -401,7 +454,7 @@ class RubricReview:
             schema_version=1,
             created_at=created_at,
             inputs=inputs,
-            code_revision=self._draft.code_revision,
+            code_revision=self._producer_revision,
             rubric_id=rubric_id,
             dimensions=self._draft.dimensions,
             source_task_set_id=self._draft.source_task_set_id,
@@ -433,7 +486,7 @@ class RubricReview:
         event = self._event("finalize", tuple(item.dimension_id for item in rubric.dimensions))
         self._draft = RubricReviewDraft(
             source_task_set_id=self._draft.source_task_set_id,
-            code_revision=self._draft.code_revision,
+            code_revision=self._producer_revision,
             proposals=self._draft.proposals,
             dimensions=rubric.dimensions,
             rejected_dimension_ids=self._draft.rejected_dimension_ids,
@@ -441,7 +494,6 @@ class RubricReview:
             status="finalized",
             finalized_rubric=rubric,
         )
-        self._save()
         return rubric
 
     def _candidate(self, dimension_id: ArtifactId) -> RubricDimension:
@@ -475,7 +527,7 @@ class RubricReview:
         event = self._event(event_kind, event_dimension_ids)
         self._draft = RubricReviewDraft(
             source_task_set_id=self._draft.source_task_set_id,
-            code_revision=self._draft.code_revision,
+            code_revision=self._producer_revision,
             proposals=self._draft.proposals,
             dimensions=dimensions,
             rejected_dimension_ids=(
@@ -485,7 +537,35 @@ class RubricReview:
             ),
             events=(*self._draft.events, event),
         )
-        self._save()
+
+    def _mutate(self, transition: Callable[[RubricReview], None]) -> None:
+        """Reload and apply one namespace transition while the review lock is held."""
+        selected: list[RubricReviewDraft] = []
+
+        def update(current: JsonValue | None) -> JsonObject:
+            root = _root_review_from_value(current)
+            saved = root.get("rubric_review")
+            if saved is None:
+                raise RubricReviewError("rubric review draft disappeared before mutation")
+            draft = _validated_draft(
+                saved,
+                source_task_set_id=self._draft.source_task_set_id,
+                proposals=self._proposals,
+            )
+            working = RubricReview(
+                self._store,
+                draft,
+                self._proposals,
+                self._producer_revision,
+                self._clock,
+            )
+            transition(working)
+            root["rubric_review"] = working._draft.model_dump(mode="json")
+            selected.append(working._draft)
+            return root
+
+        self._store.update_review(update)
+        self._draft = selected[0]
 
     def _event(
         self,
@@ -517,15 +597,9 @@ class RubricReview:
             raise RubricReviewError("rubric review clock must return a timezone-aware time")
         return value
 
-    def _save(self) -> None:
-        """Save only this service's namespace while preserving other review-draft fields."""
-        self._root_review["rubric_review"] = self._draft.model_dump(mode="json")
-        self._store.write_review(self._root_review)
 
-
-def _read_root_review(store: ProjectStore) -> JsonObject:
-    """Return the mutable review root as an object suitable for namespace-preserving writes."""
-    review = store.read_review()
+def _root_review_from_value(review: JsonValue | None) -> JsonObject:
+    """Validate one locked review value as an object suitable for namespace updates."""
     if review is None:
         return {}
     if not isinstance(review, dict):
@@ -536,6 +610,24 @@ def _read_root_review(store: ProjectStore) -> JsonObject:
             raise RubricReviewError("review.json must use string field names")
         root[key] = value
     return root
+
+
+def _validated_draft(
+    saved: JsonValue,
+    *,
+    source_task_set_id: ArtifactId,
+    proposals: tuple[RubricProposal, ...],
+) -> RubricReviewDraft:
+    """Validate a persisted rubric namespace against its selected task set and proposals."""
+    try:
+        draft = RubricReviewDraft.model_validate(saved)
+    except ValueError as exc:
+        raise RubricReviewError("review.json contains an invalid rubric review draft") from exc
+    if draft.source_task_set_id != source_task_set_id:
+        raise RubricReviewError("existing rubric review belongs to another task set")
+    if proposals and proposals != draft.proposals:
+        raise RubricReviewError("existing rubric review has a different proposal set")
+    return draft
 
 
 def _same_rubric_identity(left: Rubric, right: Rubric) -> bool:

--- a/wmo/common/judging/review_test.py
+++ b/wmo/common/judging/review_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -196,3 +197,76 @@ def test_review_finalize_recovers_after_artifact_write_before_draft_lock(tmp_pat
     )
 
     assert resumed.finalize() == rubric
+
+
+def test_concurrent_review_transitions_reload_under_lock_and_retain_both_events(
+    tmp_path: Path,
+) -> None:
+    """Two stale service instances cannot erase one another's accepted scale or event."""
+    store = _store(tmp_path)
+    proposal = _proposal()
+    first = RubricReview.open(
+        store,
+        source_task_set_id="task-set-1",
+        code_revision="producer-current",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+    second = RubricReview.open(
+        store,
+        source_task_set_id="task-set-1",
+        code_revision="producer-current",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = (
+            executor.submit(first.accept, "task-success"),
+            executor.submit(second.accept, "policy-compliance"),
+        )
+        for future in futures:
+            future.result()
+
+    resumed = RubricReview.open(
+        store,
+        source_task_set_id="task-set-1",
+        code_revision="producer-current",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+    assert {item.dimension_id for item in resumed.draft.dimensions} == {
+        "task-success",
+        "policy-compliance",
+    }
+    assert tuple(event.kind for event in resumed.draft.events) == ("accept", "accept")
+
+
+def test_resumed_review_uses_current_producer_revision_for_new_rubric(tmp_path: Path) -> None:
+    """A new rubric records the current producer rather than its task or draft revision."""
+    store = _store(tmp_path)
+    _write_task_set(store)
+    proposal = _proposal()
+    original = RubricReview.open(
+        store,
+        source_task_set_id="task-set-1",
+        code_revision="old-review-producer",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+    original.accept("task-success")
+
+    resumed = RubricReview.open(
+        store,
+        source_task_set_id="task-set-1",
+        code_revision="current-review-producer",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+    rubric = resumed.finalize()
+
+    assert rubric.code_revision == "current-review-producer"
+    assert all(
+        store.artifacts.read(artifact_id).manifest.code_revision == "current-review-producer"
+        for artifact_id in rubric.accepted_proposal_evidence_ids
+    )

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -7,7 +7,7 @@ import logging
 import os
 import shutil
 import stat
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
@@ -383,7 +383,7 @@ class ProjectStore:
             raise ProjectStoreError(str(exc)) from exc
 
     def write_review(self, review: BaseModel | JsonValue) -> None:
-        """Atomically replace the sole mutable local review draft.
+        """Lock and atomically replace the sole mutable local review draft.
 
         Args:
             review: Structured draft task, rubric, or calibration review state.
@@ -391,11 +391,35 @@ class ProjectStore:
         Raises:
             ProjectStoreError: The draft crosses the local no-secret boundary.
         """
-        try:
-            assert_secret_free(review)
-        except SecretBoundaryError as exc:
-            raise ProjectStoreError(str(exc)) from exc
-        write_bytes_atomic(self.paths.review_json, canonical_json_bytes(review))
+        with file_write_lock(self.paths.review_json, what="project review"):
+            self._write_review_unlocked(review)
+
+    def update_review(
+        self,
+        update: Callable[[JsonValue | None], BaseModel | JsonValue],
+    ) -> JsonValue:
+        """Lock the complete review read-modify-write cycle and return the stored value.
+
+        Args:
+            update: Transition that receives the latest draft while the project lock is held.
+
+        Returns:
+            The validated JSON value written atomically by this transaction.
+
+        Raises:
+            ProjectStoreError: The current draft is corrupt or the replacement crosses the
+                no-secret boundary.
+        """
+        with file_write_lock(self.paths.review_json, what="project review"):
+            current = self._read_review_unlocked()
+            replacement = update(current)
+            payload = canonical_json_bytes(replacement)
+            try:
+                stored = _JSON_VALUE_ADAPTER.validate_json(payload)
+            except ValidationError as exc:
+                raise ProjectStoreError("review update did not produce valid JSON") from exc
+            self._write_review_unlocked(stored)
+            return stored
 
     def read_review(self) -> JsonValue | None:
         """Load the mutable review draft, returning ``None`` before any draft exists.
@@ -406,6 +430,18 @@ class ProjectStore:
         Raises:
             ProjectStoreError: If the draft cannot be read or is not valid JSON.
         """
+        return self._read_review_unlocked()
+
+    def _write_review_unlocked(self, review: BaseModel | JsonValue) -> None:
+        """Atomically write a review value while the caller owns the project review lock."""
+        try:
+            assert_secret_free(review)
+        except SecretBoundaryError as exc:
+            raise ProjectStoreError(str(exc)) from exc
+        write_bytes_atomic(self.paths.review_json, canonical_json_bytes(review))
+
+    def _read_review_unlocked(self) -> JsonValue | None:
+        """Read the review value without taking a lock for callers that already hold it."""
         if not self.paths.review_json.exists():
             return None
         try:

--- a/wmo/repo_structure_test.py
+++ b/wmo/repo_structure_test.py
@@ -20,6 +20,7 @@ ALLOWED_TOP_DIRS = {
     "wmo",
     "docs",
     "assets",
+    "web",
     ".claude",
     ".github",
 }
@@ -37,7 +38,7 @@ ALLOWED_TOP_FILES = {
     "uv.lock",
 }
 
-RETIRED_TOP_DIRS = (".agents/", "deploy/", "examples/", "packages/", "web/")
+RETIRED_TOP_DIRS = (".agents/", "deploy/", "examples/", "packages/")
 _RETIRED_PATTERNS = tuple(
     (retired, re.compile(rf"(?<![\w./-]){re.escape(retired)}")) for retired in RETIRED_TOP_DIRS
 )

--- a/wmo/review_server.py
+++ b/wmo/review_server.py
@@ -305,7 +305,18 @@ class ReviewApplication:
         report_id: ArtifactId,
         approval: CalibrationApproval,
     ) -> ReviewMutationResponse:
-        """Approve one exact visible W6 report only after explicit human confirmation."""
+        """Approve one exact visible W6 report only after explicit human confirmation.
+
+        Args:
+            report_id: Visible persisted calibration report selected for approval.
+            approval: Explicit confirmation and low-sample risk-acceptance fields.
+
+        Returns:
+            The refreshed local review state and immutable approval notice.
+
+        Raises:
+            ReviewServerError: Confirmation, finalization, report, or risk requirements fail.
+        """
         if not approval.confirmed:
             raise ReviewServerError("calibration approval requires explicit confirmation")
         review = self._rubric_review(self._loaded_task_set())
@@ -452,6 +463,9 @@ def create_review_app(
 
     Returns:
         A FastAPI application with no auth, tenant, provider, or deployment integration.
+
+    Raises:
+        ReviewServerError: The requested local loopback port is outside the valid range.
     """
     if not 1 <= port <= 65535:
         raise ReviewServerError("review port must be between 1 and 65535")

--- a/wmo/review_server.py
+++ b/wmo/review_server.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 from urllib.parse import SplitResult, urlsplit
+from uuid import UUID
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -96,6 +97,7 @@ class ScoreOverride(BaseModel):
     lineage_id: ArtifactId
     dimension_id: ArtifactId
     score: ScoreValue
+    submission_id: UUID
 
 
 class CalibrationApproval(BaseModel):
@@ -295,6 +297,7 @@ class ReviewApplication:
             lineage_id=override.lineage_id,
             dimension_id=override.dimension_id,
             score=override.score,
+            submission_id=str(override.submission_id),
             created_at=self._now(),
         )
         notice = self._refresh_calibration(rubric_id=rubric.rubric_id, score_review=score_review)

--- a/wmo/review_server.py
+++ b/wmo/review_server.py
@@ -7,23 +7,26 @@ directly. It calls this local adapter, which delegates every mutation to the W5 
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable, Sequence
+import subprocess
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
+from urllib.parse import SplitResult, urlsplit
 
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from pydantic import BaseModel, Field
+from starlette.responses import JSONResponse
 
-from wmo.common.core.artifacts import ArtifactId, stable_id
+from wmo.common.core.artifacts import ArtifactId
 from wmo.common.judging import (
     CalibrationError,
     CalibrationReport,
-    HumanScore,
     HumanScoreHistory,
     HumanScoreReview,
+    JudgeCalibration,
     JudgeCalibrationService,
     JudgeScoreObservation,
     Judgment,
@@ -70,6 +73,7 @@ class ReviewSnapshot(BaseModel):
     human_score_history: HumanScoreHistory
     rollouts: tuple[ReviewRolloutView, ...]
     calibration_reports: tuple[CalibrationReport, ...]
+    calibrations: tuple[JudgeCalibration, ...]
 
 
 class RubricMutation(BaseModel):
@@ -92,6 +96,13 @@ class ScoreOverride(BaseModel):
     lineage_id: ArtifactId
     dimension_id: ArtifactId
     score: ScoreValue
+
+
+class CalibrationApproval(BaseModel):
+    """Explicit confirmation fields for one persisted calibration-report approval."""
+
+    confirmed: bool = False
+    accept_insufficient_risk: bool = False
 
 
 class ReviewMutationResponse(BaseModel):
@@ -124,15 +135,23 @@ class ReviewApplication:
         self,
         store: ProjectStore,
         *,
+        code_revision: str,
+        task_set_id: ArtifactId | None = None,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
         """Create one local adapter without reading credentials or starting a provider client.
 
         Args:
             store: One initialized project-local WMO store.
+            code_revision: Exact current repository revision for newly produced artifacts.
+            task_set_id: Optional explicit task-set selection when no saved draft exists.
             clock: Optional deterministic clock used by review and label persistence.
         """
+        if not code_revision.strip():
+            raise ReviewServerError("review producer revision must be nonempty")
         self._store = store
+        self._code_revision = code_revision
+        self._task_set_id = task_set_id
         self._clock = _utc_now if clock is None else clock
 
     def snapshot(self) -> ReviewSnapshot:
@@ -170,6 +189,11 @@ class ReviewApplication:
             for report in _load_calibration_reports(self._store)
             if finalized is not None and report.rubric_id == finalized.rubric_id
         )
+        calibrations = tuple(
+            calibration
+            for calibration in _load_calibrations(self._store)
+            if finalized is not None and calibration.rubric_id == finalized.rubric_id
+        )
         return ReviewSnapshot(
             project_id=self._store.paths.project_id,
             local_data_notice=(
@@ -184,6 +208,7 @@ class ReviewApplication:
             human_score_history=score_review.history,
             rollouts=rollouts,
             calibration_reports=reports,
+            calibrations=calibrations,
         )
 
     def rubric_action(
@@ -264,45 +289,73 @@ class ReviewApplication:
             raise ReviewServerError("the stored judgment does not score the requested dimension")
 
         score_review = HumanScoreReview.open(self._store)
-        existing = _active_score(
-            score_review.history,
-            rubric_id=rubric.rubric_id,
-            rollout_id=override.rollout_id,
-            lineage_id=override.lineage_id,
-            dimension_id=override.dimension_id,
-        )
-        created_at = self._now()
-        label = HumanScore(
-            label_id=stable_id(
-                "human-score",
-                {
-                    "rubric_id": rubric.rubric_id,
-                    "rollout_id": override.rollout_id,
-                    "lineage_id": override.lineage_id,
-                    "dimension_id": override.dimension_id,
-                    "score": override.score,
-                    "sequence": len(score_review.history.scores),
-                },
-            ),
+        score_review.upsert(
             rubric_id=rubric.rubric_id,
             rollout_id=override.rollout_id,
             lineage_id=override.lineage_id,
             dimension_id=override.dimension_id,
             score=override.score,
-            created_at=created_at,
-            supersedes_label_id=None if existing is None else existing.label_id,
+            created_at=self._now(),
         )
-        if existing is None:
-            score_review.append(label)
-        else:
-            score_review.correct(label)
         notice = self._refresh_calibration(rubric_id=rubric.rubric_id, score_review=score_review)
         return ReviewMutationResponse(snapshot=self.snapshot(), notice=notice)
 
+    def approve_calibration(
+        self,
+        report_id: ArtifactId,
+        approval: CalibrationApproval,
+    ) -> ReviewMutationResponse:
+        """Approve one exact visible W6 report only after explicit human confirmation."""
+        if not approval.confirmed:
+            raise ReviewServerError("calibration approval requires explicit confirmation")
+        review = self._rubric_review(self._loaded_task_set())
+        rubric = review.draft.finalized_rubric
+        if rubric is None:
+            raise ReviewServerError("finalize the rubric before approving judge calibration")
+        report = next(
+            (
+                item
+                for item in _load_calibration_reports(self._store)
+                if item.report_id == report_id and item.rubric_id == rubric.rubric_id
+            ),
+            None,
+        )
+        if report is None:
+            raise ReviewServerError("the selected calibration report is missing for this rubric")
+        if report.status == "insufficient" and not approval.accept_insufficient_risk:
+            raise ReviewServerError(
+                "fewer than ten eligible rollouts require explicit insufficient-risk acceptance"
+            )
+        if report.status != "insufficient" and approval.accept_insufficient_risk:
+            raise ReviewServerError(
+                "insufficient-risk acceptance applies only to an insufficient report"
+            )
+        service = JudgeCalibrationService()
+        calibration = service.approve(
+            self._store,
+            report,
+            approved_at=self._now(),
+            accept_insufficient_labels=approval.accept_insufficient_risk,
+        )
+        stored = service.write_calibration(
+            self._store,
+            report=report,
+            calibration=calibration,
+        )
+        return ReviewMutationResponse(
+            snapshot=self.snapshot(),
+            notice=f"Human-calibrated judge artifact {stored.calibration_id} approved locally.",
+        )
+
     def _loaded_task_set(self) -> LoadedTaskSet:
-        """Resolve the sole selected task set used by this local review session."""
+        """Resolve the saved or explicitly selected task set for this local review session."""
         try:
-            return resolve_task_set(self._store.artifacts)
+            persisted = _persisted_task_set_id(self._store)
+            if persisted is not None and self._task_set_id not in {None, persisted}:
+                raise ReviewServerError(
+                    "--task-set conflicts with the task set already persisted in review.json"
+                )
+            return resolve_task_set(self._store.artifacts, persisted or self._task_set_id)
         except ArtifactCorruptionError as exc:
             raise ReviewServerError(str(exc)) from exc
 
@@ -312,7 +365,7 @@ class ReviewApplication:
             return RubricReview.open(
                 self._store,
                 source_task_set_id=task_set.task_set.task_set_id,
-                code_revision=task_set.task_set.code_revision,
+                code_revision=self._code_revision,
                 clock=self._clock,
             )
         except RubricReviewError as exc:
@@ -344,7 +397,7 @@ class ReviewApplication:
         try:
             label_set = score_review.finalize(
                 rubric_id=rubric_id,
-                code_revision=source_report.code_revision,
+                code_revision=self._code_revision,
                 created_at=created_at,
             )
             observations = _observations_for_active_scores(
@@ -360,7 +413,7 @@ class ReviewApplication:
                 router_lineage_split_id=source_report.router_lineage_split_id,
                 observations=observations,
                 created_at=created_at,
-                code_revision=source_report.code_revision,
+                code_revision=self._code_revision,
             )
             stored = service.write_report(self._store, report)
         except (CalibrationError, ProjectStoreError, ValueError) as exc:
@@ -382,6 +435,9 @@ def create_review_app(
     root: Path,
     project_id: str,
     *,
+    code_revision: str,
+    task_set_id: ArtifactId | None = None,
+    port: int = 8017,
     clock: Callable[[], datetime] | None = None,
 ) -> FastAPI:
     """Create the loopback API over one project-local WMO review store.
@@ -389,18 +445,40 @@ def create_review_app(
     Args:
         root: Local `.wmo` root containing the project directory.
         project_id: One validated project identifier below the local root.
+        code_revision: Exact current producer revision for newly approved artifacts.
+        task_set_id: Optional task-set selection before a draft has persisted one.
+        port: Exact loopback port accepted in the HTTP Host boundary.
         clock: Optional deterministic clock for tests and local review writes.
 
     Returns:
         A FastAPI application with no auth, tenant, provider, or deployment integration.
     """
-    application = ReviewApplication(ProjectStore(root, project_id), clock=clock)
+    if not 1 <= port <= 65535:
+        raise ReviewServerError("review port must be between 1 and 65535")
+    application = ReviewApplication(
+        ProjectStore(root, project_id),
+        code_revision=code_revision,
+        task_set_id=task_set_id,
+        clock=clock,
+    )
     app = FastAPI(
         title="WMO local review",
         docs_url=None,
         redoc_url=None,
         openapi_url=None,
     )
+
+    @app.middleware("http")
+    async def enforce_loopback_request(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Reject DNS rebinding and cross-origin requests before any local evidence read."""
+        try:
+            _validate_loopback_request(request, port=port)
+        except ReviewServerError as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
+        return await call_next(request)
 
     @app.get("/health")
     def health() -> dict[str, str]:
@@ -434,6 +512,20 @@ def create_review_app(
         except _LOCAL_REVIEW_ERRORS as exc:
             raise _http_error(exc) from exc
 
+    @app.post(
+        "/api/review/calibration/{report_id}/approve",
+        response_model=ReviewMutationResponse,
+    )
+    def approve_calibration(
+        report_id: ArtifactId,
+        approval: CalibrationApproval,
+    ) -> ReviewMutationResponse:
+        """Persist an explicitly confirmed human-calibrated W6 judge artifact."""
+        try:
+            return application.approve_calibration(report_id, approval)
+        except _LOCAL_REVIEW_ERRORS as exc:
+            raise _http_error(exc) from exc
+
     return app
 
 
@@ -452,6 +544,79 @@ def _http_error(error: Exception) -> HTTPException:
     return HTTPException(status_code=400, detail=str(error))
 
 
+def _validate_loopback_request(request: Request, *, port: int) -> None:
+    """Require one exact loopback Host and same-origin Origin or Referer when supplied."""
+    host_values = _raw_header_values(request, b"host")
+    if len(host_values) != 1:
+        raise ReviewServerError("local review requests require exactly one Host header")
+    allowed_hosts = {
+        f"127.0.0.1:{port}",
+        f"localhost:{port}",
+        f"[::1]:{port}",
+    }
+    host = host_values[0].casefold()
+    if host not in allowed_hosts:
+        raise ReviewServerError("local review Host must be loopback with the expected port")
+    expected = _origin_tuple(urlsplit(f"http://{host}"), label="Host")
+    for header_name in (b"origin", b"referer"):
+        values = _raw_header_values(request, header_name)
+        if len(values) > 1:
+            raise ReviewServerError(
+                f"local review requests may include at most one {header_name.decode()} header"
+            )
+        if values:
+            supplied = _origin_tuple(
+                urlsplit(values[0]),
+                label=header_name.decode().title(),
+            )
+            if supplied != expected:
+                raise ReviewServerError(
+                    f"local review {header_name.decode()} must match the loopback Host origin"
+                )
+
+
+def _raw_header_values(request: Request, name: bytes) -> tuple[str, ...]:
+    """Return every decoded raw request-header value for duplicate rejection."""
+    return tuple(
+        value.decode("latin-1").strip()
+        for key, value in request.scope.get("headers", ())
+        if key.lower() == name
+    )
+
+
+def _origin_tuple(value: SplitResult, *, label: str) -> tuple[str, str, int]:
+    """Parse one strict local HTTP origin for Host, Origin, and Referer comparison."""
+    try:
+        port = value.port
+    except ValueError as exc:
+        raise ReviewServerError(f"local review {label} has an invalid port") from exc
+    if (
+        value.scheme.casefold() != "http"
+        or value.hostname is None
+        or port is None
+        or value.username is not None
+        or value.password is not None
+    ):
+        raise ReviewServerError(f"local review {label} must be an explicit HTTP origin")
+    return value.scheme.casefold(), value.hostname.casefold(), port
+
+
+def _persisted_task_set_id(store: ProjectStore) -> ArtifactId | None:
+    """Return the task-set identity already selected by a valid resumable review draft."""
+    review = store.read_review()
+    if review is None:
+        return None
+    if not isinstance(review, dict):
+        raise ReviewServerError("review.json must be a JSON object")
+    saved = review.get("rubric_review")
+    if saved is None:
+        return None
+    try:
+        return RubricReviewDraft.model_validate(saved).source_task_set_id
+    except ValueError as exc:
+        raise ReviewServerError("review.json contains an invalid rubric review draft") from exc
+
+
 def _load_coverage(store: ProjectStore, task_set: LoadedTaskSet) -> CoverageReport | None:
     """Load coverage only from the selected immutable W5 task-set artifact."""
     envelope = task_set.task_set
@@ -462,7 +627,7 @@ def _load_coverage(store: ProjectStore, task_set: LoadedTaskSet) -> CoverageRepo
             store.artifacts.read_bytes(envelope.task_set_id, envelope.coverage_path)
         )
     except (ArtifactCorruptionError, ValueError) as exc:
-        raise ReviewServerError("the selected task-set coverage report is invalid") from exc
+        raise ReviewServerError("the selected task-set coverage report is corrupt") from exc
 
 
 def _load_rollout_records(store: ProjectStore) -> dict[ArtifactId, _RolloutRecord]:
@@ -470,18 +635,24 @@ def _load_rollout_records(store: ProjectStore) -> dict[ArtifactId, _RolloutRecor
     records: dict[ArtifactId, _RolloutRecord] = {}
     for artifact_id in store.artifacts.list_ids():
         stored = store.artifacts.read(artifact_id)
-        if stored.manifest.artifact_type not in {"rollout", "simulation-artifact-set"}:
+        if stored.manifest.artifact_type != "rollout":
             continue
-        for path in (item.path for item in stored.manifest.files):
-            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
-                try:
-                    rollout = RolloutArtifact.model_validate_json(payload)
-                except ValueError:
-                    continue
-                records.setdefault(
-                    rollout.rollout_id,
-                    _RolloutRecord(artifact_id=artifact_id, rollout=rollout),
-                )
+        try:
+            rollout = RolloutArtifact.model_validate_json(
+                store.artifacts.read_bytes(artifact_id, "rollout.json")
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise ReviewServerError(f"rollout artifact {artifact_id} is corrupt") from exc
+        if rollout.artifact_id != artifact_id:
+            raise ReviewServerError(
+                f"rollout artifact {artifact_id} does not match its record identity"
+            )
+        if rollout.rollout_id in records:
+            raise ReviewServerError(f"rollout ID {rollout.rollout_id} is stored more than once")
+        records[rollout.rollout_id] = _RolloutRecord(
+            artifact_id=artifact_id,
+            rollout=rollout,
+        )
     return records
 
 
@@ -492,16 +663,20 @@ def _load_judgment_records(store: ProjectStore) -> dict[ArtifactId, _JudgmentRec
         stored = store.artifacts.read(artifact_id)
         if stored.manifest.artifact_type != "judgment":
             continue
-        for path in (item.path for item in stored.manifest.files):
-            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
-                try:
-                    judgment = Judgment.model_validate_json(payload)
-                except ValueError:
-                    continue
-                records.setdefault(
-                    judgment.judgment_id,
-                    _JudgmentRecord(artifact_id=artifact_id, judgment=judgment),
-                )
+        try:
+            judgment = Judgment.model_validate_json(
+                store.artifacts.read_bytes(artifact_id, "judgment.json")
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise ReviewServerError(f"judgment artifact {artifact_id} is corrupt") from exc
+        if judgment.judgment_id != artifact_id:
+            raise ReviewServerError(
+                f"judgment artifact {artifact_id} does not match its record identity"
+            )
+        records[judgment.judgment_id] = _JudgmentRecord(
+            artifact_id=artifact_id,
+            judgment=judgment,
+        )
     return records
 
 
@@ -512,22 +687,41 @@ def _load_calibration_reports(store: ProjectStore) -> tuple[CalibrationReport, .
         stored = store.artifacts.read(artifact_id)
         if stored.manifest.artifact_type != "judge-calibration-report":
             continue
-        for path in (item.path for item in stored.manifest.files):
-            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
-                try:
-                    reports.append(CalibrationReport.model_validate_json(payload))
-                except ValueError:
-                    continue
+        try:
+            report = CalibrationReport.model_validate_json(
+                store.artifacts.read_bytes(artifact_id, "report.json")
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise ReviewServerError(
+                f"judge-calibration report artifact {artifact_id} is corrupt"
+            ) from exc
+        if report.report_id != artifact_id:
+            raise ReviewServerError(
+                f"judge-calibration report {artifact_id} does not match its record identity"
+            )
+        reports.append(report)
     return tuple(sorted(reports, key=lambda item: (item.created_at, item.report_id)))
 
 
-def _json_records(payload: bytes, path: str) -> tuple[bytes, ...]:
-    """Return JSON object payloads from one known immutable artifact data file."""
-    if path.endswith(".json"):
-        return (payload,)
-    if path.endswith(".jsonl"):
-        return tuple(line for line in payload.splitlines() if line)
-    return ()
+def _load_calibrations(store: ProjectStore) -> tuple[JudgeCalibration, ...]:
+    """Read immutable W6 judge calibrations and fail closed on semantic corruption."""
+    calibrations: list[JudgeCalibration] = []
+    for artifact_id in store.artifacts.list_ids():
+        stored = store.artifacts.read(artifact_id)
+        if stored.manifest.artifact_type != "judge-calibration":
+            continue
+        try:
+            calibration = JudgeCalibration.model_validate_json(
+                store.artifacts.read_bytes(artifact_id, "calibration.json")
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise ReviewServerError(f"judge-calibration artifact {artifact_id} is corrupt") from exc
+        if calibration.calibration_id != artifact_id:
+            raise ReviewServerError(
+                f"judge-calibration {artifact_id} does not match its record identity"
+            )
+        calibrations.append(calibration)
+    return tuple(sorted(calibrations, key=lambda item: (item.created_at, item.calibration_id)))
 
 
 def _judgment_by_rollout(
@@ -629,26 +823,6 @@ def _task_for_rollout(rollout: RolloutArtifact, tasks: tuple[TaskCase, ...]) -> 
     raise ReviewServerError("the score target rollout does not belong to the selected task set")
 
 
-def _active_score(
-    history: HumanScoreHistory,
-    *,
-    rubric_id: ArtifactId,
-    rollout_id: ArtifactId,
-    lineage_id: ArtifactId,
-    dimension_id: ArtifactId,
-) -> HumanScore | None:
-    """Find the active prior label that a new score must correct, if one exists."""
-    for score in history.active_scores():
-        if (
-            score.rubric_id == rubric_id
-            and score.rollout_id == rollout_id
-            and score.lineage_id == lineage_id
-            and score.dimension_id == dimension_id
-        ):
-            return score
-    return None
-
-
 def _required_id(value: ArtifactId | None, field_name: str) -> ArtifactId:
     """Require one named artifact identity from a rubric mutation."""
     if value is None:
@@ -689,6 +863,19 @@ def _loopback_host(value: str) -> str:
     return value
 
 
+def _current_revision() -> str:
+    """Return the repository revision that will produce new local review artifacts."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    revision = result.stdout.strip()
+    return revision if result.returncode == 0 and revision else "local-unversioned"
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     """Run the local review adapter on loopback for the top-level TypeScript app.
 
@@ -698,6 +885,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Serve the WMO local review adapter on loopback.")
     parser.add_argument("--root", type=Path, default=Path(".wmo"))
     parser.add_argument("--project", default="default")
+    parser.add_argument("--task-set", default=None)
     parser.add_argument("--host", type=_loopback_host, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8017)
     arguments = parser.parse_args(argv)
@@ -708,7 +896,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     except ProjectStoreError as exc:
         parser.error(str(exc))
     uvicorn.run(
-        create_review_app(arguments.root, arguments.project),
+        create_review_app(
+            arguments.root,
+            arguments.project,
+            code_revision=_current_revision(),
+            task_set_id=arguments.task_set,
+            port=arguments.port,
+        ),
         host=arguments.host,
         port=arguments.port,
         log_level="warning",

--- a/wmo/review_server.py
+++ b/wmo/review_server.py
@@ -1,0 +1,719 @@
+"""Loopback-only review adapter over the canonical task and judging services.
+
+The TypeScript review app never edits task, rubric, score-history, or calibration artifacts
+directly. It calls this local adapter, which delegates every mutation to the W5 and W6 services.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from wmo.common.core.artifacts import ArtifactId, stable_id
+from wmo.common.judging import (
+    CalibrationError,
+    CalibrationReport,
+    HumanScore,
+    HumanScoreHistory,
+    HumanScoreReview,
+    JudgeCalibrationService,
+    JudgeScoreObservation,
+    Judgment,
+    RubricReview,
+    RubricReviewDraft,
+    RubricReviewError,
+    ScoreAnchor,
+)
+from wmo.common.judging.rubric import RubricDimension
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
+from wmo.common.rollouts import RolloutArtifact
+from wmo.common.tasks import LoadedTaskSet, TaskCase, resolve_task_set
+from wmo.simulation.mining.coverage import CoverageReport
+
+ScoreValue = Literal[0, 1, 2, 3, 4, 5]
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+class ReviewServerError(ValueError):
+    """Raised when a local review request cannot be mapped to canonical evidence."""
+
+
+class ReviewRolloutView(BaseModel):
+    """One locally stored rollout paired with its visible judgment and task lineage."""
+
+    rollout: RolloutArtifact
+    lineage_id: ArtifactId | None = None
+    judgment: Judgment | None = None
+
+
+class ReviewSnapshot(BaseModel):
+    """The complete local review state rendered by the TypeScript application."""
+
+    project_id: str
+    local_data_notice: str
+    task_set: LoadedTaskSet
+    coverage: CoverageReport | None = None
+    rubric_review: RubricReviewDraft
+    human_score_history: HumanScoreHistory
+    rollouts: tuple[ReviewRolloutView, ...]
+    calibration_reports: tuple[CalibrationReport, ...]
+
+
+class RubricMutation(BaseModel):
+    """One UI request that the canonical rubric-review service validates and persists."""
+
+    dimension_id: ArtifactId | None = None
+    name: str | None = Field(default=None, min_length=1, max_length=256)
+    description: str | None = Field(default=None, min_length=1)
+    anchors: tuple[ScoreAnchor, ...] | None = None
+    dimension: RubricDimension | None = None
+    dimensions: tuple[RubricDimension, ...] | None = None
+    dimension_ids: tuple[ArtifactId, ...] | None = None
+    confirmed: bool = False
+
+
+class ScoreOverride(BaseModel):
+    """A human score or correction for one stored rollout and rubric dimension."""
+
+    rollout_id: ArtifactId
+    lineage_id: ArtifactId
+    dimension_id: ArtifactId
+    score: ScoreValue
+
+
+class ReviewMutationResponse(BaseModel):
+    """Updated local state plus a precise result message for one review write."""
+
+    snapshot: ReviewSnapshot
+    notice: str
+
+
+@dataclass(frozen=True)
+class _RolloutRecord:
+    """One parsed rollout with the immutable artifact directory that owns it."""
+
+    artifact_id: ArtifactId
+    rollout: RolloutArtifact
+
+
+@dataclass(frozen=True)
+class _JudgmentRecord:
+    """One parsed judgment with the immutable artifact directory that owns it."""
+
+    artifact_id: ArtifactId
+    judgment: Judgment
+
+
+class ReviewApplication:
+    """Maps loopback UI actions to the existing W5 task and W6 judging services."""
+
+    def __init__(
+        self,
+        store: ProjectStore,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        """Create one local adapter without reading credentials or starting a provider client.
+
+        Args:
+            store: One initialized project-local WMO store.
+            clock: Optional deterministic clock used by review and label persistence.
+        """
+        self._store = store
+        self._clock = _utc_now if clock is None else clock
+
+    def snapshot(self) -> ReviewSnapshot:
+        """Return the current verified task, review, score, rollout, and calibration state.
+
+        Returns:
+            A presentation-ready view composed only from local immutable artifacts and review.json.
+
+        Raises:
+            ReviewServerError: The project has no unambiguous task set or saved review state is
+                invalid.
+        """
+        loaded = self._loaded_task_set()
+        rubric_review = self._rubric_review(loaded)
+        score_review = HumanScoreReview.open(self._store)
+        coverage = _load_coverage(self._store, loaded)
+        rollout_records = _load_rollout_records(self._store)
+        judgments = _load_judgment_records(self._store)
+        task_by_id = {task.task_id: task for task in loaded.tasks}
+        finalized = rubric_review.draft.finalized_rubric
+        judgment_by_rollout = _judgment_by_rollout(
+            judgments,
+            rubric_id=None if finalized is None else finalized.rubric_id,
+        )
+        rollouts = tuple(
+            ReviewRolloutView(
+                rollout=record.rollout,
+                lineage_id=_lineage_for_rollout(record.rollout, task_by_id),
+                judgment=judgment_by_rollout.get(record.rollout.rollout_id),
+            )
+            for record in sorted(rollout_records.values(), key=lambda item: item.rollout.rollout_id)
+        )
+        reports = tuple(
+            report
+            for report in _load_calibration_reports(self._store)
+            if finalized is not None and report.rubric_id == finalized.rubric_id
+        )
+        return ReviewSnapshot(
+            project_id=self._store.paths.project_id,
+            local_data_notice=(
+                "This review stays on this machine. WMO reads local artifacts and writes only "
+                "the project review draft plus immutable approved artifacts. Browser restarts "
+                "resume review.json; remove the local project directory yourself to clear all "
+                "project data."
+            ),
+            task_set=loaded,
+            coverage=coverage,
+            rubric_review=rubric_review.draft,
+            human_score_history=score_review.history,
+            rollouts=rollouts,
+            calibration_reports=reports,
+        )
+
+    def rubric_action(
+        self,
+        action: Literal["accept", "reject", "edit", "add", "replace_all", "order", "finalize"],
+        mutation: RubricMutation,
+    ) -> ReviewSnapshot:
+        """Apply one validated rubric change through W6's persisted review service.
+
+        Args:
+            action: The exact service transition requested by the local interface.
+            mutation: Typed UI fields consumed by that transition.
+
+        Returns:
+            The complete updated local review state.
+
+        Raises:
+            ReviewServerError: The request omits required fields or rejects finalization consent.
+        """
+        review = self._rubric_review(self._loaded_task_set())
+        match action:
+            case "accept":
+                review.accept(_required_id(mutation.dimension_id, "dimension_id"))
+            case "reject":
+                review.reject(_required_id(mutation.dimension_id, "dimension_id"))
+            case "edit":
+                review.edit(
+                    _required_id(mutation.dimension_id, "dimension_id"),
+                    name=mutation.name,
+                    description=mutation.description,
+                    anchors=mutation.anchors,
+                )
+            case "add":
+                review.add(_required_dimension(mutation.dimension))
+            case "replace_all":
+                review.replace_all(_required_dimensions(mutation.dimensions))
+            case "order":
+                review.order(_required_ids(mutation.dimension_ids, "dimension_ids"))
+            case "finalize":
+                if not mutation.confirmed:
+                    raise ReviewServerError("finalizing a rubric requires explicit confirmation")
+                review.finalize()
+        return self.snapshot()
+
+    def score_override(self, override: ScoreOverride) -> ReviewMutationResponse:
+        """Append or correct one human score and refresh a ready calibration report.
+
+        Args:
+            override: Existing rollout, frozen lineage, rubric dimension, and zero-to-five score.
+
+        Returns:
+            The refreshed local review state and the calibration refresh outcome.
+
+        Raises:
+            ReviewServerError: The rubric, rollout, lineage, or dimension cannot be verified.
+        """
+        review = self._rubric_review(self._loaded_task_set())
+        rubric = review.draft.finalized_rubric
+        if rubric is None:
+            raise ReviewServerError("finalize the rubric before adding calibration labels")
+        if override.dimension_id not in {item.dimension_id for item in rubric.dimensions}:
+            raise ReviewServerError("the score dimension is not part of the finalized rubric")
+        record = _load_rollout_records(self._store).get(override.rollout_id)
+        if record is None:
+            raise ReviewServerError("the score target rollout is not stored in this project")
+        task = _task_for_rollout(record.rollout, self._loaded_task_set().tasks)
+        if task.lineage_group_id != override.lineage_id:
+            raise ReviewServerError("the supplied lineage does not match the rollout's frozen task")
+        judgment = _judgment_by_rollout(
+            _load_judgment_records(self._store),
+            rubric_id=rubric.rubric_id,
+        ).get(
+            override.rollout_id,
+        )
+        if judgment is None or judgment.rubric_id != rubric.rubric_id:
+            raise ReviewServerError("the rollout needs a stored judgment for this finalized rubric")
+        if override.dimension_id not in {item.dimension_id for item in judgment.dimensions}:
+            raise ReviewServerError("the stored judgment does not score the requested dimension")
+
+        score_review = HumanScoreReview.open(self._store)
+        existing = _active_score(
+            score_review.history,
+            rubric_id=rubric.rubric_id,
+            rollout_id=override.rollout_id,
+            lineage_id=override.lineage_id,
+            dimension_id=override.dimension_id,
+        )
+        created_at = self._now()
+        label = HumanScore(
+            label_id=stable_id(
+                "human-score",
+                {
+                    "rubric_id": rubric.rubric_id,
+                    "rollout_id": override.rollout_id,
+                    "lineage_id": override.lineage_id,
+                    "dimension_id": override.dimension_id,
+                    "score": override.score,
+                    "sequence": len(score_review.history.scores),
+                },
+            ),
+            rubric_id=rubric.rubric_id,
+            rollout_id=override.rollout_id,
+            lineage_id=override.lineage_id,
+            dimension_id=override.dimension_id,
+            score=override.score,
+            created_at=created_at,
+            supersedes_label_id=None if existing is None else existing.label_id,
+        )
+        if existing is None:
+            score_review.append(label)
+        else:
+            score_review.correct(label)
+        notice = self._refresh_calibration(rubric_id=rubric.rubric_id, score_review=score_review)
+        return ReviewMutationResponse(snapshot=self.snapshot(), notice=notice)
+
+    def _loaded_task_set(self) -> LoadedTaskSet:
+        """Resolve the sole selected task set used by this local review session."""
+        try:
+            return resolve_task_set(self._store.artifacts)
+        except ArtifactCorruptionError as exc:
+            raise ReviewServerError(str(exc)) from exc
+
+    def _rubric_review(self, task_set: LoadedTaskSet) -> RubricReview:
+        """Open W6's resumable draft against the immutable W5 task-set identity."""
+        try:
+            return RubricReview.open(
+                self._store,
+                source_task_set_id=task_set.task_set.task_set_id,
+                code_revision=task_set.task_set.code_revision,
+                clock=self._clock,
+            )
+        except RubricReviewError as exc:
+            raise ReviewServerError(str(exc)) from exc
+
+    def _refresh_calibration(
+        self,
+        *,
+        rubric_id: ArtifactId,
+        score_review: HumanScoreReview,
+    ) -> str:
+        """Write a new calibration report when a provisional report already fixes its evidence.
+
+        The adapter never invents a lineage split or judge evidence. It only reuses the latest
+        persisted report's exact split and observations after W6 has durably frozen the labels.
+        """
+        reports = tuple(
+            report
+            for report in _load_calibration_reports(self._store)
+            if report.rubric_id == rubric_id
+        )
+        if not reports:
+            return (
+                "Score saved locally. A calibration report will refresh after the judge and "
+                "frozen lineage split are available."
+            )
+        source_report = max(reports, key=lambda item: (item.created_at, item.report_id))
+        created_at = self._now()
+        try:
+            label_set = score_review.finalize(
+                rubric_id=rubric_id,
+                code_revision=source_report.code_revision,
+                created_at=created_at,
+            )
+            observations = _observations_for_active_scores(
+                self._store,
+                history=score_review.history,
+                rubric_id=rubric_id,
+            )
+            service = JudgeCalibrationService()
+            report = service.build_report(
+                self._store,
+                rubric_id=rubric_id,
+                label_set_id=label_set.label_set_id,
+                router_lineage_split_id=source_report.router_lineage_split_id,
+                observations=observations,
+                created_at=created_at,
+                code_revision=source_report.code_revision,
+            )
+            stored = service.write_report(self._store, report)
+        except (CalibrationError, ProjectStoreError, ValueError) as exc:
+            return f"Score saved locally. Calibration refresh needs more verified evidence: {exc}"
+        return (
+            "Score saved and calibration report "
+            f"{stored.report_id} refreshed with status {stored.status}."
+        )
+
+    def _now(self) -> datetime:
+        """Return a timezone-aware timestamp before a local mutable write occurs."""
+        value = self._clock()
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewServerError("review clock must return a timezone-aware time")
+        return value
+
+
+def create_review_app(
+    root: Path,
+    project_id: str,
+    *,
+    clock: Callable[[], datetime] | None = None,
+) -> FastAPI:
+    """Create the loopback API over one project-local WMO review store.
+
+    Args:
+        root: Local `.wmo` root containing the project directory.
+        project_id: One validated project identifier below the local root.
+        clock: Optional deterministic clock for tests and local review writes.
+
+    Returns:
+        A FastAPI application with no auth, tenant, provider, or deployment integration.
+    """
+    application = ReviewApplication(ProjectStore(root, project_id), clock=clock)
+    app = FastAPI(
+        title="WMO local review",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        """Return a local liveness response without reading customer evidence."""
+        return {"status": "ok"}
+
+    @app.get("/api/review", response_model=ReviewSnapshot)
+    def get_review() -> ReviewSnapshot:
+        """Return the current local review workspace."""
+        try:
+            return application.snapshot()
+        except _LOCAL_REVIEW_ERRORS as exc:
+            raise _http_error(exc) from exc
+
+    @app.post("/api/review/rubric/{action}", response_model=ReviewSnapshot)
+    def mutate_rubric(
+        action: Literal["accept", "reject", "edit", "add", "replace_all", "order", "finalize"],
+        mutation: RubricMutation,
+    ) -> ReviewSnapshot:
+        """Apply one canonical rubric-review transition to review.json."""
+        try:
+            return application.rubric_action(action, mutation)
+        except _LOCAL_REVIEW_ERRORS as exc:
+            raise _http_error(exc) from exc
+
+    @app.post("/api/review/score", response_model=ReviewMutationResponse)
+    def override_score(override: ScoreOverride) -> ReviewMutationResponse:
+        """Persist an append-only human score and refresh reusable calibration evidence."""
+        try:
+            return application.score_override(override)
+        except _LOCAL_REVIEW_ERRORS as exc:
+            raise _http_error(exc) from exc
+
+    return app
+
+
+_LOCAL_REVIEW_ERRORS = (
+    ArtifactCorruptionError,
+    CalibrationError,
+    ProjectStoreError,
+    ReviewServerError,
+    RubricReviewError,
+    ValueError,
+)
+
+
+def _http_error(error: Exception) -> HTTPException:
+    """Translate one expected local validation failure into a readable HTTP response."""
+    return HTTPException(status_code=400, detail=str(error))
+
+
+def _load_coverage(store: ProjectStore, task_set: LoadedTaskSet) -> CoverageReport | None:
+    """Load coverage only from the selected immutable W5 task-set artifact."""
+    envelope = task_set.task_set
+    if envelope.coverage_path is None:
+        return None
+    try:
+        return CoverageReport.model_validate_json(
+            store.artifacts.read_bytes(envelope.task_set_id, envelope.coverage_path)
+        )
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise ReviewServerError("the selected task-set coverage report is invalid") from exc
+
+
+def _load_rollout_records(store: ProjectStore) -> dict[ArtifactId, _RolloutRecord]:
+    """Discover persisted rollout records without rereading raw traces or provider data."""
+    records: dict[ArtifactId, _RolloutRecord] = {}
+    for artifact_id in store.artifacts.list_ids():
+        stored = store.artifacts.read(artifact_id)
+        if stored.manifest.artifact_type not in {"rollout", "simulation-artifact-set"}:
+            continue
+        for path in (item.path for item in stored.manifest.files):
+            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
+                try:
+                    rollout = RolloutArtifact.model_validate_json(payload)
+                except ValueError:
+                    continue
+                records.setdefault(
+                    rollout.rollout_id,
+                    _RolloutRecord(artifact_id=artifact_id, rollout=rollout),
+                )
+    return records
+
+
+def _load_judgment_records(store: ProjectStore) -> dict[ArtifactId, _JudgmentRecord]:
+    """Discover immutable W6 judgments from their own artifact owner only."""
+    records: dict[ArtifactId, _JudgmentRecord] = {}
+    for artifact_id in store.artifacts.list_ids():
+        stored = store.artifacts.read(artifact_id)
+        if stored.manifest.artifact_type != "judgment":
+            continue
+        for path in (item.path for item in stored.manifest.files):
+            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
+                try:
+                    judgment = Judgment.model_validate_json(payload)
+                except ValueError:
+                    continue
+                records.setdefault(
+                    judgment.judgment_id,
+                    _JudgmentRecord(artifact_id=artifact_id, judgment=judgment),
+                )
+    return records
+
+
+def _load_calibration_reports(store: ProjectStore) -> tuple[CalibrationReport, ...]:
+    """Read immutable W6 calibration reports in deterministic review order."""
+    reports: list[CalibrationReport] = []
+    for artifact_id in store.artifacts.list_ids():
+        stored = store.artifacts.read(artifact_id)
+        if stored.manifest.artifact_type != "judge-calibration-report":
+            continue
+        for path in (item.path for item in stored.manifest.files):
+            for payload in _json_records(store.artifacts.read_bytes(artifact_id, path), path):
+                try:
+                    reports.append(CalibrationReport.model_validate_json(payload))
+                except ValueError:
+                    continue
+    return tuple(sorted(reports, key=lambda item: (item.created_at, item.report_id)))
+
+
+def _json_records(payload: bytes, path: str) -> tuple[bytes, ...]:
+    """Return JSON object payloads from one known immutable artifact data file."""
+    if path.endswith(".json"):
+        return (payload,)
+    if path.endswith(".jsonl"):
+        return tuple(line for line in payload.splitlines() if line)
+    return ()
+
+
+def _judgment_by_rollout(
+    records: dict[ArtifactId, _JudgmentRecord],
+    *,
+    rubric_id: ArtifactId | None = None,
+) -> dict[ArtifactId, Judgment]:
+    """Choose the latest deterministic judgment for each rollout and optional rubric."""
+    by_rollout: dict[ArtifactId, Judgment] = {}
+    for record in sorted(
+        records.values(), key=lambda item: (item.judgment.created_at, item.judgment.judgment_id)
+    ):
+        if rubric_id is not None and record.judgment.rubric_id != rubric_id:
+            continue
+        by_rollout[record.judgment.rollout_id] = record.judgment
+    return by_rollout
+
+
+def _observations_for_active_scores(
+    store: ProjectStore,
+    *,
+    history: HumanScoreHistory,
+    rubric_id: ArtifactId,
+) -> tuple[JudgeScoreObservation, ...]:
+    """Map active local labels to their exact persisted W6 judgment and rollout inputs.
+
+    This adapter does not create scores or evidence. It merely supplies W6's calibration service
+    the immutable input references required to rebuild a report after a human correction.
+    """
+    rollouts = _load_rollout_records(store)
+    judgments = _load_judgment_records(store)
+    by_rollout: dict[ArtifactId, _JudgmentRecord] = {}
+    for record in sorted(
+        judgments.values(), key=lambda item: (item.judgment.created_at, item.judgment.judgment_id)
+    ):
+        if record.judgment.rubric_id == rubric_id:
+            by_rollout[record.judgment.rollout_id] = record
+    observations: list[JudgeScoreObservation] = []
+    active_scores = sorted(
+        history.for_rubric(rubric_id).active_scores(),
+        key=lambda item: (item.rollout_id, item.lineage_id, item.dimension_id),
+    )
+    for score in active_scores:
+        rollout_record = rollouts.get(score.rollout_id)
+        judgment_record = by_rollout.get(score.rollout_id)
+        if rollout_record is None or judgment_record is None:
+            raise ReviewServerError(
+                "a human score needs matching stored rollout and judgment evidence"
+            )
+        dimension = next(
+            (
+                item
+                for item in judgment_record.judgment.dimensions
+                if item.dimension_id == score.dimension_id
+            ),
+            None,
+        )
+        if dimension is None:
+            raise ReviewServerError(
+                "a human score dimension needs matching stored judgment evidence"
+            )
+        try:
+            judgment_input = artifact_input(
+                store.artifacts.read(judgment_record.artifact_id).manifest
+            )
+            rollout_input = artifact_input(
+                store.artifacts.read(rollout_record.artifact_id).manifest
+            )
+        except ArtifactCorruptionError as exc:
+            raise ReviewServerError("a human score source artifact is no longer readable") from exc
+        observations.append(
+            JudgeScoreObservation(
+                judgment=judgment_input,
+                source_rollout=rollout_input,
+                dimension_id=score.dimension_id,
+                raw_score=dimension.raw_score,
+                evidence_span_ids=dimension.evidence_span_ids,
+            )
+        )
+    if not observations:
+        raise ReviewServerError("calibration refresh needs at least one active human score")
+    return tuple(observations)
+
+
+def _lineage_for_rollout(
+    rollout: RolloutArtifact,
+    task_by_id: dict[ArtifactId, TaskCase],
+) -> ArtifactId | None:
+    """Return the frozen W5 lineage for one rollout when its selected task is still present."""
+    task = task_by_id.get(rollout.task_id)
+    return None if task is None else task.lineage_group_id
+
+
+def _task_for_rollout(rollout: RolloutArtifact, tasks: tuple[TaskCase, ...]) -> TaskCase:
+    """Resolve one rollout's selected task or reject an untraceable review write."""
+    for task in tasks:
+        if task.task_id == rollout.task_id:
+            return task
+    raise ReviewServerError("the score target rollout does not belong to the selected task set")
+
+
+def _active_score(
+    history: HumanScoreHistory,
+    *,
+    rubric_id: ArtifactId,
+    rollout_id: ArtifactId,
+    lineage_id: ArtifactId,
+    dimension_id: ArtifactId,
+) -> HumanScore | None:
+    """Find the active prior label that a new score must correct, if one exists."""
+    for score in history.active_scores():
+        if (
+            score.rubric_id == rubric_id
+            and score.rollout_id == rollout_id
+            and score.lineage_id == lineage_id
+            and score.dimension_id == dimension_id
+        ):
+            return score
+    return None
+
+
+def _required_id(value: ArtifactId | None, field_name: str) -> ArtifactId:
+    """Require one named artifact identity from a rubric mutation."""
+    if value is None:
+        raise ReviewServerError(f"{field_name} is required")
+    return value
+
+
+def _required_ids(value: tuple[ArtifactId, ...] | None, field_name: str) -> tuple[ArtifactId, ...]:
+    """Require one non-null ordered collection from a rubric mutation."""
+    if value is None:
+        raise ReviewServerError(f"{field_name} is required")
+    return value
+
+
+def _required_dimension(value: RubricDimension | None) -> RubricDimension:
+    """Require one complete human-authored rubric dimension from a mutation."""
+    if value is None:
+        raise ReviewServerError("dimension is required")
+    return value
+
+
+def _required_dimensions(value: tuple[RubricDimension, ...] | None) -> tuple[RubricDimension, ...]:
+    """Require one complete replacement scale set from a mutation."""
+    if value is None:
+        raise ReviewServerError("dimensions is required")
+    return value
+
+
+def _utc_now() -> datetime:
+    """Return the local adapter's timezone-aware clock value."""
+    return datetime.now(UTC)
+
+
+def _loopback_host(value: str) -> str:
+    """Validate that the local review adapter cannot bind a non-loopback interface."""
+    if value not in _LOOPBACK_HOSTS:
+        raise argparse.ArgumentTypeError("local review may bind only to a loopback host")
+    return value
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the local review adapter on loopback for the top-level TypeScript app.
+
+    Args:
+        argv: Optional explicit arguments for tests or an embedded local launcher.
+    """
+    parser = argparse.ArgumentParser(description="Serve the WMO local review adapter on loopback.")
+    parser.add_argument("--root", type=Path, default=Path(".wmo"))
+    parser.add_argument("--project", default="default")
+    parser.add_argument("--host", type=_loopback_host, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8017)
+    arguments = parser.parse_args(argv)
+    if not 1 <= arguments.port <= 65535:
+        parser.error("--port must be between 1 and 65535")
+    try:
+        ProjectStore(arguments.root, arguments.project).load_project()
+    except ProjectStoreError as exc:
+        parser.error(str(exc))
+    uvicorn.run(
+        create_review_app(arguments.root, arguments.project),
+        host=arguments.host,
+        port=arguments.port,
+        log_level="warning",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/wmo/review_server_test.py
+++ b/wmo/review_server_test.py
@@ -1,0 +1,539 @@
+"""Behavior tests for the loopback W5 and W6 review adapter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from wmo.common.core.artifacts import SourceIdentity
+from wmo.common.judging import (
+    DimensionJudgment,
+    HumanScoreReview,
+    JudgeCalibrationService,
+    Judgment,
+    LMJudge,
+    PromptDefinition,
+    ProposedRubricDimension,
+    RouterLineageAssignment,
+    RouterLineageSplit,
+    RubricDimension,
+    RubricProposal,
+    RubricReview,
+    ScoreAnchor,
+    write_router_lineage_split,
+)
+from wmo.common.models import (
+    AssistantAction,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+)
+from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    RolloutSpan,
+    SimulationMode,
+    StopReason,
+    WorldModelSimulatorSnapshot,
+)
+from wmo.common.traces import Trace, TraceSource, TraceSpan
+from wmo.review_server import _loopback_host, create_review_app
+from wmo.simulation.mining.descriptors import HashingDescriptorEmbedder
+from wmo.simulation.mining.service import MiningSpec, mine_tasks, persist_task_set
+
+_DIGEST = "a" * 64
+_TIME = datetime(2026, 8, 12, tzinfo=UTC)
+
+
+class _FakeJudgeClient:
+    """Return one deterministic local score without initializing a provider client."""
+
+    def __init__(self, model: ModelSnapshot) -> None:
+        self._model = model
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Return the W6 structured judgment response for the persisted fixture span."""
+        del request
+        return ModelResponse(
+            output=AssistantAction(
+                content=json.dumps(
+                    {
+                        "dimensions": [
+                            {
+                                "dimension_id": "task-success",
+                                "raw_score": 3,
+                                "evidence_span_ids": ["span-calibration-1"],
+                                "feedback": "The request was resolved in the rollout.",
+                            }
+                        ]
+                    }
+                )
+            ),
+            model=self._model,
+            economics=OperationEconomics(),
+        )
+
+
+def _model(model_id: str) -> ModelSnapshot:
+    """Return one deterministic model identity for local review fixtures."""
+    return ModelSnapshot(
+        provider="fake",
+        model_id=model_id,
+        capabilities_sha256=_DIGEST,
+        connection_sha256=_DIGEST,
+    )
+
+
+def _trace(index: int) -> Trace:
+    """Return a representative source trace that W5 can mine without network access."""
+    started_at = _TIME + timedelta(minutes=index)
+    return Trace(
+        trace_id=f"trace-{index}",
+        conversation_id=f"conversation-{index}",
+        task=f"Resolve customer request {index}",
+        initial_context={"channel": "email"},
+        spans=(
+            TraceSpan(
+                span_id=f"trace-span-{index}",
+                name="agent.model_call",
+                started_at=started_at,
+                ended_at=started_at + timedelta(seconds=1),
+                attributes={"gen_ai.provider.name": "fake"},
+            ),
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(kind="production", source_id="fixture", sha256=_DIGEST),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def _dimension() -> RubricDimension:
+    """Return one complete zero-to-five rubric scale for a deterministic proposal."""
+    return RubricDimension(
+        dimension_id="task-success",
+        name="Task success",
+        description="Whether the customer received the requested outcome.",
+        anchors=tuple(
+            ScoreAnchor(score=score, description=f"Task success anchor {score}.")
+            for score in (0, 1, 2, 3, 4, 5)
+        ),
+    )
+
+
+def _communication_dimension() -> RubricDimension:
+    """Return a second complete human-authored fixture scale for ordering coverage."""
+    return RubricDimension(
+        dimension_id="customer-clarity",
+        name="Customer clarity",
+        description="Whether the response gives the customer a clear next step.",
+        anchors=tuple(
+            ScoreAnchor(score=score, description=f"Customer clarity anchor {score}.")
+            for score in (0, 1, 2, 3, 4, 5)
+        ),
+    )
+
+
+def _project(tmp_path: Path) -> tuple[ProjectStore, str, str]:
+    """Create one W5 task set and W6 draft without a provider or raw file reread."""
+    root = tmp_path / ".wmo"
+    store = ProjectStore(root, "support")
+    store.initialize(ProjectConfig(project_id="support"))
+    result = mine_tasks(
+        (_trace(1), _trace(2)),
+        MiningSpec(fit_task_budget=1, held_out_task_budget=1),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    task_set = persist_task_set(
+        result,
+        store.artifacts,
+        task_set_id="task-set-1",
+        created_at=_TIME,
+        code_revision="review-test",
+    )
+    proposal = RubricProposal(
+        proposal_id="proposal-1",
+        source_task_set_id=task_set.task_set_id,
+        proposer_model=_model("rubric-proposer"),
+        prompt_id="rubric-prompt-v1",
+        prompt_sha256=_DIGEST,
+        dimensions=(
+            ProposedRubricDimension(
+                dimension=_dimension(),
+                source_rollout_ids=("rollout-success", "rollout-failed"),
+                evidence_span_ids=("span-success", "span-failed"),
+            ),
+        ),
+        successful_rollout_ids=("rollout-success",),
+        failed_rollout_ids=("rollout-failed",),
+        source_lineage_ids=("lineage-fit-1", "lineage-fit-2"),
+        excluded_router_held_out_lineage_ids=("lineage-held-out",),
+    )
+    RubricReview.open(
+        store,
+        source_task_set_id=task_set.task_set_id,
+        code_revision="review-test",
+        proposals=(proposal,),
+        clock=lambda: _TIME,
+    )
+    return store, task_set.task_ids[0], task_set.task_ids[1]
+
+
+def _write_rollout_and_judgment(
+    store: ProjectStore,
+    *,
+    task_id: str,
+    rubric_id: str,
+) -> None:
+    """Persist one viewed rollout and one canonical W6 score for override coverage."""
+    candidate = _model("candidate")
+    rollout = RolloutArtifact(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="review-test",
+        artifact_id="rollout-1",
+        simulation_id="simulation-1",
+        cell_id="cell-1",
+        mode=SimulationMode.WORLD_MODEL,
+        rollout_id="rollout-1",
+        trace_id="0" * 32,
+        evidence_source="world_model",
+        source_run_id="run-1",
+        task_id=task_id,
+        candidate=candidate,
+        agent_id="customer-agent",
+        simulator=WorldModelSimulatorSnapshot(
+            simulator_id="world-model-v1",
+            prompt_id="world-prompt-v1",
+            world_model=_model("world-model"),
+        ),
+        world_model=_model("world-model"),
+        seed=7,
+        repeat=0,
+        spans=(
+            RolloutSpan(
+                span_id="span-1",
+                kind=RolloutEventKind.AGENT_MODEL_CALL,
+                started_at=_TIME,
+                ended_at=_TIME + timedelta(seconds=1),
+                payload={"text": "I resolved the request."},
+                model=candidate,
+            ),
+        ),
+        stop_reason=StopReason.COMPLETED,
+        candidate_economics=OperationEconomics(),
+        simulation_spec_sha256=_DIGEST,
+    )
+    store.artifacts.write_json(
+        artifact_id=rollout.artifact_id,
+        artifact_type="rollout",
+        envelope=rollout,
+        files={"rollout.json": rollout},
+    )
+    judgment = Judgment(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="review-test",
+        judgment_id="judgment-1",
+        rollout_id=rollout.rollout_id,
+        rubric_id=rubric_id,
+        calibration_id="calibration-1",
+        judge_model=_model("judge"),
+        judge_prompt_id="judge-prompt-v1",
+        judge_prompt_sha256=_DIGEST,
+        dimensions=(
+            DimensionJudgment(
+                dimension_id="task-success",
+                raw_score=3,
+                calibrated_score=3.0,
+                evidence_span_ids=("span-1",),
+                feedback="The response resolves the stated request.",
+            ),
+        ),
+        overall_score=0.6,
+    )
+    store.artifacts.write_json(
+        artifact_id=judgment.judgment_id,
+        artifact_type="judgment",
+        envelope=judgment,
+        files={"judgment.json": judgment},
+    )
+
+
+def _write_calibratable_judgment(
+    store: ProjectStore,
+    *,
+    task_id: str,
+    rubric_id: str,
+    lineage_id: str,
+) -> None:
+    """Persist a W6-provenance-valid local rollout and provisional judgment fixture."""
+    candidate = _model("candidate")
+    rollout = RolloutArtifact(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="review-test",
+        artifact_id="rollout-calibration-1",
+        simulation_id="simulation-calibration-1",
+        cell_id="cell-calibration-1",
+        mode=SimulationMode.WORLD_MODEL,
+        rollout_id="rollout-calibration-1",
+        trace_id="1" * 32,
+        evidence_source="world_model",
+        source_run_id="run-calibration-1",
+        task_id=task_id,
+        candidate=candidate,
+        agent_id="customer-agent",
+        simulator=WorldModelSimulatorSnapshot(
+            simulator_id="world-model-v1",
+            prompt_id="world-prompt-v1",
+            world_model=_model("world-model"),
+        ),
+        world_model=_model("world-model"),
+        seed=17,
+        repeat=0,
+        spans=(
+            RolloutSpan(
+                span_id="span-calibration-1",
+                kind=RolloutEventKind.AGENT_MODEL_CALL,
+                started_at=_TIME,
+                ended_at=_TIME + timedelta(seconds=1),
+                payload={"text": "I resolved the request."},
+                model=candidate,
+            ),
+        ),
+        stop_reason=StopReason.COMPLETED,
+        candidate_economics=OperationEconomics(),
+        simulation_spec_sha256=_DIGEST,
+    )
+    store.artifacts.write_json(
+        artifact_id=rollout.artifact_id,
+        artifact_type="rollout",
+        envelope=rollout,
+        files={"rollout.json": rollout},
+    )
+    split = write_router_lineage_split(
+        store,
+        RouterLineageSplit(
+            schema_version=1,
+            created_at=_TIME,
+            inputs=(artifact_input(store.artifacts.read("task-set-1").manifest),),
+            code_revision="review-test",
+            split_id="router-lineage-split-1",
+            source_task_set_id="task-set-1",
+            fit_lineage_ids=(lineage_id,),
+            held_out_lineage_ids=(),
+            assignments=(
+                RouterLineageAssignment(
+                    rollout_id=rollout.rollout_id,
+                    lineage_id=lineage_id,
+                ),
+            ),
+        ),
+    )
+    empty_label_set = HumanScoreReview.open(store).finalize(
+        rubric_id=rubric_id,
+        code_revision="review-test",
+        created_at=_TIME,
+    )
+    judge_model = _model("judge")
+    prompt = PromptDefinition.from_text("judge-prompt-v1", "Return structured scores.")
+    calibration = JudgeCalibrationService().bootstrap_provisional(
+        store,
+        rubric_id=rubric_id,
+        label_set_id=empty_label_set.label_set_id,
+        router_lineage_split_id=split.split_id,
+        judge_model=judge_model,
+        judge_prompt=prompt,
+        created_at=_TIME,
+        code_revision="review-test",
+    )
+    LMJudge(
+        _FakeJudgeClient(judge_model),
+        prompt,
+        code_revision="review-test",
+        clock=lambda: _TIME,
+    ).judge_and_write(
+        store,
+        rollout_artifact_id=rollout.artifact_id,
+        rubric_artifact_id=rubric_id,
+        calibration_artifact_id=calibration.calibration_id,
+    )
+
+
+def test_review_api_resumes_w5_tasks_and_w6_rubric_transitions(tmp_path: Path) -> None:
+    """The adapter exposes provenance and delegates all rubric writes to W6."""
+    store, first_task_id, _second_task_id = _project(tmp_path)
+    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+
+    initial = client.get("/api/review")
+
+    assert initial.status_code == 200
+    body = initial.json()
+    assert body["task_set"]["task_set"]["task_ids"] == [first_task_id, _second_task_id]
+    assert body["coverage"]["selections"]
+    assert body["rubric_review"]["status"] == "draft"
+    assert store.read_review() is not None
+
+    accepted = client.post(
+        "/api/review/rubric/accept",
+        json={"dimension_id": "task-success"},
+    )
+    unconfirmed = client.post("/api/review/rubric/finalize", json={"confirmed": False})
+    finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
+
+    assert accepted.status_code == 200
+    assert accepted.json()["rubric_review"]["dimensions"][0]["dimension_id"] == "task-success"
+    assert unconfirmed.status_code == 400
+    assert "explicit confirmation" in unconfirmed.json()["detail"]
+    assert finalized.status_code == 200
+    assert finalized.json()["rubric_review"]["status"] == "finalized"
+
+
+def test_review_api_supports_reject_edit_add_order_and_replace_all(tmp_path: Path) -> None:
+    """The adapter maps every editable rubric control to W6's persisted draft service."""
+    store, _first_task_id, _second_task_id = _project(tmp_path)
+    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    edited = client.post(
+        "/api/review/rubric/edit",
+        json={
+            "dimension_id": "task-success",
+            "name": "Outcome quality",
+            "description": "Whether the requested outcome was completed correctly.",
+            "anchors": [anchor.model_dump(mode="json") for anchor in _dimension().anchors],
+        },
+    )
+    added = client.post(
+        "/api/review/rubric/add",
+        json={"dimension": _communication_dimension().model_dump(mode="json")},
+    )
+    ordered = client.post(
+        "/api/review/rubric/order",
+        json={"dimension_ids": ["customer-clarity", "task-success"]},
+    )
+    replaced = client.post(
+        "/api/review/rubric/replace_all",
+        json={"dimensions": ordered.json()["rubric_review"]["dimensions"]},
+    )
+    rejected = client.post(
+        "/api/review/rubric/reject",
+        json={"dimension_id": "task-success"},
+    )
+
+    assert edited.status_code == 200
+    assert edited.json()["rubric_review"]["dimensions"][0]["name"] == "Outcome quality"
+    assert added.status_code == 200
+    assert [item["dimension_id"] for item in ordered.json()["rubric_review"]["dimensions"]] == [
+        "customer-clarity",
+        "task-success",
+    ]
+    assert replaced.status_code == 200
+    assert rejected.status_code == 200
+    review = rejected.json()["rubric_review"]
+    assert review["rejected_dimension_ids"] == ["task-success"]
+    assert [item["dimension_id"] for item in review["dimensions"]] == ["customer-clarity"]
+
+
+def test_review_api_keeps_human_score_corrections_and_never_requires_provider_work(
+    tmp_path: Path,
+) -> None:
+    """Score overrides append through W6 and report when calibration inputs are not ready."""
+    store, first_task_id, _second_task_id = _project(tmp_path)
+    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client.post("/api/review/rubric/accept", json={"dimension_id": "task-success"})
+    finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
+    rubric_id = finalized.json()["rubric_review"]["finalized_rubric"]["rubric_id"]
+    task_set = client.get("/api/review").json()["task_set"]
+    first_task = next(item for item in task_set["tasks"] if item["task_id"] == first_task_id)
+    _write_rollout_and_judgment(store, task_id=first_task_id, rubric_id=rubric_id)
+
+    first = client.post(
+        "/api/review/score",
+        json={
+            "rollout_id": "rollout-1",
+            "lineage_id": first_task["lineage_group_id"],
+            "dimension_id": "task-success",
+            "score": 2,
+        },
+    )
+    second = client.post(
+        "/api/review/score",
+        json={
+            "rollout_id": "rollout-1",
+            "lineage_id": first_task["lineage_group_id"],
+            "dimension_id": "task-success",
+            "score": 4,
+        },
+    )
+
+    assert first.status_code == 200
+    assert "Score saved locally" in first.json()["notice"]
+    assert second.status_code == 200
+    history = second.json()["snapshot"]["human_score_history"]["scores"]
+    assert [score["score"] for score in history] == [2, 4]
+    assert history[1]["supersedes_label_id"] == history[0]["label_id"]
+
+
+def test_review_api_refreshes_w6_calibration_after_a_human_score_correction(
+    tmp_path: Path,
+) -> None:
+    """A corrected active score regenerates W6 calibration from verified local evidence."""
+    store, first_task_id, _second_task_id = _project(tmp_path)
+    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client.post("/api/review/rubric/accept", json={"dimension_id": "task-success"})
+    finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
+    rubric_id = finalized.json()["rubric_review"]["finalized_rubric"]["rubric_id"]
+    task_set = client.get("/api/review").json()["task_set"]
+    first_task = next(item for item in task_set["tasks"] if item["task_id"] == first_task_id)
+    lineage_id = first_task["lineage_group_id"]
+    _write_calibratable_judgment(
+        store,
+        task_id=first_task_id,
+        rubric_id=rubric_id,
+        lineage_id=lineage_id,
+    )
+
+    first = client.post(
+        "/api/review/score",
+        json={
+            "rollout_id": "rollout-calibration-1",
+            "lineage_id": lineage_id,
+            "dimension_id": "task-success",
+            "score": 2,
+        },
+    )
+    corrected = client.post(
+        "/api/review/score",
+        json={
+            "rollout_id": "rollout-calibration-1",
+            "lineage_id": lineage_id,
+            "dimension_id": "task-success",
+            "score": 4,
+        },
+    )
+
+    assert first.status_code == 200
+    assert "refreshed" in first.json()["notice"]
+    assert corrected.status_code == 200
+    assert "refreshed" in corrected.json()["notice"]
+    reports = corrected.json()["snapshot"]["calibration_reports"]
+    refreshed = [report for report in reports if report["eligible_label_count"] == 1]
+    assert len(refreshed) == 2
+    assert all(report["status"] == "insufficient" for report in refreshed)
+    active_scores = corrected.json()["snapshot"]["human_score_history"]["scores"]
+    assert active_scores[-1]["score"] == 4
+    assert active_scores[-1]["supersedes_label_id"] == active_scores[-2]["label_id"]
+
+
+def test_review_server_rejects_a_non_loopback_bind_target() -> None:
+    """The local adapter cannot become a remotely reachable service by configuration."""
+    assert _loopback_host("127.0.0.1") == "127.0.0.1"
+    with pytest.raises(argparse.ArgumentTypeError, match="loopback"):
+        _loopback_host("0.0.0.0")

--- a/wmo/review_server_test.py
+++ b/wmo/review_server_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from wmo.common.core.artifacts import SourceIdentity
+from wmo.common.core.artifacts import ArtifactEnvelope, SourceIdentity
 from wmo.common.judging import (
     DimensionJudgment,
     HumanScoreReview,
@@ -55,8 +55,9 @@ _TIME = datetime(2026, 8, 12, tzinfo=UTC)
 class _FakeJudgeClient:
     """Return one deterministic local score without initializing a provider client."""
 
-    def __init__(self, model: ModelSnapshot) -> None:
+    def __init__(self, model: ModelSnapshot, span_id: str = "span-calibration-1") -> None:
         self._model = model
+        self._span_id = span_id
 
     def complete(self, request: ModelRequest) -> ModelResponse:
         """Return the W6 structured judgment response for the persisted fixture span."""
@@ -69,7 +70,7 @@ class _FakeJudgeClient:
                             {
                                 "dimension_id": "task-success",
                                 "raw_score": 3,
-                                "evidence_span_ids": ["span-calibration-1"],
+                                "evidence_span_ids": [self._span_id],
                                 "feedback": "The request was resolved in the rollout.",
                             }
                         ]
@@ -184,6 +185,27 @@ def _project(tmp_path: Path) -> tuple[ProjectStore, str, str]:
         clock=lambda: _TIME,
     )
     return store, task_set.task_ids[0], task_set.task_ids[1]
+
+
+def _client(
+    store: ProjectStore,
+    *,
+    code_revision: str = "review-producer",
+    task_set_id: str | None = None,
+    port: int = 8017,
+) -> TestClient:
+    """Create a test client with the exact loopback authority accepted by the adapter."""
+    return TestClient(
+        create_review_app(
+            store.paths.root,
+            store.paths.project_id,
+            code_revision=code_revision,
+            task_set_id=task_set_id,
+            port=port,
+            clock=lambda: _TIME,
+        ),
+        base_url=f"http://127.0.0.1:{port}",
+    )
 
 
 def _write_rollout_and_judgment(
@@ -368,10 +390,115 @@ def _write_calibratable_judgment(
     )
 
 
+def _write_calibration_batch(
+    store: ProjectStore,
+    *,
+    rubric_id: str,
+    task_ids: tuple[str, str],
+    task_lineages: tuple[str, str],
+    label_count: int,
+) -> tuple[str, ...]:
+    """Persist a complete two-lineage calibration fixture with deterministic labels."""
+    candidate = _model("candidate")
+    judge_model = _model("judge")
+    prompt = PromptDefinition.from_text("judge-prompt-v1", "Return structured scores.")
+    rollout_ids = tuple(f"rollout-calibration-{index}" for index in range(label_count))
+    assignments: list[RouterLineageAssignment] = []
+    for index, rollout_id in enumerate(rollout_ids):
+        lineage_id = task_lineages[index % 2]
+        span_id = f"span-calibration-{index}"
+        rollout = RolloutArtifact(
+            schema_version=1,
+            created_at=_TIME,
+            code_revision="fixture-source",
+            artifact_id=rollout_id,
+            simulation_id=f"simulation-calibration-{index}",
+            cell_id=f"cell-calibration-{index}",
+            mode=SimulationMode.WORLD_MODEL,
+            rollout_id=rollout_id,
+            trace_id=f"{index + 1:032x}",
+            evidence_source="world_model",
+            source_run_id="run-calibration-batch",
+            task_id=task_ids[index % 2],
+            candidate=candidate,
+            agent_id="customer-agent",
+            simulator=WorldModelSimulatorSnapshot(
+                simulator_id="world-model-v1",
+                prompt_id="world-prompt-v1",
+                world_model=_model("world-model"),
+            ),
+            world_model=_model("world-model"),
+            seed=index,
+            repeat=0,
+            spans=(
+                RolloutSpan(
+                    span_id=span_id,
+                    kind=RolloutEventKind.AGENT_MODEL_CALL,
+                    started_at=_TIME,
+                    ended_at=_TIME + timedelta(seconds=1),
+                    payload={"text": f"Resolved fixture {index}."},
+                    model=candidate,
+                ),
+            ),
+            stop_reason=StopReason.COMPLETED,
+            candidate_economics=OperationEconomics(),
+            simulation_spec_sha256=_DIGEST,
+        )
+        store.artifacts.write_json(
+            artifact_id=rollout.artifact_id,
+            artifact_type="rollout",
+            envelope=rollout,
+            files={"rollout.json": rollout},
+        )
+        assignments.append(RouterLineageAssignment(rollout_id=rollout_id, lineage_id=lineage_id))
+    split = write_router_lineage_split(
+        store,
+        RouterLineageSplit(
+            schema_version=1,
+            created_at=_TIME,
+            inputs=(artifact_input(store.artifacts.read("task-set-1").manifest),),
+            code_revision="fixture-source",
+            split_id="router-lineage-split-batch",
+            source_task_set_id="task-set-1",
+            fit_lineage_ids=tuple(sorted(task_lineages)),
+            held_out_lineage_ids=(),
+            assignments=tuple(assignments),
+        ),
+    )
+    empty_label_set = HumanScoreReview.open(store).finalize(
+        rubric_id=rubric_id,
+        code_revision="fixture-source",
+        created_at=_TIME,
+    )
+    calibration = JudgeCalibrationService().bootstrap_provisional(
+        store,
+        rubric_id=rubric_id,
+        label_set_id=empty_label_set.label_set_id,
+        router_lineage_split_id=split.split_id,
+        judge_model=judge_model,
+        judge_prompt=prompt,
+        created_at=_TIME,
+        code_revision="fixture-source",
+    )
+    for index, rollout_id in enumerate(rollout_ids):
+        LMJudge(
+            _FakeJudgeClient(judge_model, f"span-calibration-{index}"),
+            prompt,
+            code_revision="fixture-source",
+            clock=lambda: _TIME,
+        ).judge_and_write(
+            store,
+            rollout_artifact_id=rollout_id,
+            rubric_artifact_id=rubric_id,
+            calibration_artifact_id=calibration.calibration_id,
+        )
+    return rollout_ids
+
+
 def test_review_api_resumes_w5_tasks_and_w6_rubric_transitions(tmp_path: Path) -> None:
     """The adapter exposes provenance and delegates all rubric writes to W6."""
     store, first_task_id, _second_task_id = _project(tmp_path)
-    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client = _client(store)
 
     initial = client.get("/api/review")
 
@@ -395,12 +522,15 @@ def test_review_api_resumes_w5_tasks_and_w6_rubric_transitions(tmp_path: Path) -
     assert "explicit confirmation" in unconfirmed.json()["detail"]
     assert finalized.status_code == 200
     assert finalized.json()["rubric_review"]["status"] == "finalized"
+    assert (
+        finalized.json()["rubric_review"]["finalized_rubric"]["code_revision"] == "review-producer"
+    )
 
 
 def test_review_api_supports_reject_edit_add_order_and_replace_all(tmp_path: Path) -> None:
     """The adapter maps every editable rubric control to W6's persisted draft service."""
     store, _first_task_id, _second_task_id = _project(tmp_path)
-    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client = _client(store)
     edited = client.post(
         "/api/review/rubric/edit",
         json={
@@ -446,7 +576,7 @@ def test_review_api_keeps_human_score_corrections_and_never_requires_provider_wo
 ) -> None:
     """Score overrides append through W6 and report when calibration inputs are not ready."""
     store, first_task_id, _second_task_id = _project(tmp_path)
-    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client = _client(store)
     client.post("/api/review/rubric/accept", json={"dimension_id": "task-success"})
     finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
     rubric_id = finalized.json()["rubric_review"]["finalized_rubric"]["rubric_id"]
@@ -486,7 +616,7 @@ def test_review_api_refreshes_w6_calibration_after_a_human_score_correction(
 ) -> None:
     """A corrected active score regenerates W6 calibration from verified local evidence."""
     store, first_task_id, _second_task_id = _project(tmp_path)
-    client = TestClient(create_review_app(store.paths.root, "support", clock=lambda: _TIME))
+    client = _client(store)
     client.post("/api/review/rubric/accept", json={"dimension_id": "task-success"})
     finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
     rubric_id = finalized.json()["rubric_review"]["finalized_rubric"]["rubric_id"]
@@ -527,9 +657,91 @@ def test_review_api_refreshes_w6_calibration_after_a_human_score_correction(
     refreshed = [report for report in reports if report["eligible_label_count"] == 1]
     assert len(refreshed) == 2
     assert all(report["status"] == "insufficient" for report in refreshed)
+    assert all(report["code_revision"] == "review-producer" for report in refreshed)
+    assert all(
+        store.artifacts.read(report["label_set_id"]).manifest.code_revision == "review-producer"
+        for report in refreshed
+    )
     active_scores = corrected.json()["snapshot"]["human_score_history"]["scores"]
     assert active_scores[-1]["score"] == 4
     assert active_scores[-1]["supersedes_label_id"] == active_scores[-2]["label_id"]
+
+
+@pytest.mark.parametrize(
+    ("label_count", "expected_status", "requires_risk"),
+    ((2, "insufficient", True), (10, "ready_for_approval", False)),
+)
+def test_review_api_requires_explicit_calibration_confirmation_and_writes_artifact(
+    tmp_path: Path,
+    label_count: int,
+    expected_status: str,
+    requires_risk: bool,
+) -> None:
+    """Ready and low-sample reports require the matching explicit approval ceremony."""
+    store, first_task_id, second_task_id = _project(tmp_path)
+    client = _client(store)
+    client.post("/api/review/rubric/accept", json={"dimension_id": "task-success"})
+    finalized = client.post("/api/review/rubric/finalize", json={"confirmed": True})
+    rubric_id = finalized.json()["rubric_review"]["finalized_rubric"]["rubric_id"]
+    tasks = finalized.json()["task_set"]["tasks"]
+    task_lineages = tuple(
+        next(item["lineage_group_id"] for item in tasks if item["task_id"] == task_id)
+        for task_id in (first_task_id, second_task_id)
+    )
+    rollout_ids = _write_calibration_batch(
+        store,
+        rubric_id=rubric_id,
+        task_ids=(first_task_id, second_task_id),
+        task_lineages=task_lineages,
+        label_count=label_count,
+    )
+    response = None
+    for index, rollout_id in enumerate(rollout_ids):
+        response = client.post(
+            "/api/review/score",
+            json={
+                "rollout_id": rollout_id,
+                "lineage_id": task_lineages[index % 2],
+                "dimension_id": "task-success",
+                "score": 2 + (index % 3),
+            },
+        )
+        assert response.status_code == 200, response.text
+    assert response is not None
+    reports = response.json()["snapshot"]["calibration_reports"]
+    report = next(
+        item
+        for item in reports
+        if item["eligible_label_count"] == label_count and item["status"] == expected_status
+    )
+    endpoint = f"/api/review/calibration/{report['report_id']}/approve"
+
+    unconfirmed = client.post(
+        endpoint,
+        json={"confirmed": False, "accept_insufficient_risk": requires_risk},
+    )
+    assert unconfirmed.status_code == 400
+    assert "explicit confirmation" in unconfirmed.json()["detail"]
+
+    if requires_risk:
+        missing_risk = client.post(
+            endpoint,
+            json={"confirmed": True, "accept_insufficient_risk": False},
+        )
+        assert missing_risk.status_code == 400
+        assert "risk acceptance" in missing_risk.json()["detail"]
+
+    approved = client.post(
+        endpoint,
+        json={"confirmed": True, "accept_insufficient_risk": requires_risk},
+    )
+    assert approved.status_code == 200
+    calibrations = approved.json()["snapshot"]["calibrations"]
+    human_calibrated = [item for item in calibrations if item["status"] == "human_calibrated"]
+    assert len(human_calibrated) == 1
+    assert human_calibrated[0]["out_of_fold_report_id"] == report["report_id"]
+    assert (human_calibrated[0]["risk_acceptance"] is not None) is requires_risk
+    assert human_calibrated[0]["code_revision"] == "review-producer"
 
 
 def test_review_server_rejects_a_non_loopback_bind_target() -> None:
@@ -537,3 +749,117 @@ def test_review_server_rejects_a_non_loopback_bind_target() -> None:
     assert _loopback_host("127.0.0.1") == "127.0.0.1"
     with pytest.raises(argparse.ArgumentTypeError, match="loopback"):
         _loopback_host("0.0.0.0")
+
+
+def test_review_server_rejects_dns_rebinding_and_cross_origin_headers(tmp_path: Path) -> None:
+    """Host, Origin, and Referer cannot cross the exact loopback same-origin boundary."""
+    store, _first_task_id, _second_task_id = _project(tmp_path)
+    client = _client(store)
+
+    allowed = client.get(
+        "/api/review",
+        headers={
+            "origin": "http://127.0.0.1:8017",
+            "referer": "http://127.0.0.1:8017/review",
+        },
+    )
+    allowed_ipv6 = client.get(
+        "/api/review",
+        headers={"host": "[::1]:8017", "origin": "http://[::1]:8017"},
+    )
+    evil_host = client.get(
+        "/api/review",
+        headers={"host": "rebound.example:8017"},
+    )
+    wrong_port = client.get(
+        "/api/review",
+        headers={"host": "127.0.0.1:9999"},
+    )
+    evil_origin = client.get(
+        "/api/review",
+        headers={"origin": "http://rebound.example:8017"},
+    )
+    cross_loopback_origin = client.get(
+        "/api/review",
+        headers={"origin": "http://localhost:8017"},
+    )
+
+    assert allowed.status_code == 200
+    assert allowed_ipv6.status_code == 200
+    assert evil_host.status_code == 400
+    assert "Host" in evil_host.json()["detail"]
+    assert wrong_port.status_code == 400
+    assert evil_origin.status_code == 400
+    assert cross_loopback_origin.status_code == 400
+
+
+def test_review_resume_uses_persisted_task_set_when_project_has_multiple_sets(
+    tmp_path: Path,
+) -> None:
+    """A saved draft remains unambiguous after another immutable task set is produced."""
+    store, _first_task_id, _second_task_id = _project(tmp_path)
+    second = persist_task_set(
+        mine_tasks(
+            (_trace(3), _trace(4)),
+            MiningSpec(fit_task_budget=1, held_out_task_budget=1),
+            embedder=HashingDescriptorEmbedder(),
+        ),
+        store.artifacts,
+        task_set_id="task-set-2",
+        created_at=_TIME,
+        code_revision="second-build",
+    )
+
+    resumed = _client(store).get("/api/review")
+    conflict = _client(store, task_set_id=second.task_set_id).get("/api/review")
+
+    assert resumed.status_code == 200
+    assert resumed.json()["task_set"]["task_set"]["task_set_id"] == "task-set-1"
+    assert conflict.status_code == 400
+    assert "conflicts" in conflict.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("artifact_type", "file_name", "detail"),
+    (
+        ("rollout", "rollout.json", "rollout artifact corrupt-artifact is corrupt"),
+        ("judgment", "judgment.json", "judgment artifact corrupt-artifact is corrupt"),
+        (
+            "judge-calibration-report",
+            "report.json",
+            "judge-calibration report artifact corrupt-artifact is corrupt",
+        ),
+        (
+            "judge-calibration",
+            "calibration.json",
+            "judge-calibration artifact corrupt-artifact is corrupt",
+        ),
+    ),
+)
+def test_review_fails_closed_on_semantically_corrupt_artifact_but_allows_missing_records(
+    tmp_path: Path,
+    artifact_type: str,
+    file_name: str,
+    detail: str,
+) -> None:
+    """Missing records are empty state, while typed artifacts with bad data are errors."""
+    store, _first_task_id, _second_task_id = _project(tmp_path)
+    client = _client(store)
+    missing = client.get("/api/review")
+    store.artifacts.write_json(
+        artifact_id="corrupt-artifact",
+        artifact_type=artifact_type,
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=_TIME,
+            code_revision="corrupt-fixture",
+        ),
+        files={file_name: {"artifact_id": "corrupt-artifact"}},
+    )
+
+    corrupt = client.get("/api/review")
+
+    assert missing.status_code == 200
+    assert missing.json()["rollouts"] == []
+    assert corrupt.status_code == 400
+    assert corrupt.json()["detail"] == detail

--- a/wmo/review_server_test.py
+++ b/wmo/review_server_test.py
@@ -647,6 +647,7 @@ def test_review_api_keeps_human_score_corrections_and_never_requires_provider_wo
             "lineage_id": first_task["lineage_group_id"],
             "dimension_id": "task-success",
             "score": 2,
+            "submission_id": "00000000-0000-4000-8000-000000000001",
         },
     )
     second = client.post(
@@ -656,13 +657,25 @@ def test_review_api_keeps_human_score_corrections_and_never_requires_provider_wo
             "lineage_id": first_task["lineage_group_id"],
             "dimension_id": "task-success",
             "score": 4,
+            "submission_id": "00000000-0000-4000-8000-000000000002",
+        },
+    )
+    delayed = client.post(
+        "/api/review/score",
+        json={
+            "rollout_id": "rollout-1",
+            "lineage_id": first_task["lineage_group_id"],
+            "dimension_id": "task-success",
+            "score": 2,
+            "submission_id": "00000000-0000-4000-8000-000000000001",
         },
     )
 
     assert first.status_code == 200
     assert "Score saved locally" in first.json()["notice"]
     assert second.status_code == 200
-    history = second.json()["snapshot"]["human_score_history"]["scores"]
+    assert delayed.status_code == 200
+    history = delayed.json()["snapshot"]["human_score_history"]["scores"]
     assert [score["score"] for score in history] == [2, 4]
     assert history[1]["supersedes_label_id"] == history[0]["label_id"]
 
@@ -693,6 +706,7 @@ def test_review_api_refreshes_w6_calibration_after_a_human_score_correction(
             "lineage_id": lineage_id,
             "dimension_id": "task-success",
             "score": 2,
+            "submission_id": "00000000-0000-4000-8000-000000000011",
         },
     )
     corrected = client.post(
@@ -702,6 +716,7 @@ def test_review_api_refreshes_w6_calibration_after_a_human_score_correction(
             "lineage_id": lineage_id,
             "dimension_id": "task-success",
             "score": 4,
+            "submission_id": "00000000-0000-4000-8000-000000000012",
         },
     )
 
@@ -760,6 +775,7 @@ def test_review_api_requires_explicit_calibration_confirmation_and_writes_artifa
                 "lineage_id": task_lineages[index % 2],
                 "dimension_id": "task-success",
                 "score": 2 + (index % 3),
+                "submission_id": f"00000000-0000-4000-8000-{index + 100:012d}",
             },
         )
         assert response.status_code == 200, response.text

--- a/wmo/review_server_test.py
+++ b/wmo/review_server_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from wmo.common.core.artifacts import ArtifactEnvelope, SourceIdentity
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactInput, SourceIdentity
 from wmo.common.judging import (
     DimensionJudgment,
     HumanScoreReview,
@@ -39,6 +39,7 @@ from wmo.common.rollouts import (
     RolloutArtifact,
     RolloutEventKind,
     RolloutSpan,
+    SimulationCellBinding,
     SimulationMode,
     StopReason,
     WorldModelSimulatorSnapshot,
@@ -90,6 +91,46 @@ def _model(model_id: str) -> ModelSnapshot:
         capabilities_sha256=_DIGEST,
         connection_sha256=_DIGEST,
     )
+
+
+def _world_model_rollout_provenance(
+    candidate: ModelSnapshot,
+    world_model: ModelSnapshot,
+    *,
+    agent_id: str,
+    repeat: int,
+) -> tuple[tuple[ArtifactInput, ...], WorldModelSimulatorSnapshot, SimulationCellBinding]:
+    """Return the complete W8 binding required by a local world-model fixture."""
+    plan_input = ArtifactInput(artifact_id="evaluation-plan", sha256=_DIGEST)
+    specification_input = ArtifactInput(artifact_id="simulation-spec", sha256=_DIGEST)
+    task_set_input = ArtifactInput(artifact_id="task-set-1", sha256=_DIGEST)
+    simulator = WorldModelSimulatorSnapshot(
+        simulator_id="world-model-v1",
+        prompt_id="world-prompt-v1",
+        prompt_version="v1",
+        prompt_sha256=_DIGEST,
+        world_model=world_model,
+    )
+    binding = SimulationCellBinding(
+        evaluation_plan_input=plan_input,
+        task_set_input=task_set_input,
+        task_set_tasks_sha256=_DIGEST,
+        task_sha256=_DIGEST,
+        candidate_alias="candidate",
+        candidate=candidate,
+        agent_id=agent_id,
+        repeat=repeat,
+        world_model_alias="world-model",
+        world_model=world_model,
+        simulator_id=simulator.simulator_id,
+        prompt_id=simulator.prompt_id,
+        prompt_version=simulator.prompt_version,
+        prompt_sha256=simulator.prompt_sha256,
+        simulation_spec_input=specification_input,
+        simulation_spec_sha256=_DIGEST,
+        simulation_inputs_sha256=_DIGEST,
+    )
+    return (plan_input, specification_input, task_set_input), simulator, binding
 
 
 def _trace(index: int) -> Trace:
@@ -216,9 +257,17 @@ def _write_rollout_and_judgment(
 ) -> None:
     """Persist one viewed rollout and one canonical W6 score for override coverage."""
     candidate = _model("candidate")
+    world_model = _model("world-model")
+    inputs, simulator, binding = _world_model_rollout_provenance(
+        candidate,
+        world_model,
+        agent_id="customer-agent",
+        repeat=0,
+    )
     rollout = RolloutArtifact(
         schema_version=1,
         created_at=_TIME,
+        inputs=inputs,
         code_revision="review-test",
         artifact_id="rollout-1",
         simulation_id="simulation-1",
@@ -231,12 +280,8 @@ def _write_rollout_and_judgment(
         task_id=task_id,
         candidate=candidate,
         agent_id="customer-agent",
-        simulator=WorldModelSimulatorSnapshot(
-            simulator_id="world-model-v1",
-            prompt_id="world-prompt-v1",
-            world_model=_model("world-model"),
-        ),
-        world_model=_model("world-model"),
+        simulator=simulator,
+        world_model=world_model,
         seed=7,
         repeat=0,
         spans=(
@@ -252,6 +297,7 @@ def _write_rollout_and_judgment(
         stop_reason=StopReason.COMPLETED,
         candidate_economics=OperationEconomics(),
         simulation_spec_sha256=_DIGEST,
+        simulation_binding=binding,
     )
     store.artifacts.write_json(
         artifact_id=rollout.artifact_id,
@@ -298,9 +344,17 @@ def _write_calibratable_judgment(
 ) -> None:
     """Persist a W6-provenance-valid local rollout and provisional judgment fixture."""
     candidate = _model("candidate")
+    world_model = _model("world-model")
+    inputs, simulator, binding = _world_model_rollout_provenance(
+        candidate,
+        world_model,
+        agent_id="customer-agent",
+        repeat=0,
+    )
     rollout = RolloutArtifact(
         schema_version=1,
         created_at=_TIME,
+        inputs=inputs,
         code_revision="review-test",
         artifact_id="rollout-calibration-1",
         simulation_id="simulation-calibration-1",
@@ -313,12 +367,8 @@ def _write_calibratable_judgment(
         task_id=task_id,
         candidate=candidate,
         agent_id="customer-agent",
-        simulator=WorldModelSimulatorSnapshot(
-            simulator_id="world-model-v1",
-            prompt_id="world-prompt-v1",
-            world_model=_model("world-model"),
-        ),
-        world_model=_model("world-model"),
+        simulator=simulator,
+        world_model=world_model,
         seed=17,
         repeat=0,
         spans=(
@@ -334,6 +384,7 @@ def _write_calibratable_judgment(
         stop_reason=StopReason.COMPLETED,
         candidate_economics=OperationEconomics(),
         simulation_spec_sha256=_DIGEST,
+        simulation_binding=binding,
     )
     store.artifacts.write_json(
         artifact_id=rollout.artifact_id,
@@ -400,6 +451,7 @@ def _write_calibration_batch(
 ) -> tuple[str, ...]:
     """Persist a complete two-lineage calibration fixture with deterministic labels."""
     candidate = _model("candidate")
+    world_model = _model("world-model")
     judge_model = _model("judge")
     prompt = PromptDefinition.from_text("judge-prompt-v1", "Return structured scores.")
     rollout_ids = tuple(f"rollout-calibration-{index}" for index in range(label_count))
@@ -407,9 +459,16 @@ def _write_calibration_batch(
     for index, rollout_id in enumerate(rollout_ids):
         lineage_id = task_lineages[index % 2]
         span_id = f"span-calibration-{index}"
+        inputs, simulator, binding = _world_model_rollout_provenance(
+            candidate,
+            world_model,
+            agent_id="customer-agent",
+            repeat=0,
+        )
         rollout = RolloutArtifact(
             schema_version=1,
             created_at=_TIME,
+            inputs=inputs,
             code_revision="fixture-source",
             artifact_id=rollout_id,
             simulation_id=f"simulation-calibration-{index}",
@@ -422,12 +481,8 @@ def _write_calibration_batch(
             task_id=task_ids[index % 2],
             candidate=candidate,
             agent_id="customer-agent",
-            simulator=WorldModelSimulatorSnapshot(
-                simulator_id="world-model-v1",
-                prompt_id="world-prompt-v1",
-                world_model=_model("world-model"),
-            ),
-            world_model=_model("world-model"),
+            simulator=simulator,
+            world_model=world_model,
             seed=index,
             repeat=0,
             spans=(
@@ -443,6 +498,7 @@ def _write_calibration_batch(
             stop_reason=StopReason.COMPLETED,
             candidate_economics=OperationEconomics(),
             simulation_spec_sha256=_DIGEST,
+            simulation_binding=binding,
         )
         store.artifacts.write_json(
             artifact_id=rollout.artifact_id,


### PR DESCRIPTION
## Summary
- Adds the loopback-only local W5 and W6 review workbench with modal review dialogs.
- Preserves the approved W7 web tree byte-for-byte after restacking on W8.
- Aligns W7 fixture provenance with W8 simulation bindings and records the intentionally added `web/` surface in the closed repository inventory.

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Focused W5/W6/W7/W8 security, provenance, calibration, and concurrency suite: 189 passed.
- CI W1 guardrail suite: 88 passed.
- `npm test`, `npm run lint`, and `npm run build`.
- Wheel build, clean install, package import, and `wmo --help` smoke.
- Production loopback adapter, HTTP proxy, host-rejection, and in-app browser smoke.

`uv run pytest -q` still has the existing unmodified-main `wmo.cli.model_app.run_distillation` seam failure. The first failure occurs after 83 passing tests and is outside this PR diff.