### PR TITLE
Add immutable runtime trace snapshots

### DIFF
--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -32,6 +32,16 @@ from wmo.runtime.router.runtime import (
     RouterRuntime,
     RouterRuntimeIntegrityError,
 )
+from wmo.runtime.router.snapshot import (
+    LoadedRuntimeTraceSnapshot,
+    PersistedRuntimeTraceExport,
+    RuntimeTraceAttempt,
+    RuntimeTraceInteraction,
+    RuntimeTraceSnapshot,
+    RuntimeTraceSnapshotError,
+    load_runtime_trace_snapshot,
+    seal_runtime_trace_snapshot,
+)
 
 __all__ = [
     "RoutedModelResponse",
@@ -53,6 +63,14 @@ __all__ = [
     "RouterCompletionFailedError",
     "RouterRuntime",
     "RouterRuntimeIntegrityError",
+    "LoadedRuntimeTraceSnapshot",
+    "PersistedRuntimeTraceExport",
+    "RuntimeTraceAttempt",
+    "RuntimeTraceInteraction",
+    "RuntimeTraceSnapshot",
+    "RuntimeTraceSnapshotError",
+    "load_runtime_trace_snapshot",
+    "seal_runtime_trace_snapshot",
     "create_router_endpoint",
     "RouterApplicationError",
     "create_project_router_app",

--- a/wmo/runtime/router/snapshot.py
+++ b/wmo/runtime/router/snapshot.py
@@ -1,0 +1,781 @@
+"""Immutable snapshots of routed interactions and their canonical production traces."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ContractModel,
+    JsonObject,
+    Sha256,
+    SourceIdentity,
+    canonical_json_bytes,
+    stable_id,
+    validate_artifact_file_path,
+)
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.traces import Trace, TraceDataset, TraceOutcome, TraceSource, TraceSpan
+from wmo.runtime.router.journal import (
+    RuntimeAcceptedEvent,
+    RuntimeAttemptFailedEvent,
+    RuntimeCompletedEvent,
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    RuntimeJournalEvent,
+    _validate_events,
+)
+
+_SNAPSHOT_ARTIFACT_TYPE = "runtime-trace-snapshot"
+_SNAPSHOT_PATH = "runtime-trace-snapshot.json"
+_INTERACTIONS_PATH = "interactions.jsonl"
+_TRACE_DATASET_ARTIFACT_TYPE = "trace-dataset"
+_TRACE_DATASET_PATH = "trace-dataset.json"
+_TRACES_PATH = "traces.jsonl"
+_RUNTIME_TRACE_CONVENTION = "wmo.runtime.router.v1"
+_JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
+RuntimeTerminalEvent = Annotated[
+    RuntimeAttemptFailedEvent | RuntimeCompletedEvent,
+    Field(discriminator="event"),
+]
+
+
+class RuntimeTraceSnapshotError(ValueError):
+    """A runtime journal cannot be sealed as canonical production trace evidence."""
+
+
+class RuntimeTraceAttempt(ContractModel):
+    """One accepted routed attempt and every terminal event that names it."""
+
+    disposition: Literal[
+        "open",
+        "retryable_failure",
+        "permanent_failure",
+        "completed",
+        "superseded",
+    ]
+    accepted: RuntimeAcceptedEvent
+    terminal_events: tuple[RuntimeTerminalEvent, ...] = ()
+
+    @model_validator(mode="after")
+    def _require_coherent_attempt(self) -> RuntimeTraceAttempt:
+        event_ordinals = tuple(event.ordinal for event in self.terminal_events)
+        if event_ordinals != tuple(sorted(event_ordinals)) or len(set(event_ordinals)) != len(
+            event_ordinals
+        ):
+            raise ValueError("runtime attempt terminal events must have unique ordered ordinals")
+        failures = []
+        completions = []
+        for event in self.terminal_events:
+            if (
+                event.interaction_id != self.accepted.interaction_id
+                or event.attempt_ordinal != self.accepted.attempt_ordinal
+                or event.ordinal <= self.accepted.ordinal
+            ):
+                raise ValueError("runtime attempt terminal event differs from its acceptance")
+            if isinstance(event, RuntimeAttemptFailedEvent):
+                failures.append(event)
+            else:
+                completions.append(event)
+        if len(failures) > 1 or len(completions) > 1:
+            raise ValueError("runtime attempt cannot repeat failure or completion events")
+        if failures and completions and not failures[0].retryable:
+            raise ValueError("runtime attempt completion cannot follow a permanent failure")
+        expected_disposition: str
+        if completions:
+            expected_disposition = "completed"
+        elif failures:
+            expected_disposition = (
+                "retryable_failure" if failures[0].retryable else "permanent_failure"
+            )
+        else:
+            if self.disposition not in {"open", "superseded"}:
+                raise ValueError(
+                    "runtime attempts without terminal events must be open or superseded"
+                )
+            expected_disposition = self.disposition
+        if self.disposition != expected_disposition:
+            raise ValueError("runtime attempt disposition differs from its terminal events")
+        return self
+
+
+class RuntimeTraceInteraction(ContractModel):
+    """One logical routed interaction with complete retry and terminal provenance."""
+
+    interaction_id: ArtifactId
+    attempts: tuple[RuntimeTraceAttempt, ...] = Field(min_length=1)
+    completed_attempt_ordinal: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _require_coherent_interaction(self) -> RuntimeTraceInteraction:
+        accepted = tuple(attempt.accepted for attempt in self.attempts)
+        if any(event.interaction_id != self.interaction_id for event in accepted):
+            raise ValueError("runtime interaction attempts name another interaction")
+        attempt_ordinals = tuple(event.attempt_ordinal for event in accepted)
+        if attempt_ordinals != tuple(range(1, len(accepted) + 1)):
+            raise ValueError("runtime interaction attempt ordinals must be contiguous")
+        original_pins = _accepted_pins(accepted[0])
+        if any(_accepted_pins(event) != original_pins for event in accepted[1:]):
+            raise ValueError("runtime interaction retry pins differ from the original acceptance")
+        completed_attempts = tuple(
+            attempt
+            for attempt in self.attempts
+            if any(isinstance(event, RuntimeCompletedEvent) for event in attempt.terminal_events)
+        )
+        if len(completed_attempts) > 1:
+            raise ValueError("runtime interaction cannot contain multiple completed targets")
+        expected_completed_ordinal = (
+            completed_attempts[0].accepted.attempt_ordinal if completed_attempts else None
+        )
+        if self.completed_attempt_ordinal != expected_completed_ordinal:
+            raise ValueError("completed attempt ordinal differs from interaction events")
+        unterminated = tuple(attempt for attempt in self.attempts if not attempt.terminal_events)
+        if completed_attempts:
+            if any(attempt.disposition != "superseded" for attempt in unterminated):
+                raise ValueError("unterminated attempts must be superseded after completion")
+        elif unterminated:
+            if unterminated != (self.attempts[-1],) or unterminated[0].disposition != "open":
+                raise ValueError("only the latest incomplete runtime attempt may remain open")
+        return self
+
+
+_INTERACTION_ADAPTER = TypeAdapter(RuntimeTraceInteraction)
+
+
+class RuntimeTraceSnapshot(ArtifactEnvelope):
+    """One immutable, content-addressed prefix of a routed-interaction journal."""
+
+    snapshot_id: ArtifactId
+    project_id: ArtifactId
+    last_ordinal: int = Field(gt=0)
+    prefix_sha256: Sha256
+    interactions_path: str = Field(min_length=1)
+    interactions_sha256: Sha256
+    interaction_ids: tuple[ArtifactId, ...]
+    completed_target_count: int = Field(ge=0)
+    failed_attempt_count: int = Field(ge=0)
+
+    @field_validator("interactions_path")
+    @classmethod
+    def _require_safe_interactions_path(cls, value: str) -> str:
+        return validate_artifact_file_path(value).as_posix()
+
+    @field_validator("interaction_ids")
+    @classmethod
+    def _require_unique_interactions(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        if not value:
+            raise ValueError("a runtime trace snapshot needs at least one interaction")
+        if len(set(value)) != len(value):
+            raise ValueError("runtime trace snapshot interaction IDs must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def _require_content_identity(self) -> RuntimeTraceSnapshot:
+        if self.completed_target_count > len(self.interaction_ids):
+            raise ValueError("completed target count exceeds the interaction count")
+        expected_id = stable_id(
+            "runtime-trace-snapshot",
+            {
+                "project_id": self.project_id,
+                "last_ordinal": self.last_ordinal,
+                "prefix_sha256": self.prefix_sha256,
+            },
+        )
+        if self.snapshot_id != expected_id:
+            raise ValueError("runtime trace snapshot ID differs from its canonical prefix")
+        if (
+            self.source is None
+            or self.source.kind != "production"
+            or self.source.sha256 != self.prefix_sha256
+        ):
+            raise ValueError("runtime trace snapshot source must name its production prefix")
+        return self
+
+
+@dataclass(frozen=True)
+class LoadedRuntimeTraceSnapshot:
+    """One verified runtime snapshot and its ordered logical interactions."""
+
+    snapshot: RuntimeTraceSnapshot
+    manifest: ArtifactManifest
+    interactions: tuple[RuntimeTraceInteraction, ...]
+
+
+@dataclass(frozen=True)
+class PersistedRuntimeTraceExport:
+    """One runtime snapshot and the canonical trace dataset derived from its targets."""
+
+    snapshot: RuntimeTraceSnapshot
+    snapshot_manifest: ArtifactManifest
+    interactions: tuple[RuntimeTraceInteraction, ...]
+    dataset: TraceDataset
+    dataset_manifest: ArtifactManifest
+    traces: tuple[Trace, ...]
+
+
+def seal_runtime_trace_snapshot(
+    journal: RuntimeInteractionJournal,
+    store: ArtifactStore,
+    *,
+    created_at: datetime,
+    code_revision: str,
+    last_ordinal: int | None = None,
+) -> PersistedRuntimeTraceExport:
+    """Seal a validated journal prefix and derive completed targets as canonical traces.
+
+    Args:
+        journal: Project runtime journal whose prefix is being sealed.
+        store: Immutable artifact store for the same project.
+        created_at: Time the new immutable artifact is materialized.
+        code_revision: Exact WMO revision producing the artifact.
+        last_ordinal: Optional inclusive prefix boundary. The full durable journal is used when
+            omitted.
+
+    Returns:
+        The immutable prefix snapshot and its sibling canonical trace dataset.
+
+    Raises:
+        RuntimeTraceSnapshotError: The journal is empty, has no completed target in the selected
+            prefix, does not belong to the artifact store, or contains inconsistent routed output.
+        RuntimeJournalError: The journal prefix violates its event or transition contracts.
+    """
+    _require_same_project(journal, store)
+    all_events = journal.read_events()
+    events = _select_prefix(all_events, last_ordinal)
+    prefix_sha256 = _sha256(_jsonl_bytes(events))
+    interactions = _build_interactions(events)
+    interactions_payload = _jsonl_bytes(interactions)
+    source = SourceIdentity(
+        kind="production",
+        source_id=f"{journal.project_id}/runtime/interactions",
+        sha256=prefix_sha256,
+    )
+    interaction_ids = tuple(interaction.interaction_id for interaction in interactions)
+    completed_target_count = sum(
+        interaction.completed_attempt_ordinal is not None for interaction in interactions
+    )
+    if completed_target_count == 0:
+        raise RuntimeTraceSnapshotError(
+            "runtime trace snapshots require at least one completed routed interaction"
+        )
+    failed_attempt_count = sum(
+        isinstance(event, RuntimeAttemptFailedEvent)
+        for interaction in interactions
+        for attempt in interaction.attempts
+        for event in attempt.terminal_events
+    )
+    snapshot_id = stable_id(
+        "runtime-trace-snapshot",
+        {
+            "project_id": journal.project_id,
+            "last_ordinal": events[-1].ordinal,
+            "prefix_sha256": prefix_sha256,
+        },
+    )
+    snapshot = RuntimeTraceSnapshot(
+        schema_version=1,
+        created_at=created_at,
+        code_revision=code_revision,
+        source=source,
+        snapshot_id=snapshot_id,
+        project_id=journal.project_id,
+        last_ordinal=events[-1].ordinal,
+        prefix_sha256=prefix_sha256,
+        interactions_path=_INTERACTIONS_PATH,
+        interactions_sha256=_sha256(interactions_payload),
+        interaction_ids=interaction_ids,
+        completed_target_count=completed_target_count,
+        failed_attempt_count=failed_attempt_count,
+    )
+    traces = _derive_traces(interactions, snapshot)
+    loaded_snapshot = _persist_snapshot(store, snapshot, interactions, interactions_payload)
+    dataset, dataset_manifest = _persist_dataset(
+        store,
+        traces,
+        loaded_snapshot,
+    )
+    return PersistedRuntimeTraceExport(
+        snapshot=loaded_snapshot.snapshot,
+        snapshot_manifest=loaded_snapshot.manifest,
+        interactions=loaded_snapshot.interactions,
+        dataset=dataset,
+        dataset_manifest=dataset_manifest,
+        traces=traces,
+    )
+
+
+def load_runtime_trace_snapshot(
+    store: ArtifactStore, snapshot_id: str
+) -> LoadedRuntimeTraceSnapshot:
+    """Load and fully validate one immutable runtime journal prefix."""
+    stored = store.read(snapshot_id)
+    if stored.manifest.artifact_type != _SNAPSHOT_ARTIFACT_TYPE:
+        raise ArtifactCorruptionError(f"artifact {snapshot_id} is not a runtime trace snapshot")
+    try:
+        snapshot = RuntimeTraceSnapshot.model_validate_json(
+            store.read_bytes(snapshot_id, _SNAPSHOT_PATH)
+        )
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} has an invalid envelope"
+        ) from exc
+    if snapshot.snapshot_id != snapshot_id:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot envelope ID differs from artifact {snapshot_id}"
+        )
+    payload = store.read_bytes(snapshot_id, snapshot.interactions_path)
+    if _sha256(payload) != snapshot.interactions_sha256:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} interaction digest differs from envelope"
+        )
+    try:
+        interactions = _parse_canonical_interactions(payload)
+        events = _events_from_interactions(interactions)
+    except (RuntimeJournalError, ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} has invalid interaction events"
+        ) from exc
+    if not events or events[-1].ordinal != snapshot.last_ordinal:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} event boundary differs from envelope"
+        )
+    if _sha256(_jsonl_bytes(events)) != snapshot.prefix_sha256:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} journal prefix differs from envelope"
+        )
+    interaction_ids = tuple(interaction.interaction_id for interaction in interactions)
+    if interaction_ids != snapshot.interaction_ids:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} interaction order differs from envelope"
+        )
+    if (
+        sum(interaction.completed_attempt_ordinal is not None for interaction in interactions)
+        != snapshot.completed_target_count
+    ):
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} completed target count differs from envelope"
+        )
+    if sum(event.event == "attempt_failed" for event in events) != snapshot.failed_attempt_count:
+        raise ArtifactCorruptionError(
+            f"runtime trace snapshot {snapshot_id} failed attempt count differs from envelope"
+        )
+    _require_envelope_matches_manifest(snapshot, stored.manifest)
+    return LoadedRuntimeTraceSnapshot(
+        snapshot=snapshot,
+        manifest=stored.manifest,
+        interactions=interactions,
+    )
+
+
+def _select_prefix(
+    events: tuple[RuntimeJournalEvent, ...], last_ordinal: int | None
+) -> tuple[RuntimeJournalEvent, ...]:
+    """Return one inclusive validated prefix boundary."""
+    if not events:
+        raise RuntimeTraceSnapshotError("runtime journal has no durable events to snapshot")
+    if last_ordinal is None:
+        return events
+    if last_ordinal <= 0 or last_ordinal > len(events):
+        raise RuntimeTraceSnapshotError(
+            f"last_ordinal must be between 1 and {len(events)} inclusive"
+        )
+    prefix = events[:last_ordinal]
+    _validate_events(prefix)
+    return prefix
+
+
+def _build_interactions(
+    events: tuple[RuntimeJournalEvent, ...],
+) -> tuple[RuntimeTraceInteraction, ...]:
+    """Group globally ordered journal events into canonical logical interactions."""
+    accepted_by_interaction: dict[str, list[RuntimeAcceptedEvent]] = {}
+    terminals_by_attempt: dict[tuple[str, int], list[RuntimeTerminalEvent]] = {}
+    interaction_ids = []
+    for event in events:
+        if isinstance(event, RuntimeAcceptedEvent):
+            attempts = accepted_by_interaction.setdefault(event.interaction_id, [])
+            if not attempts:
+                interaction_ids.append(event.interaction_id)
+            attempts.append(event)
+        else:
+            terminals_by_attempt.setdefault(
+                (event.interaction_id, event.attempt_ordinal), []
+            ).append(event)
+    interactions = []
+    for interaction_id in interaction_ids:
+        accepted_events = accepted_by_interaction[interaction_id]
+        completed_ordinal = next(
+            (
+                accepted.attempt_ordinal
+                for accepted in accepted_events
+                if any(
+                    isinstance(event, RuntimeCompletedEvent)
+                    for event in terminals_by_attempt.get(
+                        (interaction_id, accepted.attempt_ordinal), []
+                    )
+                )
+            ),
+            None,
+        )
+        attempts = []
+        for accepted in accepted_events:
+            terminal_events = tuple(
+                terminals_by_attempt.get(
+                    (interaction_id, accepted.attempt_ordinal),
+                    [],
+                )
+            )
+            completion = next(
+                (event for event in terminal_events if isinstance(event, RuntimeCompletedEvent)),
+                None,
+            )
+            failure = next(
+                (
+                    event
+                    for event in terminal_events
+                    if isinstance(event, RuntimeAttemptFailedEvent)
+                ),
+                None,
+            )
+            disposition: Literal[
+                "open",
+                "retryable_failure",
+                "permanent_failure",
+                "completed",
+                "superseded",
+            ]
+            if completion is not None:
+                disposition = "completed"
+            elif failure is not None:
+                disposition = "retryable_failure" if failure.retryable else "permanent_failure"
+            elif completed_ordinal is not None:
+                disposition = "superseded"
+            else:
+                disposition = "open"
+            attempts.append(
+                RuntimeTraceAttempt(
+                    disposition=disposition,
+                    accepted=accepted,
+                    terminal_events=terminal_events,
+                )
+            )
+        interactions.append(
+            RuntimeTraceInteraction(
+                interaction_id=interaction_id,
+                attempts=tuple(attempts),
+                completed_attempt_ordinal=completed_ordinal,
+            )
+        )
+    result = tuple(interactions)
+    if _events_from_interactions(result) != events:
+        raise RuntimeTraceSnapshotError(
+            "canonical interactions do not preserve the exact runtime journal prefix"
+        )
+    return result
+
+
+def _derive_traces(
+    interactions: tuple[RuntimeTraceInteraction, ...], snapshot: RuntimeTraceSnapshot
+) -> tuple[Trace, ...]:
+    """Map one completed target per interaction into the shared trace contracts."""
+    traces = []
+    trace_source = TraceSource(
+        identity=SourceIdentity(
+            kind="production",
+            source_id=snapshot.snapshot_id,
+            sha256=snapshot.prefix_sha256,
+        ),
+        semantic_convention_version=_RUNTIME_TRACE_CONVENTION,
+    )
+    for interaction in interactions:
+        if interaction.completed_attempt_ordinal is None:
+            continue
+        completed_attempt = interaction.attempts[interaction.completed_attempt_ordinal - 1]
+        accepted = completed_attempt.accepted
+        completed = next(
+            event
+            for event in completed_attempt.terminal_events
+            if isinstance(event, RuntimeCompletedEvent)
+        )
+        request_context = _JSON_OBJECT_ADAPTER.validate_python(
+            {
+                "model_request": accepted.request.model_dump(mode="json"),
+                "routing_decision": accepted.decision.model_dump(mode="json"),
+            }
+        )
+        attributes = _JSON_OBJECT_ADAPTER.validate_python(
+            {
+                "runtime.interaction_id": interaction.interaction_id,
+                "runtime.lineage_id": accepted.lineage_id,
+                "runtime.request_sha256": accepted.request_sha256,
+                "runtime.response_sha256": completed.response_sha256,
+                "runtime.attempt_ordinal": completed.attempt_ordinal,
+                "runtime.selected_alias": accepted.selected_alias,
+                "runtime.selected_model": accepted.selected_model.model_dump(mode="json"),
+                "runtime.response_model": completed.response.model.model_dump(mode="json"),
+                "runtime.policy_id": accepted.policy_input.artifact_id,
+                "runtime.policy_sha256": accepted.policy_input.sha256,
+                "runtime.finish_reason": completed.response.finish_reason,
+                "runtime.response_output": completed.response.output.model_dump(mode="json"),
+                "runtime.economics": completed.response.economics.model_dump(mode="json"),
+            }
+        )
+        traces.append(
+            Trace(
+                trace_id=interaction.interaction_id,
+                conversation_id=accepted.lineage_id,
+                task=_task_text(accepted),
+                initial_context=request_context,
+                tools=accepted.request.tools,
+                spans=(
+                    TraceSpan(
+                        span_id=completed.event_id,
+                        name="wmo.router.completion",
+                        started_at=accepted.attempt_started_at,
+                        ended_at=completed.completed_at,
+                        attributes=attributes,
+                        model=completed.response.model,
+                        usage=completed.response.economics.usage,
+                    ),
+                ),
+                outcome=TraceOutcome(status="success", outcome_name="routed_completion"),
+                source=trace_source,
+            )
+        )
+    if len(traces) != snapshot.completed_target_count:
+        raise RuntimeTraceSnapshotError(
+            "runtime trace derivation did not produce exactly one target per completion"
+        )
+    return tuple(traces)
+
+
+def _task_text(accepted: RuntimeAcceptedEvent) -> str:
+    """Choose a stable human-readable task while retaining the full request context."""
+    for message in reversed(accepted.request.messages):
+        if message.role == "user" and message.content:
+            return message.content
+    for message in accepted.request.messages:
+        if message.content:
+            return message.content
+    return "Complete the routed model request."
+
+
+def _persist_snapshot(
+    store: ArtifactStore,
+    snapshot: RuntimeTraceSnapshot,
+    interactions: tuple[RuntimeTraceInteraction, ...],
+    interactions_payload: bytes,
+) -> LoadedRuntimeTraceSnapshot:
+    """Write a new prefix snapshot or return its exact existing materialization."""
+    try:
+        store.write(
+            artifact_id=snapshot.snapshot_id,
+            artifact_type=_SNAPSHOT_ARTIFACT_TYPE,
+            envelope=snapshot,
+            files={
+                _INTERACTIONS_PATH: interactions_payload,
+                _SNAPSHOT_PATH: canonical_json_bytes(snapshot),
+            },
+        )
+    except ArtifactAlreadyExistsError:
+        loaded = load_runtime_trace_snapshot(store, snapshot.snapshot_id)
+        replay = snapshot.model_copy(update={"created_at": loaded.snapshot.created_at})
+        if loaded.snapshot != replay or loaded.interactions != interactions:
+            raise RuntimeTraceSnapshotError(
+                "existing runtime trace snapshot differs from the journal prefix replay"
+            ) from None
+        return loaded
+    return load_runtime_trace_snapshot(store, snapshot.snapshot_id)
+
+
+def _persist_dataset(
+    store: ArtifactStore,
+    traces: tuple[Trace, ...],
+    loaded_snapshot: LoadedRuntimeTraceSnapshot,
+) -> tuple[TraceDataset, ArtifactManifest]:
+    """Persist completed runtime targets through the shared canonical trace envelope."""
+    traces_payload = _jsonl_bytes(traces)
+    snapshot_input = artifact_input(loaded_snapshot.manifest)
+    dataset_id = stable_id(
+        "trace-dataset",
+        {
+            "snapshot": snapshot_input.model_dump(mode="json"),
+            "traces_sha256": _sha256(traces_payload),
+        },
+    )
+    dataset = TraceDataset(
+        schema_version=1,
+        created_at=loaded_snapshot.snapshot.created_at,
+        inputs=(snapshot_input,),
+        code_revision=loaded_snapshot.snapshot.code_revision,
+        source=SourceIdentity(
+            kind="production",
+            source_id=loaded_snapshot.snapshot.snapshot_id,
+            sha256=loaded_snapshot.snapshot.prefix_sha256,
+        ),
+        dataset_id=dataset_id,
+        semantic_convention_version=_RUNTIME_TRACE_CONVENTION,
+        traces_path=_TRACES_PATH,
+        traces_sha256=_sha256(traces_payload),
+        trace_ids=tuple(trace.trace_id for trace in traces),
+    )
+    try:
+        manifest = store.write(
+            artifact_id=dataset.dataset_id,
+            artifact_type=_TRACE_DATASET_ARTIFACT_TYPE,
+            envelope=dataset,
+            files={
+                _TRACE_DATASET_PATH: canonical_json_bytes(dataset),
+                _TRACES_PATH: traces_payload,
+            },
+        )
+    except ArtifactAlreadyExistsError:
+        return _load_exact_dataset_replay(store, dataset, traces_payload)
+    return dataset, manifest
+
+
+def _load_exact_dataset_replay(
+    store: ArtifactStore,
+    expected: TraceDataset,
+    traces_payload: bytes,
+) -> tuple[TraceDataset, ArtifactManifest]:
+    """Return an existing byte-identical dataset derived from the same snapshot."""
+    stored = store.read(expected.dataset_id)
+    if stored.manifest.artifact_type != _TRACE_DATASET_ARTIFACT_TYPE:
+        raise RuntimeTraceSnapshotError(
+            f"existing artifact {expected.dataset_id} is not a trace dataset"
+        )
+    try:
+        existing = TraceDataset.model_validate_json(
+            store.read_bytes(expected.dataset_id, _TRACE_DATASET_PATH)
+        )
+    except (ValidationError, ValueError) as exc:
+        raise RuntimeTraceSnapshotError(
+            f"existing trace dataset {expected.dataset_id} has an invalid envelope"
+        ) from exc
+    if existing != expected:
+        raise RuntimeTraceSnapshotError(
+            "existing runtime trace dataset differs from the snapshot replay"
+        )
+    if store.read_bytes(expected.dataset_id, _TRACES_PATH) != traces_payload:
+        raise RuntimeTraceSnapshotError(
+            "existing runtime trace dataset records differ from the snapshot replay"
+        )
+    _require_envelope_matches_manifest(existing, stored.manifest)
+    return existing, stored.manifest
+
+
+def _parse_canonical_interactions(
+    payload: bytes,
+) -> tuple[RuntimeTraceInteraction, ...]:
+    """Parse canonical logical interactions from newline-terminated JSONL."""
+    if payload and not payload.endswith(b"\n"):
+        raise RuntimeJournalError("snapshot interaction JSONL must end with a newline")
+    interactions = []
+    for index, line in enumerate(payload.splitlines(), start=1):
+        if not line:
+            raise RuntimeJournalError(f"snapshot interaction JSONL has blank line {index}")
+        try:
+            interactions.append(_INTERACTION_ADAPTER.validate_json(line))
+        except (UnicodeDecodeError, ValidationError) as exc:
+            raise RuntimeJournalError(
+                f"snapshot interaction JSONL has invalid line {index}"
+            ) from exc
+    canonical = _jsonl_bytes(interactions)
+    if canonical != payload:
+        raise RuntimeJournalError("snapshot interaction JSONL is not canonical")
+    return tuple(interactions)
+
+
+def _events_from_interactions(
+    interactions: tuple[RuntimeTraceInteraction, ...],
+) -> tuple[RuntimeJournalEvent, ...]:
+    """Restore the exact global event prefix from canonical interaction provenance."""
+    events: list[RuntimeJournalEvent] = []
+    for interaction in interactions:
+        for attempt in interaction.attempts:
+            events.append(attempt.accepted)
+            events.extend(attempt.terminal_events)
+    events.sort(key=lambda event: event.ordinal)
+    _validate_events(events)
+    expected_interaction_ids = tuple(
+        dict.fromkeys(
+            event.interaction_id for event in events if isinstance(event, RuntimeAcceptedEvent)
+        )
+    )
+    actual_interaction_ids = tuple(interaction.interaction_id for interaction in interactions)
+    if actual_interaction_ids != expected_interaction_ids:
+        raise RuntimeJournalError(
+            "snapshot interaction rows differ from first-acceptance journal order"
+        )
+    return tuple(events)
+
+
+def _accepted_pins(event: RuntimeAcceptedEvent) -> JsonObject:
+    """Return the immutable interaction fields that every retry must preserve."""
+    material = event.model_dump(mode="json")
+    for field in ("event_id", "ordinal", "attempt_ordinal", "attempt_started_at"):
+        del material[field]
+    return _JSON_OBJECT_ADAPTER.validate_python(material)
+
+
+def _require_same_project(journal: RuntimeInteractionJournal, store: ArtifactStore) -> None:
+    """Require mutable and immutable paths to belong to one project boundary."""
+    expected_path = store.project_directory / "runtime" / "interactions.jsonl"
+    if journal.project_id != store.project_directory.name or (
+        journal.path.resolve() != expected_path.resolve()
+    ):
+        raise RuntimeTraceSnapshotError(
+            "runtime journal and artifact store must belong to the same project"
+        )
+
+
+def _require_envelope_matches_manifest(
+    envelope: ArtifactEnvelope, manifest: ArtifactManifest
+) -> None:
+    """Require shared provenance fields to match the immutable artifact manifest."""
+    if (
+        manifest.schema_version,
+        manifest.created_at,
+        manifest.inputs,
+        manifest.code_revision,
+        manifest.source,
+    ) != (
+        envelope.schema_version,
+        envelope.created_at,
+        envelope.inputs,
+        envelope.code_revision,
+        envelope.source,
+    ):
+        raise ArtifactCorruptionError("artifact envelope differs from its manifest")
+
+
+def _jsonl_bytes(records: Sequence[BaseModel]) -> bytes:
+    """Serialize ordered contract records as deterministic newline-terminated JSONL."""
+    payload = b"\n".join(canonical_json_bytes(record) for record in records)
+    return payload + b"\n" if payload else b""
+
+
+def _sha256(payload: bytes) -> str:
+    """Return a content digest for immutable runtime evidence."""
+    return hashlib.sha256(payload, usedforsecurity=False).hexdigest()

--- a/wmo/runtime/router/snapshot.py
+++ b/wmo/runtime/router/snapshot.py
@@ -79,6 +79,7 @@ class RuntimeTraceAttempt(ContractModel):
 
     @model_validator(mode="after")
     def _require_coherent_attempt(self) -> RuntimeTraceAttempt:
+        """Validate ordered terminal events and derive the attempt disposition."""
         event_ordinals = tuple(event.ordinal for event in self.terminal_events)
         if event_ordinals != tuple(sorted(event_ordinals)) or len(set(event_ordinals)) != len(
             event_ordinals
@@ -128,6 +129,7 @@ class RuntimeTraceInteraction(ContractModel):
 
     @model_validator(mode="after")
     def _require_coherent_interaction(self) -> RuntimeTraceInteraction:
+        """Validate retry lineage and the interaction's unique terminal target."""
         accepted = tuple(attempt.accepted for attempt in self.attempts)
         if any(event.interaction_id != self.interaction_id for event in accepted):
             raise ValueError("runtime interaction attempts name another interaction")
@@ -178,11 +180,13 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
     @field_validator("interactions_path")
     @classmethod
     def _require_safe_interactions_path(cls, value: str) -> str:
+        """Normalize and validate the relative interactions artifact path."""
         return validate_artifact_file_path(value).as_posix()
 
     @field_validator("interaction_ids")
     @classmethod
     def _require_unique_interactions(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
+        """Require a nonempty ordered set of unique interaction IDs."""
         if not value:
             raise ValueError("a runtime trace snapshot needs at least one interaction")
         if len(set(value)) != len(value):
@@ -191,6 +195,7 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_content_identity(self) -> RuntimeTraceSnapshot:
+        """Validate snapshot identity, counts, and production-source binding."""
         if self.completed_target_count > len(self.interaction_ids):
             raise ValueError("completed target count exceeds the interaction count")
         expected_id = stable_id(

--- a/wmo/runtime/router/snapshot.py
+++ b/wmo/runtime/router/snapshot.py
@@ -79,7 +79,14 @@ class RuntimeTraceAttempt(ContractModel):
 
     @model_validator(mode="after")
     def _require_coherent_attempt(self) -> RuntimeTraceAttempt:
-        """Validate ordered terminal events and derive the attempt disposition."""
+        """Validate ordered terminal events and derive the attempt disposition.
+
+        Returns:
+            The validated attempt with a disposition matching its terminal events.
+
+        Raises:
+            ValueError: Event identity, order, multiplicity, or disposition is inconsistent.
+        """
         event_ordinals = tuple(event.ordinal for event in self.terminal_events)
         if event_ordinals != tuple(sorted(event_ordinals)) or len(set(event_ordinals)) != len(
             event_ordinals
@@ -129,7 +136,14 @@ class RuntimeTraceInteraction(ContractModel):
 
     @model_validator(mode="after")
     def _require_coherent_interaction(self) -> RuntimeTraceInteraction:
-        """Validate retry lineage and the interaction's unique terminal target."""
+        """Validate retry lineage and the interaction's unique terminal target.
+
+        Returns:
+            The validated logical interaction.
+
+        Raises:
+            ValueError: Attempts diverge from their lineage or terminal-target contract.
+        """
         accepted = tuple(attempt.accepted for attempt in self.attempts)
         if any(event.interaction_id != self.interaction_id for event in accepted):
             raise ValueError("runtime interaction attempts name another interaction")
@@ -186,7 +200,17 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
     @field_validator("interaction_ids")
     @classmethod
     def _require_unique_interactions(cls, value: tuple[ArtifactId, ...]) -> tuple[ArtifactId, ...]:
-        """Require a nonempty ordered set of unique interaction IDs."""
+        """Require a nonempty ordered set of unique interaction IDs.
+
+        Args:
+            value: Ordered interaction identities declared by the snapshot.
+
+        Returns:
+            The validated interaction identities.
+
+        Raises:
+            ValueError: The sequence is empty or repeats an identity.
+        """
         if not value:
             raise ValueError("a runtime trace snapshot needs at least one interaction")
         if len(set(value)) != len(value):
@@ -195,15 +219,25 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_content_identity(self) -> RuntimeTraceSnapshot:
-        """Validate snapshot identity, counts, and production-source binding."""
+        """Validate snapshot identity, counts, and production-source binding.
+
+        Returns:
+            The validated immutable snapshot envelope.
+
+        Raises:
+            ValueError: Counts, inputs, source identity, or content identity are inconsistent.
+        """
         if self.completed_target_count > len(self.interaction_ids):
             raise ValueError("completed target count exceeds the interaction count")
+        if self.inputs:
+            raise ValueError("runtime trace snapshots cannot declare upstream artifact inputs")
         expected_id = stable_id(
             "runtime-trace-snapshot",
             {
                 "project_id": self.project_id,
                 "last_ordinal": self.last_ordinal,
                 "prefix_sha256": self.prefix_sha256,
+                "code_revision": self.code_revision,
             },
         )
         if self.snapshot_id != expected_id:
@@ -211,6 +245,7 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
         if (
             self.source is None
             or self.source.kind != "production"
+            or self.source.source_id != f"{self.project_id}/runtime/interactions"
             or self.source.sha256 != self.prefix_sha256
         ):
             raise ValueError("runtime trace snapshot source must name its production prefix")
@@ -295,6 +330,7 @@ def seal_runtime_trace_snapshot(
             "project_id": journal.project_id,
             "last_ordinal": events[-1].ordinal,
             "prefix_sha256": prefix_sha256,
+            "code_revision": code_revision,
         },
     )
     snapshot = RuntimeTraceSnapshot(
@@ -332,7 +368,19 @@ def seal_runtime_trace_snapshot(
 def load_runtime_trace_snapshot(
     store: ArtifactStore, snapshot_id: str
 ) -> LoadedRuntimeTraceSnapshot:
-    """Load and fully validate one immutable runtime journal prefix."""
+    """Load and fully validate one immutable runtime journal prefix.
+
+    Args:
+        store: Project artifact store containing the snapshot.
+        snapshot_id: Content identity of the snapshot to load.
+
+    Returns:
+        Verified envelope, manifest, and canonical interactions.
+
+    Raises:
+        ArtifactCorruptionError: Artifact type, envelope, files, events, or provenance differ from
+            the declared immutable snapshot.
+    """
     stored = store.read(snapshot_id)
     if stored.manifest.artifact_type != _SNAPSHOT_ARTIFACT_TYPE:
         raise ArtifactCorruptionError(f"artifact {snapshot_id} is not a runtime trace snapshot")
@@ -395,7 +443,19 @@ def load_runtime_trace_snapshot(
 def _select_prefix(
     events: tuple[RuntimeJournalEvent, ...], last_ordinal: int | None
 ) -> tuple[RuntimeJournalEvent, ...]:
-    """Return one inclusive validated prefix boundary."""
+    """Select one inclusive validated journal prefix.
+
+    Args:
+        events: Complete durable journal event sequence.
+        last_ordinal: Optional inclusive final event ordinal.
+
+    Returns:
+        Nonempty validated event prefix.
+
+    Raises:
+        RuntimeTraceSnapshotError: The journal is empty or the boundary is outside the journal.
+        RuntimeJournalError: The selected prefix violates journal event contracts.
+    """
     if not events:
         raise RuntimeTraceSnapshotError("runtime journal has no durable events to snapshot")
     if last_ordinal is None:
@@ -412,7 +472,18 @@ def _select_prefix(
 def _build_interactions(
     events: tuple[RuntimeJournalEvent, ...],
 ) -> tuple[RuntimeTraceInteraction, ...]:
-    """Group globally ordered journal events into canonical logical interactions."""
+    """Group globally ordered journal events into canonical logical interactions.
+
+    Args:
+        events: Validated durable journal prefix in ordinal order.
+
+    Returns:
+        Interactions ordered by first acceptance, with retry dispositions and terminal evidence.
+
+    Raises:
+        RuntimeTraceSnapshotError: Grouping cannot reproduce the exact global event prefix.
+        ValueError: An interaction or attempt violates its validated contract.
+    """
     accepted_by_interaction: dict[str, list[RuntimeAcceptedEvent]] = {}
     terminals_by_attempt: dict[tuple[str, int], list[RuntimeTerminalEvent]] = {}
     interaction_ids = []
@@ -502,7 +573,19 @@ def _build_interactions(
 def _derive_traces(
     interactions: tuple[RuntimeTraceInteraction, ...], snapshot: RuntimeTraceSnapshot
 ) -> tuple[Trace, ...]:
-    """Map one completed target per interaction into the shared trace contracts."""
+    """Map one completed target per interaction into the shared trace contracts.
+
+    Args:
+        interactions: Canonical logical interactions from the sealed prefix.
+        snapshot: Immutable snapshot that binds trace provenance.
+
+    Returns:
+        Canonical production traces for completed interaction targets only.
+
+    Raises:
+        RuntimeTraceSnapshotError: Derived target count differs from the snapshot contract.
+        ValidationError: Preserved request or response metadata is not canonical JSON.
+    """
     traces = []
     trace_source = TraceSource(
         identity=SourceIdentity(
@@ -575,7 +658,14 @@ def _derive_traces(
 
 
 def _task_text(accepted: RuntimeAcceptedEvent) -> str:
-    """Choose a stable human-readable task while retaining the full request context."""
+    """Choose a stable human-readable task from an accepted request.
+
+    Args:
+        accepted: Accepted runtime event containing the full model request.
+
+    Returns:
+        Last visible user text, first available message text, or a stable fallback task.
+    """
     for message in reversed(accepted.request.messages):
         if message.role == "user" and message.content:
             return message.content
@@ -591,7 +681,21 @@ def _persist_snapshot(
     interactions: tuple[RuntimeTraceInteraction, ...],
     interactions_payload: bytes,
 ) -> LoadedRuntimeTraceSnapshot:
-    """Write a new prefix snapshot or return its exact existing materialization."""
+    """Write a new prefix snapshot or return its exact existing materialization.
+
+    Args:
+        store: Project artifact store receiving the snapshot.
+        snapshot: Validated immutable snapshot envelope.
+        interactions: Canonical logical interactions bound by the envelope.
+        interactions_payload: Canonical serialized interaction records.
+
+    Returns:
+        Fully reloaded and verified snapshot materialization.
+
+    Raises:
+        RuntimeTraceSnapshotError: An existing snapshot differs from exact replay.
+        ArtifactStoreError: A new artifact cannot be persisted safely.
+    """
     try:
         store.write(
             artifact_id=snapshot.snapshot_id,
@@ -618,7 +722,20 @@ def _persist_dataset(
     traces: tuple[Trace, ...],
     loaded_snapshot: LoadedRuntimeTraceSnapshot,
 ) -> tuple[TraceDataset, ArtifactManifest]:
-    """Persist completed runtime targets through the shared canonical trace envelope."""
+    """Persist completed runtime targets through the shared canonical trace envelope.
+
+    Args:
+        store: Project artifact store receiving the dataset.
+        traces: Canonical completed-target traces.
+        loaded_snapshot: Verified snapshot that owns the dataset provenance.
+
+    Returns:
+        Canonical trace dataset and its verified artifact manifest.
+
+    Raises:
+        RuntimeTraceSnapshotError: Existing dataset material differs from exact replay.
+        ArtifactStoreError: A new dataset cannot be persisted safely.
+    """
     traces_payload = _jsonl_bytes(traces)
     snapshot_input = artifact_input(loaded_snapshot.manifest)
     dataset_id = stable_id(
@@ -626,6 +743,8 @@ def _persist_dataset(
         {
             "snapshot": snapshot_input.model_dump(mode="json"),
             "traces_sha256": _sha256(traces_payload),
+            "code_revision": loaded_snapshot.snapshot.code_revision,
+            "semantic_convention_version": _RUNTIME_TRACE_CONVENTION,
         },
     )
     dataset = TraceDataset(
@@ -664,7 +783,19 @@ def _load_exact_dataset_replay(
     expected: TraceDataset,
     traces_payload: bytes,
 ) -> tuple[TraceDataset, ArtifactManifest]:
-    """Return an existing byte-identical dataset derived from the same snapshot."""
+    """Load an existing byte-identical dataset derived from the same snapshot.
+
+    Args:
+        store: Project artifact store containing the expected dataset.
+        expected: Exact dataset envelope derived from the current snapshot.
+        traces_payload: Exact canonical trace bytes derived from the current snapshot.
+
+    Returns:
+        Verified existing dataset and artifact manifest.
+
+    Raises:
+        RuntimeTraceSnapshotError: Type, envelope, trace bytes, or provenance differs from replay.
+    """
     stored = store.read(expected.dataset_id)
     if stored.manifest.artifact_type != _TRACE_DATASET_ARTIFACT_TYPE:
         raise RuntimeTraceSnapshotError(
@@ -693,7 +824,17 @@ def _load_exact_dataset_replay(
 def _parse_canonical_interactions(
     payload: bytes,
 ) -> tuple[RuntimeTraceInteraction, ...]:
-    """Parse canonical logical interactions from newline-terminated JSONL."""
+    """Parse canonical logical interactions from newline-terminated JSONL.
+
+    Args:
+        payload: Serialized interaction records to parse and canonicalize.
+
+    Returns:
+        Validated logical interactions in serialized order.
+
+    Raises:
+        RuntimeJournalError: Encoding, line framing, validation, or canonical bytes are invalid.
+    """
     if payload and not payload.endswith(b"\n"):
         raise RuntimeJournalError("snapshot interaction JSONL must end with a newline")
     interactions = []
@@ -715,7 +856,17 @@ def _parse_canonical_interactions(
 def _events_from_interactions(
     interactions: tuple[RuntimeTraceInteraction, ...],
 ) -> tuple[RuntimeJournalEvent, ...]:
-    """Restore the exact global event prefix from canonical interaction provenance."""
+    """Restore the exact global event prefix from canonical interaction provenance.
+
+    Args:
+        interactions: Canonical logical interactions ordered by first acceptance.
+
+    Returns:
+        Validated journal events in global ordinal order.
+
+    Raises:
+        RuntimeJournalError: Event ordering or first-acceptance interaction ordering is invalid.
+    """
     events: list[RuntimeJournalEvent] = []
     for interaction in interactions:
         for attempt in interaction.attempts:
@@ -745,7 +896,15 @@ def _accepted_pins(event: RuntimeAcceptedEvent) -> JsonObject:
 
 
 def _require_same_project(journal: RuntimeInteractionJournal, store: ArtifactStore) -> None:
-    """Require mutable and immutable paths to belong to one project boundary."""
+    """Require mutable and immutable paths to belong to one project boundary.
+
+    Args:
+        journal: Mutable routed-interaction journal.
+        store: Immutable project artifact store.
+
+    Raises:
+        RuntimeTraceSnapshotError: Project identity or canonical journal path differs.
+    """
     expected_path = store.project_directory / "runtime" / "interactions.jsonl"
     if journal.project_id != store.project_directory.name or (
         journal.path.resolve() != expected_path.resolve()
@@ -758,7 +917,15 @@ def _require_same_project(journal: RuntimeInteractionJournal, store: ArtifactSto
 def _require_envelope_matches_manifest(
     envelope: ArtifactEnvelope, manifest: ArtifactManifest
 ) -> None:
-    """Require shared provenance fields to match the immutable artifact manifest."""
+    """Require shared provenance fields to match the immutable artifact manifest.
+
+    Args:
+        envelope: Domain artifact envelope loaded from a data file.
+        manifest: Store-level manifest that digests that file.
+
+    Raises:
+        ArtifactCorruptionError: Shared schema or provenance fields differ.
+    """
     if (
         manifest.schema_version,
         manifest.created_at,

--- a/wmo/runtime/router/snapshot.py
+++ b/wmo/runtime/router/snapshot.py
@@ -181,11 +181,12 @@ _INTERACTION_ADAPTER = TypeAdapter(RuntimeTraceInteraction)
 class RuntimeTraceSnapshot(ArtifactEnvelope):
     """One immutable, content-addressed prefix of a routed-interaction journal."""
 
+    schema_version: Literal[1] = 1
     snapshot_id: ArtifactId
     project_id: ArtifactId
     last_ordinal: int = Field(gt=0)
     prefix_sha256: Sha256
-    interactions_path: str = Field(min_length=1)
+    interactions_path: Literal["interactions.jsonl"] = _INTERACTIONS_PATH
     interactions_sha256: Sha256
     interaction_ids: tuple[ArtifactId, ...]
     completed_target_count: int = Field(ge=0)
@@ -233,12 +234,7 @@ class RuntimeTraceSnapshot(ArtifactEnvelope):
             raise ValueError("runtime trace snapshots cannot declare upstream artifact inputs")
         expected_id = stable_id(
             "runtime-trace-snapshot",
-            {
-                "project_id": self.project_id,
-                "last_ordinal": self.last_ordinal,
-                "prefix_sha256": self.prefix_sha256,
-                "code_revision": self.code_revision,
-            },
+            self.model_dump(mode="json", exclude={"created_at", "snapshot_id"}),
         )
         if self.snapshot_id != expected_id:
             raise ValueError("runtime trace snapshot ID differs from its canonical prefix")
@@ -324,18 +320,28 @@ def seal_runtime_trace_snapshot(
         for attempt in interaction.attempts
         for event in attempt.terminal_events
     )
+    interactions_sha256 = _sha256(interactions_payload)
     snapshot_id = stable_id(
         "runtime-trace-snapshot",
         {
+            "schema_version": 1,
+            "inputs": [],
+            "code_revision": code_revision,
+            "source": source.model_dump(mode="json"),
             "project_id": journal.project_id,
             "last_ordinal": events[-1].ordinal,
             "prefix_sha256": prefix_sha256,
-            "code_revision": code_revision,
+            "interactions_path": _INTERACTIONS_PATH,
+            "interactions_sha256": interactions_sha256,
+            "interaction_ids": list(interaction_ids),
+            "completed_target_count": completed_target_count,
+            "failed_attempt_count": failed_attempt_count,
         },
     )
     snapshot = RuntimeTraceSnapshot(
         schema_version=1,
         created_at=created_at,
+        inputs=(),
         code_revision=code_revision,
         source=source,
         snapshot_id=snapshot_id,
@@ -343,7 +349,7 @@ def seal_runtime_trace_snapshot(
         last_ordinal=events[-1].ordinal,
         prefix_sha256=prefix_sha256,
         interactions_path=_INTERACTIONS_PATH,
-        interactions_sha256=_sha256(interactions_payload),
+        interactions_sha256=interactions_sha256,
         interaction_ids=interaction_ids,
         completed_target_count=completed_target_count,
         failed_attempt_count=failed_attempt_count,
@@ -737,14 +743,28 @@ def _persist_dataset(
         ArtifactStoreError: A new dataset cannot be persisted safely.
     """
     traces_payload = _jsonl_bytes(traces)
+    traces_sha256 = _sha256(traces_payload)
     snapshot_input = artifact_input(loaded_snapshot.manifest)
+    source = SourceIdentity(
+        kind="production",
+        source_id=loaded_snapshot.snapshot.snapshot_id,
+        sha256=loaded_snapshot.snapshot.prefix_sha256,
+    )
+    trace_ids = tuple(trace.trace_id for trace in traces)
     dataset_id = stable_id(
         "trace-dataset",
         {
-            "snapshot": snapshot_input.model_dump(mode="json"),
-            "traces_sha256": _sha256(traces_payload),
+            "schema_version": 1,
+            "inputs": [snapshot_input.model_dump(mode="json")],
             "code_revision": loaded_snapshot.snapshot.code_revision,
+            "source": source.model_dump(mode="json"),
             "semantic_convention_version": _RUNTIME_TRACE_CONVENTION,
+            "traces_path": _TRACES_PATH,
+            "traces_sha256": traces_sha256,
+            "issues_path": None,
+            "issues_sha256": None,
+            "invalid_trace_count": 0,
+            "trace_ids": list(trace_ids),
         },
     )
     dataset = TraceDataset(
@@ -752,16 +772,12 @@ def _persist_dataset(
         created_at=loaded_snapshot.snapshot.created_at,
         inputs=(snapshot_input,),
         code_revision=loaded_snapshot.snapshot.code_revision,
-        source=SourceIdentity(
-            kind="production",
-            source_id=loaded_snapshot.snapshot.snapshot_id,
-            sha256=loaded_snapshot.snapshot.prefix_sha256,
-        ),
+        source=source,
         dataset_id=dataset_id,
         semantic_convention_version=_RUNTIME_TRACE_CONVENTION,
         traces_path=_TRACES_PATH,
-        traces_sha256=_sha256(traces_payload),
-        trace_ids=tuple(trace.trace_id for trace in traces),
+        traces_sha256=traces_sha256,
+        trace_ids=trace_ids,
     )
     try:
         manifest = store.write(
@@ -809,6 +825,14 @@ def _load_exact_dataset_replay(
         raise RuntimeTraceSnapshotError(
             f"existing trace dataset {expected.dataset_id} has an invalid envelope"
         ) from exc
+    expected_existing_id = stable_id(
+        "trace-dataset",
+        existing.model_dump(mode="json", exclude={"created_at", "dataset_id"}),
+    )
+    if existing.dataset_id != expected_existing_id:
+        raise RuntimeTraceSnapshotError(
+            "existing runtime trace dataset ID differs from its canonical content"
+        )
     if existing != expected:
         raise RuntimeTraceSnapshotError(
             "existing runtime trace dataset differs from the snapshot replay"

--- a/wmo/runtime/router/snapshot_test.py
+++ b/wmo/runtime/router/snapshot_test.py
@@ -27,7 +27,12 @@ from wmo.common.models import (
     OperationEconomics,
     Usage,
 )
-from wmo.common.project import ArtifactStore, ArtifactStoreError, ProjectPaths
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactStore,
+    ArtifactStoreError,
+    ProjectPaths,
+)
 from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
 from wmo.common.traces import load_trace_dataset
 from wmo.runtime.router.journal import (
@@ -49,7 +54,14 @@ _TIME = datetime(2026, 8, 13, tzinfo=UTC)
 
 
 def _snapshot(*, model_id: str = "gpt-test") -> ModelSnapshot:
-    """Build a frozen test model snapshot."""
+    """Build a frozen test model snapshot.
+
+    Args:
+        model_id: Provider model identity to preserve in the fixture.
+
+    Returns:
+        Deterministic model snapshot with fixed capability and connection digests.
+    """
     return ModelSnapshot(
         provider="openai",
         model_id=model_id,
@@ -59,7 +71,14 @@ def _snapshot(*, model_id: str = "gpt-test") -> ModelSnapshot:
 
 
 def _request(content: str = "Help me") -> ModelRequest:
-    """Build a deterministic two-message model request."""
+    """Build a deterministic two-message model request.
+
+    Args:
+        content: User message included after the fixed system instruction.
+
+    Returns:
+        Provider-neutral request used by runtime snapshot fixtures.
+    """
     return ModelRequest(
         messages=(
             ModelMessage(role="system", content="You are helpful."),
@@ -69,7 +88,15 @@ def _request(content: str = "Help me") -> ModelRequest:
 
 
 def _response(*, model: ModelSnapshot | None = None, content: str = "Done") -> ModelResponse:
-    """Build a deterministic successful model response."""
+    """Build a deterministic successful model response.
+
+    Args:
+        model: Optional provider-resolved model identity.
+        content: Assistant text returned by the fixture.
+
+    Returns:
+        Successful response with fixed token economics.
+    """
     return ModelResponse(
         output=AssistantAction(content=content),
         model=model or _snapshot(),
@@ -80,7 +107,15 @@ def _response(*, model: ModelSnapshot | None = None, content: str = "Done") -> M
 
 
 def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
-    """Build a content-addressed routing decision for one request lineage."""
+    """Build a content-addressed routing decision for one request lineage.
+
+    Args:
+        lineage_id: Stable conversation lineage used by the runtime journal.
+        request: Request whose extracted feature defines the decision identity.
+
+    Returns:
+        Deterministic candidate selection with canonical content identity.
+    """
     episode_sha256 = hashlib.sha256(lineage_id.encode("utf-8"), usedforsecurity=False).hexdigest()
     feature = RouterFeatureExtractor().from_request(request)
     material = {
@@ -121,7 +156,18 @@ def _accept(
     conversation_id: str | None = None,
     now: datetime = _TIME,
 ) -> RuntimeAcceptedEvent:
-    """Accept one deterministic interaction into the runtime journal."""
+    """Accept one deterministic interaction into the runtime journal.
+
+    Args:
+        journal: Mutable runtime journal receiving the acceptance.
+        key: Caller idempotency key used only to derive the interaction identity.
+        request: Optional request override.
+        conversation_id: Optional stable routed conversation identity.
+        now: Acceptance timestamp.
+
+    Returns:
+        Durable accepted event produced by the journal claim.
+    """
     routed_request = request or _request()
     identity = _interaction_identity(
         journal.project_id,
@@ -157,7 +203,19 @@ def _complete(
     now: datetime = _TIME,
     response: ModelResponse | None = None,
 ) -> RuntimeAcceptedEvent:
-    """Accept and complete one deterministic journal interaction."""
+    """Accept and complete one deterministic journal interaction.
+
+    Args:
+        journal: Mutable runtime journal receiving both events.
+        key: Caller idempotency key used to derive the interaction identity.
+        request: Optional request override.
+        conversation_id: Optional stable routed conversation identity.
+        now: Acceptance timestamp used to derive completion time.
+        response: Optional provider result override.
+
+    Returns:
+        Accepted event named by the recorded completion.
+    """
     accepted = _accept(
         journal,
         key=key,
@@ -174,7 +232,15 @@ def _complete(
 
 
 def _artifact_bytes(store: ArtifactStore, artifact_id: str) -> dict[str, bytes]:
-    """Read every file in an artifact directory as stable relative-path bytes."""
+    """Read every file in an artifact directory as stable relative-path bytes.
+
+    Args:
+        store: Project artifact store containing the target artifact.
+        artifact_id: Immutable artifact identity to inspect.
+
+    Returns:
+        Mapping from relative file paths to exact bytes.
+    """
     directory = store.read(artifact_id).directory
     return {
         path.relative_to(directory).as_posix(): path.read_bytes()
@@ -184,7 +250,11 @@ def _artifact_bytes(store: ArtifactStore, artifact_id: str) -> dict[str, bytes]:
 
 
 def test_identical_replay_and_later_append_preserve_old_snapshot(tmp_path: Path) -> None:
-    """The same prefix replays exactly, while a later prefix creates new immutable siblings."""
+    """Prove exact replay and later append preserve the original snapshot.
+
+    The same prefix reuses identical artifact bytes, while a newly appended journal event creates
+    distinct immutable snapshot and dataset siblings without changing the first export.
+    """
     journal, store = _journal_and_store(tmp_path)
     _complete(journal, key="first-key", conversation_id="conversation-a")
 
@@ -240,7 +310,11 @@ def test_identical_replay_and_later_append_preserve_old_snapshot(tmp_path: Path)
 
 
 def test_equivalent_prefixes_produce_identical_artifact_files(tmp_path: Path) -> None:
-    """Canonical serialization yields the same IDs and bytes in independent project roots."""
+    """Prove equivalent prefixes produce identical artifacts across project roots.
+
+    Independently materialized journals with equal events yield the same content identities and
+    byte-for-byte artifact files.
+    """
     first_journal, first_store = _journal_and_store(tmp_path / "first")
     second_journal, second_store = _journal_and_store(tmp_path / "second")
     for journal in (first_journal, second_journal):
@@ -269,10 +343,92 @@ def test_equivalent_prefixes_produce_identical_artifact_files(tmp_path: Path) ->
     )
 
 
+def test_code_revision_drift_creates_distinct_snapshot_and_dataset_ids(tmp_path: Path) -> None:
+    """Prove revision-sensitive envelopes receive distinct content identities.
+
+    Sealing the same journal prefix from another code revision produces immutable snapshot and
+    dataset siblings instead of colliding with the original envelopes.
+    """
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="revision-key")
+
+    first = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="revision-a",
+    )
+    second = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=2),
+        code_revision="revision-b",
+    )
+
+    assert first.snapshot.snapshot_id != second.snapshot.snapshot_id
+    assert first.dataset.dataset_id != second.dataset.dataset_id
+    assert first.snapshot.prefix_sha256 == second.snapshot.prefix_sha256
+    assert first.dataset.trace_ids == second.dataset.trace_ids
+    assert first.traces[0].model_dump(exclude={"source"}) == second.traces[0].model_dump(
+        exclude={"source"}
+    )
+    assert first.traces[0].source != second.traces[0].source
+
+
+@pytest.mark.parametrize("mutation", ["inputs", "source-id"])
+def test_loader_rejects_forged_snapshot_provenance(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    """Prove verified artifact files cannot attach unbound snapshot provenance.
+
+    Args:
+        tmp_path: Isolated project root.
+        mutation: Shared envelope and manifest field rewritten with valid digests.
+    """
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="forged-provenance-key")
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    directory = store.read(exported.snapshot.snapshot_id).directory
+    snapshot_path = directory / "runtime-trace-snapshot.json"
+    manifest_path = directory / "manifest.json"
+    snapshot = json.loads(snapshot_path.read_bytes())
+    manifest = json.loads(manifest_path.read_bytes())
+    if mutation == "inputs":
+        forged_inputs = [
+            ArtifactInput(artifact_id="forged-input", sha256="f" * 64).model_dump(mode="json")
+        ]
+        snapshot["inputs"] = forged_inputs
+        manifest["inputs"] = forged_inputs
+    else:
+        snapshot["source"]["source_id"] = "forged/runtime/interactions"
+        manifest["source"]["source_id"] = "forged/runtime/interactions"
+    snapshot_payload = canonical_json_bytes(snapshot)
+    snapshot_path.write_bytes(snapshot_payload)
+    snapshot_entry = next(
+        entry for entry in manifest["files"] if entry["path"] == "runtime-trace-snapshot.json"
+    )
+    snapshot_entry["sha256"] = hashlib.sha256(snapshot_payload).hexdigest()
+    snapshot_entry["size_bytes"] = len(snapshot_payload)
+    manifest_path.write_bytes(canonical_json_bytes(manifest))
+
+    with pytest.raises(ArtifactCorruptionError, match="invalid envelope"):
+        load_runtime_trace_snapshot(store, exported.snapshot.snapshot_id)
+
+
 def test_retry_success_is_one_target_and_failures_remain_prefix_provenance(
     tmp_path: Path,
 ) -> None:
-    """Failed attempts stay in the snapshot, and only the eventual response enters traces."""
+    """Prove retry failures remain provenance while one success becomes the target.
+
+    The snapshot retains both failed and completed attempts, but normalized traces contain exactly
+    the eventual completed response for the logical interaction.
+    """
     journal, store = _journal_and_store(tmp_path)
     request = _request("Reset my password")
     first = _accept(
@@ -361,7 +517,11 @@ def test_retry_success_is_one_target_and_failures_remain_prefix_provenance(
 
 
 def test_late_original_success_preserves_failure_and_superseded_retry(tmp_path: Path) -> None:
-    """A late winning target retains both the failed original attempt and its unused retry."""
+    """Prove a late original success preserves failure and superseded retry evidence.
+
+    A retry accepted after a retryable failure becomes superseded when the original attempt later
+    completes, and the original acceptance time remains the trace span start.
+    """
     journal, store = _journal_and_store(tmp_path)
     request = _request("Summarize the account")
     original = _accept(journal, key="late-key", request=request)
@@ -419,7 +579,12 @@ def test_late_original_success_preserves_failure_and_superseded_retry(tmp_path: 
     ["duplicate", "event-id", "request-hash", "response-hash"],
 )
 def test_malformed_ids_digests_and_transitions_fail_closed(tmp_path: Path, corruption: str) -> None:
-    """A structurally valid rewrite cannot bypass journal identity and transition checks."""
+    """Prove structural rewrites cannot bypass journal identity and transition checks.
+
+    Args:
+        tmp_path: Isolated project root.
+        corruption: Event mutation applied before sealing the journal.
+    """
     journal, store = _journal_and_store(tmp_path)
     _complete(journal, key="corrupt-key")
     lines = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
@@ -445,7 +610,11 @@ def test_malformed_ids_digests_and_transitions_fail_closed(tmp_path: Path, corru
 def test_provider_resolved_response_model_preserves_both_model_identities(
     tmp_path: Path,
 ) -> None:
-    """The routed snapshot and provider-resolved response model remain distinct provenance."""
+    """Prove routed and provider-resolved model identities remain distinct provenance.
+
+    The normalized trace records both the selected frozen model and the exact model identity
+    returned by the provider rather than requiring them to be equal.
+    """
     journal, store = _journal_and_store(tmp_path)
     _complete(
         journal,
@@ -471,7 +640,11 @@ def test_provider_resolved_response_model_preserves_both_model_identities(
 def test_torn_tail_is_ignored_but_newline_terminated_corruption_is_rejected(
     tmp_path: Path,
 ) -> None:
-    """Only the journal's explicit non-newline final tear is outside the sealed prefix."""
+    """Prove only an explicit non-newline journal tail is excluded from sealing.
+
+    A torn final write is ignored by journal recovery, while newline-terminated malformed content
+    remains part of the durable prefix and fails closed.
+    """
     journal, store = _journal_and_store(tmp_path)
     _complete(journal, key="tail-key")
     clean = journal.path.read_bytes()
@@ -506,7 +679,11 @@ def test_torn_tail_is_ignored_but_newline_terminated_corruption_is_rejected(
 def test_secret_idempotency_key_is_hashed_and_secret_prompts_are_rejected(
     tmp_path: Path,
 ) -> None:
-    """Runtime artifacts omit caller keys and reject detectable credentials in trace content."""
+    """Prove runtime artifacts hash caller keys and reject credentials in prompts.
+
+    A benign interaction leaves no raw idempotency key in artifact bytes, while a detectable secret
+    in request content prevents canonical trace persistence.
+    """
     journal, store = _journal_and_store(tmp_path / "safe")
     raw_key = "sk-this-is-fake-secret-material-123456789"
     _complete(journal, key=raw_key)
@@ -541,7 +718,11 @@ def test_secret_idempotency_key_is_hashed_and_secret_prompts_are_rejected(
 
 
 def test_empty_or_failed_only_prefix_has_no_canonical_target_dataset(tmp_path: Path) -> None:
-    """A trace dataset is created only when the selected prefix has a completed target."""
+    """Prove a dataset requires a completed target in the selected prefix.
+
+    Empty journals and prefixes containing only accepted or failed attempts fail before a canonical
+    target dataset can be materialized.
+    """
     journal, store = _journal_and_store(tmp_path)
     with pytest.raises(RuntimeTraceSnapshotError, match="no durable events"):
         seal_runtime_trace_snapshot(
@@ -575,7 +756,11 @@ def test_empty_or_failed_only_prefix_has_no_canonical_target_dataset(tmp_path: P
 def test_attempt_contract_requires_terminal_evidence_for_terminal_dispositions(
     tmp_path: Path,
 ) -> None:
-    """A standalone attempt cannot claim completion or failure without its terminal event."""
+    """Prove terminal attempt dispositions require corresponding terminal evidence.
+
+    Pydantic validation rejects completed and failed dispositions when the attempt contains only
+    its acceptance event.
+    """
     journal, _ = _journal_and_store(tmp_path)
     accepted = _accept(journal, key="contract-key")
     with pytest.raises(ValidationError, match="must be open or superseded"):

--- a/wmo/runtime/router/snapshot_test.py
+++ b/wmo/runtime/router/snapshot_test.py
@@ -1,0 +1,574 @@
+"""Adversarial coverage for immutable runtime trace snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import (
+    ArtifactInput,
+    FailureAttribution,
+    FailureCode,
+    StructuredFailure,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.models import (
+    AssistantAction,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    Usage,
+)
+from wmo.common.project import ArtifactStore, ArtifactStoreError, ProjectPaths
+from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
+from wmo.common.traces import load_trace_dataset
+from wmo.runtime.router.journal import (
+    RuntimeAcceptance,
+    RuntimeAcceptedEvent,
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    _interaction_identity,
+)
+from wmo.runtime.router.snapshot import (
+    RuntimeTraceAttempt,
+    RuntimeTraceSnapshotError,
+    load_runtime_trace_snapshot,
+    seal_runtime_trace_snapshot,
+)
+
+_DIGEST = "a" * 64
+_TIME = datetime(2026, 8, 13, tzinfo=UTC)
+
+
+def _snapshot(*, model_id: str = "gpt-test") -> ModelSnapshot:
+    return ModelSnapshot(
+        provider="openai",
+        model_id=model_id,
+        capabilities_sha256=_DIGEST,
+        connection_sha256="b" * 64,
+    )
+
+
+def _request(content: str = "Help me") -> ModelRequest:
+    return ModelRequest(
+        messages=(
+            ModelMessage(role="system", content="You are helpful."),
+            ModelMessage(role="user", content=content),
+        )
+    )
+
+
+def _response(*, model: ModelSnapshot | None = None, content: str = "Done") -> ModelResponse:
+    return ModelResponse(
+        output=AssistantAction(content=content),
+        model=model or _snapshot(),
+        economics=OperationEconomics(
+            usage=Usage(input_tokens=12, output_tokens=3, cached_input_tokens=2)
+        ),
+    )
+
+
+def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
+    episode_sha256 = hashlib.sha256(lineage_id.encode("utf-8"), usedforsecurity=False).hexdigest()
+    feature = RouterFeatureExtractor().from_request(request)
+    material = {
+        "policy_id": "router-policy-a",
+        "policy_sha256": _DIGEST,
+        "request_sha256": hashlib.sha256(
+            feature.encode("utf-8"), usedforsecurity=False
+        ).hexdigest(),
+        "episode_id_sha256": episode_sha256,
+        "selected_alias": "candidate-a",
+        "baseline_alias": "candidate-a",
+        "neighbor_count": 8,
+        "paired_count": 8,
+        "best_similarity": 1.0,
+        "estimated_quality_difference": None,
+        "uncertainty": None,
+        "fallback_reason": None,
+    }
+    return RoutingDecision(
+        decision_id=stable_id("routing-decision", material),
+        **material,
+    )
+
+
+def _journal_and_store(
+    tmp_path: Path,
+) -> tuple[RuntimeInteractionJournal, ArtifactStore]:
+    paths = ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
+    return RuntimeInteractionJournal(paths), ArtifactStore(paths)
+
+
+def _accept(
+    journal: RuntimeInteractionJournal,
+    *,
+    key: str,
+    request: ModelRequest | None = None,
+    conversation_id: str | None = None,
+    now: datetime = _TIME,
+) -> RuntimeAcceptedEvent:
+    routed_request = request or _request()
+    identity = _interaction_identity(
+        journal.project_id,
+        key,
+        routed_request,
+        conversation_id,
+    )
+    decision = _decision(identity.lineage_id, routed_request)
+    claim = journal.claim(
+        identity,
+        RuntimeAcceptance(
+            decision=decision,
+            selected_alias=decision.selected_alias,
+            selected_model=_snapshot(),
+            policy_input=ArtifactInput(
+                artifact_id=decision.policy_id,
+                sha256=decision.policy_sha256,
+            ),
+        ),
+        now=now,
+        stale_after=timedelta(minutes=5),
+    )
+    assert claim.accepted is not None
+    return claim.accepted
+
+
+def _complete(
+    journal: RuntimeInteractionJournal,
+    *,
+    key: str,
+    request: ModelRequest | None = None,
+    conversation_id: str | None = None,
+    now: datetime = _TIME,
+    response: ModelResponse | None = None,
+) -> RuntimeAcceptedEvent:
+    accepted = _accept(
+        journal,
+        key=key,
+        request=request,
+        conversation_id=conversation_id,
+        now=now,
+    )
+    journal.record_completed(
+        accepted,
+        response or _response(),
+        completed_at=now + timedelta(seconds=1),
+    )
+    return accepted
+
+
+def _artifact_bytes(store: ArtifactStore, artifact_id: str) -> dict[str, bytes]:
+    directory = store.read(artifact_id).directory
+    return {
+        path.relative_to(directory).as_posix(): path.read_bytes()
+        for path in sorted(directory.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_identical_replay_and_later_append_preserve_old_snapshot(tmp_path: Path) -> None:
+    """The same prefix replays exactly, while a later prefix creates new immutable siblings."""
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="first-key", conversation_id="conversation-a")
+
+    first = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    first_snapshot_bytes = _artifact_bytes(store, first.snapshot.snapshot_id)
+    first_dataset_bytes = _artifact_bytes(store, first.dataset.dataset_id)
+    replay = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(days=1),
+        code_revision="test-revision",
+    )
+
+    assert replay == first
+    assert _artifact_bytes(store, first.snapshot.snapshot_id) == first_snapshot_bytes
+    assert _artifact_bytes(store, first.dataset.dataset_id) == first_dataset_bytes
+
+    _complete(
+        journal,
+        key="second-key",
+        conversation_id="conversation-b",
+        now=_TIME + timedelta(minutes=2),
+    )
+    later = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=3),
+        code_revision="test-revision",
+    )
+    explicit_old = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(days=2),
+        code_revision="test-revision",
+        last_ordinal=first.snapshot.last_ordinal,
+    )
+
+    assert explicit_old == first
+    assert later.snapshot.snapshot_id != first.snapshot.snapshot_id
+    assert later.dataset.dataset_id != first.dataset.dataset_id
+    assert later.snapshot.interaction_ids == (
+        first.snapshot.interaction_ids[0],
+        later.snapshot.interaction_ids[1],
+    )
+    assert later.dataset.trace_ids == later.snapshot.interaction_ids
+    assert _artifact_bytes(store, first.snapshot.snapshot_id) == first_snapshot_bytes
+    assert _artifact_bytes(store, first.dataset.dataset_id) == first_dataset_bytes
+
+
+def test_equivalent_prefixes_produce_identical_artifact_files(tmp_path: Path) -> None:
+    """Canonical serialization yields the same IDs and bytes in independent project roots."""
+    first_journal, first_store = _journal_and_store(tmp_path / "first")
+    second_journal, second_store = _journal_and_store(tmp_path / "second")
+    for journal in (first_journal, second_journal):
+        _complete(journal, key="same-key", conversation_id="same-lineage")
+
+    first = seal_runtime_trace_snapshot(
+        first_journal,
+        first_store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    second = seal_runtime_trace_snapshot(
+        second_journal,
+        second_store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+
+    assert second.snapshot == first.snapshot
+    assert second.dataset == first.dataset
+    assert _artifact_bytes(first_store, first.snapshot.snapshot_id) == _artifact_bytes(
+        second_store, second.snapshot.snapshot_id
+    )
+    assert _artifact_bytes(first_store, first.dataset.dataset_id) == _artifact_bytes(
+        second_store, second.dataset.dataset_id
+    )
+
+
+def test_retry_success_is_one_target_and_failures_remain_prefix_provenance(
+    tmp_path: Path,
+) -> None:
+    """Failed attempts stay in the snapshot, and only the eventual response enters traces."""
+    journal, store = _journal_and_store(tmp_path)
+    request = _request("Reset my password")
+    first = _accept(
+        journal,
+        key="retry-key",
+        request=request,
+        conversation_id="customer-thread",
+    )
+    journal.record_failure(
+        first,
+        StructuredFailure(
+            code=FailureCode.TIMEOUT,
+            message="routed model provider attempt failed",
+            retryable=True,
+            attribution=FailureAttribution.MODEL,
+        ),
+        failed_at=_TIME + timedelta(seconds=1),
+    )
+    identity = _interaction_identity(
+        journal.project_id,
+        "retry-key",
+        request,
+        "customer-thread",
+    )
+    retry = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(minutes=5),
+    )
+    assert retry.accepted is not None
+    journal.record_completed(
+        retry.accepted,
+        _response(content="Use the reset link."),
+        completed_at=_TIME + timedelta(seconds=3),
+    )
+
+    permanent = _accept(
+        journal,
+        key="permanent-key",
+        now=_TIME + timedelta(seconds=4),
+    )
+    journal.record_failure(
+        permanent,
+        StructuredFailure(
+            code=FailureCode.PROVIDER,
+            message="routed model provider attempt failed permanently",
+            retryable=False,
+            attribution=FailureAttribution.MODEL,
+        ),
+        failed_at=_TIME + timedelta(seconds=5),
+    )
+
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+
+    assert exported.snapshot.completed_target_count == 1
+    assert exported.snapshot.failed_attempt_count == 2
+    assert len(exported.snapshot.interaction_ids) == 2
+    assert exported.snapshot.prefix_sha256 != exported.snapshot.interactions_sha256
+    assert len(
+        store.read_bytes(exported.snapshot.snapshot_id, "interactions.jsonl").splitlines()
+    ) == len(exported.snapshot.interaction_ids)
+    assert [
+        [attempt.disposition for attempt in interaction.attempts]
+        for interaction in exported.interactions
+    ] == [
+        ["retryable_failure", "completed"],
+        ["permanent_failure"],
+    ]
+    assert exported.dataset.trace_ids == (first.interaction_id,)
+    assert len(exported.traces) == 1
+    trace = exported.traces[0]
+    assert trace.trace_id == first.interaction_id
+    assert trace.conversation_id == first.lineage_id
+    assert trace.task == "Reset my password"
+    assert trace.spans[0].started_at == retry.accepted.attempt_started_at
+    assert trace.spans[0].attributes["runtime.attempt_ordinal"] == 2
+    assert trace.source.identity.source_id == exported.snapshot.snapshot_id
+    assert trace.source.identity.sha256 == exported.snapshot.prefix_sha256
+    assert load_trace_dataset(store, exported.dataset.dataset_id).traces == exported.traces
+
+
+def test_late_original_success_preserves_failure_and_superseded_retry(tmp_path: Path) -> None:
+    """A late winning target retains both the failed original attempt and its unused retry."""
+    journal, store = _journal_and_store(tmp_path)
+    request = _request("Summarize the account")
+    original = _accept(journal, key="late-key", request=request)
+    journal.record_failure(
+        original,
+        StructuredFailure(
+            code=FailureCode.TIMEOUT,
+            message="routed model provider attempt became stale",
+            retryable=True,
+            attribution=FailureAttribution.MODEL,
+        ),
+        failed_at=_TIME + timedelta(seconds=1),
+    )
+    identity = _interaction_identity(journal.project_id, "late-key", request, None)
+    replacement = journal.claim(
+        identity,
+        None,
+        now=_TIME + timedelta(seconds=2),
+        stale_after=timedelta(minutes=5),
+    )
+    assert replacement.accepted is not None
+    journal.record_completed(
+        original,
+        _response(content="Account summary"),
+        completed_at=_TIME + timedelta(seconds=3),
+    )
+
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+
+    interaction = exported.interactions[0]
+    assert interaction.completed_attempt_ordinal == 1
+    assert [attempt.disposition for attempt in interaction.attempts] == [
+        "completed",
+        "superseded",
+    ]
+    assert [event.event for event in interaction.attempts[0].terminal_events] == [
+        "attempt_failed",
+        "completed",
+    ]
+    assert interaction.attempts[1].terminal_events == ()
+    assert exported.snapshot.failed_attempt_count == 1
+    assert exported.snapshot.completed_target_count == 1
+    assert exported.dataset.trace_ids == (original.interaction_id,)
+    assert len(exported.traces) == 1
+    assert exported.traces[0].spans[0].started_at == original.attempt_started_at
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["duplicate", "event-id", "request-hash", "response-hash"],
+)
+def test_malformed_ids_digests_and_transitions_fail_closed(tmp_path: Path, corruption: str) -> None:
+    """A structurally valid rewrite cannot bypass journal identity and transition checks."""
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="corrupt-key")
+    lines = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
+    if corruption == "duplicate":
+        lines.append(lines[1])
+    elif corruption == "event-id":
+        lines[0]["event_id"] = "runtime-event-ffffffffffffffffffff"
+    elif corruption == "request-hash":
+        lines[0]["request_sha256"] = "f" * 64
+    else:
+        lines[1]["response_sha256"] = "f" * 64
+    journal.path.write_bytes(b"\n".join(canonical_json_bytes(line) for line in lines) + b"\n")
+
+    with pytest.raises(RuntimeJournalError):
+        seal_runtime_trace_snapshot(
+            journal,
+            store,
+            created_at=_TIME + timedelta(minutes=1),
+            code_revision="test-revision",
+        )
+
+
+def test_provider_resolved_response_model_preserves_both_model_identities(
+    tmp_path: Path,
+) -> None:
+    """The routed snapshot and provider-resolved response model remain distinct provenance."""
+    journal, store = _journal_and_store(tmp_path)
+    _complete(
+        journal,
+        key="wrong-model-key",
+        response=_response(model=_snapshot(model_id="different-model")),
+    )
+
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+
+    span = exported.traces[0].spans[0]
+    assert span.model == _snapshot(model_id="different-model")
+    assert span.attributes["runtime.selected_model"] == _snapshot().model_dump(mode="json")
+    assert span.attributes["runtime.response_model"] == _snapshot(
+        model_id="different-model"
+    ).model_dump(mode="json")
+
+
+def test_torn_tail_is_ignored_but_newline_terminated_corruption_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Only the journal's explicit non-newline final tear is outside the sealed prefix."""
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="tail-key")
+    clean = journal.path.read_bytes()
+    journal.path.write_bytes(clean + b'{"event":"accepted"')
+
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    loaded = load_runtime_trace_snapshot(store, exported.snapshot.snapshot_id)
+
+    assert loaded.interactions == exported.interactions
+    assert (
+        exported.snapshot.prefix_sha256 == hashlib.sha256(clean, usedforsecurity=False).hexdigest()
+    )
+    assert (
+        len(store.read_bytes(exported.snapshot.snapshot_id, "interactions.jsonl").splitlines()) == 1
+    )
+
+    journal.path.write_bytes(clean + b'{"event":"accepted"\n')
+    with pytest.raises(RuntimeJournalError, match="invalid interior line"):
+        seal_runtime_trace_snapshot(
+            journal,
+            store,
+            created_at=_TIME + timedelta(minutes=2),
+            code_revision="test-revision",
+        )
+
+
+def test_secret_idempotency_key_is_hashed_and_secret_prompts_are_rejected(
+    tmp_path: Path,
+) -> None:
+    """Runtime artifacts omit caller keys and reject detectable credentials in trace content."""
+    journal, store = _journal_and_store(tmp_path / "safe")
+    raw_key = "sk-this-is-fake-secret-material-123456789"
+    _complete(journal, key=raw_key)
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    artifact_payload = b"".join(
+        _artifact_bytes(store, artifact_id)[path]
+        for artifact_id in (exported.snapshot.snapshot_id, exported.dataset.dataset_id)
+        for path in sorted(_artifact_bytes(store, artifact_id))
+    )
+    assert raw_key.encode() not in journal.path.read_bytes()
+    assert raw_key.encode() not in artifact_payload
+
+    unsafe_journal, unsafe_store = _journal_and_store(tmp_path / "unsafe")
+    _complete(
+        unsafe_journal,
+        key="safe-key",
+        request=_request("Use sk-this-is-fake-secret-material-987654321"),
+    )
+    with pytest.raises(ArtifactStoreError, match="secret boundary"):
+        seal_runtime_trace_snapshot(
+            unsafe_journal,
+            unsafe_store,
+            created_at=_TIME + timedelta(minutes=1),
+            code_revision="test-revision",
+        )
+    assert unsafe_store.list_ids() == ()
+
+
+def test_empty_or_failed_only_prefix_has_no_canonical_target_dataset(tmp_path: Path) -> None:
+    """A trace dataset is created only when the selected prefix has a completed target."""
+    journal, store = _journal_and_store(tmp_path)
+    with pytest.raises(RuntimeTraceSnapshotError, match="no durable events"):
+        seal_runtime_trace_snapshot(
+            journal,
+            store,
+            created_at=_TIME,
+            code_revision="test-revision",
+        )
+
+    accepted = _accept(journal, key="failed-only")
+    journal.record_failure(
+        accepted,
+        StructuredFailure(
+            code=FailureCode.PROVIDER,
+            message="routed model provider attempt failed permanently",
+            retryable=False,
+            attribution=FailureAttribution.MODEL,
+        ),
+        failed_at=_TIME + timedelta(seconds=1),
+    )
+    with pytest.raises(RuntimeTraceSnapshotError, match="completed routed interaction"):
+        seal_runtime_trace_snapshot(
+            journal,
+            store,
+            created_at=_TIME + timedelta(minutes=1),
+            code_revision="test-revision",
+        )
+    assert store.list_ids() == ()
+
+
+def test_attempt_contract_requires_terminal_evidence_for_terminal_dispositions(
+    tmp_path: Path,
+) -> None:
+    """A standalone attempt cannot claim completion or failure without its terminal event."""
+    journal, _ = _journal_and_store(tmp_path)
+    accepted = _accept(journal, key="contract-key")
+    with pytest.raises(ValidationError, match="must be open or superseded"):
+        RuntimeTraceAttempt(disposition="completed", accepted=accepted)

--- a/wmo/runtime/router/snapshot_test.py
+++ b/wmo/runtime/router/snapshot_test.py
@@ -49,6 +49,7 @@ _TIME = datetime(2026, 8, 13, tzinfo=UTC)
 
 
 def _snapshot(*, model_id: str = "gpt-test") -> ModelSnapshot:
+    """Build a frozen test model snapshot."""
     return ModelSnapshot(
         provider="openai",
         model_id=model_id,
@@ -58,6 +59,7 @@ def _snapshot(*, model_id: str = "gpt-test") -> ModelSnapshot:
 
 
 def _request(content: str = "Help me") -> ModelRequest:
+    """Build a deterministic two-message model request."""
     return ModelRequest(
         messages=(
             ModelMessage(role="system", content="You are helpful."),
@@ -67,6 +69,7 @@ def _request(content: str = "Help me") -> ModelRequest:
 
 
 def _response(*, model: ModelSnapshot | None = None, content: str = "Done") -> ModelResponse:
+    """Build a deterministic successful model response."""
     return ModelResponse(
         output=AssistantAction(content=content),
         model=model or _snapshot(),
@@ -77,6 +80,7 @@ def _response(*, model: ModelSnapshot | None = None, content: str = "Done") -> M
 
 
 def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
+    """Build a content-addressed routing decision for one request lineage."""
     episode_sha256 = hashlib.sha256(lineage_id.encode("utf-8"), usedforsecurity=False).hexdigest()
     feature = RouterFeatureExtractor().from_request(request)
     material = {
@@ -104,6 +108,7 @@ def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
 def _journal_and_store(
     tmp_path: Path,
 ) -> tuple[RuntimeInteractionJournal, ArtifactStore]:
+    """Build an isolated runtime journal and artifact store."""
     paths = ProjectPaths(root=tmp_path / ".wmo", project_id="support-agent")
     return RuntimeInteractionJournal(paths), ArtifactStore(paths)
 
@@ -116,6 +121,7 @@ def _accept(
     conversation_id: str | None = None,
     now: datetime = _TIME,
 ) -> RuntimeAcceptedEvent:
+    """Accept one deterministic interaction into the runtime journal."""
     routed_request = request or _request()
     identity = _interaction_identity(
         journal.project_id,
@@ -151,6 +157,7 @@ def _complete(
     now: datetime = _TIME,
     response: ModelResponse | None = None,
 ) -> RuntimeAcceptedEvent:
+    """Accept and complete one deterministic journal interaction."""
     accepted = _accept(
         journal,
         key=key,
@@ -167,6 +174,7 @@ def _complete(
 
 
 def _artifact_bytes(store: ArtifactStore, artifact_id: str) -> dict[str, bytes]:
+    """Read every file in an artifact directory as stable relative-path bytes."""
     directory = store.read(artifact_id).directory
     return {
         path.relative_to(directory).as_posix(): path.read_bytes()

--- a/wmo/runtime/router/snapshot_test.py
+++ b/wmo/runtime/router/snapshot_test.py
@@ -375,7 +375,7 @@ def test_code_revision_drift_creates_distinct_snapshot_and_dataset_ids(tmp_path:
     assert first.traces[0].source != second.traces[0].source
 
 
-@pytest.mark.parametrize("mutation", ["inputs", "source-id"])
+@pytest.mark.parametrize("mutation", ["inputs", "source-id", "schema-version", "path"])
 def test_loader_rejects_forged_snapshot_provenance(
     tmp_path: Path,
     mutation: str,
@@ -405,9 +405,14 @@ def test_loader_rejects_forged_snapshot_provenance(
         ]
         snapshot["inputs"] = forged_inputs
         manifest["inputs"] = forged_inputs
-    else:
+    elif mutation == "source-id":
         snapshot["source"]["source_id"] = "forged/runtime/interactions"
         manifest["source"]["source_id"] = "forged/runtime/interactions"
+    elif mutation == "schema-version":
+        snapshot["schema_version"] = 2
+        manifest["schema_version"] = 2
+    else:
+        snapshot["interactions_path"] = "forged-interactions.jsonl"
     snapshot_payload = canonical_json_bytes(snapshot)
     snapshot_path.write_bytes(snapshot_payload)
     snapshot_entry = next(
@@ -419,6 +424,88 @@ def test_loader_rejects_forged_snapshot_provenance(
 
     with pytest.raises(ArtifactCorruptionError, match="invalid envelope"):
         load_runtime_trace_snapshot(store, exported.snapshot.snapshot_id)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "schema-version",
+        "traces-path",
+        "semantic-convention",
+        "inputs",
+        "code-revision",
+        "trace-ids",
+        "source",
+        "traces-digest",
+        "issues",
+    ],
+)
+def test_dataset_replay_rejects_envelope_fields_outside_its_identity(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    """Prove every replay-sensitive dataset field is bound to its content identity.
+
+    Args:
+        tmp_path: Isolated project root.
+        mutation: Valid envelope field rewrite applied with updated file and manifest digests.
+    """
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="forged-dataset-key")
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    directory = store.read(exported.dataset.dataset_id).directory
+    dataset_path = directory / "trace-dataset.json"
+    manifest_path = directory / "manifest.json"
+    dataset = json.loads(dataset_path.read_bytes())
+    manifest = json.loads(manifest_path.read_bytes())
+    if mutation == "schema-version":
+        dataset["schema_version"] = 2
+        manifest["schema_version"] = 2
+    elif mutation == "traces-path":
+        dataset["traces_path"] = "alternate-traces.jsonl"
+    elif mutation == "semantic-convention":
+        dataset["semantic_convention_version"] = "wmo.runtime.router.v2"
+    elif mutation == "inputs":
+        forged_inputs = [
+            ArtifactInput(artifact_id="forged-input", sha256="f" * 64).model_dump(mode="json")
+        ]
+        dataset["inputs"] = forged_inputs
+        manifest["inputs"] = forged_inputs
+    elif mutation == "code-revision":
+        dataset["code_revision"] = "forged-revision"
+        manifest["code_revision"] = "forged-revision"
+    elif mutation == "trace-ids":
+        dataset["trace_ids"] = ["forged-trace"]
+    elif mutation == "source":
+        dataset["source"]["source_id"] = "forged-snapshot"
+        manifest["source"]["source_id"] = "forged-snapshot"
+    elif mutation == "traces-digest":
+        dataset["traces_sha256"] = "f" * 64
+    else:
+        dataset["issues_path"] = "issues.jsonl"
+        dataset["issues_sha256"] = "f" * 64
+        dataset["invalid_trace_count"] = 1
+    dataset_payload = canonical_json_bytes(dataset)
+    dataset_path.write_bytes(dataset_payload)
+    dataset_entry = next(
+        entry for entry in manifest["files"] if entry["path"] == "trace-dataset.json"
+    )
+    dataset_entry["sha256"] = hashlib.sha256(dataset_payload).hexdigest()
+    dataset_entry["size_bytes"] = len(dataset_payload)
+    manifest_path.write_bytes(canonical_json_bytes(manifest))
+
+    with pytest.raises(RuntimeTraceSnapshotError, match="ID differs"):
+        seal_runtime_trace_snapshot(
+            journal,
+            store,
+            created_at=_TIME + timedelta(minutes=2),
+            code_revision="test-revision",
+        )
 
 
 def test_retry_success_is_one_target_and_failures_remain_prefix_provenance(

--- a/wmo/runtime/router/snapshot_test.py
+++ b/wmo/runtime/router/snapshot_test.py
@@ -426,6 +426,55 @@ def test_loader_rejects_forged_snapshot_provenance(
         load_runtime_trace_snapshot(store, exported.snapshot.snapshot_id)
 
 
+@pytest.mark.parametrize("mutation", ["schema-version", "path"])
+def test_loader_rejects_reidentified_noncanonical_snapshot_constants(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    """Prove a recomputed ID cannot legitimize unsupported snapshot constants.
+
+    Args:
+        tmp_path: Isolated project root.
+        mutation: Schema or interactions-path constant rewritten before identity recomputation.
+    """
+    journal, store = _journal_and_store(tmp_path)
+    _complete(journal, key="reidentified-constant-key")
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=_TIME + timedelta(minutes=1),
+        code_revision="test-revision",
+    )
+    directory = store.read(exported.snapshot.snapshot_id).directory
+    snapshot_path = directory / "runtime-trace-snapshot.json"
+    manifest_path = directory / "manifest.json"
+    snapshot = json.loads(snapshot_path.read_bytes())
+    manifest = json.loads(manifest_path.read_bytes())
+    if mutation == "schema-version":
+        snapshot["schema_version"] = 2
+        manifest["schema_version"] = 2
+    else:
+        snapshot["interactions_path"] = "alternate-interactions.jsonl"
+    identity_material = {
+        key: value for key, value in snapshot.items() if key not in {"created_at", "snapshot_id"}
+    }
+    forged_id = stable_id("runtime-trace-snapshot", identity_material)
+    snapshot["snapshot_id"] = forged_id
+    manifest["artifact_id"] = forged_id
+    snapshot_payload = canonical_json_bytes(snapshot)
+    snapshot_path.write_bytes(snapshot_payload)
+    snapshot_entry = next(
+        entry for entry in manifest["files"] if entry["path"] == "runtime-trace-snapshot.json"
+    )
+    snapshot_entry["sha256"] = hashlib.sha256(snapshot_payload).hexdigest()
+    snapshot_entry["size_bytes"] = len(snapshot_payload)
+    manifest_path.write_bytes(canonical_json_bytes(manifest))
+    directory.rename(directory.parent / forged_id)
+
+    with pytest.raises(ArtifactCorruptionError, match="invalid envelope"):
+        load_runtime_trace_snapshot(store, forged_id)
+
+
 @pytest.mark.parametrize(
     "mutation",
     [


### PR DESCRIPTION
## What changed

- seal an immutable, content-addressed prefix of the routed interaction journal
- preserve accepted requests, routing decisions, selected model identity, provider results, economics, retries, and terminal failures
- reject torn, incoherent, path-unsafe, or identity-mismatched snapshot material
- bind code revision, empty-input provenance, and the exact production journal source to snapshot identity
- expose canonical interaction and normalized trace artifacts for downstream training

## Why

Router traffic needs a durable, reproducible production-data boundary before accumulated interactions can feed SFT. The snapshot binds normalized data to the exact journal prefix without adding generated world-model predictions to the trace corpus.

## Boundary

This PR consumes the durable interaction journal already on main. It does not change online routing, append generated simulation data, filter completed interactions by success evidence, or start model training.

## Verification

Exact head: `b6b9b4f18b8873e5525219ba836d89773d2a99fe`

- based on main `0929ecabcfc1520c6df6e67af50edf0e1c0b2e16`
- all five commits are range-diff identical after PR #434 merged
- full pre-restack suite: 711 passed, 1 skipped
- focused exact-head snapshot suite: 29 passed
- adversarial tests reject forged snapshot and dataset envelope semantics, including input/source provenance, schema, paths, convention, revision, trace identity, digests, and issue metadata
- code-revision drift creates distinct snapshot and dataset identities while preserving equivalent journal evidence
- recomputed IDs cannot legitimize unsupported schema versions or alternate interaction paths
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv build`
- production module remains below 1,000 lines; test modules remain cohesive
- README unchanged

Ready for review and intentionally unmerged.
