### PR TITLE
Add provider-first model setup

### DIFF
--- a/wmo/cli/cli_commands_regression_test.py
+++ b/wmo/cli/cli_commands_regression_test.py
@@ -16,9 +16,10 @@ def test_root_command_surface_is_locked() -> None:
     assert group_names == {"config", "optimize"}
 
 
-def test_config_requires_only_the_telemetry_subtree() -> None:
-    """The retained config command is the thin local telemetry preference service."""
-    result = CliRunner().invoke(app, ["config", "telemetry", "status"])
+def test_config_exposes_telemetry_and_provider_setup() -> None:
+    """Config contains only local telemetry and model-provider state."""
+    result = CliRunner().invoke(app, ["config", "--help"])
 
     assert result.exit_code == 0, result.output
-    assert "telemetry enabled" in result.output
+    assert "telemetry" in result.output
+    assert "providers" in result.output

--- a/wmo/cli/cli_help_test.py
+++ b/wmo/cli/cli_help_test.py
@@ -14,11 +14,12 @@ from wmo.cli.app import app
         ["--help"],
         ["build", "--help"],
         ["config", "telemetry", "--help"],
+        ["config", "providers", "--help"],
         ["optimize", "router", "--help"],
         ["optimize", "model", "--help"],
         ["run", "--help"],
     ],
-    ids=["root", "build", "telemetry", "router", "model", "run"],
+    ids=["root", "build", "telemetry", "providers", "router", "model", "run"],
 )
 def test_help_renders_only_user_facing_descriptions(argv: list[str]) -> None:
     """Command help exposes the approved surface without docstring scaffolding."""

--- a/wmo/cli/config_cmd.py
+++ b/wmo/cli/config_cmd.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import typer
 from rich.console import Console
 
+from wmo.cli.provider_setup import ProviderSetupOptions, run_provider_setup
 from wmo.common.config import (
     ARTIFACT_DIR,
     load_settings,
     set_telemetry_enabled,
     settings_path,
 )
+from wmo.common.core.locks import FileLockTimeout
 
 config_app = typer.Typer(help="Manage project-local wmo settings.", no_args_is_help=True)
 _console = Console()
+_PROVIDER_ROOT_OPTION = typer.Option(Path(ARTIFACT_DIR), "--root", help="Local .wmo root.")
 
 
 @config_app.command("telemetry", help="View or change project-local usage telemetry settings.")
