### PR TITLE
W9: add sandbox simulation runtime

### DIFF
--- a/wmo/common/rollouts/__init__.py
+++ b/wmo/common/rollouts/__init__.py
@@ -2,6 +2,7 @@
 
 from wmo.common.rollouts.artifact import (
     RolloutArtifact,
+    SandboxSimulationCellBinding,
     SimulationArtifact,
     SimulationArtifactSet,
     SimulationCellBinding,
@@ -23,6 +24,7 @@ __all__ = [
     "RolloutEventKind",
     "RolloutSpan",
     "SandboxSimulatorSnapshot",
+    "SandboxSimulationCellBinding",
     "SimulationArtifact",
     "SimulationArtifactSet",
     "SimulationCellBinding",

--- a/wmo/common/rollouts/artifact.py
+++ b/wmo/common/rollouts/artifact.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from enum import StrEnum
 from typing import Literal
 
@@ -40,6 +41,7 @@ class StopReason(StrEnum):
     COMPLETED = "completed"
     AGENT_STOP = "agent_stop"
     MAXIMUM_STEPS = "maximum_steps"
+    MAXIMUM_TIME = "maximum_time"
     MAXIMUM_COST = "maximum_cost"
     CONTEXT_OVERFLOW = "context_overflow"
     LENGTH = "length"
@@ -84,6 +86,44 @@ class SimulationCellBinding(ContractModel):
     simulation_inputs_sha256: Sha256
 
 
+class SandboxSimulationCellBinding(ContractModel):
+    """Exact task, model, environment, and artifact identity for one sandbox cell."""
+
+    cell_id: ArtifactId
+    task_id: ArtifactId
+    purpose: Literal["fit", "held_out", "fidelity"]
+    evaluation_plan_input: ArtifactInput
+    task_set_input: ArtifactInput
+    task_set_tasks_sha256: Sha256
+    task_sha256: Sha256
+    task_lineage_group_id: ArtifactId
+    candidate_alias: ModelAlias
+    candidate: ModelSnapshot
+    candidate_maximum_call_cost_usd: float | None = Field(default=None, gt=0)
+    candidate_cost_is_observable: bool = False
+    environment_maximum_episode_cost_usd: float | None = Field(default=None, ge=0)
+    environment_cost_is_observable: bool = False
+    agent_id: str = Field(min_length=1, max_length=256)
+    repeat: int = Field(ge=0)
+    simulator_id: str = Field(min_length=1, max_length=256)
+    environment_id: ArtifactId
+    environment_sha256: Sha256
+    simulation_spec_input: ArtifactInput
+    simulation_spec_sha256: Sha256
+    simulation_inputs_sha256: Sha256
+
+    @field_validator(
+        "candidate_maximum_call_cost_usd",
+        "environment_maximum_episode_cost_usd",
+    )
+    @classmethod
+    def _require_finite_call_cost(cls, value: float | None) -> float | None:
+        """Reject a reservation that cannot enforce a finite spend boundary."""
+        if value is not None and not math.isfinite(value):
+            raise ValueError("sandbox cost reservations must be finite")
+        return value
+
+
 class RolloutArtifact(SimulationArtifact):
     """The v1 simulation artifact subtype that preserves one full agent episode."""
 
@@ -109,6 +149,7 @@ class RolloutArtifact(SimulationArtifact):
     orchestration_economics: OperationEconomics | None = None
     simulation_spec_sha256: Sha256 | None = None
     simulation_binding: SimulationCellBinding | None = None
+    sandbox_binding: SandboxSimulationCellBinding | None = None
 
     @field_validator("spans")
     @classmethod
@@ -133,6 +174,8 @@ class RolloutArtifact(SimulationArtifact):
                 raise ValueError("production rollouts require a production simulator snapshot")
             if self.world_model is not None:
                 raise ValueError("production rollouts must not name a world model")
+            if self.sandbox_binding is not None:
+                raise ValueError("production rollouts must not contain a sandbox binding")
         elif self.evidence_source == "world_model":
             if self.mode != SimulationMode.WORLD_MODEL:
                 raise ValueError("world-model rollouts require world_model mode")
@@ -140,6 +183,8 @@ class RolloutArtifact(SimulationArtifact):
                 raise ValueError("world-model rollouts require a world-model simulator snapshot")
             if self.world_model != self.simulator.world_model:
                 raise ValueError("world-model rollout identity must match its simulator snapshot")
+            if self.sandbox_binding is not None:
+                raise ValueError("world-model rollouts must not contain a sandbox binding")
             _require_world_model_binding(self)
         elif self.evidence_source == "sandbox":
             if self.mode != SimulationMode.SANDBOX:
@@ -148,6 +193,9 @@ class RolloutArtifact(SimulationArtifact):
                 raise ValueError("sandbox rollouts require a sandbox simulator snapshot")
             if self.world_model is not None:
                 raise ValueError("sandbox rollouts must not name a world model")
+            if self.simulation_binding is not None:
+                raise ValueError("sandbox rollouts must not contain a world-model binding")
+            _require_sandbox_binding(self)
         return self
 
 
@@ -186,6 +234,40 @@ def _require_world_model_binding(rollout: RolloutArtifact) -> None:
     }
     if not required_inputs.issubset(set(rollout.inputs)):
         raise ValueError("world-model rollout inputs must retain every bound simulation input")
+
+
+def _require_sandbox_binding(rollout: RolloutArtifact) -> None:
+    """Verify an executable rollout agrees with its complete sandbox cell binding."""
+    binding = rollout.sandbox_binding
+    simulator = rollout.simulator
+    if binding is None:
+        raise ValueError("sandbox rollouts require a complete sandbox cell binding")
+    if not isinstance(simulator, SandboxSimulatorSnapshot):
+        raise ValueError("sandbox rollouts require a sandbox simulator snapshot")
+    if binding.simulation_spec_sha256 != rollout.simulation_spec_sha256:
+        raise ValueError("sandbox binding must match the rollout simulation specification")
+    if binding.cell_id != rollout.cell_id or binding.task_id != rollout.task_id:
+        raise ValueError("sandbox binding cell and task must match the rollout")
+    if binding.task_set_input.artifact_id == binding.evaluation_plan_input.artifact_id:
+        raise ValueError("sandbox binding task-set and evaluation-plan inputs must differ")
+    if binding.candidate != rollout.candidate:
+        raise ValueError("sandbox binding candidate must match the rollout candidate")
+    if binding.agent_id != rollout.agent_id or binding.repeat != rollout.repeat:
+        raise ValueError("sandbox binding agent and repeat must match the rollout")
+    if binding.simulator_id != simulator.simulator_id:
+        raise ValueError("sandbox binding simulator must match the rollout simulator")
+    if (
+        binding.environment_id != simulator.environment_id
+        or binding.environment_sha256 != simulator.environment_sha256
+    ):
+        raise ValueError("sandbox binding environment must match the rollout simulator")
+    required_inputs = {
+        binding.evaluation_plan_input,
+        binding.task_set_input,
+        binding.simulation_spec_input,
+    }
+    if not required_inputs.issubset(set(rollout.inputs)):
+        raise ValueError("sandbox rollout inputs must retain every bound simulation input")
 
 
 class SimulationArtifactSet(ArtifactEnvelope):

--- a/wmo/common/rollouts/otel.py
+++ b/wmo/common/rollouts/otel.py
@@ -76,6 +76,7 @@ class SandboxSimulatorSnapshot(ContractModel):
     kind: Literal["sandbox"] = "sandbox"
     simulator_id: str = Field(min_length=1, max_length=256)
     environment_id: str = Field(min_length=1, max_length=256)
+    environment_sha256: Sha256
 
 
 SimulatorSnapshot = Annotated[

--- a/wmo/runtime/environments/__init__.py
+++ b/wmo/runtime/environments/__init__.py
@@ -1,10 +1,57 @@
 """Customer executable-environment contracts."""
 
+from wmo.runtime.environments.harbor import (
+    E2BTemplateResources,
+    HarborCleanupUnprovenError,
+    HarborCommandResult,
+    HarborEnvironmentRuntime,
+    HarborExecutableSession,
+    HarborRetryableCommandError,
+    HarborSessionFactory,
+    HarborTemplateStatusError,
+    HarborTranscriptEntry,
+    e2b_template_resource_digest,
+    e2b_template_resource_payload,
+    qualify_harbor_e2b_template_name,
+    resolve_e2b_template_resources,
+    retry_template_status,
+)
 from wmo.runtime.environments.interface import (
     EnvironmentResetError,
     EnvironmentRuntime,
     EnvironmentSession,
     Observation,
 )
+from wmo.runtime.environments.local import (
+    LocalProcessCleanupError,
+    LocalProcessCrashError,
+    LocalProcessEnvironmentRuntime,
+    LocalProcessLimits,
+    LocalProcessProtocolError,
+)
 
-__all__ = ["EnvironmentResetError", "EnvironmentRuntime", "EnvironmentSession", "Observation"]
+__all__ = [
+    "EnvironmentResetError",
+    "EnvironmentRuntime",
+    "EnvironmentSession",
+    "E2BTemplateResources",
+    "HarborCommandResult",
+    "HarborCleanupUnprovenError",
+    "HarborEnvironmentRuntime",
+    "HarborExecutableSession",
+    "HarborRetryableCommandError",
+    "HarborSessionFactory",
+    "HarborTemplateStatusError",
+    "HarborTranscriptEntry",
+    "LocalProcessCleanupError",
+    "LocalProcessCrashError",
+    "LocalProcessEnvironmentRuntime",
+    "LocalProcessLimits",
+    "LocalProcessProtocolError",
+    "Observation",
+    "e2b_template_resource_digest",
+    "e2b_template_resource_payload",
+    "qualify_harbor_e2b_template_name",
+    "resolve_e2b_template_resources",
+    "retry_template_status",
+]

--- a/wmo/runtime/environments/harbor.py
+++ b/wmo/runtime/environments/harbor.py
@@ -1,0 +1,639 @@
+"""Harbor and E2B executable-environment adapters behind the canonical runtime seam.
+
+The optional Harbor and E2B dependencies stay outside this module's import path. A caller gives
+this adapter a narrow synchronous session factory, normally backed by Harbor's E2B lifecycle, so
+the simulator still owns one context exit, partial transcript, and cleanup ledger.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from types import TracebackType
+from typing import Literal, Protocol, runtime_checkable
+
+from wmo.common.core.artifacts import ContractModel, JsonObject
+from wmo.common.models import OperationEconomics, ToolCall
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments.interface import EnvironmentSession, Observation
+from wmo.runtime.harness.e2b_ledger import SandboxLedger
+
+E2B_TEMPLATE_POLICY_VERSION = "1"
+"""Version pinned into E2B template resource identities."""
+
+E2B_DEFAULT_CPU_COUNT = 2
+E2B_DEFAULT_MEMORY_MB = 1024
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 240
+DEFAULT_RETRY_DELAYS_SECONDS = (0.25, 0.5, 1.0, 2.0, 4.0)
+DEFAULT_MAXIMUM_OBSERVATION_CHARACTERS = 20_000
+
+
+class HarborRetryableCommandError(RuntimeError):
+    """A safe read-only Harbor command may be retried against the same environment."""
+
+
+class HarborTemplateStatusError(RuntimeError):
+    """A retryable template-status request did not succeed within its configured attempts."""
+
+
+class HarborCleanupUnprovenError(RuntimeError):
+    """An injected Harbor context returned without proving that its sandbox was released."""
+
+
+@dataclass(frozen=True)
+class E2BTemplateResources:
+    """Resource-qualified E2B template values used in the persistent template identity."""
+
+    cpu_count: int
+    memory_mb: int
+
+
+class HarborCommandResult(ContractModel):
+    """One normalized output returned by an injected Harbor executable session."""
+
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int
+    timed_out: bool = False
+    economics: OperationEconomics = OperationEconomics()
+
+
+class HarborTranscriptEntry(ContractModel):
+    """One tool attempt retained when an episode ends before its final artifact is written."""
+
+    action: ToolCall
+    observation: Observation
+
+
+@runtime_checkable
+class HarborExecutableSession(Protocol):
+    """Narrow synchronous slice of an already-open Harbor or E2B task environment."""
+
+    sandbox_id: str
+    template_id: str
+
+    def execute_command(
+        self,
+        command: str,
+        *,
+        environment: Mapping[str, str] | None,
+        timeout_seconds: int,
+    ) -> HarborCommandResult:
+        """Execute one environment command and return normalized process evidence.
+
+        Args:
+            command: Shell command to execute in the task environment.
+            environment: Optional explicit environment passed to the command.
+            timeout_seconds: Finite command execution timeout.
+
+        Returns:
+            Normalized exit, output, and economics evidence.
+        """
+
+    def cleanup_verified(self) -> bool:
+        """Return whether the backing service proved the exact sandbox is no longer live.
+
+        Returns:
+            Whether cleanup conclusively released this session's sandbox.
+        """
+
+
+@runtime_checkable
+class HarborSessionFactory(Protocol):
+    """Opens an optional Harbor or E2B environment for exactly one canonical task."""
+
+    def open(
+        self,
+        task: TaskCase,
+        *,
+        template_name: str,
+    ) -> AbstractContextManager[HarborExecutableSession]:
+        """Create an externally-managed session whose context exit proves cleanup.
+
+        Args:
+            task: Canonical task to execute in the environment.
+            template_name: Resource-qualified template selected for the task.
+
+        Returns:
+            Context manager that yields one executable environment session.
+        """
+
+
+class HarborEnvironmentRuntime:
+    """Adapts an injected Harbor or E2B task session to ``EnvironmentRuntime``.
+
+    This class neither downloads benchmark tasks nor scores them. Its only job is environment
+    lifecycle and the three canonical file or shell tools needed by a customer agent.
+    """
+
+    def __init__(
+        self,
+        factory: HarborSessionFactory,
+        *,
+        environment_id: str,
+        template_name: str,
+        ledger: SandboxLedger | None = None,
+        command_timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        retry_delays_seconds: Sequence[float] = DEFAULT_RETRY_DELAYS_SECONDS,
+        maximum_observation_characters: int = DEFAULT_MAXIMUM_OBSERVATION_CHARACTERS,
+        workspace_root: str = "/workspace",
+    ) -> None:
+        """Configure one optional Harbor backend without creating a cloud sandbox.
+
+        Args:
+            factory: Injected optional Harbor or E2B implementation.
+            environment_id: Stable customer environment identity recorded in rollout provenance.
+            template_name: Resource-qualified E2B template alias selected by the caller.
+            ledger: Durable sandbox ledger. The default preserves legacy orphan-reaping behavior.
+            command_timeout_seconds: Finite limit forwarded to every environment command.
+            retry_delays_seconds: Retry delays used only for read-only transport failures.
+            maximum_observation_characters: Bound for tool text retained in a rollout transcript.
+            workspace_root: Absolute task root used to confine canonical file tools.
+        """
+        if not environment_id:
+            raise ValueError("Harbor environment_id must be nonempty")
+        if not template_name:
+            raise ValueError("Harbor template_name must be nonempty")
+        if isinstance(command_timeout_seconds, bool) or command_timeout_seconds < 1:
+            raise ValueError("Harbor command_timeout_seconds must be a positive integer")
+        if isinstance(maximum_observation_characters, bool) or maximum_observation_characters < 1:
+            raise ValueError("Harbor maximum_observation_characters must be a positive integer")
+        normalized_root = PurePosixPath(workspace_root)
+        if not normalized_root.is_absolute() or ".." in normalized_root.parts:
+            raise ValueError("Harbor workspace_root must be an absolute normalized path")
+        normalized_delays = tuple(float(delay) for delay in retry_delays_seconds)
+        if any(delay < 0 for delay in normalized_delays):
+            raise ValueError("Harbor retry delays must be nonnegative")
+        self._factory = factory
+        self.environment_id = environment_id
+        self.template_name = template_name
+        self._ledger = ledger or SandboxLedger()
+        self._command_timeout_seconds = command_timeout_seconds
+        self._retry_delays_seconds = normalized_delays
+        self._maximum_observation_characters = maximum_observation_characters
+        self._workspace_root = normalized_root.as_posix()
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Return the simulator-owned cleanup context for one task environment.
+
+        Args:
+            task: Canonical task passed to the injected Harbor or E2B session factory.
+
+        Returns:
+            An execute-only environment context that records proven cleanup in the ledger.
+        """
+        return _HarborSessionContext(self, task)
+
+
+class _HarborSessionContext(AbstractContextManager[EnvironmentSession]):
+    """Records a created sandbox before use and releases it only after a successful context exit."""
+
+    def __init__(self, runtime: HarborEnvironmentRuntime, task: TaskCase) -> None:
+        self._runtime = runtime
+        self._task = task
+        self._context: AbstractContextManager[HarborExecutableSession] | None = None
+        self._session: HarborExecutableSession | None = None
+
+    def __enter__(self) -> EnvironmentSession:
+        """Open, ledger-record, and adapt one task-local Harbor session."""
+        context = self._runtime._factory.open(self._task, template_name=self._runtime.template_name)
+        self._context = context
+        try:
+            session = context.__enter__()
+        except Exception:
+            self._context = None
+            raise
+        if not session.sandbox_id or not session.template_id:
+            try:
+                context.__exit__(None, None, None)
+            finally:
+                self._context = None
+            raise ValueError(
+                "Harbor executable sessions must expose nonempty sandbox and template IDs"
+            )
+        self._session = session
+        self._runtime._ledger.record_created(
+            sandbox_id=session.sandbox_id,
+            template_id=session.template_id,
+        )
+        return _HarborEnvironmentSession(
+            session,
+            command_timeout_seconds=self._runtime._command_timeout_seconds,
+            retry_delays_seconds=self._runtime._retry_delays_seconds,
+            maximum_observation_characters=self._runtime._maximum_observation_characters,
+            workspace_root=self._runtime._workspace_root,
+        )
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Release a ledger entry only when the injected session cleanup actually returns."""
+        context = self._context
+        session = self._session
+        if context is None or session is None:
+            return False
+        try:
+            suppressed = context.__exit__(exception_type, exception, traceback)
+        except Exception:
+            raise
+        if not session.cleanup_verified():
+            raise HarborCleanupUnprovenError(
+                "Harbor cleanup returned without proof that the sandbox was released"
+            )
+        self._runtime._ledger.record_released(session.sandbox_id)
+        return bool(suppressed)
+
+
+class _HarborEnvironmentSession:
+    """Maps canonical tool calls to safe Harbor task-environment commands."""
+
+    def __init__(
+        self,
+        session: HarborExecutableSession,
+        *,
+        command_timeout_seconds: int,
+        retry_delays_seconds: tuple[float, ...],
+        maximum_observation_characters: int,
+        workspace_root: str,
+    ) -> None:
+        self._session = session
+        self._command_timeout_seconds = command_timeout_seconds
+        self._retry_delays_seconds = retry_delays_seconds
+        self._maximum_observation_characters = maximum_observation_characters
+        self._workspace_root = workspace_root
+        self._partial_transcript: list[HarborTranscriptEntry] = []
+
+    @property
+    def partial_transcript(self) -> tuple[HarborTranscriptEntry, ...]:
+        """Return every tool observation observed before a complete rollout is materialized."""
+        return tuple(self._partial_transcript)
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Execute one canonical action and retain its result even when the environment fails."""
+        try:
+            observation = self._execute(action)
+        except Exception as error:  # noqa: BLE001 - customer environment failures are evidence
+            observation = Observation(
+                content=f"environment command failed: {type(error).__name__}",
+                is_error=True,
+                metadata={
+                    "exception_type": type(error).__name__,
+                    "retryable": isinstance(error, HarborRetryableCommandError),
+                },
+            )
+        self._partial_transcript.append(
+            HarborTranscriptEntry(action=action, observation=observation)
+        )
+        return observation
+
+    def _execute(self, action: ToolCall) -> Observation:
+        """Validate and dispatch only the supported canonical executable tools."""
+        if action.name == "bash":
+            command = _string_argument(action.arguments, "command")
+            if command is None:
+                return _invalid_arguments("bash", "command must be a string")
+            return _command_observation(self._run(command, retryable=False))
+        if action.name == "read_file":
+            raw_path = _string_argument(action.arguments, "path", nonempty=True)
+            path = _safe_relative_path(raw_path) if raw_path is not None else None
+            if path is None:
+                return _invalid_arguments("read_file", "path must be a nonempty string")
+            return _command_observation(
+                self._run(
+                    _guarded_read_command(),
+                    environment=self._file_environment(path),
+                    retryable=True,
+                ),
+                maximum_characters=self._maximum_observation_characters,
+            )
+        if action.name == "write_file":
+            raw_path = _string_argument(action.arguments, "path", nonempty=True)
+            path = _safe_relative_path(raw_path) if raw_path is not None else None
+            content = _string_argument(action.arguments, "content")
+            if path is None or content is None:
+                return _invalid_arguments(
+                    "write_file",
+                    "path must be nonempty and content must be a string",
+                )
+            encoded = base64.b64encode(content.encode()).decode()
+            result = self._run(
+                _guarded_write_command(),
+                environment={
+                    **self._file_environment(path),
+                    "WMO_FILE_CONTENT_B64": encoded,
+                },
+                retryable=False,
+            )
+            observation = _command_observation(
+                result,
+                maximum_characters=self._maximum_observation_characters,
+            )
+            if observation.is_error:
+                return observation
+            return Observation(content=f"wrote {path}", metadata=observation.metadata)
+        return Observation(content=f"tool {action.name!r} not available", is_error=True)
+
+    def _file_environment(self, path: str) -> dict[str, str]:
+        """Return non-secret variables consumed by the path-confinement shell fragment."""
+        return {"WMO_FILE_PATH": path, "WMO_SANDBOX_ROOT": self._workspace_root}
+
+    def _run(
+        self,
+        command: str,
+        *,
+        environment: Mapping[str, str] | None = None,
+        retryable: bool,
+    ) -> HarborCommandResult:
+        """Run one command, retrying only a read-only transport failure."""
+        attempts = len(self._retry_delays_seconds) + 1 if retryable else 1
+        for attempt in range(attempts):
+            try:
+                return self._session.execute_command(
+                    command,
+                    environment=environment,
+                    timeout_seconds=self._command_timeout_seconds,
+                )
+            except HarborRetryableCommandError:
+                if attempt + 1 == attempts:
+                    raise
+                time.sleep(self._retry_delays_seconds[attempt])
+        raise AssertionError("Harbor command retry loop exhausted without a result")
+
+
+def resolve_e2b_template_resources(
+    *,
+    cpu_count: int | None,
+    memory_mb: int | None,
+) -> E2BTemplateResources:
+    """Resolve absent template resource settings to the frozen Harbor E2B defaults.
+
+    Args:
+        cpu_count: Requested CPU count, or ``None`` for the policy default.
+        memory_mb: Requested memory in MiB, or ``None`` for the policy default.
+
+    Returns:
+        Validated concrete resource settings.
+
+    Raises:
+        ValueError: A supplied value is not an integer or is below the policy minimum.
+    """
+    if any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in (cpu_count, memory_mb)
+        if value is not None
+    ):
+        raise ValueError("E2B template CPU and memory values must be integers")
+    resolved_cpu = E2B_DEFAULT_CPU_COUNT if cpu_count is None else cpu_count
+    resolved_memory = E2B_DEFAULT_MEMORY_MB if memory_mb is None else memory_mb
+    if resolved_cpu < 1 or resolved_memory < 128:
+        raise ValueError("E2B template CPU must be positive and memory must be at least 128 MiB")
+    return E2BTemplateResources(cpu_count=resolved_cpu, memory_mb=resolved_memory)
+
+
+def e2b_template_resource_payload(
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+    harbor_version: str,
+    e2b_sdk_version: str,
+) -> dict[str, int | str]:
+    """Return the frozen resource-complete payload used to identify one E2B template.
+
+    Args:
+        environment_id: Canonical Harbor environment identity.
+        build_source_kind: Whether the template is built from an image or Dockerfile.
+        build_source_reference: Immutable build source reference.
+        resources: Concrete CPU and memory allocation.
+        harbor_version: Harbor dependency version used for the build.
+        e2b_sdk_version: E2B SDK version used for the build.
+
+    Returns:
+        Canonical JSON-compatible identity payload.
+
+    Raises:
+        ValueError: A required identity or version value is empty.
+    """
+    if not environment_id:
+        raise ValueError("Harbor environment_id must be nonempty")
+    if not build_source_reference:
+        raise ValueError("E2B template build source must be nonempty")
+    if not harbor_version or not e2b_sdk_version:
+        raise ValueError("Harbor and E2B versions must be nonempty")
+    return {
+        "schema_version": E2B_TEMPLATE_POLICY_VERSION,
+        "harbor_environment_id": environment_id,
+        "build_source_kind": build_source_kind,
+        "build_source_reference": build_source_reference,
+        "cpu_count": resources.cpu_count,
+        "memory_mb": resources.memory_mb,
+        "harbor_version": harbor_version,
+        "e2b_sdk_version": e2b_sdk_version,
+    }
+
+
+def e2b_template_resource_digest(
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+    harbor_version: str,
+    e2b_sdk_version: str,
+) -> str:
+    """Hash one canonical Harbor content, resources, and dependency-version identity.
+
+    Args:
+        environment_id: Canonical Harbor environment identity.
+        build_source_kind: Whether the template is built from an image or Dockerfile.
+        build_source_reference: Immutable build source reference.
+        resources: Concrete CPU and memory allocation.
+        harbor_version: Harbor dependency version used for the build.
+        e2b_sdk_version: E2B SDK version used for the build.
+
+    Returns:
+        Stable SHA-256 digest of the canonical identity payload.
+    """
+    payload = e2b_template_resource_payload(
+        environment_id=environment_id,
+        build_source_kind=build_source_kind,
+        build_source_reference=build_source_reference,
+        resources=resources,
+        harbor_version=harbor_version,
+        e2b_sdk_version=e2b_sdk_version,
+    )
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def qualify_harbor_e2b_template_name(
+    base_name: str,
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+    harbor_version: str,
+    e2b_sdk_version: str,
+    snapshot_hash_length: int,
+) -> str:
+    """Derive the resource-qualified E2B alias without importing optional SDKs.
+
+    ``snapshot_hash_length`` comes from the optional Harbor integration, preserving its exact
+    native content-name validation without making ordinary local runs import Harbor.
+
+    Args:
+        base_name: Harbor's content-derived base template name.
+        environment_id: Canonical Harbor environment identity.
+        build_source_kind: Whether the template is built from an image or Dockerfile.
+        build_source_reference: Immutable build source reference.
+        resources: Concrete CPU and memory allocation.
+        harbor_version: Harbor dependency version used for the build.
+        e2b_sdk_version: E2B SDK version used for the build.
+        snapshot_hash_length: Harbor's validated environment-ID prefix length.
+
+    Returns:
+        Resource-qualified immutable E2B template alias.
+
+    Raises:
+        ValueError: The environment identity, prefix length, or base alias is invalid.
+    """
+    if len(environment_id) != 32 or any(
+        character not in "0123456789abcdef" for character in environment_id
+    ):
+        raise ValueError("Harbor environment_id must be 32 lowercase hexadecimal characters")
+    if snapshot_hash_length < 1:
+        raise ValueError("Harbor snapshot_hash_length must be positive")
+    if not base_name.endswith(environment_id[:snapshot_hash_length]):
+        raise ValueError("Harbor E2B template name does not match its environment_id")
+    digest = e2b_template_resource_digest(
+        environment_id=environment_id,
+        build_source_kind=build_source_kind,
+        build_source_reference=build_source_reference,
+        resources=resources,
+        harbor_version=harbor_version,
+        e2b_sdk_version=e2b_sdk_version,
+    )
+    return f"wmo-hb-v1-{digest}"
+
+
+def retry_template_status[T](
+    read_status: Callable[[], T],
+    *,
+    retry_delays_seconds: Sequence[float] = DEFAULT_RETRY_DELAYS_SECONDS,
+) -> T:
+    """Retry an idempotent template-status read without replaying a template submission.
+
+    Args:
+        read_status: Idempotent status read to retry after transient status errors.
+        retry_delays_seconds: Delays before each permitted retry.
+
+    Returns:
+        The first successful status result.
+
+    Raises:
+        HarborTemplateStatusError: The final permitted status read still fails.
+    """
+    delays = tuple(retry_delays_seconds)
+    for attempt in range(len(delays) + 1):
+        try:
+            return read_status()
+        except HarborTemplateStatusError:
+            if attempt == len(delays):
+                raise
+            time.sleep(delays[attempt])
+    raise AssertionError("Harbor template status retry loop exhausted without a result")
+
+
+def _string_argument(
+    arguments: JsonObject,
+    name: str,
+    *,
+    nonempty: bool = False,
+) -> str | None:
+    """Return one string tool argument when it meets the requested nonempty constraint."""
+    value = arguments.get(name)
+    if not isinstance(value, str) or (nonempty and not value):
+        return None
+    return value
+
+
+def _invalid_arguments(tool: str, message: str) -> Observation:
+    """Build one agent-visible tool-input error without executing a customer environment command."""
+    return Observation(content=f"invalid {tool} arguments: {message}", is_error=True)
+
+
+def _safe_relative_path(value: str) -> str | None:
+    """Accept one normalized relative POSIX path with no traversal component."""
+    path = PurePosixPath(value)
+    if path.is_absolute() or value in {"", "."} or any(part in {"", ".."} for part in path.parts):
+        return None
+    normalized = path.as_posix()
+    if normalized != value:
+        return None
+    return normalized
+
+
+def _guarded_read_command() -> str:
+    """Return a shell fragment that rejects lexical and symlink escapes before reading."""
+    return (
+        'set -eu; root=$(cd "$WMO_SANDBOX_ROOT" && pwd -P); '
+        "rel=$WMO_FILE_PATH; parent=${rel%/*}; name=${rel##*/}; "
+        '[ "$parent" = "$rel" ] && parent=.; '
+        'target_parent=$(cd "$root/$parent" && pwd -P); '
+        'case "$target_parent/" in "$root/"*) ;; *) exit 73 ;; esac; '
+        '[ ! -L "$target_parent/$name" ] || exit 73; cat "$target_parent/$name"'
+    )
+
+
+def _guarded_write_command() -> str:
+    """Return a shell fragment that confines creation and replacement to the task root."""
+    return (
+        'set -eu; root=$(cd "$WMO_SANDBOX_ROOT" && pwd -P); '
+        "rel=$WMO_FILE_PATH; parent=${rel%/*}; name=${rel##*/}; "
+        '[ "$parent" = "$rel" ] && parent=.; '
+        'target_parent=$(cd "$root/$parent" && pwd -P); '
+        'case "$target_parent/" in "$root/"*) ;; *) exit 73 ;; esac; '
+        '[ ! -L "$target_parent/$name" ] || exit 73; '
+        'printf \'%s\' "$WMO_FILE_CONTENT_B64" | base64 -d > "$target_parent/$name"'
+    )
+
+
+def _command_observation(
+    result: HarborCommandResult,
+    *,
+    maximum_characters: int = DEFAULT_MAXIMUM_OBSERVATION_CHARACTERS,
+) -> Observation:
+    """Convert process evidence into a bounded canonical tool observation."""
+    content = result.stdout if result.stdout else result.stderr
+    if len(content) > maximum_characters:
+        omitted = len(content) - maximum_characters
+        content = f"{content[:maximum_characters]}\n[truncated {omitted} characters]"
+    metadata: JsonObject = {
+        "exit_code": result.exit_code,
+        "timed_out": result.timed_out,
+        "economics": result.economics.model_dump(mode="json"),
+    }
+    if result.timed_out:
+        return Observation(
+            content=content or "environment command timed out",
+            is_error=True,
+            metadata=metadata,
+        )
+    if result.exit_code != 0:
+        return Observation(
+            content=content or f"command exited {result.exit_code}",
+            is_error=True,
+            metadata=metadata,
+        )
+    return Observation(content=content, metadata=metadata)

--- a/wmo/runtime/environments/harbor_test.py
+++ b/wmo/runtime/environments/harbor_test.py
@@ -1,0 +1,376 @@
+"""Tests for the narrow optional Harbor and E2B environment adapter."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from pathlib import Path
+from types import TracebackType
+from typing import Protocol, cast
+
+import pytest
+
+from wmo.common.models import ToolCall
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments.harbor import (
+    HarborCleanupUnprovenError,
+    HarborCommandResult,
+    HarborEnvironmentRuntime,
+    HarborRetryableCommandError,
+    HarborTemplateStatusError,
+    HarborTranscriptEntry,
+    e2b_template_resource_digest,
+    qualify_harbor_e2b_template_name,
+    resolve_e2b_template_resources,
+    retry_template_status,
+)
+from wmo.runtime.harness.e2b_ledger import SandboxLedger, read_ledger_files
+
+
+class _TranscriptEnvironmentSession(Protocol):
+    """Narrow test-only view of the Harbor session transcript capability."""
+
+    @property
+    def partial_transcript(self) -> tuple[HarborTranscriptEntry, ...]:
+        """Return every environment observation retained by this Harbor adapter."""
+        ...
+
+
+def test_harbor_runtime_preserves_partial_transcript_and_proven_cleanup(tmp_path: Path) -> None:
+    """The environment seam records create, tools, and release without benchmark ownership."""
+    ledger = SandboxLedger(tmp_path / "ledger", pid=827)
+    session = _Session()
+    runtime = HarborEnvironmentRuntime(
+        _Factory(session),
+        environment_id="customer-env",
+        template_name="wmo-hb-v1-fixture",
+        ledger=ledger,
+        retry_delays_seconds=(),
+    )
+
+    with runtime.open(_task()) as environment:
+        observation = environment.execute(
+            ToolCall(call_id="call-1", name="read_file", arguments={"path": "notes.txt"})
+        )
+        assert observation.content == "fixture output"
+        assert not observation.is_error
+        partial = cast(_TranscriptEnvironmentSession, environment).partial_transcript
+        assert partial[0].action.name == "read_file"
+        assert partial[0].observation == observation
+
+    ledgers = read_ledger_files(tmp_path / "ledger")
+    assert len(ledgers) == 1
+    assert ledgers[0].held == ()
+    assert ledgers[0].released_ids == ("sandbox-1",)
+    assert session.closed
+    assert len(session.commands) == 1
+    assert "pwd -P" in session.commands[0][0]
+    assert session.commands[0][1] == {
+        "WMO_FILE_PATH": "notes.txt",
+        "WMO_SANDBOX_ROOT": "/workspace",
+    }
+
+
+def test_harbor_runtime_retries_only_read_only_transport_failures(tmp_path: Path) -> None:
+    """A read can retry, while a mutation makes one exact environment call only."""
+    ledger = SandboxLedger(tmp_path / "ledger", pid=828)
+    session = _Session(fail_read_once=True)
+    runtime = HarborEnvironmentRuntime(
+        _Factory(session),
+        environment_id="customer-env",
+        template_name="wmo-hb-v1-fixture",
+        ledger=ledger,
+        retry_delays_seconds=(0.0,),
+    )
+
+    with runtime.open(_task()) as environment:
+        assert (
+            environment.execute(
+                ToolCall(call_id="call-read", name="read_file", arguments={"path": "notes.txt"})
+            ).content
+            == "fixture output"
+        )
+        assert (
+            environment.execute(
+                ToolCall(
+                    call_id="call-write",
+                    name="write_file",
+                    arguments={"path": "notes.txt", "content": "new content"},
+                )
+            ).content
+            == "wrote notes.txt"
+        )
+
+    assert len(session.commands) == 3
+    assert "pwd -P" in session.commands[0][0]
+    assert session.commands[1][0] == session.commands[0][0]
+    assert "WMO_FILE_PATH" in (session.commands[2][1] or {})
+
+
+def test_harbor_runtime_does_not_mark_unproven_cleanup_released(tmp_path: Path) -> None:
+    """A factory cleanup error leaves the durable ledger holding the sandbox for a reaper."""
+    ledger = SandboxLedger(tmp_path / "ledger", pid=829)
+    session = _Session()
+    runtime = HarborEnvironmentRuntime(
+        _Factory(session, fail_close=True),
+        environment_id="customer-env",
+        template_name="wmo-hb-v1-fixture",
+        ledger=ledger,
+    )
+
+    with pytest.raises(OSError, match="cleanup"):
+        with runtime.open(_task()):
+            pass
+
+    ledgers = read_ledger_files(tmp_path / "ledger")
+    assert len(ledgers) == 1
+    assert tuple(record.sandbox_id for record in ledgers[0].held) == ("sandbox-1",)
+
+
+def test_harbor_runtime_rejects_false_cleanup_proof_and_keeps_ledger_hold(
+    tmp_path: Path,
+) -> None:
+    """A clean context return is insufficient when the backend reports cleanup as unverified."""
+    ledger = SandboxLedger(tmp_path / "ledger", pid=830)
+    session = _Session(cleanup_proven=False)
+    runtime = HarborEnvironmentRuntime(
+        _Factory(session),
+        environment_id="customer-env",
+        template_name="wmo-hb-v1-fixture",
+        ledger=ledger,
+    )
+
+    with pytest.raises(HarborCleanupUnprovenError, match="without proof"):
+        with runtime.open(_task()):
+            pass
+
+    ledgers = read_ledger_files(tmp_path / "ledger")
+    assert tuple(record.sandbox_id for record in ledgers[0].held) == ("sandbox-1",)
+
+
+def test_harbor_file_tools_reject_lexical_and_symlink_path_escapes(tmp_path: Path) -> None:
+    """Canonical file actions cannot traverse or follow a link outside the configured root."""
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    (workspace / "escape").symlink_to(outside, target_is_directory=True)
+    session = _ShellSession()
+    runtime = HarborEnvironmentRuntime(
+        _Factory(session),
+        environment_id="customer-env",
+        template_name="wmo-hb-v1-fixture",
+        ledger=SandboxLedger(tmp_path / "ledger", pid=831),
+        retry_delays_seconds=(),
+        workspace_root=str(workspace),
+    )
+
+    with runtime.open(_task()) as environment:
+        lexical = environment.execute(
+            ToolCall(call_id="call-lexical", name="read_file", arguments={"path": "../secret"})
+        )
+        symlink = environment.execute(
+            ToolCall(
+                call_id="call-symlink",
+                name="read_file",
+                arguments={"path": "escape/secret.txt"},
+            )
+        )
+        write = environment.execute(
+            ToolCall(
+                call_id="call-write",
+                name="write_file",
+                arguments={"path": "escape/new.txt", "content": "blocked"},
+            )
+        )
+
+    assert lexical.is_error
+    assert symlink.is_error and symlink.metadata["exit_code"] == 73
+    assert write.is_error and write.metadata["exit_code"] == 73
+    assert not (outside / "new.txt").exists()
+    assert len(session.commands) == 2
+
+
+def test_template_identity_includes_resources_and_dependency_versions() -> None:
+    """Changing resources or an SDK version cannot silently reuse another template."""
+    resources = resolve_e2b_template_resources(cpu_count=None, memory_mb=None)
+    first = e2b_template_resource_digest(
+        environment_id="a" * 32,
+        build_source_kind="docker_image",
+        build_source_reference="fixture:image",
+        resources=resources,
+        harbor_version="0.20.0",
+        e2b_sdk_version="2.31.0",
+    )
+    second = e2b_template_resource_digest(
+        environment_id="a" * 32,
+        build_source_kind="docker_image",
+        build_source_reference="fixture:image",
+        resources=resolve_e2b_template_resources(cpu_count=4, memory_mb=None),
+        harbor_version="0.20.0",
+        e2b_sdk_version="2.31.0",
+    )
+
+    assert first != second
+    assert (
+        qualify_harbor_e2b_template_name(
+            "harbor-template-aaaaaaaa",
+            environment_id="a" * 32,
+            build_source_kind="docker_image",
+            build_source_reference="fixture:image",
+            resources=resources,
+            harbor_version="0.20.0",
+            e2b_sdk_version="2.31.0",
+            snapshot_hash_length=8,
+        )
+        == f"wmo-hb-v1-{first}"
+    )
+
+
+def test_template_status_retry_retries_only_the_idempotent_read() -> None:
+    """The retry helper is usable for status reads without making submission replayable."""
+    attempts = 0
+
+    def read_status() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise HarborTemplateStatusError("temporary status transport failure")
+        return "ready"
+
+    assert retry_template_status(read_status, retry_delays_seconds=(0.0,)) == "ready"
+    assert attempts == 2
+
+
+class _Factory:
+    """Opens one in-memory optional Harbor session for deterministic adapter tests."""
+
+    def __init__(
+        self,
+        session: _Session | _ShellSession,
+        *,
+        fail_close: bool = False,
+    ) -> None:
+        self._session = session
+        self._fail_close = fail_close
+
+    def open(
+        self,
+        task: TaskCase,
+        *,
+        template_name: str,
+    ) -> AbstractContextManager[_Session | _ShellSession]:
+        assert task == _task()
+        assert template_name == "wmo-hb-v1-fixture"
+        return _Context(self._session, fail_close=self._fail_close)
+
+
+class _Context(AbstractContextManager["_Session | _ShellSession"]):
+    """Makes successful and failed cleanup explicit in adapter lifecycle fixtures."""
+
+    def __init__(self, session: _Session | _ShellSession, *, fail_close: bool) -> None:
+        self._session = session
+        self._fail_close = fail_close
+
+    def __enter__(self) -> _Session | _ShellSession:
+        return self._session
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        del exception_type, exception, traceback
+        self._session.closed = True
+        if self._fail_close:
+            raise OSError("cleanup not proved")
+        return False
+
+
+class _Session:
+    """A scriptable session that conforms to the narrow optional Harbor protocol."""
+
+    sandbox_id = "sandbox-1"
+    template_id = "wmo-hb-v1-fixture"
+
+    def __init__(
+        self,
+        *,
+        fail_read_once: bool = False,
+        cleanup_proven: bool = True,
+    ) -> None:
+        self._fail_read_once = fail_read_once
+        self._cleanup_proven = cleanup_proven
+        self.commands: list[tuple[str, Mapping[str, str] | None, int]] = []
+        self.closed = False
+
+    def execute_command(
+        self,
+        command: str,
+        *,
+        environment: Mapping[str, str] | None,
+        timeout_seconds: int,
+    ) -> HarborCommandResult:
+        self.commands.append((command, environment, timeout_seconds))
+        if self._fail_read_once:
+            self._fail_read_once = False
+            raise HarborRetryableCommandError("temporary transport failure")
+        return HarborCommandResult(stdout="fixture output", exit_code=0)
+
+    def cleanup_verified(self) -> bool:
+        """Report the scripted cleanup proof only after the context has closed."""
+        return self.closed and self._cleanup_proven
+
+
+class _ShellSession:
+    """Execute guarded file fragments locally to exercise real symlink resolution."""
+
+    sandbox_id = "sandbox-shell"
+    template_id = "wmo-hb-v1-fixture"
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        self.closed = False
+
+    def execute_command(
+        self,
+        command: str,
+        *,
+        environment: Mapping[str, str] | None,
+        timeout_seconds: int,
+    ) -> HarborCommandResult:
+        """Run one injected fragment with only its explicit variables and a safe system path."""
+        self.commands.append(command)
+        result = subprocess.run(
+            ["/bin/sh", "-c", command],
+            check=False,
+            capture_output=True,
+            env={"PATH": os.defpath, **dict(environment or {})},
+            text=True,
+            timeout=timeout_seconds,
+        )
+        return HarborCommandResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )
+
+    def cleanup_verified(self) -> bool:
+        """Return true once the deterministic local context has exited."""
+        return self.closed
+
+
+def _task() -> TaskCase:
+    """Build one fixed canonical task for Harbor environment lifecycle fixtures."""
+    return TaskCase(
+        task_id="task-1",
+        lineage_group_id="lineage-1",
+        partition="fit",
+        instruction="Run the optional environment fixture.",
+        workload_weight=1.0,
+        source_trace_ids=("trace-1",),
+    )

--- a/wmo/runtime/environments/local.py
+++ b/wmo/runtime/environments/local.py
@@ -26,7 +26,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
-from typing import cast
+from typing import Protocol, cast
 
 from wmo.common.core.artifacts import JsonObject
 from wmo.common.models import ToolCall
@@ -61,6 +61,41 @@ class _ProcessRecord:
     zombie: bool
 
 
+class _KqueueEvent(Protocol):
+    fflags: int
+
+
+class _Kqueue(Protocol):
+    """The Darwin queue operations owned by one descendant tracker."""
+
+    def close(self) -> None: ...
+
+    def control(self, changes: object, max_events: int, timeout: int) -> list[_KqueueEvent]: ...
+
+
+class _KqueueFactory(Protocol):
+    def __call__(self) -> _Kqueue: ...
+
+
+class _KeventFactory(Protocol):
+    """Create one Darwin process-notification registration event."""
+
+    def __call__(self, ident: int, *, filter: int, flags: int, fflags: int) -> object: ...
+
+
+@dataclass(frozen=True)
+class _DarwinKqueueBindings:
+    """Dynamically loaded Darwin-only ``select`` bindings for containment proof."""
+
+    kqueue: _KqueueFactory
+    kevent: _KeventFactory
+    filter_process: int
+    event_add: int
+    event_clear: int
+    note_fork: int
+    note_exit: int
+
+
 class _DarwinProcBsdInfo(ctypes.Structure):
     """ABI layout returned by Darwin ``PROC_PIDTBSDINFO``."""
 
@@ -93,7 +128,11 @@ class _DarwinProcBsdInfo(ctypes.Structure):
 class _DescendantTracker:
     """Track exact descendants and kernel fork evidence without trusting numeric groups."""
 
-    def __init__(self, root_identity: _ProcessIdentity) -> None:
+    def __init__(
+        self,
+        root_identity: _ProcessIdentity,
+        bindings: _DarwinKqueueBindings,
+    ) -> None:
         snapshot = _process_snapshot()
         root = snapshot.get(root_identity.pid)
         if root is None or root.identity != root_identity:
@@ -104,13 +143,14 @@ class _DescendantTracker:
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._failure: Exception | None = None
-        self._kqueue = select.kqueue()
+        self._bindings = bindings
+        self._kqueue = bindings.kqueue()
         try:
-            event = select.kevent(
+            event = bindings.kevent(
                 root_identity.pid,
-                filter=select.KQ_FILTER_PROC,
-                flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
-                fflags=select.KQ_NOTE_FORK | select.KQ_NOTE_EXIT,
+                filter=bindings.filter_process,
+                flags=bindings.event_add | bindings.event_clear,
+                fflags=bindings.note_fork | bindings.note_exit,
             )
             self._kqueue.control((event,), 0, 0)
             self._thread = threading.Thread(
@@ -175,7 +215,7 @@ class _DescendantTracker:
     def _read_kernel_events(self) -> None:
         """Latch kernel fork evidence even when no numeric child PID remains observable."""
         for event in self._kqueue.control(None, 8, 0):
-            if event.fflags & select.KQ_NOTE_FORK:
+            if event.fflags & self._bindings.note_fork:
                 with self._lock:
                     self._fork_observed = True
 
@@ -210,12 +250,30 @@ def _process_snapshot() -> dict[int, _ProcessRecord]:
     raise LocalProcessCleanupError("local descendant tracking requires Darwin or Linux")
 
 
-def _require_containment_support() -> None:
-    """Fail before resource allocation when kernel fork evidence is unavailable."""
-    if sys.platform != "darwin" or not hasattr(select, "kqueue"):
+def _require_containment_support() -> _DarwinKqueueBindings:
+    """Load required Darwin queue bindings before allocating process resources."""
+    if sys.platform != "darwin":
         raise LocalProcessCleanupError(
             "local process containment requires Darwin kernel fork notifications"
         )
+
+    def binding(name: str) -> object:
+        return getattr(select, name)
+
+    try:
+        return _DarwinKqueueBindings(
+            kqueue=cast(_KqueueFactory, binding("kqueue")),
+            kevent=cast(_KeventFactory, binding("kevent")),
+            filter_process=cast(int, binding("KQ_FILTER_PROC")),
+            event_add=cast(int, binding("KQ_EV_ADD")),
+            event_clear=cast(int, binding("KQ_EV_CLEAR")),
+            note_fork=cast(int, binding("KQ_NOTE_FORK")),
+            note_exit=cast(int, binding("KQ_NOTE_EXIT")),
+        )
+    except AttributeError as error:
+        raise LocalProcessCleanupError(
+            "local process containment requires Darwin kernel fork notifications"
+        ) from error
 
 
 def _read_process_identity(pid: int) -> _ProcessIdentity:
@@ -494,7 +552,7 @@ class _LocalProcessSession:
 
     def start(self, task: TaskCase) -> None:
         """Create workspace, launch the child, and verify the mandatory ready response."""
-        _require_containment_support()
+        bindings = _require_containment_support()
         workspace_parent = self._workspace_parent
         if workspace_parent is not None:
             workspace_parent.mkdir(parents=True, exist_ok=True)
@@ -543,7 +601,7 @@ class _LocalProcessSession:
         root_identity: _ProcessIdentity | None = None
         try:
             root_identity = _read_process_identity(self._process.pid)
-            self._descendants = _DescendantTracker(root_identity)
+            self._descendants = _DescendantTracker(root_identity, bindings)
             os.write(gate_write, b"1")
             _close_fd(gate_write)
         except BaseException as error:  # noqa: BLE001 - preserve startup errors after no-fail cleanup

--- a/wmo/runtime/environments/local.py
+++ b/wmo/runtime/environments/local.py
@@ -1,0 +1,940 @@
+"""A bounded JSONL local-process implementation of the executable environment seam.
+
+This adapter gives every episode a new temporary workspace and a long-lived process. It is an
+execution boundary, not a security boundary: a customer process still has the permissions of the
+user who starts WMO. Customers that need an isolated VM can provide an E2B or other
+``EnvironmentRuntime`` implementation instead.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import math
+import os
+import queue
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import cast
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import ToolCall
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments.interface import EnvironmentSession, Observation
+
+_WORKSPACE_ENVIRONMENT_VARIABLE = "WMO_SANDBOX_WORKSPACE"
+_END_OF_STREAM = object()
+_ALLOWED_CHILD_ENVIRONMENT_KEYS = frozenset({"LANG", "LC_ALL", "LC_CTYPE", "PATH", "TZ"})
+_DEFAULT_CHILD_ENVIRONMENT = {
+    "LANG": "C.UTF-8",
+    "LC_ALL": "C.UTF-8",
+    "PATH": os.defpath,
+    "TZ": "UTC",
+}
+
+
+@dataclass(frozen=True)
+class _ProcessIdentity:
+    """PID plus kernel start time, which prevents signaling a reused PID."""
+
+    pid: int
+    started: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class _ProcessRecord:
+    """One process-tree snapshot row."""
+
+    identity: _ProcessIdentity
+    parent_pid: int
+    zombie: bool
+
+
+class _DarwinProcBsdInfo(ctypes.Structure):
+    """ABI layout returned by Darwin ``PROC_PIDTBSDINFO``."""
+
+    _fields_ = [
+        ("flags", ctypes.c_uint32),
+        ("status", ctypes.c_uint32),
+        ("xstatus", ctypes.c_uint32),
+        ("pid", ctypes.c_uint32),
+        ("ppid", ctypes.c_uint32),
+        ("uid", ctypes.c_uint32),
+        ("gid", ctypes.c_uint32),
+        ("ruid", ctypes.c_uint32),
+        ("rgid", ctypes.c_uint32),
+        ("svuid", ctypes.c_uint32),
+        ("svgid", ctypes.c_uint32),
+        ("rfu_1", ctypes.c_uint32),
+        ("comm", ctypes.c_char * 16),
+        ("name", ctypes.c_char * 32),
+        ("nfiles", ctypes.c_uint32),
+        ("pgid", ctypes.c_uint32),
+        ("pjobc", ctypes.c_uint32),
+        ("e_tdev", ctypes.c_uint32),
+        ("e_tpgid", ctypes.c_uint32),
+        ("nice", ctypes.c_int32),
+        ("start_seconds", ctypes.c_uint64),
+        ("start_microseconds", ctypes.c_uint64),
+    ]
+
+
+class _DescendantTracker:
+    """Track exact descendants and kernel fork evidence without trusting numeric groups."""
+
+    def __init__(self, root_identity: _ProcessIdentity) -> None:
+        snapshot = _process_snapshot()
+        root = snapshot.get(root_identity.pid)
+        if root is None or root.identity != root_identity:
+            raise LocalProcessCleanupError("could not identify local environment process")
+        self._known = {root.identity}
+        self._root = root.identity
+        self._fork_observed = False
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._failure: Exception | None = None
+        self._kqueue = select.kqueue()
+        try:
+            event = select.kevent(
+                root_identity.pid,
+                filter=select.KQ_FILTER_PROC,
+                flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
+                fflags=select.KQ_NOTE_FORK | select.KQ_NOTE_EXIT,
+            )
+            self._kqueue.control((event,), 0, 0)
+            self._thread = threading.Thread(
+                target=self._monitor,
+                name=f"wmo-local-descendants-{root_identity.pid}",
+                daemon=True,
+            )
+            self._thread.start()
+        except BaseException:  # noqa: BLE001 - constructor must close its partially-owned FD
+            self._kqueue.close()
+            raise
+
+    def live_identities(self) -> tuple[_ProcessIdentity, ...]:
+        """Refresh and return only identities still owned by the tracked tree."""
+        self._refresh()
+        if self._failure is not None:
+            raise LocalProcessCleanupError("local descendant monitor failed") from self._failure
+        snapshot = _process_snapshot()
+        with self._lock:
+            return tuple(
+                identity
+                for identity in self._known
+                if (record := snapshot.get(identity.pid)) is not None
+                and record.identity == identity
+                and not record.zombie
+            )
+
+    def stop(self, timeout_seconds: float) -> str | None:
+        """Stop the monitor and return any immutable fork-containment failure evidence."""
+        self._stop.set()
+        self._thread.join(timeout_seconds)
+        if self._thread.is_alive():
+            raise LocalProcessCleanupError("local descendant monitor did not stop")
+        try:
+            if self._failure is not None:
+                raise LocalProcessCleanupError("local descendant monitor failed") from self._failure
+            return self.containment_failure()
+        finally:
+            self._kqueue.close()
+
+    def containment_failure(self) -> str | None:
+        """Return immutable root PID evidence when any fork prevents containment proof."""
+        self._read_kernel_events()
+        with self._lock:
+            if not self._fork_observed:
+                return None
+            return (
+                f"fork observed from root pid={self._root.pid} "
+                f"start={self._root.started[0]}.{self._root.started[1]}"
+            )
+
+    def _monitor(self) -> None:
+        """Poll the kernel tree while the root is alive and through teardown."""
+        try:
+            while not self._stop.wait(0.005):
+                self._read_kernel_events()
+                self._refresh()
+        except Exception as exc:  # noqa: BLE001 - surfaced synchronously during cleanup
+            self._failure = exc
+            self._stop.set()
+
+    def _read_kernel_events(self) -> None:
+        """Latch kernel fork evidence even when no numeric child PID remains observable."""
+        for event in self._kqueue.control(None, 8, 0):
+            if event.fflags & select.KQ_NOTE_FORK:
+                with self._lock:
+                    self._fork_observed = True
+
+    def _refresh(self) -> None:
+        """Add recursively reachable children without forgetting detached identities."""
+        snapshot = _process_snapshot()
+        with self._lock:
+            live_parent_pids = {
+                identity.pid
+                for identity in self._known
+                if (record := snapshot.get(identity.pid)) is not None
+                and record.identity == identity
+            }
+            changed = True
+            while changed:
+                changed = False
+                for record in snapshot.values():
+                    if record.parent_pid not in live_parent_pids:
+                        continue
+                    if record.identity not in self._known:
+                        self._known.add(record.identity)
+                        changed = True
+                    live_parent_pids.add(record.identity.pid)
+
+
+def _process_snapshot() -> dict[int, _ProcessRecord]:
+    """Read an identity-bearing process table without invoking a shell or ``ps``."""
+    if sys.platform == "darwin":
+        return _darwin_process_snapshot()
+    if sys.platform.startswith("linux"):
+        return _linux_process_snapshot()
+    raise LocalProcessCleanupError("local descendant tracking requires Darwin or Linux")
+
+
+def _require_containment_support() -> None:
+    """Fail before resource allocation when kernel fork evidence is unavailable."""
+    if sys.platform != "darwin" or not hasattr(select, "kqueue"):
+        raise LocalProcessCleanupError(
+            "local process containment requires Darwin kernel fork notifications"
+        )
+
+
+def _read_process_identity(pid: int) -> _ProcessIdentity:
+    """Read one gated child identity independently from descendant-table initialization."""
+    if sys.platform != "darwin":  # pragma: no cover - support preflight rejects other platforms
+        raise LocalProcessCleanupError("local process identity requires Darwin libproc")
+    record = _darwin_process_record(pid)
+    if record is None:
+        raise LocalProcessCleanupError("could not read gated local process identity")
+    return record.identity
+
+
+def _darwin_process_snapshot() -> dict[int, _ProcessRecord]:
+    """Read Darwin's libproc table with PID start timestamps."""
+    library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    count = library.proc_listallpids(None, 0)
+    if count <= 0:
+        raise OSError(ctypes.get_errno(), "proc_listallpids failed")
+    pids = (ctypes.c_int * (count + 64))()
+    returned = library.proc_listallpids(pids, ctypes.sizeof(pids))
+    records: dict[int, _ProcessRecord] = {}
+    for pid in pids[: max(0, returned)]:
+        if pid <= 0:
+            continue
+        if record := _darwin_process_record(pid, library=library):
+            records[pid] = record
+    return records
+
+
+def _darwin_process_record(
+    pid: int,
+    *,
+    library: ctypes.CDLL | None = None,
+) -> _ProcessRecord | None:
+    """Read one Darwin process record with its kernel start timestamp."""
+    proc = library or ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    info = _DarwinProcBsdInfo()
+    size = proc.proc_pidinfo(pid, 3, 0, ctypes.byref(info), ctypes.sizeof(info))
+    if size != ctypes.sizeof(info):
+        return None
+    identity = _ProcessIdentity(pid=pid, started=(info.start_seconds, info.start_microseconds))
+    return _ProcessRecord(
+        identity=identity,
+        parent_pid=info.ppid,
+        zombie=info.status == 5,
+    )
+
+
+def _linux_process_snapshot() -> dict[int, _ProcessRecord]:
+    """Read Linux procfs process relationships and kernel start ticks."""
+    records: dict[int, _ProcessRecord] = {}
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text(encoding="utf-8")
+            fields = stat[stat.rfind(")") + 2 :].split()
+            pid = int(entry.name)
+            identity = _ProcessIdentity(pid=pid, started=(int(fields[19]), 0))
+            records[pid] = _ProcessRecord(
+                identity=identity,
+                parent_pid=int(fields[1]),
+                zombie=fields[0] == "Z",
+            )
+        except (FileNotFoundError, PermissionError, ValueError, IndexError):
+            continue
+    return records
+
+
+def _signal_exact_identity(identity: _ProcessIdentity, signal_number: int) -> None:
+    """Signal a PID only while its kernel start identity still matches the tracked process."""
+    record = _process_snapshot().get(identity.pid)
+    if record is None or record.identity != identity or record.zombie:
+        return
+    try:
+        os.kill(identity.pid, signal_number)
+    except ProcessLookupError:
+        return
+
+
+def _close_fd(file_descriptor: int) -> None:
+    """Close one owned descriptor while treating an already-closed descriptor as complete."""
+    try:
+        os.close(file_descriptor)
+    except OSError:
+        return
+
+
+class LocalProcessProtocolError(RuntimeError):
+    """The local executable did not follow the JSONL environment protocol."""
+
+
+class LocalProcessCrashError(RuntimeError):
+    """The local executable exited before it returned the required response."""
+
+
+class LocalProcessCleanupError(RuntimeError):
+    """The local executable or its temporary workspace could not be cleaned up."""
+
+
+@dataclass(frozen=True)
+class LocalProcessLimits:
+    """Finite resource limits applied to each local executable environment session.
+
+    Args:
+        request_timeout_seconds: Wall-clock limit for one protocol request and response.
+        session_timeout_seconds: Wall-clock limit for the complete local process lifetime.
+        cleanup_timeout_seconds: Grace period before a live process is force-killed.
+        maximum_output_bytes: Largest accepted JSON response line from the environment.
+        maximum_stderr_bytes: Bounded tail retained only to drain the child error pipe.
+    """
+
+    request_timeout_seconds: float = 30.0
+    session_timeout_seconds: float = 300.0
+    cleanup_timeout_seconds: float = 5.0
+    maximum_output_bytes: int = 1_000_000
+    maximum_stderr_bytes: int = 32_768
+
+    def __post_init__(self) -> None:
+        """Validate all resource bounds before a local child process can start."""
+        for name, value in (
+            ("request_timeout_seconds", self.request_timeout_seconds),
+            ("session_timeout_seconds", self.session_timeout_seconds),
+            ("cleanup_timeout_seconds", self.cleanup_timeout_seconds),
+        ):
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a finite positive number")
+        if self.request_timeout_seconds > self.session_timeout_seconds:
+            raise ValueError("request_timeout_seconds cannot exceed session_timeout_seconds")
+        for name, value in (
+            ("maximum_output_bytes", self.maximum_output_bytes),
+            ("maximum_stderr_bytes", self.maximum_stderr_bytes),
+        ):
+            if isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+class LocalProcessEnvironmentRuntime:
+    """Creates one fresh JSONL process and temporary workspace per executable episode.
+
+    The child receives one line for ``open``, one per ``execute`` request, and one best-effort
+    ``close`` line. It must respond to ``open`` with ``{"ready": true}``, then respond to every
+    execution request with a canonical :class:`Observation` JSON object. The command is supplied
+    by the customer and is never persisted in a simulation artifact.
+    """
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        limits: LocalProcessLimits | None = None,
+        workspace_parent: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        """Configure the local executable without launching it yet.
+
+        Args:
+            command: Direct executable argv. Shell parsing is intentionally unsupported.
+            limits: Per-session lifetime, response, and cleanup bounds.
+            workspace_parent: Optional parent for generated per-episode workspaces.
+            environment: Optional overrides for the documented locale, path, and timezone
+                allowlist. Parent credentials and arbitrary variables are never inherited.
+        """
+        if not command or any(not isinstance(item, str) or not item for item in command):
+            raise ValueError("local environment command must be a nonempty sequence of strings")
+        if environment is not None and any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in environment.items()
+        ):
+            raise ValueError("local environment variables must be string-to-string mappings")
+        unsupported = sorted(set(environment or {}).difference(_ALLOWED_CHILD_ENVIRONMENT_KEYS))
+        if unsupported:
+            raise ValueError(
+                "local environment variables are outside the safe allowlist: "
+                + ", ".join(unsupported)
+            )
+        self._command = tuple(command)
+        self._limits = limits or LocalProcessLimits()
+        self._workspace_parent = workspace_parent
+        self._environment = dict(environment or {})
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Return a simulator-owned context that opens a fresh child only when entered.
+
+        Args:
+            task: Task whose canonical JSON is supplied in the JSONL ``open`` request.
+
+        Returns:
+            A context manager that always terminates the child and removes its workspace.
+        """
+        return _LocalProcessContext(
+            self._command,
+            self._limits,
+            self._workspace_parent,
+            self._environment,
+            task,
+        )
+
+
+class _LocalProcessContext(AbstractContextManager[EnvironmentSession]):
+    """One context manager that starts and later proves cleanup of one local child process."""
+
+    def __init__(
+        self,
+        command: tuple[str, ...],
+        limits: LocalProcessLimits,
+        workspace_parent: Path | None,
+        environment: Mapping[str, str],
+        task: TaskCase,
+    ) -> None:
+        self._command = command
+        self._limits = limits
+        self._workspace_parent = workspace_parent
+        self._environment = environment
+        self._task = task
+        self._session: _LocalProcessSession | None = None
+
+    def __enter__(self) -> EnvironmentSession:
+        """Start the child and complete its bounded protocol handshake."""
+        session = _LocalProcessSession(
+            self._command,
+            self._limits,
+            self._workspace_parent,
+            self._environment,
+        )
+        self._session = session
+        try:
+            session.start(self._task)
+        except BaseException:
+            try:
+                session.close()
+            except LocalProcessCleanupError:
+                pass
+            raise
+        return session
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Terminate the child and remove its private workspace on every exit path."""
+        del exception_type, exception, traceback
+        if self._session is not None:
+            self._session.close()
+        return False
+
+
+class _LocalProcessSession:
+    """One stateful JSONL protocol session over a bounded child process."""
+
+    def __init__(
+        self,
+        command: tuple[str, ...],
+        limits: LocalProcessLimits,
+        workspace_parent: Path | None,
+        environment: Mapping[str, str],
+    ) -> None:
+        self._command = command
+        self._limits = limits
+        self._workspace_parent = workspace_parent
+        self._environment = dict(environment)
+        self._process: subprocess.Popen[bytes] | None = None
+        self._descendants: _DescendantTracker | None = None
+        self._workspace: Path | None = None
+        self._stdout: queue.Queue[bytes | object] = queue.Queue(maxsize=1)
+        self._stderr_tail = bytearray()
+        self._stderr_lock = threading.Lock()
+        self._request_lock = threading.Lock()
+        self._io_stop = threading.Event()
+        self._io_threads: list[threading.Thread] = []
+        self._started_at: float | None = None
+        self._closed = False
+        self._termination_complete = False
+
+    def start(self, task: TaskCase) -> None:
+        """Create workspace, launch the child, and verify the mandatory ready response."""
+        _require_containment_support()
+        workspace_parent = self._workspace_parent
+        if workspace_parent is not None:
+            workspace_parent.mkdir(parents=True, exist_ok=True)
+            if (
+                workspace_parent.is_symlink()
+                or not workspace_parent.is_dir()
+                or workspace_parent.resolve() != workspace_parent.absolute()
+            ):
+                raise LocalProcessProtocolError(
+                    "local environment workspace parent must be a real directory"
+                )
+        self._workspace = Path(tempfile.mkdtemp(prefix="wmo-sandbox-", dir=workspace_parent))
+        child_environment = dict(_DEFAULT_CHILD_ENVIRONMENT)
+        child_environment.update(self._environment)
+        child_environment[_WORKSPACE_ENVIRONMENT_VARIABLE] = str(self._workspace)
+        child_environment["HOME"] = str(self._workspace)
+        child_environment["TMPDIR"] = str(self._workspace)
+        gate_read, gate_write = os.pipe()
+        gate_program = Path(__file__).with_name("local_exec_gate.py")
+        try:
+            self._process = subprocess.Popen(
+                (sys.executable, str(gate_program), str(gate_read), *self._command),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._workspace,
+                env=child_environment,
+                start_new_session=True,
+                pass_fds=(gate_read,),
+            )
+        except OSError as error:
+            _close_fd(gate_read)
+            _close_fd(gate_write)
+            launch_error = LocalProcessCrashError(
+                f"local environment process could not start: {type(error).__name__}"
+            )
+            try:
+                self._remove_workspace()
+            except OSError as cleanup_error:
+                launch_error.add_note(
+                    "local startup cleanup evidence: workspace cleanup failed with "
+                    f"{type(cleanup_error).__name__}"
+                )
+            raise launch_error from error
+        _close_fd(gate_read)
+        root_identity: _ProcessIdentity | None = None
+        try:
+            root_identity = _read_process_identity(self._process.pid)
+            self._descendants = _DescendantTracker(root_identity)
+            os.write(gate_write, b"1")
+            _close_fd(gate_write)
+        except BaseException as error:  # noqa: BLE001 - preserve startup errors after no-fail cleanup
+            evidence = self._abort_gated_start(gate_write, root_identity)
+            if evidence:
+                error.add_note("local startup cleanup evidence: " + "; ".join(evidence))
+            raise
+        self._started_at = time.monotonic()
+        assert self._process.stdout is not None
+        assert self._process.stderr is not None
+        assert self._process.stdin is not None
+        for stream in (self._process.stdin, self._process.stdout, self._process.stderr):
+            os.set_blocking(stream.fileno(), False)
+        stdout_thread = threading.Thread(
+            target=self._drain_stdout,
+            args=(self._process.stdout.fileno(),),
+            name="wmo-local-environment-stdout",
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            args=(self._process.stderr.fileno(),),
+            name="wmo-local-environment-stderr",
+            daemon=True,
+        )
+        self._io_threads = [stdout_thread, stderr_thread]
+        for thread in self._io_threads:
+            thread.start()
+        response = self._request({"kind": "open", "task": task.model_dump(mode="json")})
+        if response != {"ready": True}:
+            raise LocalProcessProtocolError(
+                "local environment open response must be {'ready': true}"
+            )
+
+    def _abort_gated_start(
+        self,
+        gate_write: int,
+        root_identity: _ProcessIdentity | None,
+    ) -> tuple[str, ...]:
+        """Close a failed launch without masking its original exception or leaking resources."""
+        evidence: list[str] = []
+        deadline = time.monotonic() + self._limits.cleanup_timeout_seconds
+        _close_fd(gate_write)
+        process = self._process
+        if process is not None:
+            try:
+                process.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                if root_identity is None:
+                    evidence.append("gated root identity unavailable; signal withheld")
+                else:
+                    try:
+                        _signal_exact_identity(root_identity, signal.SIGKILL)
+                    except Exception as error:  # noqa: BLE001 - retained as cleanup evidence
+                        evidence.append(f"identity signal failed with {type(error).__name__}")
+                try:
+                    process.wait(timeout=max(0.0, deadline - time.monotonic()))
+                except subprocess.TimeoutExpired:
+                    evidence.append("gated root did not exit before cleanup deadline")
+                except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+                    evidence.append(f"bounded root wait failed with {type(error).__name__}")
+            except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+                evidence.append(f"initial root wait failed with {type(error).__name__}")
+            tracker = self._descendants
+            if tracker is not None:
+                try:
+                    containment = tracker.stop(max(0.0, deadline - time.monotonic()))
+                    if containment:
+                        evidence.append(containment)
+                except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+                    evidence.append(f"tracker cleanup failed with {type(error).__name__}")
+            try:
+                self._close_unstarted_pipes(process, evidence)
+            except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+                evidence.append(f"pipe cleanup failed with {type(error).__name__}")
+        try:
+            self._remove_workspace()
+        except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+            evidence.append(f"workspace cleanup failed with {type(error).__name__}")
+        self._descendants = None
+        self._closed = True
+        try:
+            self._termination_complete = process is None or process.poll() is not None
+        except BaseException as error:  # noqa: BLE001 - cleanup evidence must not mask
+            evidence.append(f"root status check failed with {type(error).__name__}")
+            self._termination_complete = False
+        return tuple(evidence)
+
+    @staticmethod
+    def _close_unstarted_pipes(
+        process: subprocess.Popen[bytes],
+        evidence: list[str],
+    ) -> None:
+        """Close raw pipes created before any reader worker can exist."""
+        for attribute in ("stdin", "stdout", "stderr"):
+            stream = getattr(process, attribute)
+            if stream is None:
+                continue
+            try:
+                stream.raw.close()
+            except OSError as error:
+                evidence.append(f"{attribute} close failed with {type(error).__name__}")
+            setattr(process, attribute, None)
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Send one canonical tool call to the child and parse its bounded observation response."""
+        response = self._request({"kind": "execute", "action": action.model_dump(mode="json")})
+        try:
+            return Observation.model_validate(response)
+        except ValueError as error:
+            raise LocalProcessProtocolError(
+                "local environment execute response must be a canonical Observation"
+            ) from error
+
+    def close(self) -> None:
+        """Best-effort protocol close followed by mandatory process and workspace cleanup."""
+        if self._closed:
+            return
+        self._closed = True
+        cleanup_errors: list[str] = []
+        try:
+            self._send_close()
+        except (OSError, ValueError):
+            cleanup_errors.append("close protocol request failed")
+        try:
+            self._terminate_process()
+        except (
+            LocalProcessCleanupError,
+            OSError,
+            ValueError,
+            subprocess.TimeoutExpired,
+        ) as error:
+            cleanup_errors.append(f"child process termination failed: {error}")
+        try:
+            self._remove_workspace()
+        except OSError:
+            cleanup_errors.append("temporary workspace removal failed")
+        if cleanup_errors:
+            rendered = ", ".join(cleanup_errors)
+            raise LocalProcessCleanupError(f"local environment cleanup failed: {rendered}")
+
+    def _request(self, payload: JsonObject) -> JsonObject:
+        """Write one JSONL request and return the next bounded object response."""
+        if self._closed:
+            raise LocalProcessProtocolError("local environment session is already closed")
+        self._require_within_session_limit()
+        process = self._require_process()
+        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode() + b"\n"
+        with self._request_lock:
+            if process.poll() is not None:
+                raise self._crash_error(process)
+            stdin = process.stdin
+            if stdin is None:
+                raise LocalProcessCrashError("local environment process has no stdin pipe")
+            try:
+                self._write_pipe(stdin.fileno(), encoded, self._remaining_timeout())
+            except (OSError, TimeoutError) as error:
+                raise LocalProcessCrashError(
+                    f"local environment request pipe failed: {type(error).__name__}"
+                ) from error
+            return self._read_response(process)
+
+    def _read_response(self, process: subprocess.Popen[bytes]) -> JsonObject:
+        """Wait for one output line without allowing a child to block an episode indefinitely."""
+        timeout = self._remaining_timeout()
+        try:
+            value = self._stdout.get(timeout=timeout)
+        except queue.Empty as error:
+            self._terminate_process()
+            raise TimeoutError(
+                "local environment response exceeded its configured timeout"
+            ) from error
+        if value is _END_OF_STREAM:
+            raise self._crash_error(process)
+        line = cast(bytes, value)
+        if len(line) > self._limits.maximum_output_bytes:
+            self._terminate_process()
+            raise LocalProcessProtocolError(
+                "local environment response exceeded maximum_output_bytes"
+            )
+        if not line.endswith(b"\n"):
+            raise LocalProcessProtocolError(
+                "local environment response must be one newline-delimited JSON object"
+            )
+        try:
+            decoded = json.loads(line)
+        except (TypeError, ValueError) as error:
+            raise LocalProcessProtocolError(
+                "local environment response is not valid JSON"
+            ) from error
+        if not isinstance(decoded, dict):
+            raise LocalProcessProtocolError("local environment response must be a JSON object")
+        return cast(JsonObject, decoded)
+
+    def _send_close(self) -> None:
+        """Write a non-blocking close hint while preserving cleanup authority in this process."""
+        process = self._process
+        if process is None or process.poll() is not None or process.stdin is None:
+            return
+        try:
+            os.write(process.stdin.fileno(), b'{"kind":"close"}\n')
+        except (BlockingIOError, OSError):
+            return
+
+    def _terminate_process(self) -> None:
+        """Terminate every identity-tracked descendant, including detached process groups."""
+        process = self._process
+        if process is None or self._termination_complete:
+            return
+        tracker = self._descendants
+        cleanup_error: Exception | None = None
+        started = time.monotonic()
+        deadline = started + self._limits.cleanup_timeout_seconds
+        try:
+            if tracker is None:
+                raise LocalProcessCleanupError("local descendant tracker is unavailable")
+            term_deadline = started + self._limits.cleanup_timeout_seconds * 0.25
+            if not self._signal_until_empty(process, tracker, signal.SIGTERM, term_deadline):
+                kill_deadline = started + self._limits.cleanup_timeout_seconds * 0.75
+                if not self._signal_until_empty(process, tracker, signal.SIGKILL, kill_deadline):
+                    raise subprocess.TimeoutExpired(
+                        self._command,
+                        self._limits.cleanup_timeout_seconds,
+                    )
+        except Exception as exc:  # noqa: BLE001 - re-raised after the monitor is joined
+            cleanup_error = exc
+        finally:
+            if tracker is not None:
+                try:
+                    evidence = tracker.stop(max(0.0, deadline - time.monotonic()))
+                    if evidence:
+                        containment_error = LocalProcessCleanupError(
+                            f"local process containment is unproven: {evidence}"
+                        )
+                        cleanup_error = cleanup_error or containment_error
+                except Exception as exc:  # noqa: BLE001 - combined with termination evidence
+                    cleanup_error = cleanup_error or exc
+            self._descendants = None
+            try:
+                self._close_pipe_workers(process, deadline)
+            except Exception as exc:  # noqa: BLE001 - combined with termination evidence
+                cleanup_error = cleanup_error or exc
+        if cleanup_error is not None:
+            raise cleanup_error
+        self._termination_complete = True
+
+    def _signal_until_empty(
+        self,
+        process: subprocess.Popen[bytes],
+        tracker: _DescendantTracker,
+        signal_number: int,
+        deadline: float,
+    ) -> bool:
+        """Re-scan and signal exact live identities until none remain or grace expires."""
+        while True:
+            identities = tracker.live_identities()
+            for identity in identities:
+                _signal_exact_identity(identity, signal_number)
+            leader_exited = process.poll() is not None
+            if leader_exited and not tracker.live_identities():
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            if not leader_exited:
+                try:
+                    process.wait(timeout=min(0.01, remaining))
+                except subprocess.TimeoutExpired:
+                    pass
+            else:
+                time.sleep(min(0.005, remaining))
+
+    def _close_pipe_workers(
+        self,
+        process: subprocess.Popen[bytes],
+        deadline: float,
+    ) -> None:
+        """Stop nonblocking pipe readers and close raw FDs within one cleanup grace."""
+        self._io_stop.set()
+        worker_failed = False
+        for thread in self._io_threads:
+            thread.join(max(0.0, deadline - time.monotonic()))
+            if thread.is_alive():
+                worker_failed = True
+        for attribute in ("stdin", "stdout", "stderr"):
+            stream = getattr(process, attribute)
+            if stream is None:
+                continue
+            stream.raw.close()
+            setattr(process, attribute, None)
+        if worker_failed:
+            raise LocalProcessCleanupError("local pipe worker did not stop before cleanup deadline")
+
+    @staticmethod
+    def _write_pipe(file_descriptor: int, payload: bytes, timeout_seconds: float) -> None:
+        """Write a complete request through a nonblocking pipe within a finite wait."""
+        deadline = time.monotonic() + timeout_seconds
+        offset = 0
+        while offset < len(payload):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("local environment request pipe write timed out")
+            _, writable, _ = select.select((), (file_descriptor,), (), remaining)
+            if not writable:
+                raise TimeoutError("local environment request pipe write timed out")
+            offset += os.write(file_descriptor, payload[offset:])
+
+    def _remove_workspace(self) -> None:
+        """Delete only the uniquely-created per-session workspace after process termination."""
+        if self._workspace is None:
+            return
+        shutil.rmtree(self._workspace)
+        self._workspace = None
+
+    def _require_process(self) -> subprocess.Popen[bytes]:
+        """Return the active process or fail before attempting an invalid pipe operation."""
+        if self._process is None:
+            raise LocalProcessProtocolError("local environment session has not started")
+        return self._process
+
+    def _require_within_session_limit(self) -> None:
+        """Fail and terminate a child whose complete episode budget has expired."""
+        if self._started_at is None:
+            raise LocalProcessProtocolError("local environment session has not started")
+        if time.monotonic() - self._started_at <= self._limits.session_timeout_seconds:
+            return
+        self._terminate_process()
+        raise TimeoutError("local environment session exceeded its configured timeout")
+
+    def _remaining_timeout(self) -> float:
+        """Return the smaller request and complete-session wait budget."""
+        if self._started_at is None:
+            raise LocalProcessProtocolError("local environment session has not started")
+        elapsed = time.monotonic() - self._started_at
+        remaining_session = self._limits.session_timeout_seconds - elapsed
+        if remaining_session <= 0:
+            self._terminate_process()
+            raise TimeoutError("local environment session exceeded its configured timeout")
+        return min(self._limits.request_timeout_seconds, remaining_session)
+
+    def _crash_error(self, process: subprocess.Popen[bytes]) -> LocalProcessCrashError:
+        """Build a non-secret crash error without embedding potentially sensitive child stderr."""
+        return LocalProcessCrashError(
+            f"local environment process exited before its response (return code {process.poll()})"
+        )
+
+    def _drain_stdout(self, file_descriptor: int) -> None:
+        """Move framed output through a nonblocking reader that cleanup can always join."""
+        buffered = bytearray()
+        try:
+            while not self._io_stop.is_set():
+                readable, _, _ = select.select((file_descriptor,), (), (), 0.01)
+                if not readable:
+                    continue
+                chunk = os.read(file_descriptor, min(65_536, self._limits.maximum_output_bytes + 1))
+                if not chunk:
+                    return
+                buffered.extend(chunk)
+                newline = buffered.find(b"\n")
+                if newline >= 0:
+                    self._queue_stdout(bytes(buffered[: newline + 1]))
+                    del buffered[: newline + 1]
+                elif len(buffered) > self._limits.maximum_output_bytes:
+                    self._queue_stdout(bytes(buffered))
+                    buffered.clear()
+        except (OSError, ValueError):
+            return
+        finally:
+            self._queue_stdout(_END_OF_STREAM)
+
+    def _drain_stderr(self, file_descriptor: int) -> None:
+        """Drain stderr nonblockingly while retaining only a bounded tail."""
+        try:
+            while not self._io_stop.is_set():
+                readable, _, _ = select.select((file_descriptor,), (), (), 0.01)
+                if not readable:
+                    continue
+                chunk = os.read(file_descriptor, 4_096)
+                if not chunk:
+                    return
+                with self._stderr_lock:
+                    self._stderr_tail.extend(chunk)
+                    excess = len(self._stderr_tail) - self._limits.maximum_stderr_bytes
+                    if excess > 0:
+                        del self._stderr_tail[:excess]
+        except (OSError, ValueError):
+            return
+
+    def _queue_stdout(self, value: bytes | object) -> None:
+        """Publish one bounded protocol item without letting a malicious writer block cleanup."""
+        try:
+            self._stdout.put_nowait(value)
+        except queue.Full:
+            return

--- a/wmo/runtime/environments/local_exec_gate.py
+++ b/wmo/runtime/environments/local_exec_gate.py
@@ -1,0 +1,26 @@
+"""Tiny exec gate that lets the parent install kernel containment before customer code runs."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    """Wait for one parent byte, then replace this process with the requested executable.
+
+    Raises:
+        SystemExit: The parent did not provide a command or declined to open the execution gate.
+    """
+    if len(sys.argv) < 3:
+        raise SystemExit(64)
+    gate_fd = int(sys.argv[1])
+    command = sys.argv[2:]
+    if os.read(gate_fd, 1) != b"1":
+        raise SystemExit(70)
+    os.close(gate_fd)
+    os.execvpe(command[0], command, os.environ)
+
+
+if __name__ == "__main__":
+    main()

--- a/wmo/runtime/environments/local_test.py
+++ b/wmo/runtime/environments/local_test.py
@@ -272,6 +272,15 @@ def test_unsupported_platform_fails_before_customer_or_worker_spawn(
     assert _local_worker_threads() == before_threads
 
 
+def test_darwin_without_kqueue_binding_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Darwin build without the kernel-notification binding cannot open local execution."""
+    monkeypatch.setattr(local_module.sys, "platform", "darwin")
+    monkeypatch.delattr(local_module.select, "kqueue", raising=False)
+
+    with pytest.raises(LocalProcessCleanupError, match="requires Darwin"):
+        local_module._require_containment_support()
+
+
 def test_snapshot_failure_after_gated_spawn_is_cleaned_without_masking(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/wmo/runtime/environments/local_test.py
+++ b/wmo/runtime/environments/local_test.py
@@ -1,0 +1,440 @@
+"""Tests for the bounded local JSONL executable-environment runtime."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from wmo.common.models import ToolCall
+from wmo.common.tasks import TaskCase
+from wmo.runtime.environments import local as local_module
+from wmo.runtime.environments.local import (
+    LocalProcessCleanupError,
+    LocalProcessCrashError,
+    LocalProcessEnvironmentRuntime,
+    LocalProcessLimits,
+    LocalProcessProtocolError,
+    _ProcessIdentity,
+    _ProcessRecord,
+    _signal_exact_identity,
+)
+
+
+def test_local_process_environment_executes_in_an_ephemeral_workspace(tmp_path: Path) -> None:
+    """Each episode gets a private workspace that disappears after simulator-owned cleanup."""
+    runtime = _runtime(tmp_path)
+
+    with runtime.open(_task()) as session:
+        observation = session.execute(ToolCall(call_id="call-1", name="workspace"))
+        workspace = Path(str(observation.metadata["workspace"]))
+        assert workspace.is_dir()
+        assert (workspace / "tool-output.txt").read_text(encoding="utf-8") == "written"
+
+    assert not workspace.exists()
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_local_process_environment_times_out_and_cleans_up(tmp_path: Path) -> None:
+    """A blocked tool response reaches the configured bound instead of hanging a rollout."""
+    runtime = _runtime(
+        tmp_path,
+        limits=LocalProcessLimits(
+            request_timeout_seconds=0.05,
+            session_timeout_seconds=1.0,
+            cleanup_timeout_seconds=1.0,
+        ),
+    )
+
+    with runtime.open(_task()) as session:
+        with pytest.raises(TimeoutError, match="response exceeded"):
+            session.execute(ToolCall(call_id="call-1", name="sleep"))
+
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_local_process_environment_records_a_child_crash_without_stderr_leakage(
+    tmp_path: Path,
+) -> None:
+    """A child exit becomes a typed environment failure and still removes its workspace."""
+    runtime = _runtime(tmp_path)
+
+    with runtime.open(_task()) as session:
+        with pytest.raises(LocalProcessCrashError, match="return code 7"):
+            session.execute(ToolCall(call_id="call-1", name="crash"))
+
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_local_process_environment_rejects_an_oversized_or_unframed_response(
+    tmp_path: Path,
+) -> None:
+    """A malicious output line cannot consume unbounded memory or masquerade as an observation."""
+    runtime = _runtime(
+        tmp_path,
+        limits=LocalProcessLimits(
+            request_timeout_seconds=1.0,
+            session_timeout_seconds=2.0,
+            cleanup_timeout_seconds=1.0,
+            maximum_output_bytes=32,
+        ),
+    )
+
+    with runtime.open(_task()) as session:
+        with pytest.raises(LocalProcessProtocolError, match="maximum_output_bytes"):
+            session.execute(ToolCall(call_id="call-1", name="oversized"))
+
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_local_process_environment_rejects_malformed_json_and_cleans_up(tmp_path: Path) -> None:
+    """Malformed child output remains protocol failure evidence and leaves no workspace."""
+    runtime = _runtime(tmp_path)
+
+    with runtime.open(_task()) as session:
+        with pytest.raises(LocalProcessProtocolError, match="not valid JSON"):
+            session.execute(ToolCall(call_id="call-1", name="malformed"))
+
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_local_process_child_receives_only_the_documented_environment_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deterministic child dump proves parent credentials cannot cross the process boundary."""
+    monkeypatch.setenv("WMO_PARENT_SECRET", "must-not-cross")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-cross-either")
+    runtime = _runtime(tmp_path)
+
+    with runtime.open(_task()) as session:
+        observation = session.execute(ToolCall(call_id="call-1", name="environment"))
+
+    keys = observation.metadata["keys"]
+    assert isinstance(keys, list)
+    assert set(keys).difference({"__CF_USER_TEXT_ENCODING"}) == {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "TMPDIR",
+        "TZ",
+        "WMO_SANDBOX_WORKSPACE",
+    }
+    assert "WMO_PARENT_SECRET" not in keys
+    assert "OPENAI_API_KEY" not in keys
+
+
+def test_local_process_cleanup_kills_orphaned_grandchild_after_leader_exit(
+    tmp_path: Path,
+) -> None:
+    """A fork is identity-cleaned where observed but still fails containment proof closed."""
+    runtime = _runtime(tmp_path)
+
+    with pytest.raises(LocalProcessCleanupError, match=r"fork observed from root pid=\d+"):
+        with runtime.open(_task()) as session:
+            observation = session.execute(ToolCall(call_id="call-1", name="orphan-grandchild"))
+            raw_grandchild_pid = observation.metadata["grandchild_pid"]
+            assert isinstance(raw_grandchild_pid, int)
+            grandchild_pid = raw_grandchild_pid
+            time.sleep(0.05)
+
+    if _pid_is_running(grandchild_pid):
+        os.kill(grandchild_pid, 9)
+    deadline = time.monotonic() + 2.0
+    while _pid_is_running(grandchild_pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not _pid_is_running(grandchild_pid)
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def test_cleanup_kills_setsid_descendant_without_touching_unrelated_process(
+    tmp_path: Path,
+) -> None:
+    """Immediate setsid escape fails closed without pipe hang or unrelated process signaling."""
+    cleanup_timeout = 0.4
+    runtime = _runtime(
+        tmp_path,
+        limits=LocalProcessLimits(
+            request_timeout_seconds=1.0,
+            session_timeout_seconds=2.0,
+            cleanup_timeout_seconds=cleanup_timeout,
+        ),
+    )
+    unrelated = subprocess.Popen(
+        (sys.executable, "-c", "import time; time.sleep(60)"),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    grandchild_pid: int | None = None
+    try:
+        started = time.monotonic()
+        with pytest.raises(LocalProcessCleanupError) as raised:
+            with runtime.open(_task()) as session:
+                observation = session.execute(
+                    ToolCall(call_id="call-detached", name="detached-grandchild")
+                )
+                raw_pid = observation.metadata["grandchild_pid"]
+                assert isinstance(raw_pid, int)
+                grandchild_pid = raw_pid
+        assert time.monotonic() - started <= cleanup_timeout + 0.25
+        assert "fork observed from root pid=" in str(raised.value)
+        assert unrelated.poll() is None
+        assert not any(
+            thread.name.startswith(("wmo-local-descendants-", "wmo-local-environment-"))
+            for thread in threading.enumerate()
+        )
+    finally:
+        if grandchild_pid is not None and _pid_is_running(grandchild_pid):
+            os.kill(grandchild_pid, 9)
+        unrelated.terminate()
+        unrelated.wait(timeout=2.0)
+
+
+def test_reused_pid_identity_is_never_signaled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale PID or former group member cannot authorize a signal after PID reuse."""
+    stale = _ProcessIdentity(pid=12345, started=(100, 1))
+    replacement = _ProcessRecord(
+        identity=_ProcessIdentity(pid=12345, started=(200, 2)),
+        parent_pid=1,
+        zombie=False,
+    )
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(local_module, "_process_snapshot", lambda: {12345: replacement})
+    monkeypatch.setattr(local_module.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    _signal_exact_identity(stale, 9)
+
+    assert signals == []
+
+
+def test_local_process_rejects_unsafe_environment_keys_and_symlinked_parent(
+    tmp_path: Path,
+) -> None:
+    """Configuration cannot reintroduce credentials or redirect workspaces through a symlink."""
+    with pytest.raises(ValueError, match="outside the safe allowlist"):
+        LocalProcessEnvironmentRuntime(
+            (sys.executable, "fixture.py"),
+            environment={"API_KEY": "secret"},
+        )
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    runtime = LocalProcessEnvironmentRuntime(
+        (sys.executable, "fixture.py"),
+        workspace_parent=linked_parent,
+    )
+    with pytest.raises(LocalProcessProtocolError, match="real directory"):
+        with runtime.open(_task()):
+            pass
+
+
+def test_local_process_limits_reject_invalid_values_before_launch() -> None:
+    """The local resource contract fails before it can start a user executable."""
+    with pytest.raises(ValueError, match="cannot exceed"):
+        LocalProcessLimits(request_timeout_seconds=2.0, session_timeout_seconds=1.0)
+    with pytest.raises(ValueError, match="positive integer"):
+        LocalProcessLimits(maximum_output_bytes=0)
+
+
+def test_unsupported_platform_fails_before_customer_or_worker_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public context preflight allocates no gate, process, pipe, or worker resources."""
+    marker = tmp_path / "customer-executed"
+    runtime = LocalProcessEnvironmentRuntime(
+        (sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"),
+        workspace_parent=tmp_path,
+    )
+    monkeypatch.setattr(local_module.sys, "platform", "unsupported-test")
+    before_fds = _open_file_descriptors()
+    before_threads = _local_worker_threads()
+    started = time.monotonic()
+    context = runtime.open(_task())
+
+    with pytest.raises(LocalProcessCleanupError, match="requires Darwin"):
+        context.__enter__()
+
+    assert time.monotonic() - started < 0.25
+    assert not marker.exists()
+    session = context.__dict__["_session"]
+    assert session.__dict__["_process"] is None
+    assert _open_file_descriptors() == before_fds
+    assert _local_worker_threads() == before_threads
+
+
+def test_snapshot_failure_after_gated_spawn_is_cleaned_without_masking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A table failure preserves its error after the blocked root, pipes, and FDs are reaped."""
+    marker = tmp_path / "customer-executed"
+    runtime = LocalProcessEnvironmentRuntime(
+        (sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"),
+        limits=LocalProcessLimits(cleanup_timeout_seconds=0.4),
+        workspace_parent=tmp_path,
+    )
+    monkeypatch.setattr(
+        local_module,
+        "_process_snapshot",
+        lambda: (_ for _ in ()).throw(OSError("injected snapshot failure")),
+    )
+    before_fds = _open_file_descriptors()
+    before_threads = _local_worker_threads()
+    started = time.monotonic()
+    context = runtime.open(_task())
+
+    with pytest.raises(OSError, match="injected snapshot failure"):
+        context.__enter__()
+
+    assert time.monotonic() - started <= 0.65
+    assert not marker.exists()
+    session = context.__dict__["_session"]
+    process = session.__dict__["_process"]
+    assert process is not None and process.poll() is not None
+    assert _open_file_descriptors() == before_fds
+    assert _local_worker_threads() == before_threads
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def _pid_exists(pid: int) -> bool:
+    """Return whether one exact process ID still exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _pid_is_running(pid: int) -> bool:
+    """Return whether one PID still names a non-zombie process."""
+    record = local_module._process_snapshot().get(pid)
+    return record is not None and not record.zombie
+
+
+def _open_file_descriptors() -> frozenset[int]:
+    """Return low numbered open FDs without allocating a directory-enumeration descriptor."""
+    open_fds: set[int] = set()
+    for file_descriptor in range(256):
+        try:
+            fcntl.fcntl(file_descriptor, fcntl.F_GETFD)
+        except OSError:
+            continue
+        open_fds.add(file_descriptor)
+    return frozenset(open_fds)
+
+
+def _local_worker_threads() -> frozenset[str]:
+    """Return every runtime worker thread name visible to the public test process."""
+    return frozenset(
+        thread.name
+        for thread in threading.enumerate()
+        if thread.name.startswith(("wmo-local-descendants-", "wmo-local-environment-"))
+    )
+
+
+def _runtime(
+    workspace_parent: Path,
+    *,
+    limits: LocalProcessLimits | None = None,
+) -> LocalProcessEnvironmentRuntime:
+    """Create one deterministic Python JSONL fixture process without network access."""
+    fixture = workspace_parent / "environment_fixture.py"
+    fixture.write_text(_FIXTURE_SOURCE, encoding="utf-8")
+    return LocalProcessEnvironmentRuntime(
+        (sys.executable, str(fixture)),
+        limits=limits,
+        workspace_parent=workspace_parent,
+    )
+
+
+def _task() -> TaskCase:
+    """Return one task whose canonical payload is safe to pass to the fixture process."""
+    return TaskCase(
+        task_id="task-1",
+        lineage_group_id="lineage-1",
+        partition="fit",
+        instruction="Use the environment fixture.",
+        workload_weight=1.0,
+        source_trace_ids=("trace-1",),
+    )
+
+
+_FIXTURE_SOURCE = """\
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if request["kind"] == "open":
+        print(json.dumps({"ready": True}), flush=True)
+        continue
+    if request["kind"] == "close":
+        break
+    action = request["action"]
+    if action["name"] == "sleep":
+        time.sleep(1)
+    if action["name"] == "crash":
+        print("private child stderr", file=sys.stderr, flush=True)
+        raise SystemExit(7)
+    if action["name"] == "oversized":
+        sys.stdout.write("x" * 200)
+        sys.stdout.flush()
+        continue
+    if action["name"] == "malformed":
+        print("{not-json", flush=True)
+        continue
+    if action["name"] == "environment":
+        print(json.dumps({"content": "ok", "metadata": {"keys": sorted(os.environ)}}), flush=True)
+        continue
+    if action["name"] == "orphan-grandchild":
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+        print(
+            json.dumps(
+                {"content": "spawned", "metadata": {"grandchild_pid": child.pid}}
+            ),
+            flush=True,
+        )
+        raise SystemExit(0)
+    if action["name"] == "detached-grandchild":
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=True,
+        )
+        print(
+            json.dumps(
+                {"content": "spawned", "metadata": {"grandchild_pid": child.pid}}
+            ),
+            flush=True,
+        )
+        raise SystemExit(0)
+    if action["name"] == "workspace":
+        workspace = Path(os.environ["WMO_SANDBOX_WORKSPACE"])
+        (workspace / "tool-output.txt").write_text("written", encoding="utf-8")
+        print(json.dumps({"content": "ok", "metadata": {"workspace": str(workspace)}}), flush=True)
+        continue
+    print(json.dumps({"content": "ok"}), flush=True)
+"""

--- a/wmo/simulation/__init__.py
+++ b/wmo/simulation/__init__.py
@@ -1,6 +1,43 @@
-"""World-model execution surfaces retained outside canonical trace mining."""
+"""Canonical text and executable simulation contracts and engines."""
 
+from wmo.simulation.comparison import (
+    PairedSimulationCell,
+    PairedSimulationOutcome,
+    SimulationComparisonError,
+    SimulationComparisonReport,
+    SimulationComparisonSpec,
+    compare_text_and_sandbox,
+    persist_comparison,
+    persist_comparison_spec,
+)
 from wmo.simulation.environment import WorldModelEnv
 from wmo.simulation.model import WorldModel
+from wmo.simulation.orchestration.interface import (
+    SimulationModeUnsupportedError,
+    Simulator,
+)
+from wmo.simulation.specs import (
+    MixedRealitySettings,
+    SandboxSettings,
+    SimulationSpec,
+    WorldModelSettings,
+)
 
-__all__ = ["WorldModel", "WorldModelEnv"]
+__all__ = [
+    "MixedRealitySettings",
+    "PairedSimulationCell",
+    "PairedSimulationOutcome",
+    "SandboxSettings",
+    "SimulationComparisonError",
+    "SimulationComparisonReport",
+    "SimulationComparisonSpec",
+    "SimulationSpec",
+    "Simulator",
+    "SimulationModeUnsupportedError",
+    "WorldModel",
+    "WorldModelEnv",
+    "WorldModelSettings",
+    "compare_text_and_sandbox",
+    "persist_comparison",
+    "persist_comparison_spec",
+]

--- a/wmo/simulation/comparison.py
+++ b/wmo/simulation/comparison.py
@@ -1,0 +1,792 @@
+"""Immutable held-out text-versus-sandbox comparison without provider calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    FailureCode,
+    Sha256,
+    StructuredFailure,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan
+from wmo.common.models import ModelSnapshot
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactStore,
+    StoredArtifact,
+    artifact_input,
+)
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    SandboxSimulatorSnapshot,
+    SimulationArtifactSet,
+    SimulationMode,
+    WorldModelSimulatorSnapshot,
+)
+from wmo.common.tasks import LoadedTaskSet, TaskCase, load_task_set
+from wmo.simulation.specs import SimulationSpec
+
+_COMPARISON_SPEC_FILE = "simulation-comparison-spec.json"
+_COMPARISON_REPORT_FILE = "simulation-comparison-report.json"
+_PLAN_FILE = "evaluation-plan.json"
+_SIMULATION_SPEC_FILE = "simulation-spec.json"
+_ARTIFACT_SET_FILE = "artifact-set.json"
+_ROLLOUT_FILE = "rollout.json"
+
+
+class PairedSimulationCell(ContractModel):
+    """One exact held-out task coordinate and its two expected simulator artifacts."""
+
+    pair_id: ArtifactId
+    task_id: ArtifactId
+    task_lineage_group_id: ArtifactId
+    task_sha256: Sha256
+    candidate_alias: ArtifactId
+    candidate: ModelSnapshot
+    agent_id: str = Field(min_length=1, max_length=256)
+    repeat: int = Field(ge=0)
+    text_cell_id: ArtifactId
+    sandbox_cell_id: ArtifactId
+    text_rollout_id: ArtifactId
+    text_rollout_sha256: Sha256 | None = None
+    sandbox_rollout_id: ArtifactId
+    sandbox_rollout_sha256: Sha256 | None = None
+    text_simulator: WorldModelSimulatorSnapshot
+    sandbox_simulator: SandboxSimulatorSnapshot
+
+
+class SimulationComparisonSpec(ArtifactEnvelope):
+    """Frozen post-lock comparison protocol over exact plans, specs, and artifact sets."""
+
+    comparison_id: ArtifactId
+    policy_lock_input: ArtifactInput
+    task_set_input: ArtifactInput
+    text_evaluation_plan_input: ArtifactInput
+    sandbox_evaluation_plan_input: ArtifactInput
+    text_simulation_spec_input: ArtifactInput
+    sandbox_simulation_spec_input: ArtifactInput
+    text_artifact_set_input: ArtifactInput
+    sandbox_artifact_set_input: ArtifactInput
+    pairs: tuple[PairedSimulationCell, ...] = Field(min_length=1)
+
+    @field_validator("pairs")
+    @classmethod
+    def _require_unique_pair_coordinates(
+        cls,
+        value: tuple[PairedSimulationCell, ...],
+    ) -> tuple[PairedSimulationCell, ...]:
+        """Reject any repeated pair, text cell, or sandbox cell denominator."""
+        for label, values in (
+            ("pair IDs", tuple(pair.pair_id for pair in value)),
+            ("text cell IDs", tuple(pair.text_cell_id for pair in value)),
+            ("sandbox cell IDs", tuple(pair.sandbox_cell_id for pair in value)),
+        ):
+            if len(set(values)) != len(values):
+                raise ValueError(f"simulation comparison must have unique {label}")
+        return value
+
+    @model_validator(mode="after")
+    def _require_exact_inputs(self) -> SimulationComparisonSpec:
+        """Make every named immutable dependency a hash-bound envelope input."""
+        expected = _sorted_unique_inputs(
+            self.policy_lock_input,
+            self.task_set_input,
+            self.text_evaluation_plan_input,
+            self.sandbox_evaluation_plan_input,
+            self.text_simulation_spec_input,
+            self.sandbox_simulation_spec_input,
+            self.text_artifact_set_input,
+            self.sandbox_artifact_set_input,
+        )
+        if self.inputs != expected:
+            raise ValueError("comparison spec inputs must exactly match every named artifact")
+        if self.text_simulation_spec_input == self.sandbox_simulation_spec_input:
+            raise ValueError("text and sandbox comparison specs must be distinct")
+        if self.text_artifact_set_input == self.sandbox_artifact_set_input:
+            raise ValueError("text and sandbox artifact sets must be distinct")
+        return self
+
+
+class PairedSimulationOutcome(ContractModel):
+    """One preserved denominator row with complete identity and both failure states."""
+
+    pair_id: ArtifactId
+    task_id: ArtifactId
+    task_lineage_group_id: ArtifactId
+    candidate_alias: ArtifactId
+    candidate: ModelSnapshot
+    agent_id: str = Field(min_length=1, max_length=256)
+    repeat: int = Field(ge=0)
+    text_cell_id: ArtifactId
+    sandbox_cell_id: ArtifactId
+    expected_text_rollout_id: ArtifactId
+    expected_sandbox_rollout_id: ArtifactId
+    text_rollout_id: ArtifactId | None = None
+    sandbox_rollout_id: ArtifactId | None = None
+    text_simulator: WorldModelSimulatorSnapshot
+    sandbox_simulator: SandboxSimulatorSnapshot
+    text_failure: StructuredFailure | None = None
+    sandbox_failure: StructuredFailure | None = None
+    terminal_match: bool | None = None
+
+    @model_validator(mode="after")
+    def _require_complete_pair_state(self) -> PairedSimulationOutcome:
+        """Keep missing and failed sides explicit without ambiguous null values."""
+        if self.text_rollout_id is None and self.text_failure is None:
+            raise ValueError("missing text rollout requires a structured failure")
+        if self.sandbox_rollout_id is None and self.sandbox_failure is None:
+            raise ValueError("missing sandbox rollout requires a structured failure")
+        if self.terminal_match is not None and (
+            self.text_rollout_id is None
+            or self.sandbox_rollout_id is None
+            or self.text_failure is not None
+            or self.sandbox_failure is not None
+        ):
+            raise ValueError("terminal_match requires two usable rollouts")
+        return self
+
+
+class SimulationComparisonReport(ArtifactEnvelope):
+    """Structural agreement report with exact missing and failure denominators."""
+
+    report_id: ArtifactId
+    comparison_id: ArtifactId
+    comparison_spec_sha256: Sha256
+    expected_pairs: int = Field(gt=0)
+    paired_rollouts: int = Field(ge=0)
+    usable_pairs: int = Field(ge=0)
+    missing_text_rollouts: int = Field(ge=0)
+    missing_sandbox_rollouts: int = Field(ge=0)
+    failed_text_rollouts: int = Field(ge=0)
+    failed_sandbox_rollouts: int = Field(ge=0)
+    terminal_matches: int = Field(ge=0)
+    outcomes: tuple[PairedSimulationOutcome, ...]
+
+    @model_validator(mode="after")
+    def _require_exact_report_counts(self) -> SimulationComparisonReport:
+        """Derive every report count from the preserved denominator rows."""
+        if len(self.outcomes) != self.expected_pairs:
+            raise ValueError("comparison outcomes must equal expected_pairs")
+        if len({outcome.pair_id for outcome in self.outcomes}) != len(self.outcomes):
+            raise ValueError("comparison outcomes must have unique pair IDs")
+        counts = _outcome_counts(self.outcomes)
+        rendered = (
+            self.paired_rollouts,
+            self.usable_pairs,
+            self.missing_text_rollouts,
+            self.missing_sandbox_rollouts,
+            self.failed_text_rollouts,
+            self.failed_sandbox_rollouts,
+            self.terminal_matches,
+        )
+        if rendered != counts:
+            raise ValueError("comparison report counts do not match raw outcomes")
+        return self
+
+
+class SimulationComparisonError(ValueError):
+    """An immutable input is not one exact post-lock held-out comparison protocol."""
+
+
+@dataclass(frozen=True)
+class _ResolvedInputs:
+    """Typed, digest-verified comparison dependencies loaded from the artifact store."""
+
+    comparison_spec_input: ArtifactInput
+    lock_created_at: datetime
+    task_set_input: ArtifactInput
+    text_plan_input: ArtifactInput
+    sandbox_plan_input: ArtifactInput
+    text_spec_input: ArtifactInput
+    sandbox_spec_input: ArtifactInput
+    tasks: Mapping[str, TaskCase]
+    task_set: LoadedTaskSet
+    text_plan: EvaluationPlan
+    sandbox_plan: EvaluationPlan
+    text_spec: SimulationSpec
+    sandbox_spec: SimulationSpec
+    text_set: SimulationArtifactSet
+    sandbox_set: SimulationArtifactSet
+
+
+def persist_comparison_spec(
+    spec: SimulationComparisonSpec,
+    store: ArtifactStore,
+) -> ArtifactInput:
+    """Persist the frozen protocol before resolving any rollout evidence.
+
+    Args:
+        spec: Complete hash-bound post-lock comparison protocol.
+        store: Project-local immutable artifact store.
+
+    Returns:
+        Exact manifest identity required by the report.
+    """
+    manifest = store.write_json(
+        artifact_id=spec.comparison_id,
+        artifact_type="simulation-comparison-spec",
+        envelope=spec,
+        files={_COMPARISON_SPEC_FILE: spec},
+    )
+    return artifact_input(manifest)
+
+
+def compare_text_and_sandbox(
+    spec: SimulationComparisonSpec,
+    *,
+    store: ArtifactStore,
+    created_at: datetime,
+    code_revision: str,
+) -> SimulationComparisonReport:
+    """Resolve a frozen comparison using only immutable local artifacts.
+
+    The function accepts no model client, provider, environment, judge, or mutable task mapping.
+    It can therefore report structural agreement only after the named policy lock.
+
+    Args:
+        spec: Already-persisted comparison protocol.
+        store: Store containing every exact input and available rollout.
+        created_at: Aware report completion time after the comparison protocol was frozen.
+        code_revision: Exact source revision producing the report.
+
+    Returns:
+        Exact-denominator report over available and missing rollout evidence.
+
+    Raises:
+        SimulationComparisonError: Any hash, mode, lineage, lock, plan, or rollout binding drifts.
+    """
+    resolved = _resolve_inputs(spec, store)
+    if created_at < spec.created_at:
+        raise SimulationComparisonError("comparison report cannot predate its frozen protocol")
+    text_ids = set(resolved.text_set.artifact_ids)
+    sandbox_ids = set(resolved.sandbox_set.artifact_ids)
+    outcomes = tuple(
+        _pair_outcome(pair, resolved, store, text_ids, sandbox_ids) for pair in spec.pairs
+    )
+    report_id = stable_id(
+        "simulation-comparison-report",
+        {
+            "comparison_spec_input": resolved.comparison_spec_input.model_dump(mode="json"),
+            "outcomes": [outcome.model_dump(mode="json") for outcome in outcomes],
+        },
+    )
+    counts = _outcome_counts(outcomes)
+    return SimulationComparisonReport(
+        schema_version=1,
+        created_at=created_at,
+        inputs=_sorted_unique_inputs(resolved.comparison_spec_input, *spec.inputs),
+        code_revision=code_revision,
+        source=spec.source,
+        report_id=report_id,
+        comparison_id=spec.comparison_id,
+        comparison_spec_sha256=sha256_json(spec),
+        expected_pairs=len(spec.pairs),
+        paired_rollouts=counts[0],
+        usable_pairs=counts[1],
+        missing_text_rollouts=counts[2],
+        missing_sandbox_rollouts=counts[3],
+        failed_text_rollouts=counts[4],
+        failed_sandbox_rollouts=counts[5],
+        terminal_matches=counts[6],
+        outcomes=outcomes,
+    )
+
+
+def persist_comparison(report: SimulationComparisonReport, store: ArtifactStore) -> None:
+    """Write one immutable report without expanding raw task text.
+
+    Args:
+        report: Fully resolved structural comparison output.
+        store: Project-local immutable artifact store.
+    """
+    store.write(
+        artifact_id=report.report_id,
+        artifact_type="simulation-comparison-report",
+        envelope=report,
+        files={_COMPARISON_REPORT_FILE: canonical_json_bytes(report)},
+    )
+
+
+def _resolve_inputs(spec: SimulationComparisonSpec, store: ArtifactStore) -> _ResolvedInputs:
+    """Load and cross-check every exact named protocol dependency."""
+    comparison_stored = _read_exact(
+        store,
+        ArtifactInput(
+            artifact_id=spec.comparison_id, sha256=_manifest_digest(store, spec.comparison_id)
+        ),
+        "simulation-comparison-spec",
+    )
+    try:
+        persisted = SimulationComparisonSpec.model_validate_json(
+            store.read_bytes(spec.comparison_id, _COMPARISON_SPEC_FILE)
+        )
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SimulationComparisonError("persisted comparison protocol is invalid") from exc
+    if persisted != spec:
+        raise SimulationComparisonError("supplied comparison protocol differs from stored bytes")
+    comparison_input = artifact_input(comparison_stored.manifest)
+    lock = _read_exact(store, spec.policy_lock_input)
+    task_set_stored = _read_exact(store, spec.task_set_input, "task-set")
+    del task_set_stored
+    try:
+        task_set = load_task_set(store, spec.task_set_input.artifact_id)
+    except ArtifactCorruptionError as exc:
+        raise SimulationComparisonError("comparison task set is invalid") from exc
+    text_plan = _load_plan(store, spec.text_evaluation_plan_input)
+    sandbox_plan = _load_plan(store, spec.sandbox_evaluation_plan_input)
+    text_spec = _load_simulation_spec(store, spec.text_simulation_spec_input)
+    sandbox_spec = _load_simulation_spec(store, spec.sandbox_simulation_spec_input)
+    text_set = _load_artifact_set(store, spec.text_artifact_set_input)
+    sandbox_set = _load_artifact_set(store, spec.sandbox_artifact_set_input)
+    if spec.created_at < lock.manifest.created_at:
+        raise SimulationComparisonError("comparison protocol must be frozen after the policy lock")
+    _validate_root_bindings(
+        spec,
+        task_set,
+        text_plan,
+        sandbox_plan,
+        text_spec,
+        sandbox_spec,
+        text_set,
+        sandbox_set,
+        lock.manifest.created_at,
+    )
+    tasks = {task.task_id: task for task in task_set.tasks}
+    return _ResolvedInputs(
+        comparison_spec_input=comparison_input,
+        lock_created_at=lock.manifest.created_at,
+        task_set_input=spec.task_set_input,
+        text_plan_input=spec.text_evaluation_plan_input,
+        sandbox_plan_input=spec.sandbox_evaluation_plan_input,
+        text_spec_input=spec.text_simulation_spec_input,
+        sandbox_spec_input=spec.sandbox_simulation_spec_input,
+        tasks=tasks,
+        task_set=task_set,
+        text_plan=text_plan,
+        sandbox_plan=sandbox_plan,
+        text_spec=text_spec,
+        sandbox_spec=sandbox_spec,
+        text_set=text_set,
+        sandbox_set=sandbox_set,
+    )
+
+
+def _validate_root_bindings(
+    comparison: SimulationComparisonSpec,
+    task_set: LoadedTaskSet,
+    text_plan: EvaluationPlan,
+    sandbox_plan: EvaluationPlan,
+    text_spec: SimulationSpec,
+    sandbox_spec: SimulationSpec,
+    text_set: SimulationArtifactSet,
+    sandbox_set: SimulationArtifactSet,
+    locked_at: datetime,
+) -> None:
+    """Verify modes, task set, plans, specs, sets, and post-lock timestamps."""
+    if text_plan.task_set_id != task_set.task_set.task_set_id:
+        raise SimulationComparisonError("text plan names a different task set")
+    if sandbox_plan.task_set_id != task_set.task_set.task_set_id:
+        raise SimulationComparisonError("sandbox plan names a different task set")
+    for label, plan, plan_input, simulation, simulation_input, artifact_set in (
+        (
+            "text",
+            text_plan,
+            comparison.text_evaluation_plan_input,
+            text_spec,
+            comparison.text_simulation_spec_input,
+            text_set,
+        ),
+        (
+            "sandbox",
+            sandbox_plan,
+            comparison.sandbox_evaluation_plan_input,
+            sandbox_spec,
+            comparison.sandbox_simulation_spec_input,
+            sandbox_set,
+        ),
+    ):
+        expected_mode = SimulationMode.WORLD_MODEL if label == "text" else SimulationMode.SANDBOX
+        if simulation.mode is not expected_mode:
+            raise SimulationComparisonError(f"{label} simulation spec has the wrong mode")
+        if simulation.evaluation_plan_id != plan.plan_id:
+            raise SimulationComparisonError(f"{label} simulation spec names a different plan")
+        if (
+            plan_input not in simulation.inputs
+            or comparison.task_set_input not in simulation.inputs
+        ):
+            raise SimulationComparisonError(f"{label} simulation spec omits an exact input")
+        if artifact_set.simulation_id != simulation.simulation_id:
+            raise SimulationComparisonError(f"{label} artifact set names a different simulation")
+        required_set_inputs = {plan_input, comparison.task_set_input, simulation_input}
+        if not required_set_inputs.issubset(set(artifact_set.inputs)):
+            raise SimulationComparisonError(f"{label} artifact set omits an exact input")
+        if simulation.created_at < locked_at or artifact_set.created_at < locked_at:
+            raise SimulationComparisonError(f"{label} evidence predates the policy lock")
+
+
+def _pair_outcome(
+    pair: PairedSimulationCell,
+    resolved: _ResolvedInputs,
+    store: ArtifactStore,
+    text_set_ids: set[str],
+    sandbox_set_ids: set[str],
+) -> PairedSimulationOutcome:
+    """Resolve one exact task coordinate and preserve both sides of its denominator."""
+    task = resolved.tasks.get(pair.task_id)
+    if task is None or task.partition != "held_out":
+        raise SimulationComparisonError("text-versus-sandbox comparison uses held-out tasks only")
+    if task.lineage_group_id != pair.task_lineage_group_id or sha256_json(task) != pair.task_sha256:
+        raise SimulationComparisonError("comparison task lineage or digest drifted")
+    text_cell = _cell(resolved.text_plan, pair.text_cell_id, "text")
+    sandbox_cell = _cell(resolved.sandbox_plan, pair.sandbox_cell_id, "sandbox")
+    _validate_plan_candidate(pair, resolved.text_plan, "text")
+    _validate_plan_candidate(pair, resolved.sandbox_plan, "sandbox")
+    _validate_cell(pair, text_cell, resolved.text_spec, "text")
+    _validate_cell(pair, sandbox_cell, resolved.sandbox_spec, "sandbox")
+    text = _optional_rollout(
+        store,
+        pair.text_rollout_id,
+        pair.text_rollout_sha256,
+        text_set_ids,
+        "text",
+    )
+    sandbox = _optional_rollout(
+        store,
+        pair.sandbox_rollout_id,
+        pair.sandbox_rollout_sha256,
+        sandbox_set_ids,
+        "sandbox",
+    )
+    if text is not None:
+        _validate_rollout(pair, text, resolved, SimulationMode.WORLD_MODEL)
+    if sandbox is not None:
+        _validate_rollout(pair, sandbox, resolved, SimulationMode.SANDBOX)
+    text_failure = (
+        text.failure if text is not None else _missing_failure("text", pair.text_rollout_id)
+    )
+    sandbox_failure = (
+        sandbox.failure
+        if sandbox is not None
+        else _missing_failure("sandbox", pair.sandbox_rollout_id)
+    )
+    terminal_match = None
+    if (
+        text is not None
+        and sandbox is not None
+        and text_failure is None
+        and sandbox_failure is None
+    ):
+        terminal_match = (
+            text.stop_reason == sandbox.stop_reason and text.final_output == sandbox.final_output
+        )
+    return PairedSimulationOutcome(
+        pair_id=pair.pair_id,
+        task_id=pair.task_id,
+        task_lineage_group_id=pair.task_lineage_group_id,
+        candidate_alias=pair.candidate_alias,
+        candidate=pair.candidate,
+        agent_id=pair.agent_id,
+        repeat=pair.repeat,
+        text_cell_id=pair.text_cell_id,
+        sandbox_cell_id=pair.sandbox_cell_id,
+        expected_text_rollout_id=pair.text_rollout_id,
+        expected_sandbox_rollout_id=pair.sandbox_rollout_id,
+        text_rollout_id=text.rollout_id if text is not None else None,
+        sandbox_rollout_id=sandbox.rollout_id if sandbox is not None else None,
+        text_simulator=pair.text_simulator,
+        sandbox_simulator=pair.sandbox_simulator,
+        text_failure=text_failure,
+        sandbox_failure=sandbox_failure,
+        terminal_match=terminal_match,
+    )
+
+
+def _validate_cell(
+    pair: PairedSimulationCell,
+    cell: EvaluationCell,
+    simulation: SimulationSpec,
+    label: str,
+) -> None:
+    """Require one plan cell to be the exact simulated held-out pair coordinate."""
+    if cell.purpose != "held_out" or cell.execution != "simulate":
+        raise SimulationComparisonError(f"{label} comparison cell is not simulated held-out data")
+    if (
+        cell.task_id,
+        cell.candidate_alias,
+        cell.repeat,
+    ) != (pair.task_id, pair.candidate_alias, pair.repeat):
+        raise SimulationComparisonError(f"{label} plan cell does not match its pair coordinate")
+    if cell.cell_id not in simulation.cell_ids or simulation.agent_id != pair.agent_id:
+        raise SimulationComparisonError(f"{label} simulation spec does not bind the pair")
+
+
+def _validate_rollout(
+    pair: PairedSimulationCell,
+    rollout: RolloutArtifact,
+    resolved: _ResolvedInputs,
+    mode: SimulationMode,
+) -> None:
+    """Verify task, model, agent, simulator, spec, and per-cell binding identity."""
+    is_text = mode is SimulationMode.WORLD_MODEL
+    cell_id = pair.text_cell_id if is_text else pair.sandbox_cell_id
+    simulation = resolved.text_spec if is_text else resolved.sandbox_spec
+    expected_simulator = pair.text_simulator if is_text else pair.sandbox_simulator
+    if (
+        rollout.mode is not mode
+        or rollout.evidence_source != ("world_model" if is_text else "sandbox")
+        or rollout.cell_id != cell_id
+        or rollout.task_id != pair.task_id
+        or rollout.repeat != pair.repeat
+        or rollout.candidate != pair.candidate
+        or rollout.agent_id != pair.agent_id
+        or rollout.simulator != expected_simulator
+        or rollout.simulation_id != simulation.simulation_id
+        or rollout.simulation_spec_sha256 != sha256_json(simulation)
+    ):
+        raise SimulationComparisonError(f"{mode.value} rollout identity does not match its pair")
+    if rollout.created_at < resolved.lock_created_at:
+        raise SimulationComparisonError(f"{mode.value} rollout predates the policy lock")
+    if is_text:
+        binding = rollout.simulation_binding
+        settings = resolved.text_spec.world_model
+        if binding is None or (
+            settings is None
+            or binding.task_sha256 != pair.task_sha256
+            or binding.candidate_alias != pair.candidate_alias
+            or binding.world_model_alias != settings.world_model_alias
+            or binding.prompt_version != settings.prompt_version
+            or binding.evaluation_plan_input != resolved.text_plan_input
+            or binding.task_set_input != resolved.task_set_input
+            or binding.simulation_spec_input != resolved.text_spec_input
+        ):
+            raise SimulationComparisonError("text rollout binding drifted")
+    else:
+        binding = rollout.sandbox_binding
+        settings = resolved.sandbox_spec.sandbox
+        if binding is None or (
+            settings is None
+            or binding.cell_id != cell_id
+            or binding.task_id != pair.task_id
+            or binding.purpose != "held_out"
+            or binding.task_sha256 != pair.task_sha256
+            or binding.task_lineage_group_id != pair.task_lineage_group_id
+            or binding.candidate_alias != pair.candidate_alias
+            or binding.environment_id != settings.environment_id
+            or binding.environment_sha256 != settings.environment_sha256
+            or binding.evaluation_plan_input != resolved.sandbox_plan_input
+            or binding.task_set_input != resolved.task_set_input
+            or binding.simulation_spec_input != resolved.sandbox_spec_input
+        ):
+            raise SimulationComparisonError("sandbox rollout binding drifted")
+
+
+def _validate_plan_candidate(
+    pair: PairedSimulationCell,
+    plan: EvaluationPlan,
+    label: str,
+) -> None:
+    """Require the pair's candidate alias to resolve to the plan's exact model snapshot."""
+    candidates = {candidate.alias: candidate.model for candidate in plan.candidate_snapshots}
+    if candidates.get(pair.candidate_alias) != pair.candidate:
+        raise SimulationComparisonError(f"{label} plan candidate identity drifted")
+
+
+def _optional_rollout(
+    store: ArtifactStore,
+    rollout_id: str,
+    expected_sha256: str | None,
+    artifact_set_ids: set[str],
+    label: str,
+) -> RolloutArtifact | None:
+    """Resolve an exact rollout or preserve an explicitly absent denominator side."""
+    listed = rollout_id in artifact_set_ids
+    exists = rollout_id in set(store.list_ids())
+    if expected_sha256 is None:
+        if listed and exists:
+            raise SimulationComparisonError(
+                f"available {label} rollout requires its exact manifest digest"
+            )
+        return None
+    if not listed:
+        raise SimulationComparisonError(f"{label} rollout digest is not named by its artifact set")
+    stored = _read_exact(
+        store,
+        ArtifactInput(artifact_id=rollout_id, sha256=expected_sha256),
+        "rollout",
+    )
+    try:
+        rollout = RolloutArtifact.model_validate_json(store.read_bytes(rollout_id, _ROLLOUT_FILE))
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SimulationComparisonError(f"{label} rollout is invalid") from exc
+    if rollout.rollout_id != rollout_id or stored.manifest.artifact_id != rollout_id:
+        raise SimulationComparisonError(f"{label} rollout ID drifted")
+    return rollout
+
+
+def _load_plan(store: ArtifactStore, reference: ArtifactInput) -> EvaluationPlan:
+    """Load one exact evaluation plan."""
+    _read_exact(store, reference, "evaluation-plan")
+    return _parse_model(store, reference.artifact_id, _PLAN_FILE, EvaluationPlan, "plan")
+
+
+def _load_simulation_spec(store: ArtifactStore, reference: ArtifactInput) -> SimulationSpec:
+    """Load one exact simulation specification."""
+    _read_exact(store, reference, "simulation-spec")
+    return _parse_model(
+        store,
+        reference.artifact_id,
+        _SIMULATION_SPEC_FILE,
+        SimulationSpec,
+        "simulation spec",
+    )
+
+
+def _load_artifact_set(store: ArtifactStore, reference: ArtifactInput) -> SimulationArtifactSet:
+    """Load one exact artifact set and verify its canonical ID index bytes."""
+    _read_exact(store, reference, "simulation-artifact-set")
+    artifact_set = _parse_model(
+        store,
+        reference.artifact_id,
+        _ARTIFACT_SET_FILE,
+        SimulationArtifactSet,
+        "artifact set",
+    )
+    try:
+        payload = store.read_bytes(reference.artifact_id, artifact_set.artifacts_path)
+    except ArtifactCorruptionError as exc:
+        raise SimulationComparisonError("artifact set index cannot be read") from exc
+    if hashlib.sha256(payload).hexdigest() != artifact_set.artifacts_sha256:
+        raise SimulationComparisonError("artifact set index digest disagrees with its envelope")
+    parsed: list[str] = []
+    try:
+        for raw_line in payload.splitlines():
+            record = json.loads(raw_line)
+            if (
+                not isinstance(record, dict)
+                or set(record) != {"artifact_id"}
+                or not isinstance(record["artifact_id"], str)
+                or canonical_json_bytes(record) != raw_line
+            ):
+                raise ValueError("noncanonical artifact index row")
+            parsed.append(record["artifact_id"])
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise SimulationComparisonError("artifact set index is malformed") from exc
+    if tuple(parsed) != artifact_set.artifact_ids:
+        raise SimulationComparisonError("artifact set index disagrees with artifact_ids")
+    return artifact_set
+
+
+def _parse_model[T: BaseModel](
+    store: ArtifactStore,
+    artifact_id: str,
+    path: str,
+    model: type[T],
+    label: str,
+) -> T:
+    """Parse one verified JSON file into its frozen Pydantic contract."""
+    try:
+        return model.model_validate_json(store.read_bytes(artifact_id, path))
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SimulationComparisonError(f"comparison {label} is invalid") from exc
+
+
+def _read_exact(
+    store: ArtifactStore,
+    reference: ArtifactInput,
+    artifact_type: str | None = None,
+) -> StoredArtifact:
+    """Read one immutable artifact and require its exact manifest digest and optional type."""
+    try:
+        stored = store.read(reference.artifact_id)
+    except ArtifactCorruptionError as exc:
+        raise SimulationComparisonError(
+            f"comparison input {reference.artifact_id!r} is missing or corrupt"
+        ) from exc
+    if artifact_input(stored.manifest) != reference:
+        raise SimulationComparisonError(
+            f"comparison input {reference.artifact_id!r} manifest digest drifted"
+        )
+    if artifact_type is not None and stored.manifest.artifact_type != artifact_type:
+        raise SimulationComparisonError(
+            f"comparison input {reference.artifact_id!r} has the wrong artifact type"
+        )
+    return stored
+
+
+def _manifest_digest(store: ArtifactStore, artifact_id: str) -> Sha256:
+    """Return the verified manifest digest for an already-required stored artifact."""
+    try:
+        return artifact_input(store.read(artifact_id).manifest).sha256
+    except ArtifactCorruptionError as exc:
+        raise SimulationComparisonError("comparison protocol must be persisted first") from exc
+
+
+def _cell(plan: EvaluationPlan, cell_id: str, label: str) -> EvaluationCell:
+    """Resolve one exact plan cell without inferring a broader grid."""
+    cells = {cell.cell_id: cell for cell in plan.cells}
+    try:
+        return cells[cell_id]
+    except KeyError as exc:
+        raise SimulationComparisonError(f"{label} comparison cell is absent from its plan") from exc
+
+
+def _outcome_counts(
+    outcomes: tuple[PairedSimulationOutcome, ...],
+) -> tuple[int, int, int, int, int, int, int]:
+    """Count paired, usable, missing, failed, and matching denominator rows."""
+    paired = sum(
+        item.text_rollout_id is not None and item.sandbox_rollout_id is not None
+        for item in outcomes
+    )
+    usable = sum(
+        item.text_rollout_id is not None
+        and item.sandbox_rollout_id is not None
+        and item.text_failure is None
+        and item.sandbox_failure is None
+        for item in outcomes
+    )
+    missing_text = sum(item.text_rollout_id is None for item in outcomes)
+    missing_sandbox = sum(item.sandbox_rollout_id is None for item in outcomes)
+    failed_text = sum(
+        item.text_rollout_id is not None and item.text_failure is not None for item in outcomes
+    )
+    failed_sandbox = sum(
+        item.sandbox_rollout_id is not None and item.sandbox_failure is not None
+        for item in outcomes
+    )
+    matches = sum(item.terminal_match is True for item in outcomes)
+    return paired, usable, missing_text, missing_sandbox, failed_text, failed_sandbox, matches
+
+
+def _missing_failure(mode: str, rollout_id: str) -> StructuredFailure:
+    """Describe one absent expected artifact without silently shrinking the denominator."""
+    return StructuredFailure(
+        code=FailureCode.VALIDATION,
+        message=f"required {mode} rollout {rollout_id} is absent from its frozen artifact set",
+        details={"mode": mode, "rollout_id": rollout_id, "phase": "artifact_resolution"},
+    )
+
+
+def _sorted_unique_inputs(*inputs: ArtifactInput) -> tuple[ArtifactInput, ...]:
+    """Return one exact reference per artifact ID, rejecting same-ID hash drift."""
+    by_id: dict[str, ArtifactInput] = {}
+    for item in inputs:
+        previous = by_id.get(item.artifact_id)
+        if previous is not None and previous != item:
+            raise ValueError(f"artifact input {item.artifact_id!r} has conflicting digests")
+        by_id[item.artifact_id] = item
+    return tuple(by_id[artifact_id] for artifact_id in sorted(by_id))

--- a/wmo/simulation/comparison_test.py
+++ b/wmo/simulation/comparison_test.py
@@ -1,0 +1,699 @@
+"""Tests for immutable post-lock text-versus-sandbox comparison artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactInput,
+    FailureAttribution,
+    FailureCode,
+    StructuredFailure,
+    canonical_json_bytes,
+    sha256_json,
+)
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan
+from wmo.common.models import (
+    AssistantAction,
+    ModelSnapshot,
+    OperationEconomics,
+    RoutedCandidateSnapshot,
+)
+from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    RolloutSpan,
+    SandboxSimulationCellBinding,
+    SandboxSimulatorSnapshot,
+    SimulationArtifactSet,
+    SimulationCellBinding,
+    SimulationMode,
+    StopReason,
+    WorldModelSimulatorSnapshot,
+)
+from wmo.common.tasks import TaskCase, TaskSet
+from wmo.simulation.comparison import (
+    PairedSimulationCell,
+    SimulationComparisonError,
+    SimulationComparisonSpec,
+    compare_text_and_sandbox,
+    persist_comparison,
+    persist_comparison_spec,
+)
+from wmo.simulation.specs import SandboxSettings, SimulationSpec, WorldModelSettings
+
+_BEFORE_LOCK = datetime(2026, 8, 12, 10, tzinfo=UTC)
+_LOCKED_AT = datetime(2026, 8, 12, 11, tzinfo=UTC)
+_EVIDENCE_AT = datetime(2026, 8, 12, 12, tzinfo=UTC)
+_PROTOCOL_AT = datetime(2026, 8, 12, 13, tzinfo=UTC)
+_REPORT_AT = datetime(2026, 8, 12, 14, tzinfo=UTC)
+_ENVIRONMENT_SHA256 = "e" * 64
+_PROMPT_SHA256 = "9" * 64
+
+
+def test_comparison_resolves_exact_inputs_preserves_missing_denominator_and_persists(
+    tmp_path: Path,
+) -> None:
+    """A report binds its protocol and retains one absent sandbox side without shrinking."""
+    fixture = _protocol(tmp_path, sandbox_states=("success", "missing"))
+
+    report = compare_text_and_sandbox(
+        fixture.spec,
+        store=fixture.store,
+        created_at=_REPORT_AT,
+        code_revision="report-revision",
+    )
+    persist_comparison(report, fixture.store)
+
+    assert report.expected_pairs == 2
+    assert report.paired_rollouts == 1
+    assert report.usable_pairs == 1
+    assert report.missing_text_rollouts == 0
+    assert report.missing_sandbox_rollouts == 1
+    assert report.failed_text_rollouts == 0
+    assert report.failed_sandbox_rollouts == 0
+    assert report.terminal_matches == 1
+    assert report.comparison_spec_sha256 == sha256_json(fixture.spec)
+    assert fixture.comparison_spec_input in report.inputs
+    assert report.outcomes[1].sandbox_rollout_id is None
+    assert report.outcomes[1].sandbox_failure is not None
+    assert report.outcomes[1].sandbox_failure.code is FailureCode.VALIDATION
+    assert fixture.store.read_bytes(report.report_id, "simulation-comparison-report.json")
+
+
+def test_comparison_keeps_completed_failures_separate_from_missing_rollouts(
+    tmp_path: Path,
+) -> None:
+    """A failed sandbox artifact remains paired but unusable and is not counted as missing."""
+    fixture = _protocol(tmp_path, sandbox_states=("failure", "success"))
+
+    report = compare_text_and_sandbox(
+        fixture.spec,
+        store=fixture.store,
+        created_at=_REPORT_AT,
+        code_revision="report-revision",
+    )
+
+    assert report.paired_rollouts == 2
+    assert report.usable_pairs == 1
+    assert report.missing_sandbox_rollouts == 0
+    assert report.failed_sandbox_rollouts == 1
+    assert report.terminal_matches == 1
+    assert report.outcomes[0].sandbox_failure is not None
+    assert report.outcomes[0].sandbox_failure.code is FailureCode.TIMEOUT
+    assert report.outcomes[0].terminal_match is None
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    (
+        ("fit-task", "held-out tasks only"),
+        ("lineage-drift", "lineage or digest drifted"),
+        ("pre-lock", "predates the policy lock"),
+        ("wrong-mode", "sandbox simulation spec has the wrong mode"),
+        ("manifest-drift", "manifest digest drifted"),
+        ("rollout-drift", "manifest digest drifted"),
+    ),
+)
+def test_comparison_rejects_leakage_and_every_hash_or_identity_drift(
+    tmp_path: Path,
+    case: str,
+    message: str,
+) -> None:
+    """Held-out, mode, plan, spec, artifact-set, rollout, and lineage pins fail closed."""
+    fixture = _protocol(
+        tmp_path,
+        task_partition="fit" if case == "fit-task" else "held_out",
+        pair_lineage="wrong-lineage" if case == "lineage-drift" else None,
+        evidence_at=_BEFORE_LOCK if case == "pre-lock" else _EVIDENCE_AT,
+        sandbox_as_world=case == "wrong-mode",
+        drift_reference="sandbox-spec" if case == "manifest-drift" else None,
+        drift_rollout_hash=case == "rollout-drift",
+    )
+
+    with pytest.raises(SimulationComparisonError, match=message):
+        compare_text_and_sandbox(
+            fixture.spec,
+            store=fixture.store,
+            created_at=_REPORT_AT,
+            code_revision="report-revision",
+        )
+
+
+def test_comparison_rejects_malformed_artifact_set_index(tmp_path: Path) -> None:
+    """A digest-valid but noncanonical artifact index cannot redefine the paired denominator."""
+    fixture = _protocol(tmp_path, malformed_sandbox_index=True)
+
+    with pytest.raises(SimulationComparisonError, match="index is malformed"):
+        compare_text_and_sandbox(
+            fixture.spec,
+            store=fixture.store,
+            created_at=_REPORT_AT,
+            code_revision="report-revision",
+        )
+
+
+def test_comparison_spec_requires_every_named_hash_bound_input(tmp_path: Path) -> None:
+    """The protocol envelope cannot omit a plan, spec, set, task set, or policy lock input."""
+    fixture = _protocol(tmp_path)
+    payload = fixture.spec.model_dump(mode="json")
+    payload["inputs"] = payload["inputs"][1:]
+
+    with pytest.raises(ValueError, match="exactly match every named artifact"):
+        SimulationComparisonSpec.model_validate(payload)
+
+
+@dataclass(frozen=True)
+class _Fixture:
+    """Persisted comparison protocol and its immutable local store."""
+
+    store: ArtifactStore
+    spec: SimulationComparisonSpec
+    comparison_spec_input: ArtifactInput
+
+
+def _protocol(
+    root: Path,
+    *,
+    sandbox_states: tuple[Literal["success", "failure", "missing"], ...] = (
+        "success",
+        "success",
+    ),
+    task_partition: Literal["fit", "held_out"] = "held_out",
+    pair_lineage: str | None = None,
+    evidence_at: datetime = _EVIDENCE_AT,
+    sandbox_as_world: bool = False,
+    drift_reference: Literal["sandbox-spec"] | None = None,
+    drift_rollout_hash: bool = False,
+    malformed_sandbox_index: bool = False,
+) -> _Fixture:
+    """Persist a complete two-pair protocol without any provider, judge, or environment call."""
+    store = ArtifactStore(ProjectPaths(root=root, project_id="comparison-project"))
+    lock_input = _persist_lock(store)
+    tasks = (_task("task-a", task_partition), _task("task-b", task_partition))
+    task_set, task_input = _persist_tasks(store, tasks)
+    text_plan, text_plan_input = _persist_plan(store, tasks, task_input, "text")
+    sandbox_plan, sandbox_plan_input = _persist_plan(store, tasks, task_input, "sandbox")
+    text_spec, text_spec_input = _persist_spec(
+        store,
+        text_plan,
+        text_plan_input,
+        task_input,
+        SimulationMode.WORLD_MODEL,
+        evidence_at,
+    )
+    sandbox_spec, sandbox_spec_input = _persist_spec(
+        store,
+        sandbox_plan,
+        sandbox_plan_input,
+        task_input,
+        SimulationMode.WORLD_MODEL if sandbox_as_world else SimulationMode.SANDBOX,
+        evidence_at,
+        artifact_id="simulation-sandbox",
+    )
+    text_simulator = _text_simulator()
+    sandbox_simulator = _sandbox_simulator()
+    text_rollouts = tuple(
+        _persist_rollout(
+            store,
+            task,
+            text_plan.cells[index],
+            text_plan_input,
+            task_input,
+            task_set,
+            text_spec,
+            text_spec_input,
+            text_simulator,
+            None,
+            evidence_at,
+        )
+        for index, task in enumerate(tasks)
+    )
+    sandbox_rollouts = []
+    for index, (task, state) in enumerate(zip(tasks, sandbox_states, strict=True)):
+        if state == "missing":
+            sandbox_rollouts.append(None)
+            continue
+        failure = (
+            StructuredFailure(
+                code=FailureCode.TIMEOUT,
+                message="sandbox timed out",
+                attribution=FailureAttribution.ENVIRONMENT,
+            )
+            if state == "failure"
+            else None
+        )
+        sandbox_rollouts.append(
+            _persist_rollout(
+                store,
+                task,
+                sandbox_plan.cells[index],
+                sandbox_plan_input,
+                task_input,
+                task_set,
+                sandbox_spec,
+                sandbox_spec_input,
+                sandbox_simulator,
+                failure,
+                evidence_at,
+            )
+        )
+    text_set_input = _persist_artifact_set(
+        store,
+        "text-artifact-set",
+        text_spec,
+        text_plan_input,
+        task_input,
+        text_spec_input,
+        tuple(item[0].artifact_id for item in text_rollouts),
+        evidence_at,
+    )
+    sandbox_set_input = _persist_artifact_set(
+        store,
+        "sandbox-artifact-set",
+        sandbox_spec,
+        sandbox_plan_input,
+        task_input,
+        sandbox_spec_input,
+        tuple(item[0].artifact_id for item in sandbox_rollouts if item is not None),
+        evidence_at,
+        malformed=malformed_sandbox_index,
+    )
+    named_sandbox_spec_input = (
+        sandbox_spec_input.model_copy(update={"sha256": "0" * 64})
+        if drift_reference == "sandbox-spec"
+        else sandbox_spec_input
+    )
+    pairs = tuple(
+        PairedSimulationCell(
+            pair_id=f"pair-{suffix}",
+            task_id=task.task_id,
+            task_lineage_group_id=pair_lineage or task.lineage_group_id,
+            task_sha256=sha256_json(task),
+            candidate_alias="candidate-a",
+            candidate=_candidate(),
+            agent_id="customer-agent",
+            repeat=0,
+            text_cell_id=text_plan.cells[index].cell_id,
+            sandbox_cell_id=sandbox_plan.cells[index].cell_id,
+            text_rollout_id=text_rollouts[index][0].artifact_id,
+            text_rollout_sha256=text_rollouts[index][1].sha256,
+            sandbox_rollout_id=f"sandbox-rollout-{suffix}",
+            sandbox_rollout_sha256=_optional_rollout_sha(
+                sandbox_rollouts[index],
+                drift=drift_rollout_hash and index == 0,
+            ),
+            text_simulator=text_simulator,
+            sandbox_simulator=sandbox_simulator,
+        )
+        for index, (task, suffix) in enumerate(zip(tasks, ("a", "b"), strict=True))
+    )
+    inputs = _inputs(
+        lock_input,
+        task_input,
+        text_plan_input,
+        sandbox_plan_input,
+        text_spec_input,
+        named_sandbox_spec_input,
+        text_set_input,
+        sandbox_set_input,
+    )
+    comparison = SimulationComparisonSpec(
+        schema_version=1,
+        created_at=_PROTOCOL_AT,
+        inputs=inputs,
+        code_revision="comparison-revision",
+        comparison_id="comparison-1",
+        policy_lock_input=lock_input,
+        task_set_input=task_input,
+        text_evaluation_plan_input=text_plan_input,
+        sandbox_evaluation_plan_input=sandbox_plan_input,
+        text_simulation_spec_input=text_spec_input,
+        sandbox_simulation_spec_input=named_sandbox_spec_input,
+        text_artifact_set_input=text_set_input,
+        sandbox_artifact_set_input=sandbox_set_input,
+        pairs=pairs,
+    )
+    comparison_input = persist_comparison_spec(comparison, store)
+    return _Fixture(store=store, spec=comparison, comparison_spec_input=comparison_input)
+
+
+def _persist_lock(store: ArtifactStore) -> ArtifactInput:
+    """Persist an opaque immutable policy-lock barrier without implementing router behavior."""
+    envelope = ArtifactEnvelope(
+        schema_version=1,
+        created_at=_LOCKED_AT,
+        code_revision="lock-revision",
+    )
+    manifest = store.write_json(
+        artifact_id="policy-lock-1",
+        artifact_type="policy-lock",
+        envelope=envelope,
+        files={"policy-lock.json": {"locked": True}},
+    )
+    return artifact_input(manifest)
+
+
+def _persist_tasks(
+    store: ArtifactStore,
+    tasks: tuple[TaskCase, ...],
+) -> tuple[TaskSet, ArtifactInput]:
+    """Persist canonical tasks and return their digest-bearing set."""
+    payload = b"\n".join(canonical_json_bytes(task) for task in tasks) + b"\n"
+    task_set = TaskSet(
+        schema_version=1,
+        created_at=_BEFORE_LOCK,
+        code_revision="fixture-revision",
+        task_set_id="task-set-1",
+        task_ids=tuple(task.task_id for task in tasks),
+        tasks_path="tasks.jsonl",
+        tasks_sha256=hashlib.sha256(payload).hexdigest(),
+    )
+    manifest = store.write(
+        artifact_id=task_set.task_set_id,
+        artifact_type="task-set",
+        envelope=task_set,
+        files={"task-set.json": canonical_json_bytes(task_set), "tasks.jsonl": payload},
+    )
+    return task_set, artifact_input(manifest)
+
+
+def _persist_plan(
+    store: ArtifactStore,
+    tasks: tuple[TaskCase, ...],
+    task_input: ArtifactInput,
+    label: Literal["text", "sandbox"],
+) -> tuple[EvaluationPlan, ArtifactInput]:
+    """Persist one mode-specific plan over the same held-out task coordinates."""
+    cells = tuple(
+        EvaluationCell(
+            cell_id=f"{label}-cell-{suffix}",
+            task_id=task.task_id,
+            candidate_alias="candidate-a",
+            repeat=0,
+            purpose="held_out",
+            execution="simulate",
+        )
+        for task, suffix in zip(tasks, ("a", "b"), strict=True)
+    )
+    plan = EvaluationPlan(
+        schema_version=1,
+        created_at=_BEFORE_LOCK,
+        inputs=(task_input,),
+        code_revision="fixture-revision",
+        plan_id=f"{label}-plan-1",
+        task_set_id="task-set-1",
+        candidate_snapshots=(RoutedCandidateSnapshot(alias="candidate-a", model=_candidate()),),
+        fidelity_gate_id="fidelity-gate-1",
+        fidelity_gate_sha256="f" * 64,
+        cells=cells,
+    )
+    manifest = store.write_json(
+        artifact_id=plan.plan_id,
+        artifact_type="evaluation-plan",
+        envelope=plan,
+        files={"evaluation-plan.json": plan},
+    )
+    return plan, artifact_input(manifest)
+
+
+def _persist_spec(
+    store: ArtifactStore,
+    plan: EvaluationPlan,
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    mode: SimulationMode,
+    created_at: datetime,
+    *,
+    artifact_id: str | None = None,
+) -> tuple[SimulationSpec, ArtifactInput]:
+    """Persist one exact shared simulation spec for the selected mode."""
+    simulation_id = artifact_id or f"simulation-{mode.value}"
+    spec = SimulationSpec(
+        schema_version=1,
+        created_at=created_at,
+        inputs=_inputs(plan_input, task_input),
+        code_revision="fixture-revision",
+        simulation_id=simulation_id,
+        evaluation_plan_id=plan.plan_id,
+        cell_ids=tuple(cell.cell_id for cell in plan.cells),
+        agent_id="customer-agent",
+        mode=mode,
+        world_model=(
+            WorldModelSettings(
+                world_model_alias="world-model-a",
+                prompt_version="text-world-model-v1",
+            )
+            if mode is SimulationMode.WORLD_MODEL
+            else None
+        ),
+        sandbox=(
+            SandboxSettings(
+                environment_id="customer-environment",
+                environment_sha256=_ENVIRONMENT_SHA256,
+            )
+            if mode is SimulationMode.SANDBOX
+            else None
+        ),
+        seed=3,
+        maximum_steps=3,
+    )
+    manifest = store.write_json(
+        artifact_id=spec.simulation_id,
+        artifact_type="simulation-spec",
+        envelope=spec,
+        files={"simulation-spec.json": spec},
+    )
+    return spec, artifact_input(manifest)
+
+
+def _persist_rollout(
+    store: ArtifactStore,
+    task: TaskCase,
+    cell: EvaluationCell,
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    task_set: TaskSet,
+    spec: SimulationSpec,
+    spec_input: ArtifactInput,
+    simulator: WorldModelSimulatorSnapshot | SandboxSimulatorSnapshot,
+    failure: StructuredFailure | None,
+    created_at: datetime,
+) -> tuple[RolloutArtifact, ArtifactInput]:
+    """Persist one canonical bound rollout without executing either simulator."""
+    is_text = isinstance(simulator, WorldModelSimulatorSnapshot)
+    prefix = "text" if is_text else "sandbox"
+    suffix = cell.cell_id.rsplit("-", maxsplit=1)[-1]
+    rollout_id = f"{prefix}-rollout-{suffix}"
+    common_binding = {
+        "evaluation_plan_input": plan_input,
+        "task_set_input": task_input,
+        "task_set_tasks_sha256": task_set.tasks_sha256,
+        "task_sha256": sha256_json(task),
+        "candidate_alias": "candidate-a",
+        "candidate": _candidate(),
+        "agent_id": "customer-agent",
+        "repeat": 0,
+        "simulator_id": simulator.simulator_id,
+        "simulation_spec_input": spec_input,
+        "simulation_spec_sha256": sha256_json(spec),
+        "simulation_inputs_sha256": sha256_json(
+            [item.model_dump(mode="json") for item in spec.inputs]
+        ),
+    }
+    text_binding = (
+        SimulationCellBinding(
+            **common_binding,
+            world_model_alias="world-model-a",
+            world_model=_world_model(),
+            prompt_id=simulator.prompt_id,
+            prompt_version=simulator.prompt_version,
+            prompt_sha256=simulator.prompt_sha256,
+        )
+        if is_text and isinstance(simulator, WorldModelSimulatorSnapshot)
+        else None
+    )
+    sandbox_binding = (
+        SandboxSimulationCellBinding(
+            **common_binding,
+            cell_id=cell.cell_id,
+            task_id=cell.task_id,
+            purpose=cell.purpose,
+            task_lineage_group_id=task.lineage_group_id,
+            candidate_maximum_call_cost_usd=None,
+            candidate_cost_is_observable=False,
+            environment_maximum_episode_cost_usd=None,
+            environment_cost_is_observable=False,
+            environment_id=simulator.environment_id,
+            environment_sha256=simulator.environment_sha256,
+        )
+        if not is_text and isinstance(simulator, SandboxSimulatorSnapshot)
+        else None
+    )
+    rollout = RolloutArtifact(
+        schema_version=1,
+        created_at=created_at,
+        inputs=_inputs(plan_input, task_input, spec_input),
+        code_revision="fixture-revision",
+        artifact_id=rollout_id,
+        simulation_id=spec.simulation_id,
+        cell_id=cell.cell_id,
+        mode=SimulationMode.WORLD_MODEL if is_text else SimulationMode.SANDBOX,
+        rollout_id=rollout_id,
+        trace_id=("0" if is_text else "1") * 32,
+        evidence_source="world_model" if is_text else "sandbox",
+        source_run_id=f"{prefix}-run-1",
+        task_id=task.task_id,
+        candidate=_candidate(),
+        agent_id="customer-agent",
+        simulator=simulator,
+        world_model=_world_model() if is_text else None,
+        seed=3,
+        repeat=0,
+        spans=(
+            RolloutSpan(
+                span_id=f"span-{rollout_id}",
+                kind=RolloutEventKind.LIFECYCLE,
+                started_at=created_at,
+                ended_at=created_at,
+                payload={"fixture": prefix},
+            ),
+        ),
+        final_output=None if failure is not None else AssistantAction(content="completed"),
+        stop_reason=StopReason.FAILURE if failure is not None else StopReason.COMPLETED,
+        failure=failure,
+        candidate_economics=OperationEconomics(),
+        world_model_economics=OperationEconomics() if is_text else None,
+        sandbox_economics=OperationEconomics() if not is_text else None,
+        simulation_spec_sha256=sha256_json(spec),
+        simulation_binding=text_binding,
+        sandbox_binding=sandbox_binding,
+    )
+    manifest = store.write_json(
+        artifact_id=rollout_id,
+        artifact_type="rollout",
+        envelope=rollout,
+        files={"rollout.json": rollout},
+    )
+    return rollout, artifact_input(manifest)
+
+
+def _persist_artifact_set(
+    store: ArtifactStore,
+    artifact_set_id: str,
+    spec: SimulationSpec,
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    spec_input: ArtifactInput,
+    artifact_ids: tuple[str, ...],
+    created_at: datetime,
+    *,
+    malformed: bool = False,
+) -> ArtifactInput:
+    """Persist one exact simulation artifact set and its canonical or adversarial index."""
+    payload = (
+        f'{{"artifact_id": "{artifact_ids[0]}"}}\n'.encode()
+        if malformed
+        else b"\n".join(canonical_json_bytes({"artifact_id": item}) for item in artifact_ids)
+        + b"\n"
+    )
+    artifact_set = SimulationArtifactSet(
+        schema_version=1,
+        created_at=created_at,
+        inputs=_inputs(plan_input, task_input, spec_input),
+        code_revision="fixture-revision",
+        artifact_set_id=artifact_set_id,
+        simulation_id=spec.simulation_id,
+        artifact_ids=artifact_ids,
+        artifacts_path="artifact-ids.jsonl",
+        artifacts_sha256=hashlib.sha256(payload).hexdigest(),
+    )
+    manifest = store.write(
+        artifact_id=artifact_set_id,
+        artifact_type="simulation-artifact-set",
+        envelope=artifact_set,
+        files={
+            "artifact-set.json": canonical_json_bytes(artifact_set),
+            "artifact-ids.jsonl": payload,
+        },
+    )
+    return artifact_input(manifest)
+
+
+def _task(task_id: str, partition: Literal["fit", "held_out"]) -> TaskCase:
+    """Create one comparison task with fixed lineage and text."""
+    return TaskCase(
+        task_id=task_id,
+        lineage_group_id=f"lineage-{task_id}",
+        partition=partition,
+        instruction=f"Evaluate {task_id} after lock.",
+        workload_weight=1.0,
+        source_trace_ids=(f"trace-{task_id}",),
+    )
+
+
+def _candidate() -> ModelSnapshot:
+    """Return the exact candidate identity shared by both evidence modes."""
+    return ModelSnapshot(
+        provider="fixture",
+        model_id="candidate-a",
+        revision="v1",
+        capabilities_sha256="a" * 64,
+        connection_sha256="b" * 64,
+    )
+
+
+def _world_model() -> ModelSnapshot:
+    """Return the exact text simulator model identity."""
+    return ModelSnapshot(
+        provider="fixture",
+        model_id="world-model-a",
+        revision="v1",
+        capabilities_sha256="c" * 64,
+        connection_sha256="d" * 64,
+    )
+
+
+def _text_simulator() -> WorldModelSimulatorSnapshot:
+    """Return the exact prompt and world-model identity for text rollouts."""
+    return WorldModelSimulatorSnapshot(
+        simulator_id="world-model-v1",
+        prompt_id="world-model-text-system",
+        prompt_version="text-world-model-v1",
+        prompt_sha256=_PROMPT_SHA256,
+        world_model=_world_model(),
+    )
+
+
+def _sandbox_simulator() -> SandboxSimulatorSnapshot:
+    """Return the exact executable environment identity for sandbox rollouts."""
+    return SandboxSimulatorSnapshot(
+        simulator_id="sandbox-v1",
+        environment_id="customer-environment",
+        environment_sha256=_ENVIRONMENT_SHA256,
+    )
+
+
+def _inputs(*items: ArtifactInput) -> tuple[ArtifactInput, ...]:
+    """Return unique immutable references in canonical artifact-ID order."""
+    by_id = {item.artifact_id: item for item in items}
+    return tuple(by_id[artifact_id] for artifact_id in sorted(by_id))
+
+
+def _optional_rollout_sha(
+    item: tuple[RolloutArtifact, ArtifactInput] | None,
+    *,
+    drift: bool,
+) -> str | None:
+    """Return one available rollout digest with an optional adversarial replacement."""
+    if item is None:
+        return None
+    return "0" * 64 if drift else item[1].sha256

--- a/wmo/simulation/engines/__init__.py
+++ b/wmo/simulation/engines/__init__.py
@@ -1,1 +1,19 @@
-"""Concrete simulation engines selected by immutable simulation specifications."""
+"""Concrete text and executable simulation engines."""
+
+from wmo.simulation.engines.sandbox import (
+    CandidateBinding,
+    EnvironmentCostBinding,
+    SandboxContentionError,
+    SandboxResumeError,
+    SandboxSimulationError,
+    SandboxSimulator,
+)
+
+__all__ = [
+    "CandidateBinding",
+    "EnvironmentCostBinding",
+    "SandboxContentionError",
+    "SandboxResumeError",
+    "SandboxSimulationError",
+    "SandboxSimulator",
+]

--- a/wmo/simulation/engines/sandbox.py
+++ b/wmo/simulation/engines/sandbox.py
@@ -466,7 +466,14 @@ class SandboxSimulator:
             else max(0.0, spec.maximum_cost_usd - (claim.observed_spend_usd or 0.0))
         )
         environment_reservation = binding.environment_maximum_episode_cost_usd
