### PR TITLE
Restore OpenAI-native router APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,10 +57,10 @@ uv run pytest -q
   evidence, and writes the report without a model, simulator, judge, provider, or network client.
 - `wmo run PROJECT --root ROOT --port PORT` loads one frozen policy and exposes OpenAI Chat
   Completions, Responses, and Models routes on loopback. Public request and response types come
-  from the official OpenAI SDK. Chat transcript prefixes and Responses `previous_response_id`
-  provide internal routing affinity without WMO-specific request fields or headers. Request-time
-  embedding failure uses the frozen conservative baseline, and neither path mutates policy or
-  evidence.
+  from the official OpenAI SDK. Chat retries use the standard `Idempotency-Key`; Responses
+  continuations use `previous_response_id`. WMO never joins unrelated Chat callers by transcript
+  prefix and requires no proprietary request fields or headers. Request-time embedding failure
+  uses the frozen conservative baseline, and neither path mutates policy or evidence.
 
 ## Worker-agent execution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,12 @@ uv run pytest -q
 - `wmo optimize router PROJECT --config FILE --root ROOT` consumes only explicit completed
   evidence. It verifies the plan and rollout membership, fits and locks the router, opens held-out
   evidence, and writes the report without a model, simulator, judge, provider, or network client.
-- `wmo run PROJECT --root ROOT --port PORT` loads one frozen policy and exposes only the
-  development loopback adapter. Each request supplies `X-WMO-Episode-ID`; the first decision is
-  sticky for that episode, request-time embedding failure uses the frozen conservative baseline,
-  and neither path mutates policy or evidence.
+- `wmo run PROJECT --root ROOT --port PORT` loads one frozen policy and exposes OpenAI Chat
+  Completions, Responses, and Models routes on loopback. Public request and response types come
+  from the official OpenAI SDK. Chat transcript prefixes and Responses `previous_response_id`
+  provide internal routing affinity without WMO-specific request fields or headers. Request-time
+  embedding failure uses the frozen conservative baseline, and neither path mutates policy or
+  evidence.
 
 ## Worker-agent execution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "rich>=14.1",
     "tomli-w>=1.0",  # writing project and telemetry TOML; every `wmo build` needs it
     "posthog>=7.0",