@@ -44,3 +49,97 @@ def config_telemetry(
         settings = set_telemetry_enabled(normalized == "enable", root)
     state = "enabled" if settings.telemetry.enabled else "disabled"
     _console.print(f"telemetry {state} ({settings_path(root)})")
+
+
+@config_app.command("providers", help="Configure model providers and build-time model roles.")
+def config_providers(
+    root: Path = _PROVIDER_ROOT_OPTION,
+    provider: str | None = typer.Option(None, "--provider", help="Primary provider kind."),
+    connection: str | None = typer.Option(
+        None, "--connection", help="Stable primary connection name."
+    ),
+    api_key_env: str | None = typer.Option(
+        None, "--api-key-env", help="Credential environment variable name."
+    ),
+    base_url: str | None = typer.Option(
+        None, "--base-url", help="Base URL for an OpenAI-compatible provider only."
+    ),
+    world_model: str | None = typer.Option(
+        None, "--world-model", help="Exact provider-side world model ID."
+    ),
+    judge: str | None = typer.Option(None, "--judge", help="Exact provider-side judge model ID."),
+    embedder: str | None = typer.Option(
+        None, "--embedder", help="Exact provider-side embedding model ID."
+    ),
+    embedder_provider: str | None = typer.Option(
+        None, "--embedder-provider", help="Provider for a separate embedding connection."
+    ),
+    embedder_connection: str | None = typer.Option(
+        None, "--embedder-connection", help="Stable separate embedding connection name."
+    ),
+    embedder_api_key_env: str | None = typer.Option(
+        None,
+        "--embedder-api-key-env",
+        help="Credential environment variable for a separate embedding connection.",
+    ),
+    embedder_base_url: str | None = typer.Option(
+        None,
+        "--embedder-base-url",
+        help="Base URL for a separate OpenAI-compatible embedding provider only.",
+    ),
+    world_model_tools: bool = typer.Option(
+        False,
+        "--world-model-tools/--no-world-model-tools",
+        help="Record explicit tool support for the world model.",
+    ),
+    judge_tools: bool = typer.Option(
+        False,
+        "--judge-tools/--no-judge-tools",
+        help="Record explicit tool support for the judge.",
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Require complete flags instead of prompting.",
+    ),
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help="Replace conflicting provider connections or build-time role aliases.",
+    ),
+) -> None:
+    """Configure provider connections before selecting exact build-time role models.
+
+    Credential values are never requested or persisted. Only environment-variable names are
+    written. Router candidates remain untouched until ``wmo optimize router``.
+    """
+    options = ProviderSetupOptions(
+        provider=provider,
+        connection=connection,
+        api_key_env=api_key_env,
+        base_url=base_url,
+        world_model=world_model,
+        judge=judge,
+        embedder=embedder,
+        embedder_provider=embedder_provider,
+        embedder_connection=embedder_connection,
+        embedder_api_key_env=embedder_api_key_env,
+        embedder_base_url=embedder_base_url,
+        world_model_tools=world_model_tools,
+        judge_tools=judge_tools,
+    )
+    try:
+        catalog = run_provider_setup(
+            root,
+            options,
+            non_interactive=non_interactive,
+            replace=replace,
+            console=_console,
+        )
+    except (ValueError, FileLockTimeout) as exc:
+        raise typer.BadParameter(str(exc)) from None
+    roles = catalog.roles
+    _console.print(
+        f"configured providers at {root / 'models.toml'} "
+        f"(world_model={roles.world_model}, judge={roles.judge}, embedder={roles.embedder})"
+    )

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -228,6 +228,8 @@ def _prompt_connection(
     selected_provider = provider or Prompt.ask(
         f"{label} provider", choices=list(providers), console=console
     )
+    if selected_provider not in providers:
+        raise typer.BadParameter(f"{label} provider must be one of: {', '.join(providers)}")
     selected_name = (
         name
         or Prompt.ask(

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -1,0 +1,283 @@
+"""Simple Rich provider setup reused by CLI entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+
+from wmo.common.models import (
+    ModelCatalog,
+    ProviderConnection,
+    ProviderModelSelection,
+    ProviderSetup,
+    configure_provider_catalog,
+)
+
+_PROVIDERS = ("openai", "openrouter", "anthropic", "gemini", "openai-compatible")
+_EMBEDDING_PROVIDERS = ("openai", "openrouter", "gemini", "openai-compatible")
+_CREDENTIAL_ENV_SUGGESTIONS = {
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "openai-compatible": "OPENAI_COMPATIBLE_API_KEY",
+}
+_JUDGE_GUIDANCE = {
+    "openai": "an exact OpenAI model ID with enough reasoning quality for stable scoring",
+    "openrouter": ("an exact provider/model ID on OpenRouter, preferably a stable, pinned judge"),
+    "anthropic": "an exact Anthropic model ID with enough quality for stable scoring",
+    "gemini": "an exact Gemini model ID with enough quality for stable scoring",
+    "openai-compatible": (
+        "an exact model ID that this endpoint serves and can use reliably for scoring"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ProviderSetupOptions:
+    """Optional CLI values used directly or completed with Rich prompts."""
+
+    provider: str | None = None
+    connection: str | None = None
+    api_key_env: str | None = None
+    base_url: str | None = None
+    world_model: str | None = None
+    judge: str | None = None
+    embedder: str | None = None
+    embedder_provider: str | None = None
+    embedder_connection: str | None = None
+    embedder_api_key_env: str | None = None
+    embedder_base_url: str | None = None
+    world_model_tools: bool = False
+    judge_tools: bool = False
+
+
+def run_provider_setup(
+    root: Path,
+    options: ProviderSetupOptions,
+    *,
+    non_interactive: bool,
+    replace: bool,
+    console: Console,
+) -> ModelCatalog:
+    """Collect a complete setup before atomically updating ``models.toml``.
+
+    This is the CLI reuse seam for a later build command. All prompts finish before the service
+    writes, so cancellation cannot leave a partial catalog.
+
+    Args:
+        root: Local ``.wmo`` root.
+        options: Values supplied through command flags.
+        non_interactive: Whether missing values must fail instead of prompting.
+        replace: Whether existing conflicting build-time role aliases may be replaced.
+        console: Rich console used for prompts and guidance.
+
+    Returns:
+        The complete validated catalog written by the setup service.
+
+    Raises:
+        typer.BadParameter: Required noninteractive values are absent.
+    """
+    setup = (
+        _noninteractive_setup(options)
+        if non_interactive
+        else _interactive_setup(options, console=console)
+    )
+    return configure_provider_catalog(root / "models.toml", setup, replace=replace)
+
+
+def _noninteractive_setup(options: ProviderSetupOptions) -> ProviderSetup:
+    """Build exact setup input from flags or report every missing value."""
+    required = {
+        "--provider": options.provider,
+        "--connection": options.connection,
+        "--api-key-env": options.api_key_env,
+        "--world-model": options.world_model,
+        "--judge": options.judge,
+        "--embedder": options.embedder,
+    }
+    missing = tuple(flag for flag, value in required.items() if value is None)
+    if missing:
+        raise typer.BadParameter(
+            "--non-interactive requires " + ", ".join(missing) + "; add the missing flags"
+        )
+    assert options.provider is not None
+    assert options.connection is not None
+    assert options.api_key_env is not None
+    assert options.world_model is not None
+    assert options.judge is not None
+    assert options.embedder is not None
+
+    primary = ProviderConnection(
+        name=options.connection,
+        provider=options.provider,
+        api_key_env=options.api_key_env,
+        base_url=options.base_url,
+    )
+    embedder_connection = _noninteractive_embedder_connection(options, primary=primary)
+    connections = (primary,) if embedder_connection == primary else (primary, embedder_connection)
+    return _setup_from_values(
+        options, connections=connections, primary=primary, embedder_connection=embedder_connection
+    )
+
+
+def _noninteractive_embedder_connection(
+    options: ProviderSetupOptions,
+    *,
+    primary: ProviderConnection,
+) -> ProviderConnection:
+    """Resolve an optional separate embedder connection without provider inference."""
+    separate_values = (
+        options.embedder_provider,
+        options.embedder_connection,
+        options.embedder_api_key_env,
+        options.embedder_base_url,
+    )
+    if not any(value is not None for value in separate_values):
+        return primary
+    required = {
+        "--embedder-provider": options.embedder_provider,
+        "--embedder-connection": options.embedder_connection,
+        "--embedder-api-key-env": options.embedder_api_key_env,
+    }
+    missing = tuple(flag for flag, value in required.items() if value is None)
+    if missing:
+        raise typer.BadParameter("a separate embedder connection requires " + ", ".join(missing))
+    assert options.embedder_provider is not None
+    assert options.embedder_connection is not None
+    assert options.embedder_api_key_env is not None
+    return ProviderConnection(
+        name=options.embedder_connection,
+        provider=options.embedder_provider,
+        api_key_env=options.embedder_api_key_env,
+        base_url=options.embedder_base_url,
+    )
+
+
+def _interactive_setup(options: ProviderSetupOptions, *, console: Console) -> ProviderSetup:
+    """Collect provider connections first, then exact build-time role model IDs."""
+    console.print("[bold]Provider setup[/bold]")
+    primary = _prompt_connection(
+        console,
+        provider=options.provider,
+        name=options.connection,
+        api_key_env=options.api_key_env,
+        base_url=options.base_url,
+        providers=_PROVIDERS,
+        label="Primary",
+    )
+    use_primary_for_embeddings = primary.provider != "anthropic" and Confirm.ask(
+        "Use this connection for embeddings?", default=True, console=console
+    )
+    if use_primary_for_embeddings:
+        embedder_connection = primary
+    else:
+        if primary.provider == "anthropic":
+            console.print("Anthropic needs a separate embedding provider in the current runtime.")
+        embedder_connection = _prompt_connection(
+            console,
+            provider=options.embedder_provider,
+            name=options.embedder_connection,
+            api_key_env=options.embedder_api_key_env,
+            base_url=options.embedder_base_url,
+            providers=_EMBEDDING_PROVIDERS,
+            label="Embedder",
+        )
+    connections = (primary,) if embedder_connection == primary else (primary, embedder_connection)
+
+    world_model = options.world_model or Prompt.ask("Exact world model ID", console=console).strip()
+    console.print(
+        f"[dim]Judge suggestion: reuse {world_model!r} for consistency, or choose "
+        f"{_JUDGE_GUIDANCE[primary.provider]}.[/dim]"
+    )
+    judge = options.judge or Prompt.ask("Exact judge model ID", console=console).strip()
+    if options.judge is None and not Confirm.ask(
+        f"Use {judge!r} as the judge?", default=True, console=console
+    ):
+        raise typer.Abort()
+    embedder = options.embedder or Prompt.ask("Exact embedding model ID", console=console).strip()
+    completed = replace(
+        options,
+        world_model=world_model,
+        judge=judge,
+        embedder=embedder,
+    )
+    return _setup_from_values(
+        completed,
+        connections=connections,
+        primary=primary,
+        embedder_connection=embedder_connection,
+    )
+
+
+def _prompt_connection(
+    console: Console,
+    *,
+    provider: str | None,
+    name: str | None,
+    api_key_env: str | None,
+    base_url: str | None,
+    providers: tuple[str, ...],
+    label: str,
+) -> ProviderConnection:
+    """Prompt for one connection without selecting a provider automatically."""
+    selected_provider = provider or Prompt.ask(
+        f"{label} provider", choices=list(providers), console=console
+    )
+    selected_name = (
+        name
+        or Prompt.ask(
+            f"{label} connection name", default=selected_provider, console=console
+        ).strip()
+    )
+    selected_env = (
+        api_key_env
+        or Prompt.ask(
+            "Credential environment variable",
+            default=_CREDENTIAL_ENV_SUGGESTIONS[selected_provider],
+            console=console,
+        ).strip()
+    )
+    selected_base_url = base_url
+    if selected_provider == "openai-compatible" and selected_base_url is None:
+        selected_base_url = Prompt.ask("OpenAI-compatible base URL", console=console).strip()
+    return ProviderConnection(
+        name=selected_name,
+        provider=selected_provider,
+        api_key_env=selected_env,
+        base_url=selected_base_url,
+    )
+
+
+def _setup_from_values(
+    options: ProviderSetupOptions,
+    *,
+    connections: tuple[ProviderConnection, ...],
+    primary: ProviderConnection,
+    embedder_connection: ProviderConnection,
+) -> ProviderSetup:
+    """Create typed role selections after all connection and model input is complete."""
+    assert options.world_model is not None
+    assert options.judge is not None
+    assert options.embedder is not None
+    return ProviderSetup(
+        connections=connections,
+        world_model=ProviderModelSelection(
+            connection=primary.name,
+            model=options.world_model,
+            supports_tools=options.world_model_tools,
+        ),
+        judge=ProviderModelSelection(
+            connection=primary.name,
+            model=options.judge,
+            supports_tools=options.judge_tools,
+        ),
+        embedder=ProviderModelSelection(
+            connection=embedder_connection.name,
+            model=options.embedder,
+        ),
+    )

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -1,0 +1,80 @@
+"""Provider setup CLI tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wmo.cli.app import app
+from wmo.common.models import load_model_catalog
+
+
+def test_noninteractive_provider_setup_writes_exact_roles(tmp_path: Path) -> None:
+    """Automation can configure all build-time roles without a prompt."""
+    root = tmp_path / ".wmo"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--provider",
+            "openai",
+            "--connection",
+            "openai-main",
+            "--api-key-env",
+            "OPENAI_API_KEY",
+            "--world-model",
+            "world-id",
+            "--judge",
+            "judge-id",
+            "--embedder",
+            "embed-id",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "configured providers" in result.output
+    catalog = load_model_catalog(root / "models.toml")
+    assert catalog.models["world-model"].model == "world-id"
+    assert catalog.models["judge"].model == "judge-id"
+    assert catalog.models["embedder"].model == "embed-id"
+    assert catalog.roles.candidates == ()
+
+
+def test_noninteractive_setup_reports_all_missing_required_flags(tmp_path: Path) -> None:
+    """Automation failures explain how to complete setup."""
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--non-interactive",
+            "--provider",
+            "openai",
+        ],
+    )
+
+    assert result.exit_code == 2
+    for flag in ("--connection", "--api-key-env", "--world-model", "--judge", "--embedder"):
+        assert flag in result.output
+    assert not (tmp_path / ".wmo" / "models.toml").exists()
+
+
+def test_interactive_judge_rejection_cancels_without_writing(tmp_path: Path) -> None:
+    """The interactive collector finishes before the atomic service is invoked."""
+    root = tmp_path / ".wmo"
+    result = CliRunner().invoke(
+        app,
+        ["config", "providers", "--root", str(root)],
+        input="openai\n\n\ny\nworld-id\njudge-id\nn\n",
+    )
+
+    assert result.exit_code == 1
+    assert not (root / "models.toml").exists()

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -78,3 +78,33 @@ def test_interactive_judge_rejection_cancels_without_writing(tmp_path: Path) -> 
 
     assert result.exit_code == 1
     assert not (root / "models.toml").exists()
+
+
+def test_anthropic_noninteractive_setup_reports_separate_embedder_flags(tmp_path: Path) -> None:
+    """A provider without runtime embeddings gives actionable noninteractive remediation."""
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--non-interactive",
+            "--provider",
+            "anthropic",
+            "--connection",
+            "anthropic-main",
+            "--api-key-env",
+            "ANTHROPIC_API_KEY",
+            "--world-model",
+            "world-id",
+            "--judge",
+            "judge-id",
+            "--embedder",
+            "embed-id",
+        ],
+    )
+
+    assert result.exit_code == 2
+    for flag in ("--embedder-provider", "--embedder-connection", "--embedder-api-key-env"):
+        assert flag in result.output

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -59,11 +60,13 @@ def test_noninteractive_setup_reports_all_missing_required_flags(tmp_path: Path)
             "--provider",
             "openai",
         ],
