### PR TITLE
Clarify cohesive test ownership policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,12 @@ uv run pytest -q
    has unrelated failures, record them and keep them out of the patch; fix them only when they are
    in scope or prevent meaningful validation.
 
-2. **Tests live inline next to the code.** A module `foo.py` is tested by `foo_test.py` in the same
-   directory (for example, `wmo/workflow/router.py` maps to `wmo/workflow/router_test.py`). There
-   is no top-level `tests/` directory. Pytest is configured (`python_files = ["*_test.py"]`) to
-   discover these.
+2. **Tests live inline next to the code.** Keep behavior-oriented `_test.py` files in the package
+   that owns the behavior. A cohesive test module may cover several cooperating production modules
+   when that gives the behavior one clear home; there is no paired-test-file requirement. Cohesive
+   `_test.py` files may exceed the 999-line production limit and should not be split solely for
+   line count. Do not add empty test markers or vacuous assertions. There is no top-level `tests/`
+   directory. Pytest is configured (`python_files = ["*_test.py"]`) to discover these files.
 
 3. **Avoid generic types.** Do not use `Any`, bare `dict`/`object`, or untyped `**kwargs` where a
    concrete type is practical. Prefer explicit pydantic models and fields; for genuinely arbitrary


### PR DESCRIPTION
## Summary

Clarifies the repository's current test-ownership policy:

- tests stay inline and package-owned
- one cohesive behavior-oriented `_test.py` may cover several cooperating modules
- `_test.py` files may exceed the 999-line production limit and should not be split solely for line count
- there is no paired test file requirement
- empty marker files and vacuous assertions are not allowed
- there is no top-level `tests/` directory

This controlled replacement supersedes PR #436, whose automated source branch repeatedly restored the opposite policy. PR #436 remains open and draft; this PR does not merge or close it.

Documentation only. No production or test behavior changes.

Exact head: `466bd357dd75420bfb570d4bcbaf9aaea5293502`

Base: `0929ecabcfc1520c6df6e67af50edf0e1c0b2e16`