+    # Public router request and response types follow the official OpenAI-generated schemas.
+    "openai>=3.0,<4",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -641,6 +641,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -658,6 +671,32 @@ wheels = [
 [package.optional-dependencies]
 http2 = [
     { name = "h2" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -717,6 +756,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -1218,6 +1325,25 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "openai"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
 ]
 
 [[package]]
@@ -2293,6 +2419,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.56"
 source = { registry = "https://pypi.org/simple" }
@@ -2394,6 +2529,7 @@ dependencies = [
     { name = "filelock" },
     { name = "httpx" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "posthog" },
     { name = "pydantic" },
     { name = "rich" },
@@ -2422,6 +2558,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.12" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "openai", specifier = ">=3.0,<4" },
     { name = "posthog", specifier = ">=7.0" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },

--- a/wmo/__init__.py
+++ b/wmo/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         create_project_router_app as create_project_router_app,
     )
     from wmo.runtime.router.application import load_project_router as load_project_router
+    from wmo.runtime.router.application import load_router as load_router
     from wmo.runtime.router.runtime import RouterRuntime as RouterRuntime
     from wmo.simulation.build import BuildReviewReadiness as BuildReviewReadiness
     from wmo.simulation.build import ProjectBuild as ProjectBuild
@@ -64,6 +65,7 @@ _EXPORT_MODULES = {
     "RouterRuntime": "wmo.runtime.router.runtime",
     "create_project_router_app": "wmo.runtime.router.application",
     "load_project_router": "wmo.runtime.router.application",
+    "load_router": "wmo.runtime.router.application",
     "ApprovedRouterReview": "wmo.workflow.router",
     "LocalTraceSource": "wmo.workflow.router",
     "FidelityApprovalDecision": "wmo.workflow.router",

--- a/wmo/api_test.py
+++ b/wmo/api_test.py
@@ -7,7 +7,11 @@ import sys
 
 import wmo
 from wmo.optimize.router.workflow import fit_router, optimize_router, report_router
-from wmo.runtime.router.application import create_project_router_app, load_project_router
+from wmo.runtime.router.application import (
+    create_project_router_app,
+    load_project_router,
+    load_router,
+)
 from wmo.runtime.router.runtime import RouterRuntime
 from wmo.simulation.build import build_project
 from wmo.workflow.router import compose_router
@@ -22,6 +26,7 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.RouterRuntime is RouterRuntime
     assert wmo.compose_router is compose_router
     assert wmo.load_project_router is load_project_router
+    assert wmo.load_router is load_router
     assert wmo.create_project_router_app is create_project_router_app
     assert "ActionKind" not in wmo.__all__
 

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -24,9 +24,9 @@ def run(
 ) -> None:
     """Start a development-only loopback adapter over one frozen router.
 
-    Every completion request must provide a caller-owned ``X-WMO-Episode-ID``. The command
-    cannot bind remotely and performs no online learning, deployment, or provider call at
-    startup.
+    The server exposes OpenAI Chat Completions and Responses routes. Transcript and response-ID
+    affinity remain internal, so callers need no WMO-specific request fields or headers. The
+    command cannot bind remotely and performs no provider call at startup.
 
     Args:
         project: Canonical project identifier and endpoint model name.
@@ -48,7 +48,5 @@ def run(
     typer.echo(
         f"loaded policy {runtime.policy.policy_id} with {runtime.policy.judgment_status} judgment"
     )
-    typer.echo(
-        f"development-only router at http://{_LOOPBACK_HOST}:{port}; X-WMO-Episode-ID is required"
-    )
+    typer.echo(f"OpenAI API router at http://{_LOOPBACK_HOST}:{port}/v1")
     uvicorn.run(create_project_router_app(project, runtime), host=_LOOPBACK_HOST, port=port)

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -43,7 +43,6 @@ def test_run_loads_once_and_can_only_bind_loopback(monkeypatch: pytest.MonkeyPat
     assert result.exit_code == 0, result.output
     assert loaded == [("project-a", Path("/tmp/local-wmo"), "policy-a")]
     assert served == [(application, "127.0.0.1", 8123)]
-    assert "development-only" in result.output
     assert "provisional judgment" in result.output
-    assert "X-WMO-Episode-ID is required" in result.output
+    assert "OpenAI API router at http://127.0.0.1:8123/v1" in result.output
     assert "--host" not in CliRunner().invoke(app, ["run", "--help"]).output

--- a/wmo/common/package_layout_test.py
+++ b/wmo/common/package_layout_test.py
@@ -67,7 +67,6 @@ def test_retired_provider_imports_do_not_return() -> None:
             "environment_capture",
             "mlx",
             "mlx_lm",
-            "openai",
             "opentelemetry",
             "sklearn",
             "transformers",

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -210,6 +210,7 @@ def test_w16_public_evidence_apis_resolve_from_release_owners() -> None:
 
     assert callable(wmo.compose_router)
     assert callable(wmo.load_project_router)
+    assert callable(wmo.load_router)
     assert callable(wmo.create_project_router_app)
     assert callable(compare_text_and_sandbox)
     assert SandboxSimulator.__module__ == "wmo.simulation.engines.sandbox"

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -13,7 +13,7 @@ import pytest
 
 BUILT_DIST_ENV = "WMO_BUILT_DIST_DIR"
 RETIRED_REQUIREMENT = re.compile(
-    r"(?mi)^Requires-Dist:\s*(?:anthropic|boto3|environment-capture|gepa|mlx-lm|openai|"
+    r"(?mi)^Requires-Dist:\s*(?:anthropic|boto3|environment-capture|gepa|mlx-lm|"
     r"opentelemetry-proto|scikit-learn|transformers)(?:\s|[<>=;~!])"
 )
 REQUIRED_CORE_REQUIREMENTS = frozenset(
@@ -23,6 +23,7 @@ REQUIRED_CORE_REQUIREMENTS = frozenset(
         "filelock",
         "httpx",
         "numpy",
+        "openai",
         "posthog",
         "pydantic",
         "rich",
@@ -193,7 +194,6 @@ def test_requirement_scanner_rejects_removed_dependencies() -> None:
         "environment-capture",
         "gepa",
         "mlx-lm",
-        "openai",
         "opentelemetry-proto",
         "scikit-learn",
         "transformers",

--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -4,6 +4,7 @@ from wmo.runtime.router.application import (
     RouterApplicationError,
     create_project_router_app,
     load_project_router,
+    load_router,
 )
 from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.runtime import (
@@ -23,5 +24,6 @@ __all__ = [
     "create_router_endpoint",
     "RouterApplicationError",
     "create_project_router_app",
+    "load_router",
     "load_project_router",
 ]

--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -9,6 +9,7 @@ from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.runtime import (
     RoutedModelResponse,
     RouterEpisodeConflictError,
+    RouterModelCapabilityError,
     RouterRuntime,
     RouterRuntimeIntegrityError,
 )
@@ -16,6 +17,7 @@ from wmo.runtime.router.runtime import (
 __all__ = [
     "RoutedModelResponse",
     "RouterEpisodeConflictError",
+    "RouterModelCapabilityError",
     "RouterRuntime",
     "RouterRuntimeIntegrityError",
     "create_router_endpoint",

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from openai import OpenAI
 
@@ -90,6 +92,24 @@ def create_project_router_app(project: str, runtime: RouterRuntime) -> FastAPI:
         title="WMO local router",
         description="Development-only loopback adapter over one frozen RouterRuntime.",
     )
+
+    @application.exception_handler(RequestValidationError)
+    async def openai_validation_error(
+        _request: Request, _error: RequestValidationError
+    ) -> JSONResponse:
+        """Return the OpenAI error envelope for public request validation failures."""
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": "Invalid OpenAI request",
+                    "type": "invalid_request_error",
+                    "param": None,
+                    "code": "invalid_request",
+                }
+            },
+        )
+
     application.include_router(create_router_endpoint({project: runtime}))
     return application
 

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from openai import OpenAI
 
 from wmo.common.core.artifacts import ArtifactId
 from wmo.common.models import load_model_catalog
@@ -90,6 +92,46 @@ def create_project_router_app(project: str, runtime: RouterRuntime) -> FastAPI:
     )
     application.include_router(create_router_endpoint({project: runtime}))
     return application
+
+
+def load_router(
+    project: str,
+    root: Path = Path(".wmo"),
+    *,
+    policy_id: ArtifactId | None = None,
+    environment: Mapping[str, str] | None = None,
+    runtime_catalog: RuntimeModelCatalog | None = None,
+    decision_sink: DecisionSink | None = None,
+) -> OpenAI:
+    """Load one local project as an official synchronous OpenAI client.
+
+    Args:
+        project: Canonical project identifier and public OpenAI model name.
+        root: Local ``.wmo`` root. Defaults to the happy-path project location.
+        policy_id: Optional exact policy identity when the project contains several.
+        environment: Optional credential mapping for runtime client construction.
+        runtime_catalog: Optional explicit catalog for deterministic applications and tests.
+        decision_sink: Optional aggregate-safe routing-decision recorder.
+
+    Returns:
+        Official OpenAI client whose Chat Completions and Responses resources call the local
+        verified router in process. Close it or use it as a context manager when finished.
+    """
+    runtime = load_project_router(
+        project,
+        root,
+        policy_id=policy_id,
+        environment=environment,
+        runtime_catalog=runtime_catalog,
+        decision_sink=decision_sink,
+    )
+    application = create_project_router_app(project, runtime)
+    transport = TestClient(application, raise_server_exceptions=False)
+    return OpenAI(
+        api_key="wmo-local-runtime",
+        base_url="http://wmo.local/v1",
+        http_client=transport,
+    )
 
 
 def _only_policy(store: ArtifactStore) -> ArtifactId:

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -82,7 +82,7 @@ def create_project_router_app(project: str, runtime: RouterRuntime) -> FastAPI:
         runtime: Already verified frozen router runtime.
 
     Returns:
-        FastAPI application requiring ``X-WMO-Episode-ID`` on every completion.
+        FastAPI application exposing OpenAI Chat Completions and Responses routes.
     """
     application = FastAPI(
         title="WMO local router",

--- a/wmo/runtime/router/application_openai_test.py
+++ b/wmo/runtime/router/application_openai_test.py
@@ -1,0 +1,34 @@
+"""Public official OpenAI Python client over a loaded project router."""
+
+from pathlib import Path
+
+import pytest
+from openai import OpenAI
+from openai.types.chat import ChatCompletion
+from openai.types.responses import Response
+
+from wmo.runtime.router.application import load_router
+from wmo.runtime.router.runtime_test import _runtime
+
+
+def test_load_router_exposes_official_chat_and_responses_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The happy-path Python API needs no WMO request or message types."""
+    runtime, model_client = _runtime()
+    monkeypatch.setattr(
+        "wmo.runtime.router.application.load_project_router",
+        lambda project, root, **kwargs: runtime,
+    )
+
+    with load_router("support-agent", Path(".wmo")) as router:
+        assert isinstance(router, OpenAI)
+        chat = router.chat.completions.create(
+            model="support-agent",
+            messages=[{"role": "user", "content": "Help me"}],
+        )
+        response = router.responses.create(model="support-agent", input="Help me")
+
+    assert isinstance(chat, ChatCompletion)
+    assert isinstance(response, Response)
+    assert model_client.complete_calls == 2

--- a/wmo/runtime/router/application_openai_test.py
+++ b/wmo/runtime/router/application_openai_test.py
@@ -1,7 +1,5 @@
 """Public official OpenAI Python client over a loaded project router."""
 
-from pathlib import Path
-
 import pytest
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
@@ -21,7 +19,7 @@ def test_load_router_exposes_official_chat_and_responses_resources(
         lambda project, root, **kwargs: runtime,
     )
 
-    with load_router("support-agent", Path(".wmo")) as router:
+    with load_router("support-agent") as router:
         assert isinstance(router, OpenAI)
         chat = router.chat.completions.create(
             model="support-agent",

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -35,6 +35,7 @@ from wmo.common.tasks import ToolSchema
 from wmo.runtime.router.runtime import RouterEpisodeConflictError, RouterRuntime
 
 _AFFINITY_CAPACITY = 4096
+_IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
 
 
 class HttpFunctionCall(BaseModel):
@@ -168,18 +169,19 @@ class _TranscriptAffinity:
     """
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._idempotency: OrderedDict[str, tuple[str, str, float]] = OrderedDict()
         self._responses: OrderedDict[str, _ResponseState] = OrderedDict()
 
-    def chat_episode(self, messages: tuple[HttpMessage, ...], idempotency_key: str | None) -> str:
+    def chat_episode(self, request_sha256: str, idempotency_key: str | None) -> str:
         """Return a stable internal episode only for a standard idempotent retry."""
-        del messages
-        if idempotency_key is not None:
-            return "idempotency-" + hashlib.sha256(idempotency_key.encode()).hexdigest()
-        return f"openai-{uuid.uuid4().hex}"
+        return self._idempotent_episode(request_sha256, idempotency_key, existing_episode=None)
 
     def response_context(
-        self, previous_response_id: str | None, idempotency_key: str | None
+        self,
+        previous_response_id: str | None,
+        request_sha256: str,
+        idempotency_key: str | None,
     ) -> _ResponseState:
         """Resolve prior Responses state or start a new internal conversation."""
         with self._lock:
@@ -188,12 +190,11 @@ class _TranscriptAffinity:
                 if state is None:
                     raise ValueError("previous_response_id does not name a local response")
                 self._responses.move_to_end(previous_response_id)
-                return state
-        identity = (
-            "idempotency-" + hashlib.sha256(idempotency_key.encode()).hexdigest()
-            if idempotency_key is not None
-            else f"openai-{uuid.uuid4().hex}"
-        )
+                identity = self._idempotent_episode(
+                    request_sha256, idempotency_key, existing_episode=state.episode_id
+                )
+                return _ResponseState(episode_id=identity, messages=state.messages)
+        identity = self._idempotent_episode(request_sha256, idempotency_key, existing_episode=None)
         return _ResponseState(episode_id=identity, messages=())
 
     def remember_response(self, response_id: str, state: _ResponseState) -> None:
@@ -203,6 +204,42 @@ class _TranscriptAffinity:
             self._responses.move_to_end(response_id)
             while len(self._responses) > _AFFINITY_CAPACITY:
                 self._responses.popitem(last=False)
+
+    def _idempotent_episode(
+        self,
+        request_sha256: str,
+        idempotency_key: str | None,
+        *,
+        existing_episode: str | None,
+    ) -> str:
+        """Bind a standard key to one exact request and internal episode."""
+        if idempotency_key is None:
+            return existing_episode or f"openai-{uuid.uuid4().hex}"
+        key_sha256 = hashlib.sha256(idempotency_key.encode()).hexdigest()
+        with self._lock:
+            now = time.monotonic()
+            expired = tuple(
+                key for key, (_, _, deadline) in self._idempotency.items() if deadline <= now
+            )
+            for key in expired:
+                del self._idempotency[key]
+            existing = self._idempotency.get(key_sha256)
+            if existing is not None:
+                if existing[0] != request_sha256:
+                    raise RouterEpisodeConflictError(
+                        "Idempotency-Key is already bound to a different request"
+                    )
+                self._idempotency.move_to_end(key_sha256)
+                return existing[1]
+            if len(self._idempotency) >= _AFFINITY_CAPACITY:
+                raise RouterEpisodeConflictError("live idempotency-key capacity is exhausted")
+            episode_id = existing_episode or f"idempotency-{key_sha256}"
+            self._idempotency[key_sha256] = (
+                request_sha256,
+                episode_id,
+                now + _IDEMPOTENCY_TTL_SECONDS,
+            )
+            return episode_id
 
 
 def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
@@ -237,12 +274,12 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             return _error(404, f"no routed endpoint {request.model!r}")
         try:
             model_request = _chat_model_request(request)
-            episode_id = affinity.chat_episode(request.messages, idempotency_key)
+            episode_id = affinity.chat_episode(_request_sha256(request), idempotency_key)
             routed = runtime.complete(model_request, episode_id=episode_id)
+        except RouterEpisodeConflictError as exc:
+            return _error(409, str(exc))
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
-        except RouterEpisodeConflictError:
-            return _error(409, "request transcript conflicts with an earlier routed turn")
         except Exception as exc:  # noqa: BLE001
             return _error(502, f"routed model call failed ({type(exc).__name__})")
         completion = _chat_completion(request.model, routed.response.output, routed.response)
@@ -266,15 +303,17 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         if runtime is None:
             return _error(404, f"no routed endpoint {request.model!r}")
         try:
-            prior = affinity.response_context(request.previous_response_id, idempotency_key)
+            prior = affinity.response_context(
+                request.previous_response_id, _request_sha256(request), idempotency_key
+            )
             visible = _response_messages(request)
             all_messages = (*prior.messages, *visible)
             model_request = _responses_model_request(request, all_messages)
             routed = runtime.complete(model_request, episode_id=prior.episode_id)
+        except RouterEpisodeConflictError as exc:
+            return _error(409, str(exc))
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
-        except RouterEpisodeConflictError:
-            return _error(409, "response continuation conflicts with an earlier routed turn")
         except Exception as exc:  # noqa: BLE001
             return _error(502, f"routed model call failed ({type(exc).__name__})")
         response = _openai_response(
@@ -617,6 +656,13 @@ def _responses_stream(response: OpenAIResponse) -> Iterator[str]:
 
 def _response_event(name: str, data: str) -> str:
     return f"event: {name}\ndata: {data}\n\n"
+
+
+def _request_sha256(request: BaseModel) -> str:
+    """Return the complete canonical OpenAI request digest for idempotency binding."""
+    payload = request.model_dump(mode="json")
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | ToolChoice | None:

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -35,7 +35,11 @@ from wmo.common.models import (
     ToolChoice,
 )
 from wmo.common.tasks import ToolSchema
-from wmo.runtime.router.runtime import RouterEpisodeConflictError, RouterRuntime
+from wmo.runtime.router.runtime import (
+    RouterEpisodeConflictError,
+    RouterModelCapabilityError,
+    RouterRuntime,
+)
 
 _AFFINITY_CAPACITY = 4096
 _IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
@@ -334,6 +338,8 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             return _error(409, "Idempotency-Key conflicts with live request state")
         except RouterEpisodeConflictError:
             return _error(409, "request conflicts with an earlier routed turn")
+        except RouterModelCapabilityError as exc:
+            return _error(501, str(exc), code="tool_calling_unsupported")
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
         except Exception:  # noqa: BLE001
@@ -371,6 +377,8 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             return _error(409, "Idempotency-Key conflicts with live request state")
         except RouterEpisodeConflictError:
             return _error(409, "response continuation conflicts with an earlier routed turn")
+        except RouterModelCapabilityError as exc:
+            return _error(501, str(exc), code="tool_calling_unsupported")
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
         except Exception:  # noqa: BLE001
@@ -472,7 +480,9 @@ def _model_request(
         tools=tuple(
             ToolSchema(
                 name=tool.function.name,
-                description=tool.function.description,
+                # OpenAI makes function descriptions optional while WMO's stable
+                # internal task schema requires a non-empty rendering label.
+                description=tool.function.description or tool.function.name,
                 input_schema=tool.function.parameters,
             )
             for tool in tools
@@ -755,7 +765,7 @@ def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | Tool
     raise ValueError("tool_choice must be auto, none, required, or a named function")
 
 
-def _error(status: int, message: str) -> Response:
+def _error(status: int, message: str, *, code: str = "routing_error") -> Response:
     return Response(
         content=json.dumps(
             {
@@ -763,7 +773,7 @@ def _error(status: int, message: str) -> Response:
                     "message": message,
                     "type": "invalid_request_error" if status < 500 else "api_error",
                     "param": None,
-                    "code": "routing_error",
+                    "code": code,
                 }
             }
         ),

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -15,13 +15,15 @@ from typing import Literal, cast
 from fastapi import APIRouter, Header, Response
 from fastapi.responses import StreamingResponse
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.completion_create_params import CompletionCreateParams
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseCreatedEvent,
     ResponseTextDeltaEvent,
 )
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+from openai.types.responses.response_create_params import ResponseCreateParams
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, model_validator
 
 from wmo.common.core.artifacts import JsonObject
 from wmo.common.models import (
@@ -38,6 +40,33 @@ from wmo.runtime.router.runtime import RouterEpisodeConflictError, RouterRuntime
 _AFFINITY_CAPACITY = 4096
 _IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
 logger = logging.getLogger(__name__)
+_CHAT_REQUEST_ADAPTER = TypeAdapter(CompletionCreateParams)
+_RESPONSE_REQUEST_ADAPTER = TypeAdapter(ResponseCreateParams)
+_CHAT_FIELDS = frozenset(
+    {
+        "model",
+        "messages",
+        "tools",
+        "tool_choice",
+        "temperature",
+        "max_tokens",
+        "max_completion_tokens",
+        "stream",
+    }
+)
+_RESPONSE_FIELDS = frozenset(
+    {
+        "model",
+        "input",
+        "instructions",
+        "previous_response_id",
+        "tools",
+        "tool_choice",
+        "temperature",
+        "max_output_tokens",
+        "stream",
+    }
+)
 
 
 class OpenAIRequestConflictError(ValueError):
@@ -105,7 +134,7 @@ class HttpTool(BaseModel):
 class HttpChatRequest(BaseModel):
     """Supported OpenAI Chat Completions request."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     model: str
     messages: tuple[HttpMessage, ...] = Field(min_length=1)
@@ -115,6 +144,14 @@ class HttpChatRequest(BaseModel):
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
     stream: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _official_openai_shape(cls, value: object) -> object:
+        """Validate the official request type before narrowing to routed capabilities."""
+        _CHAT_REQUEST_ADAPTER.validate_python(value)
+        _reject_unsupported_fields(value, _CHAT_FIELDS, "Chat Completions")
+        return value
 
 
 class HttpResponseTool(BaseModel):
@@ -146,7 +183,7 @@ class HttpResponseFunctionOutput(BaseModel):
 class HttpResponseRequest(BaseModel):
     """Supported OpenAI Responses request."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     model: str
     input: str | tuple[HttpMessage | HttpResponseFunctionCall | HttpResponseFunctionOutput, ...]
@@ -157,6 +194,14 @@ class HttpResponseRequest(BaseModel):
     temperature: float | None = None
     max_output_tokens: int | None = None
     stream: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _official_openai_shape(cls, value: object) -> object:
+        """Validate the official request type before narrowing to routed capabilities."""
+        _RESPONSE_REQUEST_ADAPTER.validate_python(value)
+        _reject_unsupported_fields(value, _RESPONSE_FIELDS, "Responses")
+        return value
 
 
 class _ResponseState(BaseModel):
@@ -675,6 +720,18 @@ def _request_sha256(request: BaseModel) -> str:
     payload = request.model_dump(mode="json")
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _reject_unsupported_fields(value: object, supported: frozenset[str], api_name: str) -> None:
+    """Reject official fields that the routed provider-neutral seam cannot preserve."""
+    if not isinstance(value, dict):
+        return
+    unsupported = sorted(str(key) for key in value if key not in supported)
+    if unsupported:
+        raise ValueError(
+            f"{api_name} fields are not supported by this routed endpoint: "
+            + ", ".join(unsupported)
+        )
 
 
 def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | ToolChoice | None:

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -160,40 +160,23 @@ class _ResponseState(BaseModel):
 
 
 class _TranscriptAffinity:
-    """Bounded process-local transcript affinity without a proprietary caller header.
+    """Bounded standard request and response identity without a proprietary caller header.
 
-    This restores the useful prefix behavior from
-    ``e7aad17b:wmo/simulation/serving/chat.py`` while keeping the public wire format OpenAI-native.
+    This retains bounded standard request and response identities without restoring the unsafe
+    global transcript-prefix map from ``e7aad17b:wmo/simulation/serving/chat.py``. Two unrelated
+    callers can send the same transcript, so a transcript alone cannot be a conversation identity.
     """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._transcripts: OrderedDict[str, str] = OrderedDict()
         self._responses: OrderedDict[str, _ResponseState] = OrderedDict()
 
     def chat_episode(self, messages: tuple[HttpMessage, ...], idempotency_key: str | None) -> str:
-        """Return a stable internal episode for a transcript or idempotent retry."""
-        with self._lock:
-            for length in range(len(messages), 0, -1):
-                fingerprint = _messages_sha256(messages[:length])
-                known = self._transcripts.get(fingerprint)
-                if known is not None:
-                    self._transcripts.move_to_end(fingerprint)
-                    return known
+        """Return a stable internal episode only for a standard idempotent retry."""
+        del messages
         if idempotency_key is not None:
             return "idempotency-" + hashlib.sha256(idempotency_key.encode()).hexdigest()
         return f"openai-{uuid.uuid4().hex}"
-
-    def remember_chat(
-        self,
-        request_messages: tuple[HttpMessage, ...],
-        assistant: HttpMessage,
-        episode_id: str,
-    ) -> None:
-        """Remember exact request and completed transcript fingerprints."""
-        with self._lock:
-            self._remember_transcript(_messages_sha256(request_messages), episode_id)
-            self._remember_transcript(_messages_sha256((*request_messages, assistant)), episode_id)
 
     def response_context(
         self, previous_response_id: str | None, idempotency_key: str | None
@@ -220,12 +203,6 @@ class _TranscriptAffinity:
             self._responses.move_to_end(response_id)
             while len(self._responses) > _AFFINITY_CAPACITY:
                 self._responses.popitem(last=False)
-
-    def _remember_transcript(self, fingerprint: str, episode_id: str) -> None:
-        self._transcripts[fingerprint] = episode_id
-        self._transcripts.move_to_end(fingerprint)
-        while len(self._transcripts) > _AFFINITY_CAPACITY:
-            self._transcripts.popitem(last=False)
 
 
 def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
@@ -268,8 +245,6 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             return _error(409, "request transcript conflicts with an earlier routed turn")
         except Exception as exc:  # noqa: BLE001
             return _error(502, f"routed model call failed ({type(exc).__name__})")
-        assistant = _assistant_message(routed.response.output)
-        affinity.remember_chat(request.messages, assistant, episode_id)
         completion = _chat_completion(request.model, routed.response.output, routed.response)
         headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
         if request.stream:
@@ -642,12 +617,6 @@ def _responses_stream(response: OpenAIResponse) -> Iterator[str]:
 
 def _response_event(name: str, data: str) -> str:
     return f"event: {name}\ndata: {data}\n\n"
-
-
-def _messages_sha256(messages: tuple[HttpMessage, ...]) -> str:
-    payload = [message.model_dump(mode="json") for message in messages]
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(encoded).hexdigest()
 
 
 def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | ToolChoice | None:

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -1,39 +1,69 @@
-"""Loopback local non-streaming OpenAI-compatible adapter over RouterRuntime.complete."""
+"""OpenAI Chat Completions and Responses adapters over a frozen router runtime."""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import threading
+import time
 import uuid
-from typing import Literal
+from collections import OrderedDict
+from collections.abc import Iterator
+from typing import Literal, cast
 
 from fastapi import APIRouter, Header, Response
+from fastapi.responses import StreamingResponse
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.responses import Response as OpenAIResponse
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseCreatedEvent,
+    ResponseTextDeltaEvent,
+)
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
-from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolCall, ToolChoice
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import (
+    AssistantAction,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCall,
+    ToolChoice,
+)
 from wmo.common.tasks import ToolSchema
 from wmo.runtime.router.runtime import RouterEpisodeConflictError, RouterRuntime
 
+_AFFINITY_CAPACITY = 4096
+
 
 class HttpFunctionCall(BaseModel):
-    """OpenAI-compatible function name and JSON arguments string."""
+    """OpenAI function name and JSON arguments string."""
 
     name: str
     arguments: str
 
 
 class HttpToolCall(BaseModel):
-    """OpenAI-compatible assistant function call."""
+    """OpenAI assistant function call."""
 
     id: str
     type: Literal["function"] = "function"
     function: HttpFunctionCall
 
 
+class HttpTextPart(BaseModel):
+    """One supported OpenAI text content part."""
+
+    type: Literal["text", "input_text", "output_text"]
+    text: str
+
+
 class HttpMessage(BaseModel):
-    """Ordered request message preserving assistant calls and tool results."""
+    """Ordered OpenAI message preserving assistant calls and tool results."""
 
     role: Literal["system", "developer", "user", "assistant", "tool"]
-    content: str | None = None
+    content: str | tuple[HttpTextPart, ...] | None = None
     tool_calls: tuple[HttpToolCall, ...] = ()
     tool_call_id: str | None = None
 
@@ -51,7 +81,7 @@ class HttpMessage(BaseModel):
 
 
 class HttpFunctionDefinition(BaseModel):
-    """One request-visible tool schema."""
+    """One request-visible function schema."""
 
     name: str
     description: str = ""
@@ -59,14 +89,14 @@ class HttpFunctionDefinition(BaseModel):
 
 
 class HttpTool(BaseModel):
-    """One OpenAI-compatible function tool."""
+    """One OpenAI function tool."""
 
     type: Literal["function"] = "function"
     function: HttpFunctionDefinition
 
 
 class HttpChatRequest(BaseModel):
-    """Supported non-streaming OpenAI chat request."""
+    """Supported OpenAI Chat Completions request."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -80,16 +110,135 @@ class HttpChatRequest(BaseModel):
     stream: bool = False
 
 
+class HttpResponseTool(BaseModel):
+    """One OpenAI Responses function tool."""
+
+    type: Literal["function"] = "function"
+    name: str
+    description: str = ""
+    parameters: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class HttpResponseFunctionCall(BaseModel):
+    """One Responses function-call item replayed as assistant history."""
+
+    type: Literal["function_call"]
+    call_id: str
+    name: str
+    arguments: str
+
+
+class HttpResponseFunctionOutput(BaseModel):
+    """One Responses function result replayed as tool history."""
+
+    type: Literal["function_call_output"]
+    call_id: str
+    output: str
+
+
+class HttpResponseRequest(BaseModel):
+    """Supported OpenAI Responses request."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    input: str | tuple[HttpMessage | HttpResponseFunctionCall | HttpResponseFunctionOutput, ...]
+    instructions: str | None = None
+    previous_response_id: str | None = None
+    tools: tuple[HttpResponseTool, ...] = ()
+    tool_choice: JsonValue = None
+    temperature: float | None = None
+    max_output_tokens: int | None = None
+    stream: bool = False
+
+
+class _ResponseState(BaseModel):
+    """Conversation state retained for one OpenAI Responses result."""
+
+    episode_id: str
+    messages: tuple[HttpMessage, ...]
+
+
+class _TranscriptAffinity:
+    """Bounded process-local transcript affinity without a proprietary caller header.
+
+    This restores the useful prefix behavior from
+    ``e7aad17b:wmo/simulation/serving/chat.py`` while keeping the public wire format OpenAI-native.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._transcripts: OrderedDict[str, str] = OrderedDict()
+        self._responses: OrderedDict[str, _ResponseState] = OrderedDict()
+
+    def chat_episode(self, messages: tuple[HttpMessage, ...], idempotency_key: str | None) -> str:
+        """Return a stable internal episode for a transcript or idempotent retry."""
+        with self._lock:
+            for length in range(len(messages), 0, -1):
+                fingerprint = _messages_sha256(messages[:length])
+                known = self._transcripts.get(fingerprint)
+                if known is not None:
+                    self._transcripts.move_to_end(fingerprint)
+                    return known
+        if idempotency_key is not None:
+            return "idempotency-" + hashlib.sha256(idempotency_key.encode()).hexdigest()
+        return f"openai-{uuid.uuid4().hex}"
+
+    def remember_chat(
+        self,
+        request_messages: tuple[HttpMessage, ...],
+        assistant: HttpMessage,
+        episode_id: str,
+    ) -> None:
+        """Remember exact request and completed transcript fingerprints."""
+        with self._lock:
+            self._remember_transcript(_messages_sha256(request_messages), episode_id)
+            self._remember_transcript(_messages_sha256((*request_messages, assistant)), episode_id)
+
+    def response_context(
+        self, previous_response_id: str | None, idempotency_key: str | None
+    ) -> _ResponseState:
+        """Resolve prior Responses state or start a new internal conversation."""
+        with self._lock:
+            if previous_response_id is not None:
+                state = self._responses.get(previous_response_id)
+                if state is None:
+                    raise ValueError("previous_response_id does not name a local response")
+                self._responses.move_to_end(previous_response_id)
+                return state
+        identity = (
+            "idempotency-" + hashlib.sha256(idempotency_key.encode()).hexdigest()
+            if idempotency_key is not None
+            else f"openai-{uuid.uuid4().hex}"
+        )
+        return _ResponseState(episode_id=identity, messages=())
+
+    def remember_response(self, response_id: str, state: _ResponseState) -> None:
+        """Remember one bounded Responses continuation."""
+        with self._lock:
+            self._responses[response_id] = state
+            self._responses.move_to_end(response_id)
+            while len(self._responses) > _AFFINITY_CAPACITY:
+                self._responses.popitem(last=False)
+
+    def _remember_transcript(self, fingerprint: str, episode_id: str) -> None:
+        self._transcripts[fingerprint] = episode_id
+        self._transcripts.move_to_end(fingerprint)
+        while len(self._transcripts) > _AFFINITY_CAPACITY:
+            self._transcripts.popitem(last=False)
+
+
 def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
-    """Mount the sole routed model HTTP endpoint over exact runtime decisions.
+    """Mount OpenAI Chat Completions and Responses over exact router decisions.
 
     Args:
-        endpoints: Public routed model names mapped to activated local runtimes.
+        endpoints: Public model names mapped to activated local runtimes.
 
     Returns:
-        Loopback-hostable non-streaming OpenAI-compatible router.
+        Loopback-hostable OpenAI API router.
     """
     router = APIRouter()
+    affinity = _TranscriptAffinity()
 
     @router.get("/v1/models")
     def models() -> dict[str, object]:
@@ -102,123 +251,403 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         }
 
     @router.post("/v1/chat/completions")
-    def complete(
+    def complete_chat(
         request: HttpChatRequest,
-        episode_id: str | None = Header(default=None, alias="X-WMO-Episode-ID"),
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
-        if request.stream:
-            return _error(400, "stream=true is not supported by the local routed endpoint")
-        if episode_id is None or not episode_id.strip() or len(episode_id) > 512:
-            return _error(400, "X-WMO-Episode-ID is required and must be 1 to 512 characters")
         runtime = endpoints.get(request.model)
         if runtime is None:
             return _error(404, f"no routed endpoint {request.model!r}")
         try:
-            model_request = _model_request(request)
-        except ValueError as exc:
-            return _error(400, f"invalid routed request ({exc})")
-        try:
+            model_request = _chat_model_request(request)
+            episode_id = affinity.chat_episode(request.messages, idempotency_key)
             routed = runtime.complete(model_request, episode_id=episode_id)
+        except (ValueError, json.JSONDecodeError) as exc:
+            return _error(400, f"invalid routed request ({exc})")
         except RouterEpisodeConflictError:
-            return _error(409, "episode identity conflicts with an earlier request")
+            return _error(409, "request transcript conflicts with an earlier routed turn")
         except Exception as exc:  # noqa: BLE001
             return _error(502, f"routed model call failed ({type(exc).__name__})")
-        action = routed.response.output
-        message = {
-            "role": "assistant",
-            "content": action.content,
-            "tool_calls": [
-                {
-                    "id": call.call_id,
-                    "type": "function",
-                    "function": {
-                        "name": call.name,
-                        "arguments": json.dumps(call.arguments, sort_keys=True),
-                    },
-                }
-                for call in action.tool_calls
-            ],
-        }
-        usage = routed.response.economics.usage
-        body = {
-            "id": f"chatcmpl-{uuid.uuid4().hex}",
-            "object": "chat.completion",
-            "model": request.model,
-            "episode_id_sha256": routed.decision.episode_id_sha256,
-            "routing_decision": routed.decision.model_dump(mode="json"),
-            "choices": [
-                {
-                    "index": 0,
-                    "message": message,
-                    "finish_reason": "tool_calls" if action.tool_calls else "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": usage.input_tokens if usage is not None else 0,
-                "completion_tokens": usage.output_tokens if usage is not None else 0,
-            },
-        }
+        assistant = _assistant_message(routed.response.output)
+        affinity.remember_chat(request.messages, assistant, episode_id)
+        completion = _chat_completion(request.model, routed.response.output, routed.response)
+        headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
+        if request.stream:
+            return StreamingResponse(
+                _chat_stream(completion), media_type="text/event-stream", headers=headers
+            )
         return Response(
-            content=json.dumps(body),
+            content=completion.model_dump_json(exclude_none=True),
             media_type="application/json",
-            headers={
-                "X-WMO-Episode-ID-SHA256": routed.decision.episode_id_sha256,
-                "X-WMO-Routed-Model": routed.decision.selected_alias,
-            },
+            headers=headers,
+        )
+
+    @router.post("/v1/responses")
+    def complete_response(
+        request: HttpResponseRequest,
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    ) -> Response:
+        runtime = endpoints.get(request.model)
+        if runtime is None:
+            return _error(404, f"no routed endpoint {request.model!r}")
+        try:
+            prior = affinity.response_context(request.previous_response_id, idempotency_key)
+            visible = _response_messages(request)
+            all_messages = (*prior.messages, *visible)
+            model_request = _responses_model_request(request, all_messages)
+            routed = runtime.complete(model_request, episode_id=prior.episode_id)
+        except (ValueError, json.JSONDecodeError) as exc:
+            return _error(400, f"invalid routed request ({exc})")
+        except RouterEpisodeConflictError:
+            return _error(409, "response continuation conflicts with an earlier routed turn")
+        except Exception as exc:  # noqa: BLE001
+            return _error(502, f"routed model call failed ({type(exc).__name__})")
+        response = _openai_response(
+            request.model,
+            routed.response.output,
+            routed.response,
+            previous_response_id=request.previous_response_id,
+        )
+        assistant = _assistant_message(routed.response.output)
+        affinity.remember_response(
+            response.id,
+            _ResponseState(episode_id=prior.episode_id, messages=(*all_messages, assistant)),
+        )
+        headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
+        if request.stream:
+            return StreamingResponse(
+                _responses_stream(response), media_type="text/event-stream", headers=headers
+            )
+        return Response(
+            content=response.model_dump_json(exclude_none=True),
+            media_type="application/json",
+            headers=headers,
         )
 
     return router
 
 
-def _model_request(request: HttpChatRequest) -> ModelRequest:
-    """Preserve ordered text, assistant tool calls, tool results, and request tool schemas."""
-    if not any(
-        message.role == "user" and message.content is not None for message in request.messages
-    ):
+def _chat_model_request(request: HttpChatRequest) -> ModelRequest:
+    return _model_request(
+        request.messages,
+        request.tools,
+        request.tool_choice,
+        request.temperature,
+        request.max_completion_tokens or request.max_tokens,
+    )
+
+
+def _responses_model_request(
+    request: HttpResponseRequest, messages: tuple[HttpMessage, ...]
+) -> ModelRequest:
+    tools = tuple(
+        HttpTool(
+            function=HttpFunctionDefinition(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.parameters,
+            )
+        )
+        for tool in request.tools
+    )
+    return _model_request(
+        messages,
+        tools,
+        request.tool_choice,
+        request.temperature,
+        request.max_output_tokens,
+    )
+
+
+def _model_request(
+    messages: tuple[HttpMessage, ...],
+    tools: tuple[HttpTool, ...],
+    tool_choice: JsonValue,
+    temperature: float | None,
+    maximum_output_tokens: int | None,
+) -> ModelRequest:
+    if not any(message.role == "user" and _content_text(message.content) for message in messages):
         raise ValueError("routed requests require at least one user message with content")
-    messages = []
-    for message in request.messages:
+    converted = []
+    for message in messages:
         role = "system" if message.role == "developer" else message.role
+        content = _content_text(message.content)
         action = None
         if role == "assistant":
             action = AssistantAction(
-                content=message.content,
+                content=content,
                 tool_calls=tuple(
                     ToolCall(
                         call_id=call.id,
                         name=call.function.name,
-                        arguments=json.loads(call.function.arguments),
+                        arguments=_arguments(call.function.arguments),
                     )
                     for call in message.tool_calls
                 ),
             )
-        messages.append(
+        converted.append(
             ModelMessage(
                 role=role,
-                content=message.content if action is None else None,
+                content=content if action is None else None,
                 tool_call_id=message.tool_call_id,
                 assistant_action=action,
             )
         )
-    choice = _tool_choice(request.tool_choice)
     return ModelRequest(
-        messages=tuple(messages),
+        messages=tuple(converted),
         tools=tuple(
             ToolSchema(
                 name=tool.function.name,
                 description=tool.function.description,
                 input_schema=tool.function.parameters,
             )
-            for tool in request.tools
+            for tool in tools
         ),
-        tool_choice=choice,
-        temperature=request.temperature,
-        maximum_output_tokens=(
-            request.max_completion_tokens
-            if request.max_completion_tokens is not None
-            else request.max_tokens
+        tool_choice=_tool_choice(tool_choice),
+        temperature=temperature,
+        maximum_output_tokens=maximum_output_tokens,
+    )
+
+
+def _response_messages(request: HttpResponseRequest) -> tuple[HttpMessage, ...]:
+    messages: list[HttpMessage] = []
+    if request.instructions is not None:
+        messages.append(HttpMessage(role="developer", content=request.instructions))
+    if isinstance(request.input, str):
+        messages.append(HttpMessage(role="user", content=request.input))
+    else:
+        for item in request.input:
+            if isinstance(item, HttpMessage):
+                messages.append(item)
+            elif isinstance(item, HttpResponseFunctionCall):
+                messages.append(
+                    HttpMessage(
+                        role="assistant",
+                        tool_calls=(
+                            HttpToolCall(
+                                id=item.call_id,
+                                function=HttpFunctionCall(name=item.name, arguments=item.arguments),
+                            ),
+                        ),
+                    )
+                )
+            else:
+                messages.append(
+                    HttpMessage(role="tool", content=item.output, tool_call_id=item.call_id)
+                )
+    return tuple(messages)
+
+
+def _arguments(value: str) -> JsonObject:
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("tool arguments must encode one JSON object")
+    return cast(JsonObject, parsed)
+
+
+def _assistant_message(action: AssistantAction) -> HttpMessage:
+    return HttpMessage(
+        role="assistant",
+        content=action.content,
+        tool_calls=tuple(
+            HttpToolCall(
+                id=call.call_id,
+                function=HttpFunctionCall(
+                    name=call.name,
+                    arguments=json.dumps(call.arguments, sort_keys=True, separators=(",", ":")),
+                ),
+            )
+            for call in action.tool_calls
         ),
     )
+
+
+def _content_text(content: str | tuple[HttpTextPart, ...] | None) -> str | None:
+    """Normalize supported OpenAI text parts without accepting silent multimodal loss."""
+    if content is None or isinstance(content, str):
+        return content
+    return "".join(part.text for part in content)
+
+
+def _chat_completion(
+    model: str, action: AssistantAction, response: ModelResponse
+) -> ChatCompletion:
+    usage = _usage(response)
+    return ChatCompletion.model_validate(
+        {
+            "id": f"chatcmpl-{uuid.uuid4().hex}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": _assistant_message(action).model_dump(mode="json"),
+                    "finish_reason": "tool_calls" if action.tool_calls else "stop",
+                    "logprobs": None,
+                }
+            ],
+            "usage": usage,
+        }
+    )
+
+
+def _openai_response(
+    model: str,
+    action: AssistantAction,
+    response: ModelResponse,
+    *,
+    previous_response_id: str | None,
+) -> OpenAIResponse:
+    response_id = f"resp_{uuid.uuid4().hex}"
+    output: list[JsonObject] = []
+    if action.content is not None:
+        output.append(
+            {
+                "id": f"msg_{uuid.uuid4().hex}",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": action.content, "annotations": []}],
+            }
+        )
+    output.extend(
+        {
+            "id": f"fc_{uuid.uuid4().hex}",
+            "type": "function_call",
+            "call_id": call.call_id,
+            "name": call.name,
+            "arguments": json.dumps(call.arguments, sort_keys=True, separators=(",", ":")),
+            "status": "completed",
+        }
+        for call in action.tool_calls
+    )
+    return OpenAIResponse.model_validate(
+        {
+            "id": response_id,
+            "object": "response",
+            "created_at": time.time(),
+            "completed_at": time.time(),
+            "status": "completed",
+            "model": model,
+            "output": output,
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+            "previous_response_id": previous_response_id,
+            "usage": _responses_usage(response),
+        }
+    )
+
+
+def _usage(response: ModelResponse) -> JsonObject:
+    usage = response.economics.usage
+    prompt = usage.input_tokens if usage is not None else 0
+    completion = usage.output_tokens if usage is not None else 0
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+
+
+def _responses_usage(response: ModelResponse) -> JsonObject:
+    usage = _usage(response)
+    prompt = cast(int, usage["prompt_tokens"])
+    completion = cast(int, usage["completion_tokens"])
+    return {
+        "input_tokens": prompt,
+        "input_tokens_details": {"cache_write_tokens": 0, "cached_tokens": 0},
+        "output_tokens": completion,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": prompt + completion,
+    }
+
+
+def _chat_stream(completion: ChatCompletion) -> Iterator[str]:
+    choice = completion.choices[0]
+    message = choice.message
+    delta: JsonObject = {"role": "assistant"}
+    if message.content is not None:
+        delta["content"] = message.content
+    if message.tool_calls:
+        delta["tool_calls"] = [
+            {**tool.model_dump(mode="json", exclude_none=True), "index": index}
+            for index, tool in enumerate(message.tool_calls)
+        ]
+    first = ChatCompletionChunk.model_validate(
+        {
+            "id": completion.id,
+            "object": "chat.completion.chunk",
+            "created": completion.created,
+            "model": completion.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": None,
+                    "logprobs": None,
+                }
+            ],
+        }
+    )
+    terminal = ChatCompletionChunk.model_validate(
+        {
+            "id": completion.id,
+            "object": "chat.completion.chunk",
+            "created": completion.created,
+            "model": completion.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": choice.finish_reason,
+                    "logprobs": None,
+                }
+            ],
+            "usage": completion.usage.model_dump(mode="json") if completion.usage else None,
+        }
+    )
+    yield f"data: {first.model_dump_json(exclude_none=True)}\n\n"
+    yield f"data: {terminal.model_dump_json(exclude_none=True)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+def _responses_stream(response: OpenAIResponse) -> Iterator[str]:
+    created = ResponseCreatedEvent(response=response, sequence_number=0, type="response.created")
+    yield _response_event(created.type, created.model_dump_json(exclude_none=True))
+    sequence = 1
+    for output_index, item in enumerate(response.output):
+        if item.type != "message":
+            continue
+        for content_index, content in enumerate(item.content):
+            if content.type != "output_text":
+                continue
+            event = ResponseTextDeltaEvent(
+                content_index=content_index,
+                delta=content.text,
+                item_id=item.id,
+                logprobs=[],
+                output_index=output_index,
+                sequence_number=sequence,
+                type="response.output_text.delta",
+            )
+            yield _response_event(event.type, event.model_dump_json(exclude_none=True))
+            sequence += 1
+    completed = ResponseCompletedEvent(
+        response=response, sequence_number=sequence, type="response.completed"
+    )
+    yield _response_event(completed.type, completed.model_dump_json(exclude_none=True))
+
+
+def _response_event(name: str, data: str) -> str:
+    return f"event: {name}\ndata: {data}\n\n"
+
+
+def _messages_sha256(messages: tuple[HttpMessage, ...]) -> str:
+    payload = [message.model_dump(mode="json") for message in messages]
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | ToolChoice | None:
@@ -234,6 +663,8 @@ def _tool_choice(value: JsonValue) -> Literal["auto", "none", "required"] | Tool
         function = value.get("function")
         if isinstance(function, dict) and isinstance(function.get("name"), str):
             return ToolChoice(name=function["name"])
+        if value.get("type") == "function" and isinstance(value.get("name"), str):
+            return ToolChoice(name=value["name"])
     raise ValueError("tool_choice must be auto, none, required, or a named function")
 
 

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import threading
 import time
 import uuid
@@ -36,6 +37,11 @@ from wmo.runtime.router.runtime import RouterEpisodeConflictError, RouterRuntime
 
 _AFFINITY_CAPACITY = 4096
 _IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
+logger = logging.getLogger(__name__)
+
+
+class OpenAIRequestConflictError(ValueError):
+    """A standard OpenAI request identity conflicts with prior local state."""
 
 
 class HttpFunctionCall(BaseModel):
@@ -226,13 +232,13 @@ class _TranscriptAffinity:
             existing = self._idempotency.get(key_sha256)
             if existing is not None:
                 if existing[0] != request_sha256:
-                    raise RouterEpisodeConflictError(
+                    raise OpenAIRequestConflictError(
                         "Idempotency-Key is already bound to a different request"
                     )
                 self._idempotency.move_to_end(key_sha256)
                 return existing[1]
             if len(self._idempotency) >= _AFFINITY_CAPACITY:
-                raise RouterEpisodeConflictError("live idempotency-key capacity is exhausted")
+                raise OpenAIRequestConflictError("live idempotency-key capacity is exhausted")
             episode_id = existing_episode or f"idempotency-{key_sha256}"
             self._idempotency[key_sha256] = (
                 request_sha256,
@@ -276,12 +282,15 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             model_request = _chat_model_request(request)
             episode_id = affinity.chat_episode(_request_sha256(request), idempotency_key)
             routed = runtime.complete(model_request, episode_id=episode_id)
-        except RouterEpisodeConflictError as exc:
-            return _error(409, str(exc))
+        except OpenAIRequestConflictError:
+            return _error(409, "Idempotency-Key conflicts with live request state")
+        except RouterEpisodeConflictError:
+            return _error(409, "request conflicts with an earlier routed turn")
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
-        except Exception as exc:  # noqa: BLE001
-            return _error(502, f"routed model call failed ({type(exc).__name__})")
+        except Exception:  # noqa: BLE001
+            logger.exception("routed Chat Completions call failed")
+            return _error(502, "routed model call failed")
         completion = _chat_completion(request.model, routed.response.output, routed.response)
         headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
         if request.stream:
@@ -310,12 +319,15 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             all_messages = (*prior.messages, *visible)
             model_request = _responses_model_request(request, all_messages)
             routed = runtime.complete(model_request, episode_id=prior.episode_id)
-        except RouterEpisodeConflictError as exc:
-            return _error(409, str(exc))
+        except OpenAIRequestConflictError:
+            return _error(409, "Idempotency-Key conflicts with live request state")
+        except RouterEpisodeConflictError:
+            return _error(409, "response continuation conflicts with an earlier routed turn")
         except (ValueError, json.JSONDecodeError) as exc:
             return _error(400, f"invalid routed request ({exc})")
-        except Exception as exc:  # noqa: BLE001
-            return _error(502, f"routed model call failed ({type(exc).__name__})")
+        except Exception:  # noqa: BLE001
+            logger.exception("routed Responses call failed")
+            return _error(502, "routed model call failed")
         response = _openai_response(
             request.model,
             routed.response.output,

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -211,7 +211,7 @@ class _ResponseState(BaseModel):
     messages: tuple[HttpMessage, ...]
 
 
-class _TranscriptAffinity:
+class _OpenAIRequestState:
     """Bounded standard request and response identity without a proprietary caller header.
 
     This retains bounded standard request and response identities without restoring the unsafe
@@ -284,7 +284,10 @@ class _TranscriptAffinity:
                 return existing[1]
             if len(self._idempotency) >= _AFFINITY_CAPACITY:
                 raise OpenAIRequestConflictError("live idempotency-key capacity is exhausted")
-            episode_id = existing_episode or f"idempotency-{key_sha256}"
+            # An expired key starts a new logical request. Its episode must not be
+            # derived from the key, because RouterRuntime intentionally retains
+            # prior episode decisions longer than this bounded transport cache.
+            episode_id = existing_episode or f"idempotency-{uuid.uuid4().hex}"
             self._idempotency[key_sha256] = (
                 request_sha256,
                 episode_id,
@@ -303,7 +306,7 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         Loopback-hostable OpenAI API router.
     """
     router = APIRouter()
-    affinity = _TranscriptAffinity()
+    affinity = _OpenAIRequestState()
 
     @router.get("/v1/models")
     def models() -> dict[str, object]:

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -19,8 +19,8 @@ from wmo.runtime.router.runtime import RouterRuntime
 from wmo.runtime.router.runtime_test import _Client, _runtime
 
 
-def _clients() -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
-    runtime, model_client = _runtime()
+def _clients(*, candidate_tools: bool = True) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
+    runtime, model_client = _runtime(candidate_tools=candidate_tools)
     app = FastAPI()
     app.include_router(create_router_endpoint({"router-a": runtime}))
     http = TestClient(app)
@@ -97,6 +97,45 @@ def test_official_chat_client_preserves_tools_without_cross_caller_affinity() ->
 
     openai.chat.completions.create(model="router-a", messages=messages, tools=tools)
     assert model_client.embed_calls == 3
+
+
+@pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
+def test_tool_request_rejects_an_incapable_selected_model(path: str) -> None:
+    """OpenAI tool requests fail explicitly before an incapable provider call."""
+    _openai, http, _runtime_value, model_client = _clients(candidate_tools=False)
+    payload = (
+        {
+            "model": "router-a",
+            "input": "read",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "read",
+                    "parameters": {"type": "object"},
+                }
+            ],
+        }
+        if path.endswith("responses")
+        else {
+            "model": "router-a",
+            "messages": [{"role": "user", "content": "read"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        }
+    )
+
+    response = http.post(path, json=payload)
+
+    assert response.status_code == 501
+    assert response.json()["error"]["code"] == "tool_calling_unsupported"
+    assert model_client.complete_calls == 0
 
 
 def test_official_responses_client_continues_with_previous_response_id() -> None:

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -192,6 +192,30 @@ def test_idempotency_key_reuses_decision_after_provider_failure() -> None:
     assert model_client.complete_calls == 2
 
 
+@pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
+def test_idempotency_key_rejects_a_different_request(path: str) -> None:
+    """One standard idempotency key cannot merge two divergent OpenAI requests."""
+    _openai, http, _runtime_value, model_client = _clients()
+    headers = {"Idempotency-Key": "one-logical-request"}
+    if path.endswith("responses"):
+        first = {"model": "router-a", "input": "first"}
+        changed = {"model": "router-a", "input": "changed"}
+    else:
+        first = {"model": "router-a", "messages": [{"role": "user", "content": "first"}]}
+        changed = {
+            "model": "router-a",
+            "messages": [{"role": "user", "content": "changed"}],
+        }
+
+    assert http.post(path, json=first, headers=headers).status_code == 200
+    conflict = http.post(path, json=changed, headers=headers)
+
+    assert conflict.status_code == 409
+    assert "different request" in conflict.json()["error"]["message"]
+    assert model_client.embed_calls == 1
+    assert model_client.complete_calls == 1
+
+
 @pytest.mark.parametrize(
     "path,payload",
     [

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -28,8 +28,8 @@ def _clients() -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
     return openai, http, runtime, model_client
 
 
-def test_official_chat_client_preserves_tools_and_transcript_affinity() -> None:
-    """Official SDK chat calls need no WMO header and retain one transcript decision."""
+def test_official_chat_client_preserves_tools_without_cross_caller_affinity() -> None:
+    """Official SDK chat calls need no WMO header and do not join equal transcripts."""
     openai, _http, _runtime_value, model_client = _clients()
     messages: list[ChatCompletionMessageParam] = [
         {"role": "user", "content": "do it"},
@@ -92,8 +92,11 @@ def test_official_chat_client_preserves_tools_and_transcript_affinity() -> None:
     )
 
     assert next_turn.model == "router-a"
-    assert model_client.embed_calls == 1
+    assert model_client.embed_calls == 2
     assert len(model_client.requests[-1].messages) == 6
+
+    openai.chat.completions.create(model="router-a", messages=messages, tools=tools)
+    assert model_client.embed_calls == 3
 
 
 def test_official_responses_client_continues_with_previous_response_id() -> None:

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -249,6 +249,18 @@ def test_idempotency_key_rejects_a_different_request(path: str) -> None:
             "/v1/responses",
             {"model": "router-a", "input": "next", "previous_response_id": "missing"},
         ),
+        (
+            "/v1/chat/completions",
+            {
+                "model": "router-a",
+                "messages": [{"role": "user", "content": "unsupported"}],
+                "logprobs": True,
+            },
+        ),
+        (
+            "/v1/responses",
+            {"model": "router-a", "input": "unsupported", "background": True},
+        ),
     ],
 )
 def test_invalid_official_request_never_reaches_provider(

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -1,163 +1,235 @@
-"""HTTP routing endpoint transcript, retry, and caller-validation tests."""
+"""Official OpenAI SDK routing endpoint tests."""
 
 from __future__ import annotations
-
-import hashlib
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from openai import OpenAI
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessageParam,
+    ChatCompletionToolUnionParam,
+)
+from openai.types.responses import Response, ResponseStreamEvent
 
 from wmo.runtime.router import create_router_endpoint
-from wmo.runtime.router.runtime_test import _runtime
+from wmo.runtime.router.runtime import RouterRuntime
+from wmo.runtime.router.runtime_test import _Client, _runtime
 
 
-def test_endpoint_requires_episode_rejects_stream_and_preserves_tool_transcript() -> None:
-    """HTTP is non-streaming and preserves tools while keeping later turns sticky."""
-    runtime, client = _runtime()
+def _clients() -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
+    runtime, model_client = _runtime()
     app = FastAPI()
     app.include_router(create_router_endpoint({"router-a": runtime}))
     http = TestClient(app)
-    payload = {
-        "model": "router-a",
-        "messages": [
-            {"role": "user", "content": "do it"},
+    openai = OpenAI(api_key="local-test", base_url="http://testserver/v1", http_client=http)
+    return openai, http, runtime, model_client
+
+
+def test_official_chat_client_preserves_tools_and_transcript_affinity() -> None:
+    """Official SDK chat calls need no WMO header and retain one transcript decision."""
+    openai, _http, _runtime_value, model_client = _clients()
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-in",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": '{"path":"a"}'},
+                }
+            ],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "call-in"},
+    ]
+    tools: list[ChatCompletionToolUnionParam] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "read a file",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    completion = openai.chat.completions.create(model="router-a", messages=messages, tools=tools)
+
+    assert isinstance(completion, ChatCompletion)
+    assert completion.model == "router-a"
+    assert completion.choices[0].message.tool_calls is not None
+    assert completion.choices[0].message.tool_calls[0].id == "call-out"
+    assert completion.model_extra is None or "routing_decision" not in completion.model_extra
+    captured = model_client.requests[-1]
+    assert [message.role for message in captured.messages] == ["user", "assistant", "tool"]
+    assert captured.messages[1].assistant_action is not None
+    assert captured.messages[1].assistant_action.tool_calls[0].call_id == "call-in"
+    assert captured.messages[2].tool_call_id == "call-in"
+
+    next_turn = openai.chat.completions.create(
+        model="router-a",
+        messages=[
+            *messages,
             {
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
                     {
-                        "id": "call-in",
+                        "id": "call-out",
                         "type": "function",
-                        "function": {"name": "read", "arguments": '{"path":"a"}'},
+                        "function": {"name": "write", "arguments": '{"x":1}'},
                     }
                 ],
             },
-            {"role": "tool", "content": "result", "tool_call_id": "call-in"},
+            {"role": "tool", "content": "done", "tool_call_id": "call-out"},
+            {"role": "user", "content": "next turn"},
         ],
-        "tools": [
+        tools=tools,
+    )
+
+    assert next_turn.model == "router-a"
+    assert model_client.embed_calls == 1
+    assert len(model_client.requests[-1].messages) == 6
+
+
+def test_official_responses_client_continues_with_previous_response_id() -> None:
+    """Responses continuation keeps routing affinity through the standard response ID."""
+    openai, _http, _runtime_value, model_client = _clients()
+
+    first = openai.responses.create(model="router-a", input="Help me")
+    second = openai.responses.create(
+        model="router-a", input="Continue", previous_response_id=first.id
+    )
+
+    assert isinstance(first, Response)
+    assert isinstance(second, Response)
+    assert second.previous_response_id == first.id
+    assert model_client.embed_calls == 1
+    assert [message.role for message in model_client.requests[-1].messages] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+
+
+def test_openai_text_content_parts_are_preserved() -> None:
+    """Chat and Responses text parts reach the routed model as complete visible text."""
+    openai, _http, _runtime_value, model_client = _clients()
+
+    openai.chat.completions.create(
+        model="router-a",
+        messages=[
             {
-                "type": "function",
-                "function": {
-                    "name": "read",
-                    "description": "read a file",
-                    "parameters": {"type": "object"},
-                },
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first "},
+                    {"type": "text", "text": "second"},
+                ],
             }
         ],
-    }
-    assert http.post("/v1/chat/completions", json=payload).status_code == 400
-    assert (
-        http.post(
-            "/v1/chat/completions",
-            json={**payload, "stream": True},
-            headers={"X-WMO-Episode-ID": "episode-a"},
-        ).status_code
-        == 400
     )
-    response = http.post(
-        "/v1/chat/completions",
-        json=payload,
-        headers={"X-WMO-Episode-ID": "episode-a"},
+    openai.responses.create(
+        model="router-a",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "third "},
+                    {"type": "input_text", "text": "fourth"},
+                ],
+            }
+        ],
     )
 
-    assert response.status_code == 200
-    assert response.headers["X-WMO-Episode-ID-SHA256"] == hashlib.sha256(b"episode-a").hexdigest()
-    assert "episode-a" not in response.text
-    assert response.json()["choices"][0]["message"]["tool_calls"][0]["id"] == "call-out"
-    captured = client.requests[-1]
-    assert [message.role for message in captured.messages] == ["user", "assistant", "tool"]
-    assert captured.messages[1].assistant_action is not None
-    assert captured.messages[1].assistant_action.tool_calls[0].call_id == "call-in"
-    assert captured.messages[2].tool_call_id == "call-in"
-    next_turn = http.post(
-        "/v1/chat/completions",
-        json={
-            **payload,
-            "messages": [*payload["messages"], {"role": "user", "content": "next turn"}],
-        },
-        headers={"X-WMO-Episode-ID": "episode-a"},
-    )
-    assert next_turn.status_code == 200
-    assert next_turn.headers["X-WMO-Routed-Model"] == response.headers["X-WMO-Routed-Model"]
-    assert (
-        next_turn.json()["routing_decision"]["decision_id"]
-        == response.json()["routing_decision"]["decision_id"]
-    )
-    assert client.embed_calls == 1
-    assert len(client.requests[-1].messages) == 4
-    assert "episode-a" not in next_turn.text
+    assert model_client.requests[-2].messages[0].content == "first second"
+    assert model_client.requests[-1].messages[0].content == "third fourth"
 
 
-def test_endpoint_provider_retry_reuses_exact_cached_request_decision() -> None:
-    """A provider failure can retry the same turn without reselection or decision drift."""
-    runtime, client = _runtime()
-    client.completion_error = RuntimeError("provider unavailable")
-    app = FastAPI()
-    app.include_router(create_router_endpoint({"router-a": runtime}))
-    http = TestClient(app)
-    payload = {"model": "router-a", "messages": [{"role": "user", "content": "retry me"}]}
-    headers = {"X-WMO-Episode-ID": "episode-a"}
+def test_official_clients_parse_buffered_streams() -> None:
+    """Both official SDK streaming iterators parse WMO's OpenAI SSE events."""
+    openai, _http, _runtime_value, _model_client = _clients()
+
+    chat_stream = openai.chat.completions.create(
+        model="router-a", messages=[{"role": "user", "content": "stream"}], stream=True
+    )
+    chat_chunks: list[ChatCompletionChunk] = list(chat_stream)
+    response_stream = openai.responses.create(model="router-a", input="stream", stream=True)
+    response_events: list[ResponseStreamEvent] = list(response_stream)
+
+    assert chat_chunks
+    assert all(isinstance(item, ChatCompletionChunk) for item in chat_chunks)
+    assert chat_chunks[-1].choices[0].finish_reason == "tool_calls"
+    assert response_events
+    assert response_events[0].type == "response.created"
+    assert response_events[-1].type == "response.completed"
+
+
+def test_idempotency_key_reuses_decision_after_provider_failure() -> None:
+    """A standard idempotency key pins the retry decision without a WMO episode header."""
+    openai, http, runtime, model_client = _clients()
+    model_client.completion_error = RuntimeError("provider unavailable")
+    payload = {"model": "router-a", "messages": [{"role": "user", "content": "retry"}]}
+    headers = {"Idempotency-Key": "interaction-a"}
 
     assert http.post("/v1/chat/completions", json=payload, headers=headers).status_code == 502
-    cached = next(iter(runtime._request_decisions.values()))  # noqa: SLF001 - retry identity probe
-    response = http.post("/v1/chat/completions", json=payload, headers=headers)
+    cached = next(iter(runtime._request_decisions.values()))  # noqa: SLF001
+    response = openai.chat.completions.create(
+        model="router-a",
+        messages=[{"role": "user", "content": "retry"}],
+        extra_headers=headers,
+    )
 
-    assert response.status_code == 200
-    assert response.json()["routing_decision"]["decision_id"] == cached.decision_id
-    assert client.embed_calls == 1
-    assert client.complete_calls == 2
+    assert response.id.startswith("chatcmpl-")
+    assert next(iter(runtime._request_decisions.values())) == cached  # noqa: SLF001
+    assert model_client.embed_calls == 1
+    assert model_client.complete_calls == 2
 
 
 @pytest.mark.parametrize(
-    "request_update",
+    "path,payload",
     [
-        {
-            "messages": [
-                {
-                    "role": "assistant",
-                    "tool_calls": [
-                        {
-                            "id": "x",
-                            "function": {"name": "read", "arguments": "[1]"},
-                        }
-                    ],
-                }
-            ]
-        },
-        {
-            "tools": [
-                {"function": {"name": "read", "parameters": {}}},
-                {"function": {"name": "read", "parameters": {}}},
-            ]
-        },
-        {"tool_choice": {"function": {"name": "missing"}}},
-        {"max_completion_tokens": 0},
-        {"messages": [{"role": "system", "content": "no user"}]},
-        {"messages": [{"role": "assistant", "content": "no user"}]},
-        {"messages": [{"role": "user", "content": None}]},
+        (
+            "/v1/chat/completions",
+            {
+                "model": "router-a",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "x",
+                                "function": {"name": "read", "arguments": "[1]"},
+                            }
+                        ],
+                    }
+                ],
+            },
+        ),
+        (
+            "/v1/chat/completions",
+            {
+                "model": "router-a",
+                "messages": [{"role": "system", "content": "no user"}],
+            },
+        ),
+        (
+            "/v1/responses",
+            {"model": "router-a", "input": "next", "previous_response_id": "missing"},
+        ),
     ],
 )
-def test_invalid_http_request_never_reaches_selection_or_provider(
-    request_update: dict[str, object],
+def test_invalid_official_request_never_reaches_provider(
+    path: str, payload: dict[str, object]
 ) -> None:
-    """Caller message, tool, choice, and token validation failures remain actionable 4xx."""
-    runtime, client = _runtime()
-    app = FastAPI()
-    app.include_router(create_router_endpoint({"router-a": runtime}))
-    http = TestClient(app)
-    payload: dict[str, object] = {
-        "model": "router-a",
-        "messages": [{"role": "user", "content": "validate me"}],
-        **request_update,
-    }
+    """Malformed OpenAI requests fail as 4xx before embedding or model dispatch."""
+    _openai, http, _runtime_value, model_client = _clients()
 
-    response = http.post(
-        "/v1/chat/completions",
-        json=payload,
-        headers={"X-WMO-Episode-ID": "episode-a"},
-    )
+    response = http.post(path, json=payload)
 
     assert response.status_code in {400, 422}
-    assert client.embed_calls == 0
-    assert client.complete_calls == 0
+    assert model_client.embed_calls == 0
+    assert model_client.complete_calls == 0

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -218,6 +218,34 @@ def test_idempotency_key_rejects_a_different_request(path: str) -> None:
     assert model_client.complete_calls == 1
 
 
+@pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
+def test_expired_idempotency_key_starts_a_fresh_episode(
+    path: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An expired transport key cannot reconnect to retained router state."""
+    now = [100.0]
+    monkeypatch.setattr("wmo.runtime.router.endpoint.time.monotonic", lambda: now[0])
+    _openai, http, runtime, model_client = _clients()
+    headers = {"Idempotency-Key": "reusable-after-retention"}
+    if path.endswith("responses"):
+        first = {"model": "router-a", "input": "first"}
+        changed = {"model": "router-a", "input": "changed"}
+    else:
+        first = {"model": "router-a", "messages": [{"role": "user", "content": "first"}]}
+        changed = {
+            "model": "router-a",
+            "messages": [{"role": "user", "content": "changed"}],
+        }
+
+    assert http.post(path, json=first, headers=headers).status_code == 200
+    now[0] += 24 * 60 * 60 + 1
+    assert http.post(path, json=changed, headers=headers).status_code == 200
+
+    assert model_client.embed_calls == 2
+    assert model_client.complete_calls == 2
+    assert len(runtime._episode_decisions) == 2  # noqa: SLF001
+
+
 @pytest.mark.parametrize(
     "path,payload",
     [

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from openai import OpenAI
 from openai.types.chat import (
@@ -14,15 +13,14 @@ from openai.types.chat import (
 )
 from openai.types.responses import Response, ResponseStreamEvent
 
-from wmo.runtime.router import create_router_endpoint
+from wmo.runtime.router.application import create_project_router_app
 from wmo.runtime.router.runtime import RouterRuntime
 from wmo.runtime.router.runtime_test import _Client, _runtime
 
 
 def _clients(*, candidate_tools: bool = True) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
     runtime, model_client = _runtime(candidate_tools=candidate_tools)
-    app = FastAPI()
-    app.include_router(create_router_endpoint({"router-a": runtime}))
+    app = create_project_router_app("router-a", runtime)
     http = TestClient(app)
     openai = OpenAI(api_key="local-test", base_url="http://testserver/v1", http_client=http)
     return openai, http, runtime, model_client
@@ -189,6 +187,28 @@ def test_openai_text_content_parts_are_preserved() -> None:
 
     assert model_client.requests[-2].messages[0].content == "first second"
     assert model_client.requests[-1].messages[0].content == "third fourth"
+
+
+def test_request_validation_uses_an_openai_error_envelope() -> None:
+    """Public schema failures do not leak FastAPI's proprietary detail body."""
+    _openai, http, _runtime_value, model_client = _clients()
+
+    response = http.post(
+        "/v1/chat/completions",
+        json={"model": "router-a", "messages": [{"role": "invalid", "content": "x"}]},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "message": "Invalid OpenAI request",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_request",
+        }
+    }
+    assert model_client.embed_calls == 0
+    assert model_client.complete_calls == 0
 
 
 def test_official_clients_parse_buffered_streams() -> None:

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -211,7 +211,9 @@ def test_idempotency_key_rejects_a_different_request(path: str) -> None:
     conflict = http.post(path, json=changed, headers=headers)
 
     assert conflict.status_code == 409
-    assert "different request" in conflict.json()["error"]["message"]
+    assert (
+        conflict.json()["error"]["message"] == "Idempotency-Key conflicts with live request state"
+    )
     assert model_client.embed_calls == 1
     assert model_client.complete_calls == 1
 

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -26,6 +26,10 @@ class RouterEpisodeConflictError(ValueError):
     """A caller reused an episode identity with different request-visible inputs."""
 
 
+class RouterModelCapabilityError(ValueError):
+    """The selected frozen model cannot preserve the requested OpenAI capability."""
+
+
 class RoutedModelResponse(ContractModel):
     """One exact routing decision and the response produced by its selected model."""
 
@@ -320,7 +324,20 @@ class RouterRuntime:
             cached = self._request_decisions.get((expected_episode_sha256, request_sha256))
             if cached != selected:
                 raise ValueError("routing decision is not the exact cached episode decision")
-        response = self._resolve(selected.selected_alias).client.complete(request)
+        resolved = self._resolve(selected.selected_alias)
+        if _requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
+            raise RouterModelCapabilityError(
+                f"routed model alias {selected.selected_alias!r} does not support tool calls"
+            )
+        if request.maximum_output_tokens is not None and (
+            resolved.capabilities.maximum_output_tokens is None
+            or request.maximum_output_tokens > resolved.capabilities.maximum_output_tokens
+        ):
+            raise RouterModelCapabilityError(
+                f"routed model alias {selected.selected_alias!r} cannot prove the requested "
+                "output-token capacity"
+            )
+        response = resolved.client.complete(request)
         return RoutedModelResponse(decision=selected, response=response)
 
     def _require_activation_identity(
@@ -465,3 +482,16 @@ class RouterRuntime:
         if self._decision_sink is not None:
             self._decision_sink(decision)
         return decision
+
+
+def _requires_tool_protocol(request: ModelRequest) -> bool:
+    """Return whether preserving this request requires structured tool support."""
+    return bool(
+        request.tools
+        or request.tool_choice is not None
+        or any(
+            message.role == "tool"
+            or (message.assistant_action is not None and bool(message.assistant_action.tool_calls))
+            for message in request.messages
+        )
+    )

--- a/wmo/runtime/router/runtime_capability_test.py
+++ b/wmo/runtime/router/runtime_capability_test.py
@@ -1,0 +1,53 @@
+"""Request-time capability eligibility for the frozen router runtime."""
+
+import pytest
+
+from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolCall
+from wmo.runtime.router import RouterModelCapabilityError
+from wmo.runtime.router.runtime_test import _request, _runtime
+
+
+def test_selected_model_must_prove_tool_capability_before_dispatch() -> None:
+    """A tool-bearing request never reaches an incapable selected model."""
+    runtime, client = _runtime(candidate_tools=False)
+
+    with pytest.raises(RouterModelCapabilityError, match="does not support tool calls"):
+        runtime.complete(_request(tool_name="read"), episode_id="tool-episode")
+
+    assert client.complete_calls == 0
+
+
+def test_selected_model_must_prove_output_capacity_before_dispatch() -> None:
+    """An explicit output limit never reaches a model with unknown capacity."""
+    runtime, client = _runtime()
+    request = ModelRequest(
+        messages=(ModelMessage(role="user", content="route me"),),
+        maximum_output_tokens=100,
+    )
+
+    with pytest.raises(RouterModelCapabilityError, match="output-token capacity"):
+        runtime.complete(request, episode_id="capacity-episode")
+
+    assert client.complete_calls == 0
+
+
+def test_replayed_tool_history_requires_tool_capability() -> None:
+    """A tool result cannot bypass eligibility by omitting current tool definitions."""
+    runtime, client = _runtime(candidate_tools=False)
+    request = ModelRequest(
+        messages=(
+            ModelMessage(role="user", content="read it"),
+            ModelMessage(
+                role="assistant",
+                assistant_action=AssistantAction(
+                    tool_calls=(ToolCall(call_id="call-a", name="read", arguments={"path": "a"}),)
+                ),
+            ),
+            ModelMessage(role="tool", content="done", tool_call_id="call-a"),
+        )
+    )
+
+    with pytest.raises(RouterModelCapabilityError, match="does not support tool calls"):
+        runtime.complete(request, episode_id="history-episode")
+
+    assert client.complete_calls == 0

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -92,13 +92,23 @@ class _Client:
 class _Catalog:
     """Exact static identity catalog with no environment or provider access."""
 
-    def __init__(self, snapshots: dict[str, ModelSnapshot], client: _Client) -> None:
+    def __init__(
+        self,
+        snapshots: dict[str, ModelSnapshot],
+        client: _Client,
+        *,
+        candidate_tools: bool = True,
+    ) -> None:
         self.snapshots = snapshots
         self.client = client
+        self.candidate_tools = candidate_tools
         self.resolve_calls: list[str] = []
 
     def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
-        return self.snapshots[alias], ModelCapabilities(supports_embeddings=alias == "embedder")
+        return self.snapshots[alias], ModelCapabilities(
+            supports_tools=self.candidate_tools and alias != "embedder",
+            supports_embeddings=alias == "embedder",
+        )
 
     def resolve(self, alias: str) -> ResolvedModel:
         self.resolve_calls.append(alias)
@@ -413,7 +423,7 @@ def test_embedder_candidate_alias_overlap_requires_the_same_frozen_identity() ->
         )
     assert client.embed_calls == 0
 
-    embedding_capabilities = ModelCapabilities(supports_embeddings=True)
+    embedding_capabilities = ModelCapabilities(supports_tools=True, supports_embeddings=True)
     overlapping_snapshot = snapshots["baseline"].model_copy(
         update={"capabilities_sha256": sha256_json(embedding_capabilities)}
     )
@@ -440,7 +450,10 @@ def test_embedder_candidate_alias_overlap_requires_the_same_frozen_identity() ->
     class _OverlapCatalog(_Catalog):
         def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
             snapshot = self.snapshots[alias]
-            return snapshot, ModelCapabilities(supports_embeddings=alias == "baseline")
+            return snapshot, ModelCapabilities(
+                supports_tools=alias in {"baseline", "cheap"},
+                supports_embeddings=alias == "baseline",
+            )
 
     runtime = RouterRuntime(
         same,
@@ -601,14 +614,17 @@ def _request(*, tool_name: str | None = None) -> ModelRequest:
     return ModelRequest(messages=(ModelMessage(role="user", content="route me"),), tools=tools)
 
 
-def _runtime() -> tuple[RouterRuntime, _Client]:
-    policy, manifest, bank, snapshots, client = _fixture()
+def _runtime(*, candidate_tools: bool = True) -> tuple[RouterRuntime, _Client]:
+    policy, manifest, bank, snapshots, client = _fixture(candidate_tools=candidate_tools)
     return (
         RouterRuntime(
             policy,
             manifest,
             bank,
-            cast(RuntimeModelCatalog, _Catalog(snapshots, client)),
+            cast(
+                RuntimeModelCatalog,
+                _Catalog(snapshots, client, candidate_tools=candidate_tools),
+            ),
             pricing_snapshot_id="pricing-a",
             pricing_snapshot_sha256=_DIGEST,
             pricing_candidate_aliases=bank.candidate_aliases,
@@ -617,14 +633,19 @@ def _runtime() -> tuple[RouterRuntime, _Client]:
     )
 
 
-def _fixture() -> tuple[
+def _fixture(
+    *, candidate_tools: bool = True
+) -> tuple[
     KnnRouterPolicy,
     KnnBankManifest,
     KnnEvidenceBank,
     dict[str, ModelSnapshot],
     _Client,
 ]:
-    snapshots = {alias: _snapshot(alias) for alias in ("baseline", "cheap", "embedder")}
+    snapshots = {
+        alias: _snapshot(alias, candidate_tools=candidate_tools)
+        for alias in ("baseline", "cheap", "embedder")
+    }
     client = _Client()
     bank = KnnEvidenceBank(
         task_ids=tuple(f"task-{index}" for index in range(8)),
@@ -701,8 +722,11 @@ def _fixture() -> tuple[
     return policy, manifest, bank, snapshots, client
 
 
-def _snapshot(alias: str) -> ModelSnapshot:
-    capabilities = ModelCapabilities(supports_embeddings=alias == "embedder")
+def _snapshot(alias: str, *, candidate_tools: bool = True) -> ModelSnapshot:
+    capabilities = ModelCapabilities(
+        supports_tools=candidate_tools and alias != "embedder",
+        supports_embeddings=alias == "embedder",
+    )
     return ModelSnapshot(
         provider="test",
         model_id=alias,

--- a/wmo/workflow/router_evidence_test.py
+++ b/wmo/workflow/router_evidence_test.py
@@ -473,11 +473,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
         "model": "w16-router",
         "messages": [{"role": "user", "content": "Resolve customer case 17"}],
     }
-    first_http = http.post(
-        "/v1/chat/completions",
-        json=payload,
-        headers={"X-WMO-Episode-ID": "w16-customer-episode"},
-    )
+    first_http = http.post("/v1/chat/completions", json=payload)
     second_http = http.post(
         "/v1/chat/completions",
         json={
@@ -487,17 +483,13 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
                 {"role": "user", "content": "Continue with the same customer case"},
             ],
         },
-        headers={"X-WMO-Episode-ID": "w16-customer-episode"},
     )
     assert first_http.status_code == second_http.status_code == 200
     assert first_http.headers["X-WMO-Routed-Model"] == second_http.headers["X-WMO-Routed-Model"]
-    assert (
-        first_http.json()["routing_decision"]["episode_id_sha256"]
-        == second_http.json()["routing_decision"]["episode_id_sha256"]
-    )
+    assert first_http.json()["object"] == second_http.json()["object"] == "chat.completion"
     assert runtime_catalog.clients["embedder"].embed_calls == 1
     assert sum(client.complete_calls for client in runtime_catalog.clients.values()) == 2
-    assert "w16-customer-episode" not in first_http.text
+    assert "routing_decision" not in first_http.text
     provenance = verify_release_evidence(
         project.artifacts,
         expected_revision=revision,

--- a/wmo/workflow/router_evidence_test.py
+++ b/wmo/workflow/router_evidence_test.py
@@ -326,7 +326,7 @@ class _RuntimeCatalog:
         )
 
 
-def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
+def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -487,7 +487,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_sticky(
     assert first_http.status_code == second_http.status_code == 200
     assert first_http.headers["X-WMO-Routed-Model"] == second_http.headers["X-WMO-Routed-Model"]
     assert first_http.json()["object"] == second_http.json()["object"] == "chat.completion"
-    assert runtime_catalog.clients["embedder"].embed_calls == 1
+    assert runtime_catalog.clients["embedder"].embed_calls == 2
     assert sum(client.complete_calls for client in runtime_catalog.clients.values()) == 2
     assert "routing_decision" not in first_http.text
     provenance = verify_release_evidence(


### PR DESCRIPTION
## What changed
- expose both `/v1/chat/completions` and `/v1/responses` over the frozen project router
- validate public request shapes with official OpenAI 3.x generated schemas and return official SDK-parsed response and stream types
- expose `load_router(project)` as an official OpenAI Python client with `chat.completions` and `responses` resources
- preserve the useful historical serving contract from `e7aad17b:wmo/simulation/serving/chat.py` without restoring its unsafe global transcript-prefix map
- use standard Responses `previous_response_id` and request-scoped `Idempotency-Key` instead of `X-WMO-Episode-ID`
- bind every live idempotency key to one complete canonical request; expiry starts a fresh internal episode and cannot reconnect to retained routing state
- reject tool protocol or explicit output-token requests before dispatch when the selected frozen model cannot prove the required capability
- keep routing decisions out of OpenAI response bodies while retaining the aggregate-safe routed-model response header

## Why
Users should be able to point the official OpenAI client at `wmo run` and use either supported API without proprietary request fields. This restores the useful pre-refactor serving behavior on the current frozen-router architecture.

## Impact
- adds official `openai>=3,<4` as a core dependency because public router payloads are validated against its generated schemas
- supports text messages, text content parts, function tools, buffered Chat and Responses streaming, retries, and standard Responses continuation identity
- rejects currently unsupported official request fields instead of silently dropping them
- leaves durable interaction journaling and automatic trace capture to the dependent runtime-journal PR

## Checks
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `644 passed, 1 skipped` non-live suite excluding the two long evidence tests
- exact clean-head W16 router evidence: `1 passed`
- latest focused runtime/package/API: `108 passed, 1 skipped`
- fresh wheel and sdist release scan: `11 passed`
- isolated Python 3.12 wheel install, official OpenAI type import, and `wmo run --help` smoke

Ready for review. Do not merge until the restoration set receives human review.
