### PR TITLE
Add durable routed interaction journal

### DIFF
--- a/wmo/common/models/__init__.py
+++ b/wmo/common/models/__init__.py
@@ -10,7 +10,7 @@ from wmo.common.models.catalog import (
     load_model_catalog,
     write_model_catalog,
 )
-from wmo.common.models.client import EmbeddingClient, ModelClient
+from wmo.common.models.client import EmbeddingClient, IdempotentModelClient, ModelClient
 from wmo.common.models.model import (
     AssistantAction,
     Embedding,
@@ -43,6 +43,7 @@ __all__ = [
     "ConnectionConfig",
     "Embedding",
     "EmbeddingClient",
+    "IdempotentModelClient",
     "ModelCatalog",
     "ModelCatalogError",
     "ModelAlias",

--- a/wmo/common/models/client.py
+++ b/wmo/common/models/client.py
@@ -24,6 +24,26 @@ class ModelClient(Protocol):
 
 
 @runtime_checkable
+class IdempotentModelClient(Protocol):
+    """Optional provider capability for forwarding one caller-owned idempotency key.
+
+    Implementing this protocol means only that the provider accepts an idempotency key. WMO does
+    not infer remote exactly-once execution from the method's presence.
+    """
+
+    def complete_idempotent(self, request: ModelRequest, *, idempotency_key: str) -> ModelResponse:
+        """Complete one request while forwarding its validated idempotency key.
+
+        Args:
+            request: Typed visible messages, tools, and sampling parameters.
+            idempotency_key: Caller-owned key forwarded without persistence or logging.
+
+        Returns:
+            Output, resolved model identity, and observed operation economics.
+        """
+
+
+@runtime_checkable
 class EmbeddingClient(Protocol):
     """Embeds request-visible text for routing and task mining."""
 

--- a/wmo/common/project/paths.py
+++ b/wmo/common/project/paths.py
@@ -63,6 +63,16 @@ class ProjectPaths:
         return self.project_directory / "review.json"
 
     @property
+    def runtime_directory(self) -> Path:
+        """Return the mutable runtime-state directory outside immutable artifacts."""
+        return self.project_directory / "runtime"
+
+    @property
+    def runtime_journal(self) -> Path:
+        """Return the append-only routed-interaction journal path."""
+        return self.runtime_directory / "interactions.jsonl"
+
+    @property
     def artifacts_directory(self) -> Path:
         """Return the directory that contains completed immutable artifacts."""
         return self.project_directory / "artifacts"

--- a/wmo/common/project/paths_test.py
+++ b/wmo/common/project/paths_test.py
@@ -32,3 +32,12 @@ def test_project_paths_reject_a_symlink_escape(tmp_path: Path) -> None:
 
     with pytest.raises(ProjectPathError, match="escapes"):
         paths.artifact_file("artifact-1", "link/data.json")
+
+
+def test_project_paths_keep_runtime_state_outside_immutable_artifacts(tmp_path: Path) -> None:
+    """The mutable journal has one project-local path that cannot overlap artifacts."""
+    paths = ProjectPaths(root=tmp_path / ".wmo", project_id="support-project")
+
+    assert paths.runtime_directory == tmp_path / ".wmo/projects/support-project/runtime"
+    assert paths.runtime_journal == paths.runtime_directory / "interactions.jsonl"
+    assert not paths.runtime_journal.is_relative_to(paths.artifacts_directory)

--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -7,6 +7,18 @@ from wmo.runtime.router.application import (
     load_router,
 )
 from wmo.runtime.router.endpoint import create_router_endpoint
+from wmo.runtime.router.journal import (
+    JournaledRouterRuntime,
+    RuntimeAcceptedEvent,
+    RuntimeAttemptFailedEvent,
+    RuntimeCompletedEvent,
+    RuntimeIdempotencyConflictError,
+    RuntimeInteractionFailedError,
+    RuntimeInteractionInProgressError,
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    RuntimeJournalEvent,
+)
 from wmo.runtime.router.runtime import (
     RoutedModelResponse,
     RouterEpisodeConflictError,
@@ -17,6 +29,16 @@ from wmo.runtime.router.runtime import (
 
 __all__ = [
     "RoutedModelResponse",
+    "JournaledRouterRuntime",
+    "RuntimeAcceptedEvent",
+    "RuntimeAttemptFailedEvent",
+    "RuntimeCompletedEvent",
+    "RuntimeIdempotencyConflictError",
+    "RuntimeInteractionFailedError",
+    "RuntimeInteractionInProgressError",
+    "RuntimeInteractionJournal",
+    "RuntimeJournalError",
+    "RuntimeJournalEvent",
     "RouterEpisodeConflictError",
     "RouterModelCapabilityError",
     "RouterRuntime",

--- a/wmo/runtime/router/journal.py
+++ b/wmo/runtime/router/journal.py
@@ -232,6 +232,12 @@ class RuntimeInteractionJournal:
         """Bind the journal to one project's canonical mutable runtime path."""
         self.path = paths.runtime_journal
         self.project_id = paths.project_id
+        self._durability_directories = (
+            paths.runtime_directory,
+            paths.project_directory,
+            paths.projects_directory,
+            paths.root,
+        )
 
     def read_events(self) -> tuple[RuntimeJournalEvent, ...]:
         """Read and fully validate all durable records, ignoring only a torn final line."""
@@ -322,14 +328,27 @@ class RuntimeInteractionJournal:
         failure: StructuredFailure,
         *,
         failed_at: datetime,
-    ) -> RuntimeAttemptFailedEvent:
-        """Append a failure only while the named attempt is still live."""
+    ) -> RuntimeAttemptFailedEvent | RuntimeCompletedEvent:
+        """Append a live failure or reconcile with a concurrent winning outcome."""
         _require_timezone(failed_at)
         with file_write_lock(self.path, what="the routed-interaction journal"):
             events = list(self._read_unlocked())
             state = _validate_events(events).get(accepted.interaction_id)
-            if state is None or state.accepted != accepted or state.terminal is not None:
-                raise RuntimeJournalError("cannot fail an interaction attempt that is not live")
+            if state is None or accepted not in events:
+                raise RuntimeJournalError(
+                    "cannot fail an interaction attempt that was not accepted"
+                )
+            if isinstance(state.terminal, RuntimeCompletedEvent):
+                return state.terminal
+            if state.accepted != accepted:
+                prior = _attempt_failure(events, accepted)
+                if prior is None:
+                    raise RuntimeJournalError("superseded attempt has no durable failure")
+                return prior
+            if state.terminal is not None:
+                if isinstance(state.terminal, RuntimeAttemptFailedEvent):
+                    return state.terminal
+                raise RuntimeJournalError("cannot fail an interaction after completion")
             event = _failed_event(
                 accepted,
                 failure,
@@ -346,13 +365,25 @@ class RuntimeInteractionJournal:
         *,
         completed_at: datetime,
     ) -> RuntimeCompletedEvent:
-        """Append a response only while the named attempt is still live."""
+        """Commit the first response, including one returned after a stale takeover."""
         _require_timezone(completed_at)
         with file_write_lock(self.path, what="the routed-interaction journal"):
             events = list(self._read_unlocked())
             state = _validate_events(events).get(accepted.interaction_id)
-            if state is None or state.accepted != accepted or state.terminal is not None:
-                raise RuntimeJournalError("cannot complete an interaction attempt that is not live")
+            if state is None or accepted not in events:
+                raise RuntimeJournalError(
+                    "cannot complete an interaction attempt that was not accepted"
+                )
+            if isinstance(state.terminal, RuntimeCompletedEvent):
+                return state.terminal
+            if state.accepted != accepted:
+                prior = _attempt_failure(events, accepted)
+                if prior is None or not prior.retryable:
+                    raise RuntimeJournalError(
+                        "superseded attempt lacks a retryable durable failure"
+                    )
+            elif state.terminal is not None:
+                raise RuntimeJournalError("cannot complete a terminal interaction attempt")
             event = _completed_event(
                 accepted,
                 response,
@@ -390,6 +421,7 @@ class RuntimeInteractionJournal:
             raise RuntimeJournalError("runtime event ID differs from its canonical content")
         _prepare_runtime_directory(self.path)
         _truncate_torn_tail(self.path)
+        created = not self.path.exists()
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
@@ -400,6 +432,8 @@ class RuntimeInteractionJournal:
                 handle.write(canonical_json_bytes(event) + b"\n")
                 handle.flush()
                 os.fsync(handle.fileno())
+            if created:
+                _fsync_directories(self._durability_directories)
         except OSError as exc:
             raise RuntimeJournalError(f"cannot append runtime journal {self.path}") from exc
 
@@ -520,14 +554,22 @@ class JournaledRouterRuntime:
             )
         except Exception as exc:
             failure = _structured_provider_failure(exc)
-            self.journal.record_failure(accepted, failure, failed_at=self._clock())
+            terminal = self.journal.record_failure(accepted, failure, failed_at=self._clock())
+            if isinstance(terminal, RuntimeCompletedEvent):
+                return RoutedModelResponse(
+                    decision=accepted.decision,
+                    response=terminal.response,
+                )
             raise
-        self.journal.record_completed(
+        completed = self.journal.record_completed(
             accepted,
             routed.response,
             completed_at=self._clock(),
         )
-        return routed
+        return RoutedModelResponse(
+            decision=accepted.decision,
+            response=completed.response,
+        )
 
 
 def _interaction_identity(
@@ -639,6 +681,8 @@ def _validate_events(
 ) -> dict[str, _InteractionState]:
     """Validate global order, content digests, and every interaction transition."""
     states: dict[str, _InteractionState] = {}
+    accepted_attempts: dict[tuple[str, int], RuntimeAcceptedEvent] = {}
+    failed_attempts: dict[tuple[str, int], RuntimeAttemptFailedEvent] = {}
     key_owners: dict[tuple[str, str], str] = {}
     seen_event_ids: set[str] = set()
     for expected_ordinal, event in enumerate(events, start=1):
@@ -684,19 +728,33 @@ def _validate_events(
                 if _acceptance_pins(event) != _acceptance_pins(state.accepted):
                     raise RuntimeJournalError("retry drifted from the original accepted pins")
             states[event.interaction_id] = _InteractionState(event, None)
+            accepted_attempts[(event.interaction_id, event.attempt_ordinal)] = event
             continue
         if state is None:
             raise RuntimeJournalError("terminal runtime event has no accepted attempt")
-        if state.terminal is not None:
-            raise RuntimeJournalError("runtime attempt has more than one terminal event")
-        if event.attempt_ordinal != state.accepted.attempt_ordinal:
-            raise RuntimeJournalError("terminal event names a different attempt ordinal")
+        accepted = accepted_attempts.get((event.interaction_id, event.attempt_ordinal))
+        if accepted is None:
+            raise RuntimeJournalError("terminal event names an unaccepted attempt ordinal")
         if isinstance(event, RuntimeAttemptFailedEvent):
-            if event.attempt_started_at != state.accepted.attempt_started_at:
+            if state.terminal is not None:
+                raise RuntimeJournalError("runtime attempt has more than one terminal event")
+            if accepted != state.accepted:
+                raise RuntimeJournalError("failure event names a superseded attempt")
+            if event.attempt_started_at != accepted.attempt_started_at:
                 raise RuntimeJournalError("failure start time differs from accepted attempt")
-        elif event.completed_at < state.accepted.attempt_started_at:
+            failed_attempts[(event.interaction_id, event.attempt_ordinal)] = event
+            states[event.interaction_id] = _InteractionState(state.accepted, event)
+        elif event.completed_at < accepted.attempt_started_at:
             raise RuntimeJournalError("completion precedes its accepted attempt")
-        states[event.interaction_id] = _InteractionState(state.accepted, event)
+        elif isinstance(state.terminal, RuntimeCompletedEvent):
+            raise RuntimeJournalError("interaction has more than one completed response")
+        elif accepted != state.accepted:
+            prior = failed_attempts.get((event.interaction_id, event.attempt_ordinal))
+            if prior is None or not prior.retryable:
+                raise RuntimeJournalError("superseded completion lacks a retryable durable failure")
+            states[event.interaction_id] = _InteractionState(state.accepted, event)
+        else:
+            states[event.interaction_id] = _InteractionState(accepted, event)
     return states
 
 
@@ -798,6 +856,38 @@ def _prepare_runtime_directory(path: Path) -> None:
         raise RuntimeJournalError("runtime journal directory must be a real directory")
     if path.is_symlink():
         raise RuntimeJournalError("runtime journal path cannot be a symbolic link")
+
+
+def _attempt_failure(
+    events: list[RuntimeJournalEvent], accepted: RuntimeAcceptedEvent
+) -> RuntimeAttemptFailedEvent | None:
+    """Return the durable failure that closed one accepted attempt, if present."""
+    for event in events:
+        if (
+            isinstance(event, RuntimeAttemptFailedEvent)
+            and event.interaction_id == accepted.interaction_id
+            and event.attempt_ordinal == accepted.attempt_ordinal
+        ):
+            return event
+    return None
+
+
+def _fsync_directories(directories: tuple[Path, ...]) -> None:
+    """Persist a newly created journal and every project directory entry that names it."""
+    if os.name == "nt":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    for directory in directories:
+        try:
+            descriptor = os.open(directory, flags)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        except OSError as exc:
+            raise RuntimeJournalError(
+                f"cannot persist runtime journal directory {directory}"
+            ) from exc
 
 
 def _truncate_torn_tail(path: Path) -> None:

--- a/wmo/runtime/router/journal.py
+++ b/wmo/runtime/router/journal.py
@@ -1,0 +1,819 @@
+"""Durable routed-interaction journal and local idempotency boundary.
+
+The journal guarantees one local logical interaction and one durable target for each project and
+idempotency key. Provider dispatch can still be at-least-once if the process crashes after the
+provider succeeds but before the completion record reaches disk. Remote exactly-once behavior is
+available only when the selected provider honors the explicitly forwarded idempotency key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import Field, TypeAdapter, ValidationError, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactInput,
+    ContractModel,
+    FailureAttribution,
+    FailureCode,
+    Sha256,
+    StructuredFailure,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.core.locks import file_write_lock
+from wmo.common.models import ModelRequest, ModelResponse, ModelSnapshot
+from wmo.common.project import ProjectPaths
+from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
+from wmo.runtime.models.providers.transport import ProviderTransportError
+from wmo.runtime.router.runtime import (
+    RoutedModelResponse,
+    RouterRuntime,
+    RouterRuntimeIntegrityError,
+)
+
+
+class RuntimeJournalError(ValueError):
+    """The runtime journal is corrupt or an attempted transition is invalid."""
+
+
+class RuntimeIdempotencyConflictError(ValueError):
+    """An idempotency key was reused for different request or lineage content."""
+
+
+class RuntimeInteractionInProgressError(RuntimeError):
+    """Another process still owns the live provider attempt for this interaction."""
+
+    retryable = True
+
+
+class RuntimeInteractionFailedError(RuntimeError):
+    """A prior non-retryable provider attempt ended without a completed response."""
+
+    retryable = False
+
+    def __init__(self, failure: StructuredFailure) -> None:
+        super().__init__(failure.message)
+        self.failure = failure
+
+
+class RuntimeInteractionIdentity(ContractModel):
+    """Secret-free identity used to find and compare one logical interaction."""
+
+    interaction_id: str = Field(pattern=r"^interaction-[0-9a-f]{20}$")
+    project_id: str = Field(pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+    idempotency_key_sha256: Sha256
+    request: ModelRequest
+    request_sha256: Sha256
+    lineage_id: str = Field(pattern=r"^lineage-[0-9a-f]{20}$")
+
+    @model_validator(mode="after")
+    def _require_request_digest(self) -> RuntimeInteractionIdentity:
+        if self.request_sha256 != sha256_json(self.request):
+            raise ValueError("interaction request digest differs from canonical request")
+        return self
+
+
+class RuntimeAcceptance(ContractModel):
+    """Immutable route pins proposed before the first target dispatch."""
+
+    decision: RoutingDecision
+    selected_alias: str = Field(min_length=1, max_length=128)
+    selected_model: ModelSnapshot
+    policy_input: ArtifactInput
+
+    @model_validator(mode="after")
+    def _require_matching_route_pins(self) -> RuntimeAcceptance:
+        if self.selected_alias != self.decision.selected_alias:
+            raise ValueError("accepted selected alias differs from the routing decision")
+        if (
+            self.policy_input.artifact_id != self.decision.policy_id
+            or self.policy_input.sha256 != self.decision.policy_sha256
+        ):
+            raise ValueError("accepted policy input differs from the routing decision")
+        return self
+
+
+class RuntimeAcceptedEvent(ContractModel):
+    """One initial or retry attempt accepted against immutable request and route pins."""
+
+    event: Literal["accepted"] = "accepted"
+    event_id: str = Field(pattern=r"^runtime-event-[0-9a-f]{20}$")
+    ordinal: int = Field(gt=0)
+    attempt_ordinal: int = Field(gt=0)
+    interaction_id: str = Field(pattern=r"^interaction-[0-9a-f]{20}$")
+    project_id: str = Field(pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+    idempotency_key_sha256: Sha256
+    request: ModelRequest
+    request_sha256: Sha256
+    lineage_id: str = Field(pattern=r"^lineage-[0-9a-f]{20}$")
+    decision: RoutingDecision
+    selected_alias: str = Field(min_length=1, max_length=128)
+    selected_model: ModelSnapshot
+    policy_input: ArtifactInput
+    received_at: datetime
+    attempt_started_at: datetime
+
+    @field_validator("received_at", "attempt_started_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("runtime journal timestamps must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _require_matching_pins(self) -> RuntimeAcceptedEvent:
+        if self.request_sha256 != sha256_json(self.request):
+            raise ValueError("accepted request digest differs from canonical request")
+        RuntimeAcceptance(
+            decision=self.decision,
+            selected_alias=self.selected_alias,
+            selected_model=self.selected_model,
+            policy_input=self.policy_input,
+        )
+        return self
+
+
+class RuntimeAttemptFailedEvent(ContractModel):
+    """One provider attempt that ended without a response target."""
+
+    event: Literal["attempt_failed"] = "attempt_failed"
+    event_id: str = Field(pattern=r"^runtime-event-[0-9a-f]{20}$")
+    ordinal: int = Field(gt=0)
+    attempt_ordinal: int = Field(gt=0)
+    interaction_id: str = Field(pattern=r"^interaction-[0-9a-f]{20}$")
+    failure: StructuredFailure
+    retryable: bool
+    attempt_started_at: datetime
+    failed_at: datetime
+
+    @field_validator("attempt_started_at", "failed_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("runtime journal timestamps must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _require_matching_failure(self) -> RuntimeAttemptFailedEvent:
+        if self.retryable != self.failure.retryable:
+            raise ValueError("attempt retryability differs from its structured failure")
+        if self.failed_at < self.attempt_started_at:
+            raise ValueError("attempt failure precedes its start")
+        return self
+
+
+class RuntimeCompletedEvent(ContractModel):
+    """One completed canonical response committed after provider success."""
+
+    event: Literal["completed"] = "completed"
+    event_id: str = Field(pattern=r"^runtime-event-[0-9a-f]{20}$")
+    ordinal: int = Field(gt=0)
+    attempt_ordinal: int = Field(gt=0)
+    interaction_id: str = Field(pattern=r"^interaction-[0-9a-f]{20}$")
+    response: ModelResponse
+    response_sha256: Sha256
+    completed_at: datetime
+
+    @field_validator("completed_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("runtime journal timestamps must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _require_response_digest(self) -> RuntimeCompletedEvent:
+        if self.response_sha256 != sha256_json(self.response):
+            raise ValueError("completed response digest differs from canonical response")
+        return self
+
+
+RuntimeJournalEvent = Annotated[
+    RuntimeAcceptedEvent | RuntimeAttemptFailedEvent | RuntimeCompletedEvent,
+    Field(discriminator="event"),
+]
+_EVENT_ADAPTER: TypeAdapter[RuntimeJournalEvent] = TypeAdapter(RuntimeJournalEvent)
+
+
+@dataclass(frozen=True)
+class _InteractionState:
+    """Validated latest state for one interaction."""
+
+    accepted: RuntimeAcceptedEvent
+    terminal: RuntimeAttemptFailedEvent | RuntimeCompletedEvent | None
+
+
+@dataclass(frozen=True)
+class JournalClaim:
+    """Result of one atomic attempt to claim an interaction."""
+
+    status: Literal["needs_selection", "dispatch", "live", "completed", "failed"]
+    accepted: RuntimeAcceptedEvent | None = None
+    completed: RuntimeCompletedEvent | None = None
+    failure: RuntimeAttemptFailedEvent | None = None
+
+
+class RuntimeInteractionJournal:
+    """Strict append-only JSONL state for routed interactions in one project."""
+
+    def __init__(self, paths: ProjectPaths) -> None:
+        """Bind the journal to one project's canonical mutable runtime path."""
+        self.path = paths.runtime_journal
+        self.project_id = paths.project_id
+
+    def read_events(self) -> tuple[RuntimeJournalEvent, ...]:
+        """Read and fully validate all durable records, ignoring only a torn final line."""
+        with file_write_lock(self.path, what="the routed-interaction journal"):
+            return self._read_unlocked()
+
+    def claim(
+        self,
+        identity: RuntimeInteractionIdentity,
+        acceptance: RuntimeAcceptance | None,
+        *,
+        now: datetime,
+        stale_after: timedelta,
+    ) -> JournalClaim:
+        """Atomically inspect, create, or retry one provider attempt.
+
+        Args:
+            identity: Secret-free interaction identity derived from caller input.
+            acceptance: Route pins selected outside the journal lock, if selection was needed.
+            now: Current timezone-aware time.
+            stale_after: Age after which an unclosed attempt may be retried.
+
+        Returns:
+            A claim telling the caller to select, dispatch, wait, replay, or fail.
+        """
+        _require_timezone(now)
+        if stale_after.total_seconds() <= 0:
+            raise ValueError("stale_after must be positive")
+        with file_write_lock(self.path, what="the routed-interaction journal"):
+            events = list(self._read_unlocked())
+            states = _validate_events(events)
+            state = states.get(identity.interaction_id)
+            if state is None:
+                if acceptance is None:
+                    return JournalClaim("needs_selection")
+                accepted = _accepted_event(
+                    identity,
+                    acceptance,
+                    ordinal=len(events) + 1,
+                    attempt_ordinal=1,
+                    received_at=now,
+                    attempt_started_at=now,
+                )
+                self._append_unlocked(accepted)
+                return JournalClaim("dispatch", accepted=accepted)
+            _require_identity(state.accepted, identity)
+            terminal = state.terminal
+            if isinstance(terminal, RuntimeCompletedEvent):
+                return JournalClaim("completed", accepted=state.accepted, completed=terminal)
+            if isinstance(terminal, RuntimeAttemptFailedEvent) and not terminal.retryable:
+                return JournalClaim("failed", accepted=state.accepted, failure=terminal)
+            if terminal is None and now - state.accepted.attempt_started_at < stale_after:
+                return JournalClaim("live", accepted=state.accepted)
+            if terminal is None:
+                stale_failure = StructuredFailure(
+                    code=FailureCode.TIMEOUT,
+                    message="prior routed model attempt became stale",
+                    retryable=True,
+                    attribution=FailureAttribution.MODEL,
+                )
+                failed = _failed_event(
+                    state.accepted,
+                    stale_failure,
+                    ordinal=len(events) + 1,
+                    failed_at=now,
+                )
+                self._append_unlocked(failed)
+                events.append(failed)
+            accepted = _accepted_event(
+                identity,
+                RuntimeAcceptance(
+                    decision=state.accepted.decision,
+                    selected_alias=state.accepted.selected_alias,
+                    selected_model=state.accepted.selected_model,
+                    policy_input=state.accepted.policy_input,
+                ),
+                ordinal=len(events) + 1,
+                attempt_ordinal=state.accepted.attempt_ordinal + 1,
+                received_at=state.accepted.received_at,
+                attempt_started_at=now,
+            )
+            self._append_unlocked(accepted)
+            return JournalClaim("dispatch", accepted=accepted)
+
+    def record_failure(
+        self,
+        accepted: RuntimeAcceptedEvent,
+        failure: StructuredFailure,
+        *,
+        failed_at: datetime,
+    ) -> RuntimeAttemptFailedEvent:
+        """Append a failure only while the named attempt is still live."""
+        _require_timezone(failed_at)
+        with file_write_lock(self.path, what="the routed-interaction journal"):
+            events = list(self._read_unlocked())
+            state = _validate_events(events).get(accepted.interaction_id)
+            if state is None or state.accepted != accepted or state.terminal is not None:
+                raise RuntimeJournalError("cannot fail an interaction attempt that is not live")
+            event = _failed_event(
+                accepted,
+                failure,
+                ordinal=len(events) + 1,
+                failed_at=failed_at,
+            )
+            self._append_unlocked(event)
+            return event
+
+    def record_completed(
+        self,
+        accepted: RuntimeAcceptedEvent,
+        response: ModelResponse,
+        *,
+        completed_at: datetime,
+    ) -> RuntimeCompletedEvent:
+        """Append a response only while the named attempt is still live."""
+        _require_timezone(completed_at)
+        if response.model != accepted.selected_model:
+            raise RuntimeJournalError("completed response model differs from the accepted target")
+        with file_write_lock(self.path, what="the routed-interaction journal"):
+            events = list(self._read_unlocked())
+            state = _validate_events(events).get(accepted.interaction_id)
+            if state is None or state.accepted != accepted or state.terminal is not None:
+                raise RuntimeJournalError("cannot complete an interaction attempt that is not live")
+            event = _completed_event(
+                accepted,
+                response,
+                ordinal=len(events) + 1,
+                completed_at=completed_at,
+            )
+            self._append_unlocked(event)
+            return event
+
+    def _read_unlocked(self) -> tuple[RuntimeJournalEvent, ...]:
+        try:
+            payload = self.path.read_bytes()
+        except FileNotFoundError:
+            return ()
+        except OSError as exc:
+            raise RuntimeJournalError(f"cannot read runtime journal {self.path}") from exc
+        lines = payload.splitlines(keepends=True)
+        if lines and not lines[-1].endswith(b"\n"):
+            lines.pop()
+        events: list[RuntimeJournalEvent] = []
+        for index, line in enumerate(lines, start=1):
+            if not line.strip():
+                raise RuntimeJournalError(f"runtime journal has a blank interior line {index}")
+            try:
+                events.append(_EVENT_ADAPTER.validate_json(line))
+            except (UnicodeDecodeError, ValidationError) as exc:
+                raise RuntimeJournalError(
+                    f"runtime journal has invalid interior line {index}"
+                ) from exc
+        _validate_events(events)
+        return tuple(events)
+
+    def _append_unlocked(self, event: RuntimeJournalEvent) -> None:
+        if event.event_id != _event_content_id(event):
+            raise RuntimeJournalError("runtime event ID differs from its canonical content")
+        _prepare_runtime_directory(self.path)
+        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(self.path, flags, 0o600)
+            with os.fdopen(descriptor, "ab", closefd=True) as handle:
+                handle.write(canonical_json_bytes(event) + b"\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as exc:
+            raise RuntimeJournalError(f"cannot append runtime journal {self.path}") from exc
+
+
+class JournaledRouterRuntime:
+    """Idempotent completion service around one verified ``RouterRuntime``.
+
+    WMO guarantees one local logical interaction and one pinned target. A provider dispatch can
+    happen more than once only in the crash-after-success, before-journal window, unless the
+    provider itself honors the forwarded idempotency key.
+    """
+
+    def __init__(
+        self,
+        runtime: RouterRuntime,
+        journal: RuntimeInteractionJournal,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        wait_timeout_seconds: float = 10.0,
+        stale_after_seconds: float = 120.0,
+    ) -> None:
+        """Create a durable wrapper with bounded live-attempt waiting."""
+        if wait_timeout_seconds < 0 or stale_after_seconds <= 0:
+            raise ValueError("journal wait must be non-negative and stale age must be positive")
+        self.runtime = runtime
+        self.journal = journal
+        self._clock = clock
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._wait_timeout_seconds = wait_timeout_seconds
+        self._stale_after = timedelta(seconds=stale_after_seconds)
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        idempotency_key: str,
+        conversation_id: str | None = None,
+    ) -> RoutedModelResponse:
+        """Return one durable response for a caller-owned idempotency key.
+
+        Args:
+            request: Canonical provider-neutral model request.
+            idempotency_key: Standard request key. Only its SHA-256 digest is persisted.
+            conversation_id: Optional caller identity for sticky routing. Only a stable digest ID
+                is persisted. The idempotency key defines a single interaction, not a conversation.
+
+        Returns:
+            The pinned routing decision and completed or replayed model response.
+
+        Raises:
+            RuntimeIdempotencyConflictError: The key was reused for different request content.
+            RuntimeInteractionInProgressError: A live attempt exceeded the bounded local wait.
+            RuntimeInteractionFailedError: A prior attempt failed permanently.
+        """
+        _validate_external_id(idempotency_key, label="idempotency key", visible_ascii=True)
+        if conversation_id is not None:
+            _validate_external_id(conversation_id, label="conversation ID", visible_ascii=False)
+        identity = _interaction_identity(
+            self.journal.project_id,
+            idempotency_key,
+            request,
+            conversation_id,
+        )
+        deadline = self._monotonic() + self._wait_timeout_seconds
+        acceptance: RuntimeAcceptance | None = None
+        while True:
+            claim = self.journal.claim(
+                identity,
+                acceptance,
+                now=self._clock(),
+                stale_after=self._stale_after,
+            )
+            if claim.status == "needs_selection":
+                decision = self.runtime.select(request, episode_id=identity.lineage_id)
+                acceptance = RuntimeAcceptance(
+                    decision=decision,
+                    selected_alias=decision.selected_alias,
+                    selected_model=_selected_model(self.runtime, decision.selected_alias),
+                    policy_input=ArtifactInput(
+                        artifact_id=decision.policy_id,
+                        sha256=decision.policy_sha256,
+                    ),
+                )
+                continue
+            if claim.status == "completed":
+                if claim.accepted is None or claim.completed is None:
+                    raise RuntimeJournalError("completed journal claim omitted its records")
+                return RoutedModelResponse(
+                    decision=claim.accepted.decision,
+                    response=claim.completed.response,
+                )
+            if claim.status == "failed":
+                if claim.failure is None:
+                    raise RuntimeJournalError("failed journal claim omitted its failure")
+                raise RuntimeInteractionFailedError(claim.failure.failure)
+            if claim.status == "live":
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    raise RuntimeInteractionInProgressError(
+                        "another process is completing this idempotent interaction; retry"
+                    )
+                self._sleep(min(0.05, remaining))
+                acceptance = None
+                continue
+            if claim.accepted is None:
+                raise RuntimeJournalError("dispatch journal claim omitted its accepted record")
+            accepted = claim.accepted
+            break
+        try:
+            routed = self.runtime.complete(
+                request,
+                episode_id=accepted.lineage_id,
+                decision=accepted.decision,
+                provider_idempotency_key=idempotency_key,
+            )
+        except Exception as exc:
+            failure = _structured_provider_failure(exc)
+            self.journal.record_failure(accepted, failure, failed_at=self._clock())
+            raise
+        self.journal.record_completed(
+            accepted,
+            routed.response,
+            completed_at=self._clock(),
+        )
+        return routed
+
+
+def _interaction_identity(
+    project_id: str,
+    idempotency_key: str,
+    request: ModelRequest,
+    conversation_id: str | None,
+) -> RuntimeInteractionIdentity:
+    """Build stable secret-free interaction and lineage identities."""
+    key_sha256 = hashlib.sha256(idempotency_key.encode("utf-8"), usedforsecurity=False).hexdigest()
+    lineage_value = conversation_id or idempotency_key
+    lineage_sha256 = hashlib.sha256(
+        lineage_value.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
+    lineage_id = stable_id("lineage", {"project_id": project_id, "lineage_sha256": lineage_sha256})
+    interaction_id = stable_id(
+        "interaction", {"project_id": project_id, "idempotency_key_sha256": key_sha256}
+    )
+    return RuntimeInteractionIdentity(
+        interaction_id=interaction_id,
+        project_id=project_id,
+        idempotency_key_sha256=key_sha256,
+        request=request,
+        request_sha256=sha256_json(request),
+        lineage_id=lineage_id,
+    )
+
+
+def _accepted_event(
+    identity: RuntimeInteractionIdentity,
+    acceptance: RuntimeAcceptance,
+    *,
+    ordinal: int,
+    attempt_ordinal: int,
+    received_at: datetime,
+    attempt_started_at: datetime,
+) -> RuntimeAcceptedEvent:
+    """Create one content-addressed accepted attempt with exact immutable pins."""
+    provisional = RuntimeAcceptedEvent(
+        event_id="runtime-event-00000000000000000000",
+        ordinal=ordinal,
+        attempt_ordinal=attempt_ordinal,
+        interaction_id=identity.interaction_id,
+        project_id=identity.project_id,
+        idempotency_key_sha256=identity.idempotency_key_sha256,
+        request=identity.request,
+        request_sha256=identity.request_sha256,
+        lineage_id=identity.lineage_id,
+        decision=acceptance.decision,
+        selected_alias=acceptance.selected_alias,
+        selected_model=acceptance.selected_model,
+        policy_input=acceptance.policy_input,
+        received_at=received_at,
+        attempt_started_at=attempt_started_at,
+    )
+    return provisional.model_copy(update={"event_id": _event_content_id(provisional)})
+
+
+def _failed_event(
+    accepted: RuntimeAcceptedEvent,
+    failure: StructuredFailure,
+    *,
+    ordinal: int,
+    failed_at: datetime,
+) -> RuntimeAttemptFailedEvent:
+    """Create one content-addressed terminal record for a failed attempt."""
+    provisional = RuntimeAttemptFailedEvent(
+        event_id="runtime-event-00000000000000000000",
+        ordinal=ordinal,
+        attempt_ordinal=accepted.attempt_ordinal,
+        interaction_id=accepted.interaction_id,
+        failure=failure,
+        retryable=failure.retryable,
+        attempt_started_at=accepted.attempt_started_at,
+        failed_at=failed_at,
+    )
+    return provisional.model_copy(update={"event_id": _event_content_id(provisional)})
+
+
+def _completed_event(
+    accepted: RuntimeAcceptedEvent,
+    response: ModelResponse,
+    *,
+    ordinal: int,
+    completed_at: datetime,
+) -> RuntimeCompletedEvent:
+    """Create one content-addressed completed response record."""
+    provisional = RuntimeCompletedEvent(
+        event_id="runtime-event-00000000000000000000",
+        ordinal=ordinal,
+        attempt_ordinal=accepted.attempt_ordinal,
+        interaction_id=accepted.interaction_id,
+        response=response,
+        response_sha256=sha256_json(response),
+        completed_at=completed_at,
+    )
+    return provisional.model_copy(update={"event_id": _event_content_id(provisional)})
+
+
+def _event_content_id(event: RuntimeJournalEvent) -> str:
+    """Return the stable content identity for one event, excluding its own ID."""
+    material = event.model_dump(mode="json")
+    del material["event_id"]
+    return stable_id("runtime-event", material)
+
+
+def _validate_events(
+    events: list[RuntimeJournalEvent] | tuple[RuntimeJournalEvent, ...],
+) -> dict[str, _InteractionState]:
+    """Validate global order, content digests, and every interaction transition."""
+    states: dict[str, _InteractionState] = {}
+    key_owners: dict[tuple[str, str], str] = {}
+    seen_event_ids: set[str] = set()
+    for expected_ordinal, event in enumerate(events, start=1):
+        if event.ordinal != expected_ordinal:
+            raise RuntimeJournalError("runtime journal ordinals are not contiguous")
+        if event.event_id in seen_event_ids:
+            raise RuntimeJournalError("runtime journal repeats an event ID")
+        if event.event_id != _event_content_id(event):
+            raise RuntimeJournalError("runtime event ID differs from its canonical content")
+        seen_event_ids.add(event.event_id)
+        state = states.get(event.interaction_id)
+        if isinstance(event, RuntimeAcceptedEvent):
+            expected_interaction_id = stable_id(
+                "interaction",
+                {
+                    "project_id": event.project_id,
+                    "idempotency_key_sha256": event.idempotency_key_sha256,
+                },
+            )
+            if event.interaction_id != expected_interaction_id:
+                raise RuntimeJournalError("interaction ID differs from project and key digest")
+            expected_episode_sha256 = hashlib.sha256(
+                event.lineage_id.encode("utf-8"), usedforsecurity=False
+            ).hexdigest()
+            if event.decision.episode_id_sha256 != expected_episode_sha256:
+                raise RuntimeJournalError("routing decision differs from accepted lineage")
+            feature = RouterFeatureExtractor().from_request(event.request)
+            feature_sha256 = hashlib.sha256(
+                feature.encode("utf-8"), usedforsecurity=False
+            ).hexdigest()
+            if event.decision.request_sha256 != feature_sha256:
+                raise RuntimeJournalError("routing decision differs from accepted request")
+            if event.decision.decision_id != _routing_decision_content_id(event.decision):
+                raise RuntimeJournalError("routing decision ID differs from its canonical content")
+            key = (event.project_id, event.idempotency_key_sha256)
+            owner = key_owners.setdefault(key, event.interaction_id)
+            if owner != event.interaction_id:
+                raise RuntimeJournalError("idempotency key digest maps to multiple interactions")
+            if state is None:
+                if event.attempt_ordinal != 1:
+                    raise RuntimeJournalError("first interaction attempt must have ordinal one")
+            else:
+                if not isinstance(state.terminal, RuntimeAttemptFailedEvent):
+                    raise RuntimeJournalError("accepted retry does not follow a failed attempt")
+                if not state.terminal.retryable:
+                    raise RuntimeJournalError("accepted retry follows a permanent failure")
+                if event.attempt_ordinal != state.accepted.attempt_ordinal + 1:
+                    raise RuntimeJournalError("interaction attempt ordinals are not contiguous")
+                if _acceptance_pins(event) != _acceptance_pins(state.accepted):
+                    raise RuntimeJournalError("retry drifted from the original accepted pins")
+            states[event.interaction_id] = _InteractionState(event, None)
+            continue
+        if state is None:
+            raise RuntimeJournalError("terminal runtime event has no accepted attempt")
+        if state.terminal is not None:
+            raise RuntimeJournalError("runtime attempt has more than one terminal event")
+        if event.attempt_ordinal != state.accepted.attempt_ordinal:
+            raise RuntimeJournalError("terminal event names a different attempt ordinal")
+        if isinstance(event, RuntimeAttemptFailedEvent):
+            if event.attempt_started_at != state.accepted.attempt_started_at:
+                raise RuntimeJournalError("failure start time differs from accepted attempt")
+        elif event.response.model != state.accepted.selected_model:
+            raise RuntimeJournalError("completed response model differs from accepted target")
+        states[event.interaction_id] = _InteractionState(state.accepted, event)
+    return states
+
+
+def _acceptance_pins(event: RuntimeAcceptedEvent) -> tuple[object, ...]:
+    """Return fields that retries must preserve exactly."""
+    return (
+        event.interaction_id,
+        event.project_id,
+        event.idempotency_key_sha256,
+        event.request,
+        event.request_sha256,
+        event.lineage_id,
+        event.decision,
+        event.selected_alias,
+        event.selected_model,
+        event.policy_input,
+        event.received_at,
+    )
+
+
+def _require_identity(accepted: RuntimeAcceptedEvent, identity: RuntimeInteractionIdentity) -> None:
+    """Reject reuse of one key with a different request, project, or lineage."""
+    actual = (
+        accepted.interaction_id,
+        accepted.project_id,
+        accepted.idempotency_key_sha256,
+        accepted.request,
+        accepted.request_sha256,
+        accepted.lineage_id,
+    )
+    expected = (
+        identity.interaction_id,
+        identity.project_id,
+        identity.idempotency_key_sha256,
+        identity.request,
+        identity.request_sha256,
+        identity.lineage_id,
+    )
+    if actual != expected:
+        raise RuntimeIdempotencyConflictError(
+            "idempotency key was already used for different request or conversation content"
+        )
+
+
+def _selected_model(runtime: RouterRuntime, alias: str) -> ModelSnapshot:
+    """Return the policy-pinned model snapshot for one selected candidate alias."""
+    for candidate in runtime.policy.candidates:
+        if candidate.alias == alias:
+            return candidate.model
+    raise RuntimeJournalError("routing decision selected an alias outside the frozen policy")
+
+
+def _structured_provider_failure(exception: Exception) -> StructuredFailure:
+    """Normalize a target-call exception without persisting its possibly secret message."""
+    if isinstance(exception, (RouterRuntimeIntegrityError, ValueError)):
+        return StructuredFailure(
+            code=FailureCode.INTERNAL,
+            message="routed model runtime rejected the accepted target",
+            retryable=False,
+            exception_type=type(exception).__name__,
+            attribution=FailureAttribution.MODEL,
+        )
+    retryable = isinstance(exception, TimeoutError)
+    code = FailureCode.TIMEOUT if retryable else FailureCode.PROVIDER
+    if isinstance(exception, ProviderTransportError):
+        retryable = (
+            exception.status_code is None
+            or exception.status_code
+            in {
+                408,
+                409,
+                425,
+                429,
+            }
+            or (exception.status_code is not None and exception.status_code >= 500)
+        )
+        code = FailureCode.PROVIDER
+    return StructuredFailure(
+        code=code,
+        message="routed model provider attempt failed",
+        retryable=retryable,
+        exception_type=type(exception).__name__,
+        attribution=FailureAttribution.MODEL,
+    )
+
+
+def _routing_decision_content_id(decision: RoutingDecision) -> str:
+    """Return the canonical identity required by durable routing decisions."""
+    material = decision.model_dump(mode="json")
+    del material["decision_id"]
+    return stable_id("routing-decision", material)
+
+
+def _prepare_runtime_directory(path: Path) -> None:
+    """Create a private runtime directory and reject symlinked journal targets."""
+    directory = path.parent
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if directory.is_symlink() or not directory.is_dir():
+        raise RuntimeJournalError("runtime journal directory must be a real directory")
+    directory.chmod(0o700)
+    if path.is_symlink():
+        raise RuntimeJournalError("runtime journal path cannot be a symbolic link")
+
+
+def _validate_external_id(value: str, *, label: str, visible_ascii: bool) -> None:
+    """Validate a caller identity before hashing and provider forwarding."""
+    if not value or len(value) > 512 or value.strip() != value:
+        raise ValueError(f"{label} must be 1 to 512 non-blank characters")
+    if visible_ascii and any(ord(character) < 33 or ord(character) > 126 for character in value):
+        raise ValueError(f"{label} must contain only visible ASCII characters")
+
+
+def _require_timezone(value: datetime) -> None:
+    """Require an aware timestamp at the journal boundary."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("runtime journal timestamps must include a timezone")

--- a/wmo/runtime/router/journal.py
+++ b/wmo/runtime/router/journal.py
@@ -33,7 +33,7 @@ from wmo.common.core.artifacts import (
 from wmo.common.core.locks import file_write_lock
 from wmo.common.models import ModelRequest, ModelResponse, ModelSnapshot
 from wmo.common.project import ProjectPaths
-from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
+from wmo.common.routing import RoutingDecision
 from wmo.runtime.models.providers.transport import ProviderTransportError
 from wmo.runtime.router.runtime import (
     RoutedModelResponse,
@@ -134,6 +134,8 @@ class RuntimeAcceptedEvent(ContractModel):
     def _require_matching_pins(self) -> RuntimeAcceptedEvent:
         if self.request_sha256 != sha256_json(self.request):
             raise ValueError("accepted request digest differs from canonical request")
+        if self.attempt_started_at < self.received_at:
+            raise ValueError("accepted attempt start precedes request receipt")
         RuntimeAcceptance(
             decision=self.decision,
             selected_alias=self.selected_alias,
@@ -346,8 +348,6 @@ class RuntimeInteractionJournal:
     ) -> RuntimeCompletedEvent:
         """Append a response only while the named attempt is still live."""
         _require_timezone(completed_at)
-        if response.model != accepted.selected_model:
-            raise RuntimeJournalError("completed response model differs from the accepted target")
         with file_write_lock(self.path, what="the routed-interaction journal"):
             events = list(self._read_unlocked())
             state = _validate_events(events).get(accepted.interaction_id)
@@ -665,12 +665,6 @@ def _validate_events(
             ).hexdigest()
             if event.decision.episode_id_sha256 != expected_episode_sha256:
                 raise RuntimeJournalError("routing decision differs from accepted lineage")
-            feature = RouterFeatureExtractor().from_request(event.request)
-            feature_sha256 = hashlib.sha256(
-                feature.encode("utf-8"), usedforsecurity=False
-            ).hexdigest()
-            if event.decision.request_sha256 != feature_sha256:
-                raise RuntimeJournalError("routing decision differs from accepted request")
             if event.decision.decision_id != _routing_decision_content_id(event.decision):
                 raise RuntimeJournalError("routing decision ID differs from its canonical content")
             key = (event.project_id, event.idempotency_key_sha256)
@@ -700,8 +694,8 @@ def _validate_events(
         if isinstance(event, RuntimeAttemptFailedEvent):
             if event.attempt_started_at != state.accepted.attempt_started_at:
                 raise RuntimeJournalError("failure start time differs from accepted attempt")
-        elif event.response.model != state.accepted.selected_model:
-            raise RuntimeJournalError("completed response model differs from accepted target")
+        elif event.completed_at < state.accepted.attempt_started_at:
+            raise RuntimeJournalError("completion precedes its accepted attempt")
         states[event.interaction_id] = _InteractionState(state.accepted, event)
     return states
 

--- a/wmo/runtime/router/journal.py
+++ b/wmo/runtime/router/journal.py
@@ -364,8 +364,8 @@ class RuntimeInteractionJournal:
         response: ModelResponse,
         *,
         completed_at: datetime,
-    ) -> RuntimeCompletedEvent:
-        """Commit the first response, including one returned after a stale takeover."""
+    ) -> RuntimeAttemptFailedEvent | RuntimeCompletedEvent:
+        """Commit the first response or observe an earlier permanent failure."""
         _require_timezone(completed_at)
         with file_write_lock(self.path, what="the routed-interaction journal"):
             events = list(self._read_unlocked())
@@ -375,6 +375,11 @@ class RuntimeInteractionJournal:
                     "cannot complete an interaction attempt that was not accepted"
                 )
             if isinstance(state.terminal, RuntimeCompletedEvent):
+                return state.terminal
+            if (
+                isinstance(state.terminal, RuntimeAttemptFailedEvent)
+                and not state.terminal.retryable
+            ):
                 return state.terminal
             if state.accepted != accepted:
                 prior = _attempt_failure(events, accepted)
@@ -421,7 +426,6 @@ class RuntimeInteractionJournal:
             raise RuntimeJournalError("runtime event ID differs from its canonical content")
         _prepare_runtime_directory(self.path)
         _truncate_torn_tail(self.path)
-        created = not self.path.exists()
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
@@ -432,8 +436,7 @@ class RuntimeInteractionJournal:
                 handle.write(canonical_json_bytes(event) + b"\n")
                 handle.flush()
                 os.fsync(handle.fileno())
-            if created:
-                _fsync_directories(self._durability_directories)
+            _fsync_directories(self._durability_directories)
         except OSError as exc:
             raise RuntimeJournalError(f"cannot append runtime journal {self.path}") from exc
 
@@ -566,6 +569,8 @@ class JournaledRouterRuntime:
             routed.response,
             completed_at=self._clock(),
         )
+        if isinstance(completed, RuntimeAttemptFailedEvent):
+            raise RuntimeInteractionFailedError(completed.failure)
         return RoutedModelResponse(
             decision=accepted.decision,
             response=completed.response,
@@ -748,7 +753,14 @@ def _validate_events(
             raise RuntimeJournalError("completion precedes its accepted attempt")
         elif isinstance(state.terminal, RuntimeCompletedEvent):
             raise RuntimeJournalError("interaction has more than one completed response")
+        elif isinstance(state.terminal, RuntimeAttemptFailedEvent) and accepted == state.accepted:
+            raise RuntimeJournalError("runtime attempt has more than one terminal event")
         elif accepted != state.accepted:
+            if (
+                isinstance(state.terminal, RuntimeAttemptFailedEvent)
+                and not state.terminal.retryable
+            ):
+                raise RuntimeJournalError("completion follows a permanent interaction failure")
             prior = failed_attempts.get((event.interaction_id, event.attempt_ordinal))
             if prior is None or not prior.retryable:
                 raise RuntimeJournalError("superseded completion lacks a retryable durable failure")
@@ -873,7 +885,7 @@ def _attempt_failure(
 
 
 def _fsync_directories(directories: tuple[Path, ...]) -> None:
-    """Persist a newly created journal and every project directory entry that names it."""
+    """Persist the journal and every project directory entry that names it."""
     if os.name == "nt":
         return
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)

--- a/wmo/runtime/router/journal.py
+++ b/wmo/runtime/router/journal.py
@@ -389,11 +389,13 @@ class RuntimeInteractionJournal:
         if event.event_id != _event_content_id(event):
             raise RuntimeJournalError("runtime event ID differs from its canonical content")
         _prepare_runtime_directory(self.path)
+        _truncate_torn_tail(self.path)
         flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         try:
             descriptor = os.open(self.path, flags, 0o600)
+            os.fchmod(descriptor, 0o600)
             with os.fdopen(descriptor, "ab", closefd=True) as handle:
                 handle.write(canonical_json_bytes(event) + b"\n")
                 handle.flush()
@@ -800,9 +802,26 @@ def _prepare_runtime_directory(path: Path) -> None:
     directory.mkdir(mode=0o700, parents=True, exist_ok=True)
     if directory.is_symlink() or not directory.is_dir():
         raise RuntimeJournalError("runtime journal directory must be a real directory")
-    directory.chmod(0o700)
     if path.is_symlink():
         raise RuntimeJournalError("runtime journal path cannot be a symbolic link")
+
+
+def _truncate_torn_tail(path: Path) -> None:
+    """Remove only a non-newline-terminated final record before the next append."""
+    try:
+        with path.open("r+b") as handle:
+            payload = handle.read()
+            if not payload or payload.endswith(b"\n"):
+                return
+            last_newline = payload.rfind(b"\n")
+            handle.seek(last_newline + 1)
+            handle.truncate()
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise RuntimeJournalError(f"cannot repair torn runtime journal {path}") from exc
 
 
 def _validate_external_id(value: str, *, label: str, visible_ascii: bool) -> None:

--- a/wmo/runtime/router/journal_test.py
+++ b/wmo/runtime/router/journal_test.py
@@ -353,6 +353,63 @@ def test_stale_attempt_gets_failure_then_retry_with_original_route(tmp_path: Pat
     ]
 
 
+def test_original_provider_success_wins_after_concurrent_stale_takeover(tmp_path: Path) -> None:
+    """A late original success commits once and prevents a replacement response."""
+    journal = RuntimeInteractionJournal(
+        ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    )
+    request = _request()
+    identity = _interaction_identity("support-agent", "takeover-key", request, None)
+    decision = _decision(identity.lineage_id)
+    acceptance = RuntimeAcceptance(
+        decision=decision,
+        selected_alias=decision.selected_alias,
+        selected_model=_snapshot(),
+        policy_input=ArtifactInput(artifact_id=decision.policy_id, sha256=decision.policy_sha256),
+    )
+    original = journal.claim(
+        identity,
+        acceptance,
+        now=_TIME,
+        stale_after=timedelta(seconds=1),
+    )
+    replacement = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(seconds=1),
+    )
+    assert original.accepted is not None
+    assert replacement.accepted is not None
+
+    winning = journal.record_completed(
+        original.accepted,
+        _response(),
+        completed_at=_TIME + timedelta(seconds=3),
+    )
+    replay = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=4),
+        stale_after=timedelta(seconds=1),
+    )
+
+    assert replay.status == "completed"
+    assert replay.completed == winning
+    replacement_observed = journal.record_completed(
+        replacement.accepted,
+        _response().model_copy(update={"output": AssistantAction(content="replacement")}),
+        completed_at=_TIME + timedelta(seconds=5),
+    )
+    assert replacement_observed == winning
+    assert [event.event for event in journal.read_events()] == [
+        "accepted",
+        "attempt_failed",
+        "accepted",
+        "completed",
+    ]
+
+
 def test_live_attempt_wait_is_bounded_and_retryable(tmp_path: Path) -> None:
     """A live attempt produces a bounded retryable conflict instead of hanging."""
     journal = RuntimeInteractionJournal(
@@ -403,4 +460,39 @@ def test_append_flushes_and_fsyncs_before_return(
     service = _service(tmp_path / ".wmo", _FakeRuntime())
     service.complete(_request(), idempotency_key="fsync-key")
 
-    assert len(calls) == 2
+    assert len(calls) >= 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory fsync is POSIX-only")
+def test_first_append_fsyncs_file_and_new_directory_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A first accepted claim persists the file and each newly named parent entry."""
+    fsync_calls = 0
+    directory_opens: list[Path] = []
+    real_fsync = os.fsync
+    real_open = os.open
+
+    def record_fsync(descriptor: int) -> None:
+        nonlocal fsync_calls
+        fsync_calls += 1
+        real_fsync(descriptor)
+
+    def record_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+    ) -> int:
+        if flags & getattr(os, "O_DIRECTORY", 0):
+            directory_opens.append(Path(os.fsdecode(path)))
+        return real_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+    monkeypatch.setattr(os, "open", record_open)
+    service = _service(tmp_path / ".wmo", _FakeRuntime())
+    service.complete(_request(), idempotency_key="directory-fsync-key")
+
+    assert fsync_calls >= 6
+    assert {"runtime", "support-agent", "projects", ".wmo"}.issubset(
+        {path.name for path in directory_opens}
+    )

--- a/wmo/runtime/router/journal_test.py
+++ b/wmo/runtime/router/journal_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import multiprocessing
 import os
+import stat
 import threading
 import time
 from datetime import UTC, datetime, timedelta
@@ -15,7 +16,13 @@ from typing import cast
 
 import pytest
 
-from wmo.common.core.artifacts import ArtifactInput, stable_id
+from wmo.common.core.artifacts import (
+    ArtifactInput,
+    FailureAttribution,
+    FailureCode,
+    StructuredFailure,
+    stable_id,
+)
 from wmo.common.models import (
     AssistantAction,
     ModelMessage,
@@ -36,6 +43,7 @@ from wmo.runtime.router.journal import (
     RuntimeInteractionInProgressError,
     RuntimeInteractionJournal,
     RuntimeJournalError,
+    _completed_event,
     _interaction_identity,
 )
 from wmo.runtime.router.runtime import RoutedModelResponse, RouterRuntime
@@ -410,6 +418,78 @@ def test_original_provider_success_wins_after_concurrent_stale_takeover(tmp_path
     ]
 
 
+def test_replacement_permanent_failure_wins_over_late_original_success(tmp_path: Path) -> None:
+    """A replacement's permanent failure remains canonical after a late original success."""
+    journal = RuntimeInteractionJournal(
+        ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    )
+    request = _request()
+    identity = _interaction_identity("support-agent", "permanent-key", request, None)
+    decision = _decision(identity.lineage_id)
+    acceptance = RuntimeAcceptance(
+        decision=decision,
+        selected_alias=decision.selected_alias,
+        selected_model=_snapshot(),
+        policy_input=ArtifactInput(artifact_id=decision.policy_id, sha256=decision.policy_sha256),
+    )
+    original = journal.claim(
+        identity,
+        acceptance,
+        now=_TIME,
+        stale_after=timedelta(seconds=1),
+    )
+    replacement = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(seconds=1),
+    )
+    assert original.accepted is not None
+    assert replacement.accepted is not None
+    permanent = StructuredFailure(
+        code=FailureCode.PROVIDER,
+        message="routed model provider attempt failed permanently",
+        retryable=False,
+        attribution=FailureAttribution.MODEL,
+    )
+    terminal = journal.record_failure(
+        replacement.accepted,
+        permanent,
+        failed_at=_TIME + timedelta(seconds=3),
+    )
+
+    observed = journal.record_completed(
+        original.accepted,
+        _response(),
+        completed_at=_TIME + timedelta(seconds=4),
+    )
+
+    assert observed == terminal
+    failed_claim = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=5),
+        stale_after=timedelta(seconds=1),
+    )
+    assert failed_claim.status == "failed"
+    assert [event.event for event in journal.read_events()] == [
+        "accepted",
+        "attempt_failed",
+        "accepted",
+        "attempt_failed",
+    ]
+
+    corrupted_completion = _completed_event(
+        original.accepted,
+        _response(),
+        ordinal=5,
+        completed_at=_TIME + timedelta(seconds=4),
+    )
+    journal._append_unlocked(corrupted_completion)
+    with pytest.raises(RuntimeJournalError, match="permanent interaction failure"):
+        journal.read_events()
+
+
 def test_live_attempt_wait_is_bounded_and_retryable(tmp_path: Path) -> None:
     """A live attempt produces a bounded retryable conflict instead of hanging."""
     journal = RuntimeInteractionJournal(
@@ -496,3 +576,58 @@ def test_first_append_fsyncs_file_and_new_directory_entries(
     assert {"runtime", "support-agent", "projects", ".wmo"}.issubset(
         {path.name for path in directory_opens}
     )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory fsync is POSIX-only")
+def test_append_retries_directory_fsync_after_first_creation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A later append repairs directory durability after first creation fsync fails."""
+    journal = RuntimeInteractionJournal(
+        ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    )
+    request = _request()
+    identity = _interaction_identity("support-agent", "fsync-retry-key", request, None)
+    decision = _decision(identity.lineage_id)
+    acceptance = RuntimeAcceptance(
+        decision=decision,
+        selected_alias=decision.selected_alias,
+        selected_model=_snapshot(),
+        policy_input=ArtifactInput(artifact_id=decision.policy_id, sha256=decision.policy_sha256),
+    )
+    directory_failures = 0
+    successful_directory_fsyncs = 0
+    real_fsync = os.fsync
+
+    def fail_first_directory_fsync(descriptor: int) -> None:
+        nonlocal directory_failures, successful_directory_fsyncs
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            if directory_failures == 0:
+                directory_failures += 1
+                raise OSError("simulated directory fsync failure")
+            successful_directory_fsyncs += 1
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", fail_first_directory_fsync)
+    with pytest.raises(RuntimeJournalError, match="cannot persist runtime journal directory"):
+        journal.claim(
+            identity,
+            acceptance,
+            now=_TIME,
+            stale_after=timedelta(seconds=1),
+        )
+
+    retry = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(seconds=1),
+    )
+
+    assert retry.status == "dispatch"
+    assert successful_directory_fsyncs >= 8
+    assert [event.event for event in journal.read_events()] == [
+        "accepted",
+        "attempt_failed",
+        "accepted",
+    ]

--- a/wmo/runtime/router/journal_test.py
+++ b/wmo/runtime/router/journal_test.py
@@ -1,0 +1,403 @@
+"""Adversarial tests for the routed-interaction journal and idempotency service."""
+
+from __future__ import annotations
+
+import hashlib
+import multiprocessing
+import os
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from multiprocessing.sharedctypes import Synchronized
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactInput, stable_id
+from wmo.common.models import (
+    AssistantAction,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    RoutedCandidateSnapshot,
+)
+from wmo.common.project import ProjectPaths
+from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
+from wmo.runtime.router.journal import (
+    JournaledRouterRuntime,
+    RuntimeAcceptance,
+    RuntimeAcceptedEvent,
+    RuntimeAttemptFailedEvent,
+    RuntimeIdempotencyConflictError,
+    RuntimeInteractionInProgressError,
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    _interaction_identity,
+)
+from wmo.runtime.router.runtime import RoutedModelResponse, RouterRuntime
+
+_DIGEST = "a" * 64
+_TIME = datetime(2026, 8, 13, tzinfo=UTC)
+
+
+def _snapshot() -> ModelSnapshot:
+    return ModelSnapshot(
+        provider="openai",
+        model_id="gpt-test",
+        capabilities_sha256=_DIGEST,
+        connection_sha256="b" * 64,
+    )
+
+
+def _request(content: str = "Help me") -> ModelRequest:
+    return ModelRequest(messages=(ModelMessage(role="user", content=content),))
+
+
+def _response() -> ModelResponse:
+    return ModelResponse(
+        output=AssistantAction(content="Done"),
+        model=_snapshot(),
+        economics=OperationEconomics(),
+    )
+
+
+def _decision(lineage_id: str, request: ModelRequest | None = None) -> RoutingDecision:
+    episode_sha256 = hashlib.sha256(lineage_id.encode("utf-8"), usedforsecurity=False).hexdigest()
+    feature = RouterFeatureExtractor().from_request(request or _request())
+    material = {
+        "policy_id": "router-policy-a",
+        "policy_sha256": _DIGEST,
+        "request_sha256": hashlib.sha256(
+            feature.encode("utf-8"), usedforsecurity=False
+        ).hexdigest(),
+        "episode_id_sha256": episode_sha256,
+        "selected_alias": "candidate-a",
+        "baseline_alias": "candidate-a",
+        "neighbor_count": 8,
+        "paired_count": 8,
+        "best_similarity": 1.0,
+        "estimated_quality_difference": None,
+        "uncertainty": None,
+        "fallback_reason": None,
+    }
+    return RoutingDecision(
+        decision_id=stable_id("routing-decision", material),
+        **material,
+    )
+
+
+class _FakeRuntime:
+    """Small deterministic runtime with a shareable target-call counter."""
+
+    def __init__(
+        self,
+        *,
+        counter: Synchronized | None = None,
+        delay: float = 0.0,
+        fail_once: bool = False,
+    ) -> None:
+        self.policy = SimpleNamespace(
+            candidates=(RoutedCandidateSnapshot(alias="candidate-a", model=_snapshot()),)
+        )
+        self.counter = counter
+        self.delay = delay
+        self.fail_once = fail_once
+        self.select_calls = 0
+        self.complete_calls = 0
+        self.decisions: list[RoutingDecision] = []
+
+    def select(self, request: ModelRequest, *, episode_id: str | None = None) -> RoutingDecision:
+        del request
+        assert episode_id is not None
+        self.select_calls += 1
+        decision = _decision(episode_id)
+        self.decisions.append(decision)
+        return decision
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str | None = None,
+        decision: RoutingDecision | None = None,
+        provider_idempotency_key: str | None = None,
+    ) -> RoutedModelResponse:
+        del request, episode_id
+        assert decision is not None
+        assert provider_idempotency_key is not None
+        self.complete_calls += 1
+        if self.counter is not None:
+            with self.counter.get_lock():
+                self.counter.value += 1
+        if self.delay:
+            time.sleep(self.delay)
+        if self.fail_once:
+            self.fail_once = False
+            raise TimeoutError("secret provider detail")
+        return RoutedModelResponse(decision=decision, response=_response())
+
+
+def _service(
+    root: Path,
+    runtime: _FakeRuntime,
+    *,
+    wait_timeout_seconds: float = 2.0,
+    stale_after_seconds: float = 30.0,
+) -> JournaledRouterRuntime:
+    journal = RuntimeInteractionJournal(ProjectPaths(root=root, project_id="support-agent"))
+    return JournaledRouterRuntime(
+        cast(RouterRuntime, runtime),
+        journal,
+        wait_timeout_seconds=wait_timeout_seconds,
+        stale_after_seconds=stale_after_seconds,
+    )
+
+
+def test_completed_interaction_replays_after_restart_without_provider_or_selection(
+    tmp_path: Path,
+) -> None:
+    """A completed key returns its canonical response without any new runtime work."""
+    first_runtime = _FakeRuntime()
+    first = _service(tmp_path / ".wmo", first_runtime)
+    raw_key = "sk-this-is-a-fake-key-material-123456789"
+    initial = first.complete(_request(), idempotency_key=raw_key)
+
+    restarted_runtime = _FakeRuntime()
+    restarted = _service(tmp_path / ".wmo", restarted_runtime)
+    replayed = restarted.complete(_request(), idempotency_key=raw_key)
+
+    assert replayed == initial
+    assert first_runtime.select_calls == first_runtime.complete_calls == 1
+    assert restarted_runtime.select_calls == restarted_runtime.complete_calls == 0
+    payload = restarted.journal.path.read_text(encoding="utf-8")
+    assert raw_key not in payload
+    assert [event.event for event in restarted.journal.read_events()] == [
+        "accepted",
+        "completed",
+    ]
+
+
+def test_same_key_with_different_request_or_lineage_conflicts(tmp_path: Path) -> None:
+    """One key cannot silently change its canonical request or conversation lineage."""
+    service = _service(tmp_path / ".wmo", _FakeRuntime())
+    service.complete(_request(), idempotency_key="same-key", conversation_id="conversation-a")
+
+    with pytest.raises(RuntimeIdempotencyConflictError):
+        service.complete(
+            _request("Different"),
+            idempotency_key="same-key",
+            conversation_id="conversation-a",
+        )
+    with pytest.raises(RuntimeIdempotencyConflictError):
+        service.complete(
+            _request(),
+            idempotency_key="same-key",
+            conversation_id="conversation-b",
+        )
+
+
+def test_provider_failure_has_no_target_and_retry_reuses_pinned_decision(tmp_path: Path) -> None:
+    """Retryable failures are durable and never trigger a second routing selection."""
+    runtime = _FakeRuntime(fail_once=True)
+    service = _service(tmp_path / ".wmo", runtime)
+
+    with pytest.raises(TimeoutError, match="secret provider detail"):
+        service.complete(_request(), idempotency_key="retry-key")
+    events = service.journal.read_events()
+    assert [event.event for event in events] == ["accepted", "attempt_failed"]
+    failed = cast(RuntimeAttemptFailedEvent, events[-1])
+    assert failed.retryable
+    assert failed.failure.message == "routed model provider attempt failed"
+    assert "response" not in failed.model_dump(mode="json")
+    assert "secret provider detail" not in service.journal.path.read_text(encoding="utf-8")
+
+    result = service.complete(_request(), idempotency_key="retry-key")
+    retried = service.journal.read_events()
+    assert result.response == _response()
+    assert [event.event for event in retried] == [
+        "accepted",
+        "attempt_failed",
+        "accepted",
+        "completed",
+    ]
+    assert runtime.select_calls == 1
+    assert (
+        cast(RuntimeAcceptedEvent, retried[0]).decision
+        == cast(RuntimeAcceptedEvent, retried[2]).decision
+    )
+
+
+def test_two_threads_with_one_key_dispatch_target_once(tmp_path: Path) -> None:
+    """The journal serializes same-key threads while provider work runs outside the lock."""
+    runtime = _FakeRuntime(delay=0.15)
+    service = _service(tmp_path / ".wmo", runtime)
+    barrier = threading.Barrier(3)
+    results: list[RoutedModelResponse] = []
+
+    def call() -> None:
+        barrier.wait()
+        results.append(service.complete(_request(), idempotency_key="thread-key"))
+
+    threads = (threading.Thread(target=call), threading.Thread(target=call))
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 2
+    assert results[0] == results[1]
+    assert runtime.complete_calls == 1
+
+
+def _process_call(root: str, counter: Synchronized) -> None:
+    """Complete one shared-key request in a separate process."""
+    runtime = _FakeRuntime(counter=counter, delay=0.2)
+    _service(Path(root), runtime, wait_timeout_seconds=3.0).complete(
+        _request(), idempotency_key="process-key"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="cross-process lock probe needs fork")
+def test_two_processes_with_one_key_dispatch_target_once(tmp_path: Path) -> None:
+    """Independent processes observe one accepted attempt and one completed response."""
+    context = multiprocessing.get_context("fork")
+    counter = context.Value("i", 0)
+    root = tmp_path / ".wmo"
+    processes = (
+        context.Process(target=_process_call, args=(str(root), counter)),
+        context.Process(target=_process_call, args=(str(root), counter)),
+    )
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+
+    assert [process.exitcode for process in processes] == [0, 0]
+    assert counter.value == 1
+
+
+def test_torn_tail_is_ignored_but_interior_corruption_fails_closed(tmp_path: Path) -> None:
+    """Only a non-newline-terminated final record may be treated as a crash tear."""
+    service = _service(tmp_path / ".wmo", _FakeRuntime())
+    service.complete(_request(), idempotency_key="tail-key")
+    path = service.journal.path
+    clean = path.read_bytes()
+    path.write_bytes(clean + b'{"event":"accepted"')
+
+    assert len(service.journal.read_events()) == 2
+
+    path.write_bytes(clean.splitlines(keepends=True)[0] + b"not-json\n" + clean)
+    with pytest.raises(RuntimeJournalError, match="invalid interior line"):
+        service.journal.read_events()
+
+
+def test_duplicate_transition_and_digest_drift_fail_closed(tmp_path: Path) -> None:
+    """A valid JSON rewrite cannot bypass event IDs, digests, ordinals, or transitions."""
+    service = _service(tmp_path / ".wmo", _FakeRuntime())
+    service.complete(_request(), idempotency_key="corrupt-key")
+    path = service.journal.path
+    lines = path.read_text(encoding="utf-8").splitlines()
+    path.write_text(f"{lines[0]}\n{lines[0]}\n", encoding="utf-8")
+    with pytest.raises(RuntimeJournalError, match="ordinals|event ID|transition"):
+        service.journal.read_events()
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    corrupted = lines[1].replace('"response_sha256":"', '"response_sha256":"f')
+    path.write_text(f"{lines[0]}\n{corrupted}\n", encoding="utf-8")
+    with pytest.raises(RuntimeJournalError, match="invalid interior line"):
+        service.journal.read_events()
+
+
+def test_stale_attempt_gets_failure_then_retry_with_original_route(tmp_path: Path) -> None:
+    """A stale live attempt is closed explicitly before a pinned retry is dispatched."""
+    journal = RuntimeInteractionJournal(
+        ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    )
+    request = _request()
+    identity = _interaction_identity("support-agent", "stale-key", request, None)
+    decision = _decision(identity.lineage_id)
+    acceptance = RuntimeAcceptance(
+        decision=decision,
+        selected_alias=decision.selected_alias,
+        selected_model=_snapshot(),
+        policy_input=ArtifactInput(artifact_id=decision.policy_id, sha256=decision.policy_sha256),
+    )
+    first = journal.claim(
+        identity,
+        acceptance,
+        now=_TIME,
+        stale_after=timedelta(seconds=1),
+    )
+    retry = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(seconds=1),
+    )
+
+    assert first.status == retry.status == "dispatch"
+    assert retry.accepted is not None
+    assert retry.accepted.attempt_ordinal == 2
+    assert [event.event for event in journal.read_events()] == [
+        "accepted",
+        "attempt_failed",
+        "accepted",
+    ]
+
+
+def test_live_attempt_wait_is_bounded_and_retryable(tmp_path: Path) -> None:
+    """A live attempt produces a bounded retryable conflict instead of hanging."""
+    journal = RuntimeInteractionJournal(
+        ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    )
+    request = _request()
+    identity = _interaction_identity("support-agent", "live-key", request, None)
+    decision = _decision(identity.lineage_id)
+    journal.claim(
+        identity,
+        RuntimeAcceptance(
+            decision=decision,
+            selected_alias=decision.selected_alias,
+            selected_model=_snapshot(),
+            policy_input=ArtifactInput(
+                artifact_id=decision.policy_id,
+                sha256=decision.policy_sha256,
+            ),
+        ),
+        now=_TIME,
+        stale_after=timedelta(hours=1),
+    )
+    service = JournaledRouterRuntime(
+        cast(RouterRuntime, _FakeRuntime()),
+        journal,
+        clock=lambda: _TIME,
+        wait_timeout_seconds=0,
+        stale_after_seconds=3600,
+    )
+
+    with pytest.raises(RuntimeInteractionInProgressError) as caught:
+        service.complete(request, idempotency_key="live-key")
+    assert caught.value.retryable
+
+
+def test_append_flushes_and_fsyncs_before_return(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every accepted and completed line reaches fsync before the service returns."""
+    calls: list[int] = []
+    real_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        calls.append(descriptor)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+    service = _service(tmp_path / ".wmo", _FakeRuntime())
+    service.complete(_request(), idempotency_key="fsync-key")
+
+    assert len(calls) == 2

--- a/wmo/runtime/router/journal_test.py
+++ b/wmo/runtime/router/journal_test.py
@@ -290,8 +290,11 @@ def test_torn_tail_is_ignored_but_interior_corruption_fails_closed(tmp_path: Pat
     path.write_bytes(clean + b'{"event":"accepted"')
 
     assert len(service.journal.read_events()) == 2
+    service.complete(_request(), idempotency_key="after-torn-key")
+    assert len(service.journal.read_events()) == 4
 
-    path.write_bytes(clean.splitlines(keepends=True)[0] + b"not-json\n" + clean)
+    repaired = path.read_bytes()
+    path.write_bytes(repaired.splitlines(keepends=True)[0] + b"not-json\n" + repaired)
     with pytest.raises(RuntimeJournalError, match="invalid interior line"):
         service.journal.read_events()
 

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 import numpy as np
 
 from wmo.common.core.artifacts import ArtifactId, ContractModel, Sha256, sha256_json, stable_id
-from wmo.common.models import ModelAlias, ModelRequest, ModelResponse
+from wmo.common.models import IdempotentModelClient, ModelAlias, ModelRequest, ModelResponse
 from wmo.common.project import ArtifactCorruptionError, ArtifactStore
 from wmo.common.routing import KnnRouterPolicy, RouterFeatureExtractor, RoutingDecision
 from wmo.common.routing.bank import KnnBankManifest, KnnEvidenceBank, bank_bytes, load_knn_bank
@@ -289,6 +289,7 @@ class RouterRuntime:
         *,
         episode_id: str | None = None,
         decision: RoutingDecision | None = None,
+        provider_idempotency_key: str | None = None,
     ) -> RoutedModelResponse:
         """Validate one exact cached decision and call its pinned model client.
 
@@ -296,6 +297,8 @@ class RouterRuntime:
             request: Provider-neutral request to route and complete.
             episode_id: Optional caller-owned identity for sticky routing.
             decision: Optional prior decision to validate and consume without reselection.
+            provider_idempotency_key: Optional validated key forwarded only when the selected
+                client implements the explicit idempotency capability.
 
         Returns:
             Exact routing decision beside the selected model response.
@@ -319,9 +322,27 @@ class RouterRuntime:
             or selected.selected_alias not in {item.alias for item in self.policy.candidates}
         ):
             raise ValueError("routing decision does not match this policy, request, or episode")
+        if provider_idempotency_key is not None:
+            _validate_idempotency_key(provider_idempotency_key)
         self._require_bank_integrity()
         with self._episode_lock:
-            cached = self._request_decisions.get((expected_episode_sha256, request_sha256))
+            request_key = (expected_episode_sha256, request_sha256)
+            cached = self._request_decisions.get(request_key)
+            episode_decision = self._episode_decisions.get(expected_episode_sha256)
+            if cached is None and decision is not None:
+                if selected.decision_id != _decision_content_id(selected):
+                    raise ValueError(
+                        "routing decision does not match this policy, request, or episode"
+                    )
+                if (
+                    episode_decision is not None
+                    and episode_decision.selected_alias != selected.selected_alias
+                ):
+                    raise ValueError("routing decision conflicts with the cached episode model")
+                if episode_decision is None:
+                    self._episode_decisions[expected_episode_sha256] = selected
+                self._request_decisions[request_key] = selected
+                cached = selected
             if cached != selected:
                 raise ValueError("routing decision is not the exact cached episode decision")
         resolved = self._resolve(selected.selected_alias)
@@ -337,7 +358,11 @@ class RouterRuntime:
                 f"routed model alias {selected.selected_alias!r} cannot prove the requested "
                 "output-token capacity"
             )
-        response = resolved.client.complete(request)
+        client = resolved.client
+        if provider_idempotency_key is not None and isinstance(client, IdempotentModelClient):
+            response = client.complete_idempotent(request, idempotency_key=provider_idempotency_key)
+        else:
+            response = client.complete(request)
         return RoutedModelResponse(decision=selected, response=response)
 
     def _require_activation_identity(
@@ -447,15 +472,8 @@ class RouterRuntime:
     ) -> RoutingDecision:
         alias = selected_alias or self.policy.baseline_alias
         episode_id_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
-        material = {
-            "policy_id": self.policy.policy_id,
-            "request_sha256": request_sha256,
-            "episode_id_sha256": episode_id_sha256,
-            "selected_alias": alias,
-            "fallback_reason": reason,
-        }
-        return RoutingDecision(
-            decision_id=stable_id("routing-decision", material),
+        provisional = RoutingDecision(
+            decision_id="routing-decision-provisional",
             policy_id=self.policy.policy_id,
             policy_sha256=policy_content_sha256(self.policy),
             request_sha256=request_sha256,
@@ -466,6 +484,7 @@ class RouterRuntime:
             paired_count=0,
             fallback_reason=reason,
         )
+        return provisional.model_copy(update={"decision_id": _decision_content_id(provisional)})
 
     def _sticky_decision(
         self, episode_decision: RoutingDecision, request_sha256: Sha256
@@ -495,3 +514,18 @@ def _requires_tool_protocol(request: ModelRequest) -> bool:
             for message in request.messages
         )
     )
+
+
+def _decision_content_id(decision: RoutingDecision) -> str:
+    """Return the canonical content identity for a routing decision."""
+    material = decision.model_dump(mode="json")
+    del material["decision_id"]
+    return stable_id("routing-decision", material)
+
+
+def _validate_idempotency_key(value: str) -> None:
+    """Reject keys that cannot safely cross an HTTP provider boundary."""
+    if not value or len(value) > 512 or value.strip() != value:
+        raise ValueError("idempotency key must be 1 to 512 non-blank characters")
+    if any(ord(character) < 33 or ord(character) > 126 for character in value):
+        raise ValueError("idempotency key must contain only visible ASCII characters")

--- a/wmo/runtime/router/runtime_idempotency_test.py
+++ b/wmo/runtime/router/runtime_idempotency_test.py
@@ -1,0 +1,73 @@
+"""Focused restart and provider-idempotency tests for ``RouterRuntime``."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from wmo.common.models import ModelRequest, ModelResponse
+from wmo.runtime.models import RuntimeModelCatalog
+from wmo.runtime.router.runtime import RouterRuntime
+from wmo.runtime.router.runtime_test import _Catalog, _Client, _fixture, _request, _runtime
+
+_DIGEST = "a" * 64
+
+
+class _IdempotentClient(_Client):
+    """Completion fake implementing the explicit provider idempotency capability."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.idempotency_keys: list[str] = []
+
+    def complete_idempotent(self, request: ModelRequest, *, idempotency_key: str) -> ModelResponse:
+        self.idempotency_keys.append(idempotency_key)
+        return self.complete(request)
+
+
+def test_complete_reinstalls_one_canonical_prior_decision_after_restart() -> None:
+    """A verified durable decision can be consumed after the in-memory cache is lost."""
+    first, _client = _runtime()
+    request = _request(tool_name="read")
+    decision = first.select(request, episode_id="episode-a")
+    restarted, restarted_client = _runtime()
+
+    routed = restarted.complete(request, episode_id="episode-a", decision=decision)
+
+    assert routed.decision == decision
+    assert restarted_client.embed_calls == 0
+    assert restarted_client.requests == [request]
+
+
+def test_provider_idempotency_key_uses_only_the_explicit_capability() -> None:
+    """Capable clients receive the key while ordinary model clients keep their existing seam."""
+    policy, manifest, bank, snapshots, _client = _fixture()
+    capable = _IdempotentClient()
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _Catalog(snapshots, capable)),
+        pricing_snapshot_id="pricing-a",
+        pricing_snapshot_sha256=_DIGEST,
+        pricing_candidate_aliases=bank.candidate_aliases,
+    )
+    request = _request()
+    decision = runtime.select(request, episode_id="episode-a")
+
+    runtime.complete(
+        request,
+        episode_id="episode-a",
+        decision=decision,
+        provider_idempotency_key="caller-key-1",
+    )
+
+    assert capable.idempotency_keys == ["caller-key-1"]
+    with pytest.raises(ValueError, match="visible ASCII"):
+        runtime.complete(
+            request,
+            episode_id="episode-a",
+            decision=decision,
+            provider_idempotency_key="bad key",
+        )


### PR DESCRIPTION
## What changed

- Add a project-local append-only routed-interaction journal under `.wmo/projects/<project>/runtime`, outside immutable artifacts.
- Persist typed `accepted`, `attempt_failed`, and `completed` events with stable IDs, canonical request and response digests, exact routing pins, monotonic ordinals, cross-process locking, append, flush, and fsync.
- Add `JournaledRouterRuntime` for local idempotency: completed replay, request conflict detection, bounded live-attempt waits, stale retry with the original routing decision, and redacted structured failures.
- Add an explicit optional model-client capability for forwarding `Idempotency-Key` without claiming remote exactly-once execution.
- Allow a journal-verified routing decision to be reinstalled after process restart without rerouting.

## Why

Router traffic must become durable evidence for later trace and SFT work without allowing duplicate local logical interactions or target drift. This PR establishes that runtime boundary independently of the OpenAI endpoint, RAG, and SFT integration work.

The behavioral intent is adapted from `e7aad17b:wmo/simulation/serving/chat.py`, especially its request log and conversation-affinity responsibilities. It uses the current project, model, and frozen-router contracts and does not restore the old serving or provider stack.

## Exact boundary

WMO guarantees one local logical interaction and one pinned target for a project and idempotency key. Provider dispatch can still be at-least-once if a process crashes after provider success but before the completed journal record reaches disk. A capable provider may receive the original key through the explicit capability seam, but WMO does not infer provider-side exactly-once behavior.

The restack preserves the merged OpenAI runtime and its capability preflight. The journal remains endpoint-free and adds no endpoint-owned cache.

## Verification

Exact head: `7ab9a3618ba8a7c2c1397305cf41e72d89a74e05`

- rebased onto main `179402ca6e5a5876ede3b85136059b9f5997678c`
- one runtime conflict resolved by composing merged capability checks with durable idempotent dispatch; the other four commits are range-diff identical
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- focused journal, router-runtime, idempotency, and path suite: 64 passed
- pre-restack full suite: 661 passed, 1 skipped
- `uv build`
- Thread and separate-process same-key tests prove one target dispatch.
- Restart replay, request mismatch, retry pinning, torn-tail, interior-corruption, secret-redaction, and fsync regressions are covered.

No README, endpoint, RAG, SFT, web, or provider configuration behavior changes in this PR.

