### PR TITLE
Build SFT datasets from routed interactions

### DIFF
--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -30,6 +30,8 @@ from wmo.optimize.model.sft.contracts import (
     ProductionAcceptanceEvidence,
     ProductionAcceptanceRule,
     ProductionSFTSource,
+    RuntimeInteractionExampleSource,
+    RuntimeSFTSource,
     SFTDataset,
     SFTDatasetArtifact,
     SFTExample,
@@ -45,6 +47,10 @@ from wmo.optimize.model.sft.rendering import (
     context_target_fingerprint,
     parse_rendered_turn,
     render_context_target,
+)
+from wmo.optimize.model.sft.runtime_source import (
+    PreparedRuntimeSFTSnapshot,
+    resolve_runtime_source,
 )
 from wmo.optimize.model.sft.tinker import (
     TinkerSFTDatum,
@@ -76,6 +82,9 @@ __all__ = [
     "ProductionAcceptanceEvidence",
     "ProductionAcceptanceRule",
     "ProductionSFTSource",
+    "PreparedRuntimeSFTSnapshot",
+    "RuntimeInteractionExampleSource",
+    "RuntimeSFTSource",
     "SFTBuildError",
     "SFTModelOptimizationConfig",
     "SFTModelOptimizationError",
@@ -116,6 +125,7 @@ __all__ = [
     "parse_rendered_turn",
     "preflight_sft_model_optimization",
     "render_context_target",
+    "resolve_runtime_source",
     "run_sft_model_optimization",
     "sft_model_optimization_output_dir",
     "tinker_messages_from_example",

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -29,6 +29,8 @@ from wmo.optimize.model.sft.contracts import (
     InfrastructureFailureEvent,
     PartitionedSFTExample,
     ProductionSFTSource,
+    RuntimeInteractionExampleSource,
+    RuntimeSFTSource,
     SFTBuildSpec,
     SFTContextEvent,
     SFTDataset,
@@ -49,6 +51,7 @@ from wmo.optimize.model.sft.rendering import (
     context_target_fingerprint,
     partitioned_rows_sha256,
 )
+from wmo.optimize.model.sft.runtime_source import resolve_runtime_source
 from wmo.optimize.model.sft.sources import (
     PreparedSFTSource,
     SFTSourceVerificationError,
@@ -103,6 +106,7 @@ def build_sft_dataset(
     store: ProjectStore,
     production_sources: Sequence[ProductionSFTSource],
     teacher_sources: Sequence[TeacherSFTSource],
+    runtime_sources: Sequence[RuntimeSFTSource] = (),
     spec: SFTBuildSpec,
     created_at: datetime,
     code_revision: str,
@@ -113,6 +117,7 @@ def build_sft_dataset(
         store: One project-local immutable artifact store that owns every source chain.
         production_sources: Pointers to persisted production-acceptance artifacts.
         teacher_sources: Pointers to persisted teacher-acceptance artifacts.
+        runtime_sources: Pointers to verified routed-interaction snapshots.
         spec: Frozen split and sampling controls for this build.
         created_at: Time recorded in the resulting immutable dataset envelope.
         code_revision: Exact revision that built the artifact.
@@ -154,6 +159,21 @@ def build_sft_dataset(
         _require_unique_source_key(seen_source_keys, (candidate.kind, candidate.source_id))
         prepared.append(candidate)
         source_references.append(candidate.reference())
+
+    for source in sorted(runtime_sources, key=lambda item: item.snapshot_id):
+        try:
+            resolved = resolve_runtime_source(store, source)
+        except SFTSourceVerificationError as exc:
+            raise SFTBuildError(
+                f"runtime source {source.snapshot_id} is not verified production evidence: {exc}"
+            ) from exc
+        for candidate in resolved.prepared:
+            _require_unique_source_key(seen_source_keys, (candidate.kind, candidate.source_id))
+            prepared.append(candidate)
+        for reference in resolved.references:
+            _require_unique_reference(source_references, reference)
+            source_references.append(reference)
+        exclusions.extend(resolved.exclusions)
 
     scanned_actions: list[_ScannedAction] = []
     for source in prepared:
@@ -205,9 +225,23 @@ def build_sft_dataset(
         dataset_id=dataset_id,
         build_sha256=build_sha256,
         status="accepted" if train_rows else "insufficient",
-        acceptance_rule_ids=tuple(sorted({source.acceptance_rule_id for source in prepared})),
+        acceptance_rule_ids=tuple(
+            sorted(
+                {
+                    source.acceptance_rule_id
+                    for source in prepared
+                    if source.acceptance_rule_id is not None
+                }
+            )
+        ),
         acceptance_evidence_ids=tuple(
-            sorted({source.acceptance_evidence_id for source in prepared})
+            sorted(
+                {
+                    source.acceptance_evidence_id
+                    for source in prepared
+                    if source.acceptance_evidence_id is not None
+                }
+            )
         ),
         train_leakage_group_ids=train_groups,
         held_out_leakage_group_ids=held_out_groups,
@@ -399,18 +433,29 @@ def load_verified_sft_dataset(
     production_sources = tuple(
         ProductionSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
         for source in loaded.sources
-        if source.kind == "production_trace"
+        if source.kind == "production_trace" and source.acceptance_evidence is not None
     )
     teacher_sources = tuple(
         TeacherSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
         for source in loaded.sources
-        if source.kind == "teacher_rollout"
+        if source.kind == "teacher_rollout" and source.acceptance_evidence is not None
+    )
+    runtime_sources = tuple(
+        RuntimeSFTSource(snapshot_id=snapshot_id)
+        for snapshot_id in sorted(
+            {
+                source.source_artifact.artifact_id
+                for source in loaded.sources
+                if source.kind == "runtime_interaction"
+            }
+        )
     )
     try:
         rebuilt = build_sft_dataset(
             store=store,
             production_sources=production_sources,
             teacher_sources=teacher_sources,
+            runtime_sources=runtime_sources,
             spec=build_spec,
             created_at=loaded.dataset.created_at,
             code_revision=loaded.dataset.code_revision,
@@ -431,7 +476,14 @@ def load_verified_sft_dataset(
 def _scan_source_actions(
     source: PreparedSFTSource,
 ) -> tuple[list[_ScannedAction], list[SFTExclusion]]:
-    """Scan targets and fingerprints without emitting examples or assigning a partition."""
+    """Scan eligible targets and fingerprints before assigning a partition.
+
+    Args:
+        source: Verified transcript source with optional exact target indexes.
+
+    Returns:
+        Eligible action scans and source-local exclusions in transcript order.
+    """
     history: list[SFTContextEvent] = []
     scanned: list[_ScannedAction] = []
     exclusions: list[SFTExclusion] = []
@@ -466,6 +518,9 @@ def _scan_source_actions(
                     detail="infrastructure failures are excluded from SFT targets",
                 )
             )
+            continue
+        if source.target_action_indexes is not None and index not in source.target_action_indexes:
+            history.append(event)
             continue
         if index in failed_action_indexes:
             exclusions.append(
@@ -594,7 +649,7 @@ def _expand_scanned_actions(
                 partition=partition,
                 fingerprint=action.fingerprint,
                 example=SFTExample(
-                    example_id=stable_id("sft-example", {"fingerprint": action.fingerprint}),
+                    example_id=_example_id(action),
                     leakage_group_id=action.source.leakage_group_id,
                     task=action.source.task,
                     history=action.history,
@@ -612,7 +667,15 @@ def _globally_deduplicate(
     rows: Sequence[PartitionedSFTExample],
     scanned_actions: Sequence[_ScannedAction],
 ) -> tuple[tuple[PartitionedSFTExample, ...], tuple[SFTExclusion, ...]]:
-    """Keep one deterministic representative for every normalized fingerprint globally."""
+    """Retain runtime multiplicity while deduplicating other accepted evidence.
+
+    Args:
+        rows: Partitioned provisional rows for every eligible action.
+        scanned_actions: Source scans used to construct precise duplicate exclusions.
+
+    Returns:
+        Retained rows and exclusions for duplicate production or teacher examples.
+    """
     scanned_by_row_key = {
         (action.fingerprint, action.source.source_id, action.source_step_index): action
         for action in scanned_actions
@@ -624,8 +687,20 @@ def _globally_deduplicate(
     exclusions: list[SFTExclusion] = []
     for fingerprint in sorted(rows_by_fingerprint):
         candidates = sorted(rows_by_fingerprint[fingerprint], key=_dedupe_row_sort_key)
-        kept.append(candidates[0])
-        for duplicate in candidates[1:]:
+        runtime_candidates = [
+            row
+            for row in candidates
+            if isinstance(row.example.source, RuntimeInteractionExampleSource)
+        ]
+        accepted_candidates = [
+            row
+            for row in candidates
+            if not isinstance(row.example.source, RuntimeInteractionExampleSource)
+        ]
+        kept.extend(runtime_candidates)
+        if accepted_candidates:
+            kept.append(accepted_candidates[0])
+        for duplicate in accepted_candidates[1:]:
             key = (
                 duplicate.fingerprint,
                 _source_id_from_example(duplicate.example),
@@ -642,6 +717,26 @@ def _globally_deduplicate(
                 )
             )
     return tuple(kept), tuple(exclusions)
+
+
+def _example_id(action: _ScannedAction) -> ArtifactId:
+    """Derive one stable example identity without collapsing routed multiplicity.
+
+    Args:
+        action: Scanned source action and its normalized fingerprint.
+
+    Returns:
+        Fingerprint identity for accepted sources or interaction-scoped identity for runtime data.
+    """
+    material: dict[str, str | int] = {"fingerprint": action.fingerprint}
+    if action.source.kind == "runtime_interaction":
+        material.update(
+            {
+                "source_id": action.source.source_id,
+                "source_step_index": action.source_step_index,
+            }
+        )
+    return stable_id("sft-example", material)
 
 
 def _sorted_inputs(inputs: Iterable[ArtifactInput]) -> tuple[ArtifactInput, ...]:
@@ -747,6 +842,26 @@ def _require_unique_source_key(seen: set[tuple[str, str]], key: tuple[str, str])
     seen.add(key)
 
 
+def _require_unique_reference(
+    references: Sequence[SFTSourceReference],
+    candidate: SFTSourceReference,
+) -> None:
+    """Reject one routed interaction repeated through overlapping snapshots.
+
+    Args:
+        references: Source references already admitted to the build.
+        candidate: Next completed, failed, or incomplete runtime reference.
+
+    Raises:
+        SFTBuildError: The candidate kind and source identity already appear.
+    """
+    if any(
+        reference.kind == candidate.kind and reference.source_id == candidate.source_id
+        for reference in references
+    ):
+        raise SFTBuildError(f"SFT build repeats source {candidate.kind}:{candidate.source_id}")
+
+
 def _require_timezone(value: datetime, *, label: str) -> None:
     """Reject an artifact timestamp that cannot safely round trip as immutable provenance."""
     if value.tzinfo is None or value.utcoffset() is None:
@@ -757,6 +872,8 @@ def _source_id_from_example(example: SFTExample) -> str:
     """Return the source identifier encoded by one normalized SFT example."""
     if isinstance(example.source, TraceExampleSource):
         return example.source.trace_id
+    if isinstance(example.source, RuntimeInteractionExampleSource):
+        return example.source.interaction_id
     return example.source.rollout_id
 
 

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -286,6 +286,12 @@ class TeacherSFTSource(ContractModel):
     acceptance_evidence_id: ArtifactId
 
 
+class RuntimeSFTSource(ContractModel):
+    """A pointer to one verified routed-interaction snapshot artifact."""
+
+    snapshot_id: ArtifactId
+
+
 class TraceExampleSource(ContractModel):
     """Production trace provenance retained on an extracted SFT example."""
 
@@ -302,8 +308,18 @@ class RolloutExampleSource(ContractModel):
     acceptance_evidence: ArtifactInput
 
 
+class RuntimeInteractionExampleSource(ContractModel):
+    """Exact routed-interaction and snapshot provenance for one SFT target."""
+
+    kind: Literal["runtime_interaction"] = "runtime_interaction"
+    snapshot: ArtifactInput
+    interaction_id: ArtifactId
+    accepted_ordinal: int = Field(gt=0)
+    completed_ordinal: int = Field(gt=0)
+
+
 SFTExampleSource = Annotated[
-    TraceExampleSource | RolloutExampleSource,
+    TraceExampleSource | RolloutExampleSource | RuntimeInteractionExampleSource,
     Field(discriminator="kind"),
 ]
 
@@ -365,19 +381,32 @@ class SFTBuildSpec(ContractModel):
 
 
 class SFTSourceReference(ContractModel):
-    """An auditable source and acceptance-evidence reference in a frozen dataset manifest."""
+    """Auditable immutable source provenance retained in a frozen dataset manifest."""
 
-    kind: Literal["production_trace", "teacher_rollout"]
+    kind: Literal["production_trace", "teacher_rollout", "runtime_interaction"]
     source_id: str = Field(min_length=1, max_length=512)
     source_artifact: ArtifactInput
     source_record_sha256: Sha256
     leakage_group_id: ArtifactId
-    acceptance_evidence: ArtifactInput
+    acceptance_evidence: ArtifactInput | None = None
     accepted: bool
     exclusion_reason: str | None = None
 
     @model_validator(mode="after")
     def _require_consistent_source_status(self) -> SFTSourceReference:
+        """Validate evidence requirements and accepted or excluded status.
+
+        Returns:
+            The validated source reference.
+
+        Raises:
+            ValueError: Evidence is missing or forbidden, or status and exclusion disagree.
+        """
+        if self.kind == "runtime_interaction":
+            if self.acceptance_evidence is not None:
+                raise ValueError("runtime SFT sources cannot name acceptance evidence")
+        elif self.acceptance_evidence is None:
+            raise ValueError("accepted production and teacher sources require acceptance evidence")
         if self.accepted and self.exclusion_reason is not None:
             raise ValueError("accepted SFT sources must not carry an exclusion reason")
         if not self.accepted and self.exclusion_reason is None:
@@ -388,7 +417,7 @@ class SFTSourceReference(ContractModel):
 class SFTExclusion(ContractModel):
     """One source-level or action-level reason data was withheld from an SFT dataset."""
 
-    source_kind: Literal["production_trace", "teacher_rollout"]
+    source_kind: Literal["production_trace", "teacher_rollout", "runtime_interaction"]
     source_id: str = Field(min_length=1, max_length=512)
     action_index: int | None = Field(default=None, ge=0)
     reason: Literal[
@@ -397,6 +426,8 @@ class SFTExclusion(ContractModel):
         "invalid_production_acceptance",
         "invalid_teacher_acceptance",
         "observation_context_only",
+        "runtime_interaction_failed",
+        "runtime_interaction_incomplete",
         "unapproved_action",
     ]
     detail: str = Field(min_length=1)

--- a/wmo/optimize/model/sft/runtime_source.py
+++ b/wmo/optimize/model/sft/runtime_source.py
@@ -1,0 +1,294 @@
+"""Resolve validated routed interactions into unfiltered immutable SFT sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wmo.common.core.artifacts import ArtifactInput, sha256_json, stable_id
+from wmo.common.models import AssistantAction, ModelMessage
+from wmo.common.project import ArtifactCorruptionError, ProjectStore, artifact_input
+from wmo.optimize.model.sft.contracts import (
+    AssistantActionEvent,
+    RuntimeInteractionExampleSource,
+    RuntimeSFTSource,
+    SFTContextEvent,
+    SFTExclusion,
+    SFTMessage,
+    SFTSourceReference,
+    SFTTranscript,
+    ToolEvent,
+)
+from wmo.optimize.model.sft.sources import PreparedSFTSource, SFTSourceVerificationError
+from wmo.runtime.router import (
+    RuntimeAcceptedEvent,
+    RuntimeCompletedEvent,
+    RuntimeTraceInteraction,
+    load_runtime_trace_snapshot,
+)
+
+
+@dataclass(frozen=True)
+class PreparedRuntimeSFTSnapshot:
+    """Verified completed sources and excluded interactions from one runtime snapshot."""
+
+    snapshot: ArtifactInput
+    prepared: tuple[PreparedSFTSource, ...]
+    references: tuple[SFTSourceReference, ...]
+    exclusions: tuple[SFTExclusion, ...]
+
+
+def resolve_runtime_source(
+    store: ProjectStore,
+    source: RuntimeSFTSource,
+) -> PreparedRuntimeSFTSnapshot:
+    """Resolve every completed routed interaction without applying a quality filter.
+
+    Args:
+        store: Project store containing the immutable runtime snapshot.
+        source: Pointer to the exact snapshot whose completed interactions are requested.
+
+    Returns:
+        Completed interaction sources plus explicit failed and incomplete exclusions.
+
+    Raises:
+        SFTSourceVerificationError: The source is missing, corrupt, non-production, or cannot
+            preserve its exact request and completed response.
+    """
+    try:
+        loaded = load_runtime_trace_snapshot(store.artifacts, source.snapshot_id)
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTSourceVerificationError(
+            f"runtime SFT snapshot is unavailable or invalid: {source.snapshot_id}"
+        ) from exc
+    snapshot = loaded.snapshot
+    if snapshot.project_id != store.paths.project_id:
+        raise SFTSourceVerificationError("runtime SFT snapshot belongs to another project")
+    if snapshot.source is None or snapshot.source.kind != "production":
+        raise SFTSourceVerificationError("runtime SFT sources require production journal evidence")
+    snapshot_input = artifact_input(loaded.manifest)
+    prepared: list[PreparedSFTSource] = []
+    references: list[SFTSourceReference] = []
+    exclusions: list[SFTExclusion] = []
+    for interaction in loaded.interactions:
+        if interaction.completed_attempt_ordinal is None:
+            reference, exclusion = _excluded_interaction(snapshot_input, interaction)
+            references.append(reference)
+            exclusions.append(exclusion)
+            continue
+        completed = _prepared_interaction(snapshot_input, interaction)
+        prepared.append(completed)
+        references.append(completed.reference())
+    return PreparedRuntimeSFTSnapshot(
+        snapshot=snapshot_input,
+        prepared=tuple(prepared),
+        references=tuple(references),
+        exclusions=tuple(exclusions),
+    )
+
+
+def _prepared_interaction(
+    snapshot: ArtifactInput,
+    interaction: RuntimeTraceInteraction,
+) -> PreparedSFTSource:
+    """Convert one completed logical interaction into one eligible assistant target.
+
+    Args:
+        snapshot: Exact immutable snapshot manifest pointer.
+        interaction: Verified logical interaction with one completed attempt.
+
+    Returns:
+        One source whose only eligible target is the completed routed response.
+
+    Raises:
+        SFTSourceVerificationError: Completion evidence or request history is ambiguous.
+    """
+    completed_attempt_ordinal = interaction.completed_attempt_ordinal
+    if completed_attempt_ordinal is None:
+        raise SFTSourceVerificationError("runtime SFT interaction has no completed target")
+    completed_attempt = interaction.attempts[completed_attempt_ordinal - 1]
+    completed = next(
+        (
+            event
+            for event in completed_attempt.terminal_events
+            if isinstance(event, RuntimeCompletedEvent)
+        ),
+        None,
+    )
+    if completed is None:
+        raise SFTSourceVerificationError("runtime SFT completed attempt has no response event")
+    accepted = completed_attempt.accepted
+    history = _request_history(accepted.request.messages)
+    target_index = len(history)
+    try:
+        transcript = SFTTranscript(
+            events=(
+                *history,
+                AssistantActionEvent(action=completed.response.output, approved=True),
+            )
+        ).events
+    except ValueError as exc:
+        raise SFTSourceVerificationError(
+            "runtime SFT request and target do not form a valid transcript"
+        ) from exc
+    return PreparedSFTSource(
+        kind="runtime_interaction",
+        source_id=interaction.interaction_id,
+        source_artifact=snapshot,
+        source_record_sha256=sha256_json(interaction),
+        leakage_group_id=stable_id(
+            "sft-lineage",
+            {
+                "kind": "runtime_interaction",
+                "source_lineage": accepted.lineage_id,
+            },
+        ),
+        task=_task_text(accepted),
+        transcript_events=transcript,
+        example_source=RuntimeInteractionExampleSource(
+            snapshot=snapshot,
+            interaction_id=interaction.interaction_id,
+            accepted_ordinal=accepted.ordinal,
+            completed_ordinal=completed.ordinal,
+        ),
+        score=None,
+        direct_inputs=(snapshot,),
+        acceptance_rule_id=None,
+        acceptance_evidence_id=None,
+        acceptance_evidence=None,
+        target_action_indexes=(target_index,),
+    )
+
+
+def _excluded_interaction(
+    snapshot: ArtifactInput,
+    interaction: RuntimeTraceInteraction,
+) -> tuple[SFTSourceReference, SFTExclusion]:
+    """Describe why one non-completed runtime interaction emits no SFT target.
+
+    Args:
+        snapshot: Exact immutable snapshot manifest pointer.
+        interaction: Verified failed or still-open logical interaction.
+
+    Returns:
+        Rejected source reference and matching inspection exclusion.
+    """
+    accepted = interaction.attempts[0].accepted
+    failed = any(attempt.terminal_events for attempt in interaction.attempts)
+    reason = "runtime_interaction_failed" if failed else "runtime_interaction_incomplete"
+    detail = (
+        "runtime interaction ended without a completed response"
+        if failed
+        else "runtime interaction has no completed response"
+    )
+    leakage_group_id = stable_id(
+        "sft-lineage",
+        {
+            "kind": "runtime_interaction",
+            "source_lineage": accepted.lineage_id,
+        },
+    )
+    reference = SFTSourceReference(
+        kind="runtime_interaction",
+        source_id=interaction.interaction_id,
+        source_artifact=snapshot,
+        source_record_sha256=sha256_json(interaction),
+        leakage_group_id=leakage_group_id,
+        acceptance_evidence=None,
+        accepted=False,
+        exclusion_reason=detail,
+    )
+    exclusion = SFTExclusion(
+        source_kind="runtime_interaction",
+        source_id=interaction.interaction_id,
+        action_index=None,
+        reason=reason,
+        detail=detail,
+    )
+    return reference, exclusion
+
+
+def _request_history(messages: tuple[ModelMessage, ...]) -> tuple[SFTContextEvent, ...]:
+    """Convert exact request-visible messages into canonical SFT context.
+
+    Args:
+        messages: Ordered visible messages sent on the completed routed attempt.
+
+    Returns:
+        Canonical context preserving text, assistant actions, tool calls, and tool results.
+
+    Raises:
+        SFTSourceVerificationError: A message has ambiguous or incomplete canonical content.
+    """
+    history: list[SFTContextEvent] = []
+    tool_names: dict[str, str] = {}
+    for message in messages:
+        if message.role == "system":
+            if message.content is None:
+                raise SFTSourceVerificationError("runtime SFT text message has no content")
+            history.append(SFTMessage(role="system", content=message.content))
+            continue
+        if message.role == "user":
+            if message.content is None:
+                raise SFTSourceVerificationError("runtime SFT text message has no content")
+            history.append(SFTMessage(role="user", content=message.content))
+            continue
+        if message.role == "assistant":
+            action = _message_action(message)
+            history.append(AssistantActionEvent(action=action, approved=True))
+            for call in action.tool_calls:
+                tool_names[call.call_id] = call.name
+            continue
+        if message.content is None or message.tool_call_id is None:
+            raise SFTSourceVerificationError("runtime SFT tool message is incomplete")
+        history.append(
+            ToolEvent(
+                tool_call_id=message.tool_call_id,
+                content=message.content,
+                tool_name=tool_names.get(message.tool_call_id),
+            )
+        )
+    return tuple(history)
+
+
+def _message_action(message: ModelMessage) -> AssistantAction:
+    """Recover one unambiguous assistant action from request history.
+
+    Args:
+        message: Request-visible assistant message.
+
+    Returns:
+        Complete assistant action including text and ordered tool calls.
+
+    Raises:
+        SFTSourceVerificationError: Structured and plain text representations conflict.
+    """
+    action = message.assistant_action
+    if action is None:
+        if message.content is None:
+            raise SFTSourceVerificationError("runtime SFT assistant message has no action")
+        return AssistantAction(content=message.content)
+    if message.content is None or message.content == action.content:
+        return action
+    if action.content is None:
+        return action.model_copy(update={"content": message.content})
+    raise SFTSourceVerificationError(
+        "runtime SFT assistant message has conflicting text and structured action"
+    )
+
+
+def _task_text(accepted: RuntimeAcceptedEvent) -> str:
+    """Choose the stable user-visible task for one routed request.
+
+    Args:
+        accepted: Accepted event containing the exact routed request.
+
+    Returns:
+        Last user text, first available message text, or a stable fallback.
+    """
+    for message in reversed(accepted.request.messages):
+        if message.role == "user" and message.content:
+            return message.content
+    for message in accepted.request.messages:
+        if message.content:
+            return message.content
+    return "Complete the routed model request."

--- a/wmo/optimize/model/sft/runtime_source_test.py
+++ b/wmo/optimize/model/sft/runtime_source_test.py
@@ -1,0 +1,507 @@
+"""Behavior and provenance tests for routed-interaction SFT dataset sources."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactInput,
+    FailureAttribution,
+    FailureCode,
+    SourceIdentity,
+    StructuredFailure,
+    stable_id,
+)
+from wmo.common.models import (
+    AssistantAction,
+    ModelFinishReason,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+    Usage,
+)
+from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
+from wmo.optimize.model.sft import (
+    AssistantActionEvent,
+    RuntimeInteractionExampleSource,
+    RuntimeSFTSource,
+    SFTBuildError,
+    SFTBuildSpec,
+    SFTDatasetArtifact,
+    ToolEvent,
+    build_sft_dataset,
+    load_verified_sft_dataset,
+    write_sft_dataset,
+)
+from wmo.runtime.router import RuntimeAcceptedEvent, RuntimeInteractionJournal
+from wmo.runtime.router.journal import RuntimeAcceptance, _interaction_identity
+from wmo.runtime.router.snapshot import seal_runtime_trace_snapshot
+
+_DIGEST = "a" * 64
+_TIME = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def _store(tmp_path: Path) -> ProjectStore:
+    """Create one initialized project store and its matching runtime journal.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+
+    Returns:
+        Initialized project-local immutable store.
+    """
+    store = ProjectStore(tmp_path / ".wmo", "support-agent")
+    store.initialize(ProjectConfig(project_id="support-agent"))
+    return store
+
+
+def _model() -> ModelSnapshot:
+    """Return the fixed routed model identity used by journal fixtures."""
+    return ModelSnapshot(
+        provider="openai",
+        model_id="gpt-test",
+        capabilities_sha256=_DIGEST,
+        connection_sha256="b" * 64,
+    )
+
+
+def _request(*messages: ModelMessage) -> ModelRequest:
+    """Build one exact routed request from visible messages.
+
+    Args:
+        messages: Complete request history.
+
+    Returns:
+        Canonical routed request.
+    """
+    return ModelRequest(messages=messages)
+
+
+def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
+    """Build deterministic route pins for one request.
+
+    Args:
+        lineage_id: Hashed conversation identity from the journal.
+        request: Exact request being routed.
+
+    Returns:
+        Content-addressed single-candidate routing decision.
+    """
+    feature = RouterFeatureExtractor().from_request(request)
+    material = {
+        "policy_id": "router-policy-a",
+        "policy_sha256": _DIGEST,
+        "request_sha256": hashlib.sha256(
+            feature.encode("utf-8"), usedforsecurity=False
+        ).hexdigest(),
+        "episode_id_sha256": hashlib.sha256(
+            lineage_id.encode("utf-8"), usedforsecurity=False
+        ).hexdigest(),
+        "selected_alias": "candidate-a",
+        "baseline_alias": "candidate-a",
+        "neighbor_count": 2,
+        "paired_count": 2,
+        "best_similarity": 1.0,
+        "estimated_quality_difference": None,
+        "uncertainty": None,
+        "fallback_reason": None,
+    }
+    return RoutingDecision(
+        decision_id=stable_id("routing-decision", material),
+        **material,
+    )
+
+
+def _accept(
+    journal: RuntimeInteractionJournal,
+    *,
+    key: str,
+    conversation: str,
+    request: ModelRequest,
+    now: datetime,
+) -> RuntimeAcceptedEvent:
+    """Accept one routed interaction into the durable journal.
+
+    Args:
+        journal: Project journal receiving the acceptance.
+        key: Stable idempotency key.
+        conversation: Caller conversation identity.
+        request: Exact visible model request.
+        now: Acceptance timestamp.
+
+    Returns:
+        Durable accepted event ready for a terminal result.
+    """
+    identity = _interaction_identity(journal.project_id, key, request, conversation)
+    decision = _decision(identity.lineage_id, request)
+    claim = journal.claim(
+        identity,
+        RuntimeAcceptance(
+            decision=decision,
+            selected_alias=decision.selected_alias,
+            selected_model=_model(),
+            policy_input=ArtifactInput(
+                artifact_id=decision.policy_id,
+                sha256=decision.policy_sha256,
+            ),
+        ),
+        now=now,
+        stale_after=timedelta(minutes=5),
+    )
+    assert claim.accepted is not None
+    return claim.accepted
+
+
+def _complete(
+    journal: RuntimeInteractionJournal,
+    *,
+    key: str,
+    conversation: str,
+    request: ModelRequest,
+    output: AssistantAction,
+    now: datetime,
+    finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+) -> RuntimeAcceptedEvent:
+    """Accept and complete one routed interaction.
+
+    Args:
+        journal: Project journal receiving both events.
+        key: Stable idempotency key.
+        conversation: Caller conversation identity.
+        request: Exact visible model request.
+        output: Complete assistant target, including tool calls.
+        now: Acceptance timestamp.
+        finish_reason: Provider-reported terminal reason preserved in source provenance.
+
+    Returns:
+        Accepted event named by the completion.
+    """
+    accepted = _accept(
+        journal,
+        key=key,
+        conversation=conversation,
+        request=request,
+        now=now,
+    )
+    journal.record_completed(
+        accepted,
+        ModelResponse(
+            output=output,
+            model=_model(),
+            economics=OperationEconomics(
+                usage=Usage(input_tokens=8, output_tokens=3, cached_input_tokens=0)
+            ),
+            finish_reason=finish_reason,
+        ),
+        completed_at=now + timedelta(seconds=1),
+    )
+    return accepted
+
+
+def _snapshot(
+    store: ProjectStore,
+    journal: RuntimeInteractionJournal,
+    *,
+    created_at: datetime = _TIME + timedelta(hours=1),
+) -> RuntimeSFTSource:
+    """Seal the current journal and return its W12 runtime source pointer.
+
+    Args:
+        store: Store receiving the immutable runtime snapshot.
+        journal: Same-project routed interaction journal.
+        created_at: Snapshot materialization time.
+
+    Returns:
+        Runtime SFT source naming the sealed prefix.
+    """
+    export = seal_runtime_trace_snapshot(
+        journal,
+        store.artifacts,
+        created_at=created_at,
+        code_revision="runtime-source-test",
+    )
+    return RuntimeSFTSource(snapshot_id=export.snapshot.snapshot_id)
+
+
+def _build(
+    store: ProjectStore,
+    *runtime_sources: RuntimeSFTSource,
+    created_at: datetime = _TIME + timedelta(hours=2),
+) -> SFTDatasetArtifact:
+    """Build one W12 dataset from routed snapshots only.
+
+    Args:
+        store: Store owning all supplied snapshots.
+        runtime_sources: Exact routed snapshot pointers.
+        created_at: Dataset materialization time.
+
+    Returns:
+        Complete in-memory W12 dataset artifact.
+    """
+    return build_sft_dataset(
+        store=store,
+        production_sources=(),
+        teacher_sources=(),
+        runtime_sources=runtime_sources,
+        spec=SFTBuildSpec(held_out_fraction=0.5, representative_sample_count=2),
+        created_at=created_at,
+        code_revision="runtime-source-test",
+    )
+
+
+def test_completed_multiplicity_is_retained_without_quality_filter(
+    tmp_path: Path,
+) -> None:
+    """Keep every completed interaction while excluding failed and open attempts.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    store = _store(tmp_path)
+    journal = RuntimeInteractionJournal(store.paths)
+    request = _request(ModelMessage(role="user", content="Repeat this"))
+    target = AssistantAction(
+        content="Calling lookup",
+        tool_calls=(ToolCall(call_id="call-1", name="lookup", arguments={"id": "A-1"}),),
+    )
+    first = _complete(
+        journal,
+        key="first",
+        conversation="conversation-a",
+        request=request,
+        output=target,
+        now=_TIME,
+        finish_reason=ModelFinishReason.LENGTH,
+    )
+    second = _complete(
+        journal,
+        key="second",
+        conversation="conversation-a",
+        request=request,
+        output=target,
+        now=_TIME + timedelta(minutes=1),
+    )
+    failed = _accept(
+        journal,
+        key="failed",
+        conversation="conversation-a",
+        request=_request(ModelMessage(role="user", content="Provider failure")),
+        now=_TIME + timedelta(minutes=2),
+    )
+    journal.record_failure(
+        failed,
+        StructuredFailure(
+            code=FailureCode.PROVIDER,
+            message="permanent provider failure",
+            retryable=False,
+            attribution=FailureAttribution.MODEL,
+        ),
+        failed_at=_TIME + timedelta(minutes=2, seconds=1),
+    )
+    open_event = _accept(
+        journal,
+        key="open",
+        conversation="conversation-a",
+        request=_request(ModelMessage(role="user", content="Disconnected")),
+        now=_TIME + timedelta(minutes=3),
+    )
+
+    artifact = _build(store, _snapshot(store, journal))
+
+    assert len(artifact.rows) == 2
+    assert len({row.example.example_id for row in artifact.rows}) == 2
+    assert len({row.fingerprint for row in artifact.rows}) == 1
+    runtime_example_sources = tuple(
+        row.example.source
+        for row in artifact.rows
+        if isinstance(row.example.source, RuntimeInteractionExampleSource)
+    )
+    assert len(runtime_example_sources) == 2
+    assert {source.interaction_id for source in runtime_example_sources} == {
+        first.interaction_id,
+        second.interaction_id,
+    }
+    assert all(row.example.target == target for row in artifact.rows)
+    assert {row.example.leakage_group_id for row in artifact.rows} == {
+        artifact.rows[0].example.leakage_group_id
+    }
+    assert artifact.dataset.acceptance_rule_ids == ()
+    assert artifact.dataset.acceptance_evidence_ids == ()
+    assert artifact.inspection.source_count == 4
+    assert artifact.inspection.accepted_source_count == 2
+    assert {(item.source_id, item.reason) for item in artifact.inspection.exclusions} == {
+        (failed.interaction_id, "runtime_interaction_failed"),
+        (open_event.interaction_id, "runtime_interaction_incomplete"),
+    }
+
+
+def test_request_history_and_completed_tool_action_are_preserved(tmp_path: Path) -> None:
+    """Retain visible assistant tool calls and matching tool results in canonical rows.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    store = _store(tmp_path)
+    journal = RuntimeInteractionJournal(store.paths)
+    prior_action = AssistantAction(
+        tool_calls=(ToolCall(call_id="prior-call", name="lookup", arguments={"id": "A-1"}),)
+    )
+    target = AssistantAction(
+        content="I found it",
+        tool_calls=(ToolCall(call_id="next-call", name="notify", arguments={"ok": True}),),
+    )
+    accepted = _complete(
+        journal,
+        key="tool-turn",
+        conversation="conversation-tools",
+        request=_request(
+            ModelMessage(role="system", content="Use tools carefully"),
+            ModelMessage(role="user", content="Find A-1"),
+            ModelMessage(role="assistant", assistant_action=prior_action),
+            ModelMessage(role="tool", content="record A-1", tool_call_id="prior-call"),
+            ModelMessage(role="user", content="Now notify me"),
+        ),
+        output=target,
+        now=_TIME,
+    )
+
+    artifact = _build(store, _snapshot(store, journal))
+
+    assert len(artifact.rows) == 1
+    row = artifact.rows[0].example
+    assert row.target == target
+    assert row.task == "Now notify me"
+    assert isinstance(row.source, RuntimeInteractionExampleSource)
+    assert row.source.interaction_id == accepted.interaction_id
+    assert tuple(event for event in row.history if isinstance(event, AssistantActionEvent)) == (
+        AssistantActionEvent(action=prior_action, approved=True),
+    )
+    assert tuple(event for event in row.history if isinstance(event, ToolEvent)) == (
+        ToolEvent(
+            tool_call_id="prior-call",
+            content="record A-1",
+            tool_name="lookup",
+        ),
+    )
+
+
+def test_identical_rows_across_lineages_share_one_partition_component(tmp_path: Path) -> None:
+    """Link duplicate fingerprints across lineages without dropping their multiplicity.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    store = _store(tmp_path)
+    journal = RuntimeInteractionJournal(store.paths)
+    request = _request(ModelMessage(role="user", content="Same request"))
+    target = AssistantAction(content="Same response")
+    _complete(
+        journal,
+        key="lineage-a",
+        conversation="conversation-a",
+        request=request,
+        output=target,
+        now=_TIME,
+    )
+    _complete(
+        journal,
+        key="lineage-b",
+        conversation="conversation-b",
+        request=request,
+        output=target,
+        now=_TIME + timedelta(minutes=1),
+    )
+
+    artifact = _build(store, _snapshot(store, journal))
+
+    assert len(artifact.rows) == 2
+    assert len({row.fingerprint for row in artifact.rows}) == 1
+    assert len({row.example.leakage_group_id for row in artifact.rows}) == 2
+    assert len(artifact.partitions) == 1
+    assert set(artifact.partitions[0].leakage_group_ids) == {
+        row.example.leakage_group_id for row in artifact.rows
+    }
+    assert len({row.partition for row in artifact.rows}) == 1
+
+
+def test_runtime_dataset_replay_is_exact_and_overlapping_snapshots_are_rejected(
+    tmp_path: Path,
+) -> None:
+    """Reuse one exact W12 artifact and reject duplicate interactions across prefixes.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    store = _store(tmp_path)
+    journal = RuntimeInteractionJournal(store.paths)
+    _complete(
+        journal,
+        key="first",
+        conversation="conversation-a",
+        request=_request(ModelMessage(role="user", content="First")),
+        output=AssistantAction(content="Answer"),
+        now=_TIME,
+    )
+    first_source = _snapshot(store, journal)
+    first_build = _build(store, first_source)
+    persisted = write_sft_dataset(store, first_build)
+    replay = write_sft_dataset(
+        store,
+        _build(store, first_source, created_at=_TIME + timedelta(days=1)),
+    )
+
+    assert replay == persisted
+    assert load_verified_sft_dataset(store, persisted.dataset.dataset_id) == persisted
+
+    _complete(
+        journal,
+        key="second",
+        conversation="conversation-a",
+        request=_request(ModelMessage(role="user", content="Second")),
+        output=AssistantAction(content="Another answer"),
+        now=_TIME + timedelta(minutes=1),
+    )
+    longer_source = _snapshot(
+        store,
+        journal,
+        created_at=_TIME + timedelta(hours=3),
+    )
+    longer_build = _build(store, longer_source)
+    assert longer_build.dataset.dataset_id != persisted.dataset.dataset_id
+    with pytest.raises(SFTBuildError, match="repeats source runtime_interaction"):
+        _build(store, first_source, longer_source)
+
+
+def test_generated_or_non_snapshot_artifact_cannot_enter_runtime_sft(tmp_path: Path) -> None:
+    """Reject a generated artifact before it can become a routed SFT source.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    store = _store(tmp_path)
+    generated_id = "generated-runtime-source"
+    envelope = ArtifactEnvelope(
+        schema_version=1,
+        created_at=_TIME,
+        inputs=(),
+        code_revision="runtime-source-test",
+        source=SourceIdentity(kind="simulation", source_id="generated", sha256="c" * 64),
+    )
+    store.artifacts.write(
+        artifact_id=generated_id,
+        artifact_type="simulation-output",
+        envelope=envelope,
+        files={"generated.json": b"{}"},
+    )
+
+    with pytest.raises(SFTBuildError, match="not verified production evidence"):
+        _build(store, RuntimeSFTSource(snapshot_id=generated_id))

--- a/wmo/optimize/model/sft/sources.py
+++ b/wmo/optimize/model/sft/sources.py
@@ -38,6 +38,7 @@ from wmo.optimize.model.sft.contracts import (
     ProductionAcceptanceRule,
     ProductionSFTSource,
     RolloutExampleSource,
+    RuntimeInteractionExampleSource,
     SFTContextEvent,
     SFTSourceReference,
     SFTTranscript,
@@ -56,7 +57,7 @@ class SFTSourceVerificationError(ValueError):
 class PreparedSFTSource:
     """One accepted source hydrated exclusively from verified immutable artifact bytes."""
 
-    kind: Literal["production_trace", "teacher_rollout"]
+    kind: Literal["production_trace", "teacher_rollout", "runtime_interaction"]
     source_id: str
     source_artifact: ArtifactInput
     source_record_sha256: Sha256
@@ -66,12 +67,13 @@ class PreparedSFTSource:
         SFTContextEvent | InfrastructureFailureEvent,
         ...,
     ]
-    example_source: TraceExampleSource | RolloutExampleSource
+    example_source: TraceExampleSource | RolloutExampleSource | RuntimeInteractionExampleSource
     score: float | None
     direct_inputs: tuple[ArtifactInput, ...]
-    acceptance_rule_id: ArtifactId
-    acceptance_evidence_id: ArtifactId
-    acceptance_evidence: ArtifactInput
+    acceptance_rule_id: ArtifactId | None
+    acceptance_evidence_id: ArtifactId | None
+    acceptance_evidence: ArtifactInput | None
+    target_action_indexes: tuple[int, ...] | None = None
 
     def reference(self) -> SFTSourceReference:
         """Return the auditable immutable-source record for a frozen dataset manifest."""


### PR DESCRIPTION
## Summary

- add a typed `runtime_interaction` SFT source backed by verified runtime trace snapshots
- resolve every valid completed routed interaction directly into the immutable W12 dataset without judge, acceptance, success, or quality filtering
- preserve complete message and tool-call context while targeting only the completed assistant action
- retain duplicate examples with interaction-scoped IDs while leakage-linking shared fingerprints and lineages
- reject failed, incomplete, overlapping, corrupt, and non-production runtime sources

## User impact

The W12 builder can now consume routed runtime interactions as first-class SFT data. Valid completions are retained exactly once, repeated examples remain available for training, and related examples cannot split across train and held-out partitions.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`: 696 passed, 1 skipped
- `uv build`
- installed-wheel import smoke for the runtime SFT contracts, resolver, and builder
- installed-wheel `wmo --help`

README is unchanged. This PR must not be merged by automation.