+        color=True,
     )
 
     assert result.exit_code == 2
+    output = unstyle(result.output)
     for flag in ("--connection", "--api-key-env", "--world-model", "--judge", "--embedder"):
-        assert flag in result.output
+        assert flag in output
     assert not (tmp_path / ".wmo" / "models.toml").exists()
 
 
@@ -103,11 +106,13 @@ def test_anthropic_noninteractive_setup_reports_separate_embedder_flags(tmp_path
             "--embedder",
             "embed-id",
         ],
+        color=True,
     )
 
     assert result.exit_code == 2
+    output = unstyle(result.output)
     for flag in ("--embedder-provider", "--embedder-connection", "--embedder-api-key-env"):
-        assert flag in result.output
+        assert flag in output
 
 
 def test_interactive_supplied_unknown_provider_is_an_actionable_error(tmp_path: Path) -> None:

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -108,3 +108,51 @@ def test_anthropic_noninteractive_setup_reports_separate_embedder_flags(tmp_path
     assert result.exit_code == 2
     for flag in ("--embedder-provider", "--embedder-connection", "--embedder-api-key-env"):
         assert flag in result.output
+
+
+def test_interactive_supplied_unknown_provider_is_an_actionable_error(tmp_path: Path) -> None:
+    """A flag value cannot bypass the interactive provider choice validation."""
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--provider",
+            "unknown-provider",
+        ],
+        input="\n",
+    )
+
+    assert result.exit_code == 2
+    assert "Primary provider must be one of" in result.output
+    assert not (tmp_path / ".wmo" / "models.toml").exists()
+
+
+def test_interactive_supplied_nonembedding_provider_is_an_actionable_error(
+    tmp_path: Path,
+) -> None:
+    """A supplied embedder provider must satisfy the narrower provider choices."""
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--provider",
+            "openai",
+            "--connection",
+            "openai-main",
+            "--api-key-env",
+            "OPENAI_API_KEY",
+            "--embedder-provider",
+            "anthropic",
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 2
+    assert "Embedder provider must be one of" in result.output
+    assert not (tmp_path / ".wmo" / "models.toml").exists()

