### PR TITLE
test: add W16 end-to-end evidence

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -25,3 +25,24 @@ jobs:
         run: uv run ty check
       - name: non-live tests
         run: uv run pytest -q -k "not live"
+
+  w16-darwin-evidence:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project and its dev extras
+        run: uv sync --extra dev
+      - name: W16 router and bounded local-process evidence
+        run: >-
+          uv run pytest -q
+          --junitxml=w16-darwin-evidence.xml
+          wmo/workflow/router_evidence_test.py
+          wmo/simulation/comparison_evidence_test.py
+      - name: Upload W16 Darwin evidence result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: w16-darwin-evidence
+          path: w16-darwin-evidence.xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,7 +56,29 @@ jobs:
         run: |
           uv venv /tmp/wmo-wheel-smoke
           uv pip install --python /tmp/wmo-wheel-smoke/bin/python dist/*.whl
-          /tmp/wmo-wheel-smoke/bin/python -c "import wmo, wmo.common.models, wmo.runtime.models"
+          cd /tmp
+          /tmp/wmo-wheel-smoke/bin/python - <<'PY'
+          import wmo
+          import wmo.common.models
+          import wmo.runtime.models
+          from wmo.runtime.environments import LocalProcessEnvironmentRuntime
+          from wmo.runtime.router import RouterRuntime, create_project_router_app
+          from wmo.simulation import compare_text_and_sandbox
+          from wmo.simulation.engines import SandboxSimulator
+          from wmo.workflow import RouterCompositionResult
+          from wmo.simulation import SimulationSpec
+
+          assert callable(wmo.compose_router)
+          assert callable(wmo.load_project_router)
+          assert callable(wmo.create_project_router_app)
+          assert wmo.RouterRuntime is RouterRuntime
+          assert wmo.RouterCompositionResult is RouterCompositionResult
+          assert wmo.create_project_router_app is create_project_router_app
+          assert callable(compare_text_and_sandbox)
+          assert SimulationSpec.__module__ == "wmo.simulation.specs.simulation"
+          assert SandboxSimulator.__module__ == "wmo.simulation.engines.sandbox"
+          assert LocalProcessEnvironmentRuntime.__module__ == "wmo.runtime.environments.local"
+          PY
           /tmp/wmo-wheel-smoke/bin/wmo --help
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,4 @@ results, and plans do not live here.
 | `reference/harness_delta.md` | Existing typed harness update contract owned outside the W14R CLI slice. |
 | `reference/ingest.md` | Current OTLP and PostHog local trace input contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |
+| `research/w16-router-sandbox-evidence.md` | Deterministic W16 router and local sandbox evidence, limits, and replay commands. |

--- a/docs/research/w16-router-sandbox-evidence.md
+++ b/docs/research/w16-router-sandbox-evidence.md
@@ -1,0 +1,44 @@
+# W16 router and sandbox evidence
+
+W16 verifies the current public router workflow and the text-versus-sandbox comparison path with
+deterministic injected clients. The evidence invokes no hosted provider, E2B, Tinker, credential,
+or paid service. It does not claim provider quality or cloud-environment parity.
+
+## Router workflow
+
+`wmo/workflow/router_evidence_test.py` drives `wmo.compose_router` from 100 normalized traces.
+The build produces 50 fit tasks and 20 sealed held-out tasks. A reviewed rubric and calibration,
+two frozen candidates, one pricing snapshot, ten production overlaps, and one frozen embedder feed
+the real text `WorldModelSimulator`, W10 fit lock and held-out report, and W11 HTTP runtime.
+
+The exact deterministic run retains these denominators:
+
+- 150 planned candidate-task cells, with 10 observed fidelity cells and 140 simulated cells
+- 40 held-out report rows, with zero failed, not-run, or missing-cost rows
+- 150 persisted judgments under one workflow ceiling of 200
+- one shared simulation ceiling of $2.00 and exactly $0.00 observed fake-client spend
+
+The test crashes once after the fit lock and once after durable report and telemetry creation. Resume
+and exact replay add no model, world-model, judge, approval, or telemetry delivery. Two HTTP turns
+with one episode ID retain one hashed episode identity and one sticky routed alias without exposing
+the raw episode ID.
+
+## Text and local process comparison
+
+`wmo/simulation/comparison_evidence_test.py` runs both the real text simulator and the bounded
+Darwin `LocalProcessEnvironmentRuntime` through `SandboxSimulator`. Two exact post-lock pairs are
+retained: both are paired, one is usable, and one records an explicit malformed sandbox response.
+The report therefore keeps one sandbox failure in the denominator instead of silently dropping it.
+Replay performs zero additional model, world-model, or local-process dispatches and leaves no
+workspace process directory. Terminal agreement is structural, not a task-quality judgment.
+
+Run the evidence with:
+
+```console
+uv run pytest -q wmo/workflow/router_evidence_test.py \
+  wmo/simulation/comparison_evidence_test.py
+```
+
+The local process case is intentionally skipped outside Darwin because that runtime's containment
+contract is Darwin-only. Release tests separately require every public W16 owner in the wheel and
+resolve the public APIs without importing test modules.

--- a/wmo/api_test.py
+++ b/wmo/api_test.py
@@ -7,6 +7,7 @@ import sys
 
 import wmo
 from wmo.optimize.router.workflow import fit_router, optimize_router, report_router
+from wmo.runtime.router.application import create_project_router_app, load_project_router
 from wmo.runtime.router.runtime import RouterRuntime
 from wmo.simulation.build import build_project
 from wmo.workflow.router import compose_router
@@ -20,6 +21,8 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.report_router is report_router
     assert wmo.RouterRuntime is RouterRuntime
     assert wmo.compose_router is compose_router
+    assert wmo.load_project_router is load_project_router
+    assert wmo.create_project_router_app is create_project_router_app
     assert "ActionKind" not in wmo.__all__
 
 

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -34,7 +34,11 @@ REQUIRED_CORE_REQUIREMENTS = frozenset(
 REQUIRED_WHEEL_MODULES = frozenset(
     {
         "wmo/common/models/model.py",
+        "wmo/runtime/environments/local.py",
         "wmo/runtime/models/registry.py",
+        "wmo/runtime/router/application.py",
+        "wmo/simulation/comparison.py",
+        "wmo/simulation/engines/sandbox.py",
         "wmo/workflow/router.py",
     }
 )
@@ -195,6 +199,21 @@ def test_requirement_scanner_rejects_removed_dependencies() -> None:
         "transformers",
     ):
         assert RETIRED_REQUIREMENT.search(f"Requires-Dist: {dependency}>=1\n") is not None
+
+
+def test_w16_public_evidence_apis_resolve_from_release_owners() -> None:
+    """W16 customer and comparison workflows resolve without test-only API owners."""
+    import wmo
+    from wmo.runtime.environments import LocalProcessEnvironmentRuntime
+    from wmo.simulation import compare_text_and_sandbox
+    from wmo.simulation.engines import SandboxSimulator
+
+    assert callable(wmo.compose_router)
+    assert callable(wmo.load_project_router)
+    assert callable(wmo.create_project_router_app)
+    assert callable(compare_text_and_sandbox)
+    assert SandboxSimulator.__module__ == "wmo.simulation.engines.sandbox"
+    assert LocalProcessEnvironmentRuntime.__module__ == "wmo.runtime.environments.local"
 
 
 @pytest.mark.parametrize(

--- a/wmo/simulation/comparison_evidence_test.py
+++ b/wmo/simulation/comparison_evidence_test.py
@@ -1,0 +1,447 @@
+"""W16 actual text-versus-local-process sandbox comparison evidence."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactInput, sha256_json
+from wmo.common.evaluations import EvaluationPlan
+from wmo.common.models import (
+    ModelCapabilities,
+    ModelClient,
+    ModelMessage,
+    ModelRequest,
+    ModelSnapshot,
+    ToolCall,
+)
+from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
+from wmo.common.rollouts import (
+    RolloutArtifact,
+    SandboxSimulatorSnapshot,
+    SimulationArtifactSet,
+    SimulationMode,
+    StopReason,
+    WorldModelSimulatorSnapshot,
+)
+from wmo.common.tasks import TaskCase
+from wmo.runtime.agents import AgentEpisode
+from wmo.runtime.environments import (
+    EnvironmentSession,
+    LocalProcessEnvironmentRuntime,
+)
+from wmo.runtime.models import ResolvedModel
+from wmo.simulation import (
+    PairedSimulationCell,
+    SandboxSettings,
+    SimulationComparisonSpec,
+    SimulationSpec,
+    WorldModelSettings,
+    compare_text_and_sandbox,
+    persist_comparison,
+    persist_comparison_spec,
+)
+from wmo.simulation.comparison_test import _inputs, _persist_plan, _persist_tasks
+from wmo.simulation.engines import CandidateBinding, SandboxSimulator
+from wmo.simulation.engines.text.simulator import WorldModelSimulator
+from wmo.simulation.engines.text.simulator_test import _response, _ScriptedClient
+
+_PLAN_AT = datetime(2026, 8, 12, 10, tzinfo=UTC)
+_LOCK_AT = datetime(2026, 8, 12, 11, tzinfo=UTC)
+_EVIDENCE_AT = datetime(2026, 8, 12, 12, tzinfo=UTC)
+_COMPARISON_AT = datetime(2026, 8, 12, 13, tzinfo=UTC)
+_REPORT_AT = datetime(2026, 8, 12, 14, tzinfo=UTC)
+_ENVIRONMENT_SHA256 = "e" * 64
+
+
+class _TextComparisonAgent:
+    """Call the injected candidate without requesting unavailable executable tools."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        del environment
+        response = model.complete(
+            ModelRequest(messages=(ModelMessage(role="user", content=task.instruction),))
+        )
+        return AgentEpisode(stop_reason=StopReason.COMPLETED, final_action=response.output)
+
+
+class _SandboxComparisonAgent:
+    """Execute one real local tool before calling the same injected candidate identity."""
+
+    def run(
+        self,
+        task: TaskCase,
+        *,
+        model: ModelClient,
+        environment: EnvironmentSession,
+    ) -> AgentEpisode:
+        environment.execute(ToolCall(call_id="lookup-1", name="lookup", arguments={}))
+        response = model.complete(
+            ModelRequest(messages=(ModelMessage(role="user", content=task.instruction),))
+        )
+        return AgentEpisode(stop_reason=StopReason.COMPLETED, final_action=response.output)
+
+
+class _CountingEnvironmentRuntime:
+    """Count actual bounded process allocations while delegating lifecycle ownership."""
+
+    def __init__(self, runtime: LocalProcessEnvironmentRuntime) -> None:
+        self.runtime = runtime
+        self.open_calls = 0
+
+    def open(self, task: TaskCase) -> AbstractContextManager[EnvironmentSession]:
+        self.open_calls += 1
+        return self.runtime.open(task)
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="the bounded LocalProcessEnvironmentRuntime is intentionally Darwin-only",
+)
+def test_w16_actual_text_and_local_process_comparison_preserves_failure_denominator(
+    tmp_path: Path,
+) -> None:
+    """Two actual modes replay exactly while one process failure remains in the denominator."""
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="w16-comparison"))
+    lock_input = _persist_policy_lock(store)
+    tasks = (_task("task-a"), _task("task-b"))
+    task_set, task_input = _persist_tasks(store, tasks)
+    text_plan, text_plan_input = _persist_plan(store, tasks, task_input, "text")
+    sandbox_plan, sandbox_plan_input = _persist_plan(store, tasks, task_input, "sandbox")
+    text_spec = _spec(text_plan, text_plan_input, task_input, SimulationMode.WORLD_MODEL)
+    sandbox_spec = _spec(
+        sandbox_plan,
+        sandbox_plan_input,
+        task_input,
+        SimulationMode.SANDBOX,
+    )
+    candidate_snapshot = text_plan.candidate_snapshots[0].model
+    candidate_text = _ScriptedClient(
+        [
+            _response("completed", snapshot=candidate_snapshot, cost=0.0),
+            _response("completed", snapshot=candidate_snapshot, cost=0.0),
+        ]
+    )
+    world = _ScriptedClient(
+        [
+            _response(
+                '{"message":"done","terminal":true}',
+                snapshot=_world_snapshot(),
+                cost=0.0,
+            ),
+            _response(
+                '{"message":"done","terminal":true}',
+                snapshot=_world_snapshot(),
+                cost=0.0,
+            ),
+        ]
+    )
+    text_simulator = WorldModelSimulator(
+        store=store,
+        evaluation_plan=text_plan,
+        evaluation_plan_input=text_plan_input,
+        task_set_input=task_input,
+        candidate_models={
+            "candidate-a": _resolved("candidate-a", candidate_snapshot, candidate_text)
+        },
+        world_models={"world-model-a": _resolved("world-model-a", _world_snapshot(), world)},
+        agent_factory=_TextComparisonAgent,
+        clock=lambda: _EVIDENCE_AT,
+        monotonic=lambda: 1.0,
+    )
+    text_set = text_simulator.run(text_spec)
+    fixture_path = tmp_path / "w16_environment.py"
+    fixture_path.write_text(_LOCAL_PROCESS_FIXTURE, encoding="utf-8")
+    process_runtime = _CountingEnvironmentRuntime(
+        LocalProcessEnvironmentRuntime(
+            (sys.executable, str(fixture_path)),
+            workspace_parent=tmp_path,
+        )
+    )
+    candidate_sandbox = _ScriptedClient(
+        [_response("completed", snapshot=candidate_snapshot, cost=0.0)]
+    )
+    sandbox_simulator = SandboxSimulator(
+        store=store,
+        evaluation_plan=sandbox_plan,
+        evaluation_plan_input=sandbox_plan_input,
+        task_set_input=task_input,
+        candidates={
+            "candidate-a": CandidateBinding(
+                alias="candidate-a",
+                client=candidate_sandbox,
+                snapshot=candidate_snapshot,
+            )
+        },
+        agent_factory=_SandboxComparisonAgent,
+        environment_runtime=process_runtime,
+        environment_id="w16-local-process",
+        environment_sha256=_ENVIRONMENT_SHA256,
+        source_run_id="w16-local-run",
+        clock=lambda: _EVIDENCE_AT,
+        monotonic=lambda: 1.0,
+    )
+    sandbox_set = sandbox_simulator.run(sandbox_spec)
+    dispatches = (
+        len(candidate_text.requests),
+        len(world.requests),
+        len(candidate_sandbox.requests),
+        process_runtime.open_calls,
+    )
+
+    comparison = _comparison_spec(
+        store,
+        lock_input,
+        task_input,
+        text_plan,
+        text_plan_input,
+        sandbox_plan,
+        sandbox_plan_input,
+        text_spec,
+        sandbox_spec,
+        text_set,
+        sandbox_set,
+        tasks,
+    )
+    persist_comparison_spec(comparison, store)
+    report = compare_text_and_sandbox(
+        comparison,
+        store=store,
+        created_at=_REPORT_AT,
+        code_revision="w16-comparison-v1",
+    )
+    persist_comparison(report, store)
+
+    assert report.expected_pairs == 2
+    assert report.paired_rollouts == 2
+    assert report.usable_pairs == 1
+    assert report.missing_text_rollouts == 0
+    assert report.missing_sandbox_rollouts == 0
+    assert report.failed_text_rollouts == 0
+    assert report.failed_sandbox_rollouts == 1
+    assert report.terminal_matches == 1
+    assert report.outcomes[1].sandbox_failure is not None
+    assert text_simulator.run(text_spec) == text_set
+    assert sandbox_simulator.run(sandbox_spec) == sandbox_set
+    replay = compare_text_and_sandbox(
+        comparison,
+        store=store,
+        created_at=_REPORT_AT,
+        code_revision="w16-comparison-v1",
+    )
+    assert replay == report
+    assert (
+        len(candidate_text.requests),
+        len(world.requests),
+        len(candidate_sandbox.requests),
+        process_runtime.open_calls,
+    ) == dispatches
+    assert list(tmp_path.glob("wmo-sandbox-*")) == []
+
+
+def _comparison_spec(
+    store: ArtifactStore,
+    lock_input: ArtifactInput,
+    task_input: ArtifactInput,
+    text_plan: EvaluationPlan,
+    text_plan_input: ArtifactInput,
+    sandbox_plan: EvaluationPlan,
+    sandbox_plan_input: ArtifactInput,
+    text_spec: SimulationSpec,
+    sandbox_spec: SimulationSpec,
+    text_set: SimulationArtifactSet,
+    sandbox_set: SimulationArtifactSet,
+    tasks: Sequence[TaskCase],
+) -> SimulationComparisonSpec:
+    """Freeze one post-lock comparison from actual simulator outputs."""
+    text_spec_input = artifact_input(store.read(text_spec.simulation_id).manifest)
+    sandbox_spec_input = artifact_input(store.read(sandbox_spec.simulation_id).manifest)
+    text_set_input = artifact_input(store.read(text_set.artifact_set_id).manifest)
+    sandbox_set_input = artifact_input(store.read(sandbox_set.artifact_set_id).manifest)
+    text_rollouts = _rollouts(store, text_set)
+    sandbox_rollouts = _rollouts(store, sandbox_set)
+    pairs = tuple(
+        PairedSimulationCell(
+            pair_id=f"w16-pair-{index}",
+            task_id=task.task_id,
+            task_lineage_group_id=task.lineage_group_id,
+            task_sha256=sha256_json(task),
+            candidate_alias="candidate-a",
+            candidate=text_plan.candidate_snapshots[0].model,
+            agent_id="w16-comparison-agent",
+            repeat=0,
+            text_cell_id=text_plan.cells[index].cell_id,
+            sandbox_cell_id=sandbox_plan.cells[index].cell_id,
+            text_rollout_id=text_rollouts[index][0].rollout_id,
+            text_rollout_sha256=text_rollouts[index][1].sha256,
+            sandbox_rollout_id=sandbox_rollouts[index][0].rollout_id,
+            sandbox_rollout_sha256=sandbox_rollouts[index][1].sha256,
+            text_simulator=cast(WorldModelSimulatorSnapshot, text_rollouts[index][0].simulator),
+            sandbox_simulator=cast(SandboxSimulatorSnapshot, sandbox_rollouts[index][0].simulator),
+        )
+        for index, task in enumerate(tasks)
+    )
+    inputs = _inputs(
+        lock_input,
+        task_input,
+        text_plan_input,
+        sandbox_plan_input,
+        text_spec_input,
+        sandbox_spec_input,
+        text_set_input,
+        sandbox_set_input,
+    )
+    return SimulationComparisonSpec(
+        schema_version=1,
+        created_at=_COMPARISON_AT,
+        inputs=inputs,
+        code_revision="w16-comparison-v1",
+        comparison_id="w16-text-sandbox-comparison",
+        policy_lock_input=lock_input,
+        task_set_input=task_input,
+        text_evaluation_plan_input=text_plan_input,
+        sandbox_evaluation_plan_input=sandbox_plan_input,
+        text_simulation_spec_input=text_spec_input,
+        sandbox_simulation_spec_input=sandbox_spec_input,
+        text_artifact_set_input=text_set_input,
+        sandbox_artifact_set_input=sandbox_set_input,
+        pairs=pairs,
+    )
+
+
+def _persist_policy_lock(store: ArtifactStore) -> ArtifactInput:
+    """Persist the immutable policy barrier required before comparison evidence."""
+    envelope = ArtifactEnvelope(
+        schema_version=1,
+        created_at=_LOCK_AT,
+        code_revision="w16-lock-v1",
+    )
+    manifest = store.write_json(
+        artifact_id="w16-policy-lock",
+        artifact_type="router-policy-lock",
+        envelope=envelope,
+        files={"policy-lock.json": {"locked": True}},
+    )
+    return artifact_input(manifest)
+
+
+def _spec(
+    plan: EvaluationPlan,
+    plan_input: ArtifactInput,
+    task_input: ArtifactInput,
+    mode: SimulationMode,
+) -> SimulationSpec:
+    """Return one exact executable specification without pre-persisting its outputs."""
+    return SimulationSpec(
+        schema_version=1,
+        created_at=_EVIDENCE_AT,
+        inputs=_inputs(plan_input, task_input),
+        code_revision="w16-comparison-v1",
+        simulation_id=f"w16-{mode.value}-simulation",
+        evaluation_plan_id=plan.plan_id,
+        cell_ids=tuple(cell.cell_id for cell in plan.cells),
+        agent_id="w16-comparison-agent",
+        mode=mode,
+        world_model=(
+            WorldModelSettings(
+                world_model_alias="world-model-a",
+                prompt_version="text-world-model-v1",
+            )
+            if mode is SimulationMode.WORLD_MODEL
+            else None
+        ),
+        sandbox=(
+            SandboxSettings(
+                environment_id="w16-local-process",
+                environment_sha256=_ENVIRONMENT_SHA256,
+                maximum_time_seconds=10.0,
+            )
+            if mode is SimulationMode.SANDBOX
+            else None
+        ),
+        seed=16,
+        maximum_steps=2,
+    )
+
+
+def _resolved(alias: str, snapshot: ModelSnapshot, client: ModelClient) -> ResolvedModel:
+    """Return one exact local fake model binding."""
+    return ResolvedModel(
+        alias=alias,
+        snapshot=snapshot,
+        capabilities=ModelCapabilities(
+            context_window_tokens=100_000,
+            maximum_output_tokens=16_000,
+        ),
+        client=client,
+        embedding_client=None,
+    )
+
+
+def _rollouts(
+    store: ArtifactStore,
+    artifact_set: SimulationArtifactSet,
+) -> tuple[tuple[RolloutArtifact, ArtifactInput], ...]:
+    """Load actual rollouts with exact persisted manifest identities."""
+    return tuple(
+        (
+            RolloutArtifact.model_validate_json(store.read_bytes(rollout_id, "rollout.json")),
+            artifact_input(store.read(rollout_id).manifest),
+        )
+        for rollout_id in artifact_set.artifact_ids
+    )
+
+
+def _task(task_id: str) -> TaskCase:
+    """Return one held-out task shared across text and executable modes."""
+    return TaskCase(
+        task_id=task_id,
+        lineage_group_id=f"lineage-{task_id}",
+        partition="held_out",
+        instruction=f"Complete {task_id} with the customer runtime.",
+        workload_weight=0.5,
+        source_trace_ids=(f"trace-{task_id}",),
+    )
+
+
+def _world_snapshot() -> ModelSnapshot:
+    """Return the frozen fake world-model identity."""
+    return ModelSnapshot(
+        provider="test",
+        model_id="world-model-a",
+        revision="fixture",
+        capabilities_sha256="a" * 64,
+        connection_sha256="b" * 64,
+    )
+
+
+_LOCAL_PROCESS_FIXTURE = """\
+import json
+import sys
+
+task_id = None
+for line in sys.stdin:
+    request = json.loads(line)
+    if request["kind"] == "open":
+        task_id = request["task"]["task_id"]
+        print(json.dumps({"ready": True}), flush=True)
+        continue
+    if request["kind"] == "close":
+        break
+    if task_id == "task-b":
+        print("{malformed", flush=True)
+        continue
+    print(json.dumps({"content": "local result", "is_error": False, "metadata": {}}), flush=True)
+"""

--- a/wmo/workflow/router_evidence_test.py
+++ b/wmo/workflow/router_evidence_test.py
@@ -1,0 +1,493 @@
+"""W16 deterministic customer-path evidence over the public router composition API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+import wmo
+from wmo.common.evaluations import EvaluationPlan, EvaluationProtocol, ObservedProductionCell
+from wmo.common.evaluations.build_test import _persist_rollout, _production_rollout
+from wmo.common.judging import Judgment
+from wmo.common.models import (
+    AssistantAction,
+    CandidateTokenPrice,
+    ModelClient,
+    ModelFinishReason,
+    ModelRequest,
+    ModelResponse,
+    NumericMeasurement,
+    OperationEconomics,
+    PricingSnapshot,
+    RoutedCandidateSnapshot,
+    ToolCall,
+    Usage,
+)
+from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
+from wmo.common.routing import KnnGuard
+from wmo.common.tasks import load_task_set
+from wmo.optimize.router.workflow_test import _persist_embeddings
+from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.router.application import create_project_router_app
+from wmo.simulation.build_test import _trace
+from wmo.simulation.engines.text.simulator import WorldModelSimulator
+from wmo.simulation.engines.text.simulator_test import (
+    _OneTurnAgent,
+    _response,
+    _ScriptedClient,
+)
+from wmo.simulation.ingest.otlp import TraceNormalizationResult
+from wmo.simulation.orchestration import Simulator
+from wmo.simulation.specs import WorldModelSettings
+from wmo.workflow.judgment_budget import JudgmentDispatchReceipt
+from wmo.workflow.router import (
+    ApprovedRouterReview,
+    RouterCompositionBudget,
+    RouterEvaluationSetup,
+    RouterWorkflowServices,
+)
+from wmo.workflow.router_test import (
+    _capabilities,
+    _FidelityApproval,
+    _Judge,
+    _resolved,
+    _ReviewSupplier,
+    _snapshot,
+)
+
+_TIME = datetime(2026, 8, 12, tzinfo=UTC)
+_REVISION = "w16-deterministic-evidence-v1"
+
+
+class _EvidenceSetupSupplier:
+    """Persist two measured candidates, reviewed overlaps, embeddings, and pricing."""
+
+    def __call__(
+        self,
+        project: ProjectStore,
+        build: wmo.ProjectBuild,
+        review: ApprovedRouterReview,
+        budget: RouterCompositionBudget,
+    ) -> RouterEvaluationSetup:
+        del review, budget
+        tasks = load_task_set(project.artifacts, build.artifacts.task_set.task_set_id).tasks
+        candidates = tuple(
+            RoutedCandidateSnapshot(alias=alias, model=_snapshot(alias))
+            for alias in ("candidate-baseline", "candidate-economy")
+        )
+        fit_tasks = tuple(task for task in tasks if task.partition == "fit")
+        observed = []
+        for index, task in enumerate(fit_tasks[:10]):
+            rollout_id = f"w16-production-{index:02d}"
+            if rollout_id not in project.artifacts.list_ids():
+                rollout = _production_rollout(
+                    rollout_id,
+                    cell_id=f"w16-import-{index}",
+                    task=task,
+                    candidate=candidates[0].model,
+                ).model_copy(update={"trace_id": task.source_trace_ids[0]})
+                _persist_rollout(project.artifacts, rollout)
+            observed.append(
+                ObservedProductionCell(
+                    task_id=task.task_id,
+                    candidate_alias="candidate-baseline",
+                    repeat=0,
+                    rollout_artifact_id=rollout_id,
+                )
+            )
+        if "w16-pricing" not in project.artifacts.list_ids():
+            pricing = PricingSnapshot(
+                schema_version=1,
+                created_at=_TIME,
+                code_revision=_REVISION,
+                pricing_snapshot_id="w16-pricing",
+                candidate_prices=(
+                    CandidateTokenPrice(
+                        candidate_alias="candidate-baseline",
+                        input_usd_per_million_tokens=2.0,
+                        output_usd_per_million_tokens=4.0,
+                    ),
+                    CandidateTokenPrice(
+                        candidate_alias="candidate-economy",
+                        input_usd_per_million_tokens=1.0,
+                        output_usd_per_million_tokens=2.0,
+                    ),
+                ),
+            )
+            project.artifacts.write_json(
+                artifact_id=pricing.pricing_snapshot_id,
+                artifact_type="pricing-snapshot",
+                envelope=pricing,
+                files={"pricing.json": pricing},
+            )
+            _persist_embeddings(project.artifacts, tasks)
+        production = EvaluationProtocol(
+            protocol_id="w16-production-protocol",
+            evidence_source="production",
+            agent_id="agent-a",
+            simulator_id="production-import-v1",
+            rubric_id="rubric-a",
+            judge_calibration_id="calibration-a",
+            pricing_snapshot_id="w16-pricing",
+        )
+        world = EvaluationProtocol(
+            protocol_id="w16-world-protocol",
+            evidence_source="world_model",
+            agent_id="agent-a",
+            simulator_id="text-world-model-v1",
+            world_model=_snapshot("world-model-a"),
+            simulator_prompt_id="world-model-text-v1",
+            rubric_id="rubric-a",
+            judge_calibration_id="calibration-a",
+            pricing_snapshot_id="w16-pricing",
+        )
+        return RouterEvaluationSetup(
+            candidates=candidates,
+            observed_cells=tuple(observed),
+            production_protocol=production,
+            simulation_protocol=world,
+            embedding_set_id="embeddings-a",
+            pricing_snapshot_id="w16-pricing",
+            incumbent_alias="candidate-baseline",
+            guard=KnnGuard(
+                maximum_neighbors=10,
+                minimum_paired_observations=8,
+                relative_similarity_threshold=0.0,
+                uncertainty_multiplier=0.5,
+                quality_tolerance=0.0,
+            ),
+            judgment_status="provisional",
+            world_model_settings=WorldModelSettings(
+                world_model_alias="world-model-a",
+                prompt_version="text-world-model-v1",
+            ),
+            agent_id="agent-a",
+            seed=16,
+            maximum_steps=2,
+            maximum_concurrency=1,
+        )
+
+
+class _EvidenceSimulatorFactory:
+    """Bind the actual text simulator to deterministic local model-client fakes."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.candidates = {
+            "candidate-baseline": _ScriptedClient(
+                [
+                    _response(
+                        "Resolved by baseline.",
+                        snapshot=_snapshot("candidate-baseline"),
+                        cost=0.0,
+                    )
+                ]
+                * 100
+            ),
+            "candidate-economy": _ScriptedClient(
+                [
+                    _response(
+                        "Resolved by economy.",
+                        snapshot=_snapshot("candidate-economy"),
+                        cost=0.0,
+                    )
+                ]
+                * 100
+            ),
+        }
+        self.world = _ScriptedClient(
+            [
+                _response(
+                    '{"message":"Done.","terminal":true}',
+                    snapshot=_snapshot("world-model-a"),
+                    cost=0.0,
+                )
+            ]
+            * 200
+        )
+
+    def __call__(self, project: ProjectStore, plan: EvaluationPlan) -> Simulator:
+        self.calls += 1
+        return WorldModelSimulator(
+            store=project.artifacts,
+            evaluation_plan=plan,
+            evaluation_plan_input=artifact_input(project.artifacts.read(plan.plan_id).manifest),
+            task_set_input=artifact_input(project.artifacts.read(plan.task_set_id).manifest),
+            candidate_models={
+                alias: _resolved(alias, cast(ModelClient, client))
+                for alias, client in self.candidates.items()
+            },
+            world_models={
+                "world-model-a": _resolved("world-model-a", cast(ModelClient, self.world))
+            },
+            agent_factory=_OneTurnAgent,
+            clock=lambda: _TIME,
+            monotonic=lambda: 1.0,
+        )
+
+
+class _EvidenceJudge(_Judge):
+    """Persist the deterministic judgment with an explicit observed zero-dollar cost."""
+
+    def judge_persisted(
+        self,
+        store: ProjectStore,
+        *,
+        rollout_artifact_id: str,
+        rubric_artifact_id: str,
+        calibration_artifact_id: str,
+    ) -> Judgment:
+        judgment = super().judge_persisted(
+            store,
+            rollout_artifact_id=rollout_artifact_id,
+            rubric_artifact_id=rubric_artifact_id,
+            calibration_artifact_id=calibration_artifact_id,
+        )
+        return judgment.model_copy(
+            update={
+                "judge_economics": OperationEconomics(
+                    cost_usd=NumericMeasurement(value=0.0, provenance="observed")
+                )
+            }
+        )
+
+
+class _RuntimeClient:
+    """Return one exact routed candidate identity while counting local calls."""
+
+    def __init__(self, alias: str) -> None:
+        self.alias = alias
+        self.complete_calls = 0
+        self.embed_calls = 0
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        self.complete_calls += 1
+        return ModelResponse(
+            output=AssistantAction(
+                tool_calls=(ToolCall(call_id="w16-call", name="resolve", arguments={}),)
+            ),
+            model=_snapshot(self.alias),
+            economics=OperationEconomics(
+                usage=Usage(input_tokens=7, output_tokens=3, cached_input_tokens=0),
+                cost_usd=NumericMeasurement(value=0.0, provenance="observed"),
+            ),
+            finish_reason=ModelFinishReason.COMPLETED,
+        )
+
+    def embed(self, texts) -> tuple:  # noqa: ANN001, ANN201 - protocol fixture
+        self.embed_calls += 1
+        assert len(texts) == 1
+        from wmo.common.models import Embedding
+
+        return (Embedding(values=(1.0, 0.0)),)
+
+
+class _RuntimeCatalog:
+    """Resolve exact candidate and embedder clients without a provider or environment."""
+
+    def __init__(self) -> None:
+        self.clients = {
+            alias: _RuntimeClient(alias)
+            for alias in ("candidate-baseline", "candidate-economy", "embedder")
+        }
+
+    def snapshot(self, alias: str) -> tuple:
+        return _snapshot(alias), _capabilities(alias)
+
+    def resolve(self, alias: str) -> ResolvedModel:
+        snapshot, capabilities = self.snapshot(alias)
+        client = self.clients[alias]
+        return ResolvedModel(
+            alias=alias,
+            snapshot=snapshot,
+            capabilities=capabilities,
+            client=client,
+            embedding_client=client if alias == "embedder" else None,
+        )
+
+
+def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One 100-trace public workflow proves phase locks, replay, budgets, and HTTP stickiness."""
+    project = ProjectStore(tmp_path, "w16-project")
+    project.initialize(ProjectConfig(project_id="w16-project"))
+    normalized = TraceNormalizationResult(
+        traces=tuple(_trace(index) for index in range(100)),
+        issues=(),
+    )
+    simulator = _EvidenceSimulatorFactory()
+    judge = _EvidenceJudge()
+    approval = _FidelityApproval()
+    runtime_catalog = _RuntimeCatalog()
+    services = RouterWorkflowServices(
+        review_supplier=_ReviewSupplier(),
+        setup_supplier=_EvidenceSetupSupplier(),
+        simulator_factory=simulator,
+        judge=judge,
+        fidelity_approval=approval,
+        runtime_catalog=cast(RuntimeModelCatalog, runtime_catalog),
+    )
+    budget = RouterCompositionBudget(
+        maximum_simulation_cost_usd=2.0,
+        maximum_judgments=200,
+    )
+    telemetry_attempts: list[str] = []
+    telemetry_delivered: set[str] = set()
+
+    def capture(_event, completion_id, _properties, *, root):  # noqa: ANN001, ANN202
+        assert root == tmp_path
+        telemetry_attempts.append(completion_id)
+        if completion_id in telemetry_delivered:
+            return False
+        telemetry_delivered.add(completion_id)
+        return True
+
+    monkeypatch.setattr("wmo.workflow.router.capture_completion_once", capture)
+    crash_after_policy = True
+    crash_after_report = True
+
+    def checkpoint(phase: str) -> None:
+        nonlocal crash_after_policy, crash_after_report
+        if phase == "policy_locked" and crash_after_policy:
+            crash_after_policy = False
+            raise RuntimeError("w16 crash after fit lock")
+        if phase == "report_complete" and crash_after_report:
+            crash_after_report = False
+            raise RuntimeError("w16 crash after durable report and telemetry")
+
+    with pytest.raises(RuntimeError, match="after fit lock"):
+        wmo.compose_router(
+            project,
+            normalized,
+            services=services,
+            budget=budget,
+            created_at=_TIME,
+            code_revision=_REVISION,
+            phase_hook=checkpoint,
+        )
+    dispatches_after_crash = _dispatch_counts(simulator, judge, approval)
+    with pytest.raises(RuntimeError, match="after durable report"):
+        wmo.compose_router(
+            project,
+            normalized,
+            services=services,
+            budget=budget,
+            created_at=_TIME,
+            code_revision=_REVISION,
+            phase_hook=checkpoint,
+        )
+    result = wmo.compose_router(
+        project,
+        normalized,
+        services=services,
+        budget=budget,
+        created_at=_TIME,
+        code_revision=_REVISION,
+        phase_hook=checkpoint,
+    )
+    dispatches_after_completion = _dispatch_counts(simulator, judge, approval)
+    replay = wmo.compose_router(
+        project,
+        normalized,
+        services=services,
+        budget=budget,
+        created_at=_TIME,
+        code_revision=_REVISION,
+    )
+
+    tasks = load_task_set(project.artifacts, result.plan.task_set_id).tasks
+    assert len(normalized.traces) == 100
+    assert len(tuple(task for task in tasks if task.partition == "fit")) == 50
+    assert len(tuple(task for task in tasks if task.partition == "held_out")) == 20
+    assert result.build.review.status == "proposals_pending"
+    assert result.review.rubric_id == "rubric-a"
+    assert result.review.calibration_id == "calibration-a"
+    assert result.fidelity_approval_id
+    assert result.policy_lock_id
+    report = result.optimization.optimization.report
+    assert len(report.held_out_task_ids) == 20
+    assert report.coverage.planned_row_count == 40
+    assert report.coverage.failed_row_count == 0
+    assert report.coverage.not_run_row_count == 0
+    assert report.source_strata
+    assert result.build.review.paid_calls_made == 0
+    assert result.phase_a_simulation_spend_usd == 0.0
+    assert result.held_out_simulation_spend_usd == 0.0
+    assert result.total_simulation_spend_usd == 0.0
+    assert result.held_out_simulation_spec.maximum_cost_usd == (budget.maximum_simulation_cost_usd)
+    assert report.run_spend.candidate.known_total_usd == 0.0
+    assert report.run_spend.world_model.known_total_usd == 0.0
+    assert report.run_spend.judge.known_total_usd == 0.0
+    assert report.run_spend.candidate.missing_row_count == 0
+    assert report.run_spend.world_model.missing_row_count == 0
+    assert report.run_spend.judge.missing_row_count == 0
+    assert replay.optimization == result.optimization
+    assert _dispatch_counts(simulator, judge, approval) == dispatches_after_completion
+    assert dispatches_after_completion[0] > dispatches_after_crash[0]
+    planned_phase_cells = len(result.simulation_spec.cell_ids) + len(
+        result.held_out_simulation_spec.cell_ids
+    )
+    assert planned_phase_cells == 140
+    assert dispatches_after_completion[:2] == (
+        140,
+        140,
+    )
+    reservations = tuple(
+        JudgmentDispatchReceipt.model_validate_json(
+            project.artifacts.read_bytes(artifact_id, "dispatch.json")
+        )
+        for artifact_id in project.artifacts.list_ids()
+        if project.artifacts.read(artifact_id).manifest.artifact_type == "judgment-dispatch"
+    )
+    assert len(reservations) == judge.calls == len(result.plan.cells) == 150
+    assert judge.calls <= budget.maximum_judgments
+    assert len(telemetry_delivered) == 1
+    assert len(telemetry_attempts) == 3
+
+    app = create_project_router_app("w16-router", result.runtime)
+    http = TestClient(app)
+    payload = {
+        "model": "w16-router",
+        "messages": [{"role": "user", "content": "Resolve customer case 17"}],
+    }
+    first_http = http.post(
+        "/v1/chat/completions",
+        json=payload,
+        headers={"X-WMO-Episode-ID": "w16-customer-episode"},
+    )
+    second_http = http.post(
+        "/v1/chat/completions",
+        json={
+            **payload,
+            "messages": [
+                *payload["messages"],
+                {"role": "user", "content": "Continue with the same customer case"},
+            ],
+        },
+        headers={"X-WMO-Episode-ID": "w16-customer-episode"},
+    )
+    assert first_http.status_code == second_http.status_code == 200
+    assert first_http.headers["X-WMO-Routed-Model"] == second_http.headers["X-WMO-Routed-Model"]
+    assert (
+        first_http.json()["routing_decision"]["episode_id_sha256"]
+        == second_http.json()["routing_decision"]["episode_id_sha256"]
+    )
+    assert runtime_catalog.clients["embedder"].embed_calls == 1
+    assert sum(client.complete_calls for client in runtime_catalog.clients.values()) == 2
+    assert "w16-customer-episode" not in first_http.text
+
+
+def _dispatch_counts(
+    simulator: _EvidenceSimulatorFactory,
+    judge: _Judge,
+    approval: _FidelityApproval,
+) -> tuple[int, int, int, int]:
+    """Return model, world-model, judge, and approval dispatch totals."""
+    candidate_calls = sum(len(client.requests) for client in simulator.candidates.values())
+    return candidate_calls, len(simulator.world.requests), judge.calls, approval.calls


### PR DESCRIPTION
## Summary

- add deterministic W16 evidence for the public 100-trace router composition path through fit lock, held-out reporting, replay, and sticky HTTP runtime
- add actual text-versus-bounded-local-process sandbox comparison evidence with explicit missing and failure denominators
- document exact evidence scope and limitations, and extend release ownership and public API guards

## Evidence

- 150 plan cells: 10 observed fidelity cells and 140 simulated cells
- 50 fit tasks, 20 held-out tasks, and 40 held-out report rows with zero failed or not-run rows
- 150 durable judgments under one ceiling of 200
- exact observed candidate, world-model, judge, and total simulation spend of $0
- crashes after fit lock and durable report/telemetry resume with zero duplicate dispatch or telemetry delivery
- local comparison retains 2 expected, 2 paired, 1 usable, and 1 explicit sandbox failure

## Validation

- `uv run pytest -q -k "not live"`: 634 passed, 1 skipped, 10 deselected
- focused W9-W16 contracts: 143 passed, 1 skipped
- W16R and W16S independent exact-head audit: 2 passed
- Ruff, format, and Ty: pass
- web tests, TypeScript lint, and production build: pass
- fresh wheel and sdist archive guards: 10 passed
- installed-wheel public W16 imports and CLI help: pass
- CLI and PostHog ingress/outbound gates: 51 passed

## Boundaries

No hosted provider, E2B, Tinker, credentials, environment secrets, or paid calls were used. The bounded local-process comparison intentionally runs on Darwin and skips elsewhere because its containment contract is Darwin-only. Terminal agreement is structural, not a task-quality claim.
