### PR TITLE
Restore immutable real-trace RAG

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ results, and plans do not live here.
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config telemetry. |
 | `cookbook/router.md` | Provider-free local artifact and loopback runtime walkthrough. |
 | `reference/ingest.md` | Current OTLP and PostHog local trace input contract. |
+| `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |
 | `release-scope.md` | Supported and explicitly excluded release claims. |
 | `research/w16-router-sandbox-evidence.md` | Deterministic W16 router and local sandbox evidence, limits, and replay commands. |

--- a/docs/reference/immutable-real-trace-rag.md
+++ b/docs/reference/immutable-real-trace-rag.md
@@ -1,0 +1,39 @@
+# Immutable real-trace RAG contract
+
+WMO stores retrieval demonstrations as an immutable, versioned artifact derived only from verified
+real imported traces. The artifact records its exact source manifests, stable trace, conversation,
+transition, and leakage-lineage identities, the key schema, the embedder model and capability
+digest, all vectors, vector dimensions, and the complete fit-lineage set.
+
+Retrieval is read-only. It removes excluded query lineages before scoring, then ranks by cosine
+similarity with transition ID as the stable tie break. The default local embedder is deterministic
+and provider-free. A semantic embedder is allowed only through an explicit client and exact
+`ModelSnapshot` that can be supplied again when the artifact is loaded.
+
+Only a real action with a subsequently observed user or environment response becomes a retrieval
+transition. A terminal assistant response has no following observation and is excluded. Generated
+world-model predictions, simulator rollouts, teacher data, judgments, evaluations, and manual
+examples cannot enter this index.
+
+Trace count is not a validation boundary. A corpus with any positive number of valid traces is
+accepted. The 100 to 1,000 range is only a common happy path for useful coverage.
+
+## Historical provenance
+
+This design restores useful behavior from the last coherent pre-refactor implementation:
+
+- `e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever.index/topk/save/load`
+  established offline embedding, cosine retrieval, and reload without re-embedding.
+- `e7aad17b:wmo/simulation/model/world_model.py::WorldModel.load/new_session/step` established the
+  intended built-artifact to stateful simulation flow and the default top-k of five.
+- `e7aad17b:wmo/simulation/model/loader.py::load_world_model` established one shared artifact load
+  path for Python and serving callers.
+- The related historical retriever and world-model tests established persistence and top-k behavior.
+
+The current contracts intentionally do not restore the historical provider types, GEPA, object
+identity leak guards, or `EmbeddingRetriever.add`. In particular, the old `WorldModel.step` path
+could add a generated prediction to the shared replay buffer. That behavior is forbidden now.
+
+The current retrieval package provides the immutable artifact, loader, and retriever seam. A
+dependent integration can wire canonical build output and the current simulator to it without
+importing the deleted public types or provider stack.

--- a/wmo/simulation/package_layout_test.py
+++ b/wmo/simulation/package_layout_test.py
@@ -13,6 +13,7 @@ def test_simulation_domains_are_nested() -> None:
         "engines",
         "mining",
         "orchestration",
+        "retrieval",
         "specs",
     }
     actual_dirs = {
@@ -34,7 +35,7 @@ def test_simulation_domains_are_nested() -> None:
 
     retired = sorted(
         name
-        for name in ("evaluation", "model", "retrieval", "environment.py")
+        for name in ("evaluation", "model", "environment.py")
         if (SIMULATION_DIR / name).is_file() or any((SIMULATION_DIR / name).rglob("*.py"))
     )
     assert not retired, f"retired simulation owners returned: {retired}"

--- a/wmo/simulation/retrieval/__init__.py
+++ b/wmo/simulation/retrieval/__init__.py
@@ -1,0 +1,41 @@
+"""Immutable retrieval grounded exclusively in verified real trace transitions."""
+
+from wmo.simulation.retrieval.build import PersistedRAGIndex, persist_trace_rag
+from wmo.simulation.retrieval.contracts import (
+    RAGAction,
+    RAGIndex,
+    RAGLineageBinding,
+    RAGMatch,
+    RAGObservation,
+    RAGQuery,
+    RAGSourceRef,
+    RAGTransition,
+    RAGVector,
+)
+from wmo.simulation.retrieval.embedding import (
+    HashingRAGEmbedder,
+    RAGEmbedderBinding,
+    default_rag_embedder,
+)
+from wmo.simulation.retrieval.retriever import TraceRAGRetriever
+from wmo.simulation.retrieval.store import LoadedRAGIndex, load_rag_index
+
+__all__ = [
+    "HashingRAGEmbedder",
+    "LoadedRAGIndex",
+    "PersistedRAGIndex",
+    "RAGAction",
+    "RAGEmbedderBinding",
+    "RAGIndex",
+    "RAGLineageBinding",
+    "RAGMatch",
+    "RAGObservation",
+    "RAGQuery",
+    "RAGSourceRef",
+    "RAGTransition",
+    "RAGVector",
+    "TraceRAGRetriever",
+    "default_rag_embedder",
+    "load_rag_index",
+    "persist_trace_rag",
+]

--- a/wmo/simulation/retrieval/build.py
+++ b/wmo/simulation/retrieval/build.py
@@ -115,11 +115,19 @@ def persist_trace_rag(
     if not fit_lineages:
         raise ValueError("RAG construction needs at least one fit lineage")
     content = {
+        "code_revision": code_revision,
+        "default_top_k": default_top_k,
         "embedder": binding.snapshot.model_dump(mode="json"),
+        "embedding_dimension": dimensions,
         "fit_lineage_ids": list(fit_lineages),
         "key_schema_version": RAG_KEY_SCHEMA_VERSION,
+        "schema_version": 1,
         "sources": [source.model_dump(mode="json") for source in sources],
+        "transition_count": len(transitions),
+        "transition_ids": [item.transition_id for item in transitions],
+        "transitions_path": RAG_TRANSITIONS_PATH,
         "transitions_sha256": hashlib.sha256(transitions_payload).hexdigest(),
+        "vectors_path": RAG_VECTORS_PATH,
         "vectors_sha256": hashlib.sha256(vectors_payload).hexdigest(),
     }
     resolved_id = rag_id or stable_id("trace-rag", content)

--- a/wmo/simulation/retrieval/build.py
+++ b/wmo/simulation/retrieval/build.py
@@ -1,0 +1,232 @@
+"""Build immutable RAG artifacts from verified real traces.
+
+This restores the useful offline index, save, and reload behavior from
+``e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever`` while replacing its mutable
+buffer with digest-verified artifacts. It deliberately does not restore ``Retriever.add``, so
+world-model predictions can never become retrieval demonstrations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from wmo.common.core.artifacts import ArtifactInput, canonical_json_bytes, stable_id
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactManifest,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.traces import Trace, load_trace_dataset
+from wmo.simulation.retrieval.contracts import (
+    RAG_ARTIFACT_TYPE,
+    RAG_INDEX_PATH,
+    RAG_KEY_SCHEMA_VERSION,
+    RAG_TRANSITIONS_PATH,
+    RAG_VECTORS_PATH,
+    RAGIndex,
+    RAGLineageBinding,
+    RAGSourceRef,
+    RAGTransition,
+    RAGVector,
+)
+from wmo.simulation.retrieval.embedding import (
+    RAGEmbedderBinding,
+    default_rag_embedder,
+    embed_rag_texts,
+)
+from wmo.simulation.retrieval.store import load_rag_index
+from wmo.simulation.retrieval.transitions import extract_fit_transitions
+
+_REAL_SOURCE_KINDS = frozenset({"file", "otlp", "production"})
+
+
+@dataclass(frozen=True)
+class PersistedRAGIndex:
+    """Completed RAG index with the exact records and manifest persisted for it."""
+
+    index: RAGIndex
+    manifest: ArtifactManifest
+    transitions: tuple[RAGTransition, ...]
+    vectors: tuple[RAGVector, ...]
+
+
+def persist_trace_rag(
+    store: ArtifactStore,
+    source_inputs: Sequence[ArtifactInput],
+    lineage_bindings: Sequence[RAGLineageBinding],
+    *,
+    created_at: datetime,
+    code_revision: str,
+    embedder: RAGEmbedderBinding | None = None,
+    rag_id: str | None = None,
+    default_top_k: int = 5,
+) -> PersistedRAGIndex:
+    """Build a read-only fit-side index from any positive number of real imported traces.
+
+    Trace count is not a product restriction. Roughly 100 to 1,000 traces is a useful common
+    starting range, but one trace and corpora larger than 1,000 follow the same contract.
+
+    Args:
+        store: Project-local immutable artifact store.
+        source_inputs: Exact manifest references for verified trace-dataset artifacts.
+        lineage_bindings: Frozen fit or held-out lineage assignment for every source trace.
+        created_at: Time this completed artifact is materialized.
+        code_revision: Exact WMO revision producing the artifact.
+        embedder: Explicit semantic embedding client and snapshot. A deterministic local hashing
+            embedder is used when omitted.
+        rag_id: Optional explicit artifact ID. Content addressing is used when omitted.
+        default_top_k: Default number of matches returned by the loaded retriever.
+
+    Returns:
+        The immutable envelope, manifest, observed transitions, and persisted vectors.
+
+    Raises:
+        ValueError: A source is not verified real trace evidence, lineage is incomplete, no real
+            fit transition exists, or the embedder violates its contract.
+    """
+    if not source_inputs:
+        raise ValueError("RAG construction needs at least one verified real trace source")
+    if default_top_k <= 0:
+        raise ValueError("RAG default top_k must be positive")
+    sources, traces = _load_real_sources(store, source_inputs)
+    transitions = extract_fit_transitions(traces, lineage_bindings)
+    if not transitions:
+        raise ValueError(
+            "verified fit traces contain no real action-to-subsequent-observation transitions"
+        )
+    binding = embedder or default_rag_embedder()
+    embedded = embed_rag_texts(binding, tuple(item.key_text for item in transitions))
+    vectors = tuple(
+        RAGVector(transition_id=transition.transition_id, values=values)
+        for transition, values in zip(transitions, embedded, strict=True)
+    )
+    dimensions = len(vectors[0].values)
+    transitions_payload = _jsonl_bytes(transitions)
+    vectors_payload = _jsonl_bytes(vectors)
+    fit_lineages = tuple(
+        sorted({binding.lineage_id for binding in lineage_bindings if binding.partition == "fit"})
+    )
+    if not fit_lineages:
+        raise ValueError("RAG construction needs at least one fit lineage")
+    content = {
+        "embedder": binding.snapshot.model_dump(mode="json"),
+        "fit_lineage_ids": list(fit_lineages),
+        "key_schema_version": RAG_KEY_SCHEMA_VERSION,
+        "sources": [source.model_dump(mode="json") for source in sources],
+        "transitions_sha256": hashlib.sha256(transitions_payload).hexdigest(),
+        "vectors_sha256": hashlib.sha256(vectors_payload).hexdigest(),
+    }
+    resolved_id = rag_id or stable_id("trace-rag", content)
+    index = RAGIndex(
+        schema_version=1,
+        created_at=created_at,
+        inputs=tuple(source.artifact_input for source in sources),
+        code_revision=code_revision,
+        source=None,
+        rag_id=resolved_id,
+        sources=sources,
+        embedder=binding.snapshot,
+        transitions_sha256=hashlib.sha256(transitions_payload).hexdigest(),
+        vectors_sha256=hashlib.sha256(vectors_payload).hexdigest(),
+        transition_ids=tuple(item.transition_id for item in transitions),
+        fit_lineage_ids=fit_lineages,
+        embedding_dimension=dimensions,
+        transition_count=len(transitions),
+        default_top_k=default_top_k,
+    )
+    files = {
+        RAG_INDEX_PATH: canonical_json_bytes(index),
+        RAG_TRANSITIONS_PATH: transitions_payload,
+        RAG_VECTORS_PATH: vectors_payload,
+    }
+    destination = store.project_directory / "artifacts" / index.rag_id
+    if destination.exists():
+        return _load_exact_replay(store, index, transitions, vectors, files)
+    try:
+        manifest = store.write(
+            artifact_id=index.rag_id,
+            artifact_type=RAG_ARTIFACT_TYPE,
+            envelope=index,
+            files=files,
+        )
+    except ArtifactAlreadyExistsError:
+        return _load_exact_replay(store, index, transitions, vectors, files)
+    return PersistedRAGIndex(index, manifest, transitions, vectors)
+
+
+def _load_real_sources(
+    store: ArtifactStore,
+    supplied_inputs: Sequence[ArtifactInput],
+) -> tuple[tuple[RAGSourceRef, ...], tuple[Trace, ...]]:
+    """Verify exact source manifests and reject generated or evaluation evidence."""
+    by_id = {item.artifact_id: item for item in supplied_inputs}
+    if len(by_id) != len(supplied_inputs):
+        raise ValueError("RAG source inputs must not repeat an artifact")
+    sources: list[RAGSourceRef] = []
+    traces: list[Trace] = []
+    for source_input in sorted(supplied_inputs, key=lambda item: item.artifact_id):
+        stored = store.read(source_input.artifact_id)
+        if artifact_input(stored.manifest) != source_input:
+            raise ValueError(
+                f"RAG source {source_input.artifact_id} does not match its supplied manifest digest"
+            )
+        if stored.manifest.artifact_type != "trace-dataset":
+            raise ValueError(
+                f"RAG source {source_input.artifact_id} has forbidden artifact type "
+                f"{stored.manifest.artifact_type!r}; only verified real trace datasets are "
+                "supported"
+            )
+        loaded = load_trace_dataset(store, source_input.artifact_id)
+        source = loaded.dataset.source
+        if source is None or source.kind not in _REAL_SOURCE_KINDS:
+            kind = "missing" if source is None else source.kind
+            raise ValueError(
+                f"RAG source {source_input.artifact_id} has forbidden provenance {kind!r}; "
+                "generated, simulation, teacher, judgment, evaluation, and manual evidence "
+                "cannot ground retrieval"
+            )
+        sources.append(
+            RAGSourceRef(
+                kind="trace_dataset",
+                artifact_input=source_input,
+                source=source,
+                records_sha256=loaded.dataset.traces_sha256,
+                trace_ids=tuple(sorted(loaded.dataset.trace_ids)),
+            )
+        )
+        traces.extend(loaded.traces)
+    return tuple(sources), tuple(traces)
+
+
+def _jsonl_bytes(records: Sequence[BaseModel]) -> bytes:
+    """Serialize Pydantic records as deterministic newline-terminated JSONL."""
+    payloads = [canonical_json_bytes(record) for record in records]
+    return b"\n".join(payloads) + b"\n"
+
+
+def _load_exact_replay(
+    store: ArtifactStore,
+    expected: RAGIndex,
+    transitions: tuple[RAGTransition, ...],
+    vectors: tuple[RAGVector, ...],
+    files: dict[str, bytes],
+) -> PersistedRAGIndex:
+    """Reuse a content-identical immutable index after complete verification."""
+    loaded = load_rag_index(store, expected.rag_id)
+    replay = expected.model_copy(update={"created_at": loaded.index.created_at})
+    if loaded.index != replay:
+        raise ValueError("existing RAG index differs from replayed real-trace evidence")
+    if loaded.transitions != transitions or loaded.vectors != vectors:
+        raise ValueError("existing RAG records differ from replayed real-trace evidence")
+    for path, payload in files.items():
+        if path == RAG_INDEX_PATH:
+            continue
+        if store.read_bytes(expected.rag_id, path) != payload:
+            raise ValueError(f"existing RAG payload {path} differs from replayed evidence")
+    return PersistedRAGIndex(loaded.index, loaded.manifest, transitions, vectors)

--- a/wmo/simulation/retrieval/build.py
+++ b/wmo/simulation/retrieval/build.py
@@ -1,9 +1,7 @@
-"""Build immutable RAG artifacts from verified real traces.
+"""Build digest-verified immutable RAG artifacts from real traces only.
 
-This restores the useful offline index, save, and reload behavior from
-``e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever`` while replacing its mutable
-buffer with digest-verified artifacts. It deliberately does not restore ``Retriever.add``, so
-world-model predictions can never become retrieval demonstrations.
+The artifact has no mutation surface, so generated world-model predictions cannot become
+retrieval demonstrations.
 """
 
 from __future__ import annotations

--- a/wmo/simulation/retrieval/contracts.py
+++ b/wmo/simulation/retrieval/contracts.py
@@ -1,0 +1,201 @@
+"""Immutable contracts for retrieval grounded only in observed production transitions."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from pydantic import Field, JsonValue, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    JsonObject,
+    Sha256,
+    SourceIdentity,
+    validate_artifact_file_path,
+)
+from wmo.common.models import ModelSnapshot
+
+RAG_ARTIFACT_TYPE = "trace-rag-index"
+RAG_KEY_SCHEMA_VERSION = "observed-transition-key-v1"
+RAG_TRANSITIONS_PATH = "transitions.jsonl"
+RAG_VECTORS_PATH = "vectors.jsonl"
+RAG_INDEX_PATH = "rag-index.json"
+
+
+class RAGSourceRef(ContractModel):
+    """Exact verified real-trace artifact consumed by one RAG index."""
+
+    kind: Literal["trace_dataset", "runtime_trace_snapshot"]
+    artifact_input: ArtifactInput
+    source: SourceIdentity
+    records_sha256: Sha256
+    trace_ids: tuple[str, ...] = Field(min_length=1)
+
+    @field_validator("trace_ids")
+    @classmethod
+    def _require_ordered_unique_trace_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("RAG source trace IDs must be unique")
+        if value != tuple(sorted(value)):
+            raise ValueError("RAG source trace IDs must be sorted")
+        return value
+
+
+class RAGLineageBinding(ContractModel):
+    """Frozen fit or held-out assignment for one real source trace."""
+
+    trace_id: str = Field(min_length=1, max_length=512)
+    lineage_id: ArtifactId
+    partition: Literal["fit", "held_out"]
+
+
+class RAGAction(ContractModel):
+    """One visible agent action captured in a real trace."""
+
+    kind: Literal["message", "tool_call"]
+    content: str | None = None
+    tool_name: str | None = Field(default=None, min_length=1, max_length=256)
+    tool_arguments: JsonValue = None
+
+    @model_validator(mode="after")
+    def _require_kind_payload(self) -> RAGAction:
+        if self.kind == "message":
+            if not self.content:
+                raise ValueError("message RAG actions need visible content")
+            if self.tool_name is not None or self.tool_arguments is not None:
+                raise ValueError("message RAG actions cannot carry tool fields")
+        else:
+            if self.tool_name is None:
+                raise ValueError("tool-call RAG actions need a tool name")
+            if self.content is not None:
+                raise ValueError("tool-call RAG actions cannot carry message content")
+        return self
+
+
+class RAGObservation(ContractModel):
+    """One real user or environment observation following an agent action."""
+
+    kind: Literal["message", "tool_result"]
+    content: str = Field(min_length=1)
+
+
+class RAGTransition(ContractModel):
+    """One immutable real action-to-subsequent-observation demonstration."""
+
+    transition_id: ArtifactId
+    trace_id: str = Field(min_length=1, max_length=512)
+    conversation_id: str | None = Field(default=None, max_length=512)
+    lineage_id: ArtifactId
+    action_span_id: str = Field(min_length=1, max_length=256)
+    observation_span_id: str = Field(min_length=1, max_length=256)
+    task: str = Field(min_length=1)
+    initial_context: JsonObject = Field(default_factory=dict)
+    action: RAGAction
+    observation: RAGObservation
+    key_text: str = Field(min_length=1)
+    key_sha256: Sha256
+
+
+class RAGVector(ContractModel):
+    """Persisted unit vector bound to one exact observed transition."""
+
+    transition_id: ArtifactId
+    values: tuple[float, ...] = Field(min_length=1)
+
+    @field_validator("values")
+    @classmethod
+    def _require_finite_unit_vector(cls, value: tuple[float, ...]) -> tuple[float, ...]:
+        if not all(math.isfinite(item) for item in value):
+            raise ValueError("RAG vectors must be finite")
+        norm = math.sqrt(sum(item * item for item in value))
+        if not math.isclose(norm, 1.0, rel_tol=1e-6, abs_tol=1e-6):
+            raise ValueError("RAG vectors must have unit norm")
+        return value
+
+
+class RAGIndex(ArtifactEnvelope):
+    """Completed immutable observed-transition index and its exact embedding identity."""
+
+    rag_id: ArtifactId
+    key_schema_version: Literal["observed-transition-key-v1"] = RAG_KEY_SCHEMA_VERSION
+    sources: tuple[RAGSourceRef, ...] = Field(min_length=1)
+    embedder: ModelSnapshot
+    transitions_path: str = RAG_TRANSITIONS_PATH
+    transitions_sha256: Sha256
+    vectors_path: str = RAG_VECTORS_PATH
+    vectors_sha256: Sha256
+    transition_ids: tuple[ArtifactId, ...] = Field(min_length=1)
+    fit_lineage_ids: tuple[ArtifactId, ...] = Field(min_length=1)
+    embedding_dimension: int = Field(gt=0)
+    transition_count: int = Field(gt=0)
+    default_top_k: int = Field(default=5, gt=0)
+
+    @field_validator("transitions_path", "vectors_path")
+    @classmethod
+    def _require_safe_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+    @field_validator("sources")
+    @classmethod
+    def _require_sorted_unique_sources(
+        cls, value: tuple[RAGSourceRef, ...]
+    ) -> tuple[RAGSourceRef, ...]:
+        ids = tuple(item.artifact_input.artifact_id for item in value)
+        if len(set(ids)) != len(ids):
+            raise ValueError("RAG sources must not repeat artifacts")
+        if ids != tuple(sorted(ids)):
+            raise ValueError("RAG sources must be sorted by artifact ID")
+        return value
+
+    @field_validator("transition_ids", "fit_lineage_ids")
+    @classmethod
+    def _require_sorted_unique_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("RAG artifact IDs must be unique")
+        if value != tuple(sorted(value)):
+            raise ValueError("RAG artifact IDs must be sorted")
+        return value
+
+    @model_validator(mode="after")
+    def _require_consistent_counts_and_inputs(self) -> RAGIndex:
+        if self.transition_count != len(self.transition_ids):
+            raise ValueError("RAG transition count must match transition IDs")
+        source_inputs = tuple(source.artifact_input for source in self.sources)
+        if self.inputs != source_inputs:
+            raise ValueError("RAG envelope inputs must exactly match source inputs")
+        return self
+
+
+class RAGQuery(ContractModel):
+    """Read-only retrieval query with explicit leakage exclusions."""
+
+    task: str = Field(min_length=1)
+    initial_context: JsonObject = Field(default_factory=dict)
+    action: RAGAction
+    excluded_lineage_ids: tuple[ArtifactId, ...] = ()
+    top_k: int = Field(default=5, gt=0)
+
+    @field_validator("excluded_lineage_ids")
+    @classmethod
+    def _require_unique_exclusions(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("excluded RAG lineage IDs must be unique")
+        return value
+
+
+class RAGMatch(ContractModel):
+    """One retrieved real transition and its cosine-similarity score."""
+
+    transition: RAGTransition
+    score: float
+
+    @field_validator("score")
+    @classmethod
+    def _require_finite_score(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("RAG match scores must be finite")
+        return value

--- a/wmo/simulation/retrieval/contracts.py
+++ b/wmo/simulation/retrieval/contracts.py
@@ -177,7 +177,7 @@ class RAGQuery(ContractModel):
     initial_context: JsonObject = Field(default_factory=dict)
     action: RAGAction
     excluded_lineage_ids: tuple[ArtifactId, ...] = ()
-    top_k: int = Field(default=5, gt=0)
+    top_k: int | None = Field(default=None, gt=0)
 
     @field_validator("excluded_lineage_ids")
     @classmethod

--- a/wmo/simulation/retrieval/embedding.py
+++ b/wmo/simulation/retrieval/embedding.py
@@ -1,0 +1,122 @@
+"""Deterministic local and explicit semantic embedding bindings for trace RAG."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from wmo.common.core.artifacts import sha256_json
+from wmo.common.models import (
+    Embedding,
+    EmbeddingClient,
+    ModelCapabilities,
+    ModelSnapshot,
+)
+
+DEFAULT_HASHING_DIMENSIONS = 256
+_TOKEN_PATTERN = re.compile(r"[\w]+", re.UNICODE)
+
+
+class HashingRAGEmbedder:
+    """Provider-free signed hashing embedder used by default for local RAG builds."""
+
+    def __init__(self, dimensions: int = DEFAULT_HASHING_DIMENSIONS) -> None:
+        if dimensions < 8:
+            raise ValueError("the local RAG hashing embedder needs at least 8 dimensions")
+        self.dimensions = dimensions
+
+    def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Return deterministic unit vectors without network, credentials, or model calls.
+
+        Args:
+            texts: Canonical versioned RAG key texts.
+
+        Returns:
+            One normalized hashing vector per input text.
+        """
+        return tuple(Embedding(values=self._embed_one(text)) for text in texts)
+
+    def _embed_one(self, text: str) -> tuple[float, ...]:
+        """Hash normalized tokens into one fixed-width signed vector."""
+        vector = [0.0] * self.dimensions
+        tokens = _TOKEN_PATTERN.findall(text.casefold()) or ["empty"]
+        for token in tokens:
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            index = int.from_bytes(digest[:4], "big") % self.dimensions
+            sign = 1.0 if digest[4] % 2 == 0 else -1.0
+            vector[index] += sign
+        norm = math.sqrt(sum(value * value for value in vector))
+        return tuple(value / norm for value in vector)
+
+
+@dataclass(frozen=True)
+class RAGEmbedderBinding:
+    """An embedding client paired with the exact identity persisted beside its vectors.
+
+    Args:
+        client: Explicit provider-free or semantic embedding implementation.
+        snapshot: Exact model, capability, and secret-free connection identity.
+    """
+
+    client: EmbeddingClient
+    snapshot: ModelSnapshot
+
+
+def default_rag_embedder(
+    dimensions: int = DEFAULT_HASHING_DIMENSIONS,
+) -> RAGEmbedderBinding:
+    """Create WMO's deterministic no-network RAG embedder binding.
+
+    Args:
+        dimensions: Fixed hashing vector width.
+
+    Returns:
+        Local hashing client and its exact persisted model snapshot.
+    """
+    capabilities = ModelCapabilities(supports_embeddings=True)
+    identity = {
+        "algorithm": "signed-blake2b-token-hashing",
+        "dimensions": dimensions,
+        "version": 1,
+    }
+    return RAGEmbedderBinding(
+        client=HashingRAGEmbedder(dimensions),
+        snapshot=ModelSnapshot(
+            provider="local",
+            model_id=f"wmo-hashing-v1-{dimensions}",
+            revision="1",
+            capabilities_sha256=sha256_json(capabilities),
+            connection_sha256=sha256_json(identity),
+        ),
+    )
+
+
+def embed_rag_texts(
+    binding: RAGEmbedderBinding,
+    texts: Sequence[str],
+) -> tuple[tuple[float, ...], ...]:
+    """Embed canonical texts while failing closed on count, shape, or numeric drift.
+
+    Args:
+        binding: Explicit embedding client and persisted model identity.
+        texts: Ordered canonical RAG key texts.
+
+    Returns:
+        Equal-width finite unit vectors in input order.
+
+    Raises:
+        ValueError: The client violates the embedding contract.
+    """
+    embeddings = binding.client.embed(texts)
+    if len(embeddings) != len(texts):
+        raise ValueError("RAG embedder returned a vector count different from its inputs")
+    vectors = tuple(tuple(float(value) for value in item.values) for item in embeddings)
+    dimensions = {len(vector) for vector in vectors}
+    if len(dimensions) > 1:
+        raise ValueError("RAG embedder returned vectors with inconsistent dimensions")
+    if texts and (not vectors or not vectors[0]):
+        raise ValueError("RAG embedder returned an empty vector")
+    return vectors

--- a/wmo/simulation/retrieval/retrieval_test.py
+++ b/wmo/simulation/retrieval/retrieval_test.py
@@ -1,0 +1,493 @@
+"""End-to-end tests for immutable real-trace RAG construction and retrieval."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactInput,
+    SourceIdentity,
+    canonical_json_bytes,
+    sha256_json,
+)
+from wmo.common.models import Embedding, ModelCapabilities, ModelSnapshot
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactFile,
+    ArtifactManifest,
+    ArtifactStore,
+    ProjectPaths,
+    artifact_input,
+)
+from wmo.common.traces import Trace, TraceSource, TraceSpan
+from wmo.simulation.ingest import (
+    TraceNormalizationResult,
+    persist_trace_dataset,
+)
+from wmo.simulation.retrieval import (
+    RAGAction,
+    RAGEmbedderBinding,
+    RAGLineageBinding,
+    RAGQuery,
+    TraceRAGRetriever,
+    load_rag_index,
+    persist_trace_rag,
+)
+
+_CREATED_AT = datetime(2026, 8, 13, tzinfo=UTC)
+SourceKind = Literal["file", "otlp", "production", "simulation", "manual", "generated"]
+
+
+class _ConstantEmbedder:
+    """Return one fixed unit vector for deterministic tie tests."""
+
+    def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+        return tuple(Embedding(values=(1.0, 0.0)) for _ in texts)
+
+
+def test_one_trace_and_more_than_one_thousand_traces_are_valid(tmp_path: Path) -> None:
+    """Trace-count guidance never becomes an enforced product boundary."""
+    for count, project_id in ((1, "one-trace"), (1_001, "many-traces")):
+        store = _store(tmp_path / project_id, project_id)
+        source_input, traces = _persist_traces(store, count=count)
+        result = persist_trace_rag(
+            store,
+            (source_input,),
+            _bindings(traces),
+            created_at=_CREATED_AT,
+            code_revision="revision-a",
+        )
+        assert result.index.transition_count == count
+
+
+def test_build_reload_is_deterministic_and_terminal_turns_are_excluded(tmp_path: Path) -> None:
+    store = _store(tmp_path, "reload")
+    source_input, traces = _persist_traces(store, count=2)
+    first = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+    replay = persist_trace_rag(
+        store,
+        (source_input,),
+        tuple(reversed(_bindings(traces))),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+    loaded = load_rag_index(store, first.index.rag_id)
+
+    assert replay.index == first.index == loaded.index
+    assert replay.transitions == first.transitions == loaded.transitions
+    assert replay.vectors == first.vectors == loaded.vectors
+    assert all(item.action_span_id.endswith("-request") for item in loaded.transitions)
+    assert all(item.observation_span_id.endswith("-answer") for item in loaded.transitions)
+
+
+def test_tool_calls_require_real_following_results(tmp_path: Path) -> None:
+    store = _store(tmp_path, "tools")
+    trace = _tool_trace(with_result=True)
+    terminal = _tool_trace(with_result=False, index=2)
+    source_input, _ = _persist_trace_values(store, (trace, terminal))
+    result = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings((trace, terminal)),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+
+    assert len(result.transitions) == 1
+    transition = result.transitions[0]
+    assert transition.action.kind == "tool_call"
+    assert transition.action.tool_name == "lookup_account"
+    assert transition.observation.kind == "tool_result"
+    assert transition.observation.content == "account found"
+
+
+def test_held_out_lineages_never_enter_the_index(tmp_path: Path) -> None:
+    store = _store(tmp_path, "fit-only")
+    source_input, traces = _persist_traces(store, count=2)
+    bindings = (
+        RAGLineageBinding(
+            trace_id=traces[0].trace_id,
+            lineage_id="lineage-fit",
+            partition="fit",
+        ),
+        RAGLineageBinding(
+            trace_id=traces[1].trace_id,
+            lineage_id="lineage-held-out",
+            partition="held_out",
+        ),
+    )
+
+    result = persist_trace_rag(
+        store,
+        (source_input,),
+        bindings,
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+
+    assert result.index.fit_lineage_ids == ("lineage-fit",)
+    assert {item.trace_id for item in result.transitions} == {traces[0].trace_id}
+
+
+def test_retrieve_filters_lineage_before_stable_tie_break_and_never_mutates(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, "retrieve")
+    source_input, traces = _persist_traces(store, count=2)
+    embedder = _constant_binding()
+    persisted = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+        embedder=embedder,
+    )
+    loaded = load_rag_index(store, persisted.index.rag_id)
+    retriever = TraceRAGRetriever(loaded, embedder=embedder)
+    excluded = loaded.transitions[0].lineage_id
+    query = RAGQuery(
+        task="reset password 0",
+        action=RAGAction(kind="message", content="Which email is on the account?"),
+        excluded_lineage_ids=(excluded,),
+    )
+    query_before = query.model_dump_json()
+    index_before = loaded
+    artifact_before = store.read_bytes(persisted.index.rag_id, "vectors.jsonl")
+
+    matches = retriever.retrieve(query)
+
+    assert [item.transition.lineage_id for item in matches] == [loaded.transitions[1].lineage_id]
+    assert query.model_dump_json() == query_before
+    assert loaded == index_before
+    assert store.read_bytes(persisted.index.rag_id, "vectors.jsonl") == artifact_before
+
+
+def test_equal_scores_use_transition_id_order(tmp_path: Path) -> None:
+    store = _store(tmp_path, "ties")
+    source_input, traces = _persist_traces(store, count=3)
+    embedder = _constant_binding()
+    persisted = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+        embedder=embedder,
+    )
+    query = RAGQuery(
+        task="anything",
+        action=RAGAction(kind="message", content="anything"),
+        top_k=2,
+    )
+
+    matches = TraceRAGRetriever(
+        load_rag_index(store, persisted.index.rag_id), embedder=embedder
+    ).retrieve(query)
+
+    assert [match.transition.transition_id for match in matches] == list(
+        persisted.index.transition_ids[:2]
+    )
+
+
+@pytest.mark.parametrize("artifact_type", ["simulation", "teacher-rollout", "judgment"])
+def test_non_trace_artifact_sources_are_forbidden(tmp_path: Path, artifact_type: str) -> None:
+    store = _store(tmp_path, "forbidden-artifact")
+    envelope = ArtifactEnvelope(
+        schema_version=1,
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+    manifest = store.write(
+        artifact_id=f"forbidden-{artifact_type}",
+        artifact_type=artifact_type,
+        envelope=envelope,
+        files={"evidence.json": b"{}"},
+    )
+
+    with pytest.raises(ValueError, match="forbidden artifact type"):
+        persist_trace_rag(
+            store,
+            (artifact_input(manifest),),
+            (),
+            created_at=_CREATED_AT,
+            code_revision="revision-a",
+        )
+
+
+@pytest.mark.parametrize("kind", ["generated", "simulation", "manual"])
+def test_non_real_trace_provenance_is_forbidden(tmp_path: Path, kind: SourceKind) -> None:
+    store = _store(tmp_path, f"forbidden-{kind}")
+    trace = _message_trace(0, source_kind=kind)
+    source_input, _ = _persist_trace_values(store, (trace,))
+
+    with pytest.raises(ValueError, match="forbidden provenance"):
+        persist_trace_rag(
+            store,
+            (source_input,),
+            _bindings((trace,)),
+            created_at=_CREATED_AT,
+            code_revision="revision-a",
+        )
+
+
+def test_loader_fails_closed_on_payload_hash_change(tmp_path: Path) -> None:
+    store, rag_id = _built_index(tmp_path, "bad-hash")
+    path = store.project_directory / "artifacts" / rag_id / "transitions.jsonl"
+    path.write_bytes(path.read_bytes() + b"\n")
+
+    with pytest.raises(ArtifactCorruptionError, match="digest mismatch"):
+        load_rag_index(store, rag_id)
+
+
+def test_loader_fails_closed_on_envelope_identity_change(tmp_path: Path) -> None:
+    store, rag_id = _built_index(tmp_path, "bad-id")
+    loaded = load_rag_index(store, rag_id)
+    mismatched = loaded.index.model_copy(update={"rag_id": "trace-rag-other"})
+    store.write(
+        artifact_id="trace-rag-mismatched",
+        artifact_type="trace-rag-index",
+        envelope=mismatched,
+        files={
+            "rag-index.json": canonical_json_bytes(mismatched),
+            "transitions.jsonl": store.read_bytes(rag_id, "transitions.jsonl"),
+            "vectors.jsonl": store.read_bytes(rag_id, "vectors.jsonl"),
+        },
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="does not match artifact"):
+        load_rag_index(store, "trace-rag-mismatched")
+
+
+def test_loader_fails_closed_on_vector_dimension_change(tmp_path: Path) -> None:
+    store, rag_id = _built_index(tmp_path, "bad-dimension")
+    loaded = load_rag_index(store, rag_id)
+    vector_payload = (
+        canonical_json_bytes(loaded.vectors[0].model_copy(update={"values": (1.0,)})) + b"\n"
+    )
+    changed = loaded.index.model_copy(
+        update={"vectors_sha256": hashlib.sha256(vector_payload).hexdigest()}
+    )
+    store.write(
+        artifact_id="trace-rag-bad-dimension",
+        artifact_type="trace-rag-index",
+        envelope=changed.model_copy(update={"rag_id": "trace-rag-bad-dimension"}),
+        files={
+            "rag-index.json": canonical_json_bytes(
+                changed.model_copy(update={"rag_id": "trace-rag-bad-dimension"})
+            ),
+            "transitions.jsonl": store.read_bytes(rag_id, "transitions.jsonl"),
+            "vectors.jsonl": vector_payload,
+        },
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="dimension"):
+        load_rag_index(store, "trace-rag-bad-dimension")
+
+
+def test_loader_fails_closed_on_nan_vector(tmp_path: Path) -> None:
+    store, rag_id = _built_index(tmp_path, "bad-nan")
+    directory = store.project_directory / "artifacts" / rag_id
+    vector_path = directory / "vectors.jsonl"
+    value = json.loads(vector_path.read_text(encoding="utf-8").splitlines()[0])
+    value["values"][0] = float("nan")
+    payload = (json.dumps(value, separators=(",", ":")) + "\n").encode()
+    vector_path.write_bytes(payload)
+    manifest_path = directory / "manifest.json"
+    manifest = ArtifactManifest.model_validate_json(manifest_path.read_bytes())
+    files = tuple(
+        ArtifactFile(
+            path=item.path,
+            sha256=hashlib.sha256(payload).hexdigest(),
+            size_bytes=len(payload),
+        )
+        if item.path == "vectors.jsonl"
+        else item
+        for item in manifest.files
+    )
+    manifest_path.write_bytes(canonical_json_bytes(manifest.model_copy(update={"files": files})))
+
+    with pytest.raises(ArtifactCorruptionError):
+        load_rag_index(store, rag_id)
+
+
+def _built_index(tmp_path: Path, project_id: str) -> tuple[ArtifactStore, str]:
+    """Build one valid local index and return its store and identity."""
+    store = _store(tmp_path, project_id)
+    source_input, traces = _persist_traces(store, count=1)
+    persisted = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+    return store, persisted.index.rag_id
+
+
+def _store(root: Path, project_id: str) -> ArtifactStore:
+    """Create a project-scoped artifact store for a test."""
+    return ArtifactStore(ProjectPaths(root=root, project_id=project_id))
+
+
+def _persist_traces(
+    store: ArtifactStore,
+    *,
+    count: int,
+) -> tuple[ArtifactInput, tuple[Trace, ...]]:
+    """Persist a requested positive number of canonical real message traces."""
+    traces = tuple(_message_trace(index) for index in range(count))
+    source_input, _ = _persist_trace_values(store, traces)
+    return source_input, traces
+
+
+def _persist_trace_values(
+    store: ArtifactStore,
+    traces: tuple[Trace, ...],
+) -> tuple[ArtifactInput, tuple[Trace, ...]]:
+    """Persist exact canonical traces and return their verified manifest input."""
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=traces, issues=()),
+        store,
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+    )
+    return artifact_input(persisted.manifest), persisted.traces
+
+
+def _bindings(traces: tuple[Trace, ...]) -> tuple[RAGLineageBinding, ...]:
+    """Assign one deterministic fit lineage per source trace."""
+    return tuple(
+        RAGLineageBinding(
+            trace_id=trace.trace_id,
+            lineage_id=f"lineage-{index}",
+            partition="fit",
+        )
+        for index, trace in enumerate(traces)
+    )
+
+
+def _message_trace(index: int, *, source_kind: SourceKind = "otlp") -> Trace:
+    """Create one real two-call transcript with one nonterminal observed transition."""
+    start = _CREATED_AT + timedelta(seconds=index * 10)
+    request = f"reset password {index}"
+    question = "Which email is on the account?"
+    answer = f"customer-{index}@example.com"
+    return Trace(
+        trace_id=f"trace-{index}",
+        conversation_id=f"conversation-{index}",
+        task=request,
+        spans=(
+            TraceSpan(
+                span_id=f"span-{index}-request",
+                name="chat",
+                started_at=start,
+                ended_at=start + timedelta(seconds=1),
+                attributes={
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.input.messages": [{"role": "user", "content": request}],
+                    "gen_ai.completion": question,
+                },
+            ),
+            TraceSpan(
+                span_id=f"span-{index}-answer",
+                name="chat",
+                started_at=start + timedelta(seconds=2),
+                ended_at=start + timedelta(seconds=3),
+                attributes={
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.input.messages": [
+                        {"role": "user", "content": request},
+                        {"role": "assistant", "content": question},
+                        {"role": "user", "content": answer},
+                    ],
+                    "gen_ai.completion": "A reset link is on the way.",
+                },
+            ),
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(
+                kind=source_kind,
+                source_id="trace-fixture",
+                sha256="a" * 64,
+            ),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def _tool_trace(*, with_result: bool, index: int = 1) -> Trace:
+    """Create a tool call with an optional real following tool observation."""
+    start = _CREATED_AT + timedelta(seconds=index * 10)
+    spans = [
+        TraceSpan(
+            span_id=f"span-{index}-tool-call",
+            name="chat",
+            started_at=start,
+            ended_at=start + timedelta(seconds=1),
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.tool.name": "lookup_account",
+                "gen_ai.tool.call.id": f"call-{index}",
+                "gen_ai.tool.call.arguments": {"customer": index},
+            },
+        )
+    ]
+    if with_result:
+        spans.append(
+            TraceSpan(
+                span_id=f"span-{index}-tool-result",
+                name="execute_tool lookup_account",
+                started_at=start + timedelta(seconds=2),
+                ended_at=start + timedelta(seconds=3),
+                attributes={
+                    "gen_ai.operation.name": "execute_tool",
+                    "gen_ai.tool.name": "lookup_account",
+                    "gen_ai.tool.call.id": f"call-{index}",
+                    "gen_ai.tool.message": "account found",
+                },
+            )
+        )
+    return Trace(
+        trace_id=f"tool-trace-{index}",
+        conversation_id=f"tool-conversation-{index}",
+        task="find the account",
+        spans=tuple(spans),
+        source=TraceSource(
+            identity=SourceIdentity(
+                kind="otlp",
+                source_id="trace-fixture",
+                sha256="a" * 64,
+            ),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def _constant_binding() -> RAGEmbedderBinding:
+    """Return a semantic-style explicit constant embedding binding."""
+    capabilities = ModelCapabilities(supports_embeddings=True)
+    return RAGEmbedderBinding(
+        client=_ConstantEmbedder(),
+        snapshot=ModelSnapshot(
+            provider="test",
+            model_id="constant",
+            revision="1",
+            capabilities_sha256=sha256_json(capabilities),
+            connection_sha256="b" * 64,
+        ),
+    )

--- a/wmo/simulation/retrieval/retrieval_test.py
+++ b/wmo/simulation/retrieval/retrieval_test.py
@@ -204,6 +204,68 @@ def test_equal_scores_use_transition_id_order(tmp_path: Path) -> None:
     )
 
 
+def test_omitted_query_limit_uses_index_default_and_explicit_limit_overrides(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path, "persisted-top-k")
+    source_input, traces = _persist_traces(store, count=3)
+    embedder = _constant_binding()
+    persisted = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+        embedder=embedder,
+        default_top_k=1,
+    )
+    retriever = TraceRAGRetriever(load_rag_index(store, persisted.index.rag_id), embedder=embedder)
+    action = RAGAction(kind="message", content="anything")
+
+    inherited = retriever.retrieve(RAGQuery(task="anything", action=action))
+    overridden = retriever.retrieve(RAGQuery(task="anything", action=action, top_k=2))
+
+    assert len(inherited) == 1
+    assert len(overridden) == 2
+
+
+@pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [("default_top_k", 1), ("code_revision", "revision-b")],
+)
+def test_replay_sensitive_fields_produce_distinct_artifact_ids(
+    tmp_path: Path,
+    changed_field: str,
+    changed_value: str | int,
+) -> None:
+    store = _store(tmp_path, f"identity-{changed_field}")
+    source_input, traces = _persist_traces(store, count=2)
+    kwargs: dict[str, str | int] = {
+        "code_revision": "revision-a",
+        "default_top_k": 5,
+    }
+    kwargs[changed_field] = changed_value
+    original = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision="revision-a",
+        default_top_k=5,
+    )
+    changed = persist_trace_rag(
+        store,
+        (source_input,),
+        _bindings(traces),
+        created_at=_CREATED_AT,
+        code_revision=str(kwargs["code_revision"]),
+        default_top_k=int(kwargs["default_top_k"]),
+    )
+
+    assert changed.index.rag_id != original.index.rag_id
+    assert load_rag_index(store, changed.index.rag_id).index == changed.index
+
+
 @pytest.mark.parametrize("artifact_type", ["simulation", "teacher-rollout", "judgment"])
 def test_non_trace_artifact_sources_are_forbidden(tmp_path: Path, artifact_type: str) -> None:
     store = _store(tmp_path, "forbidden-artifact")

--- a/wmo/simulation/retrieval/retriever.py
+++ b/wmo/simulation/retrieval/retriever.py
@@ -1,8 +1,6 @@
-"""Read-only retrieval from a loaded immutable observed-transition index.
+"""Read-only cosine retrieval from a loaded immutable observed-transition index.
 
-The ``retrieve`` behavior adapts top-k cosine ranking from
-``e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever.topk``. Unlike that historical
-class, this retriever has no index or add method. Its corpus and vectors are frozen before load.
+The corpus and vectors are frozen before load and expose no mutation surface.
 """
 
 from __future__ import annotations

--- a/wmo/simulation/retrieval/retriever.py
+++ b/wmo/simulation/retrieval/retriever.py
@@ -54,7 +54,8 @@ class TraceRAGRetriever:
         """Return top cosine matches after excluding query-related lineages.
 
         Args:
-            query: Request-visible task, initial context, action, lineage exclusions, and limit.
+            query: Request-visible task, initial context, action, lineage exclusions, and optional
+                limit. An omitted limit uses the immutable index default.
 
         Returns:
             Up to ``top_k`` fit-side real transitions. Equal scores use transition ID order.
@@ -83,4 +84,5 @@ class TraceRAGRetriever:
             )
             candidates.append(RAGMatch(transition=transition, score=score))
         candidates.sort(key=lambda match: (-match.score, match.transition.transition_id))
-        return tuple(candidates[: query.top_k])
+        limit = self._index.default_top_k if query.top_k is None else query.top_k
+        return tuple(candidates[:limit])

--- a/wmo/simulation/retrieval/retriever.py
+++ b/wmo/simulation/retrieval/retriever.py
@@ -1,0 +1,86 @@
+"""Read-only retrieval from a loaded immutable observed-transition index.
+
+The ``retrieve`` behavior adapts top-k cosine ranking from
+``e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever.topk``. Unlike that historical
+class, this retriever has no index or add method. Its corpus and vectors are frozen before load.
+"""
+
+from __future__ import annotations
+
+from wmo.simulation.retrieval.contracts import RAGMatch, RAGQuery
+from wmo.simulation.retrieval.embedding import (
+    RAGEmbedderBinding,
+    default_rag_embedder,
+    embed_rag_texts,
+)
+from wmo.simulation.retrieval.store import LoadedRAGIndex
+from wmo.simulation.retrieval.transitions import render_rag_key
+
+
+class TraceRAGRetriever:
+    """Serve stable nearest real transitions without mutating the persisted corpus."""
+
+    def __init__(
+        self,
+        loaded: LoadedRAGIndex,
+        *,
+        embedder: RAGEmbedderBinding | None = None,
+    ) -> None:
+        """Bind one loaded index to the exact embedder identity used at build time.
+
+        Args:
+            loaded: Fully verified immutable RAG index.
+            embedder: Explicit semantic embedder binding. The built-in hashing client is
+                reconstructed automatically only when its complete snapshot matches the index.
+
+        Raises:
+            ValueError: A semantic index lacks an explicit matching client or snapshots differ.
+        """
+        if embedder is None:
+            default = default_rag_embedder(loaded.index.embedding_dimension)
+            if default.snapshot != loaded.index.embedder:
+                raise ValueError(
+                    "semantic RAG indexes require the exact explicit embedder used at build time"
+                )
+            embedder = default
+        if embedder.snapshot != loaded.index.embedder:
+            raise ValueError("RAG query embedder snapshot differs from the persisted index")
+        self._index = loaded.index
+        self._transitions = loaded.transitions
+        self._vectors = loaded.vectors
+        self._embedder = embedder
+
+    def retrieve(self, query: RAGQuery) -> tuple[RAGMatch, ...]:
+        """Return top cosine matches after excluding query-related lineages.
+
+        Args:
+            query: Request-visible task, initial context, action, lineage exclusions, and limit.
+
+        Returns:
+            Up to ``top_k`` fit-side real transitions. Equal scores use transition ID order.
+
+        Raises:
+            ValueError: Query embedding dimensions differ from the frozen index.
+        """
+        key_text = render_rag_key(
+            task=query.task,
+            initial_context=query.initial_context,
+            action=query.action,
+        )
+        query_vector = embed_rag_texts(self._embedder, (key_text,))[0]
+        if len(query_vector) != self._index.embedding_dimension:
+            raise ValueError(
+                f"RAG query embedding has dimension {len(query_vector)}, expected "
+                f"{self._index.embedding_dimension}"
+            )
+        excluded = set(query.excluded_lineage_ids)
+        candidates = []
+        for transition, vector in zip(self._transitions, self._vectors, strict=True):
+            if transition.lineage_id in excluded:
+                continue
+            score = sum(
+                left * right for left, right in zip(query_vector, vector.values, strict=True)
+            )
+            candidates.append(RAGMatch(transition=transition, score=score))
+        candidates.sort(key=lambda match: (-match.score, match.transition.transition_id))
+        return tuple(candidates[: query.top_k])

--- a/wmo/simulation/retrieval/store.py
+++ b/wmo/simulation/retrieval/store.py
@@ -1,0 +1,200 @@
+"""Digest-verified loading of immutable real-trace RAG indexes."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import JsonValue, stable_id
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.traces import Trace, load_trace_dataset
+from wmo.simulation.retrieval.contracts import (
+    RAG_ARTIFACT_TYPE,
+    RAG_INDEX_PATH,
+    RAGIndex,
+    RAGTransition,
+    RAGVector,
+)
+from wmo.simulation.retrieval.transitions import render_rag_key
+
+_REAL_SOURCE_KINDS = frozenset({"file", "otlp", "production"})
+
+
+@dataclass(frozen=True)
+class LoadedRAGIndex:
+    """Verified immutable RAG envelope, manifest, transitions, and vectors."""
+
+    index: RAGIndex
+    manifest: ArtifactManifest
+    transitions: tuple[RAGTransition, ...]
+    vectors: tuple[RAGVector, ...]
+
+
+def load_rag_index(store: ArtifactStore, rag_id: str) -> LoadedRAGIndex:
+    """Load and fully verify one completed immutable RAG artifact.
+
+    Args:
+        store: Project-local artifact store that owns the index and its exact inputs.
+        rag_id: Immutable RAG artifact identity.
+
+    Returns:
+        Verified envelope and exact ordered observed-transition records.
+
+    Raises:
+        ArtifactCorruptionError: Any type, hash, dimension, ID, lineage, source, or numeric
+            invariant fails closed.
+    """
+    stored = store.read(rag_id)
+    if stored.manifest.artifact_type != RAG_ARTIFACT_TYPE:
+        raise ArtifactCorruptionError(f"artifact {rag_id} is not a trace RAG index")
+    try:
+        index = RAGIndex.model_validate_json(store.read_bytes(rag_id, RAG_INDEX_PATH))
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} has an invalid envelope") from exc
+    if index.rag_id != rag_id:
+        raise ArtifactCorruptionError(
+            f"RAG envelope ID {index.rag_id} does not match artifact {rag_id}"
+        )
+    manifest_identity = (
+        stored.manifest.schema_version,
+        stored.manifest.created_at,
+        stored.manifest.inputs,
+        stored.manifest.code_revision,
+        stored.manifest.source,
+    )
+    envelope_identity = (
+        index.schema_version,
+        index.created_at,
+        index.inputs,
+        index.code_revision,
+        index.source,
+    )
+    if manifest_identity != envelope_identity:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} differs from its artifact manifest")
+    transitions_payload = store.read_bytes(rag_id, index.transitions_path)
+    vectors_payload = store.read_bytes(rag_id, index.vectors_path)
+    if hashlib.sha256(transitions_payload).hexdigest() != index.transitions_sha256:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} transition digest does not match")
+    if hashlib.sha256(vectors_payload).hexdigest() != index.vectors_sha256:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} vector digest does not match")
+    transitions = _parse_transitions(rag_id, transitions_payload)
+    vectors = _parse_vectors(rag_id, vectors_payload)
+    _verify_records(index, transitions, vectors)
+    _verify_sources(store, index, transitions)
+    return LoadedRAGIndex(index, stored.manifest, transitions, vectors)
+
+
+def _parse_transitions(rag_id: str, payload: bytes) -> tuple[RAGTransition, ...]:
+    """Parse all transition JSONL records with strict Pydantic contracts."""
+    try:
+        return tuple(
+            RAGTransition.model_validate_json(line)
+            for line in payload.decode("utf-8").splitlines()
+            if line
+        )
+    except (UnicodeDecodeError, ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} has invalid transitions") from exc
+
+
+def _parse_vectors(rag_id: str, payload: bytes) -> tuple[RAGVector, ...]:
+    """Parse all vector JSONL records and reject NaN, infinity, and non-unit values."""
+    try:
+        return tuple(
+            RAGVector.model_validate_json(line)
+            for line in payload.decode("utf-8").splitlines()
+            if line
+        )
+    except (UnicodeDecodeError, ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(f"RAG index {rag_id} has invalid vectors") from exc
+
+
+def _verify_records(
+    index: RAGIndex,
+    transitions: tuple[RAGTransition, ...],
+    vectors: tuple[RAGVector, ...],
+) -> None:
+    """Verify ordering, IDs, key hashes, lineage membership, and vector dimensions."""
+    transition_ids = tuple(item.transition_id for item in transitions)
+    vector_ids = tuple(item.transition_id for item in vectors)
+    if transition_ids != index.transition_ids or vector_ids != index.transition_ids:
+        raise ArtifactCorruptionError("RAG records do not match ordered transition IDs")
+    if len(transitions) != index.transition_count or len(vectors) != index.transition_count:
+        raise ArtifactCorruptionError("RAG record counts do not match the envelope")
+    fit_lineages = set(index.fit_lineage_ids)
+    for transition, vector in zip(transitions, vectors, strict=True):
+        if transition.lineage_id not in fit_lineages:
+            raise ArtifactCorruptionError("RAG transition is outside the frozen fit lineages")
+        key_text = render_rag_key(
+            task=transition.task,
+            initial_context=transition.initial_context,
+            action=transition.action,
+        )
+        if key_text != transition.key_text:
+            raise ArtifactCorruptionError("RAG transition key differs from its versioned fields")
+        if hashlib.sha256(key_text.encode("utf-8")).hexdigest() != transition.key_sha256:
+            raise ArtifactCorruptionError("RAG transition key hash does not match")
+        material: JsonValue = {
+            "action": transition.action.model_dump(mode="json", exclude_none=False),
+            "action_span_id": transition.action_span_id,
+            "key_schema_version": index.key_schema_version,
+            "lineage_id": transition.lineage_id,
+            "observation": transition.observation.model_dump(mode="json"),
+            "observation_span_id": transition.observation_span_id,
+            "trace_id": transition.trace_id,
+        }
+        if stable_id("rag-transition", material) != transition.transition_id:
+            raise ArtifactCorruptionError("RAG transition ID does not match its observed evidence")
+        if len(vector.values) != index.embedding_dimension:
+            raise ArtifactCorruptionError("RAG vector dimension does not match the envelope")
+
+
+def _verify_sources(
+    store: ArtifactStore,
+    index: RAGIndex,
+    transitions: tuple[RAGTransition, ...],
+) -> None:
+    """Reopen every exact real source and bind transitions to its trace and span identities."""
+    traces: dict[str, Trace] = {}
+    for source in index.sources:
+        stored = store.read(source.artifact_input.artifact_id)
+        if artifact_input(stored.manifest) != source.artifact_input:
+            raise ArtifactCorruptionError("RAG source manifest digest no longer matches")
+        if stored.manifest.artifact_type != "trace-dataset" or source.kind != "trace_dataset":
+            raise ArtifactCorruptionError("RAG source is not a supported real trace dataset")
+        loaded = load_trace_dataset(store, source.artifact_input.artifact_id)
+        if (
+            loaded.dataset.source != source.source
+            or loaded.dataset.traces_sha256 != source.records_sha256
+            or tuple(sorted(loaded.dataset.trace_ids)) != source.trace_ids
+        ):
+            raise ArtifactCorruptionError("RAG source reference differs from its trace dataset")
+        if source.source.kind not in _REAL_SOURCE_KINDS:
+            raise ArtifactCorruptionError("RAG source provenance is not verified real evidence")
+        for trace in loaded.traces:
+            if trace.trace_id in traces:
+                raise ArtifactCorruptionError("RAG sources repeat a trace ID")
+            traces[trace.trace_id] = trace
+    for transition in transitions:
+        trace = traces.get(transition.trace_id)
+        if trace is None:
+            raise ArtifactCorruptionError("RAG transition names an unknown source trace")
+        if (
+            transition.task != trace.task
+            or transition.initial_context != trace.initial_context
+            or transition.conversation_id != trace.conversation_id
+        ):
+            raise ArtifactCorruptionError("RAG transition differs from its source trace fields")
+        spans = {span.span_id: span for span in trace.spans}
+        action_span = spans.get(transition.action_span_id)
+        observation_span = spans.get(transition.observation_span_id)
+        if action_span is None or observation_span is None:
+            raise ArtifactCorruptionError("RAG transition names an unknown source span")
+        if observation_span.started_at < action_span.ended_at:
+            raise ArtifactCorruptionError("RAG observation precedes its source action")

--- a/wmo/simulation/retrieval/transitions.py
+++ b/wmo/simulation/retrieval/transitions.py
@@ -1,0 +1,275 @@
+"""Extraction and versioned key rendering for real observed trace transitions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+
+from pydantic import JsonValue
+
+from wmo.common.core.artifacts import canonical_json_bytes, stable_id
+from wmo.common.core.text import normalize_durable_text
+from wmo.common.traces import Trace, TraceSpan
+from wmo.simulation.retrieval.contracts import (
+    RAG_KEY_SCHEMA_VERSION,
+    RAGAction,
+    RAGLineageBinding,
+    RAGObservation,
+    RAGTransition,
+)
+
+_TOOL_OPERATION = "execute_tool"
+
+
+def extract_fit_transitions(
+    traces: Sequence[Trace],
+    lineage_bindings: Sequence[RAGLineageBinding],
+) -> tuple[RAGTransition, ...]:
+    """Extract only fit-side real action-to-following-observation transitions.
+
+    Args:
+        traces: Verified canonical traces from immutable real-source datasets.
+        lineage_bindings: Frozen leakage-safe assignment for every supplied trace.
+
+    Returns:
+        Deterministically ordered fit transitions. Terminal assistant messages without a real
+        subsequent user or environment observation are intentionally absent.
+
+    Raises:
+        ValueError: Trace identities and lineage bindings differ or repeat.
+    """
+    trace_ids = tuple(trace.trace_id for trace in traces)
+    if len(set(trace_ids)) != len(trace_ids):
+        raise ValueError("RAG source datasets repeat a trace ID")
+    binding_by_trace = {binding.trace_id: binding for binding in lineage_bindings}
+    if len(binding_by_trace) != len(lineage_bindings):
+        raise ValueError("RAG lineage bindings repeat a trace ID")
+    if set(binding_by_trace) != set(trace_ids):
+        raise ValueError("RAG lineage bindings must cover exactly the verified source traces")
+    transitions: list[RAGTransition] = []
+    for trace in traces:
+        binding = binding_by_trace[trace.trace_id]
+        if binding.partition != "fit":
+            continue
+        transitions.extend(_trace_transitions(trace, binding.lineage_id))
+    ordered = tuple(sorted(transitions, key=lambda item: item.transition_id))
+    ids = tuple(item.transition_id for item in ordered)
+    if len(set(ids)) != len(ids):
+        raise ValueError("real trace evidence produced duplicate RAG transition IDs")
+    return ordered
+
+
+def render_rag_key(
+    *, task: str, initial_context: Mapping[str, JsonValue], action: RAGAction
+) -> str:
+    """Render the exact versioned fit and query key without using an observation.
+
+    Args:
+        task: Request-visible source task or query task.
+        initial_context: Request-visible starting context.
+        action: Visible agent action whose environment response is sought.
+
+    Returns:
+        Canonical JSON text shared by index construction and retrieval queries.
+    """
+    return canonical_json_bytes(
+        {
+            "action": action.model_dump(mode="json", exclude_none=False),
+            "initial_context": dict(initial_context),
+            "key_schema_version": RAG_KEY_SCHEMA_VERSION,
+            "task": task,
+        }
+    ).decode("utf-8")
+
+
+def _trace_transitions(trace: Trace, lineage_id: str) -> list[RAGTransition]:
+    """Extract ordered message and tool transitions from one verified real trace."""
+    spans = tuple(sorted(trace.spans, key=lambda item: (item.started_at, item.span_id)))
+    transitions: list[RAGTransition] = []
+    used_tool_observations: set[str] = set()
+    for index, span in enumerate(spans):
+        action = _action(span)
+        if action is None:
+            continue
+        if action.kind == "tool_call":
+            observation_pair = _tool_observation(
+                span,
+                spans[index + 1 :],
+                used_tool_observations,
+            )
+        else:
+            observation_pair = _message_observation(span, spans[index + 1 :])
+        if observation_pair is None:
+            continue
+        observation_span, observation = observation_pair
+        key_text = render_rag_key(
+            task=trace.task,
+            initial_context=trace.initial_context,
+            action=action,
+        )
+        material: JsonValue = {
+            "action": action.model_dump(mode="json", exclude_none=False),
+            "action_span_id": span.span_id,
+            "key_schema_version": RAG_KEY_SCHEMA_VERSION,
+            "lineage_id": lineage_id,
+            "observation": observation.model_dump(mode="json"),
+            "observation_span_id": observation_span.span_id,
+            "trace_id": trace.trace_id,
+        }
+        transitions.append(
+            RAGTransition(
+                transition_id=stable_id("rag-transition", material),
+                trace_id=trace.trace_id,
+                conversation_id=trace.conversation_id,
+                lineage_id=lineage_id,
+                action_span_id=span.span_id,
+                observation_span_id=observation_span.span_id,
+                task=trace.task,
+                initial_context=trace.initial_context,
+                action=action,
+                observation=observation,
+                key_text=key_text,
+                key_sha256=hashlib.sha256(key_text.encode("utf-8")).hexdigest(),
+            )
+        )
+    return transitions
+
+
+def _action(span: TraceSpan) -> RAGAction | None:
+    """Return a real visible agent action from one source span, if present."""
+    attributes = span.attributes
+    operation = attributes.get("gen_ai.operation.name")
+    if operation == _TOOL_OPERATION:
+        return None
+    tool_name = attributes.get("gen_ai.tool.name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        return RAGAction(
+            kind="tool_call",
+            tool_name=normalize_durable_text(tool_name.strip()),
+            tool_arguments=_tool_arguments(attributes.get("gen_ai.tool.call.arguments")),
+        )
+    content = _assistant_text(attributes)
+    if content is None:
+        return None
+    return RAGAction(kind="message", content=content)
+
+
+def _tool_observation(
+    action_span: TraceSpan,
+    later_spans: Sequence[TraceSpan],
+    used_span_ids: set[str],
+) -> tuple[TraceSpan, RAGObservation] | None:
+    """Find the exact subsequent observed result for one real tool call."""
+    call_id = action_span.attributes.get("gen_ai.tool.call.id")
+    tool_name = action_span.attributes.get("gen_ai.tool.name")
+    for span in later_spans:
+        if span.span_id in used_span_ids or span.started_at < action_span.ended_at:
+            continue
+        if span.attributes.get("gen_ai.operation.name") != _TOOL_OPERATION:
+            continue
+        if call_id is not None:
+            if span.attributes.get("gen_ai.tool.call.id") != call_id:
+                continue
+        elif span.attributes.get("gen_ai.tool.name") != tool_name:
+            continue
+        content = _visible_text(span.attributes.get("gen_ai.tool.message"))
+        if content is None:
+            continue
+        used_span_ids.add(span.span_id)
+        return span, RAGObservation(kind="tool_result", content=content)
+    return None
+
+
+def _message_observation(
+    action_span: TraceSpan,
+    later_spans: Sequence[TraceSpan],
+) -> tuple[TraceSpan, RAGObservation] | None:
+    """Find a genuinely new user-visible message after one assistant response."""
+    previous_user_text = _user_text(action_span.attributes)
+    for span in later_spans:
+        if span.started_at < action_span.ended_at:
+            continue
+        content = _user_text(span.attributes)
+        if content is None or content == previous_user_text:
+            continue
+        return span, RAGObservation(kind="message", content=content)
+    return None
+
+
+def _assistant_text(attributes: Mapping[str, JsonValue]) -> str | None:
+    """Read visible assistant output from standard or legacy GenAI attributes."""
+    messages = _json_value(attributes.get("gen_ai.output.messages"))
+    text = _last_role_message(messages, frozenset({"assistant", "model"}))
+    if text is not None:
+        return text
+    return _visible_text(attributes.get("gen_ai.completion"))
+
+
+def _user_text(attributes: Mapping[str, JsonValue]) -> str | None:
+    """Read the latest visible user input from one model-call span."""
+    messages = _json_value(attributes.get("gen_ai.input.messages"))
+    text = _last_role_message(messages, frozenset({"user", "human"}))
+    if text is not None:
+        return text
+    return _visible_text(attributes.get("gen_ai.prompt"))
+
+
+def _last_role_message(value: JsonValue, roles: frozenset[str]) -> str | None:
+    """Return the last text message whose role belongs to the requested set."""
+    if not isinstance(value, list):
+        return None
+    for item in reversed(value):
+        if not isinstance(item, dict) or item.get("role") not in roles:
+            continue
+        content = _message_content(item.get("content"))
+        if content is not None:
+            return content
+    return None
+
+
+def _message_content(value: JsonValue) -> str | None:
+    """Read plain text from a GenAI message content value."""
+    if isinstance(value, str):
+        return _visible_text(value)
+    if not isinstance(value, list):
+        return None
+    pieces = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text.strip():
+            pieces.append(text.strip())
+    return _visible_text("\n".join(pieces)) if pieces else None
+
+
+def _tool_arguments(value: JsonValue) -> JsonValue:
+    """Preserve exact JSON tool arguments when present, otherwise retain visible text."""
+    parsed = _json_value(value)
+    if parsed is None:
+        return {}
+    return parsed
+
+
+def _json_value(value: JsonValue) -> JsonValue:
+    """Decode JSON-valued semantic attributes without guessing malformed text."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _visible_text(value: JsonValue) -> str | None:
+    """Render a non-empty captured JSON value as stable visible text."""
+    if isinstance(value, str):
+        text = value.strip()
+    elif value is None:
+        return None
+    else:
+        text = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    if not text:
+        return None
+    return normalize_durable_text(text)


### PR DESCRIPTION
## What changed

- add an immutable, versioned RAG artifact over verified real `TraceDataset` inputs
- extract only fit-side real action to subsequent observation transitions
- persist exact source manifests, trace/conversation/lineage/span IDs, versioned keys, vectors, dimensions, model snapshots, and capability digests
- add a deterministic local hashing embedder plus an explicit semantic embedder seam
- add digest-verified reload and read-only cosine retrieval with pre-score lineage exclusion, default top-k 5, and stable transition-ID ties
- add adversarial coverage for generated/simulation/teacher/judgment rejection, terminal-turn omission, trace counts below 100 and above 1,000, held-out exclusion, deterministic replay, no mutation, and corrupt hashes/IDs/dimensions/NaN

## Why

The rebuilt product retained normalized traces but lost the grounded retrieval artifact that made a built world model directly reusable. This restores that boundary without restoring the old mutable replay buffer or deleted provider stack.

Any positive trace count is valid. The 100 to 1,000 range is guidance, not validation.

## Historical provenance

This adapts the useful behavior from:

- `e7aad17b:wmo/simulation/retrieval/retriever.py::EmbeddingRetriever.index/topk/save/load`
- `e7aad17b:wmo/simulation/model/world_model.py::WorldModel.load/new_session/step`
- `e7aad17b:wmo/simulation/model/loader.py::load_world_model`
- the related historical retriever and world-model tests

It intentionally does not restore the old provider types, GEPA, object-identity leak guards, or mutable `EmbeddingRetriever.add`. In particular, generated world-model predictions cannot enter this index.

## Impact

This PR provides the independent immutable RAG contract, loader, and retriever seam. A dependent PR can wire `wmo build` and the current simulator to it without importing deleted surfaces. It does not change README prose or merge any integration behavior.

## Validation

Exact head: `b96ca4325752c26a17c0b8c5d5cffa8949851d71`

- rebased onto main `179402ca6e5a5876ede3b85136059b9f5997678c`
- range-diff is semantically identical for both feature commits
- production module contracts are self-contained; historical provenance remains in this PR body
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- focused retrieval and package-layout suite: 20 passed
- pre-restack full suite: 664 passed, 1 skipped
- `uv build`
- every changed hand-authored file is below 1,000 lines