--- a/wmo/common/models/__init__.py
+++ b/wmo/common/models/__init__.py
@@ -29,6 +29,13 @@ from wmo.common.models.model import (
     Usage,
 )
 from wmo.common.models.pricing import CandidateTokenPrice, PricingSnapshot, load_pricing_snapshot
+from wmo.common.models.setup import (
+    ProviderConnection,
+    ProviderModelSelection,
+    ProviderSetup,
+    ProviderSetupError,
+    configure_provider_catalog,
+)
 
 __all__ = [
     "AssistantAction",
@@ -51,6 +58,10 @@ __all__ = [
     "NumericMeasurement",
     "OperationEconomics",
     "PricingSnapshot",
+    "ProviderConnection",
+    "ProviderModelSelection",
+    "ProviderSetup",
+    "ProviderSetupError",
     "RoutedCandidateSnapshot",
     "SFTModelProvenance",
     "ToolCall",
@@ -58,5 +69,6 @@ __all__ = [
     "Usage",
     "load_model_catalog",
     "load_pricing_snapshot",
+    "configure_provider_catalog",
     "write_model_catalog",
 ]

--- a/wmo/common/models/setup.py
+++ b/wmo/common/models/setup.py
@@ -106,7 +106,8 @@ class ProviderSetup(ContractModel):
         if providers[self.embedder.connection] == "anthropic":
             raise ValueError(
                 "anthropic does not expose embeddings through the current runtime; "
-                "select an OpenAI, OpenRouter, Gemini, or OpenAI-compatible embedder connection"
+                "select an OpenAI, OpenRouter, Gemini, or OpenAI-compatible embedder connection "
+                "with --embedder-provider, --embedder-connection, and --embedder-api-key-env"
             )
         return self
 

--- a/wmo/common/models/setup.py
+++ b/wmo/common/models/setup.py
@@ -19,6 +19,7 @@ from wmo.common.models.catalog import (
 from wmo.common.models.model import ModelCapabilities
 
 SETUP_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openai-compatible", "openrouter"})
+_BUILD_ROLE_ALIASES = frozenset({"world-model", "judge", "embedder"})
 
 
 class ProviderSetupError(ValueError):
@@ -153,6 +154,16 @@ def _merge_provider_setup(
     connections = dict(existing.connections) if existing is not None else {}
     models = dict(existing.models) if existing is not None else {}
     roles = existing.roles if existing is not None else ModelRoles()
+    preserved_role_aliases = set(roles.candidates)
+    preserved_role_aliases.update(
+        role_alias
+        for role_alias in (
+            roles.incumbent,
+            roles.rubric_proposer,
+            roles.teacher,
+        )
+        if role_alias is not None
+    )
 
     for selected in setup.connections:
         proposed = selected.catalog_config()
@@ -165,7 +176,7 @@ def _merge_provider_setup(
             alias
             for alias, record in models.items()
             if record.connection == selected.name
-            and alias not in {"world-model", "judge", "embedder"}
+            and (alias not in _BUILD_ROLE_ALIASES or alias in preserved_role_aliases)
         )
         if current is not None and current != proposed and preserved_aliases:
             raise ProviderSetupError(
@@ -188,16 +199,6 @@ def _merge_provider_setup(
         current = models.get(alias)
         if current is not None and current != proposed and not replace:
             raise ProviderSetupError(f"model alias {alias!r} already differs; rerun with --replace")
-        preserved_role_aliases = set(roles.candidates)
-        preserved_role_aliases.update(
-            role_alias
-            for role_alias in (
-                roles.incumbent,
-                roles.rubric_proposer,
-                roles.teacher,
-            )
-            if role_alias is not None
-        )
         if current is not None and current != proposed and alias in preserved_role_aliases:
             raise ProviderSetupError(
                 f"model alias {alias!r} is assigned to a preserved router or training role; "

--- a/wmo/common/models/setup.py
+++ b/wmo/common/models/setup.py
@@ -1,0 +1,215 @@
+"""Provider-first model catalog setup with atomic, secret-free updates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field, model_validator
+
+from wmo.common.core.artifacts import ContractModel
+from wmo.common.core.locks import file_write_lock
+from wmo.common.models.catalog import (
+    ConnectionConfig,
+    ModelCatalog,
+    ModelRecord,
+    ModelRoles,
+    load_model_catalog,
+    write_model_catalog,
+)
+from wmo.common.models.model import ModelCapabilities
+
+SETUP_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openai-compatible", "openrouter"})
+
+
+class ProviderSetupError(ValueError):
+    """Provider setup cannot be applied without replacing existing catalog state."""
+
+
+class ProviderConnection(ContractModel):
+    """One named, secret-free provider connection collected during setup."""
+
+    name: str = Field(min_length=1, max_length=128)
+    provider: str = Field(min_length=1, max_length=128)
+    api_key_env: str = Field(min_length=1, max_length=256)
+    base_url: str | None = Field(default=None, max_length=2_048)
+
+    @model_validator(mode="after")
+    def _require_supported_connection_shape(self) -> ProviderConnection:
+        if self.provider not in SETUP_PROVIDERS:
+            choices = ", ".join(sorted(SETUP_PROVIDERS))
+            raise ValueError(f"provider must be one of: {choices}")
+        if self.provider == "openai-compatible" and self.base_url is None:
+            raise ValueError("openai-compatible requires an explicit base_url")
+        if self.provider != "openai-compatible" and self.base_url is not None:
+            raise ValueError(
+                "base_url is only accepted for provider='openai-compatible'; native providers "
+                "use their official endpoint"
+            )
+        ConnectionConfig(
+            provider=self.provider,
+            base_url=self.base_url,
+            api_key_env=self.api_key_env,
+        )
+        return self
+
+    def catalog_config(self) -> ConnectionConfig:
+        """Return the validated catalog connection represented by this input."""
+        return ConnectionConfig(
+            provider=self.provider,
+            base_url=self.base_url,
+            api_key_env=self.api_key_env,
+        )
+
+
+class ProviderModelSelection(ContractModel):
+    """One exact provider-side model selected for a build-time role."""
+
+    connection: str = Field(min_length=1, max_length=128)
+    model: str = Field(min_length=1, max_length=2_048)
+    supports_tools: bool = False
+    context_window_tokens: int | None = Field(default=None, gt=0)
+    maximum_output_tokens: int | None = Field(default=None, gt=0)
+
+    def capabilities(self, *, embeddings: bool = False) -> ModelCapabilities:
+        """Return the explicit capabilities captured by provider setup."""
+        return ModelCapabilities(
+            supports_tools=self.supports_tools,
+            supports_embeddings=embeddings,
+            context_window_tokens=self.context_window_tokens,
+            maximum_output_tokens=self.maximum_output_tokens,
+        )
+
+
+class ProviderSetup(ContractModel):
+    """Complete provider connections and exact build-time role selections."""
+
+    connections: tuple[ProviderConnection, ...] = Field(min_length=1)
+    world_model: ProviderModelSelection
+    judge: ProviderModelSelection
+    embedder: ProviderModelSelection
+
+    @model_validator(mode="after")
+    def _require_unique_referenced_connections(self) -> ProviderSetup:
+        names = tuple(connection.name for connection in self.connections)
+        if len(set(names)) != len(names):
+            raise ValueError("provider connection names must be unique")
+        unknown = {
+            selection.connection
+            for selection in (self.world_model, self.judge, self.embedder)
+            if selection.connection not in names
+        }
+        if unknown:
+            raise ValueError(
+                f"role selections name unknown connections: {', '.join(sorted(unknown))}"
+            )
+        providers = {connection.name: connection.provider for connection in self.connections}
+        if providers[self.embedder.connection] == "anthropic":
+            raise ValueError(
+                "anthropic does not expose embeddings through the current runtime; "
+                "select an OpenAI, OpenRouter, Gemini, or OpenAI-compatible embedder connection"
+            )
+        return self
+
+
+def configure_provider_catalog(
+    path: Path,
+    setup: ProviderSetup,
+    *,
+    replace: bool = False,
+) -> ModelCatalog:
+    """Atomically add connections and assign build-time roles in ``models.toml``.
+
+    Existing connections, model aliases, and router candidate roles are preserved. Fixed role
+    aliases are replaced only when ``replace`` is explicit. The function never reads credential
+    values and stores only their environment-variable names.
+
+    Args:
+        path: Local ``.wmo/models.toml`` path.
+        setup: Fully collected connections and exact role model IDs.
+        replace: Whether conflicting connection or fixed role aliases may be replaced.
+
+    Returns:
+        The complete validated catalog written to ``path``.
+
+    Raises:
+        ProviderSetupError: Existing state conflicts and replacement was not authorized.
+        ModelCatalogError: Existing catalog content is invalid.
+    """
+    with file_write_lock(path, what="provider model configuration"):
+        existing = load_model_catalog(path) if path.exists() else None
+        catalog = _merge_provider_setup(existing, setup, replace=replace)
+        write_model_catalog(path, catalog)
+        return catalog
+
+
+def _merge_provider_setup(
+    existing: ModelCatalog | None,
+    setup: ProviderSetup,
+    *,
+    replace: bool,
+) -> ModelCatalog:
+    """Merge one setup into existing catalog state without changing router roles."""
+    connections = dict(existing.connections) if existing is not None else {}
+    models = dict(existing.models) if existing is not None else {}
+    roles = existing.roles if existing is not None else ModelRoles()
+
+    for selected in setup.connections:
+        proposed = selected.catalog_config()
+        current = connections.get(selected.name)
+        if current is not None and current != proposed and not replace:
+            raise ProviderSetupError(
+                f"connection {selected.name!r} already differs; rerun with --replace"
+            )
+        preserved_aliases = tuple(
+            alias
+            for alias, record in models.items()
+            if record.connection == selected.name
+            and alias not in {"world-model", "judge", "embedder"}
+        )
+        if current is not None and current != proposed and preserved_aliases:
+            raise ProviderSetupError(
+                f"connection {selected.name!r} is used by preserved model aliases "
+                f"{', '.join(sorted(preserved_aliases))}; use a new connection name"
+            )
+        connections[selected.name] = proposed
+
+    selections = {
+        "world-model": (setup.world_model, False),
+        "judge": (setup.judge, False),
+        "embedder": (setup.embedder, True),
+    }
+    for alias, (selection, embeddings) in selections.items():
+        proposed = ModelRecord(
+            connection=selection.connection,
+            model=selection.model,
+            capabilities=selection.capabilities(embeddings=embeddings),
+        )
+        current = models.get(alias)
+        if current is not None and current != proposed and not replace:
+            raise ProviderSetupError(f"model alias {alias!r} already differs; rerun with --replace")
+        preserved_role_aliases = set(roles.candidates)
+        preserved_role_aliases.update(
+            role_alias
+            for role_alias in (
+                roles.incumbent,
+                roles.rubric_proposer,
+                roles.teacher,
+            )
+            if role_alias is not None
+        )
+        if current is not None and current != proposed and alias in preserved_role_aliases:
+            raise ProviderSetupError(
+                f"model alias {alias!r} is assigned to a preserved router or training role; "
+                "rename that alias before provider setup"
+            )
+        models[alias] = proposed
+
+    role_values = roles.model_dump()
+    role_values.update(world_model="world-model", judge="judge", embedder="embedder")
+    updated_roles = ModelRoles.model_validate(role_values)
+    return ModelCatalog(
+        schema_version=existing.schema_version if existing is not None else 1,
+        connections=connections,
+        models=models,
+        roles=updated_roles,
+    )

--- a/wmo/common/models/setup_test.py
+++ b/wmo/common/models/setup_test.py
@@ -148,6 +148,31 @@ def test_anthropic_primary_can_use_a_separate_gemini_embedder(tmp_path: Path) ->
 
 
 @pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("openai", None),
+        ("openrouter", None),
+        ("anthropic", None),
+        ("gemini", None),
+        ("openai-compatible", "https://models.example.test/v1"),
+    ],
+)
+def test_setup_accepts_each_supported_provider_connection(
+    provider: str, base_url: str | None
+) -> None:
+    """The setup contract covers every current provider without choosing one."""
+    connection = ProviderConnection(
+        name="selected-provider",
+        provider=provider,
+        api_key_env="SELECTED_PROVIDER_API_KEY",
+        base_url=base_url,
+    )
+
+    assert connection.provider == provider
+    assert connection.base_url == base_url
+
+
+@pytest.mark.parametrize(
     ("connection", "message"),
     [
         (

--- a/wmo/common/models/setup_test.py
+++ b/wmo/common/models/setup_test.py
@@ -1,0 +1,191 @@
+"""Provider-first model catalog setup tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmo.common.models import (
+    ConnectionConfig,
+    ModelCapabilities,
+    ModelCatalog,
+    ModelRecord,
+    ModelRoles,
+    ProviderConnection,
+    ProviderModelSelection,
+    ProviderSetup,
+    ProviderSetupError,
+    configure_provider_catalog,
+    load_model_catalog,
+    write_model_catalog,
+)
+
+
+def _openai_setup(*, judge: str = "judge-id") -> ProviderSetup:
+    """Return one exact native-provider setup without model defaults."""
+    return ProviderSetup(
+        connections=(
+            ProviderConnection(
+                name="openai-main",
+                provider="openai",
+                api_key_env="OPENAI_API_KEY",
+            ),
+        ),
+        world_model=ProviderModelSelection(
+            connection="openai-main",
+            model="world-id",
+            supports_tools=True,
+        ),
+        judge=ProviderModelSelection(connection="openai-main", model=judge),
+        embedder=ProviderModelSelection(connection="openai-main", model="embedding-id"),
+    )
+
+
+def test_setup_creates_secret_free_build_roles_and_is_idempotent(tmp_path: Path) -> None:
+    """Setup records exact role IDs and credential names, never values."""
+    path = tmp_path / "models.toml"
+
+    first = configure_provider_catalog(path, _openai_setup())
+    second = configure_provider_catalog(path, _openai_setup())
+
+    assert second == first
+    assert first.roles.world_model == "world-model"
+    assert first.roles.judge == "judge"
+    assert first.roles.embedder == "embedder"
+    assert first.models["world-model"].capabilities == ModelCapabilities(supports_tools=True)
+    assert first.models["embedder"].capabilities == ModelCapabilities(supports_embeddings=True)
+    payload = path.read_text()
+    assert "OPENAI_API_KEY" in payload
+    assert "sk-secret-value" not in payload
+
+
+def test_setup_preserves_existing_catalog_and_router_candidates(tmp_path: Path) -> None:
+    """Adding build-time roles does not select or mutate router candidates."""
+    path = tmp_path / "models.toml"
+    existing = ModelCatalog(
+        connections={
+            "router-provider": ConnectionConfig(
+                provider="openrouter", api_key_env="OPENROUTER_API_KEY"
+            )
+        },
+        models={"candidate-a": ModelRecord(connection="router-provider", model="vendor/candidate")},
+        roles=ModelRoles(
+            candidates=("candidate-a",),
+            incumbent="candidate-a",
+            teacher="candidate-a",
+        ),
+    )
+    write_model_catalog(path, existing)
+
+    configured = configure_provider_catalog(path, _openai_setup())
+
+    assert configured.connections["router-provider"] == existing.connections["router-provider"]
+    assert configured.models["candidate-a"] == existing.models["candidate-a"]
+    assert configured.roles.candidates == ("candidate-a",)
+    assert configured.roles.incumbent == "candidate-a"
+    assert configured.roles.teacher == "candidate-a"
+
+
+def test_conflict_fails_without_changing_catalog_until_replace(tmp_path: Path) -> None:
+    """A conflicting setup needs explicit replacement and failed writes leave state intact."""
+    path = tmp_path / "models.toml"
+    original = configure_provider_catalog(path, _openai_setup())
+    original_payload = path.read_bytes()
+
+    with pytest.raises(ProviderSetupError, match="--replace"):
+        configure_provider_catalog(path, _openai_setup(judge="different-judge"))
+
+    assert path.read_bytes() == original_payload
+    assert load_model_catalog(path) == original
+    replaced = configure_provider_catalog(
+        path, _openai_setup(judge="different-judge"), replace=True
+    )
+    assert replaced.models["judge"].model == "different-judge"
+
+
+def test_replace_does_not_mutate_a_connection_used_by_router_candidates(tmp_path: Path) -> None:
+    """Even explicit build-role replacement cannot change an existing router candidate."""
+    path = tmp_path / "models.toml"
+    existing = ModelCatalog(
+        connections={
+            "openai-main": ConnectionConfig(provider="openrouter", api_key_env="OPENROUTER_API_KEY")
+        },
+        models={"candidate-a": ModelRecord(connection="openai-main", model="vendor/candidate")},
+        roles=ModelRoles(candidates=("candidate-a",), incumbent="candidate-a"),
+    )
+    write_model_catalog(path, existing)
+
+    with pytest.raises(ProviderSetupError, match="use a new connection name"):
+        configure_provider_catalog(path, _openai_setup(), replace=True)
+
+    assert load_model_catalog(path) == existing
+
+
+def test_anthropic_primary_can_use_a_separate_gemini_embedder(tmp_path: Path) -> None:
+    """Provider setup represents roles on separate current-runtime connections."""
+    setup = ProviderSetup(
+        connections=(
+            ProviderConnection(
+                name="anthropic-main",
+                provider="anthropic",
+                api_key_env="ANTHROPIC_API_KEY",
+            ),
+            ProviderConnection(
+                name="gemini-embed",
+                provider="gemini",
+                api_key_env="GEMINI_API_KEY",
+            ),
+        ),
+        world_model=ProviderModelSelection(connection="anthropic-main", model="world-id"),
+        judge=ProviderModelSelection(connection="anthropic-main", model="judge-id"),
+        embedder=ProviderModelSelection(connection="gemini-embed", model="embedding-id"),
+    )
+
+    configured = configure_provider_catalog(tmp_path / "models.toml", setup)
+
+    assert configured.models["embedder"].connection == "gemini-embed"
+
+
+@pytest.mark.parametrize(
+    ("connection", "message"),
+    [
+        (
+            {
+                "name": "native",
+                "provider": "openai",
+                "api_key_env": "OPENAI_API_KEY",
+                "base_url": "https://example.test/v1",
+            },
+            "base_url is only accepted",
+        ),
+        (
+            {
+                "name": "custom",
+                "provider": "openai-compatible",
+                "api_key_env": "CUSTOM_API_KEY",
+            },
+            "requires an explicit base_url",
+        ),
+    ],
+)
+def test_connection_endpoint_rules_are_explicit(connection: dict[str, str], message: str) -> None:
+    """Native endpoints stay fixed while compatible endpoints name their URL."""
+    with pytest.raises(ValueError, match=message):
+        ProviderConnection.model_validate(connection)
+
+
+def test_anthropic_cannot_be_declared_as_the_embedder() -> None:
+    """Setup rejects a role the current Anthropic runtime cannot satisfy."""
+    connection = ProviderConnection(
+        name="anthropic-main",
+        provider="anthropic",
+        api_key_env="ANTHROPIC_API_KEY",
+    )
+    with pytest.raises(ValueError, match="does not expose embeddings"):
+        ProviderSetup(
+            connections=(connection,),
+            world_model=ProviderModelSelection(connection="anthropic-main", model="world-id"),
+            judge=ProviderModelSelection(connection="anthropic-main", model="judge-id"),
+            embedder=ProviderModelSelection(connection="anthropic-main", model="embed-id"),
+        )

--- a/wmo/common/models/setup_test.py
+++ b/wmo/common/models/setup_test.py
@@ -122,6 +122,32 @@ def test_replace_does_not_mutate_a_connection_used_by_router_candidates(tmp_path
     assert load_model_catalog(path) == existing
 
 
+def test_replace_cannot_drift_connection_behind_an_identical_preserved_alias(
+    tmp_path: Path,
+) -> None:
+    """Connection changes are blocked even when a preserved fixed-alias record stays equal."""
+    path = tmp_path / "models.toml"
+    existing = ModelCatalog(
+        connections={
+            "openai-main": ConnectionConfig(provider="openrouter", api_key_env="OPENROUTER_API_KEY")
+        },
+        models={
+            "judge": ModelRecord(
+                connection="openai-main",
+                model="judge-id",
+                capabilities=ModelCapabilities(),
+            )
+        },
+        roles=ModelRoles(candidates=("judge",), incumbent="judge", judge="judge"),
+    )
+    write_model_catalog(path, existing)
+
+    with pytest.raises(ProviderSetupError, match="use a new connection name"):
+        configure_provider_catalog(path, _openai_setup(), replace=True)
+
+    assert load_model_catalog(path) == existing
+
+
 def test_anthropic_primary_can_use_a_separate_gemini_embedder(tmp_path: Path) -> None:
     """Provider setup represents roles on separate current-runtime connections."""
     setup = ProviderSetup(

--- a/wmo/repo_layout_test.py
+++ b/wmo/repo_layout_test.py
@@ -113,7 +113,10 @@ def test_root_cli_and_subgroups_are_exact() -> None:
     root_context = Context(root)
     assert set(root.list_commands(root_context)) == {"build", "config", "optimize", "run"}
 
-    expected_subcommands = {"config": {"telemetry"}, "optimize": {"model", "router"}}
+    expected_subcommands = {
+        "config": {"providers", "telemetry"},
+        "optimize": {"model", "router"},
+    }
     for name, expected in expected_subcommands.items():
         command = root.get_command(root_context, name)
         assert isinstance(command, TyperGroup)


### PR DESCRIPTION
## Summary

- add a reusable provider-first setup service for `.wmo/models.toml`
- add a simple Rich `wmo config providers` flow with complete noninteractive flags
- collect OpenAI, OpenRouter, Anthropic, Gemini, and OpenAI-compatible connections before exact world model, judge, and embedder selections
- preserve existing catalog entries and router candidates, and require explicit replacement for conflicting build-time roles

## Contract

- stores credential environment-variable names, never credential values
- requires explicit base URLs only for OpenAI-compatible endpoints
- does not choose model IDs, configure router candidates, verify paid providers, or calibrate judges
- supports a separate embedding provider when the primary provider cannot serve embeddings
- exposes `run_provider_setup` for later first-build integration without coupling this PR to RAG work

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q` (`669 passed, 1 skipped`)
- `uv build`
- packaged `wmo config providers` smoke test, including idempotent replay

README.md is preserved byte-for-byte from main.
