### PR TITLE
Complete OpenAI router compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ uv run pytest -q
   simulation, optimize, or cli; runtime may not import simulation, optimize, or cli; simulation
   may not import optimize or cli; optimize may not import simulation or cli. The AST gate rejects
   every current forbidden edge directly.
-- Public Python modules, classes, protocols, functions, and methods use Google-style docstrings.
-  A trivial public function may use one clear summary line. Private helpers and test functions do
-  not need a docstring when their behavior is obvious.
+- Every Python function and method uses a Google-style docstring. An absolutely trivial function
+  or method may use one clear summary line. This rule includes private helpers, nested functions,
+  and test helpers so each callable states its current contract locally.
 - The root CLI command set is exact: `build`, `config`, `optimize`, and `run`; package-layout and
   release tests enforce the current module and distribution shape.
 - There is no 800-line warning and no numeric modules-per-directory gate.
@@ -110,8 +110,8 @@ uv run pytest -q
 ## Python
 
 - Every Python file must have a module docstring.
-- Write Google-style docstrings for all classes and functions with significant logic. Use plain
-  one-line docstrings for simple/self-explanatory classes and functions.
+- Write Google-style docstrings for all classes and functions. Use plain one-line docstrings only
+  for absolutely trivial classes and functions.
 - **Never `print`.** All diagnostic/progress output goes through a module logger
   (`logging.getLogger(__name__)`), never the `print` builtin — enforced by ruff's `T20` rules.
   The one exception is deliberate user-facing CLI presentation, which goes through a local rich

--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -6,6 +6,12 @@ from wmo.runtime.router.application import (
     load_project_router,
     load_router,
 )
+from wmo.runtime.router.completion import (
+    RouterCompletionConflictError,
+    RouterCompletionFailedError,
+    RouterCompletionInProgressError,
+    RouterCompletionService,
+)
 from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.journal import (
     JournaledRouterRuntime,
@@ -41,6 +47,10 @@ __all__ = [
     "RuntimeJournalEvent",
     "RouterEpisodeConflictError",
     "RouterModelCapabilityError",
+    "RouterCompletionService",
+    "RouterCompletionConflictError",
+    "RouterCompletionInProgressError",
+    "RouterCompletionFailedError",
     "RouterRuntime",
     "RouterRuntimeIntegrityError",
     "create_router_endpoint",

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -21,6 +21,7 @@ from wmo.common.project import (
 )
 from wmo.common.routing import KnnRouterPolicy
 from wmo.runtime.models import RuntimeModelCatalog
+from wmo.runtime.router.completion import RouterCompletionService
 from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.runtime import DecisionSink, RouterRuntime
 
@@ -78,12 +79,18 @@ def load_project_router(
         raise RouterApplicationError(str(exc)) from exc
 
 
-def create_project_router_app(project: str, runtime: RouterRuntime) -> FastAPI:
+def create_project_router_app(
+    project: str,
+    runtime: RouterRuntime,
+    *,
+    completion_service: RouterCompletionService | None = None,
+) -> FastAPI:
     """Create the dev-only loopback HTTP adapter for one loaded project router.
 
     Args:
         project: Public local model name accepted by the endpoint.
         runtime: Already verified frozen router runtime.
+        completion_service: Optional durable service for standard idempotent requests.
 
     Returns:
         FastAPI application exposing OpenAI Chat Completions and Responses routes.
@@ -110,7 +117,10 @@ def create_project_router_app(project: str, runtime: RouterRuntime) -> FastAPI:
             },
         )
 
-    application.include_router(create_router_endpoint({project: runtime}))
+    services = {project: completion_service} if completion_service is not None else None
+    application.include_router(
+        create_router_endpoint({project: runtime}, completion_services=services)
+    )
     return application
 
 

--- a/wmo/runtime/router/completion.py
+++ b/wmo/runtime/router/completion.py
@@ -21,6 +21,7 @@ class RouterCompletionFailedError(RuntimeError):
     """A durable interaction has a stable terminal provider failure."""
 
     def __init__(self, failure: StructuredFailure) -> None:
+        """Initialize the error with its durable structured failure."""
         super().__init__(failure.message)
         self.failure = failure
 

--- a/wmo/runtime/router/completion.py
+++ b/wmo/runtime/router/completion.py
@@ -36,4 +36,18 @@ class RouterCompletionService(Protocol):
         idempotency_key: str,
         conversation_id: str | None = None,
     ) -> RoutedModelResponse:
-        """Complete or replay one durable caller-keyed interaction."""
+        """Complete or replay one durable caller-keyed interaction.
+
+        Args:
+            request: Provider-neutral request to route and execute.
+            idempotency_key: Caller key that identifies the logical interaction.
+            conversation_id: Optional stable identity for sticky conversation routing.
+
+        Returns:
+            The original or replayed routed model response.
+
+        Raises:
+            RouterCompletionConflictError: The key names different request state.
+            RouterCompletionInProgressError: The keyed interaction is still running.
+            RouterCompletionFailedError: The keyed interaction has a terminal failure.
+        """

--- a/wmo/runtime/router/completion.py
+++ b/wmo/runtime/router/completion.py
@@ -1,0 +1,38 @@
+"""Neutral completion-service contract between HTTP adapters and durable runtimes."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from wmo.common.core.artifacts import StructuredFailure
+from wmo.common.models import ModelRequest
+from wmo.runtime.router.runtime import RoutedModelResponse
+
+
+class RouterCompletionConflictError(ValueError):
+    """A caller key conflicts with a previously accepted logical interaction."""
+
+
+class RouterCompletionInProgressError(RuntimeError):
+    """A durable interaction is already being completed and may be retried."""
+
+
+class RouterCompletionFailedError(RuntimeError):
+    """A durable interaction has a stable terminal provider failure."""
+
+    def __init__(self, failure: StructuredFailure) -> None:
+        super().__init__(failure.message)
+        self.failure = failure
+
+
+class RouterCompletionService(Protocol):
+    """Durable idempotent completion boundary used by public router adapters."""
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        idempotency_key: str,
+        conversation_id: str | None = None,
+    ) -> RoutedModelResponse:
+        """Complete or replay one durable caller-keyed interaction."""

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -304,7 +304,17 @@ class _OpenAIRequestState:
         self,
         previous_response_id: str | None,
     ) -> _ResponseState:
-        """Resolve prior Responses state or start a new internal conversation."""
+        """Resolve prior Responses state or start a new internal conversation.
+
+        Args:
+            previous_response_id: Optional opaque response identity to continue.
+
+        Returns:
+            Retained state for the named response, or empty state for a new conversation.
+
+        Raises:
+            ValueError: The response identity is unknown or expired.
+        """
         with self._lock:
             self._expire_responses(time.monotonic())
             if previous_response_id is not None:
@@ -321,7 +331,12 @@ class _OpenAIRequestState:
         )
 
     def remember_response(self, response_id: str, state: _ResponseState) -> None:
-        """Remember one count-, time-, and byte-bounded Responses continuation."""
+        """Remember one count-, time-, and byte-bounded Responses continuation.
+
+        Args:
+            response_id: Opaque public identity for the completed response.
+            state: Continuation state to retain until expiry or eviction.
+        """
         with self._lock:
             self._expire_responses(time.monotonic())
             previous = self._responses.pop(response_id, None)