-        dispatch_may_have_started = False
+        dispatch_intent_recorded = False
+
+        def record_dispatch_intent() -> None:
+            """Fsync the exact non-replay boundary before external sandbox work begins."""
+            nonlocal dispatch_intent_recorded, lease
+            lease = self._leases.record_dispatch_intent(lease)
+            dispatch_intent_recorded = True
+
         try:
             if (
                 remaining is not None
@@ -483,13 +490,17 @@ class SandboxSimulator:
                     spent=claim.observed_spend_usd,
                 )
             else:
-                dispatch_may_have_started = True
-                rollout = self._execute_cell(spec, cell, binding, resolution_input, remaining)
+                rollout = self._execute_cell(
+                    spec,
+                    cell,
+                    binding,
+                    resolution_input,
+                    remaining,
+                    record_dispatch_intent=record_dispatch_intent,
+                )
             persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
         except BaseException:
-            if dispatch_may_have_started:
-                self._leases.retain_non_replay_tombstone(lease)
-            else:
+            if not dispatch_intent_recorded:
                 self._leases.release(lease)
             raise
         else:
@@ -523,6 +534,8 @@ class SandboxSimulator:
         binding: SandboxSimulationCellBinding,
         resolution_input: ArtifactInput,
         remaining_cost_usd: float | None,
