### PR TITLE
Verify exact W17 release evidence

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install the project and its dev extras
         run: uv sync --extra dev
       - name: W16 router and bounded local-process evidence
+        env:
+          WMO_RELEASE_REVISION: ${{ github.sha }}
+          WMO_RELEASE_EVIDENCE_DIR: ${{ runner.temp }}/w17-release-evidence
         run: >-
           uv run pytest -q
           --junitxml=w16-darwin-evidence.xml
@@ -45,4 +48,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: w16-darwin-evidence
-          path: w16-darwin-evidence.xml
+          path: |
+            w16-darwin-evidence.xml
+            ${{ runner.temp }}/w17-release-evidence/*.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,9 @@ results, and plans do not live here.
 
 | File | Purpose |
 |---|---|
-| `usage.md` | Locked CLI map for build, optimize router, run, and config telemetry. |
+| `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config telemetry. |
 | `cookbook/router.md` | Provider-free local artifact and loopback runtime walkthrough. |
-| `reference/distill.md` | Existing model-distillation reference owned outside the W14R CLI slice. |
-| `reference/harness_delta.md` | Existing typed harness update contract owned outside the W14R CLI slice. |
 | `reference/ingest.md` | Current OTLP and PostHog local trace input contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |
+| `release-scope.md` | Supported and explicitly excluded release claims. |
 | `research/w16-router-sandbox-evidence.md` | Deterministic W16 router and local sandbox evidence, limits, and replay commands. |

--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -20,3 +20,15 @@ Build makes zero model, provider, or judge paid calls. The CLI preserves anonymo
 PostHog product telemetry, which may send after successful persistence unless the user runs
 `wmo config telemetry disable`. Telemetry does not include prompts, traces, paths, model names, or
 customer content.
+
+## Authorized PostHog HogQL pull
+
+The CLI deliberately reads only local exports. An authorized Python caller may instead import
+`PostHogPullRequest` and `pull_posthog_traces` from `wmo.simulation.ingest`. The request defaults to
+a bounded 1,000-row query and may set another positive limit through 10,000. The caller may inject a
+deterministic HTTP client; otherwise the function owns one bounded `httpx.Client`. The HTTPS host
+and credential are explicit request values or resolved from the focused PostHog environment
+settings. The query orders by `timestamp, uuid`, applies the same canonical converter as local
+export ingestion, and returns normalized traces plus retained issues. This does not weaken the
+`wmo build` local-file boundary and requires separate authorization for the customer PostHog
+project.

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -1,0 +1,35 @@
+# Release scope
+
+This release supports the current source and one wheel with either core dependencies or the
+optional `sft` dependency extra on their documented local paths. It claims only behavior exercised
+on the exact release checkout.
+
+## Supported and verified
+
+- Root CLI commands are exactly `build`, `config`, `optimize`, and `run`; optimizer commands are
+  exactly `router` and `model`.
+- Public Python exposes provider-free build, explicit router composition, frozen router load and
+  HTTP application, structural text-versus-sandbox comparison, and managed SFT composition.
+- W16 router evidence uses 100 normalized traces, 50 fit tasks, 20 held-out tasks, 150 planned
+  cells, 140 deterministic text simulations, and 150 deterministic judgments under one finite
+  simulation and judgment budget. Observed hosted-service spend is exactly $0.00.
+- W16 sandbox evidence compares two exact post-lock text and Darwin local-process pairs. It retains
+  one malformed sandbox failure in the denominator and claims structural terminal agreement only.
+- Exact-checkout CI supplies the full 40-hex Git revision, recursively verifies every evidence
+  artifact and manifest input, and publishes machine-readable JSON plus JUnit evidence.
+
+## Explicitly excluded
+
+- No paid E2B or Harbor cloud smoke ran. The repository verifies the optional `bounded-close-v1`
+  Harbor lifecycle and ledger with injected fakes, but makes no cloud cleanup, provider-quality, or
+  environment-parity claim.
+- No real Tinker training ran. Managed SFT remains fail-closed unless its immutable configuration
+  has a finite positive ceiling and its backend supplies a conservative full-schedule estimate.
+- No trained-versus-base behavioral comparison ran because this release produced no paid training
+  artifact. It makes no trained-model quality-improvement claim.
+- No hosted model, judge, embedding, telemetry, environment, credential, or `.env` path was used by
+  release evidence. The deterministic W16 evidence reports exactly $0.00 observed service spend.
+
+These exclusions are product boundaries, not evidence that the corresponding hosted services are
+unsafe or unsupported forever. Any future claim requires separately authorized, finite-budget,
+denominator-preserving evidence.

--- a/docs/research/w16-router-sandbox-evidence.md
+++ b/docs/research/w16-router-sandbox-evidence.md
@@ -4,6 +4,10 @@ W16 verifies the current public router workflow and the text-versus-sandbox comp
 deterministic injected clients. The evidence invokes no hosted provider, E2B, Tinker, credential,
 or paid service. It does not claim provider quality or cloud-environment parity.
 
+The exact-checkout gate resolves and validates the full 40-hex Git revision, writes it into every
+persisted W16 artifact, recursively verifies manifest inputs and nested artifact envelopes, and
+uploads machine-readable JSON plus JUnit output. Symbolic or mismatched revision labels fail closed.
+
 ## Router workflow
 
 `wmo/workflow/router_evidence_test.py` drives `wmo.compose_router` from 100 normalized traces.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,12 +6,16 @@ The root surface is deliberately small:
 |---|---|---|
 | `wmo build TRACE_FILE --project PROJECT --root ROOT` | Normalize 100 through 1000 local OTLP or PostHog traces and mine representative tasks. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
 | `wmo optimize router PROJECT --config FILE --root ROOT` | Fit, freeze, then report from explicit completed evidence. | Fit evaluation, bank, policy, held-out evaluation, and router report. |
+| `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run PROJECT --root ROOT` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint requiring `X-WMO-Episode-ID`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
 `build` makes zero model, provider, or judge paid calls. Successful build, router, simulation, and
 SFT operations preserve anonymous aggregate PostHog product telemetry, which may send unless
-disabled. `optimize router` does not make provider calls. `run` makes no provider call at startup.
+disabled. `optimize router` does not make provider calls. `optimize model` requires an immutable
+positive cost ceiling, a finite conservative full-schedule estimate, explicit consent, and complete
+project evidence before Tinker can open. Unknown cost or incomplete provenance fails before
+dispatch. `run` makes no provider call at startup.
 An HTTP completion or direct `RouterRuntime.complete` call is the explicit online model-call
 boundary. The router remains frozen for the process lifetime.
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,8 @@
         "@vitejs/plugin-react": "^4.3.0",
         "jsdom": "^25.0.0",
         "typescript": "^5.7.0",
-        "vitest": "^2.1.0"
+        "vite": "^6.4.3",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -486,9 +487,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -499,13 +500,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -516,13 +517,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -533,13 +534,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -550,13 +551,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -567,13 +568,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -584,13 +585,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -601,13 +602,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -618,13 +619,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -635,13 +636,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -652,13 +653,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -669,13 +670,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -686,13 +687,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -703,13 +704,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -720,13 +721,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -737,13 +738,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -754,13 +755,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -771,13 +772,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -788,13 +806,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -805,13 +840,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -822,13 +874,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -839,13 +891,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -856,13 +908,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -873,7 +925,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -2324,6 +2376,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2383,38 +2453,39 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2426,70 +2497,97 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2935,9 +3033,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2945,32 +3043,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -3001,6 +3102,24 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -3784,9 +3903,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3805,6 +3924,19 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",
@@ -4108,6 +4240,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -4171,6 +4323,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -4182,9 +4351,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4192,9 +4361,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4306,21 +4475,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4329,17 +4501,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -4362,79 +4540,92 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^25.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^2.1.0"
+    "vite": "^6.4.3",
+    "vitest": "^3.2.6"
   }
 }

--- a/wmo/cli/consent.py
+++ b/wmo/cli/consent.py
@@ -12,10 +12,9 @@ read whatever the redirect supplied, and a blank line was taken as approval.
 
 This lives in one place because the rule kept being re-implemented per command and a site kept
 being missed: `wmo optimize model` shipped proceed-and-note and spent a scripted caller's real
-money (#305), `route sweep`, managed SFT execution, and the harbor population search were fixed
-next (#307), and the world-model mode of `wmo optimize harness` was still falling through with
-no prompt and no notice after both. Every gate now calls `require_spend_consent`, so there is
-one behaviour to read and one place a future spend surface has to reach for.
+money (#305). Later router-composition and managed SFT spend surfaces exposed the same class of
+failure. Every retained gate now calls `require_spend_consent`, so there is one behaviour to read
+and one place a future spend surface has to reach for.
 """
 
 from __future__ import annotations
@@ -97,7 +96,7 @@ def require_spend_consent(
             projected dollar figure, or the rollout/episode counts when the work is unpriced).
             Printed in the refusal, so a scripted caller learns the size of what it just
             declined to authorize instead of only that something was skipped.
-        command: The command being run, e.g. `wmo optimize route sweep`, named in the refusal
+        command: The command being run, e.g. `wmo optimize model`, named in the refusal
             so the message says what to re-run.
         alternative: An optional second way out, phrased as a flag plus what it does, e.g.
             "--dry-run to see the plan without spending".

--- a/wmo/cli/consent_test.py
+++ b/wmo/cli/consent_test.py
@@ -53,9 +53,7 @@ def test_yes_consents_without_asking_even_at_a_terminal(monkeypatch: pytest.Monk
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, buffer = _console(terminal=True)
 
-    assert require_spend_consent(
-        console, yes=True, spend="~$12.00", command="wmo optimize route sweep"
-    )
+    assert require_spend_consent(console, yes=True, spend="~$12.00", command="wmo optimize model")
     assert answer.asked == []
     assert buffer.getvalue() == ""
 
@@ -68,7 +66,7 @@ def test_a_terminal_is_asked_and_a_no_declines(
     console, _buffer = _console(terminal=True)
 
     assert not require_spend_consent(
-        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+        console, yes=False, spend="~$12.00", command="wmo optimize model"
     )
     assert len(answer.asked) == 1
 
@@ -80,9 +78,7 @@ def test_a_terminal_is_asked_and_a_yes_consents(
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, _buffer = _console(terminal=True)
 
-    assert require_spend_consent(
-        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
-    )
+    assert require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
     assert len(answer.asked) == 1
 
 
@@ -103,14 +99,14 @@ def test_no_terminal_and_no_yes_refuses_naming_the_spend_and_the_flag(
             console,
             yes=False,
             spend="~$12.00 across 240 cell(s)",
-            command="wmo optimize route sweep",
+            command="wmo optimize model",
         )
 
     assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
     assert answer.asked == []  # nothing was asked, because there was nobody to ask
     flat = _flat(buffer)
     assert "cannot ask for spend consent" in flat
-    assert "wmo optimize route sweep would spend ~$12.00 across 240 cell(s) here" in flat
+    assert "wmo optimize model would spend ~$12.00 across 240 cell(s) here" in flat
     assert "Re-run the same command with --yes to consent explicitly." in flat
 
 
@@ -131,7 +127,7 @@ def test_the_refusal_names_a_second_way_out_when_the_command_has_one() -> None:
 
 # -- the input stream is half of "interactive" --------------------------------------------------
 # Checking only the console asked the wrong stream: the console reports on stdout while the
-# prompt reads stdin, so `wmo optimize route sweep < /dev/null` at a terminal passed the gate
+# prompt reads stdin, so `wmo optimize model < /dev/null` at a terminal passed the gate
 # and then had a redirect answer the money question for the absent human.
 
 
@@ -148,9 +144,7 @@ def test_a_terminal_stdout_with_redirected_stdin_refuses(
     console, buffer = _console(terminal=True)
 
     with pytest.raises(typer.Exit) as caught:
-        require_spend_consent(
-            console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
-        )
+        require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
 
     assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
     assert answer.asked == []  # never offered, so a redirect could not answer it
@@ -196,7 +190,7 @@ def test_a_blank_answer_refuses_instead_of_authorizing_the_spend(
     console, _buffer = _console(terminal=True)
 
     assert not require_spend_consent(
-        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+        console, yes=False, spend="~$12.00", command="wmo optimize model"
     )
 
 
@@ -212,13 +206,13 @@ def test_eof_at_the_prompt_is_the_documented_refusal_not_a_traceback(
             console,
             yes=False,
             spend="~$12.00 across 240 cell(s)",
-            command="wmo optimize route sweep",
+            command="wmo optimize model",
         )
 
     assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
     flat = _flat(buffer)
     assert "cannot ask for spend consent" in flat
-    assert "wmo optimize route sweep would spend ~$12.00 across 240 cell(s) here" in flat
+    assert "wmo optimize model would spend ~$12.00 across 240 cell(s) here" in flat
     assert "Re-run the same command with --yes to consent explicitly." in flat
 
 
@@ -230,6 +224,6 @@ def test_the_prompt_defaults_to_refusing(
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, _buffer = _console(terminal=True)
 
-    require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize route sweep")
+    require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
 
     assert answer.defaults == [False]

--- a/wmo/release_revision_test.py
+++ b/wmo/release_revision_test.py
@@ -1,0 +1,184 @@
+"""Exact-checkout provenance checks shared by the executable W16 release evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+from pydantic import JsonValue
+
+from wmo.common.core.artifacts import sha256_json
+from wmo.common.project import ArtifactStore
+
+_REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+
+
+def exact_checkout_revision() -> str:
+    """Return one verified 40-hex checkout revision or fail closed."""
+    revision = _git("rev-parse", "HEAD")
+    _require_revision(revision, label="checked-out revision")
+    for variable in ("WMO_RELEASE_REVISION", "GITHUB_SHA"):
+        configured = os.environ.get(variable)
+        if configured is None:
+            continue
+        _require_revision(configured, label=variable)
+        if configured != revision:
+            raise RuntimeError(f"{variable} does not match the checked-out revision")
+    if _git_status("diff", "--quiet", "--", ".") != 0:
+        raise RuntimeError("release evidence requires a checkout with no tracked source changes")
+    if _git_status("diff", "--cached", "--quiet", "--", ".") != 0:
+        raise RuntimeError("release evidence requires a checkout with no staged source changes")
+    untracked = _git("ls-files", "--others", "--exclude-standard", "--", ".")
+    if untracked:
+        raise RuntimeError("release evidence source paths contain untracked files")
+    return revision
+
+
+def verify_release_evidence(
+    store: ArtifactStore,
+    *,
+    expected_revision: str,
+    report_name: str,
+    claims: Mapping[str, JsonValue],
+) -> dict[str, JsonValue]:
+    """Recursively verify exact artifact inputs and emit one optional machine-readable report."""
+    _require_revision(expected_revision, label="expected release revision")
+    artifact_ids = store.list_ids()
+    verified_inputs = 0
+    artifact_types: dict[str, int] = {}
+    for artifact_id in artifact_ids:
+        stored = store.read(artifact_id)
+        manifest = stored.manifest
+        if manifest.code_revision != expected_revision:
+            raise AssertionError(
+                f"artifact {artifact_id} was written by {manifest.code_revision}, "
+                f"not {expected_revision}"
+            )
+        artifact_types[manifest.artifact_type] = artifact_types.get(manifest.artifact_type, 0) + 1
+        for input_record in manifest.inputs:
+            input_manifest = store.read(input_record.artifact_id).manifest
+            if sha256_json(input_manifest) != input_record.sha256:
+                raise AssertionError(
+                    f"artifact {artifact_id} input {input_record.artifact_id} has a stale digest"
+                )
+            verified_inputs += 1
+        for file_record in manifest.files:
+            if file_record.path.endswith(".json"):
+                value = json.loads(store.read_bytes(artifact_id, file_record.path))
+                _require_nested_revisions(value, expected_revision, artifact_id)
+            elif file_record.path.endswith(".jsonl"):
+                for line in store.read_bytes(artifact_id, file_record.path).splitlines():
+                    if line:
+                        _require_nested_revisions(json.loads(line), expected_revision, artifact_id)
+    report: dict[str, JsonValue] = {
+        "schema_version": 1,
+        "code_revision": expected_revision,
+        "artifact_count": len(artifact_ids),
+        "verified_input_count": verified_inputs,
+        "artifact_types": dict(sorted(artifact_types.items())),
+        "claims": dict(claims),
+    }
+    destination = os.environ.get("WMO_RELEASE_EVIDENCE_DIR")
+    if destination is not None:
+        output_directory = Path(destination)
+        output_directory.mkdir(parents=True, exist_ok=True)
+        (output_directory / f"{report_name}.json").write_text(
+            json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _require_nested_revisions(
+    value: JsonValue,
+    expected_revision: str,
+    artifact_id: str,
+) -> None:
+    """Reject any nested persisted code revision that differs from the checkout."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "code_revision" and item != expected_revision:
+                raise AssertionError(
+                    f"artifact {artifact_id} contains nested code revision {item!r}"
+                )
+            _require_nested_revisions(item, expected_revision, artifact_id)
+    elif isinstance(value, list):
+        for item in value:
+            _require_nested_revisions(item, expected_revision, artifact_id)
+
+
+def _require_revision(value: str, *, label: str) -> None:
+    """Require one full lowercase Git commit identity."""
+    if _REVISION_PATTERN.fullmatch(value) is None:
+        raise RuntimeError(f"{label} must be a full lowercase 40-hex Git revision")
+
+
+def _git(*arguments: str) -> str:
+    """Run one bounded read-only Git query against the release checkout."""
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=_REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def _git_status(*arguments: str) -> int:
+    """Return one bounded read-only Git status code."""
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=_REPOSITORY_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=30,
+    ).returncode
+
+
+def test_exact_checkout_revision_rejects_symbolic_or_mismatched_ci_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release provenance cannot be replaced by a label or a different commit."""
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "w16-release")
+    with pytest.raises(RuntimeError, match="full lowercase 40-hex"):
+        exact_checkout_revision()
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "0" * 40)
+    with pytest.raises(RuntimeError, match="does not match"):
+        exact_checkout_revision()
+
+
+@pytest.mark.parametrize("relative_path", ["release-shadow.py", "web/release-shadow.ts"])
+def test_exact_checkout_revision_rejects_untracked_checkout_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: str,
+) -> None:
+    """Root and web untracked inputs cannot hide outside the exact-checkout proof."""
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+    subprocess.run(["git", "config", "user.email", "release@example.invalid"], cwd=repository)
+    subprocess.run(["git", "config", "user.name", "Release Test"], cwd=repository)
+    tracked = repository / "tracked.txt"
+    tracked.write_text("tracked\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repository, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repository, check=True)
+    untracked = repository / relative_path
+    untracked.parent.mkdir(parents=True, exist_ok=True)
+    untracked.write_text("untracked\n", encoding="utf-8")
+    monkeypatch.setattr(sys.modules[__name__], "_REPOSITORY_ROOT", repository)
+    monkeypatch.delenv("WMO_RELEASE_REVISION", raising=False)
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+
+    with pytest.raises(RuntimeError, match="untracked files"):
+        exact_checkout_revision()

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -216,6 +216,34 @@ def test_w16_public_evidence_apis_resolve_from_release_owners() -> None:
     assert LocalProcessEnvironmentRuntime.__module__ == "wmo.runtime.environments.local"
 
 
+def test_documentation_index_commands_and_release_scope_are_current() -> None:
+    """Every indexed doc exists and release docs name current commands and explicit exclusions."""
+    repository = Path(__file__).resolve().parent.parent
+    docs = repository / "docs"
+    index = (docs / "README.md").read_text(encoding="utf-8")
+    indexed_paths = re.findall(r"\| `([^`]+\.md)` \|", index)
+    assert indexed_paths
+    assert not [path for path in indexed_paths if not (docs / path).is_file()]
+
+    usage = (docs / "usage.md").read_text(encoding="utf-8")
+    assert "wmo optimize router" in usage
+    assert "wmo optimize model" in usage
+    assert "wmo optimize route" not in usage.replace("wmo optimize router", "")
+
+    scope = (docs / "release-scope.md").read_text(encoding="utf-8")
+    for exclusion in (
+        "No paid E2B or Harbor cloud smoke ran",
+        "No real Tinker training ran",
+        "No trained-versus-base behavioral comparison ran",
+        "exactly $0.00 observed service spend",
+    ):
+        assert exclusion in scope
+
+    ingest = (docs / "reference" / "ingest.md").read_text(encoding="utf-8")
+    assert "PostHogPullRequest" in ingest
+    assert "pull_posthog_traces" in ingest
+
+
 @pytest.mark.parametrize(
     "stale_member",
     [

--- a/wmo/simulation/comparison_evidence_test.py
+++ b/wmo/simulation/comparison_evidence_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import sys
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
@@ -11,14 +12,20 @@ from typing import cast
 
 import pytest
 
-from wmo.common.core.artifacts import ArtifactEnvelope, ArtifactInput, sha256_json
-from wmo.common.evaluations import EvaluationPlan
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactInput,
+    canonical_json_bytes,
+    sha256_json,
+)
+from wmo.common.evaluations import EvaluationCell, EvaluationPlan
 from wmo.common.models import (
     ModelCapabilities,
     ModelClient,
     ModelMessage,
     ModelRequest,
     ModelSnapshot,
+    RoutedCandidateSnapshot,
     ToolCall,
 )
 from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
@@ -30,7 +37,8 @@ from wmo.common.rollouts import (
     StopReason,
     WorldModelSimulatorSnapshot,
 )
-from wmo.common.tasks import TaskCase
+from wmo.common.tasks import TaskCase, TaskSet
+from wmo.release_revision_test import exact_checkout_revision, verify_release_evidence
 from wmo.runtime.agents import AgentEpisode
 from wmo.runtime.environments import (
     EnvironmentSession,
@@ -47,7 +55,7 @@ from wmo.simulation import (
     persist_comparison,
     persist_comparison_spec,
 )
-from wmo.simulation.comparison_test import _inputs, _persist_plan, _persist_tasks
+from wmo.simulation.comparison_test import _inputs
 from wmo.simulation.engines import CandidateBinding, SandboxSimulator
 from wmo.simulation.engines.text.simulator import WorldModelSimulator
 from wmo.simulation.engines.text.simulator_test import _response, _ScriptedClient
@@ -114,18 +122,20 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
     tmp_path: Path,
 ) -> None:
     """Two actual modes replay exactly while one process failure remains in the denominator."""
+    revision = exact_checkout_revision()
     store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="w16-comparison"))
-    lock_input = _persist_policy_lock(store)
+    lock_input = _persist_policy_lock(store, revision)
     tasks = (_task("task-a"), _task("task-b"))
-    task_set, task_input = _persist_tasks(store, tasks)
-    text_plan, text_plan_input = _persist_plan(store, tasks, task_input, "text")
-    sandbox_plan, sandbox_plan_input = _persist_plan(store, tasks, task_input, "sandbox")
-    text_spec = _spec(text_plan, text_plan_input, task_input, SimulationMode.WORLD_MODEL)
+    task_set, task_input = _persist_tasks(store, tasks, revision)
+    text_plan, text_plan_input = _persist_plan(store, tasks, task_input, "text", revision)
+    sandbox_plan, sandbox_plan_input = _persist_plan(store, tasks, task_input, "sandbox", revision)
+    text_spec = _spec(text_plan, text_plan_input, task_input, SimulationMode.WORLD_MODEL, revision)
     sandbox_spec = _spec(
         sandbox_plan,
         sandbox_plan_input,
         task_input,
         SimulationMode.SANDBOX,
+        revision,
     )
     candidate_snapshot = text_plan.candidate_snapshots[0].model
     candidate_text = _ScriptedClient(
@@ -214,13 +224,14 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
         text_set,
         sandbox_set,
         tasks,
+        revision,
     )
     persist_comparison_spec(comparison, store)
     report = compare_text_and_sandbox(
         comparison,
         store=store,
         created_at=_REPORT_AT,
-        code_revision="w16-comparison-v1",
+        code_revision=revision,
     )
     persist_comparison(report, store)
 
@@ -239,7 +250,7 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
         comparison,
         store=store,
         created_at=_REPORT_AT,
-        code_revision="w16-comparison-v1",
+        code_revision=revision,
     )
     assert replay == report
     assert (
@@ -249,6 +260,24 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
         process_runtime.open_calls,
     ) == dispatches
     assert list(tmp_path.glob("wmo-sandbox-*")) == []
+    provenance = verify_release_evidence(
+        store,
+        expected_revision=revision,
+        report_name="w16-sandbox-comparison",
+        claims={
+            "expected_pair_count": 2,
+            "paired_rollout_count": 2,
+            "usable_pair_count": 1,
+            "missing_text_count": 0,
+            "missing_sandbox_count": 0,
+            "failed_text_count": 0,
+            "failed_sandbox_count": 1,
+            "observed_spend_usd": 0.0,
+            "hosted_call_count": 0,
+            "comparison_scope": "structural-only",
+        },
+    )
+    assert provenance["code_revision"] == revision
 
 
 def _comparison_spec(
@@ -264,6 +293,7 @@ def _comparison_spec(
     text_set: SimulationArtifactSet,
     sandbox_set: SimulationArtifactSet,
     tasks: Sequence[TaskCase],
+    revision: str,
 ) -> SimulationComparisonSpec:
     """Freeze one post-lock comparison from actual simulator outputs."""
     text_spec_input = artifact_input(store.read(text_spec.simulation_id).manifest)
@@ -307,7 +337,7 @@ def _comparison_spec(
         schema_version=1,
         created_at=_COMPARISON_AT,
         inputs=inputs,
-        code_revision="w16-comparison-v1",
+        code_revision=revision,
         comparison_id="w16-text-sandbox-comparison",
         policy_lock_input=lock_input,
         task_set_input=task_input,
@@ -321,12 +351,12 @@ def _comparison_spec(
     )
 
 
-def _persist_policy_lock(store: ArtifactStore) -> ArtifactInput:
+def _persist_policy_lock(store: ArtifactStore, revision: str) -> ArtifactInput:
     """Persist the immutable policy barrier required before comparison evidence."""
     envelope = ArtifactEnvelope(
         schema_version=1,
         created_at=_LOCK_AT,
-        code_revision="w16-lock-v1",
+        code_revision=revision,
     )
     manifest = store.write_json(
         artifact_id="w16-policy-lock",
@@ -342,13 +372,14 @@ def _spec(
     plan_input: ArtifactInput,
     task_input: ArtifactInput,
     mode: SimulationMode,
+    revision: str,
 ) -> SimulationSpec:
     """Return one exact executable specification without pre-persisting its outputs."""
     return SimulationSpec(
         schema_version=1,
         created_at=_EVIDENCE_AT,
         inputs=_inputs(plan_input, task_input),
-        code_revision="w16-comparison-v1",
+        code_revision=revision,
         simulation_id=f"w16-{mode.value}-simulation",
         evaluation_plan_id=plan.plan_id,
         cell_ids=tuple(cell.cell_id for cell in plan.cells),
@@ -373,6 +404,87 @@ def _spec(
         ),
         seed=16,
         maximum_steps=2,
+    )
+
+
+def _persist_tasks(
+    store: ArtifactStore,
+    tasks: tuple[TaskCase, ...],
+    revision: str,
+) -> tuple[TaskSet, ArtifactInput]:
+    """Persist exact release-bound tasks for both comparison modes."""
+    payload = b"\n".join(canonical_json_bytes(task) for task in tasks) + b"\n"
+    task_set = TaskSet(
+        schema_version=1,
+        created_at=_PLAN_AT,
+        code_revision=revision,
+        task_set_id="task-set-1",
+        task_ids=tuple(task.task_id for task in tasks),
+        tasks_path="tasks.jsonl",
+        tasks_sha256=hashlib.sha256(payload).hexdigest(),
+    )
+    manifest = store.write(
+        artifact_id=task_set.task_set_id,
+        artifact_type="task-set",
+        envelope=task_set,
+        files={"task-set.json": canonical_json_bytes(task_set), "tasks.jsonl": payload},
+    )
+    return task_set, artifact_input(manifest)
+
+
+def _persist_plan(
+    store: ArtifactStore,
+    tasks: tuple[TaskCase, ...],
+    task_input: ArtifactInput,
+    label: str,
+    revision: str,
+) -> tuple[EvaluationPlan, ArtifactInput]:
+    """Persist one release-bound mode-specific plan over the same tasks."""
+    cells = tuple(
+        EvaluationCell(
+            cell_id=f"{label}-cell-{suffix}",
+            task_id=task.task_id,
+            candidate_alias="candidate-a",
+            repeat=0,
+            purpose="held_out",
+            execution="simulate",
+        )
+        for task, suffix in zip(tasks, ("a", "b"), strict=True)
+    )
+    plan = EvaluationPlan(
+        schema_version=2,
+        created_at=_PLAN_AT,
+        inputs=(task_input,),
+        code_revision=revision,
+        plan_id=f"{label}-plan-1",
+        task_set_id="task-set-1",
+        candidate_snapshots=(
+            RoutedCandidateSnapshot(alias="candidate-a", model=_candidate_snapshot()),
+        ),
+        pricing_snapshot_id="pricing-1",
+        pricing_snapshot_sha256="d" * 64,
+        fidelity_thresholds_id="fidelity-thresholds-1",
+        fidelity_thresholds_sha256="f" * 64,
+        fidelity_protocol_sha256="e" * 64,
+        cells=cells,
+    )
+    manifest = store.write_json(
+        artifact_id=plan.plan_id,
+        artifact_type="evaluation-plan",
+        envelope=plan,
+        files={"evaluation-plan.json": plan},
+    )
+    return plan, artifact_input(manifest)
+
+
+def _candidate_snapshot() -> ModelSnapshot:
+    """Return the one frozen candidate used by both comparison modes."""
+    return ModelSnapshot(
+        provider="test",
+        model_id="candidate-a",
+        revision="fixture",
+        capabilities_sha256="c" * 64,
+        connection_sha256="d" * 64,
     )
 
 

--- a/wmo/workflow/router_evidence_test.py
+++ b/wmo/workflow/router_evidence_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -12,7 +13,14 @@ from fastapi.testclient import TestClient
 import wmo
 from wmo.common.evaluations import EvaluationPlan, EvaluationProtocol, ObservedProductionCell
 from wmo.common.evaluations.build_test import _persist_rollout, _production_rollout
-from wmo.common.judging import Judgment
+from wmo.common.judging import (
+    DimensionScoreMap,
+    JudgeCalibration,
+    Judgment,
+    Rubric,
+    RubricDimension,
+    ScoreAnchor,
+)
 from wmo.common.models import (
     AssistantAction,
     CandidateTokenPrice,
@@ -28,9 +36,9 @@ from wmo.common.models import (
     Usage,
 )
 from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
-from wmo.common.routing import KnnGuard
+from wmo.common.routing import FrozenEmbedding, FrozenEmbeddingSet, KnnGuard, RouterFeatureExtractor
 from wmo.common.tasks import load_task_set
-from wmo.optimize.router.workflow_test import _persist_embeddings
+from wmo.release_revision_test import exact_checkout_revision, verify_release_evidence
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router.application import create_project_router_app
 from wmo.simulation.build_test import _trace
@@ -55,16 +63,17 @@ from wmo.workflow.router_test import (
     _FidelityApproval,
     _Judge,
     _resolved,
-    _ReviewSupplier,
     _snapshot,
 )
 
 _TIME = datetime(2026, 8, 12, tzinfo=UTC)
-_REVISION = "w16-deterministic-evidence-v1"
 
 
 class _EvidenceSetupSupplier:
     """Persist two measured candidates, reviewed overlaps, embeddings, and pricing."""
+
+    def __init__(self, revision: str) -> None:
+        self.revision = revision
 
     def __call__(
         self,
@@ -89,7 +98,9 @@ class _EvidenceSetupSupplier:
                     cell_id=f"w16-import-{index}",
                     task=task,
                     candidate=candidates[0].model,
-                ).model_copy(update={"trace_id": task.source_trace_ids[0]})
+                ).model_copy(
+                    update={"trace_id": task.source_trace_ids[0], "code_revision": self.revision}
+                )
                 _persist_rollout(project.artifacts, rollout)
             observed.append(
                 ObservedProductionCell(
@@ -103,7 +114,7 @@ class _EvidenceSetupSupplier:
             pricing = PricingSnapshot(
                 schema_version=1,
                 created_at=_TIME,
-                code_revision=_REVISION,
+                code_revision=self.revision,
                 pricing_snapshot_id="w16-pricing",
                 candidate_prices=(
                     CandidateTokenPrice(
@@ -124,7 +135,7 @@ class _EvidenceSetupSupplier:
                 envelope=pricing,
                 files={"pricing.json": pricing},
             )
-            _persist_embeddings(project.artifacts, tasks)
+            _persist_release_embeddings(project, tasks, self.revision)
         production = EvaluationProtocol(
             protocol_id="w16-production-protocol",
             evidence_source="production",
@@ -231,7 +242,11 @@ class _EvidenceSimulatorFactory:
 
 
 class _EvidenceJudge(_Judge):
-    """Persist the deterministic judgment with an explicit observed zero-dollar cost."""
+    """Persist the deterministic judgment with exact revision and observed zero-dollar cost."""
+
+    def __init__(self, revision: str) -> None:
+        super().__init__()
+        self.revision = revision
 
     def judge_persisted(
         self,
@@ -249,9 +264,10 @@ class _EvidenceJudge(_Judge):
         )
         return judgment.model_copy(
             update={
+                "code_revision": self.revision,
                 "judge_economics": OperationEconomics(
                     cost_usd=NumericMeasurement(value=0.0, provenance="observed")
-                )
+                ),
             }
         )
 
@@ -315,6 +331,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """One 100-trace public workflow proves phase locks, replay, budgets, and HTTP stickiness."""
+    revision = exact_checkout_revision()
     project = ProjectStore(tmp_path, "w16-project")
     project.initialize(ProjectConfig(project_id="w16-project"))
     normalized = TraceNormalizationResult(
@@ -322,12 +339,12 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
         issues=(),
     )
     simulator = _EvidenceSimulatorFactory()
-    judge = _EvidenceJudge()
+    judge = _EvidenceJudge(revision)
     approval = _FidelityApproval()
     runtime_catalog = _RuntimeCatalog()
     services = RouterWorkflowServices(
-        review_supplier=_ReviewSupplier(),
-        setup_supplier=_EvidenceSetupSupplier(),
+        review_supplier=_EvidenceReviewSupplier(revision),
+        setup_supplier=_EvidenceSetupSupplier(revision),
         simulator_factory=simulator,
         judge=judge,
         fidelity_approval=approval,
@@ -368,7 +385,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
             services=services,
             budget=budget,
             created_at=_TIME,
-            code_revision=_REVISION,
+            code_revision=revision,
             phase_hook=checkpoint,
         )
     dispatches_after_crash = _dispatch_counts(simulator, judge, approval)
@@ -379,7 +396,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
             services=services,
             budget=budget,
             created_at=_TIME,
-            code_revision=_REVISION,
+            code_revision=revision,
             phase_hook=checkpoint,
         )
     result = wmo.compose_router(
@@ -388,7 +405,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
         services=services,
         budget=budget,
         created_at=_TIME,
-        code_revision=_REVISION,
+        code_revision=revision,
         phase_hook=checkpoint,
     )
     dispatches_after_completion = _dispatch_counts(simulator, judge, approval)
@@ -398,7 +415,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
         services=services,
         budget=budget,
         created_at=_TIME,
-        code_revision=_REVISION,
+        code_revision=revision,
     )
 
     tasks = load_task_set(project.artifacts, result.plan.task_set_id).tasks
@@ -481,6 +498,129 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
     assert runtime_catalog.clients["embedder"].embed_calls == 1
     assert sum(client.complete_calls for client in runtime_catalog.clients.values()) == 2
     assert "w16-customer-episode" not in first_http.text
+    provenance = verify_release_evidence(
+        project.artifacts,
+        expected_revision=revision,
+        report_name="w16-router",
+        claims={
+            "normalized_trace_count": 100,
+            "fit_task_count": 50,
+            "held_out_task_count": 20,
+            "planned_cell_count": 150,
+            "simulated_cell_count": 140,
+            "judgment_count": 150,
+            "maximum_judgments": 200,
+            "maximum_simulation_cost_usd": 2.0,
+            "observed_spend_usd": 0.0,
+            "hosted_call_count": 0,
+        },
+    )
+    assert provenance["code_revision"] == revision
+
+
+class _EvidenceReviewSupplier:
+    """Persist one exact-revision approved rubric and sealed calibration."""
+
+    def __init__(self, revision: str) -> None:
+        self.revision = revision
+
+    def __call__(
+        self,
+        project: ProjectStore,
+        build: wmo.ProjectBuild,
+        budget: RouterCompositionBudget,
+    ) -> ApprovedRouterReview:
+        del budget
+        if "rubric-a" not in project.artifacts.list_ids():
+            task_input = build.review.task_set
+            rubric = Rubric(
+                schema_version=1,
+                created_at=_TIME,
+                inputs=(task_input,),
+                code_revision=self.revision,
+                rubric_id="rubric-a",
+                dimensions=(
+                    RubricDimension(
+                        dimension_id="dimension-a",
+                        name="Task success",
+                        description="Whether the task was completed.",
+                        anchors=tuple(
+                            ScoreAnchor(score=score, description=f"Score {score} outcome.")
+                            for score in (0, 1, 2, 3, 4, 5)
+                        ),
+                    ),
+                ),
+                source_task_set_id=task_input.artifact_id,
+                status="human_approved",
+                approved_at=_TIME,
+            )
+            project.artifacts.write_json(
+                artifact_id=rubric.rubric_id,
+                artifact_type="rubric",
+                envelope=rubric,
+                files={"rubric.json": rubric},
+            )
+            tasks = load_task_set(project.artifacts, task_input.artifact_id).tasks
+            calibration = JudgeCalibration(
+                schema_version=1,
+                created_at=_TIME,
+                code_revision=self.revision,
+                calibration_id="calibration-a",
+                rubric_id="rubric-a",
+                judge_model=_snapshot("judge-model"),
+                judge_prompt_id="judge-prompt-v1",
+                judge_prompt_sha256="a" * 64,
+                label_set_id="label-set-a",
+                calibration_lineage_ids=tuple(
+                    task.lineage_group_id for task in tasks if task.partition == "fit"
+                ),
+                excluded_router_held_out_lineage_ids=tuple(
+                    task.lineage_group_id for task in tasks if task.partition == "held_out"
+                ),
+                validation_method="grouped_k_fold",
+                out_of_fold_report_id="calibration-report-a",
+                out_of_fold_report_sha256="a" * 64,
+                score_maps=(
+                    DimensionScoreMap(
+                        dimension_id="dimension-a",
+                        calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+                    ),
+                ),
+                status="provisional",
+            )
+            project.artifacts.write_json(
+                artifact_id=calibration.calibration_id,
+                artifact_type="judge-calibration",
+                envelope=calibration,
+                files={"calibration.json": calibration},
+            )
+        return ApprovedRouterReview(rubric_id="rubric-a", calibration_id="calibration-a")
+
+
+def _persist_release_embeddings(project: ProjectStore, tasks, revision: str) -> None:  # noqa: ANN001
+    """Persist exact local vectors with release-checkout provenance."""
+    extractor = RouterFeatureExtractor()
+    embeddings = FrozenEmbeddingSet(
+        schema_version=1,
+        created_at=_TIME,
+        code_revision=revision,
+        embedding_set_id="embeddings-a",
+        embedder_alias="embedder",
+        embedder=_snapshot("embedder"),
+        embeddings=tuple(
+            FrozenEmbedding(
+                text_sha256=hashlib.sha256(extractor.from_task(task).encode()).hexdigest(),
+                values=(1.0, 0.0),
+            )
+            for task in tasks
+        ),
+    )
+    project.artifacts.write_json(
+        artifact_id=embeddings.embedding_set_id,
+        artifact_type="router-embeddings",
+        envelope=embeddings,
+        files={"embeddings.json": embeddings},
+    )
 
 
 def _dispatch_counts(


### PR DESCRIPTION
## What changed

- bind W16 router and Darwin sandbox evidence to the exact clean 40-hex checkout revision
- recursively verify every artifact manifest, nested persisted revision, and manifest input digest
- publish JUnit and machine-readable exact-revision evidence from the bounded macOS gate
- document the supported release surface and explicit no-paid E2B, Tinker, and trained-model exclusions
- remove stale retired documentation and command references, and document canonical PostHog HogQL use
- upgrade Vitest and Vite to advisory-free supported versions

## Why

The final release audit found stale documentation, symbolic W16 provenance, missing supported and excluded scope, and critical/high development dependency advisories. This closes those findings without provider, environment, credential, or paid calls.

## Validation

- exact W16 revision/evidence: 5 passed; router 473 artifacts and 1,993 verified inputs; sandbox 16 artifacts and 53 verified inputs; observed spend $0
- full non-live Python: 636 passed, 1 skipped, 10 deselected
- Ruff, formatting, and Ty: pass
- web: 16 tests, TypeScript, Next production build, full and production npm audits with zero vulnerabilities
- fresh wheel and sdist: 93 release/API/layout/import/CLI/PostHog tests
- isolated core and `sft`-extra wheel installs, imports, and CLI help: pass
- two independent exact-head audits: PASS