@@ -381,7 +396,15 @@ def create_router_endpoint(
         request: HttpChatRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
-        """Serve one OpenAI Chat Completions request through the selected runtime."""
+        """Serve one OpenAI Chat Completions request through the selected runtime.
+
+        Args:
+            request: Validated OpenAI Chat Completions request.
+            idempotency_key: Optional standard key for durable replay.
+
+        Returns:
+            A JSON or event-stream response with OpenAI-compatible content.
+        """
         if idempotency_key is not None and not idempotency_key.strip():
             return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
@@ -436,7 +459,15 @@ def create_router_endpoint(
         request: HttpResponseRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
-        """Serve one OpenAI Responses request with bounded continuation state."""
+        """Serve one OpenAI Responses request with bounded continuation state.
+
+        Args:
+            request: Validated OpenAI Responses request.
+            idempotency_key: Optional standard key for durable replay.
+
+        Returns:
+            A JSON or event-stream response with OpenAI-compatible content.
+        """
         if idempotency_key is not None and not idempotency_key.strip():
             return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
@@ -623,7 +654,15 @@ def _response_history_messages(request: HttpResponseRequest) -> tuple[HttpMessag
 
 
 def _response_state(episode_id: str, messages: tuple[HttpMessage, ...]) -> _ResponseState:
-    """Measure one continuation state and assign its finite retention deadline."""
+    """Measure one continuation state and assign its finite retention deadline.
+
+    Args:
+        episode_id: Internal sticky-routing identity for the conversation.
+        messages: Complete visible message history to retain.
+
+    Returns:
+        Bounded continuation state with its serialized size and expiry.
+    """
     payload = [message.model_dump(mode="json") for message in messages]
     size_bytes = len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode())
     return _ResponseState(
@@ -672,7 +711,17 @@ def _chat_completion(
     *,
     idempotency_key: str | None = None,
 ) -> ChatCompletion:
-    """Build an official Chat Completions result from a routed model response."""
+    """Build an official Chat Completions result from a routed model response.
+
+    Args:
+        model: Public routed model name requested by the caller.
+        action: Provider-neutral assistant output.
+        response: Provider result with termination and usage metadata.
+        idempotency_key: Optional caller key used to derive replay-stable identity.
+
+    Returns:
+        An official OpenAI Chat Completion envelope.
+    """
     usage = _usage(response)
     completion_id, created = _response_identity("chatcmpl-", response, idempotency_key)
     return ChatCompletion.model_validate(
@@ -703,7 +752,19 @@ def _openai_response(
     idempotency_key: str | None,
     previous_response_id: str | None,
 ) -> OpenAIResponse:
-    """Build an official Responses result from a routed model response."""
+    """Build an official Responses result from a routed model response.
+
+    Args:
+        model: Public routed model name requested by the caller.
+        action: Provider-neutral assistant output.
+        response: Provider result with termination and usage metadata.
+        request: Validated request whose supported metadata must be preserved.
+        idempotency_key: Optional caller key used to derive replay-stable identity.
+        previous_response_id: Optional public identity of the continued response.
+
+    Returns:
+        An official OpenAI Responses envelope.
+    """
     response_id, created = _response_identity("resp_", response, idempotency_key)
     output: list[JsonObject] = []
     if action.content is not None:
@@ -760,7 +821,16 @@ def _chat_finish_reason(response: ModelResponse, action: AssistantAction) -> str
 def _response_identity(
     prefix: str, response: ModelResponse, idempotency_key: str | None
 ) -> tuple[str, int]:
-    """Return a replay-stable public identity only for a caller-keyed interaction."""
+    """Derive a public identity for one response.
+
+    Args:
+        prefix: OpenAI object-specific ID prefix.
+        response: Provider result included in keyed identity material.
+        idempotency_key: Optional caller key that requires replay-stable identity.
+
+    Returns:
+        Public object ID and creation timestamp. Keyed responses use stable values.
+    """
     if idempotency_key is None:
         return f"{prefix}{uuid.uuid4().hex}", int(time.time())
     material = idempotency_key.encode() + response.model_dump_json().encode()
@@ -769,7 +839,16 @@ def _response_identity(
 
 
 def _child_id(prefix: str, response_id: str, identity: str) -> str:
-    """Derive a stable child item identity from its public response and logical item."""
+    """Derive a stable child item identity.
+
+    Args:
+        prefix: OpenAI child object-specific ID prefix.
+        response_id: Public identity of the parent response.
+        identity: Logical identity of the child item.
+
+    Returns:
+        Deterministic public child item identity.
+    """
     digest = hashlib.sha256(f"{response_id}:{identity}".encode()).hexdigest()
     return f"{prefix}_{digest[:32]}"
 

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -159,6 +159,7 @@ class HttpFunctionDefinition(BaseModel):
 
     @model_validator(mode="after")
     def _reject_strict_mode(self) -> HttpFunctionDefinition:
+        """Reject strict schemas because routed candidates cannot guarantee them."""
         if self.strict is not None:
             raise ValueError("strict function schemas are not supported by this routed endpoint")
         return self
@@ -198,6 +199,7 @@ class HttpChatRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_parallel_tool_calls(self) -> HttpChatRequest:
+        """Reject requests that require serial tool-call execution."""
         if self.parallel_tool_calls is False:
             raise ValueError("parallel_tool_calls=false is not supported by this routed endpoint")
         return self
@@ -216,6 +218,7 @@ class HttpResponseTool(BaseModel):
 
     @model_validator(mode="after")
     def _reject_strict_mode(self) -> HttpResponseTool:
+        """Reject strict schemas because routed candidates cannot guarantee them."""
         if self.strict is not None:
             raise ValueError("strict function schemas are not supported by this routed endpoint")
         return self
@@ -268,6 +271,7 @@ class HttpResponseRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_parallel_tool_calls(self) -> HttpResponseRequest:
+        """Reject requests that require serial tool-call execution."""
         if self.parallel_tool_calls is False:
             raise ValueError("parallel_tool_calls=false is not supported by this routed endpoint")
         return self
@@ -291,6 +295,7 @@ class _OpenAIRequestState:
     """
 
     def __init__(self) -> None:
+        """Initialize empty bounded continuation state."""
         self._lock = threading.RLock()
         self._responses: OrderedDict[str, _ResponseState] = OrderedDict()
         self._response_bytes = 0
@@ -333,6 +338,7 @@ class _OpenAIRequestState:
                 self._response_bytes -= evicted.size_bytes
 
     def _expire_responses(self, now: float) -> None:
+        """Remove continuations whose monotonic expiry is at or before ``now``."""
         expired = tuple(key for key, state in self._responses.items() if state.expires_at <= now)
         for key in expired:
             self._response_bytes -= self._responses.pop(key).size_bytes
@@ -361,6 +367,7 @@ def create_router_endpoint(
 
     @router.get("/v1/models")
     def models() -> dict[str, object]:
+        """List the routed model names exposed by this endpoint."""
         return {
             "object": "list",
             "data": [
@@ -374,6 +381,7 @@ def create_router_endpoint(
         request: HttpChatRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
+        """Serve one OpenAI Chat Completions request through the selected runtime."""
         if idempotency_key is not None and not idempotency_key.strip():
             return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
@@ -428,6 +436,7 @@ def create_router_endpoint(
         request: HttpResponseRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
+        """Serve one OpenAI Responses request with bounded continuation state."""
         if idempotency_key is not None and not idempotency_key.strip():
             return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
@@ -663,6 +672,7 @@ def _chat_completion(
     *,
     idempotency_key: str | None = None,
 ) -> ChatCompletion:
+    """Build an official Chat Completions result from a routed model response."""
     usage = _usage(response)
     completion_id, created = _response_identity("chatcmpl-", response, idempotency_key)
     return ChatCompletion.model_validate(
@@ -693,6 +703,7 @@ def _openai_response(
     idempotency_key: str | None,
     previous_response_id: str | None,
 ) -> OpenAIResponse:
+    """Build an official Responses result from a routed model response."""
     response_id, created = _response_identity("resp_", response, idempotency_key)
     output: list[JsonObject] = []
     if action.content is not None:

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -9,25 +9,20 @@ import threading
 import time
 import uuid
 from collections import OrderedDict
-from collections.abc import Iterator
 from typing import Literal, cast
 
 from fastapi import APIRouter, Header, Response
 from fastapi.responses import StreamingResponse
-from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat import ChatCompletion
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from openai.types.responses import Response as OpenAIResponse
-from openai.types.responses import (
-    ResponseCompletedEvent,
-    ResponseCreatedEvent,
-    ResponseTextDeltaEvent,
-)
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, model_validator
 
 from wmo.common.core.artifacts import JsonObject
 from wmo.common.models import (
     AssistantAction,
+    ModelFinishReason,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -35,14 +30,23 @@ from wmo.common.models import (
     ToolChoice,
 )
 from wmo.common.tasks import ToolSchema
+from wmo.runtime.router.completion import (
+    RouterCompletionConflictError,
+    RouterCompletionFailedError,
+    RouterCompletionInProgressError,
+    RouterCompletionService,
+)
 from wmo.runtime.router.runtime import (
+    RoutedModelResponse,
     RouterEpisodeConflictError,
     RouterModelCapabilityError,
     RouterRuntime,
 )
+from wmo.runtime.router.streaming import chat_stream, responses_stream
 
 _AFFINITY_CAPACITY = 4096
-_IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
+_RESPONSE_TTL_SECONDS = 24 * 60 * 60
+_RESPONSE_CAPACITY_BYTES = 64 * 1024 * 1024
 logger = logging.getLogger(__name__)
 _CHAT_REQUEST_ADAPTER = TypeAdapter(CompletionCreateParams)
 _RESPONSE_REQUEST_ADAPTER = TypeAdapter(ResponseCreateParams)
@@ -55,6 +59,7 @@ _CHAT_FIELDS = frozenset(
         "temperature",
         "max_tokens",
         "max_completion_tokens",
+        "parallel_tool_calls",
         "stream",
     }
 )
@@ -68,17 +73,33 @@ _RESPONSE_FIELDS = frozenset(
         "tool_choice",
         "temperature",
         "max_output_tokens",
+        "parallel_tool_calls",
         "stream",
     }
 )
 
 
-class OpenAIRequestConflictError(ValueError):
-    """A standard OpenAI request identity conflicts with prior local state."""
+class _UnsupportedIdempotencyService:
+    """Fail closed when no durable service owns caller-keyed interactions."""
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        idempotency_key: str,
+        conversation_id: str | None = None,
+    ) -> RoutedModelResponse:
+        """Reject a keyed interaction before routing or provider dispatch."""
+        del request, idempotency_key, conversation_id
+        raise RouterCompletionConflictError(
+            "this router has no durable idempotency service; retry without Idempotency-Key"
+        )
 
 
 class HttpFunctionCall(BaseModel):
     """OpenAI function name and JSON arguments string."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     arguments: str
@@ -86,6 +107,8 @@ class HttpFunctionCall(BaseModel):
 
 class HttpToolCall(BaseModel):
     """OpenAI assistant function call."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: str
     type: Literal["function"] = "function"
@@ -95,12 +118,16 @@ class HttpToolCall(BaseModel):
 class HttpTextPart(BaseModel):
     """One supported OpenAI text content part."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: Literal["text", "input_text", "output_text"]
     text: str
 
 
 class HttpMessage(BaseModel):
     """Ordered OpenAI message preserving assistant calls and tool results."""
+
+    model_config = ConfigDict(extra="forbid")
 
     role: Literal["system", "developer", "user", "assistant", "tool"]
     content: str | tuple[HttpTextPart, ...] | None = None
@@ -123,13 +150,24 @@ class HttpMessage(BaseModel):
 class HttpFunctionDefinition(BaseModel):
     """One request-visible function schema."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
-    description: str = ""
+    description: str | None = None
     parameters: dict[str, JsonValue] = Field(default_factory=dict)
+    strict: bool | None = None
+
+    @model_validator(mode="after")
+    def _reject_strict_mode(self) -> HttpFunctionDefinition:
+        if self.strict is not None:
+            raise ValueError("strict function schemas are not supported by this routed endpoint")
+        return self
 
 
 class HttpTool(BaseModel):
     """One OpenAI function tool."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["function"] = "function"
     function: HttpFunctionDefinition
@@ -147,6 +185,7 @@ class HttpChatRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
+    parallel_tool_calls: bool | None = None
     stream: bool = False
 
     @model_validator(mode="before")
@@ -157,18 +196,35 @@ class HttpChatRequest(BaseModel):
         _reject_unsupported_fields(value, _CHAT_FIELDS, "Chat Completions")
         return value
 
+    @model_validator(mode="after")
+    def _require_parallel_tool_calls(self) -> HttpChatRequest:
+        if self.parallel_tool_calls is False:
+            raise ValueError("parallel_tool_calls=false is not supported by this routed endpoint")
+        return self
+
 
 class HttpResponseTool(BaseModel):
     """One OpenAI Responses function tool."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: Literal["function"] = "function"
     name: str
-    description: str = ""
+    description: str | None = None
     parameters: dict[str, JsonValue] = Field(default_factory=dict)
+    strict: bool | None = None
+
+    @model_validator(mode="after")
+    def _reject_strict_mode(self) -> HttpResponseTool:
+        if self.strict is not None:
+            raise ValueError("strict function schemas are not supported by this routed endpoint")
+        return self
 
 
 class HttpResponseFunctionCall(BaseModel):
     """One Responses function-call item replayed as assistant history."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["function_call"]
     call_id: str
@@ -178,6 +234,8 @@ class HttpResponseFunctionCall(BaseModel):
 
 class HttpResponseFunctionOutput(BaseModel):
     """One Responses function result replayed as tool history."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["function_call_output"]
     call_id: str
@@ -197,6 +255,7 @@ class HttpResponseRequest(BaseModel):
     tool_choice: JsonValue = None
     temperature: float | None = None
     max_output_tokens: int | None = None
+    parallel_tool_calls: bool | None = None
     stream: bool = False
 
     @model_validator(mode="before")
@@ -207,12 +266,20 @@ class HttpResponseRequest(BaseModel):
         _reject_unsupported_fields(value, _RESPONSE_FIELDS, "Responses")
         return value
 
+    @model_validator(mode="after")
+    def _require_parallel_tool_calls(self) -> HttpResponseRequest:
+        if self.parallel_tool_calls is False:
+            raise ValueError("parallel_tool_calls=false is not supported by this routed endpoint")
+        return self
+
 
 class _ResponseState(BaseModel):
     """Conversation state retained for one OpenAI Responses result."""
 
     episode_id: str
     messages: tuple[HttpMessage, ...]
+    expires_at: float
+    size_bytes: int = Field(ge=0)
 
 
 class _OpenAIRequestState:
@@ -220,97 +287,77 @@ class _OpenAIRequestState:
 
     Identity comes only from the standard ``Idempotency-Key`` and ``previous_response_id`` inputs.
     Two unrelated callers can send the same transcript, so a transcript is never treated as a
-    conversation identity here.
+    conversation identity here. Stored continuation content has count, byte, and time ceilings.
     """
 
     def __init__(self) -> None:
         self._lock = threading.RLock()
-        self._idempotency: OrderedDict[str, tuple[str, str, float]] = OrderedDict()
         self._responses: OrderedDict[str, _ResponseState] = OrderedDict()
-
-    def chat_episode(self, request_sha256: str, idempotency_key: str | None) -> str:
-        """Return a stable internal episode only for a standard idempotent retry."""
-        return self._idempotent_episode(request_sha256, idempotency_key, existing_episode=None)
+        self._response_bytes = 0
 
     def response_context(
         self,
         previous_response_id: str | None,
-        request_sha256: str,
-        idempotency_key: str | None,
     ) -> _ResponseState:
         """Resolve prior Responses state or start a new internal conversation."""
         with self._lock:
+            self._expire_responses(time.monotonic())
             if previous_response_id is not None:
                 state = self._responses.get(previous_response_id)
                 if state is None:
-                    raise ValueError("previous_response_id does not name a local response")
+                    raise ValueError("previous_response_id does not name a live local response")
                 self._responses.move_to_end(previous_response_id)
-                identity = self._idempotent_episode(
-                    request_sha256, idempotency_key, existing_episode=state.episode_id
-                )
-                return _ResponseState(episode_id=identity, messages=state.messages)
-        identity = self._idempotent_episode(request_sha256, idempotency_key, existing_episode=None)
-        return _ResponseState(episode_id=identity, messages=())
+                return state
+        return _ResponseState(
+            episode_id=f"openai-{uuid.uuid4().hex}",
+            messages=(),
+            expires_at=time.monotonic() + _RESPONSE_TTL_SECONDS,
+            size_bytes=0,
+        )
 
     def remember_response(self, response_id: str, state: _ResponseState) -> None:
-        """Remember one bounded Responses continuation."""
+        """Remember one count-, time-, and byte-bounded Responses continuation."""
         with self._lock:
+            self._expire_responses(time.monotonic())
+            previous = self._responses.pop(response_id, None)
+            if previous is not None:
+                self._response_bytes -= previous.size_bytes
             self._responses[response_id] = state
             self._responses.move_to_end(response_id)
-            while len(self._responses) > _AFFINITY_CAPACITY:
-                self._responses.popitem(last=False)
+            self._response_bytes += state.size_bytes
+            while self._responses and (
+                len(self._responses) > _AFFINITY_CAPACITY
+                or self._response_bytes > _RESPONSE_CAPACITY_BYTES
+            ):
+                _, evicted = self._responses.popitem(last=False)
+                self._response_bytes -= evicted.size_bytes
 
-    def _idempotent_episode(
-        self,
-        request_sha256: str,
-        idempotency_key: str | None,
-        *,
-        existing_episode: str | None,
-    ) -> str:
-        """Bind a standard key to one exact request and internal episode."""
-        if idempotency_key is None:
-            return existing_episode or f"openai-{uuid.uuid4().hex}"
-        key_sha256 = hashlib.sha256(idempotency_key.encode()).hexdigest()
-        with self._lock:
-            now = time.monotonic()
-            expired = tuple(
-                key for key, (_, _, deadline) in self._idempotency.items() if deadline <= now
-            )
-            for key in expired:
-                del self._idempotency[key]
-            existing = self._idempotency.get(key_sha256)
-            if existing is not None:
-                if existing[0] != request_sha256:
-                    raise OpenAIRequestConflictError(
-                        "Idempotency-Key is already bound to a different request"
-                    )
-                self._idempotency.move_to_end(key_sha256)
-                return existing[1]
-            if len(self._idempotency) >= _AFFINITY_CAPACITY:
-                raise OpenAIRequestConflictError("live idempotency-key capacity is exhausted")
-            # An expired key starts a new logical request. Its episode must not be
-            # derived from the key, because RouterRuntime intentionally retains
-            # prior episode decisions longer than this bounded transport cache.
-            episode_id = existing_episode or f"idempotency-{uuid.uuid4().hex}"
-            self._idempotency[key_sha256] = (
-                request_sha256,
-                episode_id,
-                now + _IDEMPOTENCY_TTL_SECONDS,
-            )
-            return episode_id
+    def _expire_responses(self, now: float) -> None:
+        expired = tuple(key for key, state in self._responses.items() if state.expires_at <= now)
+        for key in expired:
+            self._response_bytes -= self._responses.pop(key).size_bytes
 
 
-def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
+def create_router_endpoint(
+    endpoints: dict[str, RouterRuntime],
+    *,
+    completion_services: dict[str, RouterCompletionService] | None = None,
+) -> APIRouter:
     """Mount OpenAI Chat Completions and Responses over exact router decisions.
 
     Args:
         endpoints: Public model names mapped to activated local runtimes.
+        completion_services: Optional durable idempotent services for standard keyed requests.
 
     Returns:
         Loopback-hostable OpenAI API router.
     """
     router = APIRouter()
     affinity = _OpenAIRequestState()
+    services: dict[str, RouterCompletionService] = {
+        name: _UnsupportedIdempotencyService() for name in endpoints
+    }
+    services.update(completion_services or {})
 
     @router.get("/v1/models")
     def models() -> dict[str, object]:
@@ -327,15 +374,29 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         request: HttpChatRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
+        if idempotency_key is not None and not idempotency_key.strip():
+            return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
         if runtime is None:
             return _error(404, f"no routed endpoint {request.model!r}")
         try:
             model_request = _chat_model_request(request)
-            episode_id = affinity.chat_episode(_request_sha256(request), idempotency_key)
-            routed = runtime.complete(model_request, episode_id=episode_id)
-        except OpenAIRequestConflictError:
-            return _error(409, "Idempotency-Key conflicts with live request state")
+            routed = (
+                runtime.complete(model_request)
+                if idempotency_key is None
+                else services[request.model].complete(
+                    model_request,
+                    idempotency_key=idempotency_key,
+                )
+            )
+        except RouterCompletionConflictError:
+            return _error(409, "Idempotency-Key conflicts with durable request state")
+        except RouterCompletionInProgressError:
+            return _error(
+                409, "idempotent request is still in progress", code="request_in_progress"
+            )
+        except RouterCompletionFailedError:
+            return _error(502, "idempotent routed model call failed")
         except RouterEpisodeConflictError:
             return _error(409, "request conflicts with an earlier routed turn")
         except RouterModelCapabilityError as exc:
@@ -345,11 +406,16 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         except Exception:  # noqa: BLE001
             logger.exception("routed Chat Completions call failed")
             return _error(502, "routed model call failed")
-        completion = _chat_completion(request.model, routed.response.output, routed.response)
+        completion = _chat_completion(
+            request.model,
+            routed.response.output,
+            routed.response,
+            idempotency_key=idempotency_key,
+        )
         headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
         if request.stream:
             return StreamingResponse(
-                _chat_stream(completion), media_type="text/event-stream", headers=headers
+                chat_stream(completion), media_type="text/event-stream", headers=headers
             )
         return Response(
             content=completion.model_dump_json(exclude_none=True),
@@ -362,19 +428,33 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
         request: HttpResponseRequest,
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     ) -> Response:
+        if idempotency_key is not None and not idempotency_key.strip():
+            return _error(400, "Idempotency-Key must not be empty")
         runtime = endpoints.get(request.model)
         if runtime is None:
             return _error(404, f"no routed endpoint {request.model!r}")
         try:
-            prior = affinity.response_context(
-                request.previous_response_id, _request_sha256(request), idempotency_key
-            )
+            prior = affinity.response_context(request.previous_response_id)
             visible = _response_messages(request)
             all_messages = (*prior.messages, *visible)
             model_request = _responses_model_request(request, all_messages)
-            routed = runtime.complete(model_request, episode_id=prior.episode_id)
-        except OpenAIRequestConflictError:
-            return _error(409, "Idempotency-Key conflicts with live request state")
+            routed = (
+                runtime.complete(model_request, episode_id=prior.episode_id)
+                if idempotency_key is None
+                else services[request.model].complete(
+                    model_request,
+                    idempotency_key=idempotency_key,
+                    conversation_id=prior.episode_id,
+                )
+            )
+        except RouterCompletionConflictError:
+            return _error(409, "Idempotency-Key conflicts with durable request state")
+        except RouterCompletionInProgressError:
+            return _error(
+                409, "idempotent request is still in progress", code="request_in_progress"
+            )
+        except RouterCompletionFailedError:
+            return _error(502, "idempotent routed model call failed")
         except RouterEpisodeConflictError:
             return _error(409, "response continuation conflicts with an earlier routed turn")
         except RouterModelCapabilityError as exc:
@@ -388,17 +468,22 @@ def create_router_endpoint(endpoints: dict[str, RouterRuntime]) -> APIRouter:
             request.model,
             routed.response.output,
             routed.response,
+            request=request,
+            idempotency_key=idempotency_key,
             previous_response_id=request.previous_response_id,
         )
         assistant = _assistant_message(routed.response.output)
         affinity.remember_response(
             response.id,
-            _ResponseState(episode_id=prior.episode_id, messages=(*all_messages, assistant)),
+            _response_state(
+                prior.episode_id,
+                (*prior.messages, *_response_history_messages(request), assistant),
+            ),
         )
         headers = {"X-WMO-Routed-Model": routed.decision.selected_alias}
         if request.stream:
             return StreamingResponse(
-                _responses_stream(response), media_type="text/event-stream", headers=headers
+                responses_stream(response), media_type="text/event-stream", headers=headers
             )
         return Response(
             content=response.model_dump_json(exclude_none=True),
@@ -522,6 +607,24 @@ def _response_messages(request: HttpResponseRequest) -> tuple[HttpMessage, ...]:
     return tuple(messages)
 
 
+def _response_history_messages(request: HttpResponseRequest) -> tuple[HttpMessage, ...]:
+    """Return continuation history without the request-scoped instructions field."""
+    visible = _response_messages(request)
+    return visible[1:] if request.instructions is not None else visible
+
+
+def _response_state(episode_id: str, messages: tuple[HttpMessage, ...]) -> _ResponseState:
+    """Measure one continuation state and assign its finite retention deadline."""
+    payload = [message.model_dump(mode="json") for message in messages]
+    size_bytes = len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode())
+    return _ResponseState(
+        episode_id=episode_id,
+        messages=messages,
+        expires_at=time.monotonic() + _RESPONSE_TTL_SECONDS,
+        size_bytes=size_bytes,
+    )
+
+
 def _arguments(value: str) -> JsonObject:
     parsed = json.loads(value)
     if not isinstance(parsed, dict):
@@ -554,20 +657,25 @@ def _content_text(content: str | tuple[HttpTextPart, ...] | None) -> str | None:
 
 
 def _chat_completion(
-    model: str, action: AssistantAction, response: ModelResponse
+    model: str,
+    action: AssistantAction,
+    response: ModelResponse,
+    *,
+    idempotency_key: str | None = None,
 ) -> ChatCompletion:
     usage = _usage(response)
+    completion_id, created = _response_identity("chatcmpl-", response, idempotency_key)
     return ChatCompletion.model_validate(
         {
-            "id": f"chatcmpl-{uuid.uuid4().hex}",
+            "id": completion_id,
             "object": "chat.completion",
-            "created": int(time.time()),
+            "created": created,
             "model": model,
             "choices": [
                 {
                     "index": 0,
                     "message": _assistant_message(action).model_dump(mode="json"),
-                    "finish_reason": "tool_calls" if action.tool_calls else "stop",
+                    "finish_reason": _chat_finish_reason(response, action),
                     "logprobs": None,
                 }
             ],
@@ -581,14 +689,16 @@ def _openai_response(
     action: AssistantAction,
     response: ModelResponse,
     *,
+    request: HttpResponseRequest,
+    idempotency_key: str | None,
     previous_response_id: str | None,
 ) -> OpenAIResponse:
-    response_id = f"resp_{uuid.uuid4().hex}"
+    response_id, created = _response_identity("resp_", response, idempotency_key)
     output: list[JsonObject] = []
     if action.content is not None:
         output.append(
             {
-                "id": f"msg_{uuid.uuid4().hex}",
+                "id": _child_id("msg", response_id, "text"),
                 "type": "message",
                 "role": "assistant",
                 "status": "completed",
@@ -597,7 +707,7 @@ def _openai_response(
         )
     output.extend(
         {
-            "id": f"fc_{uuid.uuid4().hex}",
+            "id": _child_id("fc", response_id, call.call_id),
             "type": "function_call",
             "call_id": call.call_id,
             "name": call.name,
@@ -606,22 +716,51 @@ def _openai_response(
         }
         for call in action.tool_calls
     )
+    incomplete = response.finish_reason == ModelFinishReason.LENGTH
     return OpenAIResponse.model_validate(
         {
             "id": response_id,
             "object": "response",
-            "created_at": time.time(),
-            "completed_at": time.time(),
-            "status": "completed",
+            "created_at": float(created),
+            "completed_at": None if incomplete else float(created),
+            "status": "incomplete" if incomplete else "completed",
+            "incomplete_details": {"reason": "max_output_tokens"} if incomplete else None,
             "model": model,
             "output": output,
-            "parallel_tool_calls": True,
-            "tool_choice": "auto",
-            "tools": [],
+            "parallel_tool_calls": request.parallel_tool_calls is not False,
+            "tool_choice": request.tool_choice or "auto",
+            "tools": [tool.model_dump(mode="json") for tool in request.tools],
+            "instructions": request.instructions,
+            "temperature": request.temperature,
+            "max_output_tokens": request.max_output_tokens,
             "previous_response_id": previous_response_id,
             "usage": _responses_usage(response),
         }
     )
+
+
+def _chat_finish_reason(response: ModelResponse, action: AssistantAction) -> str:
+    """Map provider termination with truncation taking priority over tool calls."""
+    if response.finish_reason == ModelFinishReason.LENGTH:
+        return "length"
+    return "tool_calls" if action.tool_calls else "stop"
+
+
+def _response_identity(
+    prefix: str, response: ModelResponse, idempotency_key: str | None
+) -> tuple[str, int]:
+    """Return a replay-stable public identity only for a caller-keyed interaction."""
+    if idempotency_key is None:
+        return f"{prefix}{uuid.uuid4().hex}", int(time.time())
+    material = idempotency_key.encode() + response.model_dump_json().encode()
+    digest = hashlib.sha256(material).hexdigest()
+    return f"{prefix}{digest[:32]}", 0
+
+
+def _child_id(prefix: str, response_id: str, identity: str) -> str:
+    """Derive a stable child item identity from its public response and logical item."""
+    digest = hashlib.sha256(f"{response_id}:{identity}".encode()).hexdigest()
+    return f"{prefix}_{digest[:32]}"
 
 
 def _usage(response: ModelResponse) -> JsonObject:
@@ -646,93 +785,6 @@ def _responses_usage(response: ModelResponse) -> JsonObject:
         "output_tokens_details": {"reasoning_tokens": 0},
         "total_tokens": prompt + completion,
     }
-
-
-def _chat_stream(completion: ChatCompletion) -> Iterator[str]:
-    choice = completion.choices[0]
-    message = choice.message
-    delta: JsonObject = {"role": "assistant"}
-    if message.content is not None:
-        delta["content"] = message.content
-    if message.tool_calls:
-        delta["tool_calls"] = [
-            {**tool.model_dump(mode="json", exclude_none=True), "index": index}
-            for index, tool in enumerate(message.tool_calls)
-        ]
-    first = ChatCompletionChunk.model_validate(
-        {
-            "id": completion.id,
-            "object": "chat.completion.chunk",
-            "created": completion.created,
-            "model": completion.model,
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": delta,
-                    "finish_reason": None,
-                    "logprobs": None,
-                }
-            ],
-        }
-    )
-    terminal = ChatCompletionChunk.model_validate(
-        {
-            "id": completion.id,
-            "object": "chat.completion.chunk",
-            "created": completion.created,
-            "model": completion.model,
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": choice.finish_reason,
-                    "logprobs": None,
-                }
-            ],
-            "usage": completion.usage.model_dump(mode="json") if completion.usage else None,
-        }
-    )
-    yield f"data: {first.model_dump_json(exclude_none=True)}\n\n"
-    yield f"data: {terminal.model_dump_json(exclude_none=True)}\n\n"
-    yield "data: [DONE]\n\n"
-
-
-def _responses_stream(response: OpenAIResponse) -> Iterator[str]:
-    created = ResponseCreatedEvent(response=response, sequence_number=0, type="response.created")
-    yield _response_event(created.type, created.model_dump_json(exclude_none=True))
-    sequence = 1
-    for output_index, item in enumerate(response.output):
-        if item.type != "message":
-            continue
-        for content_index, content in enumerate(item.content):
-            if content.type != "output_text":
-                continue
-            event = ResponseTextDeltaEvent(
-                content_index=content_index,
-                delta=content.text,
-                item_id=item.id,
-                logprobs=[],
-                output_index=output_index,
-                sequence_number=sequence,
-                type="response.output_text.delta",
-            )
-            yield _response_event(event.type, event.model_dump_json(exclude_none=True))
-            sequence += 1
-    completed = ResponseCompletedEvent(
-        response=response, sequence_number=sequence, type="response.completed"
-    )
-    yield _response_event(completed.type, completed.model_dump_json(exclude_none=True))
-
-
-def _response_event(name: str, data: str) -> str:
-    return f"event: {name}\ndata: {data}\n\n"
-
-
-def _request_sha256(request: BaseModel) -> str:
-    """Return the complete canonical OpenAI request digest for idempotency binding."""
-    payload = request.model_dump(mode="json")
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(encoded).hexdigest()
 
 
 def _reject_unsupported_fields(value: object, supported: frozenset[str], api_name: str) -> None:

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -89,7 +89,16 @@ class _UnsupportedIdempotencyService:
         idempotency_key: str,
         conversation_id: str | None = None,
     ) -> RoutedModelResponse:
-        """Reject a keyed interaction before routing or provider dispatch."""
+        """Reject a keyed interaction before routing or provider dispatch.
+
+        Args:
+            request: Request that cannot be completed durably.
+            idempotency_key: Caller key with no durable owner.
+            conversation_id: Optional conversation identity supplied by the endpoint.
+
+        Raises:
+            RouterCompletionConflictError: Always, because no durable service is configured.
+        """
         del request, idempotency_key, conversation_id
         raise RouterCompletionConflictError(
             "this router has no durable idempotency service; retry without Idempotency-Key"
@@ -382,7 +391,11 @@ def create_router_endpoint(
 
     @router.get("/v1/models")
     def models() -> dict[str, object]:
-        """List the routed model names exposed by this endpoint."""
+        """List the routed model names exposed by this endpoint.
+
+        Returns:
+            OpenAI-compatible model-list envelope in deterministic name order.
+        """
         return {
             "object": "list",
             "data": [

--- a/wmo/runtime/router/endpoint_state_test.py
+++ b/wmo/runtime/router/endpoint_state_test.py
@@ -1,0 +1,44 @@
+"""Adversarial bounds for local Responses continuation state."""
+
+import pytest
+
+from wmo.runtime.router.endpoint import HttpMessage, _OpenAIRequestState, _ResponseState
+
+
+def _state(*, expires_at: float, size_bytes: int) -> _ResponseState:
+    return _ResponseState(
+        episode_id="episode-a",
+        messages=(HttpMessage(role="user", content="x"),),
+        expires_at=expires_at,
+        size_bytes=size_bytes,
+    )
+
+
+def test_response_state_expires_before_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired response identities cannot recover retained transcript content."""
+    now = [10.0]
+    monkeypatch.setattr("wmo.runtime.router.endpoint.time.monotonic", lambda: now[0])
+    state = _OpenAIRequestState()
+    state.remember_response("resp_a", _state(expires_at=11.0, size_bytes=10))
+
+    now[0] = 12.0
+
+    with pytest.raises(ValueError, match="live local response"):
+        state.response_context("resp_a")
+    assert state._response_bytes == 0  # noqa: SLF001
+
+
+def test_response_state_evicts_to_the_byte_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Large histories are evicted even when the item-count ceiling is not reached."""
+    monkeypatch.setattr("wmo.runtime.router.endpoint._RESPONSE_CAPACITY_BYTES", 15)
+    state = _OpenAIRequestState()
+
+    state.remember_response("resp_a", _state(expires_at=1e99, size_bytes=10))
+    state.remember_response("resp_b", _state(expires_at=1e99, size_bytes=10))
+
+    with pytest.raises(ValueError, match="live local response"):
+        state.response_context("resp_a")
+    assert state.response_context("resp_b").episode_id == "episode-a"
+    assert state._response_bytes == 10  # noqa: SLF001

--- a/wmo/runtime/router/endpoint_state_test.py
+++ b/wmo/runtime/router/endpoint_state_test.py
@@ -6,7 +6,15 @@ from wmo.runtime.router.endpoint import HttpMessage, _OpenAIRequestState, _Respo
 
 
 def _state(*, expires_at: float, size_bytes: int) -> _ResponseState:
-    """Build retained response state with controlled expiry and size."""
+    """Build retained response state with controlled expiry and size.
+
+    Args:
+        expires_at: Monotonic deadline for the test state.
+        size_bytes: Serialized size charged to the continuation capacity.
+
+    Returns:
+        Deterministic response state for continuation-boundary tests.
+    """
     return _ResponseState(
         episode_id="episode-a",
         messages=(HttpMessage(role="user", content="x"),),
@@ -18,7 +26,11 @@ def _state(*, expires_at: float, size_bytes: int) -> _ResponseState:
 def test_response_state_expires_before_continuation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Expired response identities cannot recover retained transcript content."""
+    """Prove expired response identities cannot recover retained transcript content.
+
+    The test advances the monotonic clock beyond the stored deadline and verifies both lookup
+    rejection and byte-accounting cleanup.
+    """
     now = [10.0]
     monkeypatch.setattr("wmo.runtime.router.endpoint.time.monotonic", lambda: now[0])
     state = _OpenAIRequestState()
@@ -32,7 +44,11 @@ def test_response_state_expires_before_continuation(
 
 
 def test_response_state_evicts_to_the_byte_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Large histories are evicted even when the item-count ceiling is not reached."""
+    """Prove byte pressure evicts history before the item-count ceiling.
+
+    The test stores two individually valid histories whose combined serialized size exceeds the
+    configured capacity, then verifies the oldest identity is unavailable.
+    """
     monkeypatch.setattr("wmo.runtime.router.endpoint._RESPONSE_CAPACITY_BYTES", 15)
     state = _OpenAIRequestState()
 

--- a/wmo/runtime/router/endpoint_state_test.py
+++ b/wmo/runtime/router/endpoint_state_test.py
@@ -6,6 +6,7 @@ from wmo.runtime.router.endpoint import HttpMessage, _OpenAIRequestState, _Respo
 
 
 def _state(*, expires_at: float, size_bytes: int) -> _ResponseState:
+    """Build retained response state with controlled expiry and size."""
     return _ResponseState(
         episode_id="episode-a",
         messages=(HttpMessage(role="user", content="x"),),

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -38,6 +38,7 @@ class _ReplayService:
     """Thread-safe test double for the durable journal completion contract."""
 
     def __init__(self, runtime: RouterRuntime) -> None:
+        """Initialize the replay service around a router runtime."""
         self.runtime = runtime
         self._lock = threading.Lock()
         self._completed: dict[str, tuple[ModelRequest, RoutedModelResponse]] = {}
@@ -49,6 +50,7 @@ class _ReplayService:
         idempotency_key: str,
         conversation_id: str | None = None,
     ) -> RoutedModelResponse:
+        """Complete a request once per key and replay the durable result."""
         if not idempotency_key:
             return self.runtime.complete(request, episode_id=conversation_id)
         with self._lock:
@@ -65,6 +67,7 @@ class _ReplayService:
 def _clients(
     *, candidate_tools: bool = True, durable: bool = False
 ) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
+    """Build official and loopback clients over one test router runtime."""
     runtime, model_client = _runtime(candidate_tools=candidate_tools)
     service = _ReplayService(runtime) if durable else None
     app = create_project_router_app("router-a", runtime, completion_service=service)

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -50,7 +50,19 @@ class _ReplayService:
         idempotency_key: str,
         conversation_id: str | None = None,
     ) -> RoutedModelResponse:
-        """Complete a request once per key and replay the durable result."""
+        """Complete a request once per key and replay the durable result.
+
+        Args:
+            request: Provider-neutral request to route.
+            idempotency_key: Caller key that owns the replay entry.
+            conversation_id: Optional stable conversation identity.
+
+        Returns:
+            Newly completed or previously retained routed response.
+
+        Raises:
+            RouterCompletionConflictError: The key is reused for another request.
+        """
         if not idempotency_key:
             return self.runtime.complete(request, episode_id=conversation_id)
         with self._lock:
@@ -67,7 +79,15 @@ class _ReplayService:
 def _clients(
     *, candidate_tools: bool = True, durable: bool = False
 ) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
-    """Build official and loopback clients over one test router runtime."""
+    """Build official and loopback clients over one test router runtime.
+
+    Args:
+        candidate_tools: Whether the routed candidate declares tool support.
+        durable: Whether to inject the replaying durable completion service.
+
+    Returns:
+        Official OpenAI client, loopback HTTP client, router runtime, and model client.
+    """
     runtime, model_client = _runtime(candidate_tools=candidate_tools)
     service = _ReplayService(runtime) if durable else None
     app = create_project_router_app("router-a", runtime, completion_service=service)
@@ -207,7 +227,11 @@ def test_official_responses_client_continues_with_previous_response_id() -> None
 
 
 def test_responses_continuation_does_not_carry_prior_instructions() -> None:
-    """Each Responses instructions field is scoped only to its own provider call."""
+    """Prove Responses instructions remain scoped to their provider call.
+
+    A continued request retains visible conversation content while excluding the earlier
+    request-scoped instruction from the next provider transcript.
+    """
     openai, _http, _runtime_value, model_client = _clients()
 
     first = openai.responses.create(model="router-a", input="one", instructions="FIRST")
@@ -301,7 +325,11 @@ def test_official_clients_parse_buffered_streams() -> None:
 
 
 def test_responses_tool_stream_emits_the_official_item_and_argument_events() -> None:
-    """Official SDK tool loops observe the complete Responses streaming lifecycle."""
+    """Prove tool streams expose the complete official Responses lifecycle.
+
+    The official SDK observes item creation, argument delta and completion, item completion, and
+    the final response event in protocol order.
+    """
     openai, _http, _runtime_value, _model_client = _clients()
 
     events = list(
@@ -331,7 +359,11 @@ def test_responses_tool_stream_emits_the_official_item_and_argument_events() -> 
 
 
 def test_nested_unsupported_official_fields_fail_before_dispatch() -> None:
-    """Official nested fields are never silently discarded by the provider-neutral seam."""
+    """Prove unsupported official nested fields fail before provider dispatch.
+
+    Strict tool schemas and serial tool-call requirements are rejected at validation, and neither
+    request reaches the model client.
+    """
     _openai, http, _runtime_value, model_client = _clients()
 
     response = http.post(
@@ -355,7 +387,11 @@ def test_nested_unsupported_official_fields_fail_before_dispatch() -> None:
 
 
 def test_length_and_responses_request_metadata_are_preserved() -> None:
-    """Truncation and supported Responses request metadata survive public adaptation."""
+    """Prove truncation and supported request metadata survive public adaptation.
+
+    The response preserves instructions, tool settings, temperature, token limits, usage, and the
+    incomplete terminal state produced by length termination.
+    """
     model_response = ModelResponse(
         output=AssistantAction(content="partial"),
         model=_snapshot("cheap"),
@@ -406,7 +442,11 @@ def test_length_and_responses_request_metadata_are_preserved() -> None:
 
 
 def test_idempotency_key_fails_closed_without_a_durable_service() -> None:
-    """A raw runtime rejects claimed idempotency before selection or provider dispatch."""
+    """Prove a keyed request fails closed without a durable completion service.
+
+    The endpoint rejects the claim before router selection or provider dispatch can create state
+    that cannot be replayed durably.
+    """
     _openai, http, runtime, model_client = _clients()
 
     response = http.post(
@@ -422,7 +462,11 @@ def test_idempotency_key_fails_closed_without_a_durable_service() -> None:
 
 @pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
 def test_empty_idempotency_key_is_rejected_before_dispatch(path: str) -> None:
-    """An empty standard idempotency key cannot become an unkeyed provider call."""
+    """Prove an empty standard idempotency key never becomes an unkeyed call.
+
+    Args:
+        path: OpenAI endpoint path exercised by the parameterized regression.
+    """
     _openai, http, runtime, model_client = _clients(durable=True)
     payload = (
         {"model": "router-a", "input": "retry"}
@@ -438,7 +482,11 @@ def test_empty_idempotency_key_is_rejected_before_dispatch(path: str) -> None:
 
 
 def test_durable_service_replays_the_same_public_completion() -> None:
-    """A durable completion service prevents duplicate dispatch and public-envelope drift."""
+    """Prove durable Chat Completion replay avoids dispatch and envelope drift.
+
+    Two calls with the same key return identical public JSON while producing only one model client
+    completion.
+    """
     _openai, http, _runtime_value, model_client = _clients(durable=True)
     payload = {"model": "router-a", "messages": [{"role": "user", "content": "same"}]}
     headers = {"Idempotency-Key": "interaction-a"}
@@ -453,7 +501,11 @@ def test_durable_service_replays_the_same_public_completion() -> None:
 
 
 def test_durable_service_replays_the_same_public_response() -> None:
-    """Responses replay preserves nested output identities without another provider call."""
+    """Prove durable Responses replay preserves nested public identities.
+
+    Reusing a caller key returns identical response and child-item IDs without another provider
+    invocation.
+    """
     _openai, http, _runtime_value, model_client = _clients(durable=True)
     payload = {"model": "router-a", "input": "same"}
     headers = {"Idempotency-Key": "interaction-response"}
@@ -468,7 +520,11 @@ def test_durable_service_replays_the_same_public_response() -> None:
 
 @pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
 def test_idempotency_key_rejects_a_different_request(path: str) -> None:
-    """One standard idempotency key cannot merge two divergent OpenAI requests."""
+    """Prove one idempotency key cannot merge divergent OpenAI requests.
+
+    Args:
+        path: OpenAI endpoint path exercised by the parameterized conflict regression.
+    """
     _openai, http, _runtime_value, model_client = _clients(durable=True)
     headers = {"Idempotency-Key": "one-logical-request"}
     if path.endswith("responses"):

--- a/wmo/runtime/router/endpoint_test.py
+++ b/wmo/runtime/router/endpoint_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 from fastapi.testclient import TestClient
 from openai import OpenAI
@@ -12,15 +14,60 @@ from openai.types.chat import (
     ChatCompletionToolUnionParam,
 )
 from openai.types.responses import Response, ResponseStreamEvent
+from openai.types.responses.function_tool_param import FunctionToolParam
 
+from wmo.common.models import (
+    AssistantAction,
+    ModelFinishReason,
+    ModelRequest,
+    ModelResponse,
+    OperationEconomics,
+)
 from wmo.runtime.router.application import create_project_router_app
-from wmo.runtime.router.runtime import RouterRuntime
-from wmo.runtime.router.runtime_test import _Client, _runtime
+from wmo.runtime.router.completion import RouterCompletionConflictError
+from wmo.runtime.router.endpoint import (
+    HttpResponseRequest,
+    _chat_completion,
+    _openai_response,
+)
+from wmo.runtime.router.runtime import RoutedModelResponse, RouterRuntime
+from wmo.runtime.router.runtime_test import _Client, _runtime, _snapshot
 
 
-def _clients(*, candidate_tools: bool = True) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
+class _ReplayService:
+    """Thread-safe test double for the durable journal completion contract."""
+
+    def __init__(self, runtime: RouterRuntime) -> None:
+        self.runtime = runtime
+        self._lock = threading.Lock()
+        self._completed: dict[str, tuple[ModelRequest, RoutedModelResponse]] = {}
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        idempotency_key: str,
+        conversation_id: str | None = None,
+    ) -> RoutedModelResponse:
+        if not idempotency_key:
+            return self.runtime.complete(request, episode_id=conversation_id)
+        with self._lock:
+            existing = self._completed.get(idempotency_key)
+            if existing is not None:
+                if existing[0] != request:
+                    raise RouterCompletionConflictError("key reused for another request")
+                return existing[1]
+            result = self.runtime.complete(request, episode_id=conversation_id or idempotency_key)
+            self._completed[idempotency_key] = (request, result)
+            return result
+
+
+def _clients(
+    *, candidate_tools: bool = True, durable: bool = False
+) -> tuple[OpenAI, TestClient, RouterRuntime, _Client]:
     runtime, model_client = _runtime(candidate_tools=candidate_tools)
-    app = create_project_router_app("router-a", runtime)
+    service = _ReplayService(runtime) if durable else None
+    app = create_project_router_app("router-a", runtime, completion_service=service)
     http = TestClient(app)
     openai = OpenAI(api_key="local-test", base_url="http://testserver/v1", http_client=http)
     return openai, http, runtime, model_client
@@ -156,6 +203,26 @@ def test_official_responses_client_continues_with_previous_response_id() -> None
     ]
 
 
+def test_responses_continuation_does_not_carry_prior_instructions() -> None:
+    """Each Responses instructions field is scoped only to its own provider call."""
+    openai, _http, _runtime_value, model_client = _clients()
+
+    first = openai.responses.create(model="router-a", input="one", instructions="FIRST")
+    openai.responses.create(
+        model="router-a",
+        input="two",
+        instructions="SECOND",
+        previous_response_id=first.id,
+    )
+
+    assert [(item.role, item.content) for item in model_client.requests[-1].messages] == [
+        ("user", "one"),
+        ("assistant", None),
+        ("system", "SECOND"),
+        ("user", "two"),
+    ]
+
+
 def test_openai_text_content_parts_are_preserved() -> None:
     """Chat and Responses text parts reach the routed model as complete visible text."""
     openai, _http, _runtime_value, model_client = _clients()
@@ -230,31 +297,176 @@ def test_official_clients_parse_buffered_streams() -> None:
     assert response_events[-1].type == "response.completed"
 
 
-def test_idempotency_key_reuses_decision_after_provider_failure() -> None:
-    """A standard idempotency key pins the retry decision without a WMO episode header."""
-    openai, http, runtime, model_client = _clients()
-    model_client.completion_error = RuntimeError("provider unavailable")
-    payload = {"model": "router-a", "messages": [{"role": "user", "content": "retry"}]}
-    headers = {"Idempotency-Key": "interaction-a"}
+def test_responses_tool_stream_emits_the_official_item_and_argument_events() -> None:
+    """Official SDK tool loops observe the complete Responses streaming lifecycle."""
+    openai, _http, _runtime_value, _model_client = _clients()
 
-    assert http.post("/v1/chat/completions", json=payload, headers=headers).status_code == 502
-    cached = next(iter(runtime._request_decisions.values()))  # noqa: SLF001
-    response = openai.chat.completions.create(
-        model="router-a",
-        messages=[{"role": "user", "content": "retry"}],
-        extra_headers=headers,
+    events = list(
+        openai.responses.create(
+            model="router-a",
+            input="write",
+            tools=[
+                FunctionToolParam(
+                    type="function",
+                    name="write",
+                    parameters={"type": "object"},
+                    strict=None,
+                )
+            ],
+            stream=True,
+        )
     )
 
-    assert response.id.startswith("chatcmpl-")
-    assert next(iter(runtime._request_decisions.values())) == cached  # noqa: SLF001
-    assert model_client.embed_calls == 1
-    assert model_client.complete_calls == 2
+    assert [event.type for event in events] == [
+        "response.created",
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+
+
+def test_nested_unsupported_official_fields_fail_before_dispatch() -> None:
+    """Official nested fields are never silently discarded by the provider-neutral seam."""
+    _openai, http, _runtime_value, model_client = _clients()
+
+    response = http.post(
+        "/v1/chat/completions",
+        json={
+            "model": "router-a",
+            "messages": [{"role": "user", "content": "read", "name": "customer"}],
+        },
+    )
+    strict = http.post(
+        "/v1/responses",
+        json={
+            "model": "router-a",
+            "input": "read",
+            "tools": [{"type": "function", "name": "read", "parameters": {}, "strict": True}],
+        },
+    )
+
+    assert response.status_code == strict.status_code == 400
+    assert model_client.embed_calls == model_client.complete_calls == 0
+
+
+def test_length_and_responses_request_metadata_are_preserved() -> None:
+    """Truncation and supported Responses request metadata survive public adaptation."""
+    model_response = ModelResponse(
+        output=AssistantAction(content="partial"),
+        model=_snapshot("cheap"),
+        economics=OperationEconomics(),
+        finish_reason=ModelFinishReason.LENGTH,
+    )
+    request = HttpResponseRequest.model_validate(
+        {
+            "model": "router-a",
+            "input": "write",
+            "instructions": "be brief",
+            "temperature": 0.2,
+            "max_output_tokens": 10,
+            "parallel_tool_calls": True,
+            "tool_choice": {"type": "function", "name": "write"},
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "write",
+                    "parameters": {"type": "object"},
+                    "strict": None,
+                }
+            ],
+        }
+    )
+
+    chat = _chat_completion("router-a", model_response.output, model_response)
+    response = _openai_response(
+        "router-a",
+        model_response.output,
+        model_response,
+        request=request,
+        idempotency_key=None,
+        previous_response_id=None,
+    )
+
+    assert chat.choices[0].finish_reason == "length"
+    assert response.status == "incomplete"
+    assert response.incomplete_details is not None
+    assert response.incomplete_details.reason == "max_output_tokens"
+    assert response.instructions == "be brief"
+    assert response.temperature == 0.2
+    assert response.max_output_tokens == 10
+    assert response.parallel_tool_calls is True
+    assert not isinstance(response.tool_choice, str)
+    assert response.tool_choice.type == "function"
+    assert response.tools[0].type == "function"
+
+
+def test_idempotency_key_fails_closed_without_a_durable_service() -> None:
+    """A raw runtime rejects claimed idempotency before selection or provider dispatch."""
+    _openai, http, runtime, model_client = _clients()
+
+    response = http.post(
+        "/v1/chat/completions",
+        json={"model": "router-a", "messages": [{"role": "user", "content": "retry"}]},
+        headers={"Idempotency-Key": "interaction-a"},
+    )
+
+    assert response.status_code == 409
+    assert model_client.embed_calls == model_client.complete_calls == 0
+    assert not runtime._request_decisions  # noqa: SLF001
+
+
+@pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
+def test_empty_idempotency_key_is_rejected_before_dispatch(path: str) -> None:
+    """An empty standard idempotency key cannot become an unkeyed provider call."""
+    _openai, http, runtime, model_client = _clients(durable=True)
+    payload = (
+        {"model": "router-a", "input": "retry"}
+        if path.endswith("responses")
+        else {"model": "router-a", "messages": [{"role": "user", "content": "retry"}]}
+    )
+
+    response = http.post(path, json=payload, headers={"Idempotency-Key": " "})
+
+    assert response.status_code == 400
+    assert model_client.embed_calls == model_client.complete_calls == 0
+    assert not runtime._request_decisions  # noqa: SLF001
+
+
+def test_durable_service_replays_the_same_public_completion() -> None:
+    """A durable completion service prevents duplicate dispatch and public-envelope drift."""
+    _openai, http, _runtime_value, model_client = _clients(durable=True)
+    payload = {"model": "router-a", "messages": [{"role": "user", "content": "same"}]}
+    headers = {"Idempotency-Key": "interaction-a"}
+
+    first = http.post("/v1/chat/completions", json=payload, headers=headers)
+    second = http.post("/v1/chat/completions", json=payload, headers=headers)
+
+    assert first.status_code == second.status_code == 200
+    assert first.content == second.content
+    assert first.json()["id"].startswith("chatcmpl-")
+    assert model_client.embed_calls == model_client.complete_calls == 1
+
+
+def test_durable_service_replays_the_same_public_response() -> None:
+    """Responses replay preserves nested output identities without another provider call."""
+    _openai, http, _runtime_value, model_client = _clients(durable=True)
+    payload = {"model": "router-a", "input": "same"}
+    headers = {"Idempotency-Key": "interaction-response"}
+
+    first = http.post("/v1/responses", json=payload, headers=headers)
+    second = http.post("/v1/responses", json=payload, headers=headers)
+
+    assert first.status_code == second.status_code == 200
+    assert first.content == second.content
+    assert model_client.embed_calls == model_client.complete_calls == 1
 
 
 @pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
 def test_idempotency_key_rejects_a_different_request(path: str) -> None:
     """One standard idempotency key cannot merge two divergent OpenAI requests."""
-    _openai, http, _runtime_value, model_client = _clients()
+    _openai, http, _runtime_value, model_client = _clients(durable=True)
     headers = {"Idempotency-Key": "one-logical-request"}
     if path.endswith("responses"):
         first = {"model": "router-a", "input": "first"}
@@ -271,38 +483,11 @@ def test_idempotency_key_rejects_a_different_request(path: str) -> None:
 
     assert conflict.status_code == 409
     assert (
-        conflict.json()["error"]["message"] == "Idempotency-Key conflicts with live request state"
+        conflict.json()["error"]["message"]
+        == "Idempotency-Key conflicts with durable request state"
     )
     assert model_client.embed_calls == 1
     assert model_client.complete_calls == 1
-
-
-@pytest.mark.parametrize("path", ("/v1/chat/completions", "/v1/responses"))
-def test_expired_idempotency_key_starts_a_fresh_episode(
-    path: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """An expired transport key cannot reconnect to retained router state."""
-    now = [100.0]
-    monkeypatch.setattr("wmo.runtime.router.endpoint.time.monotonic", lambda: now[0])
-    _openai, http, runtime, model_client = _clients()
-    headers = {"Idempotency-Key": "reusable-after-retention"}
-    if path.endswith("responses"):
-        first = {"model": "router-a", "input": "first"}
-        changed = {"model": "router-a", "input": "changed"}
-    else:
-        first = {"model": "router-a", "messages": [{"role": "user", "content": "first"}]}
-        changed = {
-            "model": "router-a",
-            "messages": [{"role": "user", "content": "changed"}],
-        }
-
-    assert http.post(path, json=first, headers=headers).status_code == 200
-    now[0] += 24 * 60 * 60 + 1
-    assert http.post(path, json=changed, headers=headers).status_code == 200
-
-    assert model_client.embed_calls == 2
-    assert model_client.complete_calls == 2
-    assert len(runtime._episode_decisions) == 2  # noqa: SLF001
 
 
 @pytest.mark.parametrize(

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -473,7 +473,17 @@ class RouterRuntime:
         request_sha256: Sha256,
         episode_id: str,
     ) -> RoutingDecision:
-        """Use a frozen eligible candidate when the original selection cannot serve the request."""
+        """Use a frozen eligible candidate when the original selection cannot serve the request.
+
+        Args:
+            request: Provider-neutral request whose capabilities must be supported.
+            decision: Original guarded routing decision.
+            request_sha256: Frozen feature identity for the request.
+            episode_id: Stable caller identity used by fallback decisions.
+
+        Returns:
+            The original decision when eligible, otherwise a guarded fallback decision.
+        """
         if _supports_request(self._resolve(decision.selected_alias), request):
             return decision
         eligible = tuple(
@@ -572,7 +582,15 @@ def _validate_idempotency_key(value: str) -> None:
 
 
 def _supports_request(resolved: ResolvedModel, request: ModelRequest) -> bool:
-    """Return whether one frozen resolved model proves every requested protocol capability."""
+    """Check whether a resolved model proves every requested protocol capability.
+
+    Args:
+        resolved: Frozen runtime model and its declared capabilities.
+        request: Provider-neutral request to evaluate.
+
+    Returns:
+        True when tool and output-token requirements are both proven.
+    """
     if _requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
         return False
     requested = request.maximum_output_tokens

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -277,6 +277,7 @@ class RouterRuntime:
                         request_sha256=request_sha256,
                         episode_id=identity,
                     )
+            decision = self._eligible_decision(request, decision, request_sha256, identity)
             self._record(decision)
             if episode_decision is None:
                 self._episode_decisions[identity_sha256] = decision
@@ -462,6 +463,42 @@ class RouterRuntime:
             self._resolved[alias] = resolved
         return resolved
 
+    def _eligible_decision(
+        self,
+        request: ModelRequest,
+        decision: RoutingDecision,
+        request_sha256: Sha256,
+        episode_id: str,
+    ) -> RoutingDecision:
+        """Use a frozen eligible candidate when the original selection cannot serve the request."""
+        if _supports_request(self._resolve(decision.selected_alias), request):
+            return decision
+        eligible = tuple(
+            candidate.alias
+            for candidate in self.policy.candidates
+            if _supports_request(self._resolve(candidate.alias), request)
+        )
+        if not eligible:
+            return decision
+        alias = (
+            self.policy.baseline_alias
+            if self.policy.baseline_alias in eligible
+            else min(
+                eligible,
+                key=lambda item: (
+                    self.bank.complete_weighted_cost(item) is None,
+                    self.bank.complete_weighted_cost(item) or 0.0,
+                    item,
+                ),
+            )
+        )
+        return self._fallback_decision(
+            request_sha256,
+            episode_id,
+            "capability_eligibility",
+            selected_alias=alias,
+        )
+
     def _fallback_decision(
         self,
         request_sha256: str,
@@ -529,3 +566,12 @@ def _validate_idempotency_key(value: str) -> None:
         raise ValueError("idempotency key must be 1 to 512 non-blank characters")
     if any(ord(character) < 33 or ord(character) > 126 for character in value):
         raise ValueError("idempotency key must contain only visible ASCII characters")
+
+
+def _supports_request(resolved: ResolvedModel, request: ModelRequest) -> bool:
+    """Return whether one frozen resolved model proves every requested protocol capability."""
+    if _requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
+        return False
+    requested = request.maximum_output_tokens
+    available = resolved.capabilities.maximum_output_tokens
+    return requested is None or (available is not None and requested <= available)

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -283,6 +283,12 @@ class RouterRuntime:
                 episode_decision is None
                 or decision.selected_alias != episode_decision.selected_alias
             ):
+                if episode_decision is not None:
+                    stale_request_keys = tuple(
+                        key for key in self._request_decisions if key[0] == identity_sha256
+                    )
+                    for stale_key in stale_request_keys:
+                        del self._request_decisions[stale_key]
                 self._episode_decisions[identity_sha256] = decision
             self._request_decisions[request_key] = decision
             return decision

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -279,7 +279,10 @@ class RouterRuntime:
                     )
             decision = self._eligible_decision(request, decision, request_sha256, identity)
             self._record(decision)
-            if episode_decision is None:
+            if (
+                episode_decision is None
+                or decision.selected_alias != episode_decision.selected_alias
+            ):
                 self._episode_decisions[identity_sha256] = decision
             self._request_decisions[request_key] = decision
             return decision

--- a/wmo/runtime/router/runtime_capability_test.py
+++ b/wmo/runtime/router/runtime_capability_test.py
@@ -117,3 +117,62 @@ def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
     assert result.decision.selected_alias == "baseline"
     assert result.decision.fallback_reason == "capability_eligibility"
     assert client.complete_calls == 1
+
+
+def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
+    """A later capability fallback remains sticky for subsequent ordinary turns."""
+    policy, manifest, bank, snapshots, client = _fixture()
+    capabilities = {
+        "cheap": ModelCapabilities(),
+        "baseline": ModelCapabilities(supports_tools=True),
+        "embedder": ModelCapabilities(supports_embeddings=True),
+    }
+    snapshots = {
+        alias: snapshot.model_copy(update={"capabilities_sha256": sha256_json(capabilities[alias])})
+        for alias, snapshot in snapshots.items()
+    }
+    policy = policy.model_copy(
+        update={
+            "candidates": tuple(
+                RoutedCandidateSnapshot(alias=item.alias, model=snapshots[item.alias])
+                for item in policy.candidates
+            ),
+            "embedder": snapshots[policy.embedder_alias],
+        }
+    )
+
+    class _MixedCatalog(_Catalog):
+        def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+            return snapshots[alias], capabilities[alias]
+
+        def resolve(self, alias: str) -> ResolvedModel:
+            snapshot, capability = self.snapshot(alias)
+            return ResolvedModel(
+                alias,
+                snapshot,
+                capability,
+                client,
+                client if capability.supports_embeddings else None,
+            )
+
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _MixedCatalog(snapshots, client)),
+        pricing_snapshot_id="pricing-a",
+        pricing_snapshot_sha256="a" * 64,
+        pricing_candidate_aliases=bank.candidate_aliases,
+    )
+
+    first = runtime.select(_request(), episode_id="eligible-sticky")
+    fallback = runtime.select(_request(tool_name="read"), episode_id="eligible-sticky")
+    later = runtime.select(
+        ModelRequest(messages=(ModelMessage(role="user", content="ordinary later turn"),)),
+        episode_id="eligible-sticky",
+    )
+
+    assert first.selected_alias == "cheap"
+    assert fallback.selected_alias == "baseline"
+    assert fallback.fallback_reason == "capability_eligibility"
+    assert later.selected_alias == "baseline"

--- a/wmo/runtime/router/runtime_capability_test.py
+++ b/wmo/runtime/router/runtime_capability_test.py
@@ -1,10 +1,23 @@
 """Request-time capability eligibility for the frozen router runtime."""
 
+from typing import cast
+
 import pytest
 
-from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolCall
+from wmo.common.core.artifacts import sha256_json
+from wmo.common.models import (
+    AssistantAction,
+    ModelCapabilities,
+    ModelMessage,
+    ModelRequest,
+    ModelSnapshot,
+    RoutedCandidateSnapshot,
+    ToolCall,
+)
+from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router import RouterModelCapabilityError
-from wmo.runtime.router.runtime_test import _request, _runtime
+from wmo.runtime.router.runtime import RouterRuntime
+from wmo.runtime.router.runtime_test import _Catalog, _fixture, _request, _runtime
 
 
 def test_selected_model_must_prove_tool_capability_before_dispatch() -> None:
@@ -51,3 +64,56 @@ def test_replayed_tool_history_requires_tool_capability() -> None:
         runtime.complete(request, episode_id="history-episode")
 
     assert client.complete_calls == 0
+
+
+def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
+    """An incapable preferred alias does not mask another eligible frozen candidate."""
+    policy, manifest, bank, snapshots, client = _fixture()
+    capabilities = {
+        "cheap": ModelCapabilities(),
+        "baseline": ModelCapabilities(supports_tools=True),
+        "embedder": ModelCapabilities(supports_embeddings=True),
+    }
+    snapshots = {
+        alias: snapshot.model_copy(update={"capabilities_sha256": sha256_json(capabilities[alias])})
+        for alias, snapshot in snapshots.items()
+    }
+    policy = policy.model_copy(
+        update={
+            "candidates": tuple(
+                RoutedCandidateSnapshot(alias=item.alias, model=snapshots[item.alias])
+                for item in policy.candidates
+            ),
+            "embedder": snapshots[policy.embedder_alias],
+        }
+    )
+
+    class _MixedCatalog(_Catalog):
+        def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+            return snapshots[alias], capabilities[alias]
+
+        def resolve(self, alias: str) -> ResolvedModel:
+            snapshot, capability = self.snapshot(alias)
+            return ResolvedModel(
+                alias,
+                snapshot,
+                capability,
+                client,
+                client if capability.supports_embeddings else None,
+            )
+
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _MixedCatalog(snapshots, client)),
+        pricing_snapshot_id="pricing-a",
+        pricing_snapshot_sha256="a" * 64,
+        pricing_candidate_aliases=bank.candidate_aliases,
+    )
+
+    result = runtime.complete(_request(tool_name="read"), episode_id="eligible")
+
+    assert result.decision.selected_alias == "baseline"
+    assert result.decision.fallback_reason == "capability_eligibility"
+    assert client.complete_calls == 1

--- a/wmo/runtime/router/runtime_capability_test.py
+++ b/wmo/runtime/router/runtime_capability_test.py
@@ -67,7 +67,11 @@ def test_replayed_tool_history_requires_tool_capability() -> None:
 
 
 def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
-    """An incapable preferred alias does not mask another eligible frozen candidate."""
+    """Prove an incapable preferred alias cannot mask an eligible frozen candidate.
+
+    The runtime evaluates request-time capabilities before dispatch and selects the frozen
+    baseline that supports the requested tool protocol.
+    """
     policy, manifest, bank, snapshots, client = _fixture()
     capabilities = {
         "cheap": ModelCapabilities(),
@@ -94,7 +98,14 @@ def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
             return snapshots[alias], capabilities[alias]
 
         def resolve(self, alias: str) -> ResolvedModel:
-            """Resolve an alias to the shared test client and frozen metadata."""
+            """Resolve an alias to the shared test client and frozen metadata.
+
+            Args:
+                alias: Frozen candidate alias to resolve.
+
+            Returns:
+                Resolved model with capability-appropriate embedding support.
+            """
             snapshot, capability = self.snapshot(alias)
             return ResolvedModel(
                 alias,
@@ -122,7 +133,11 @@ def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
 
 
 def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
-    """A later capability fallback remains sticky for subsequent ordinary turns."""
+    """Prove a capability fallback replaces the episode's sticky model.
+
+    An ordinary turn first selects the cheap model, a tool turn falls back to the eligible model,
+    and both a later turn and an exact replay of the first request remain on that replacement.
+    """
     policy, manifest, bank, snapshots, client = _fixture()
     capabilities = {
         "cheap": ModelCapabilities(),
@@ -149,7 +164,14 @@ def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
             return snapshots[alias], capabilities[alias]
 
         def resolve(self, alias: str) -> ResolvedModel:
-            """Resolve an alias to the shared test client and frozen metadata."""
+            """Resolve an alias to the shared test client and frozen metadata.
+
+            Args:
+                alias: Frozen candidate alias to resolve.
+
+            Returns:
+                Resolved model with capability-appropriate embedding support.
+            """
             snapshot, capability = self.snapshot(alias)
             return ResolvedModel(
                 alias,
@@ -175,8 +197,10 @@ def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
         ModelRequest(messages=(ModelMessage(role="user", content="ordinary later turn"),)),
         episode_id="eligible-sticky",
     )
+    replayed_first = runtime.select(_request(), episode_id="eligible-sticky")
 
     assert first.selected_alias == "cheap"
     assert fallback.selected_alias == "baseline"
     assert fallback.fallback_reason == "capability_eligibility"
     assert later.selected_alias == "baseline"
+    assert replayed_first.selected_alias == "baseline"

--- a/wmo/runtime/router/runtime_capability_test.py
+++ b/wmo/runtime/router/runtime_capability_test.py
@@ -90,9 +90,11 @@ def test_selection_uses_an_eligible_frozen_candidate_before_dispatch() -> None:
 
     class _MixedCatalog(_Catalog):
         def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+            """Return the frozen model and capabilities for an alias."""
             return snapshots[alias], capabilities[alias]
 
         def resolve(self, alias: str) -> ResolvedModel:
+            """Resolve an alias to the shared test client and frozen metadata."""
             snapshot, capability = self.snapshot(alias)
             return ResolvedModel(
                 alias,
@@ -143,9 +145,11 @@ def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
 
     class _MixedCatalog(_Catalog):
         def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+            """Return the frozen model and capabilities for an alias."""
             return snapshots[alias], capabilities[alias]
 
         def resolve(self, alias: str) -> ResolvedModel:
+            """Resolve an alias to the shared test client and frozen metadata."""
             snapshot, capability = self.snapshot(alias)
             return ResolvedModel(
                 alias,

--- a/wmo/runtime/router/streaming.py
+++ b/wmo/runtime/router/streaming.py
@@ -116,6 +116,7 @@ def responses_stream(response: OpenAIResponse) -> Iterator[str]:
 def _text_events(
     item: ResponseOutputMessage, output_index: int, sequence: int
 ) -> Generator[str, None, int]:
+    """Yield the official content-part and text lifecycle for one output message."""
     for content_index, content in enumerate(item.content):
         if content.type != "output_text":
             continue
@@ -165,6 +166,7 @@ def _text_events(
 def _function_events(
     item: ResponseFunctionToolCall, output_index: int, sequence: int
 ) -> Generator[str, None, int]:
+    """Yield the official argument lifecycle for one function-call item."""
     if item.id is None:
         raise ValueError("Responses function-call output omitted its item ID")
     events = (
@@ -190,4 +192,5 @@ def _function_events(
 
 
 def _event(name: str, data: str) -> str:
+    """Encode one named server-sent event."""
     return f"event: {name}\ndata: {data}\n\n"

--- a/wmo/runtime/router/streaming.py
+++ b/wmo/runtime/router/streaming.py
@@ -1,0 +1,193 @@
+"""Official OpenAI SSE framing for buffered routed model responses."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterator
+
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.responses import Response as OpenAIResponse
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent,
+    ResponseCreatedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
+    ResponseIncompleteEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
+)
+
+from wmo.common.core.artifacts import JsonObject
+
+
+def chat_stream(completion: ChatCompletion) -> Iterator[str]:
+    """Reframe one buffered Chat Completion as official SDK-readable chunks."""
+    choice = completion.choices[0]
+    message = choice.message
+    delta: JsonObject = {"role": "assistant"}
+    if message.content is not None:
+        delta["content"] = message.content
+    if message.tool_calls:
+        delta["tool_calls"] = [
+            {**tool.model_dump(mode="json", exclude_none=True), "index": index}
+            for index, tool in enumerate(message.tool_calls)
+        ]
+    chunks = (
+        ChatCompletionChunk.model_validate(
+            {
+                "id": completion.id,
+                "object": "chat.completion.chunk",
+                "created": completion.created,
+                "model": completion.model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None, "logprobs": None}],
+            }
+        ),
+        ChatCompletionChunk.model_validate(
+            {
+                "id": completion.id,
+                "object": "chat.completion.chunk",
+                "created": completion.created,
+                "model": completion.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": choice.finish_reason,
+                        "logprobs": None,
+                    }
+                ],
+                "usage": completion.usage.model_dump(mode="json") if completion.usage else None,
+            }
+        ),
+    )
+    for chunk in chunks:
+        yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+def responses_stream(response: OpenAIResponse) -> Iterator[str]:
+    """Emit the complete official lifecycle for buffered text and function-call output."""
+    created = ResponseCreatedEvent(response=response, sequence_number=0, type="response.created")
+    yield _event(created.type, created.model_dump_json(exclude_none=True))
+    sequence = 1
+    for output_index, item in enumerate(response.output):
+        added_item = item.model_copy(update={"status": "in_progress"})
+        if isinstance(item, ResponseOutputMessage):
+            added_item = added_item.model_copy(update={"content": []})
+        elif isinstance(item, ResponseFunctionToolCall):
+            added_item = added_item.model_copy(update={"arguments": ""})
+        added = ResponseOutputItemAddedEvent(
+            item=added_item,
+            output_index=output_index,
+            sequence_number=sequence,
+            type="response.output_item.added",
+        )
+        yield _event(added.type, added.model_dump_json(exclude_none=True))
+        sequence += 1
+        if isinstance(item, ResponseOutputMessage):
+            sequence = yield from _text_events(item, output_index, sequence)
+        elif isinstance(item, ResponseFunctionToolCall):
+            sequence = yield from _function_events(item, output_index, sequence)
+        done = ResponseOutputItemDoneEvent(
+            item=item,
+            output_index=output_index,
+            sequence_number=sequence,
+            type="response.output_item.done",
+        )
+        yield _event(done.type, done.model_dump_json(exclude_none=True))
+        sequence += 1
+    terminal = (
+        ResponseIncompleteEvent(
+            response=response, sequence_number=sequence, type="response.incomplete"
+        )
+        if response.status == "incomplete"
+        else ResponseCompletedEvent(
+            response=response, sequence_number=sequence, type="response.completed"
+        )
+    )
+    yield _event(terminal.type, terminal.model_dump_json(exclude_none=True))
+
+
+def _text_events(
+    item: ResponseOutputMessage, output_index: int, sequence: int
+) -> Generator[str, None, int]:
+    for content_index, content in enumerate(item.content):
+        if content.type != "output_text":
+            continue
+        empty = content.model_copy(update={"text": ""})
+        events = (
+            ResponseContentPartAddedEvent(
+                content_index=content_index,
+                item_id=item.id,
+                output_index=output_index,
+                part=empty,
+                sequence_number=sequence,
+                type="response.content_part.added",
+            ),
+            ResponseTextDeltaEvent(
+                content_index=content_index,
+                delta=content.text,
+                item_id=item.id,
+                logprobs=[],
+                output_index=output_index,
+                sequence_number=sequence + 1,
+                type="response.output_text.delta",
+            ),
+            ResponseTextDoneEvent(
+                content_index=content_index,
+                item_id=item.id,
+                logprobs=[],
+                output_index=output_index,
+                sequence_number=sequence + 2,
+                text=content.text,
+                type="response.output_text.done",
+            ),
+            ResponseContentPartDoneEvent(
+                content_index=content_index,
+                item_id=item.id,
+                output_index=output_index,
+                part=content,
+                sequence_number=sequence + 3,
+                type="response.content_part.done",
+            ),
+        )
+        for event in events:
+            yield _event(event.type, event.model_dump_json(exclude_none=True))
+        sequence += len(events)
+    return sequence
+
+
+def _function_events(
+    item: ResponseFunctionToolCall, output_index: int, sequence: int
+) -> Generator[str, None, int]:
+    if item.id is None:
+        raise ValueError("Responses function-call output omitted its item ID")
+    events = (
+        ResponseFunctionCallArgumentsDeltaEvent(
+            delta=item.arguments,
+            item_id=item.id,
+            output_index=output_index,
+            sequence_number=sequence,
+            type="response.function_call_arguments.delta",
+        ),
+        ResponseFunctionCallArgumentsDoneEvent(
+            arguments=item.arguments,
+            item_id=item.id,
+            name=item.name,
+            output_index=output_index,
+            sequence_number=sequence + 1,
+            type="response.function_call_arguments.done",
+        ),
+    )
+    for event in events:
+        yield _event(event.type, event.model_dump_json(exclude_none=True))
+    return sequence + len(events)
+
+
+def _event(name: str, data: str) -> str:
+    return f"event: {name}\ndata: {data}\n\n"

--- a/wmo/runtime/router/streaming.py
+++ b/wmo/runtime/router/streaming.py
@@ -26,7 +26,14 @@ from wmo.common.core.artifacts import JsonObject
 
 
 def chat_stream(completion: ChatCompletion) -> Iterator[str]:
-    """Reframe one buffered Chat Completion as official SDK-readable chunks."""
+    """Reframe one buffered Chat Completion as official SDK-readable chunks.
+
+    Args:
+        completion: Completed OpenAI Chat Completion to stream.
+
+    Yields:
+        Server-sent event data frames followed by the standard done sentinel.
+    """
     choice = completion.choices[0]
     message = choice.message
     delta: JsonObject = {"role": "assistant"}
@@ -71,7 +78,14 @@ def chat_stream(completion: ChatCompletion) -> Iterator[str]:
 
 
 def responses_stream(response: OpenAIResponse) -> Iterator[str]:
-    """Emit the complete official lifecycle for buffered text and function-call output."""
+    """Emit the official lifecycle for buffered text and function-call output.
+
+    Args:
+        response: Completed OpenAI Response to stream.
+
+    Yields:
+        Named server-sent events in monotonically increasing sequence order.
+    """
     created = ResponseCreatedEvent(response=response, sequence_number=0, type="response.created")
     yield _event(created.type, created.model_dump_json(exclude_none=True))
     sequence = 1
@@ -116,7 +130,19 @@ def responses_stream(response: OpenAIResponse) -> Iterator[str]:
 def _text_events(
     item: ResponseOutputMessage, output_index: int, sequence: int
 ) -> Generator[str, None, int]:
-    """Yield the official content-part and text lifecycle for one output message."""
+    """Emit the content-part and text lifecycle for one output message.
+
+    Args:
+        item: Completed Responses output message.
+        output_index: Position of the message in the response output.
+        sequence: Sequence number for the first emitted event.
+
+    Yields:
+        Named content-part and text server-sent events.
+
+    Returns:
+        Next unused response event sequence number.
+    """
     for content_index, content in enumerate(item.content):
         if content.type != "output_text":
             continue
@@ -166,7 +192,22 @@ def _text_events(
 def _function_events(
     item: ResponseFunctionToolCall, output_index: int, sequence: int
 ) -> Generator[str, None, int]:
-    """Yield the official argument lifecycle for one function-call item."""
+    """Emit the argument lifecycle for one function-call item.
+
+    Args:
+        item: Completed Responses function-call output.
+        output_index: Position of the call in the response output.
+        sequence: Sequence number for the first emitted event.
+
+    Yields:
+        Named function-argument delta and completion server-sent events.
+
+    Returns:
+        Next unused response event sequence number.
+
+    Raises:
+        ValueError: The function-call output has no item identity.
+    """
     if item.id is None:
         raise ValueError("Responses function-call output omitted its item ID")
     events = (

--- a/wmo/runtime/router/streaming_test.py
+++ b/wmo/runtime/router/streaming_test.py
@@ -12,7 +12,11 @@ from wmo.runtime.router.streaming import chat_stream, responses_stream
 
 
 def test_text_stream_emits_every_official_lifecycle_event() -> None:
-    """Buffered text includes item, part, delta, done, and terminal events in order."""
+    """Prove buffered text emits every official lifecycle event in order.
+
+    The stream includes response creation, item and content-part boundaries, text delta and done,
+    item completion, and the terminal response event with monotonic sequence numbers.
+    """
     response = ModelResponse(
         output=AssistantAction(content="hello"),
         model=_snapshot("cheap"),
@@ -43,7 +47,11 @@ def test_text_stream_emits_every_official_lifecycle_event() -> None:
 
 
 def test_length_streams_use_incomplete_terminals() -> None:
-    """Truncated Chat and Responses streams never report successful completion."""
+    """Prove truncated Chat and Responses streams use incomplete terminals.
+
+    Chat reports a length finish reason while Responses emits an incomplete event rather than a
+    successful completion event.
+    """
     response = ModelResponse(
         output=AssistantAction(content="partial"),
         model=_snapshot("cheap"),

--- a/wmo/runtime/router/streaming_test.py
+++ b/wmo/runtime/router/streaming_test.py
@@ -1,0 +1,65 @@
+"""Protocol-complete official streaming event regressions."""
+
+from wmo.common.models import (
+    AssistantAction,
+    ModelFinishReason,
+    ModelResponse,
+    OperationEconomics,
+)
+from wmo.runtime.router.endpoint import HttpResponseRequest, _chat_completion, _openai_response
+from wmo.runtime.router.runtime_test import _snapshot
+from wmo.runtime.router.streaming import chat_stream, responses_stream
+
+
+def test_text_stream_emits_every_official_lifecycle_event() -> None:
+    """Buffered text includes item, part, delta, done, and terminal events in order."""
+    response = ModelResponse(
+        output=AssistantAction(content="hello"),
+        model=_snapshot("cheap"),
+        economics=OperationEconomics(),
+    )
+    request = HttpResponseRequest(model="router-a", input="hello")
+    public = _openai_response(
+        "router-a",
+        response.output,
+        response,
+        request=request,
+        idempotency_key=None,
+        previous_response_id=None,
+    )
+
+    frames = list(responses_stream(public))
+
+    assert [frame.splitlines()[0] for frame in frames] == [
+        "event: response.created",
+        "event: response.output_item.added",
+        "event: response.content_part.added",
+        "event: response.output_text.delta",
+        "event: response.output_text.done",
+        "event: response.content_part.done",
+        "event: response.output_item.done",
+        "event: response.completed",
+    ]
+
+
+def test_length_streams_use_incomplete_terminals() -> None:
+    """Truncated Chat and Responses streams never report successful completion."""
+    response = ModelResponse(
+        output=AssistantAction(content="partial"),
+        model=_snapshot("cheap"),
+        economics=OperationEconomics(),
+        finish_reason=ModelFinishReason.LENGTH,
+    )
+    chat = _chat_completion("router-a", response.output, response)
+    request = HttpResponseRequest(model="router-a", input="hello")
+    public = _openai_response(
+        "router-a",
+        response.output,
+        response,
+        request=request,
+        idempotency_key=None,
+        previous_response_id=None,
+    )
+
+    assert '"finish_reason":"length"' in list(chat_stream(chat))[-2]
+    assert list(responses_stream(public))[-1].startswith("event: response.incomplete\n")


### PR DESCRIPTION
## What changed

- add a neutral `RouterCompletionService` boundary so HTTP state never owns durable idempotency
- reject nonempty idempotency keys unless a durable completion service is injected
- keep continuation state bounded by TTL, count, and serialized bytes
- isolate developer/system instructions from user continuation text
- add OpenAI-shaped Chat and Responses streaming events, tool deltas, finish reasons, incomplete reasons, usage, and metadata
- reject unsupported nested input and tool fields instead of silently dropping them
- select only candidates that can prove the requested tool and output-token capabilities before dispatch
- document every function and method changed by this PR and make that the repository rule

## Why

The OpenAI router core established the public SDK and HTTP boundaries, but several compatibility paths still silently lost protocol meaning. This follow-up makes the endpoint faithful and fail-closed while composing with the durable journal now present on main.

## Boundary

Durable key ownership remains in `journal.py`. This PR defines the provider-neutral completion protocol consumed by the HTTP adapter. The endpoint adds no durable cache and does not claim exactly-once execution without an injected service.

## Verification

Exact head: `b3b04f3c2380360c30245b615e8c2652c4ecaef0`

- based on main `5c75168069224a190e7251945cc222c3f71c2535`
- semantic range preserved while composing the completion seam with the merged journal and current self-contained docstrings
- capability fallback invalidates stale per-request decisions, so later turns and exact earlier-request replays remain pinned to the replacement model
- every function added or modified by this PR has a docstring; nontrivial production and test contracts use Google-style sections or multi-line behavioral rationale
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- complete router suite: 94 passed
- `uv build`
- README unchanged

Ready for review and intentionally unmerged.