+        *,
+        record_dispatch_intent: Callable[[], None],
     ) -> RolloutArtifact:
         """Execute one bounded customer episode and convert every normal failure into evidence."""
         started_at = _timestamp(self._clock)
@@ -545,6 +558,7 @@ class SandboxSimulator:
                 remaining_cost_usd=remaining_cost_usd,
                 maximum_call_cost_usd=candidate.maximum_call_cost_usd,
                 cost_is_observable=candidate.cost_is_observable,
+                record_dispatch_intent=record_dispatch_intent,
                 clock=self._clock,
                 monotonic=self._monotonic,
             )

--- a/wmo/simulation/engines/sandbox.py
+++ b/wmo/simulation/engines/sandbox.py
@@ -466,6 +466,7 @@ class SandboxSimulator:
             else max(0.0, spec.maximum_cost_usd - (claim.observed_spend_usd or 0.0))
         )
         environment_reservation = binding.environment_maximum_episode_cost_usd
+        dispatch_may_have_started = False
         try:
             if (
                 remaining is not None
@@ -482,10 +483,18 @@ class SandboxSimulator:
                     spent=claim.observed_spend_usd,
                 )
             else:
+                dispatch_may_have_started = True
                 rollout = self._execute_cell(spec, cell, binding, resolution_input, remaining)
-            return self._persist_rollout(rollout, cell, binding, resolution_input)
-        finally:
+            persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
+        except BaseException:
+            if dispatch_may_have_started:
+                self._leases.retain_non_replay_tombstone(lease)
+            else:
+                self._leases.release(lease)
+            raise
+        else:
             self._leases.release(lease)
+            return persisted
 
     def _known_resolution_spend(
         self,

--- a/wmo/simulation/engines/sandbox.py
+++ b/wmo/simulation/engines/sandbox.py
@@ -1,0 +1,917 @@
+"""Atomic, resumable executable simulation over explicit evaluation-plan cells."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    FailureAttribution,
+    FailureCode,
+    StructuredFailure,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan
+from wmo.common.models import AssistantAction, NumericMeasurement, OperationEconomics
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    RolloutSpan,
+    SandboxSimulationCellBinding,
+    SandboxSimulatorSnapshot,
+    SimulationArtifactSet,
+    SimulationMode,
+    StopReason,
+)
+from wmo.common.tasks import LoadedTaskSet, load_task_set
+from wmo.runtime.agents import AgentEpisode, AgentRuntime
+from wmo.runtime.environments import EnvironmentRuntime
+from wmo.simulation.engines.sandbox_bindings import (
+    SANDBOX_SIMULATOR_ID,
+    CandidateBinding,
+    EnvironmentCostBinding,
+    SandboxSimulationResolution,
+    make_sandbox_cell_binding,
+    make_sandbox_resolution,
+    sandbox_binding_digest,
+    sandbox_lease_id,
+    sandbox_rollout_id,
+)
+from wmo.simulation.engines.sandbox_recording import (
+    SandboxExecutionEvidence,
+    SandboxTimeLimitError,
+    execute_bounded_sandbox_episode,
+    merge_sandbox_spans,
+)
+from wmo.simulation.engines.text.leases import (
+    TextCellLeaseError,
+    TextCellLeaseState,
+    TextCellLeaseStore,
+)
+from wmo.simulation.orchestration import require_implemented_mode
+from wmo.simulation.specs import SimulationSpec
+
+_SPEC_FILE = "simulation-spec.json"
+_RESOLUTION_FILE = "sandbox-simulation-resolution.json"
+_ROLLOUT_FILE = "rollout.json"
+_ARTIFACT_SET_FILE = "artifact-set.json"
+_ARTIFACT_IDS_FILE = "artifact-ids.jsonl"
+
+
+class SandboxSimulationError(ValueError):
+    """A sandbox recipe or exact immutable input binding is inconsistent."""
+
+
+class SandboxResumeError(RuntimeError):
+    """Existing immutable sandbox evidence cannot safely be resumed or reused."""
+
+
+class SandboxContentionError(SandboxResumeError):
+    """Another live process owns an executable cell that may be retried later."""
+
+
+class SandboxSimulator:
+    """Run exact sandbox cells and persist each rollout before admitting another episode.
+
+    Args:
+        store: Immutable project-local artifact store.
+        evaluation_plan: Frozen sparse plan whose simulated cells may execute.
+        evaluation_plan_input: Exact persisted plan manifest identity.
+        task_set_input: Exact persisted task-set manifest identity.
+        candidates: Resolved candidate clients keyed by plan alias.
+        agent_factory: Creates a fresh customer agent runtime for every episode.
+        environment_runtime: Simulator-owned executable environment factory.
+        environment_cost: Proven environment cost ceiling and observability capability.
+        environment_id: Stable environment identity expected in sandbox settings.
+        environment_sha256: Exact environment plan or image digest expected in settings.
+        source_run_id: Durable run identity retained by every rollout.
+        clock: Aware artifact and event time source.
+        monotonic: Monotonic latency and deadline time source.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        evaluation_plan: EvaluationPlan,
+        evaluation_plan_input: ArtifactInput,
+        task_set_input: ArtifactInput,
+        candidates: Mapping[str, CandidateBinding],
+        agent_factory: Callable[[], AgentRuntime],
+        environment_runtime: EnvironmentRuntime,
+        environment_cost: EnvironmentCostBinding | None = None,
+        environment_id: str,
+        environment_sha256: str,
+        source_run_id: str,
+        clock: Callable[[], datetime] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Bind immutable inputs and verify stored task and evaluation evidence immediately."""
+        if evaluation_plan_input.artifact_id != evaluation_plan.plan_id:
+            raise SandboxSimulationError(
+                "evaluation_plan_input must name the supplied sandbox evaluation plan"
+            )
+        if not environment_id or not source_run_id:
+            raise ValueError("sandbox environment_id and source_run_id must be nonempty")
+        if len(environment_sha256) != 64:
+            raise ValueError("sandbox environment_sha256 must be a SHA-256 digest")
+        self._store = store
+        self._plan = evaluation_plan
+        self._plan_input = evaluation_plan_input
+        self._task_set_input = task_set_input
+        loaded = self._load_and_verify_task_set(task_set_input)
+        self._task_set = loaded.task_set
+        self._tasks = {task.task_id: task for task in loaded.tasks}
+        self._candidates = dict(candidates)
+        self._agent_factory = agent_factory
+        self._environment_runtime = environment_runtime
+        self._environment_cost = environment_cost or EnvironmentCostBinding()
+        self._environment_id = environment_id
+        self._environment_sha256 = environment_sha256
+        self._source_run_id = source_run_id
+        self._clock = clock or _utc_now
+        self._monotonic = monotonic
+        self._leases = TextCellLeaseStore(store.project_directory, clock=self._clock)
+        self._verify_persisted_evaluation_plan()
+
+    def run(self, spec: SimulationSpec) -> SimulationArtifactSet:
+        """Run or resume every selected cell with durable per-cell exact-once evidence.
+
+        Args:
+            spec: Validated sandbox recipe over sorted explicit plan cell IDs.
+
+        Returns:
+            Immutable final index of one independently stored rollout artifact per cell.
+
+        Raises:
+            SandboxSimulationError: Inputs disagree or finite cost cannot be enforced safely.
+            SandboxResumeError: Existing immutable evidence has conflicting provenance.
+            SandboxContentionError: Another live process owns the same in-flight cell.
+        """
+        require_implemented_mode(spec, SimulationMode.SANDBOX)
+        cells = self._validate_spec_and_bindings(spec)
+        spec_input = self._persist_specification(spec)
+        resolution, resolution_input, bindings = self._persist_resolution(
+            spec,
+            spec_input,
+            cells,
+        )
+        completed = self._load_completed_rollouts(cells, bindings, resolution_input)
+        for cell in cells:
+            if cell.cell_id in completed:
+                continue
+            completed[cell.cell_id] = self._execute_and_persist_cell(
+                spec,
+                cell,
+                resolution,
+                resolution_input,
+                bindings[cell.cell_id],
+            )
+        ordered = tuple(completed[cell.cell_id] for cell in cells)
+        return self._persist_artifact_set(spec, spec_input, resolution_input, ordered)
+
+    def _load_and_verify_task_set(self, task_set_input: ArtifactInput) -> LoadedTaskSet:
+        """Load the exact task set and reject an ID paired with another manifest digest."""
+        try:
+            stored = self._store.read(task_set_input.artifact_id)
+        except ArtifactCorruptionError as exc:
+            raise SandboxSimulationError(
+                f"sandbox task set {task_set_input.artifact_id!r} cannot be read safely"
+            ) from exc
+        if (
+            stored.manifest.artifact_type != "task-set"
+            or artifact_input(stored.manifest) != task_set_input
+        ):
+            raise SandboxSimulationError(
+                "task_set_input must name the exact persisted task-set manifest"
+            )
+        try:
+            return load_task_set(self._store, task_set_input.artifact_id)
+        except ArtifactCorruptionError as exc:
+            raise SandboxSimulationError("sandbox task-set content is invalid") from exc
+
+    def _verify_persisted_evaluation_plan(self) -> None:
+        """Reject an in-memory plan that differs from its persisted immutable bytes."""
+        try:
+            stored = self._store.read(self._plan_input.artifact_id)
+            persisted = EvaluationPlan.model_validate_json(
+                self._store.read_bytes(self._plan_input.artifact_id, "evaluation-plan.json")
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise SandboxSimulationError("sandbox evaluation plan cannot be read safely") from exc
+        if (
+            stored.manifest.artifact_type != "evaluation-plan"
+            or artifact_input(stored.manifest) != self._plan_input
+            or persisted != self._plan
+        ):
+            raise SandboxSimulationError(
+                "supplied evaluation plan differs from its immutable persisted manifest"
+            )
+        if self._plan.task_set_id != self._task_set.task_set_id:
+            raise SandboxSimulationError(
+                "sandbox evaluation plan task_set_id does not match the immutable task set"
+            )
+
+    def _validate_spec_and_bindings(
+        self,
+        spec: SimulationSpec,
+    ) -> tuple[EvaluationCell, ...]:
+        """Validate every local binding and finite-cost capability before opening an environment."""
+        if spec.evaluation_plan_id != self._plan.plan_id:
+            raise SandboxSimulationError(
+                "sandbox spec evaluation_plan_id does not match the supplied plan"
+            )
+        if self._plan_input not in spec.inputs or self._task_set_input not in spec.inputs:
+            raise SandboxSimulationError(
+                "sandbox spec inputs must include exact evaluation-plan and task-set manifests"
+            )
+        settings = spec.sandbox
+        if settings is None:  # pragma: no cover - selected settings are validated by the spec
+            raise SandboxSimulationError("sandbox settings are missing")
+        if (
+            settings.environment_id != self._environment_id
+            or settings.environment_sha256 != self._environment_sha256
+        ):
+            raise SandboxSimulationError(
+                "sandbox environment identity does not match the configured runtime"
+            )
+        plan_cells = {cell.cell_id: cell for cell in self._plan.cells}
+        expected_candidates = {
+            snapshot.alias: snapshot.model for snapshot in self._plan.candidate_snapshots
+        }
+        cells: list[EvaluationCell] = []
+        for cell_id in spec.cell_ids:
+            cell = plan_cells.get(cell_id)
+            if cell is None:
+                raise SandboxSimulationError(
+                    f"sandbox spec selected cell {cell_id!r} outside its evaluation plan"
+                )
+            if cell.execution != "simulate":
+                raise SandboxSimulationError(
+                    f"sandbox spec selected observed cell {cell.cell_id!r}; only simulate cells run"
+                )
+            if cell.task_id not in self._tasks:
+                raise SandboxSimulationError(
+                    f"sandbox task {cell.task_id!r} is unavailable from the pinned task set"
+                )
+            candidate = self._candidates.get(cell.candidate_alias)
+            if candidate is None or candidate.alias != cell.candidate_alias:
+                raise SandboxSimulationError(
+                    f"sandbox has no exact candidate binding for {cell.candidate_alias!r}"
+                )
+            if candidate.snapshot != expected_candidates[cell.candidate_alias]:
+                raise SandboxSimulationError(
+                    f"sandbox candidate {cell.candidate_alias!r} differs from the plan snapshot"
+                )
+            if spec.maximum_cost_usd is not None and (
+                not candidate.cost_is_observable or candidate.maximum_call_cost_usd is None
+            ):
+                raise SandboxSimulationError(
+                    "finite sandbox budgets require observable candidate cost and a "
+                    "maximum call cost"
+                )
+            if spec.maximum_cost_usd is not None and (
+                not self._environment_cost.cost_is_observable
+                or self._environment_cost.maximum_episode_cost_usd is None
+            ):
+                raise SandboxSimulationError(
+                    "finite sandbox budgets require observable environment cost and a "
+                    "maximum episode cost"
+                )
+            cells.append(cell)
+        return tuple(cells)
+
+    def _persist_specification(self, spec: SimulationSpec) -> ArtifactInput:
+        """Write or verify the immutable specification before any executable work."""
+        try:
+            manifest = self._store.write_json(
+                artifact_id=spec.simulation_id,
+                artifact_type="simulation-spec",
+                envelope=spec,
+                files={_SPEC_FILE: spec},
+            )
+            return artifact_input(manifest)
+        except ArtifactAlreadyExistsError as exc:
+            stored = self._store.read(spec.simulation_id)
+            try:
+                persisted = SimulationSpec.model_validate_json(
+                    self._store.read_bytes(spec.simulation_id, _SPEC_FILE)
+                )
+            except (ArtifactCorruptionError, ValueError) as error:
+                raise SandboxResumeError("sandbox simulation specification is invalid") from error
+            if stored.manifest.artifact_type != "simulation-spec" or persisted != spec:
+                raise SandboxResumeError(
+                    f"simulation ID {spec.simulation_id!r} already names another specification"
+                ) from exc
+            return artifact_input(stored.manifest)
+
+    def _persist_resolution(
+        self,
+        spec: SimulationSpec,
+        spec_input: ArtifactInput,
+        cells: Sequence[EvaluationCell],
+    ) -> tuple[
+        SandboxSimulationResolution,
+        ArtifactInput,
+        dict[ArtifactId, SandboxSimulationCellBinding],
+    ]:
+        """Persist exact task, candidate, environment, and manifest bindings before execution."""
+        bindings = {
+            cell.cell_id: make_sandbox_cell_binding(
+                spec=spec,
+                simulation_spec_input=spec_input,
+                evaluation_plan_input=self._plan_input,
+                task_set_input=self._task_set_input,
+                task_set=self._task_set,
+                cell=cell,
+                task=self._tasks[cell.task_id],
+                candidate=self._candidates[cell.candidate_alias],
+                environment_cost=self._environment_cost,
+            )
+            for cell in cells
+        }
+        resolution = make_sandbox_resolution(
+            spec=spec,
+            simulation_spec_input=spec_input,
+            evaluation_plan_input=self._plan_input,
+            task_set_input=self._task_set_input,
+            bindings=tuple(bindings[cell.cell_id] for cell in cells),
+            created_at=_timestamp(self._clock),
+        )
+        try:
+            manifest = self._store.write_json(
+                artifact_id=resolution.resolution_id,
+                artifact_type="sandbox-simulation-resolution",
+                envelope=resolution,
+                files={_RESOLUTION_FILE: resolution},
+            )
+            return resolution, artifact_input(manifest), bindings
+        except ArtifactAlreadyExistsError as exc:
+            stored = self._store.read(resolution.resolution_id)
+            try:
+                existing = SandboxSimulationResolution.model_validate_json(
+                    self._store.read_bytes(resolution.resolution_id, _RESOLUTION_FILE)
+                )
+            except (ArtifactCorruptionError, ValueError) as error:
+                raise SandboxResumeError("sandbox simulation resolution is invalid") from error
+            if (
+                stored.manifest.artifact_type != "sandbox-simulation-resolution"
+                or existing.model_copy(update={"created_at": resolution.created_at}) != resolution
+            ):
+                raise SandboxResumeError(
+                    "sandbox aliases, task, environment, or inputs changed after resolution"
+                ) from exc
+            return existing, artifact_input(stored.manifest), bindings
+
+    def _load_completed_rollouts(
+        self,
+        cells: Sequence[EvaluationCell],
+        bindings: Mapping[ArtifactId, SandboxSimulationCellBinding],
+        resolution_input: ArtifactInput,
+    ) -> dict[ArtifactId, RolloutArtifact]:
+        """Load independently completed cells whose exact immutable binding still matches."""
+        completed: dict[ArtifactId, RolloutArtifact] = {}
+        for cell in cells:
+            binding = bindings[cell.cell_id]
+            rollout = self._load_optional_rollout(sandbox_rollout_id(binding))
+            if rollout is not None:
+                self._validate_resume_rollout(rollout, cell, binding, resolution_input)
+                completed[cell.cell_id] = rollout
+        return completed
+
+    def _execute_and_persist_cell(
+        self,
+        spec: SimulationSpec,
+        cell: EvaluationCell,
+        resolution: SandboxSimulationResolution,
+        resolution_input: ArtifactInput,
+        binding: SandboxSimulationCellBinding,
+    ) -> RolloutArtifact:
+        """Claim, execute, and atomically persist one rollout before releasing its lease."""
+        rollout_id = sandbox_rollout_id(binding)
+        existing = self._load_optional_rollout(rollout_id)
+        if existing is not None:
+            self._validate_resume_rollout(existing, cell, binding, resolution_input)
+            return existing
+        try:
+            claim = self._leases.acquire(
+                lease_id=sandbox_lease_id(resolution, binding),
+                resolution_id=resolution.resolution_id,
+                simulation_id=spec.simulation_id,
+                rollout_id=rollout_id,
+                binding_sha256=sandbox_binding_digest(binding),
+                maximum_cost_usd=spec.maximum_cost_usd,
+                rollout_completed=lambda item: self._load_optional_rollout(item) is not None,
+                observed_spend_usd=lambda: self._known_resolution_spend(
+                    resolution.cell_bindings,
+                    resolution_input,
+                ),
+            )
+        except TextCellLeaseError as exc:
+            raise SandboxResumeError(f"sandbox cell {cell.cell_id!r} cannot be admitted") from exc
+        if claim.retryable:
+            raise SandboxContentionError("sandbox cell is contended; retry this run")
+        if claim.state == TextCellLeaseState.COMPLETED:
+            completed = self._load_optional_rollout(rollout_id)
+            if completed is None:
+                raise SandboxResumeError("completed sandbox claim has no readable rollout")
+            self._validate_resume_rollout(completed, cell, binding, resolution_input)
+            return completed
+        if claim.state == TextCellLeaseState.STALE:
+            rollout = self._admission_failure_rollout(
+                spec,
+                cell,
+                binding,
+                resolution_input,
+                phase="paid_cell_stale_lease",
+                message="a prior sandbox cell claim expired; WMO will not replay it",
+                spent=None,
+            )
+            return self._persist_rollout(rollout, cell, binding, resolution_input)
+        if claim.state == TextCellLeaseState.BUDGET_BLOCKED:
+            rollout = self._admission_failure_rollout(
+                spec,
+                cell,
+                binding,
+                resolution_input,
+                phase="paid_cell_admission",
+                message="sandbox spend is unknown or exhausted the finite run ceiling",
+                spent=claim.observed_spend_usd,
+            )
+            return self._persist_rollout(rollout, cell, binding, resolution_input)
+        if claim.lease is None:
+            raise SandboxResumeError("owned sandbox admission omitted its durable lease")
+        remaining = (
+            None
+            if spec.maximum_cost_usd is None
+            else max(0.0, spec.maximum_cost_usd - (claim.observed_spend_usd or 0.0))
+        )
+        environment_reservation = binding.environment_maximum_episode_cost_usd
+        if (
+            remaining is not None
+            and environment_reservation is not None
+            and environment_reservation > remaining
+        ):
+            rollout = self._admission_failure_rollout(
+                spec,
+                cell,
+                binding,
+                resolution_input,
+                phase="environment_cost_admission",
+                message="sandbox environment reservation exceeds the remaining run ceiling",
+                spent=claim.observed_spend_usd,
+            )
+            persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
+            self._leases.release(claim.lease)
+            return persisted
+        rollout = self._execute_cell(spec, cell, binding, resolution_input, remaining)
+        persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
+        self._leases.release(claim.lease)
+        return persisted
+
+    def _known_resolution_spend(
+        self,
+        bindings: Sequence[SandboxSimulationCellBinding],
+        resolution_input: ArtifactInput,
+    ) -> float | None:
+        """Return candidate spend, or unknown when any dispatched model call lacks cost."""
+        total = 0.0
+        cells = {cell.cell_id: cell for cell in self._plan.cells}
+        for binding in bindings:
+            rollout = self._load_optional_rollout(sandbox_rollout_id(binding))
+            if rollout is None:
+                continue
+            cell = cells[binding.cell_id]
+            self._validate_resume_rollout(rollout, cell, binding, resolution_input)
+            spend = _rollout_spend(rollout)
+            if spend is None:
+                return None
+            total += spend
+        return total
+
+    def _execute_cell(
+        self,
+        spec: SimulationSpec,
+        cell: EvaluationCell,
+        binding: SandboxSimulationCellBinding,
+        resolution_input: ArtifactInput,
+        remaining_cost_usd: float | None,
+    ) -> RolloutArtifact:
+        """Execute one bounded customer episode and convert every normal failure into evidence."""
+        started_at = _timestamp(self._clock)
+        started = self._monotonic()
+        candidate = self._candidates[cell.candidate_alias]
+        settings = spec.sandbox
+        if settings is None:  # pragma: no cover - run validation requires sandbox settings
+            raise SandboxSimulationError("sandbox settings are missing")
+        try:
+            episode, evidence = execute_bounded_sandbox_episode(
+                agent_factory=self._agent_factory,
+                task=self._tasks[cell.task_id],
+                candidate=candidate.client,
+                candidate_snapshot=candidate.snapshot,
+                environment_runtime=self._environment_runtime,
+                environment_maximum_episode_cost_usd=(binding.environment_maximum_episode_cost_usd),
+                environment_cost_is_observable=binding.environment_cost_is_observable,
+                maximum_steps=spec.maximum_steps,
+                maximum_time_seconds=settings.maximum_time_seconds,
+                remaining_cost_usd=remaining_cost_usd,
+                maximum_call_cost_usd=candidate.maximum_call_cost_usd,
+                cost_is_observable=candidate.cost_is_observable,
+                clock=self._clock,
+                monotonic=self._monotonic,
+            )
+        except SandboxTimeLimitError as exc:
+            failure = StructuredFailure(
+                code=FailureCode.TIMEOUT,
+                message="sandbox episode could not enforce or exceeded maximum_time_seconds",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.AGENT,
+                details={"phase": "maximum_time"},
+            )
+            episode = AgentEpisode(stop_reason=StopReason.FAILURE, failure=failure)
+            evidence = SandboxExecutionEvidence(
+                candidate_spans=(),
+                environment_spans=(),
+                candidate_economics=OperationEconomics(),
+                sandbox_economics=OperationEconomics(),
+                limit_stop_reason=StopReason.MAXIMUM_TIME,
+                limit_failure=failure,
+            )
+        except Exception as exc:  # noqa: BLE001 - construction failures are cell evidence
+            failure = StructuredFailure(
+                code=FailureCode.INTERNAL,
+                message=f"sandbox agent construction failed with {type(exc).__name__}",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.AGENT,
+                details={"phase": "agent_construction"},
+            )
+            episode = AgentEpisode(stop_reason=StopReason.FAILURE, failure=failure)
+            evidence = SandboxExecutionEvidence(
+                candidate_spans=(),
+                environment_spans=(),
+                candidate_economics=OperationEconomics(),
+                sandbox_economics=OperationEconomics(),
+                limit_stop_reason=None,
+                limit_failure=None,
+            )
+        stop_reason, failure = _terminal_state(episode, evidence)
+        ended_at = _timestamp(self._clock, not_before=started_at)
+        spans = merge_sandbox_spans(episode, evidence)
+        if not spans:
+            spans = (_terminal_span(started_at, ended_at, failure),)
+        return self._make_rollout(
+            spec,
+            cell,
+            binding,
+            resolution_input,
+            stop_reason=stop_reason,
+            failure=failure,
+            final_output=episode.final_action,
+            spans=spans,
+            candidate_economics=evidence.candidate_economics,
+            sandbox_economics=evidence.sandbox_economics,
+            orchestration_economics=_latency_economics(max(0.0, self._monotonic() - started)),
+        )
+
+    def _admission_failure_rollout(
+        self,
+        spec: SimulationSpec,
+        cell: EvaluationCell,
+        binding: SandboxSimulationCellBinding,
+        resolution_input: ArtifactInput,
+        *,
+        phase: str,
+        message: str,
+        spent: float | None,
+    ) -> RolloutArtifact:
+        """Represent a cell rejected before environment or candidate dispatch."""
+        failure = StructuredFailure(
+            code=FailureCode.BUDGET,
+            message=message,
+            attribution=FailureAttribution.MODEL,
+            details={"phase": phase, "observed_spend_usd": spent},
+        )
+        now = _timestamp(self._clock)
+        return self._make_rollout(
+            spec,
+            cell,
+            binding,
+            resolution_input,
+            stop_reason=StopReason.MAXIMUM_COST,
+            failure=failure,
+            final_output=None,
+            spans=(_terminal_span(now, now, failure),),
+            candidate_economics=OperationEconomics(),
+            sandbox_economics=OperationEconomics(),
+            orchestration_economics=_latency_economics(0.0),
+        )
+
+    def _make_rollout(
+        self,
+        spec: SimulationSpec,
+        cell: EvaluationCell,
+        binding: SandboxSimulationCellBinding,
+        resolution_input: ArtifactInput,
+        *,
+        stop_reason: StopReason,
+        failure: StructuredFailure | None,
+        final_output: AssistantAction | None,
+        spans: tuple[RolloutSpan, ...],
+        candidate_economics: OperationEconomics,
+        sandbox_economics: OperationEconomics,
+        orchestration_economics: OperationEconomics,
+    ) -> RolloutArtifact:
+        """Compose one canonical sandbox rollout from exact binding and runtime evidence."""
+        rollout_id = sandbox_rollout_id(binding)
+        return RolloutArtifact(
+            schema_version=1,
+            created_at=_timestamp(self._clock),
+            inputs=_sorted_inputs(
+                self._plan_input,
+                self._task_set_input,
+                binding.simulation_spec_input,
+                resolution_input,
+            ),
+            code_revision=spec.code_revision,
+            artifact_id=rollout_id,
+            simulation_id=spec.simulation_id,
+            cell_id=cell.cell_id,
+            mode=SimulationMode.SANDBOX,
+            rollout_id=rollout_id,
+            trace_id=hashlib.sha256(sandbox_binding_digest(binding).encode()).hexdigest()[:32],
+            evidence_source="sandbox",
+            source_run_id=self._source_run_id,
+            task_id=cell.task_id,
+            candidate=binding.candidate,
+            agent_id=spec.agent_id,
+            simulator=SandboxSimulatorSnapshot(
+                simulator_id=SANDBOX_SIMULATOR_ID,
+                environment_id=binding.environment_id,
+                environment_sha256=binding.environment_sha256,
+            ),
+            seed=spec.seed,
+            repeat=cell.repeat,
+            spans=spans,
+            final_output=final_output,
+            stop_reason=stop_reason,
+            failure=failure,
+            candidate_economics=candidate_economics,
+            sandbox_economics=sandbox_economics,
+            orchestration_economics=orchestration_economics,
+            simulation_spec_sha256=binding.simulation_spec_sha256,
+            sandbox_binding=binding,
+        )
+
+    def _persist_rollout(
+        self,
+        rollout: RolloutArtifact,
+        cell: EvaluationCell,
+        binding: SandboxSimulationCellBinding,
+        resolution_input: ArtifactInput,
+    ) -> RolloutArtifact:
+        """Persist one cell atomically and accept only an exactly bound completed counterpart."""
+        try:
+            self._store.write_json(
+                artifact_id=rollout.artifact_id,
+                artifact_type="rollout",
+                envelope=rollout,
+                files={_ROLLOUT_FILE: rollout},
+            )
+            return rollout
+        except ArtifactAlreadyExistsError:
+            existing = self._load_rollout(rollout.artifact_id)
+            self._validate_resume_rollout(existing, cell, binding, resolution_input)
+            return existing
+
+    def _load_rollout(self, rollout_id: ArtifactId) -> RolloutArtifact:
+        """Load one verified canonical rollout artifact."""
+        stored = self._store.read(rollout_id)
+        if stored.manifest.artifact_type != "rollout":
+            raise ArtifactCorruptionError(f"artifact {rollout_id!r} is not a rollout")
+        try:
+            return RolloutArtifact.model_validate_json(
+                self._store.read_bytes(rollout_id, _ROLLOUT_FILE)
+            )
+        except (ArtifactCorruptionError, ValueError) as exc:
+            raise ArtifactCorruptionError(f"sandbox rollout {rollout_id!r} is invalid") from exc
+
+    def _load_optional_rollout(self, rollout_id: ArtifactId) -> RolloutArtifact | None:
+        """Load a completed rollout while distinguishing absence from immutable corruption."""
+        if rollout_id not in self._store.list_ids():
+            return None
+        return self._load_rollout(rollout_id)
+
+    def _validate_resume_rollout(
+        self,
+        rollout: RolloutArtifact,
+        cell: EvaluationCell,
+        binding: SandboxSimulationCellBinding,
+        resolution_input: ArtifactInput,
+    ) -> None:
+        """Require every resumed cell to match its exact task, model, environment, and inputs."""
+        expected_inputs = _sorted_inputs(
+            self._plan_input,
+            self._task_set_input,
+            binding.simulation_spec_input,
+            resolution_input,
+        )
+        if (
+            binding.cell_id != cell.cell_id
+            or binding.task_id != cell.task_id
+            or binding.purpose != cell.purpose
+            or rollout.cell_id != cell.cell_id
+            or rollout.task_id != cell.task_id
+            or rollout.mode != SimulationMode.SANDBOX
+            or rollout.artifact_id != sandbox_rollout_id(binding)
+            or rollout.rollout_id != sandbox_rollout_id(binding)
+            or rollout.sandbox_binding != binding
+            or rollout.inputs != expected_inputs
+        ):
+            raise SandboxResumeError(
+                f"stored rollout {rollout.artifact_id!r} does not match its sandbox cell"
+            )
+
+    def _persist_artifact_set(
+        self,
+        spec: SimulationSpec,
+        spec_input: ArtifactInput,
+        resolution_input: ArtifactInput,
+        rollouts: Sequence[RolloutArtifact],
+    ) -> SimulationArtifactSet:
+        """Write or verify the terminal index after every per-cell artifact is durable."""
+        artifact_ids = tuple(rollout.artifact_id for rollout in rollouts)
+        payload = _jsonl_bytes(tuple({"artifact_id": item} for item in artifact_ids))
+        artifact_set_id = stable_id(
+            "simulation-artifact-set",
+            {"simulation_id": spec.simulation_id, "artifact_ids": artifact_ids},
+        )
+        artifact_set = SimulationArtifactSet(
+            schema_version=1,
+            created_at=_timestamp(self._clock),
+            inputs=_sorted_inputs(
+                self._plan_input,
+                self._task_set_input,
+                spec_input,
+                resolution_input,
+            ),
+            code_revision=spec.code_revision,
+            artifact_set_id=artifact_set_id,
+            simulation_id=spec.simulation_id,
+            artifact_ids=artifact_ids,
+            artifacts_path=_ARTIFACT_IDS_FILE,
+            artifacts_sha256=hashlib.sha256(payload).hexdigest(),
+        )
+        try:
+            self._store.write(
+                artifact_id=artifact_set_id,
+                artifact_type="simulation-artifact-set",
+                envelope=artifact_set,
+                files={
+                    _ARTIFACT_SET_FILE: canonical_json_bytes(artifact_set),
+                    _ARTIFACT_IDS_FILE: payload,
+                },
+            )
+            return artifact_set
+        except ArtifactAlreadyExistsError as exc:
+            stored = self._store.read(artifact_set_id)
+            try:
+                existing = SimulationArtifactSet.model_validate_json(
+                    self._store.read_bytes(artifact_set_id, _ARTIFACT_SET_FILE)
+                )
+            except (ArtifactCorruptionError, ValueError) as error:
+                raise SandboxResumeError("sandbox artifact set is invalid") from error
+            same_content = (
+                existing.model_copy(update={"created_at": artifact_set.created_at}) == artifact_set
+            )
+            if stored.manifest.artifact_type != "simulation-artifact-set" or not same_content:
+                raise SandboxResumeError(
+                    f"artifact set ID {artifact_set_id!r} names different rollout evidence"
+                ) from exc
+            return existing
+
+
+def _terminal_state(
+    episode: AgentEpisode,
+    evidence: SandboxExecutionEvidence,
+) -> tuple[StopReason, StructuredFailure | None]:
+    """Prefer an enforced limit while retaining ordinary agent and cleanup terminal evidence."""
+    if episode.failure is not None and episode.failure.attribution == FailureAttribution.CLEANUP:
+        return StopReason.FAILURE, episode.failure
+    if evidence.limit_stop_reason is not None:
+        return evidence.limit_stop_reason, evidence.limit_failure or episode.failure
+    failure = episode.failure
+    if failure is not None:
+        names = {
+            "SandboxStepLimitError": StopReason.MAXIMUM_STEPS,
+            "SandboxTimeLimitError": StopReason.MAXIMUM_TIME,
+            "SandboxCostLimitError": StopReason.MAXIMUM_COST,
+            "SandboxUnknownCostError": StopReason.MAXIMUM_COST,
+        }
+        mapped = names.get(failure.exception_type or "")
+        if mapped is not None:
+            return mapped, failure
+    return episode.stop_reason, failure
+
+
+def _rollout_spend(rollout: RolloutArtifact) -> float | None:
+    """Return candidate plus sandbox spend without treating unknown cost as zero."""
+    if rollout.failure is not None and (
+        rollout.failure.details.get("provider_dispatch_unknown_spend") is True
+        or rollout.failure.details.get("environment_dispatch_unknown_spend") is True
+        or rollout.failure.details.get("phase") == "paid_cell_stale_lease"
+    ):
+        return None
+    total = 0.0
+    made_candidate_call = any(
+        span.kind == RolloutEventKind.AGENT_MODEL_CALL for span in rollout.spans
+    )
+    if made_candidate_call:
+        candidate_cost = rollout.candidate_economics.cost_usd
+        if candidate_cost is None:
+            return None
+        total += candidate_cost.value
+    binding = rollout.sandbox_binding
+    if binding is None:
+        return None
+    if binding.environment_maximum_episode_cost_usd == 0:
+        return total
+    sandbox_cost = rollout.sandbox_economics.cost_usd if rollout.sandbox_economics else None
+    if sandbox_cost is None:
+        return None
+    return total + sandbox_cost.value
+
+
+def _terminal_span(
+    started_at: datetime,
+    ended_at: datetime,
+    failure: StructuredFailure | None,
+) -> RolloutSpan:
+    """Create minimum lifecycle evidence for an episode with no operation-level events."""
+    return RolloutSpan(
+        span_id="sandbox-terminal",
+        kind=RolloutEventKind.LIFECYCLE,
+        started_at=started_at,
+        ended_at=ended_at,
+        payload={"phase": "terminal"},
+        failure=failure,
+    )
+
+
+def _latency_economics(duration_seconds: float) -> OperationEconomics:
+    """Record directly observed orchestration time without manufacturing cost."""
+    return OperationEconomics(
+        latency_seconds=NumericMeasurement(value=duration_seconds, provenance="observed")
+    )
+
+
+def _sorted_inputs(*inputs: ArtifactInput) -> tuple[ArtifactInput, ...]:
+    """Return one exact immutable input per artifact ID in stable order."""
+    by_id = {item.artifact_id: item for item in inputs}
+    if len(by_id) != len(inputs):
+        raise SandboxSimulationError("sandbox artifact inputs must have distinct IDs")
+    return tuple(by_id[item] for item in sorted(by_id))
+
+
+def _jsonl_bytes(records: Sequence[Mapping[str, str]]) -> bytes:
+    """Render deterministic small JSONL artifact-index records."""
+    payload = b"\n".join(canonical_json_bytes(dict(record)) for record in records)
+    return payload + (b"\n" if payload else b"")
+
+
+def _timestamp(
+    clock: Callable[[], datetime],
+    *,
+    not_before: datetime | None = None,
+) -> datetime:
+    """Return an aware timestamp that cannot precede an earlier event."""
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("sandbox simulation clock must return timezone-aware datetimes")
+    return not_before if not_before is not None and value < not_before else value
+
+
+def _utc_now() -> datetime:
+    """Return the current aware UTC timestamp."""
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "CandidateBinding",
+    "EnvironmentCostBinding",
+    "SandboxContentionError",
+    "SandboxResumeError",
+    "SandboxSimulationError",
+    "SandboxSimulator",
+]

--- a/wmo/simulation/engines/sandbox.py
+++ b/wmo/simulation/engines/sandbox.py
@@ -53,6 +53,7 @@ from wmo.simulation.engines.sandbox_recording import (
     SandboxTimeLimitError,
     execute_bounded_sandbox_episode,
     merge_sandbox_spans,
+    require_hard_wall_timeout_support,
 )
 from wmo.simulation.engines.text.leases import (
     TextCellLeaseError,
@@ -161,6 +162,12 @@ class SandboxSimulator:
         """
         require_implemented_mode(spec, SimulationMode.SANDBOX)
         cells = self._validate_spec_and_bindings(spec)
+        try:
+            require_hard_wall_timeout_support()
+        except SandboxTimeLimitError as exc:
+            raise SandboxSimulationError(
+                "sandbox simulation cannot start without enforceable hard wall-time limits"
+            ) from exc
         spec_input = self._persist_specification(spec)
         resolution, resolution_input, bindings = self._persist_resolution(
             spec,
@@ -452,33 +459,33 @@ class SandboxSimulator:
             return self._persist_rollout(rollout, cell, binding, resolution_input)
         if claim.lease is None:
             raise SandboxResumeError("owned sandbox admission omitted its durable lease")
+        lease = claim.lease
         remaining = (
             None
             if spec.maximum_cost_usd is None
             else max(0.0, spec.maximum_cost_usd - (claim.observed_spend_usd or 0.0))
         )
         environment_reservation = binding.environment_maximum_episode_cost_usd
-        if (
-            remaining is not None
-            and environment_reservation is not None
-            and environment_reservation > remaining
-        ):
-            rollout = self._admission_failure_rollout(
-                spec,
-                cell,
-                binding,
-                resolution_input,
-                phase="environment_cost_admission",
-                message="sandbox environment reservation exceeds the remaining run ceiling",
-                spent=claim.observed_spend_usd,
-            )
-            persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
-            self._leases.release(claim.lease)
-            return persisted
-        rollout = self._execute_cell(spec, cell, binding, resolution_input, remaining)
-        persisted = self._persist_rollout(rollout, cell, binding, resolution_input)
-        self._leases.release(claim.lease)
-        return persisted
+        try:
+            if (
+                remaining is not None
+                and environment_reservation is not None
+                and environment_reservation > remaining
+            ):
+                rollout = self._admission_failure_rollout(
+                    spec,
+                    cell,
+                    binding,
+                    resolution_input,
+                    phase="environment_cost_admission",
+                    message="sandbox environment reservation exceeds the remaining run ceiling",
+                    spent=claim.observed_spend_usd,
+                )
+            else:
+                rollout = self._execute_cell(spec, cell, binding, resolution_input, remaining)
+            return self._persist_rollout(rollout, cell, binding, resolution_input)
+        finally:
+            self._leases.release(lease)
 
     def _known_resolution_spend(
         self,

--- a/wmo/simulation/engines/sandbox_bindings.py
+++ b/wmo/simulation/engines/sandbox_bindings.py
@@ -1,0 +1,243 @@
+"""Immutable task, model, environment, and artifact bindings for sandbox cells."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
+
+from pydantic import Field, field_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    JsonValue,
+    Sha256,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.evaluations import EvaluationCell
+from wmo.common.models import ModelAlias, ModelClient, ModelSnapshot
+from wmo.common.rollouts import SandboxSimulationCellBinding
+from wmo.common.tasks import TaskCase, TaskSet
+from wmo.simulation.specs import SimulationSpec
+
+SANDBOX_SIMULATOR_ID = "sandbox-v1"
+
+
+@dataclass(frozen=True)
+class CandidateBinding:
+    """One candidate alias bound to a client, snapshot, and optional strict call reservation.
+
+    Args:
+        alias: Stable candidate alias selected by evaluation cells.
+        client: Resolved model client injected into the customer agent.
+        snapshot: Exact provider and model identity pinned by the evaluation plan.
+        maximum_call_cost_usd: Proven upper bound for one candidate request. A finite run budget
+            requires this value so admission can stop before dispatch instead of overspending.
+        cost_is_observable: Whether successful responses are contractually guaranteed to report
+            cost. Finite-budget runs reject candidates without this capability before dispatch.
+    """
+
+    alias: ModelAlias
+    client: ModelClient
+    snapshot: ModelSnapshot
+    maximum_call_cost_usd: float | None = None
+    cost_is_observable: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject a nonpositive or nonfinite call reservation before provider work."""
+        value = self.maximum_call_cost_usd
+        if value is not None and (not math.isfinite(value) or value <= 0):
+            raise ValueError("candidate maximum_call_cost_usd must be finite and positive")
+
+
+@dataclass(frozen=True)
+class EnvironmentCostBinding:
+    """Preflight facts needed to enforce one finite environment budget.
+
+    Args:
+        maximum_episode_cost_usd: Proven upper bound for opening, using, and cleaning one
+            environment. Zero explicitly proves the runtime has no billed sandbox cost.
+        cost_is_observable: Whether nonzero environment cost is guaranteed to reach canonical
+            observation economics. A finite run rejects an environment without this capability.
+    """
+
+    maximum_episode_cost_usd: float | None = None
+    cost_is_observable: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject a negative or nonfinite environment reservation."""
+        value = self.maximum_episode_cost_usd
+        if value is not None and (not math.isfinite(value) or value < 0):
+            raise ValueError("environment maximum_episode_cost_usd must be finite and nonnegative")
+
+
+class SandboxSimulationResolution(ArtifactEnvelope):
+    """One frozen resolution of all executable cell aliases and evidence inputs."""
+
+    resolution_id: ArtifactId
+    simulation_id: ArtifactId
+    simulation_spec_sha256: Sha256
+    simulation_spec_input: ArtifactInput
+    cell_bindings: tuple[SandboxSimulationCellBinding, ...] = Field(min_length=1)
+
+    @field_validator("cell_bindings")
+    @classmethod
+    def _require_unique_cells(
+        cls,
+        value: tuple[SandboxSimulationCellBinding, ...],
+    ) -> tuple[SandboxSimulationCellBinding, ...]:
+        """Reject duplicate IDs or task, candidate, repeat, and purpose coordinates."""
+        cell_ids = tuple(binding.cell_id for binding in value)
+        if len(set(cell_ids)) != len(cell_ids):
+            raise ValueError("sandbox resolution cell IDs must be unique")
+        coordinates = tuple(
+            (
+                binding.task_id,
+                binding.candidate_alias,
+                binding.repeat,
+                binding.purpose,
+            )
+            for binding in value
+        )
+        if len(set(coordinates)) != len(coordinates):
+            raise ValueError("sandbox resolution must not repeat a bound evaluation cell")
+        return value
+
+
+def make_sandbox_cell_binding(
+    *,
+    spec: SimulationSpec,
+    simulation_spec_input: ArtifactInput,
+    evaluation_plan_input: ArtifactInput,
+    task_set_input: ArtifactInput,
+    task_set: TaskSet,
+    cell: EvaluationCell,
+    task: TaskCase,
+    candidate: CandidateBinding,
+    environment_cost: EnvironmentCostBinding,
+) -> SandboxSimulationCellBinding:
+    """Bind one selected cell to immutable task, candidate, environment, and spec identity.
+
+    Args:
+        spec: Persisted sandbox specification being executed.
+        simulation_spec_input: Exact manifest identity for the persisted specification.
+        evaluation_plan_input: Exact manifest identity for the evaluation plan.
+        task_set_input: Exact manifest identity for the selected task set.
+        task_set: Digest-bearing task-set envelope that owns ``task``.
+        cell: Explicit simulated plan cell.
+        task: Canonical task selected by the cell.
+        candidate: Resolved candidate identity and optional strict cost reservation.
+
+    Returns:
+        Complete identity used for rollout IDs, leases, and resume validation.
+
+    Raises:
+        ValueError: The specification does not retain sandbox settings.
+    """
+    settings = spec.sandbox
+    if settings is None:  # pragma: no cover - the concrete simulator validates its mode first
+        raise ValueError("sandbox simulation binding requires sandbox settings")
+    return SandboxSimulationCellBinding(
+        cell_id=cell.cell_id,
+        task_id=cell.task_id,
+        purpose=cell.purpose,
+        evaluation_plan_input=evaluation_plan_input,
+        task_set_input=task_set_input,
+        task_set_tasks_sha256=task_set.tasks_sha256,
+        task_sha256=sha256_json(task),
+        task_lineage_group_id=task.lineage_group_id,
+        candidate_alias=cell.candidate_alias,
+        candidate=candidate.snapshot,
+        candidate_maximum_call_cost_usd=candidate.maximum_call_cost_usd,
+        candidate_cost_is_observable=candidate.cost_is_observable,
+        environment_maximum_episode_cost_usd=environment_cost.maximum_episode_cost_usd,
+        environment_cost_is_observable=environment_cost.cost_is_observable,
+        agent_id=spec.agent_id,
+        repeat=cell.repeat,
+        simulator_id=SANDBOX_SIMULATOR_ID,
+        environment_id=settings.environment_id,
+        environment_sha256=settings.environment_sha256,
+        simulation_spec_input=simulation_spec_input,
+        simulation_spec_sha256=sha256_json(spec),
+        simulation_inputs_sha256=sha256_json(
+            cast(JsonValue, [item.model_dump(mode="json") for item in spec.inputs])
+        ),
+    )
+
+
+def make_sandbox_resolution(
+    *,
+    spec: SimulationSpec,
+    simulation_spec_input: ArtifactInput,
+    evaluation_plan_input: ArtifactInput,
+    task_set_input: ArtifactInput,
+    bindings: Sequence[SandboxSimulationCellBinding],
+    created_at: datetime,
+) -> SandboxSimulationResolution:
+    """Build one collision-detecting immutable sandbox resolution artifact.
+
+    Args:
+        spec: Persisted sandbox specification being executed.
+        simulation_spec_input: Exact manifest identity for the persisted specification.
+        evaluation_plan_input: Exact manifest identity for the evaluation plan.
+        task_set_input: Exact manifest identity for the selected task set.
+        bindings: Immutable executable bindings selected for the simulation cells.
+        created_at: Timestamp recorded in the resolution envelope.
+
+    Returns:
+        Immutable resolution that binds all selected cells to their exact inputs.
+    """
+    spec_digest = sha256_json(spec)
+    resolution_id = stable_id(
+        "sandbox-simulation-resolution",
+        {
+            "simulation_id": spec.simulation_id,
+            "simulation_spec_sha256": spec_digest,
+            "simulation_spec_input": simulation_spec_input.model_dump(mode="json"),
+        },
+    )
+    return SandboxSimulationResolution(
+        schema_version=1,
+        created_at=created_at,
+        inputs=tuple(
+            sorted(
+                (evaluation_plan_input, task_set_input, simulation_spec_input),
+                key=lambda item: item.artifact_id,
+            )
+        ),
+        code_revision=spec.code_revision,
+        resolution_id=resolution_id,
+        simulation_id=spec.simulation_id,
+        simulation_spec_sha256=spec_digest,
+        simulation_spec_input=simulation_spec_input,
+        cell_bindings=tuple(bindings),
+    )
+
+
+def sandbox_binding_digest(binding: SandboxSimulationCellBinding) -> Sha256:
+    """Return the complete immutable digest for one executable cell binding."""
+    return sha256_json(binding)
+
+
+def sandbox_rollout_id(binding: SandboxSimulationCellBinding) -> ArtifactId:
+    """Return the deterministic rollout artifact ID for one exact sandbox binding."""
+    return stable_id("rollout", {"sandbox_binding_sha256": sandbox_binding_digest(binding)})
+
+
+def sandbox_lease_id(
+    resolution: SandboxSimulationResolution,
+    binding: SandboxSimulationCellBinding,
+) -> ArtifactId:
+    """Return the durable in-flight claim ID for one exact executable cell."""
+    return stable_id(
+        "sandbox-cell-lease",
+        {
+            "resolution_id": resolution.resolution_id,
+            "binding_sha256": sandbox_binding_digest(binding),
+        },
+    )

--- a/wmo/simulation/engines/sandbox_recording.py
+++ b/wmo/simulation/engines/sandbox_recording.py
@@ -155,6 +155,7 @@ def execute_bounded_sandbox_episode(
     remaining_cost_usd: float | None,
     maximum_call_cost_usd: float | None,
     cost_is_observable: bool,
+    record_dispatch_intent: Callable[[], None],
     clock: Callable[[], datetime] | None = None,
     monotonic: Callable[[], float] = time.monotonic,
 ) -> tuple[AgentEpisode, SandboxExecutionEvidence]:
@@ -173,6 +174,8 @@ def execute_bounded_sandbox_episode(
         remaining_cost_usd: Remaining run budget, or ``None`` for an unbounded run.
         maximum_call_cost_usd: Proven upper bound reserved before each candidate dispatch.
         cost_is_observable: Whether responses must report exact or estimated finite cost.
+        record_dispatch_intent: Fsync-backed callback invoked immediately before each external
+            candidate or environment dispatch may begin.
         clock: Aware event clock.
         monotonic: Monotonic deadline and latency clock.
 
@@ -213,12 +216,14 @@ def execute_bounded_sandbox_episode(
         maximum_call_cost_usd=maximum_call_cost_usd,
         clock=event_clock,
         monotonic=monotonic,
+        record_dispatch_intent=record_dispatch_intent,
     )
     environment = _RecordingEnvironmentRuntime(
         environment_runtime,
         deadline=deadline,
         clock=event_clock,
         monotonic=monotonic,
+        record_dispatch_intent=record_dispatch_intent,
     )
     with _hard_wall_timeout(deadline):
         agent = agent_factory()
@@ -267,6 +272,7 @@ class _RecordingCandidateClient:
         maximum_call_cost_usd: float | None,
         clock: Callable[[], datetime],
         monotonic: Callable[[], float],
+        record_dispatch_intent: Callable[[], None],
     ) -> None:
         self._client = client
         self._snapshot = snapshot
@@ -276,6 +282,7 @@ class _RecordingCandidateClient:
         self._maximum_call_cost_usd = maximum_call_cost_usd
         self._clock = clock
         self._monotonic = monotonic
+        self._record_dispatch_intent = record_dispatch_intent
         self._calls = 0
         self._spent = 0.0
         self.spans: list[RolloutSpan] = []
@@ -310,6 +317,7 @@ class _RecordingCandidateClient:
         self._calls += 1
         started_at = _timestamp(self._clock)
         started = self._monotonic()
+        self._record_dispatch_intent()
         try:
             response = self._client.complete(request)
         except Exception as exc:
@@ -404,11 +412,13 @@ class _RecordingEnvironmentRuntime:
         deadline: _Deadline,
         clock: Callable[[], datetime],
         monotonic: Callable[[], float],
+        record_dispatch_intent: Callable[[], None],
     ) -> None:
         self._runtime = runtime
         self._deadline = deadline
         self._clock = clock
         self._monotonic = monotonic
+        self._record_dispatch_intent = record_dispatch_intent
         self.spans: list[RolloutSpan] = []
         self.economics: list[OperationEconomics] = []
         self.limit_stop_reason: StopReason | None = None
@@ -417,6 +427,7 @@ class _RecordingEnvironmentRuntime:
     def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
         """Open the underlying session through one evidence-recording context."""
         self._deadline.remaining()
+        self._record_dispatch_intent()
         return _RecordingEnvironmentContext(self, self._runtime.open(task))
 
 
@@ -489,6 +500,7 @@ class _RecordingEnvironmentSession:
         self._index += 1
         started_at = _timestamp(self._owner._clock)
         started = self._owner._monotonic()
+        self._owner._record_dispatch_intent()
         try:
             observation = self._session.execute(action)
         except Exception as exc:

--- a/wmo/simulation/engines/sandbox_recording.py
+++ b/wmo/simulation/engines/sandbox_recording.py
@@ -1,0 +1,784 @@
+"""Bounded model and environment recording for executable sandbox episodes."""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+import time
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from types import TracebackType
+
+from wmo.common.core.artifacts import (
+    FailureAttribution,
+    FailureCode,
+    JsonObject,
+    StructuredFailure,
+)
+from wmo.common.models import (
+    ModelClient,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    NumericMeasurement,
+    OperationEconomics,
+    ToolCall,
+    Usage,
+)
+from wmo.common.rollouts import RolloutEventKind, RolloutSpan, StopReason
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents import AgentEpisode, AgentRuntime
+from wmo.runtime.agents.lifecycle import execute_agent_episode
+from wmo.runtime.environments import EnvironmentRuntime, EnvironmentSession, Observation
+
+
+class SandboxStepLimitError(RuntimeError):
+    """The customer agent attempted another model turn after the exact step limit."""
+
+
+class SandboxTimeLimitError(TimeoutError):
+    """The complete executable episode crossed its configured wall-clock limit."""
+
+
+class SandboxCostLimitError(RuntimeError):
+    """A candidate request could not be admitted under the remaining finite spend ceiling."""
+
+
+class SandboxUnknownCostError(RuntimeError):
+    """A dispatched candidate request returned without the required finite cost evidence."""
+
+
+@dataclass(frozen=True)
+class SandboxExecutionEvidence:
+    """Recorded candidate calls, tool transcript, economics, and enforced terminal limit."""
+
+    candidate_spans: tuple[RolloutSpan, ...]
+    environment_spans: tuple[RolloutSpan, ...]
+    candidate_economics: OperationEconomics
+    sandbox_economics: OperationEconomics
+    limit_stop_reason: StopReason | None
+    limit_failure: StructuredFailure | None
+
+
+def _enforce_finite_cost_evidence(
+    evidence: SandboxExecutionEvidence,
+    *,
+    remaining_cost_usd: float | None,
+    environment_maximum_episode_cost_usd: float | None,
+) -> SandboxExecutionEvidence:
+    """Fail closed when any dispatched candidate or environment spend is unknown or unsafe."""
+    if remaining_cost_usd is None or evidence.limit_stop_reason is not None:
+        return evidence
+    if environment_maximum_episode_cost_usd is None:  # pragma: no cover - preflight requires it
+        raise ValueError("finite sandbox cost enforcement requires an environment reservation")
+    made_candidate_call = bool(evidence.candidate_spans)
+    candidate_cost = evidence.candidate_economics.cost_usd
+    if made_candidate_call and candidate_cost is None:
+        failure = _limit_failure(
+            FailureCode.BUDGET,
+            "candidate dispatch has unknown spend under a finite sandbox budget",
+            SandboxUnknownCostError,
+            "candidate_cost_unknown",
+            provider_dispatch_unknown_spend=True,
+        )
+        return replace(
+            evidence,
+            limit_stop_reason=StopReason.MAXIMUM_COST,
+            limit_failure=failure,
+        )
+    sandbox_cost = evidence.sandbox_economics.cost_usd
+    if environment_maximum_episode_cost_usd == 0:
+        environment_spend = 0.0
+        if sandbox_cost is not None and sandbox_cost.value != 0:
+            failure = _environment_cost_failure(
+                "sandbox environment reported cost inconsistent with its zero-cost proof",
+                "environment_cost_bound",
+                unknown_spend=sandbox_cost.value < 0,
+            )
+            return replace(
+                evidence,
+                limit_stop_reason=StopReason.MAXIMUM_COST,
+                limit_failure=failure,
+            )
+    elif sandbox_cost is None:
+        failure = _environment_cost_failure(
+            "sandbox environment omitted cost required by a finite run budget",
+            "environment_cost_unknown",
+            unknown_spend=True,
+        )
+        return replace(
+            evidence,
+            limit_stop_reason=StopReason.MAXIMUM_COST,
+            limit_failure=failure,
+        )
+    else:
+        environment_spend = sandbox_cost.value
+        if environment_spend < 0 or environment_spend > environment_maximum_episode_cost_usd:
+            failure = _environment_cost_failure(
+                "sandbox environment cost exceeded its proven episode reservation",
+                "environment_cost_bound",
+                unknown_spend=environment_spend < 0,
+            )
+            return replace(
+                evidence,
+                limit_stop_reason=StopReason.MAXIMUM_COST,
+                limit_failure=failure,
+            )
+    total = (candidate_cost.value if candidate_cost is not None else 0.0) + environment_spend
+    if total > remaining_cost_usd:
+        failure = _environment_cost_failure(
+            "candidate and sandbox cost exceeded the remaining run budget",
+            "maximum_cost",
+        )
+        return replace(
+            evidence,
+            limit_stop_reason=StopReason.MAXIMUM_COST,
+            limit_failure=failure,
+        )
+    return evidence
+
+
+def execute_bounded_sandbox_episode(
+    *,
+    agent_factory: Callable[[], AgentRuntime],
+    task: TaskCase,
+    candidate: ModelClient,
+    candidate_snapshot: ModelSnapshot,
+    environment_runtime: EnvironmentRuntime,
+    environment_maximum_episode_cost_usd: float | None,
+    environment_cost_is_observable: bool,
+    maximum_steps: int,
+    maximum_time_seconds: float,
+    remaining_cost_usd: float | None,
+    maximum_call_cost_usd: float | None,
+    cost_is_observable: bool,
+    clock: Callable[[], datetime] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> tuple[AgentEpisode, SandboxExecutionEvidence]:
+    """Run one customer episode with hard turn, wall-time, and finite-cost boundaries.
+
+    Args:
+        agent_factory: Creates the fresh customer agent inside the hard episode deadline.
+        task: Canonical executable task.
+        candidate: Resolved candidate model client.
+        candidate_snapshot: Exact candidate identity pinned by the evaluation plan.
+        environment_runtime: Simulator-owned executable environment factory.
+        environment_maximum_episode_cost_usd: Proven whole-episode environment reservation.
+        environment_cost_is_observable: Whether nonzero environment spend reaches observations.
+        maximum_steps: Maximum candidate model calls admitted for the episode.
+        maximum_time_seconds: Hard wall-clock bound for the whole lifecycle and cleanup path.
+        remaining_cost_usd: Remaining run budget, or ``None`` for an unbounded run.
+        maximum_call_cost_usd: Proven upper bound reserved before each candidate dispatch.
+        cost_is_observable: Whether responses must report exact or estimated finite cost.
+        clock: Aware event clock.
+        monotonic: Monotonic deadline and latency clock.
+
+    Returns:
+        The canonical agent episode plus independently recorded execution evidence.
+
+    Raises:
+        ValueError: A finite budget lacks a safe call reservation or observable cost capability.
+        SandboxTimeLimitError: The platform cannot install a hard wall timer in this thread.
+    """
+    if remaining_cost_usd is not None:
+        if maximum_call_cost_usd is None or not cost_is_observable:
+            raise ValueError(
+                "finite sandbox budgets require observable candidate cost and a maximum call cost"
+            )
+        if environment_maximum_episode_cost_usd is None or not environment_cost_is_observable:
+            raise ValueError(
+                "finite sandbox budgets require observable environment cost and a maximum "
+                "episode cost"
+            )
+        if environment_maximum_episode_cost_usd > remaining_cost_usd:
+            raise SandboxCostLimitError(
+                "environment reservation exceeds the remaining sandbox budget"
+            )
+    candidate_remaining_cost_usd = (
+        None
+        if remaining_cost_usd is None
+        else remaining_cost_usd - (environment_maximum_episode_cost_usd or 0.0)
+    )
+    event_clock = clock or _utc_now
+    deadline = _Deadline(maximum_time_seconds, monotonic)
+    model = _RecordingCandidateClient(
+        candidate,
+        candidate_snapshot,
+        maximum_steps=maximum_steps,
+        deadline=deadline,
+        remaining_cost_usd=candidate_remaining_cost_usd,
+        maximum_call_cost_usd=maximum_call_cost_usd,
+        clock=event_clock,
+        monotonic=monotonic,
+    )
+    environment = _RecordingEnvironmentRuntime(
+        environment_runtime,
+        deadline=deadline,
+        clock=event_clock,
+        monotonic=monotonic,
+    )
+    with _hard_wall_timeout(deadline):
+        agent = agent_factory()
+        episode = execute_agent_episode(agent, environment, task, model)
+    evidence = SandboxExecutionEvidence(
+        candidate_spans=tuple(model.spans),
+        environment_spans=tuple(environment.spans),
+        candidate_economics=_combine_economics(model.economics),
+        sandbox_economics=_combine_economics(environment.economics),
+        limit_stop_reason=model.limit_stop_reason or environment.limit_stop_reason,
+        limit_failure=model.limit_failure or environment.limit_failure,
+    )
+    return episode, _enforce_finite_cost_evidence(
+        evidence,
+        remaining_cost_usd=remaining_cost_usd,
+        environment_maximum_episode_cost_usd=environment_maximum_episode_cost_usd,
+    )
+
+
+class _Deadline:
+    """One monotonic per-episode deadline shared by every runtime boundary."""
+
+    def __init__(self, maximum_time_seconds: float, monotonic: Callable[[], float]) -> None:
+        self._monotonic = monotonic
+        self._deadline = monotonic() + maximum_time_seconds
+
+    def remaining(self) -> float:
+        """Return positive remaining time or raise the terminal time-limit error."""
+        remaining = self._deadline - self._monotonic()
+        if remaining <= 0:
+            raise SandboxTimeLimitError("sandbox episode exceeded maximum_time_seconds")
+        return remaining
+
+
+class _RecordingCandidateClient:
+    """Record candidate evidence and stop before unsafe turn or finite-cost dispatch."""
+
+    def __init__(
+        self,
+        client: ModelClient,
+        snapshot: ModelSnapshot,
+        *,
+        maximum_steps: int,
+        deadline: _Deadline,
+        remaining_cost_usd: float | None,
+        maximum_call_cost_usd: float | None,
+        clock: Callable[[], datetime],
+        monotonic: Callable[[], float],
+    ) -> None:
+        self._client = client
+        self._snapshot = snapshot
+        self._maximum_steps = maximum_steps
+        self._deadline = deadline
+        self._remaining_cost_usd = remaining_cost_usd
+        self._maximum_call_cost_usd = maximum_call_cost_usd
+        self._clock = clock
+        self._monotonic = monotonic
+        self._calls = 0
+        self._spent = 0.0
+        self.spans: list[RolloutSpan] = []
+        self.economics: list[OperationEconomics] = []
+        self.limit_stop_reason: StopReason | None = None
+        self.limit_failure: StructuredFailure | None = None
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Dispatch one admitted request and retain its exact response economics."""
+        self._deadline.remaining()
+        if self._calls >= self._maximum_steps:
+            failure = _limit_failure(
+                FailureCode.BUDGET,
+                "sandbox candidate reached maximum_steps",
+                SandboxStepLimitError,
+                "maximum_steps",
+            )
+            self._set_limit(StopReason.MAXIMUM_STEPS, failure)
+            raise SandboxStepLimitError(failure.message)
+        if self._remaining_cost_usd is not None:
+            reservation = self._maximum_call_cost_usd
+            if reservation is None or self._spent + reservation > self._remaining_cost_usd:
+                failure = _limit_failure(
+                    FailureCode.BUDGET,
+                    "sandbox candidate request would exceed maximum_cost_usd",
+                    SandboxCostLimitError,
+                    "maximum_cost",
+                )
+                self._set_limit(StopReason.MAXIMUM_COST, failure)
+                raise SandboxCostLimitError(failure.message)
+        call_index = self._calls
+        self._calls += 1
+        started_at = _timestamp(self._clock)
+        started = self._monotonic()
+        try:
+            response = self._client.complete(request)
+        except Exception as exc:
+            ended_at = _timestamp(self._clock, not_before=started_at)
+            failure = StructuredFailure(
+                code=FailureCode.TIMEOUT if isinstance(exc, TimeoutError) else FailureCode.PROVIDER,
+                message=f"candidate provider failed with {type(exc).__name__}",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.MODEL,
+                details={
+                    "phase": "candidate_dispatch",
+                    "provider_dispatch_unknown_spend": True,
+                },
+            )
+            self.spans.append(
+                _model_span(call_index, started_at, ended_at, self._snapshot, None, failure)
+            )
+            if isinstance(exc, SandboxTimeLimitError):
+                self._set_limit(StopReason.MAXIMUM_TIME, failure)
+            raise
+        ended_at = _timestamp(self._clock, not_before=started_at)
+        if response.model != self._snapshot:
+            failure = StructuredFailure(
+                code=FailureCode.PROVIDER,
+                message="candidate response model identity differs from the evaluation plan",
+                attribution=FailureAttribution.MODEL,
+                details={"phase": "candidate_identity", "provider_dispatch_unknown_spend": True},
+            )
+            self.spans.append(
+                _model_span(call_index, started_at, ended_at, response.model, response, failure)
+            )
+            raise SandboxUnknownCostError(failure.message)
+        economics = _with_observed_latency(
+            response.economics,
+            max(0.0, self._monotonic() - started),
+        )
+        self.economics.append(economics)
+        self.spans.append(
+            _model_span(call_index, started_at, ended_at, response.model, response, None)
+        )
+        if self._remaining_cost_usd is not None:
+            cost = economics.cost_usd
+            if cost is None:
+                failure = _limit_failure(
+                    FailureCode.BUDGET,
+                    "candidate response omitted cost required by a finite sandbox budget",
+                    SandboxUnknownCostError,
+                    "candidate_cost_unknown",
+                    provider_dispatch_unknown_spend=True,
+                )
+                self._set_limit(StopReason.MAXIMUM_COST, failure)
+                raise SandboxUnknownCostError(failure.message)
+            if cost.value < 0 or (
+                self._maximum_call_cost_usd is not None and cost.value > self._maximum_call_cost_usd
+            ):
+                failure = _limit_failure(
+                    FailureCode.BUDGET,
+                    "candidate cost violated its finite call reservation",
+                    SandboxUnknownCostError,
+                    "candidate_cost_bound",
+                    provider_dispatch_unknown_spend=True,
+                )
+                self._set_limit(StopReason.MAXIMUM_COST, failure)
+                raise SandboxUnknownCostError(failure.message)
+            self._spent += cost.value
+            if self._spent > self._remaining_cost_usd:
+                failure = _limit_failure(
+                    FailureCode.BUDGET,
+                    "candidate cost exceeded its reserved sandbox budget",
+                    SandboxCostLimitError,
+                    "maximum_cost",
+                )
+                self._set_limit(StopReason.MAXIMUM_COST, failure)
+                raise SandboxCostLimitError(failure.message)
+        self._deadline.remaining()
+        return response.model_copy(update={"economics": economics})
+
+    def _set_limit(self, reason: StopReason, failure: StructuredFailure) -> None:
+        """Retain the first terminal limit without overwriting earlier evidence."""
+        if self.limit_stop_reason is None:
+            self.limit_stop_reason = reason
+            self.limit_failure = failure
+
+
+class _RecordingEnvironmentRuntime:
+    """Wrap one environment context and retain every action, observation, and failure."""
+
+    def __init__(
+        self,
+        runtime: EnvironmentRuntime,
+        *,
+        deadline: _Deadline,
+        clock: Callable[[], datetime],
+        monotonic: Callable[[], float],
+    ) -> None:
+        self._runtime = runtime
+        self._deadline = deadline
+        self._clock = clock
+        self._monotonic = monotonic
+        self.spans: list[RolloutSpan] = []
+        self.economics: list[OperationEconomics] = []
+        self.limit_stop_reason: StopReason | None = None
+        self.limit_failure: StructuredFailure | None = None
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Open the underlying session through one evidence-recording context."""
+        self._deadline.remaining()
+        return _RecordingEnvironmentContext(self, self._runtime.open(task))
+
+
+class _RecordingEnvironmentContext(AbstractContextManager[EnvironmentSession]):
+    """Preserve cleanup authority in the original runtime context."""
+
+    def __init__(
+        self,
+        owner: _RecordingEnvironmentRuntime,
+        context: AbstractContextManager[EnvironmentSession],
+    ) -> None:
+        self._owner = owner
+        self._context = context
+
+    def __enter__(self) -> EnvironmentSession:
+        """Enter the backing context and expose only a recording execute capability."""
+        session = self._context.__enter__()
+        try:
+            self._owner._deadline.remaining()
+        except BaseException as exc:
+            self._context.__exit__(type(exc), exc, exc.__traceback__)
+            raise
+        return _RecordingEnvironmentSession(self._owner, session)
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Keep cleanup inside the hard wall bound and retain an honest terminal failure."""
+        try:
+            suppressed = self._context.__exit__(exception_type, exception, traceback)
+            self._owner._deadline.remaining()
+        except SandboxTimeLimitError as exc:
+            self._owner.limit_stop_reason = StopReason.MAXIMUM_TIME
+            self._owner.limit_failure = StructuredFailure(
+                code=FailureCode.TIMEOUT,
+                message="sandbox environment cleanup exceeded maximum_time_seconds",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.CLEANUP,
+                details={"phase": "cleanup_timeout"},
+            )
+            return False
+        except Exception as exc:  # noqa: BLE001 - cleanup failures become durable evidence
+            self._owner.limit_stop_reason = StopReason.FAILURE
+            self._owner.limit_failure = StructuredFailure(
+                code=FailureCode.INTERNAL,
+                message=f"sandbox environment cleanup failed with {type(exc).__name__}",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.CLEANUP,
+                details={"phase": "cleanup_failure"},
+            )
+            return False
+        return bool(suppressed)
+
+
+class _RecordingEnvironmentSession:
+    """Record one canonical tool transcript without exposing lifecycle methods."""
+
+    def __init__(self, owner: _RecordingEnvironmentRuntime, session: EnvironmentSession) -> None:
+        self._owner = owner
+        self._session = session
+        self._index = 0
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Execute one action, retaining partial evidence even when the call raises."""
+        self._owner._deadline.remaining()
+        index = self._index
+        self._index += 1
+        started_at = _timestamp(self._owner._clock)
+        started = self._owner._monotonic()
+        try:
+            observation = self._session.execute(action)
+        except Exception as exc:
+            ended_at = _timestamp(self._owner._clock, not_before=started_at)
+            failure = StructuredFailure(
+                code=FailureCode.TIMEOUT if isinstance(exc, TimeoutError) else FailureCode.INTERNAL,
+                message=f"environment action failed with {type(exc).__name__}",
+                exception_type=type(exc).__name__,
+                attribution=FailureAttribution.TOOL,
+                details={"phase": "environment_execute", "tool": action.name},
+            )
+            self._owner.spans.extend(
+                _tool_spans(index, action, None, started_at, ended_at, failure)
+            )
+            if isinstance(exc, SandboxTimeLimitError):
+                self._owner.limit_stop_reason = StopReason.MAXIMUM_TIME
+                self._owner.limit_failure = failure
+            raise
+        ended_at = _timestamp(self._owner._clock, not_before=started_at)
+        duration = max(0.0, self._owner._monotonic() - started)
+        economics = _observation_economics(observation, duration)
+        self._owner.economics.append(economics)
+        failure = _observation_failure(action, observation)
+        self._owner.spans.extend(
+            _tool_spans(index, action, observation, started_at, ended_at, failure)
+        )
+        self._owner._deadline.remaining()
+        return observation
+
+
+@contextmanager
+def _hard_wall_timeout(deadline: _Deadline) -> Iterator[None]:
+    """Install a POSIX main-thread timer so a silent hung agent cannot evade its limit."""
+    if os.name != "posix" or threading.current_thread() is not threading.main_thread():
+        raise SandboxTimeLimitError(
+            "hard sandbox wall-time enforcement requires the POSIX main thread"
+        )
+    if not hasattr(signal, "setitimer"):
+        raise SandboxTimeLimitError("hard sandbox wall-time enforcement is unavailable")
+    previous_delay, previous_interval = signal.getitimer(signal.ITIMER_REAL)
+    if previous_delay > 0 or previous_interval > 0:
+        raise SandboxTimeLimitError("another wall timer is already active")
+    previous_handler = signal.getsignal(signal.SIGALRM)
+
+    def raise_timeout(_signum: int, _frame: object) -> None:
+        raise SandboxTimeLimitError("sandbox episode exceeded maximum_time_seconds")
+
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, deadline.remaining())
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def merge_sandbox_spans(
+    episode: AgentEpisode,
+    evidence: SandboxExecutionEvidence,
+) -> tuple[RolloutSpan, ...]:
+    """Merge recorder spans with nonduplicated customer lifecycle evidence.
+
+    Args:
+        episode: Canonical agent episode containing recorder-generated events.
+        evidence: Candidate and environment spans captured during sandbox execution.
+
+    Returns:
+        All retained spans in deterministic timestamp and ID order.
+    """
+    retained = tuple(
+        span
+        for span in episode.events
+        if span.kind
+        not in {
+            RolloutEventKind.AGENT_MODEL_CALL,
+            RolloutEventKind.TOOL_CALL,
+            RolloutEventKind.OBSERVATION,
+        }
+    )
+    combined = (*retained, *evidence.candidate_spans, *evidence.environment_spans)
+    return tuple(sorted(combined, key=lambda span: (span.started_at, span.ended_at, span.span_id)))
+
+
+def _model_span(
+    index: int,
+    started_at: datetime,
+    ended_at: datetime,
+    model: ModelSnapshot,
+    response: ModelResponse | None,
+    failure: StructuredFailure | None,
+) -> RolloutSpan:
+    """Build one provider-call span without persisting hidden model reasoning."""
+    return RolloutSpan(
+        span_id=f"sandbox-model-{index}",
+        kind=RolloutEventKind.AGENT_MODEL_CALL,
+        started_at=started_at,
+        ended_at=ended_at,
+        payload={"finish_reason": response.finish_reason.value if response is not None else None},
+        model=model,
+        usage=response.economics.usage if response is not None else None,
+        failure=failure,
+    )
+
+
+def _tool_spans(
+    index: int,
+    action: ToolCall,
+    observation: Observation | None,
+    started_at: datetime,
+    ended_at: datetime,
+    failure: StructuredFailure | None,
+) -> tuple[RolloutSpan, RolloutSpan]:
+    """Build paired action and observation spans, including partial failure evidence."""
+    action_span = RolloutSpan(
+        span_id=f"sandbox-tool-{index}",
+        kind=RolloutEventKind.TOOL_CALL,
+        started_at=started_at,
+        ended_at=started_at,
+        payload={"call_id": action.call_id, "arguments": action.arguments},
+        tool_name=action.name,
+    )
+    payload: JsonObject = (
+        {
+            "content": observation.content,
+            "is_error": observation.is_error,
+            "metadata": observation.metadata,
+        }
+        if observation is not None
+        else {"content": "", "is_error": True}
+    )
+    observation_span = RolloutSpan(
+        span_id=f"sandbox-observation-{index}",
+        parent_span_id=action_span.span_id,
+        kind=RolloutEventKind.OBSERVATION,
+        started_at=ended_at,
+        ended_at=ended_at,
+        payload=payload,
+        tool_name=action.name,
+        failure=failure,
+    )
+    return action_span, observation_span
+
+
+def _observation_failure(
+    action: ToolCall,
+    observation: Observation,
+) -> StructuredFailure | None:
+    """Translate an error observation into structured transcript failure evidence."""
+    if not observation.is_error:
+        return None
+    timed_out = observation.metadata.get("timed_out") is True
+    exception_type = observation.metadata.get("exception_type")
+    return StructuredFailure(
+        code=FailureCode.TIMEOUT if timed_out else FailureCode.INTERNAL,
+        message=f"environment tool {action.name!r} returned an error observation",
+        retryable=observation.metadata.get("retryable") is True,
+        exception_type=exception_type if isinstance(exception_type, str) else None,
+        attribution=FailureAttribution.TOOL,
+        details={"phase": "environment_observation", "tool": action.name},
+    )
+
+
+def _observation_economics(
+    observation: Observation,
+    duration_seconds: float,
+) -> OperationEconomics:
+    """Use supplied environment economics while always retaining observed wall latency."""
+    raw = observation.metadata.get("economics")
+    try:
+        economics = OperationEconomics.model_validate(raw) if isinstance(raw, dict) else None
+    except ValueError:
+        economics = None
+    return _with_observed_latency(economics or OperationEconomics(), duration_seconds)
+
+
+def _with_observed_latency(
+    economics: OperationEconomics,
+    duration_seconds: float,
+) -> OperationEconomics:
+    """Fill only missing latency with a directly observed monotonic duration."""
+    if economics.latency_seconds is not None:
+        return economics
+    return economics.model_copy(
+        update={
+            "latency_seconds": NumericMeasurement(
+                value=duration_seconds,
+                provenance="observed",
+            )
+        }
+    )
+
+
+def _combine_economics(records: Sequence[OperationEconomics]) -> OperationEconomics:
+    """Aggregate only measurements actually present on every recorded operation."""
+    if not records:
+        return OperationEconomics()
+    usages = tuple(record.usage for record in records)
+    usage = None if any(item is None for item in usages) else _sum_usage(usages)
+    costs = tuple(record.cost_usd for record in records)
+    latencies = tuple(record.latency_seconds for record in records)
+    return OperationEconomics(
+        usage=usage,
+        cost_usd=_sum_measurements(costs),
+        latency_seconds=_sum_measurements(latencies),
+    )
+
+
+def _sum_usage(values: Sequence[Usage | None]) -> Usage:
+    """Sum complete provider usage without manufacturing missing cache counts."""
+    present = tuple(value for value in values if value is not None)
+    cached = tuple(value.cached_input_tokens for value in present)
+    cached_total = (
+        None
+        if any(value is None for value in cached)
+        else sum(value for value in cached if value is not None)
+    )
+    return Usage(
+        input_tokens=sum(value.input_tokens for value in present),
+        output_tokens=sum(value.output_tokens for value in present),
+        cached_input_tokens=cached_total,
+    )
+
+
+def _sum_measurements(
+    values: Sequence[NumericMeasurement | None],
+) -> NumericMeasurement | None:
+    """Sum a complete measurement series while retaining its weakest provenance."""
+    if any(value is None for value in values):
+        return None
+    present = tuple(value for value in values if value is not None)
+    return NumericMeasurement(
+        value=sum(value.value for value in present),
+        provenance=(
+            "observed" if all(value.provenance == "observed" for value in present) else "estimated"
+        ),
+    )
+
+
+def _limit_failure(
+    code: FailureCode,
+    message: str,
+    exception_type: type[Exception],
+    phase: str,
+    *,
+    provider_dispatch_unknown_spend: bool = False,
+) -> StructuredFailure:
+    """Create one explicit limit failure without arbitrary exception text."""
+    return StructuredFailure(
+        code=code,
+        message=message,
+        exception_type=exception_type.__name__,
+        attribution=FailureAttribution.MODEL,
+        details={
+            "phase": phase,
+            "provider_dispatch_unknown_spend": provider_dispatch_unknown_spend,
+        },
+    )
+
+
+def _environment_cost_failure(
+    message: str,
+    phase: str,
+    *,
+    unknown_spend: bool = False,
+) -> StructuredFailure:
+    """Create one environment-attributed finite-budget failure."""
+    return StructuredFailure(
+        code=FailureCode.BUDGET,
+        message=message,
+        exception_type=SandboxUnknownCostError.__name__,
+        attribution=FailureAttribution.ENVIRONMENT,
+        details={
+            "phase": phase,
+            "environment_dispatch_unknown_spend": unknown_spend,
+        },
+    )
+
+
+def _timestamp(
+    clock: Callable[[], datetime],
+    *,
+    not_before: datetime | None = None,
+) -> datetime:
+    """Return one aware timestamp that never moves behind an earlier event."""
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("sandbox simulation clock must return timezone-aware datetimes")
+    return not_before if not_before is not None and value < not_before else value
+
+
+def _utc_now() -> datetime:
+    """Return an aware UTC event timestamp."""
+    return datetime.now(UTC)

--- a/wmo/simulation/engines/sandbox_recording.py
+++ b/wmo/simulation/engines/sandbox_recording.py
@@ -519,9 +519,15 @@ class _RecordingEnvironmentSession:
         return observation
 
 
-@contextmanager
-def _hard_wall_timeout(deadline: _Deadline) -> Iterator[None]:
-    """Install a POSIX main-thread timer so a silent hung agent cannot evade its limit."""
+def require_hard_wall_timeout_support() -> tuple[float, float]:
+    """Verify that this thread can install the timer required for sandbox execution.
+
+    Returns:
+        The inactive prior timer settings that the caller must restore after execution.
+
+    Raises:
+        SandboxTimeLimitError: Hard wall-time enforcement is unavailable or already claimed.
+    """
     if os.name != "posix" or threading.current_thread() is not threading.main_thread():
         raise SandboxTimeLimitError(
             "hard sandbox wall-time enforcement requires the POSIX main thread"
@@ -531,6 +537,13 @@ def _hard_wall_timeout(deadline: _Deadline) -> Iterator[None]:
     previous_delay, previous_interval = signal.getitimer(signal.ITIMER_REAL)
     if previous_delay > 0 or previous_interval > 0:
         raise SandboxTimeLimitError("another wall timer is already active")
+    return previous_delay, previous_interval
+
+
+@contextmanager
+def _hard_wall_timeout(deadline: _Deadline) -> Iterator[None]:
+    """Install a POSIX main-thread timer so a silent hung agent cannot evade its limit."""
+    previous_delay, previous_interval = require_hard_wall_timeout_support()
     previous_handler = signal.getsignal(signal.SIGALRM)
 
     def raise_timeout(_signum: int, _frame: object) -> None:

--- a/wmo/simulation/engines/sandbox_regression_test.py
+++ b/wmo/simulation/engines/sandbox_regression_test.py
@@ -7,8 +7,13 @@ from pathlib import Path
 
 import pytest
 
+from wmo.common.models import ModelRequest, ModelResponse
 from wmo.common.rollouts import RolloutArtifact, StopReason
-from wmo.simulation.engines.sandbox import EnvironmentCostBinding, SandboxSimulationError
+from wmo.simulation.engines.sandbox import (
+    EnvironmentCostBinding,
+    SandboxContentionError,
+    SandboxSimulationError,
+)
 from wmo.simulation.engines.sandbox_test import (
     _artifact_ids_of_type,
     _EnvironmentRuntime,
@@ -20,7 +25,11 @@ from wmo.simulation.engines.sandbox_test import (
     _spec,
     _ToolAgent,
 )
-from wmo.simulation.engines.text.leases import TextCellLease, TextCellLeaseStatus
+from wmo.simulation.engines.text.leases import (
+    TextCellLease,
+    TextCellLeaseStatus,
+    TextCellLeaseStore,
+)
 
 
 def test_worker_thread_rejects_sandbox_before_any_cell_evidence(tmp_path: Path) -> None:
@@ -58,7 +67,7 @@ def test_paid_dispatch_persistence_failure_retains_non_replay_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failed paid-cell write tombstones the claim instead of replaying the dispatch."""
+    """A failed paid-cell write keeps its whole-ceiling dispatch-intent claim non-replayable."""
     store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a", "task-b"))
     runtime = _EnvironmentRuntime()
     client = _ScriptedClient([0.2])
@@ -92,23 +101,120 @@ def test_paid_dispatch_persistence_failure_retains_non_replay_barrier(
     assert len(client.requests) == 1
     assert len(lease_paths) == 1
     retained = TextCellLease.model_validate_json(lease_paths[0].read_bytes())
-    assert retained.status == TextCellLeaseStatus.STALE
-    assert retained.unknown_spend_blocks_budget
+    assert retained.status == TextCellLeaseStatus.ACTIVE
+    assert retained.dispatch_intent_recorded
+    assert not retained.unknown_spend_blocks_budget
     assert retained.reserved_cost_usd == pytest.approx(1.0)
     monkeypatch.undo()
 
-    artifact_set = simulator.run(spec)
-    first, second = tuple(_load_rollout(store, item) for item in artifact_set.artifact_ids)
+    elapsed = [0.0]
+    simulator._leases = TextCellLeaseStore(
+        store.project_directory,
+        clock=lambda: retained.claimed_at,
+        sleep=lambda seconds: elapsed.__setitem__(0, elapsed[0] + seconds),
+        monotonic=lambda: elapsed[0],
+        wait_timeout_seconds=0.05,
+    )
+    with pytest.raises(SandboxContentionError, match="contended"):
+        simulator.run(spec)
 
     assert len(client.requests) == 1
     assert runtime.opened_task_ids == ["task-a"]
-    assert first.stop_reason == StopReason.MAXIMUM_COST
-    assert first.failure is not None
-    assert first.failure.details["phase"] == "paid_cell_stale_lease"
-    assert second.stop_reason == StopReason.MAXIMUM_COST
-    assert second.failure is not None
-    assert second.failure.details["phase"] == "paid_cell_admission"
+    assert _artifact_ids_of_type(store, "rollout") == ()
+    assert len(tuple(lease_directory.glob("*.json"))) == 1
+
+
+@pytest.mark.parametrize("interruption", (KeyboardInterrupt, SystemExit))
+def test_pre_dispatch_construction_interrupt_releases_owned_lease(
+    tmp_path: Path,
+    interruption: type[BaseException],
+) -> None:
+    """Agent construction interruption occurs before dispatch intent and remains retryable."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+
+    def interrupting_factory() -> _ToolAgent:
+        raise interruption("injected construction interruption")
+
+    interrupted = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=interrupting_factory,
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",))
+    with pytest.raises(interruption, match="injected construction interruption"):
+        interrupted.run(spec)
+
+    lease_directory = store.project_directory / "simulation-leases"
+    assert runtime.opened_task_ids == []
     assert tuple(lease_directory.glob("*.json")) == ()
+
+    recovered = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    artifact_set = recovered.run(spec)
+    assert _load_rollout(store, artifact_set.artifact_ids[0]).stop_reason == StopReason.COMPLETED
+
+
+@pytest.mark.parametrize("interruption", (KeyboardInterrupt, SystemExit))
+def test_post_dispatch_interrupt_keeps_non_replay_barrier(
+    tmp_path: Path,
+    interruption: type[BaseException],
+) -> None:
+    """An interrupt after durable candidate intent never permits immediate paid redispatch."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    client = _InterruptingClient(interruption)
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=client,
+        agent_factory=_OneCallAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0,
+            cost_is_observable=True,
+        ),
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",), maximum_cost_usd=1.0)
+    with pytest.raises(interruption, match="injected post-dispatch interruption"):
+        simulator.run(spec)
+
+    lease_directory = store.project_directory / "simulation-leases"
+    lease_paths = tuple(lease_directory.glob("*.json"))
+    assert len(client.requests) == 1
+    assert _artifact_ids_of_type(store, "rollout") == ()
+    assert len(lease_paths) == 1
+    retained = TextCellLease.model_validate_json(lease_paths[0].read_bytes())
+    assert retained.status == TextCellLeaseStatus.ACTIVE
+    assert retained.dispatch_intent_recorded
+    assert retained.reserved_cost_usd == pytest.approx(1.0)
+
+    elapsed = [0.0]
+    simulator._leases = TextCellLeaseStore(
+        store.project_directory,
+        clock=lambda: retained.claimed_at,
+        sleep=lambda seconds: elapsed.__setitem__(0, elapsed[0] + seconds),
+        monotonic=lambda: elapsed[0],
+        wait_timeout_seconds=0.05,
+    )
+    with pytest.raises(SandboxContentionError, match="contended"):
+        simulator.run(spec)
+
+    assert len(client.requests) == 1
+    assert _artifact_ids_of_type(store, "rollout") == ()
 
 
 def test_pre_dispatch_persistence_failure_releases_owned_lease(
@@ -150,3 +256,16 @@ def test_pre_dispatch_persistence_failure_releases_owned_lease(
     rollout = _load_rollout(store, artifact_set.artifact_ids[0])
     assert rollout.failure is not None
     assert rollout.failure.details["phase"] == "environment_cost_admission"
+
+
+class _InterruptingClient:
+    """Record one candidate-shaped dispatch before propagating an external interruption."""
+
+    def __init__(self, interruption: type[BaseException]) -> None:
+        self._interruption = interruption
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Raise only after the recorder has crossed its durable dispatch-intent boundary."""
+        self.requests.append(request)
+        raise self._interruption("injected post-dispatch interruption")

--- a/wmo/simulation/engines/sandbox_regression_test.py
+++ b/wmo/simulation/engines/sandbox_regression_test.py
@@ -7,16 +7,20 @@ from pathlib import Path
 
 import pytest
 
-from wmo.common.rollouts import RolloutArtifact
-from wmo.simulation.engines.sandbox import SandboxSimulationError
+from wmo.common.rollouts import RolloutArtifact, StopReason
+from wmo.simulation.engines.sandbox import EnvironmentCostBinding, SandboxSimulationError
 from wmo.simulation.engines.sandbox_test import (
     _artifact_ids_of_type,
     _EnvironmentRuntime,
+    _load_rollout,
+    _OneCallAgent,
     _persist_fixture,
+    _ScriptedClient,
     _simulator,
     _spec,
     _ToolAgent,
 )
+from wmo.simulation.engines.text.leases import TextCellLease, TextCellLeaseStatus
 
 
 def test_worker_thread_rejects_sandbox_before_any_cell_evidence(tmp_path: Path) -> None:
@@ -50,22 +54,30 @@ def test_worker_thread_rejects_sandbox_before_any_cell_evidence(tmp_path: Path) 
     assert _artifact_ids_of_type(store, "rollout") == ()
 
 
-def test_persistence_failure_releases_owned_cell_lease(
+def test_paid_dispatch_persistence_failure_retains_non_replay_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failed rollout write leaves no live lease that blocks immediate recovery."""
-    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    """A failed paid-cell write tombstones the claim instead of replaying the dispatch."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a", "task-b"))
     runtime = _EnvironmentRuntime()
+    client = _ScriptedClient([0.2])
     simulator = _simulator(
         store,
         plan,
         plan_input,
         task_input,
         runtime,
-        agent_factory=_ToolAgent,
+        client=client,
+        agent_factory=_OneCallAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0,
+            cost_is_observable=True,
+        ),
     )
-    spec = _spec(plan_input, task_input, ("cell-a",))
+    spec = _spec(plan_input, task_input, ("cell-a", "cell-b"), maximum_cost_usd=1.0)
 
     def fail_persistence(*_: object) -> RolloutArtifact:
         raise OSError("injected persistence failure")
@@ -75,9 +87,66 @@ def test_persistence_failure_releases_owned_cell_lease(
         simulator.run(spec)
 
     lease_directory = store.project_directory / "simulation-leases"
+    lease_paths = tuple(lease_directory.glob("*.json"))
+    assert _artifact_ids_of_type(store, "rollout") == ()
+    assert len(client.requests) == 1
+    assert len(lease_paths) == 1
+    retained = TextCellLease.model_validate_json(lease_paths[0].read_bytes())
+    assert retained.status == TextCellLeaseStatus.STALE
+    assert retained.unknown_spend_blocks_budget
+    assert retained.reserved_cost_usd == pytest.approx(1.0)
+    monkeypatch.undo()
+
+    artifact_set = simulator.run(spec)
+    first, second = tuple(_load_rollout(store, item) for item in artifact_set.artifact_ids)
+
+    assert len(client.requests) == 1
+    assert runtime.opened_task_ids == ["task-a"]
+    assert first.stop_reason == StopReason.MAXIMUM_COST
+    assert first.failure is not None
+    assert first.failure.details["phase"] == "paid_cell_stale_lease"
+    assert second.stop_reason == StopReason.MAXIMUM_COST
+    assert second.failure is not None
+    assert second.failure.details["phase"] == "paid_cell_admission"
+    assert tuple(lease_directory.glob("*.json")) == ()
+
+
+def test_pre_dispatch_persistence_failure_releases_owned_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write failure before a candidate or environment dispatch remains safely retryable."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=2.0,
+            cost_is_observable=True,
+        ),
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",), maximum_cost_usd=1.0)
+
+    def fail_persistence(*_: object) -> RolloutArtifact:
+        raise OSError("injected pre-dispatch persistence failure")
+
+    monkeypatch.setattr(simulator, "_persist_rollout", fail_persistence)
+    with pytest.raises(OSError, match="injected pre-dispatch persistence failure"):
+        simulator.run(spec)
+
+    lease_directory = store.project_directory / "simulation-leases"
+    assert runtime.opened_task_ids == []
     assert tuple(lease_directory.glob("*.json")) == ()
     monkeypatch.undo()
 
-    simulator.run(spec)
-    assert runtime.opened_task_ids == ["task-a", "task-a"]
-    assert _artifact_ids_of_type(store, "rollout")
+    artifact_set = simulator.run(spec)
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+    assert rollout.failure is not None
+    assert rollout.failure.details["phase"] == "environment_cost_admission"

--- a/wmo/simulation/engines/sandbox_regression_test.py
+++ b/wmo/simulation/engines/sandbox_regression_test.py
@@ -1,0 +1,83 @@
+"""Regression coverage for sandbox admission and execution boundaries."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from wmo.common.rollouts import RolloutArtifact
+from wmo.simulation.engines.sandbox import SandboxSimulationError
+from wmo.simulation.engines.sandbox_test import (
+    _artifact_ids_of_type,
+    _EnvironmentRuntime,
+    _persist_fixture,
+    _simulator,
+    _spec,
+    _ToolAgent,
+)
+
+
+def test_worker_thread_rejects_sandbox_before_any_cell_evidence(tmp_path: Path) -> None:
+    """A worker cannot turn missing hard-wall support into a fake timeout rollout."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    errors: list[SandboxSimulationError] = []
+
+    def run() -> None:
+        try:
+            simulator.run(_spec(plan_input, task_input, ("cell-a",)))
+        except SandboxSimulationError as error:
+            errors.append(error)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], SandboxSimulationError)
+    assert runtime.opened_task_ids == []
+    assert _artifact_ids_of_type(store, "rollout") == ()
+
+
+def test_persistence_failure_releases_owned_cell_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed rollout write leaves no live lease that blocks immediate recovery."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",))
+
+    def fail_persistence(*_: object) -> RolloutArtifact:
+        raise OSError("injected persistence failure")
+
+    monkeypatch.setattr(simulator, "_persist_rollout", fail_persistence)
+    with pytest.raises(OSError, match="injected persistence failure"):
+        simulator.run(spec)
+
+    lease_directory = store.project_directory / "simulation-leases"
+    assert tuple(lease_directory.glob("*.json")) == ()
+    monkeypatch.undo()
+
+    simulator.run(spec)
+    assert runtime.opened_task_ids == ["task-a", "task-a"]
+    assert _artifact_ids_of_type(store, "rollout")

--- a/wmo/simulation/engines/sandbox_test.py
+++ b/wmo/simulation/engines/sandbox_test.py
@@ -1,0 +1,999 @@
+"""End-to-end tests for exact, bounded, and resumable sandbox simulation."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Literal
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactInput, canonical_json_bytes
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan
+from wmo.common.models import (
+    AssistantAction,
+    ModelClient,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    NumericMeasurement,
+    OperationEconomics,
+    RoutedCandidateSnapshot,
+    ToolCall,
+    Usage,
+)
+from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    RolloutEventKind,
+    SandboxSimulationCellBinding,
+    SimulationMode,
+    StopReason,
+)
+from wmo.common.tasks import TaskCase, TaskSet
+from wmo.runtime.agents import AgentEpisode, AgentRuntime
+from wmo.runtime.environments import EnvironmentRuntime, EnvironmentSession, Observation
+from wmo.runtime.environments.harbor import HarborCommandResult, HarborEnvironmentRuntime
+from wmo.runtime.harness.e2b_ledger import SandboxLedger, read_ledger_files
+from wmo.simulation.engines.sandbox import (
+    CandidateBinding,
+    EnvironmentCostBinding,
+    SandboxSimulationError,
+    SandboxSimulator,
+)
+from wmo.simulation.engines.sandbox_bindings import SandboxSimulationResolution
+from wmo.simulation.orchestration.interface import SimulationModeUnsupportedError
+from wmo.simulation.specs import MixedRealitySettings, SandboxSettings, SimulationSpec
+
+_TIME = datetime(2026, 8, 12, tzinfo=UTC)
+_ENVIRONMENT_DIGEST = "e" * 64
+
+
+def test_sandbox_persists_each_rollout_and_resumes_without_reexecution(tmp_path: Path) -> None:
+    """A completed cell is durable before the final set and an exact rerun performs no work."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",))
+
+    first = simulator.run(spec)
+    rollout = _load_rollout(store, first.artifact_ids[0])
+    resumed = simulator.run(spec)
+
+    assert resumed == first
+    assert runtime.opened_task_ids == ["task-a"]
+    assert runtime.close_calls == 1
+    assert rollout.stop_reason == StopReason.COMPLETED
+    assert rollout.sandbox_binding is not None
+    assert rollout.sandbox_binding.environment_sha256 == _ENVIRONMENT_DIGEST
+    assert rollout.sandbox_binding.task_lineage_group_id == "lineage-task-a"
+    assert {span.kind for span in rollout.spans}.issuperset(
+        {RolloutEventKind.TOOL_CALL, RolloutEventKind.OBSERVATION}
+    )
+    assert rollout.candidate_economics.cost_usd is None
+    assert rollout.sandbox_economics is not None
+    assert rollout.sandbox_economics.cost_usd is None
+    assert store.read(first.artifact_set_id).manifest.artifact_type == ("simulation-artifact-set")
+
+
+def test_sparse_fit_and_held_out_cells_have_distinct_exact_bindings(tmp_path: Path) -> None:
+    """Purpose and cell ID prevent legal sparse cells from colliding at resolution or rollout."""
+    cells = (
+        EvaluationCell(
+            cell_id="cell-fit",
+            task_id="task-a",
+            candidate_alias="candidate-a",
+            repeat=0,
+            purpose="fit",
+            execution="simulate",
+        ),
+        EvaluationCell(
+            cell_id="cell-held",
+            task_id="task-a",
+            candidate_alias="candidate-a",
+            repeat=0,
+            purpose="held_out",
+            execution="simulate",
+        ),
+    )
+    store, plan, plan_input, task_input = _persist_fixture(
+        tmp_path,
+        ("task-a",),
+        cells=cells,
+    )
+    artifact_set = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        _EnvironmentRuntime(),
+        agent_factory=_ToolAgent,
+    ).run(_spec(plan_input, task_input, ("cell-fit", "cell-held")))
+    rollouts = tuple(_load_rollout(store, item) for item in artifact_set.artifact_ids)
+    assert rollouts[0].rollout_id != rollouts[1].rollout_id
+    assert tuple(item.sandbox_binding.purpose for item in rollouts if item.sandbox_binding) == (
+        "fit",
+        "held_out",
+    )
+    resolution_id = _artifact_ids_of_type(store, "sandbox-simulation-resolution")[0]
+    resolution = SandboxSimulationResolution.model_validate_json(
+        store.read_bytes(resolution_id, "sandbox-simulation-resolution.json")
+    )
+    duplicate_payload = resolution.model_dump(mode="json")
+    duplicate_payload["cell_bindings"] = [
+        resolution.cell_bindings[0].model_dump(mode="json"),
+        resolution.cell_bindings[0].model_dump(mode="json"),
+    ]
+    with pytest.raises(ValueError, match="cell IDs must be unique"):
+        SandboxSimulationResolution.model_validate(duplicate_payload)
+
+
+def test_sandbox_rejects_unplanned_observed_mixed_and_environment_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Every unsupported or mismatched selection fails before a customer environment opens."""
+    store, plan, plan_input, task_input = _persist_fixture(
+        tmp_path,
+        ("task-a",),
+        execution="observed",
+    )
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(store, plan, plan_input, task_input, runtime)
+
+    with pytest.raises(SandboxSimulationError, match="observed cell"):
+        simulator.run(_spec(plan_input, task_input, ("cell-a",)))
+    with pytest.raises(SandboxSimulationError, match="outside its evaluation plan"):
+        simulator.run(_spec(plan_input, task_input, ("cell-missing",)))
+    with pytest.raises(SandboxSimulationError, match="environment identity"):
+        simulator.run(
+            _spec(
+                plan_input,
+                task_input,
+                ("cell-a",),
+                environment_sha256="f" * 64,
+            )
+        )
+    mixed = SimulationSpec(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(plan_input, task_input),
+        code_revision="test-revision",
+        simulation_id="simulation-mixed",
+        evaluation_plan_id=plan.plan_id,
+        cell_ids=("cell-a",),
+        agent_id="customer-agent",
+        mode=SimulationMode.MIXED_REALITY,
+        mixed_reality=MixedRealitySettings(policy_id="future-policy"),
+        seed=7,
+        maximum_steps=2,
+    )
+    with pytest.raises(SimulationModeUnsupportedError, match="not implemented"):
+        simulator.run(mixed)
+
+    assert runtime.opened_task_ids == []
+
+
+def test_maximum_steps_is_a_hard_candidate_dispatch_limit(tmp_path: Path) -> None:
+    """The recorder admits exactly the configured number of calls and reports the stop reason."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    client = _ScriptedClient([0.1, 0.1])
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=client,
+        agent_factory=lambda: _LoopingAgent(3),
+    )
+
+    artifact_set = simulator.run(_spec(plan_input, task_input, ("cell-a",), maximum_steps=2))
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+
+    assert len(client.requests) == 2
+    assert rollout.stop_reason == StopReason.MAXIMUM_STEPS
+    assert rollout.failure is not None
+    assert rollout.failure.exception_type == "SandboxStepLimitError"
+    assert runtime.close_calls == 1
+
+
+def test_maximum_time_interrupts_a_silent_agent_and_still_cleans_up(tmp_path: Path) -> None:
+    """A non-cooperative agent cannot evade the wall bound, and cleanup still runs once."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=lambda: _SleepingAgent(2.0),
+    )
+    started = time.monotonic()
+
+    artifact_set = simulator.run(
+        _spec(plan_input, task_input, ("cell-a",), maximum_time_seconds=0.02)
+    )
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+
+    assert time.monotonic() - started < 1.0
+    assert rollout.stop_reason == StopReason.MAXIMUM_TIME
+    assert rollout.failure is not None
+    assert rollout.failure.exception_type == "SandboxTimeLimitError"
+    assert runtime.close_calls == 1
+
+
+def test_permanently_hung_cleanup_returns_bounded_failure(tmp_path: Path) -> None:
+    """The hard episode timer interrupts cleanup and never reports the cell as completed."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime(hang_cleanup=True)
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    started = time.monotonic()
+
+    artifact_set = simulator.run(
+        _spec(plan_input, task_input, ("cell-a",), maximum_time_seconds=0.03)
+    )
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+
+    assert time.monotonic() - started < 1.0
+    assert rollout.stop_reason == StopReason.MAXIMUM_TIME
+    assert rollout.failure is not None
+    assert rollout.failure.attribution is not None
+    assert rollout.failure.attribution.value == "cleanup"
+    assert rollout.failure.details["phase"] == "cleanup_timeout"
+    assert runtime.close_calls == 1
+
+
+def test_finite_cost_is_preflighted_reserved_and_never_fabricated(tmp_path: Path) -> None:
+    """Finite spend needs a capability proof and stops before a request could exceed its cap."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime()
+    unsafe = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=lambda: _LoopingAgent(2),
+    )
+    spec = _spec(plan_input, task_input, ("cell-a",), maximum_cost_usd=1.0)
+
+    with pytest.raises(SandboxSimulationError, match="observable candidate cost"):
+        unsafe.run(spec)
+    assert runtime.opened_task_ids == []
+
+    unsafe_environment = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=_ScriptedClient([]),
+        agent_factory=lambda: _LoopingAgent(2),
+        maximum_call_cost_usd=0.7,
+        cost_is_observable=True,
+    )
+    with pytest.raises(SandboxSimulationError, match="observable environment cost"):
+        unsafe_environment.run(spec)
+    assert runtime.opened_task_ids == []
+
+    client = _ScriptedClient([0.4])
+    bounded = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=client,
+        agent_factory=lambda: _LoopingAgent(2),
+        maximum_call_cost_usd=0.7,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0,
+            cost_is_observable=True,
+        ),
+    )
+    artifact_set = bounded.run(spec)
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+
+    assert len(client.requests) == 1
+    assert rollout.stop_reason == StopReason.MAXIMUM_COST
+    assert rollout.candidate_economics.cost_usd is not None
+    assert rollout.candidate_economics.cost_usd.value == pytest.approx(0.4)
+
+
+def test_unknown_dispatched_cost_fails_closed_and_blocks_later_cells(tmp_path: Path) -> None:
+    """An unpriced dispatch is not zero spend, so a later paid cell is never admitted."""
+    store, plan, plan_input, task_input = _persist_fixture(
+        tmp_path,
+        ("task-a", "task-b"),
+    )
+    runtime = _EnvironmentRuntime()
+    client = _ScriptedClient([None])
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=client,
+        agent_factory=_OneCallAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0,
+            cost_is_observable=True,
+        ),
+    )
+
+    artifact_set = simulator.run(
+        _spec(
+            plan_input,
+            task_input,
+            ("cell-a", "cell-b"),
+            maximum_cost_usd=1.0,
+        )
+    )
+    first, second = tuple(_load_rollout(store, item) for item in artifact_set.artifact_ids)
+
+    assert len(client.requests) == 1
+    assert runtime.opened_task_ids == ["task-a"]
+    assert first.stop_reason == StopReason.MAXIMUM_COST
+    assert first.candidate_economics.cost_usd is None
+    assert first.failure is not None
+    assert first.failure.details["provider_dispatch_unknown_spend"] is True
+    assert second.stop_reason == StopReason.MAXIMUM_COST
+    assert second.failure is not None
+    assert second.failure.details["observed_spend_usd"] is None
+
+
+def test_unknown_environment_cost_fails_closed_and_blocks_later_cells(tmp_path: Path) -> None:
+    """An environment that omits promised cost cannot make a later paid cell look affordable."""
+    store, plan, plan_input, task_input = _persist_fixture(
+        tmp_path,
+        ("task-a", "task-b"),
+    )
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0.25,
+            cost_is_observable=True,
+        ),
+    )
+
+    artifact_set = simulator.run(
+        _spec(
+            plan_input,
+            task_input,
+            ("cell-a", "cell-b"),
+            maximum_cost_usd=1.0,
+        )
+    )
+    first, second = tuple(_load_rollout(store, item) for item in artifact_set.artifact_ids)
+
+    assert runtime.opened_task_ids == ["task-a"]
+    assert first.stop_reason == StopReason.MAXIMUM_COST
+    assert first.sandbox_economics is not None
+    assert first.sandbox_economics.cost_usd is None
+    assert first.failure is not None
+    assert first.failure.details["environment_dispatch_unknown_spend"] is True
+    assert second.stop_reason == StopReason.MAXIMUM_COST
+    assert second.failure is not None
+    assert second.failure.details["observed_spend_usd"] is None
+
+
+def test_observed_environment_cost_is_recorded_and_stays_inside_its_reservation(
+    tmp_path: Path,
+) -> None:
+    """A nonzero environment cost remains separate, observed, and budget-admissible."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    runtime = _EnvironmentRuntime(cost_usd=0.2)
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        client=_ScriptedClient([]),
+        agent_factory=_ToolAgent,
+        maximum_call_cost_usd=0.5,
+        cost_is_observable=True,
+        environment_cost=EnvironmentCostBinding(
+            maximum_episode_cost_usd=0.3,
+            cost_is_observable=True,
+        ),
+    )
+
+    artifact_set = simulator.run(_spec(plan_input, task_input, ("cell-a",), maximum_cost_usd=1.0))
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+
+    assert rollout.stop_reason == StopReason.COMPLETED
+    assert rollout.sandbox_economics is not None
+    assert rollout.sandbox_economics.cost_usd is not None
+    assert rollout.sandbox_economics.cost_usd.value == pytest.approx(0.2)
+    assert rollout.candidate_economics.cost_usd is None
+
+
+def test_completed_cell_survives_a_crash_between_episode_boundaries(tmp_path: Path) -> None:
+    """A process crash after cell A cannot replay A when a new simulator resumes cell B."""
+    store, plan, plan_input, task_input = _persist_fixture(
+        tmp_path,
+        ("task-a", "task-b"),
+    )
+    runtime = _EnvironmentRuntime()
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    )
+    original = simulator._execute_and_persist_cell
+
+    def crash_before_second_cell(
+        spec: SimulationSpec,
+        cell: EvaluationCell,
+        resolution: SandboxSimulationResolution,
+        resolution_input: ArtifactInput,
+        binding: SandboxSimulationCellBinding,
+    ) -> RolloutArtifact:
+        if cell.cell_id == "cell-b":
+            raise KeyboardInterrupt("simulated process crash")
+        return original(spec, cell, resolution, resolution_input, binding)
+
+    simulator.__dict__["_execute_and_persist_cell"] = crash_before_second_cell
+    spec = _spec(plan_input, task_input, ("cell-a", "cell-b"))
+    with pytest.raises(KeyboardInterrupt, match="simulated process crash"):
+        simulator.run(spec)
+
+    assert len(_artifact_ids_of_type(store, "rollout")) == 1
+    assert _artifact_ids_of_type(store, "simulation-artifact-set") == ()
+
+    resumed = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        runtime,
+        agent_factory=_ToolAgent,
+    ).run(spec)
+
+    assert len(resumed.artifact_ids) == 2
+    assert runtime.opened_task_ids == ["task-a", "task-b"]
+    assert runtime.close_calls == 2
+
+
+@pytest.mark.parametrize(
+    ("hang_cleanup", "expected_stop", "expected_phase"),
+    (
+        (False, StopReason.FAILURE, "cleanup_failure"),
+        (True, StopReason.MAXIMUM_TIME, "cleanup_timeout"),
+    ),
+)
+def test_harbor_cleanup_failure_or_hang_holds_ledger_and_partial_transcript(
+    tmp_path: Path,
+    hang_cleanup: bool,
+    expected_stop: StopReason,
+    expected_phase: str,
+) -> None:
+    """Harbor evidence survives bounded cleanup failure and remains reaper-owned."""
+    store, plan, plan_input, task_input = _persist_fixture(tmp_path, ("task-a",))
+    backend = _HarborSession(hang_cleanup=hang_cleanup)
+    ledger = SandboxLedger(tmp_path / "harbor-ledger", pid=901)
+    harbor = HarborEnvironmentRuntime(
+        _HarborFactory(backend),
+        environment_id="customer-environment",
+        template_name="wmo-hb-v1-fixture",
+        ledger=ledger,
+        retry_delays_seconds=(),
+    )
+    simulator = _simulator(
+        store,
+        plan,
+        plan_input,
+        task_input,
+        harbor,
+        agent_factory=_ReadFileAgent,
+    )
+    started = time.monotonic()
+    artifact_set = simulator.run(
+        _spec(
+            plan_input,
+            task_input,
+            ("cell-a",),
+            maximum_time_seconds=0.03 if hang_cleanup else 30.0,
+        )
+    )
+    rollout = _load_rollout(store, artifact_set.artifact_ids[0])
+    observations = tuple(
+        span for span in rollout.spans if span.kind == RolloutEventKind.OBSERVATION
+    )
+    assert time.monotonic() - started < 1.0
+    assert rollout.stop_reason == expected_stop
+    assert rollout.failure is not None
+    assert rollout.failure.attribution is not None
+    assert rollout.failure.attribution.value == "cleanup"
+    assert rollout.failure.details["phase"] == expected_phase
+    assert observations[0].payload["content"] == "partial output"
+    assert observations[0].failure is not None
+    ledger_state = read_ledger_files(tmp_path / "harbor-ledger")[0]
+    assert tuple(item.sandbox_id for item in ledger_state.held) == ("sandbox-harbor",)
+    assert ledger_state.released_ids == ()
+
+
+def _persist_fixture(
+    root: Path,
+    task_ids: tuple[str, ...],
+    *,
+    execution: Literal["observed", "simulate"] = "simulate",
+    cells: tuple[EvaluationCell, ...] | None = None,
+) -> tuple[ArtifactStore, EvaluationPlan, ArtifactInput, ArtifactInput]:
+    """Persist one exact task set and evaluation plan for sandbox tests."""
+    store = ArtifactStore(ProjectPaths(root=root, project_id="project-a"))
+    tasks = tuple(_task(task_id) for task_id in task_ids)
+    task_payload = b"\n".join(canonical_json_bytes(task) for task in tasks) + b"\n"
+    task_set = TaskSet(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="test-revision",
+        task_set_id="task-set-1",
+        task_ids=task_ids,
+        tasks_path="tasks.jsonl",
+        tasks_sha256=hashlib.sha256(task_payload).hexdigest(),
+    )
+    task_manifest = store.write(
+        artifact_id=task_set.task_set_id,
+        artifact_type="task-set",
+        envelope=task_set,
+        files={"task-set.json": canonical_json_bytes(task_set), "tasks.jsonl": task_payload},
+    )
+    selected_cells = cells or tuple(
+        _cell(index, task_id, execution=execution) for index, task_id in enumerate(task_ids)
+    )
+    plan = EvaluationPlan(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision="test-revision",
+        plan_id="plan-1",
+        task_set_id=task_set.task_set_id,
+        candidate_snapshots=(RoutedCandidateSnapshot(alias="candidate-a", model=_snapshot()),),
+        fidelity_gate_id="fidelity-gate-1",
+        fidelity_gate_sha256="f" * 64,
+        cells=selected_cells,
+    )
+    plan_manifest = store.write_json(
+        artifact_id=plan.plan_id,
+        artifact_type="evaluation-plan",
+        envelope=plan,
+        files={"evaluation-plan.json": plan},
+    )
+    return store, plan, artifact_input(plan_manifest), artifact_input(task_manifest)
+
+
+def _simulator(
+    store: ArtifactStore,
+    plan: EvaluationPlan,
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    runtime: EnvironmentRuntime,
+    *,
+    client: ModelClient | None = None,
+    agent_factory: Callable[[], AgentRuntime] | None = None,
+    maximum_call_cost_usd: float | None = None,
+    cost_is_observable: bool = False,
+    environment_cost: EnvironmentCostBinding | None = None,
+) -> SandboxSimulator:
+    """Build one fully local sandbox simulator with no provider or network access."""
+    return SandboxSimulator(
+        store=store,
+        evaluation_plan=plan,
+        evaluation_plan_input=plan_input,
+        task_set_input=task_input,
+        candidates={
+            "candidate-a": CandidateBinding(
+                alias="candidate-a",
+                client=client or _UnexpectedClient(),
+                snapshot=_snapshot(),
+                maximum_call_cost_usd=maximum_call_cost_usd,
+                cost_is_observable=cost_is_observable,
+            )
+        },
+        agent_factory=agent_factory or _OneCallAgent,
+        environment_runtime=runtime,
+        environment_cost=environment_cost,
+        environment_id="customer-environment",
+        environment_sha256=_ENVIRONMENT_DIGEST,
+        source_run_id="sandbox-run-1",
+        clock=lambda: _TIME,
+    )
+
+
+def _spec(
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    cell_ids: tuple[str, ...],
+    *,
+    maximum_steps: int = 3,
+    maximum_time_seconds: float = 30.0,
+    maximum_cost_usd: float | None = None,
+    environment_sha256: str = _ENVIRONMENT_DIGEST,
+) -> SimulationSpec:
+    """Create one exact shared W8 sandbox specification."""
+    return SimulationSpec(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(plan_input, task_input),
+        code_revision="test-revision",
+        simulation_id="simulation-1",
+        evaluation_plan_id="plan-1",
+        cell_ids=cell_ids,
+        agent_id="customer-agent",
+        mode=SimulationMode.SANDBOX,
+        sandbox=SandboxSettings(
+            environment_id="customer-environment",
+            environment_sha256=environment_sha256,
+            maximum_time_seconds=maximum_time_seconds,
+        ),
+        seed=7,
+        maximum_steps=maximum_steps,
+        maximum_cost_usd=maximum_cost_usd,
+    )
+
+
+def _cell(
+    index: int,
+    task_id: str,
+    *,
+    execution: Literal["observed", "simulate"],
+) -> EvaluationCell:
+    """Create one explicit held-out cell with an optional observed marker."""
+    suffix = chr(ord("a") + index)
+    return EvaluationCell(
+        cell_id=f"cell-{suffix}",
+        task_id=task_id,
+        candidate_alias="candidate-a",
+        repeat=0,
+        purpose="held_out",
+        execution=execution,
+        observed_rollout_id="production-rollout-1" if execution == "observed" else None,
+    )
+
+
+def _task(task_id: str) -> TaskCase:
+    """Create one held-out executable task with stable lineage."""
+    return TaskCase(
+        task_id=task_id,
+        lineage_group_id=f"lineage-{task_id}",
+        partition="held_out",
+        instruction=f"Complete {task_id} in the environment.",
+        workload_weight=1.0,
+        source_trace_ids=(f"trace-{task_id}",),
+    )
+
+
+def _snapshot() -> ModelSnapshot:
+    """Return the pinned candidate identity shared by plan and runtime."""
+    return ModelSnapshot(
+        provider="fixture",
+        model_id="candidate-a",
+        revision="v1",
+        capabilities_sha256="a" * 64,
+        connection_sha256="b" * 64,
+    )
+
+
+def _load_rollout(store: ArtifactStore, rollout_id: str) -> RolloutArtifact:
+    """Load one digest-verified canonical rollout."""
+    return RolloutArtifact.model_validate_json(store.read_bytes(rollout_id, "rollout.json"))
+
+
+def _artifact_ids_of_type(store: ArtifactStore, artifact_type: str) -> tuple[str, ...]:
+    """Return sorted stored IDs for one manifest type."""
+    return tuple(
+        artifact_id
+        for artifact_id in store.list_ids()
+        if store.read(artifact_id).manifest.artifact_type == artifact_type
+    )
+
+
+class _UnexpectedClient:
+    """Fail if a tool-only or sleeping fixture unexpectedly dispatches a model request."""
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Reject an unexpected provider-shaped call."""
+        raise AssertionError(f"unexpected model request: {request!r}")
+
+
+class _ScriptedClient:
+    """Return local responses with explicitly present or absent cost evidence."""
+
+    def __init__(self, costs: list[float | None]) -> None:
+        self._costs = list(costs)
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Record one request and return its scripted economics."""
+        self.requests.append(request)
+        cost = self._costs.pop(0)
+        return ModelResponse(
+            output=AssistantAction(content="candidate response"),
+            model=_snapshot(),
+            economics=OperationEconomics(
+                usage=Usage(input_tokens=4, output_tokens=2),
+                cost_usd=(
+                    NumericMeasurement(value=cost, provenance="observed")
+                    if cost is not None
+                    else None
+                ),
+            ),
+        )
+
+
+def _request(task: TaskCase) -> ModelRequest:
+    """Build a minimal candidate request from visible task text."""
+    return ModelRequest(messages=(ModelMessage(role="user", content=task.instruction),))
+
+
+class _OneCallAgent:
+    """Make one candidate request and return its visible action."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Execute exactly one injected model call."""
+        del environment
+        response = model.complete(_request(task))
+        return AgentEpisode(stop_reason=StopReason.COMPLETED, final_action=response.output)
+
+
+class _LoopingAgent:
+    """Attempt a fixed number of candidate calls so simulator limits can interrupt it."""
+
+    def __init__(self, calls: int) -> None:
+        self._calls = calls
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Return only when every requested candidate call was admitted."""
+        del environment
+        output: AssistantAction | None = None
+        for _ in range(self._calls):
+            output = model.complete(_request(task)).output
+        return AgentEpisode(stop_reason=StopReason.COMPLETED, final_action=output)
+
+
+class _ToolAgent:
+    """Use one executable tool without dispatching a candidate model request."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Record one successful tool result in the canonical transcript."""
+        del task, model
+        observation = environment.execute(ToolCall(call_id="call-1", name="lookup"))
+        assert observation.content == "environment output"
+        return AgentEpisode(
+            stop_reason=StopReason.COMPLETED,
+            final_action=AssistantAction(content="completed"),
+        )
+
+
+class _ReadFileAgent:
+    """Exercise the retained Harbor read adapter and ignore its expected error observation."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Return normally so the later Harbor cleanup proof is the terminal failure."""
+        del task, model
+        environment.execute(
+            ToolCall(call_id="call-read", name="read_file", arguments={"path": "notes.txt"})
+        )
+        return AgentEpisode(
+            stop_reason=StopReason.COMPLETED,
+            final_action=AssistantAction(content="saw partial output"),
+        )
+
+
+class _SleepingAgent:
+    """Block without model or tool calls to exercise the hard episode timer."""
+
+    def __init__(self, duration_seconds: float) -> None:
+        self._duration_seconds = duration_seconds
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        """Sleep longer than the configured simulator wall bound."""
+        del task, model, environment
+        time.sleep(self._duration_seconds)
+        return AgentEpisode(stop_reason=StopReason.COMPLETED)
+
+
+class _EnvironmentRuntime:
+    """Provide fresh deterministic sessions and record every cleanup boundary."""
+
+    def __init__(
+        self,
+        *,
+        cost_usd: float | None = None,
+        hang_cleanup: bool = False,
+    ) -> None:
+        self.opened_task_ids: list[str] = []
+        self.close_calls = 0
+        self.cost_usd = cost_usd
+        self.hang_cleanup = hang_cleanup
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        """Open one task-bound in-memory environment."""
+        self.opened_task_ids.append(task.task_id)
+        return _EnvironmentContext(self)
+
+
+class _EnvironmentContext(AbstractContextManager[EnvironmentSession]):
+    """Record context exit as direct cleanup evidence."""
+
+    def __init__(self, runtime: _EnvironmentRuntime) -> None:
+        self._runtime = runtime
+
+    def __enter__(self) -> EnvironmentSession:
+        """Return a fresh execute-only backing session."""
+        return _EnvironmentSession(self._runtime.cost_usd)
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Record cleanup on every normal and exceptional path."""
+        del exception_type, exception, traceback
+        self._runtime.close_calls += 1
+        if self._runtime.hang_cleanup:
+            while True:
+                pass
+        return False
+
+
+class _EnvironmentSession:
+    """Return one local observation for the sandbox tool fixture."""
+
+    def __init__(self, cost_usd: float | None) -> None:
+        self._cost_usd = cost_usd
+
+    def execute(self, action: ToolCall) -> Observation:
+        """Execute the fixture lookup action."""
+        assert action.name == "lookup"
+        economics = OperationEconomics(
+            cost_usd=(
+                NumericMeasurement(value=self._cost_usd, provenance="observed")
+                if self._cost_usd is not None
+                else None
+            )
+        )
+        return Observation(
+            content="environment output",
+            metadata={"economics": economics.model_dump(mode="json")},
+        )
+
+
+class _HarborFactory:
+    """Open one deterministic Harbor-shaped backend session."""
+
+    def __init__(self, session: _HarborSession) -> None:
+        self._session = session
+
+    def open(
+        self,
+        task: TaskCase,
+        *,
+        template_name: str,
+    ) -> AbstractContextManager[_HarborSession]:
+        """Bind the expected task and frozen template identity."""
+        assert task.task_id == "task-a"
+        assert template_name == "wmo-hb-v1-fixture"
+        return _HarborContext(self._session)
+
+
+class _HarborContext(AbstractContextManager["_HarborSession"]):
+    """Close the backend while deliberately withholding cleanup proof."""
+
+    def __init__(self, session: _HarborSession) -> None:
+        self._session = session
+
+    def __enter__(self) -> _HarborSession:
+        """Return the scriptable backend."""
+        return self._session
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Close without making the adapter's stronger cleanup claim true."""
+        del exception_type, exception, traceback
+        self._session.closed = True
+        if self._session.hang_cleanup:
+            while True:
+                pass
+        return False
+
+
+class _HarborSession:
+    """Return partial command evidence and reject final cleanup verification."""
+
+    sandbox_id = "sandbox-harbor"
+    template_id = "wmo-hb-v1-fixture"
+
+    def __init__(self, *, hang_cleanup: bool = False) -> None:
+        self.closed = False
+        self.hang_cleanup = hang_cleanup
+        self.commands: list[tuple[str, Mapping[str, str] | None]] = []
+
+    def execute_command(
+        self,
+        command: str,
+        *,
+        environment: Mapping[str, str] | None,
+        timeout_seconds: int,
+    ) -> HarborCommandResult:
+        """Return one failed command with usable stdout and explicit unknown cost."""
+        del timeout_seconds
+        self.commands.append((command, environment))
+        return HarborCommandResult(stdout="partial output", exit_code=7)
+
+    def cleanup_verified(self) -> bool:
+        """Deny cleanup proof so the durable ledger remains held for a reaper."""
+        return self.hang_cleanup

--- a/wmo/simulation/engines/text/leases.py
+++ b/wmo/simulation/engines/text/leases.py
@@ -256,6 +256,39 @@ class TextCellLeaseStore:
                 exc,
             )
 
+    def retain_non_replay_tombstone(self, lease: TextCellLease) -> None:
+        """Retain a durable unknown-spend barrier after possibly paid work lacks a rollout.
+
+        Args:
+            lease: Exact active claim whose dispatch may have completed before persistence failed.
+
+        Raises:
+            TextCellLeaseError: The claim is absent or changed before the safety barrier is durable.
+        """
+        self._ensure_directory()
+        path = self._path(lease.lease_id)
+        with file_write_lock(self._admission_path(), what="text simulation cell admission"):
+            existing = self._read_optional(path)
+            if existing is None:
+                raise TextCellLeaseError(
+                    f"text-cell lease {lease.lease_id!r} disappeared before non-replay retention"
+                )
+            if existing == lease:
+                self._tombstone(path, existing)
+                return
+            restored_active = existing.model_copy(
+                update={
+                    "status": TextCellLeaseStatus.ACTIVE,
+                    "reserved_cost_usd": lease.reserved_cost_usd,
+                    "unknown_spend_blocks_budget": False,
+                }
+            )
+            if existing.status == TextCellLeaseStatus.STALE and restored_active == lease:
+                return
+            raise TextCellLeaseError(
+                f"text-cell lease {lease.lease_id!r} changed before non-replay retention"
+            )
+
     def _admit_once(
         self,
         *,

--- a/wmo/simulation/engines/text/leases.py
+++ b/wmo/simulation/engines/text/leases.py
@@ -66,6 +66,7 @@ class TextCellLease(ContractModel):
     expires_at: datetime
     status: TextCellLeaseStatus = TextCellLeaseStatus.ACTIVE
     unknown_spend_blocks_budget: bool = False
+    dispatch_intent_recorded: bool = False
 
     @field_validator("claimed_at", "expires_at")
     @classmethod
@@ -232,7 +233,7 @@ class TextCellLeaseStore:
         """Remove this owner's claim after its immutable rollout is safely persisted.
 
         Args:
-            lease: Exact claim obtained from ``acquire``.
+            lease: Exact active claim obtained from ``acquire`` or its durable intent successor.
 
         Raises:
             TextCellLeaseError: The durable claim changed before its owner could release it.
@@ -244,7 +245,8 @@ class TextCellLeaseStore:
                 existing = self._read_optional(path)
                 if existing is None:
                     return
-                if existing != lease:
+                intended = lease.model_copy(update={"dispatch_intent_recorded": True})
+                if existing != lease and existing != intended:
                     raise TextCellLeaseError(
                         f"text-cell lease {lease.lease_id!r} changed before its owner released it"
                     )
@@ -256,37 +258,36 @@ class TextCellLeaseStore:
                 exc,
             )
 
-    def retain_non_replay_tombstone(self, lease: TextCellLease) -> None:
-        """Retain a durable unknown-spend barrier after possibly paid work lacks a rollout.
+    def record_dispatch_intent(self, lease: TextCellLease) -> TextCellLease:
+        """Durably record intent before a candidate or environment dispatch can begin.
 
         Args:
-            lease: Exact active claim whose dispatch may have completed before persistence failed.
+            lease: Exact active claim that owns the imminent external dispatch.
+
+        Returns:
+            The exact lease record with durable dispatch intent set.
 
         Raises:
-            TextCellLeaseError: The claim is absent or changed before the safety barrier is durable.
+            TextCellLeaseError: The claim is absent, changed, or not active before intent records.
         """
+        if lease.status != TextCellLeaseStatus.ACTIVE:
+            raise TextCellLeaseError("only active text-cell leases can record dispatch intent")
         self._ensure_directory()
         path = self._path(lease.lease_id)
+        intended = lease.model_copy(update={"dispatch_intent_recorded": True})
         with file_write_lock(self._admission_path(), what="text simulation cell admission"):
             existing = self._read_optional(path)
             if existing is None:
                 raise TextCellLeaseError(
-                    f"text-cell lease {lease.lease_id!r} disappeared before non-replay retention"
+                    f"text-cell lease {lease.lease_id!r} disappeared before dispatch intent"
                 )
+            if existing == intended:
+                return existing
             if existing == lease:
-                self._tombstone(path, existing)
-                return
-            restored_active = existing.model_copy(
-                update={
-                    "status": TextCellLeaseStatus.ACTIVE,
-                    "reserved_cost_usd": lease.reserved_cost_usd,
-                    "unknown_spend_blocks_budget": False,
-                }
-            )
-            if existing.status == TextCellLeaseStatus.STALE and restored_active == lease:
-                return
+                self._replace_exact(path, expected=existing, replacement=intended)
+                return intended
             raise TextCellLeaseError(
-                f"text-cell lease {lease.lease_id!r} changed before non-replay retention"
+                f"text-cell lease {lease.lease_id!r} changed before dispatch intent"
             )
 
     def _admit_once(

--- a/wmo/simulation/engines/text/leases_test.py
+++ b/wmo/simulation/engines/text/leases_test.py
@@ -19,10 +19,10 @@ _TIME = datetime(2026, 8, 12, tzinfo=UTC)
 _DIGEST = "a" * 64
 
 
-def test_paid_write_failure_tombstone_blocks_replay_until_rollout_is_durable(
+def test_dispatch_intent_blocks_replay_until_rollout_is_durable(
     tmp_path: Path,
 ) -> None:
-    """A possible paid dispatch remains non-replayable until its exact artifact can be read."""
+    """A durable dispatch intent keeps the live claim until exact rollout evidence exists."""
     project = ArtifactStore(ProjectPaths(root=tmp_path, project_id="project-a"))
     store = TextCellLeaseStore(project.project_directory, clock=lambda: _TIME)
     first = store.acquire(
@@ -37,9 +37,19 @@ def test_paid_write_failure_tombstone_blocks_replay_until_rollout_is_durable(
     )
     assert first.lease is not None
 
-    store.retain_non_replay_tombstone(first.lease)
-    store.retain_non_replay_tombstone(first.lease)
-    blocked = store.acquire(
+    intended = store.record_dispatch_intent(first.lease)
+    assert intended.dispatch_intent_recorded
+    assert intended.status == TextCellLeaseStatus.ACTIVE
+
+    elapsed = [0.0]
+    contender = TextCellLeaseStore(
+        project.project_directory,
+        clock=lambda: _TIME,
+        sleep=lambda seconds: elapsed.__setitem__(0, elapsed[0] + seconds),
+        monotonic=lambda: elapsed[0],
+        wait_timeout_seconds=0.05,
+    )
+    blocked = contender.acquire(
         lease_id="lease-a",
         resolution_id="resolution-a",
         simulation_id="simulation-a",
@@ -60,7 +70,8 @@ def test_paid_write_failure_tombstone_blocks_replay_until_rollout_is_durable(
         observed_spend_usd=lambda: 0.0,
     )
 
-    assert blocked.state == TextCellLeaseState.STALE
+    assert blocked.state == TextCellLeaseState.CONTENDED
+    assert blocked.retryable
     assert completed.state == TextCellLeaseState.COMPLETED
     assert tuple((project.project_directory / "simulation-leases").glob("*.json")) == ()
 

--- a/wmo/simulation/engines/text/leases_test.py
+++ b/wmo/simulation/engines/text/leases_test.py
@@ -19,6 +19,52 @@ _TIME = datetime(2026, 8, 12, tzinfo=UTC)
 _DIGEST = "a" * 64
 
 
+def test_paid_write_failure_tombstone_blocks_replay_until_rollout_is_durable(
+    tmp_path: Path,
+) -> None:
+    """A possible paid dispatch remains non-replayable until its exact artifact can be read."""
+    project = ArtifactStore(ProjectPaths(root=tmp_path, project_id="project-a"))
+    store = TextCellLeaseStore(project.project_directory, clock=lambda: _TIME)
+    first = store.acquire(
+        lease_id="lease-a",
+        resolution_id="resolution-a",
+        simulation_id="simulation-a",
+        rollout_id="rollout-a",
+        binding_sha256=_DIGEST,
+        maximum_cost_usd=1.0,
+        rollout_completed=lambda _rollout_id: False,
+        observed_spend_usd=lambda: 0.0,
+    )
+    assert first.lease is not None
+
+    store.retain_non_replay_tombstone(first.lease)
+    store.retain_non_replay_tombstone(first.lease)
+    blocked = store.acquire(
+        lease_id="lease-a",
+        resolution_id="resolution-a",
+        simulation_id="simulation-a",
+        rollout_id="rollout-a",
+        binding_sha256=_DIGEST,
+        maximum_cost_usd=1.0,
+        rollout_completed=lambda _rollout_id: False,
+        observed_spend_usd=lambda: 0.0,
+    )
+    completed = store.acquire(
+        lease_id="lease-a",
+        resolution_id="resolution-a",
+        simulation_id="simulation-a",
+        rollout_id="rollout-a",
+        binding_sha256=_DIGEST,
+        maximum_cost_usd=1.0,
+        rollout_completed=lambda rollout_id: rollout_id == "rollout-a",
+        observed_spend_usd=lambda: 0.0,
+    )
+
+    assert blocked.state == TextCellLeaseState.STALE
+    assert completed.state == TextCellLeaseState.COMPLETED
+    assert tuple((project.project_directory / "simulation-leases").glob("*.json")) == ()
+
+
 def test_expired_dead_paid_claim_is_recovered_as_stale_without_replay(tmp_path: Path) -> None:
     """A crash after claim creation is never silently replayed as a second paid provider call."""
     project = ArtifactStore(ProjectPaths(root=tmp_path, project_id="project-a"))

--- a/wmo/simulation/specs/simulation.py
+++ b/wmo/simulation/specs/simulation.py
@@ -6,6 +6,7 @@ mode.  A concrete simulator validates the settings it consumes before it starts 
 
 from __future__ import annotations
 
+import math
 from typing import Literal, Self
 
 from pydantic import Field, field_validator, model_validator
@@ -34,9 +35,19 @@ class WorldModelSettings(ContractModel):
 
 
 class SandboxSettings(ContractModel):
-    """Reserved executable-environment settings owned by the sandbox simulator workstream."""
+    """Versioned executable-environment identity and per-episode wall-clock limit."""
 
     environment_id: ArtifactId
+    environment_sha256: Sha256
+    maximum_time_seconds: float = Field(default=300.0, gt=0)
+
+    @field_validator("maximum_time_seconds")
+    @classmethod
+    def _require_finite_time_limit(cls, value: float) -> float:
+        """Reject a wall-clock limit that cannot stop an executable episode."""
+        if not math.isfinite(value):
+            raise ValueError("sandbox maximum_time_seconds must be finite")
+        return value
 
 
 class MixedRealitySettings(ContractModel):
@@ -75,6 +86,14 @@ class SimulationSpec(ArtifactEnvelope):
     maximum_steps: int = Field(ge=1)
     maximum_concurrency: int = Field(default=1, ge=1)
     maximum_cost_usd: float | None = Field(default=None, gt=0)
+
+    @field_validator("maximum_cost_usd")
+    @classmethod
+    def _require_finite_cost_limit(cls, value: float | None) -> float | None:
+        """Reject a spend ceiling that cannot provide a finite admission boundary."""
+        if value is not None and not math.isfinite(value):
+            raise ValueError("simulation maximum_cost_usd must be finite")
+        return value
 
     @field_validator("cell_ids")
     @classmethod

--- a/wmo/simulation/specs/simulation_test.py
+++ b/wmo/simulation/specs/simulation_test.py
@@ -62,7 +62,15 @@ def test_spec_preserves_only_the_selected_mode_settings_and_is_digest_stable() -
         ({"cell_ids": ("cell-a", "cell-a")}, "must not repeat"),
         ({"cell_ids": ()}, "at least one"),
         ({"world_model": None}, "missing settings"),
-        ({"sandbox": SandboxSettings(environment_id="sandbox-a")}, "inactive"),
+        (
+            {
+                "sandbox": SandboxSettings(
+                    environment_id="sandbox-a",
+                    environment_sha256="b" * 64,
+                )
+            },
+            "inactive",
+        ),
     ],
 )
 def test_spec_rejects_ambiguous_sparse_or_inactive_settings(
@@ -85,3 +93,15 @@ def test_mixed_reality_shape_is_persistable_but_reserved_for_a_later_simulator()
     assert spec.mixed_reality == MixedRealitySettings(policy_id="policy-a")
     with pytest.raises(SimulationModeUnsupportedError, match="not implemented"):
         require_implemented_mode(spec, SimulationMode.WORLD_MODEL)
+
+
+def test_sandbox_limits_and_run_cost_ceiling_must_be_finite() -> None:
+    """Non-finite limits fail before an environment or provider can be opened."""
+    with pytest.raises(ValidationError, match="maximum_time_seconds must be finite"):
+        SandboxSettings(
+            environment_id="sandbox-a",
+            environment_sha256="b" * 64,
+            maximum_time_seconds=float("inf"),
+        )
+    with pytest.raises(ValidationError, match="maximum_cost_usd must be finite"):
+        _spec(maximum_cost_usd=float("inf"))


### PR DESCRIPTION
## Summary

- Restack the approved W9 sandbox-simulation runtime on W7's merged mainline commit `ebd2fea54e4c9f7e750eb1438403de5e43bce18e`.
- Preserve the prior W9 patch exactly: `git range-diff ffc5777b..cbe4d7b ebd2fea5..2aba3c45` reports `cbe4d7b6 = 2aba3c45`.
- Add a scoped cross-platform typing fix: dynamically bind Darwin's `kqueue` APIs so Linux `ty` checks do not claim the standard-library members exist, while the runtime still fails closed when the required Darwin bindings are absent.
- Address the two scoped sandbox review findings: reject worker-thread runs before they can persist fabricated timeout evidence, and release an owned cell lease in `finally` when execution or rollout persistence fails.
- Add the sandbox environment, immutable execution bindings and recordings, local execution gate, Harbor template identity, comparison artifacts, and deterministic coverage.

## Validation

- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run ty check`
- W9 target suite: 56 passed
- W8 and PostHog simulation suite: 544 passed
- W7 Python review suite: 43 passed
- W12 and W13 model suite: 810 passed
- W14 routing suite with an empty Hugging Face cache, avoiding the machine-local MLX path: 539 passed, 1 skipped
- Static guardrail suites: 73 passed
- `ty check --python-platform linux`
- Package build and isolated wheel import plus `wmo --help`
- Local W7 web workbench: TypeScript lint, 16 Vitest tests, and production build
- CLI help smoke for root, build, run, optimize, optimize model, and optimize route

`uv run pytest -q` has one exact-main, unrelated early failure: `wmo/cli/model_app_test.py` expects `model_app.run_distillation`, which current main does not provide. W9 changes neither that module nor its test, verified with `git diff --quiet origin/main...HEAD -- wmo/cli/model_app.py wmo/cli/model_app_test.py`.

No paid provider, E2B, or `.env` action was performed.
