### PR TITLE
Bind build and judge artifacts to package revision

### DIFF
--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -30,9 +29,10 @@ from wmo.common.project import (
     ProjectStoreError,
     artifact_input,
 )
+from wmo.common.release_revision import installed_release_revision
 from wmo.runtime.models import CapabilityRequirement, ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.models.providers.retry import RetryPolicy
-from wmo.simulation.build import ProjectBuild, TaskSetBuild, build_project
+from wmo.simulation.build import ProjectBuild, TaskSetBuild, build_project, select_completed_build
 from wmo.simulation.ingest.otlp import (
     OtlpTraceFormatError,
     TraceNormalizationResult,
@@ -105,6 +105,7 @@ def build(
     """
     started = time.monotonic()
     try:
+        code_revision = installed_release_revision()
         ProjectStore(root, project)
         catalog = _load_or_setup_catalog(root, no_interactive=no_interactive)
         selected = _selected_roles(
@@ -141,7 +142,7 @@ def build(
             normalized,
             store,
             created_at=datetime.now(UTC),
-            code_revision=_current_revision(),
+            code_revision=code_revision,
         )
         built = _reuse_completed_grounded_artifacts(
             store,
@@ -172,7 +173,7 @@ def build(
                 resolved_embedder=resolved_embedder,
                 top_k=top_k,
             )
-        store.bind_completed_build(built)
+        select_completed_build(store, built, completed.review)
     except (ArtifactStoreError, ModelCatalogError, ProjectStoreError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from None
     _capture_local_build_telemetry(
@@ -568,19 +569,6 @@ def _load_canonical_traces(path: Path, source: str) -> TraceNormalizationResult:
         raise typer.BadParameter(f"{normalized_source} trace normalization failed: {exc}") from None
     choices = ", ".join(_CANONICAL_SOURCES)
     raise typer.BadParameter(f"unsupported --source {source!r}; choose one of: {choices}")
-
-
-def _current_revision() -> str:
-    """Return the local Git revision when available without changing repository state."""
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=Path(__file__).resolve().parents[2],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    revision = result.stdout.strip()
-    return revision if result.returncode == 0 and revision else "local-unversioned"
 
 
 def _capture_local_build_telemetry(

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -12,6 +12,8 @@ import pytest
 from click import unstyle
 from typer.testing import CliRunner
 
+import wmo.cli.build_cmd as build_command
+import wmo.simulation.build as simulation_build
 from wmo.cli.app import app
 from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
@@ -26,12 +28,35 @@ from wmo.common.models import (
     ModelSnapshot,
     write_model_catalog,
 )
-from wmo.common.project import ProjectStore, ProjectStoreError
+from wmo.common.project import ArtifactCorruptionError, ProjectStore, ProjectStoreError
 from wmo.runtime.models import ResolvedModel
 from wmo.simulation.retrieval import load_rag_index
 from wmo.simulation.world_model import GroundedWorldModelArtifact
 
 _RUNNER = CliRunner()
+
+
+def test_malformed_release_revision_fails_before_build_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject malformed producer identity before catalog, project, or artifact writes.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped invalid release revision override.
+    """
+    root = tmp_path / ".wmo"
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "HEAD")
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(tmp_path / "missing.jsonl"), "--root", str(root)],
+    )
+
+    assert result.exit_code == 2
+    assert "full lowercase 40-hex" in result.output
+    assert not root.exists()
 
 
 def _attribute(key: str, value: str) -> dict[str, object]:
@@ -308,6 +333,263 @@ def test_build_positional_happy_path_creates_two_rags_and_executable_artifact(
     with pytest.raises(ProjectStoreError, match="completed build graph"):
         store.bind_completed_build(swapped)
     assert store.load_project().build == config.build
+
+
+def test_build_package_upgrade_creates_new_immutable_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identical evidence from a new installed revision advances without mutating old artifacts.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and project root.
+        monkeypatch: Pytest patch fixture used to forbid an exact replay rebuild.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+
+    first_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "a" * 40},
+    )
+    assert first_result.exit_code == 0, first_result.output
+    store = ProjectStore(root, "support")
+    first_build = store.load_project().build
+    assert first_build is not None
+    first_review = store.read_review()
+    first_manifests = {
+        pointer.artifact_id: store.artifacts.read(pointer.artifact_id).manifest
+        for pointer in (
+            first_build.trace_dataset,
+            first_build.task_set,
+            first_build.serving_rag,
+            first_build.fit_rag,
+            first_build.world_model,
+        )
+    }
+
+    original_build_grounded = build_command._build_grounded_artifacts
+
+    def fail_after_readiness(*_args: object, **_kwargs: object) -> None:
+        """Inject failure after deterministic readiness but before completed-build selection.
+
+        Raises:
+            ValueError: Always, to simulate interrupted provider-backed construction.
+        """
+        raise ValueError("injected grounded build failure")
+
+    monkeypatch.setattr(build_command, "_build_grounded_artifacts", fail_after_readiness)
+    failed_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+    assert failed_result.exit_code == 2
+    assert "injected grounded build failure" in failed_result.output
+    assert store.load_project().build == first_build
+    assert store.read_review() == first_review
+
+    monkeypatch.setattr(build_command, "_build_grounded_artifacts", original_build_grounded)
+    second_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+
+    assert second_result.exit_code == 0, second_result.output
+    second_build = store.load_project().build
+    assert second_build is not None
+    assert second_build.trace_dataset != first_build.trace_dataset
+    assert second_build.task_set != first_build.task_set
+    assert second_build.serving_rag != first_build.serving_rag
+    assert second_build.fit_rag != first_build.fit_rag
+    assert second_build.world_model != first_build.world_model
+    for artifact_id, manifest in first_manifests.items():
+        assert store.artifacts.read(artifact_id).manifest == manifest
+    second_manifests = {
+        pointer.artifact_id: store.artifacts.read(pointer.artifact_id).manifest
+        for pointer in (
+            second_build.trace_dataset,
+            second_build.task_set,
+            second_build.serving_rag,
+            second_build.fit_rag,
+            second_build.world_model,
+        )
+    }
+
+    def forbid_rebuild(*_args: object, **_kwargs: object) -> None:
+        """Fail if exact upgraded replay attempts another provider-backed build.
+
+        Raises:
+            AssertionError: Always, because exact replay must reuse the upgraded graph.
+        """
+        raise AssertionError("exact upgraded replay must not rebuild provider-backed artifacts")
+
+    monkeypatch.setattr("wmo.cli.build_cmd._build_grounded_artifacts", forbid_rebuild)
+    replay_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+    assert replay_result.exit_code == 0, replay_result.output
+    assert store.load_project().build == second_build
+    for artifact_id, manifest in second_manifests.items():
+        assert store.artifacts.read(artifact_id).manifest == manifest
+
+
+@pytest.mark.parametrize("selected_graph", ["old", "new"])
+def test_build_package_upgrade_graphs_remain_independently_verified(
+    tmp_path: Path,
+    selected_graph: str,
+) -> None:
+    """Corruption in either immutable revision graph is detected recursively.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and project root.
+        selected_graph: Revision graph whose trace payload is corrupted.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    first_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "a" * 40},
+    )
+    assert first_result.exit_code == 0, first_result.output
+    store = ProjectStore(root, "support")
+    first_build = store.load_project().build
+    assert first_build is not None
+    second_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+    assert second_result.exit_code == 0, second_result.output
+    second_build = store.load_project().build
+    assert second_build is not None
+    selected = first_build if selected_graph == "old" else second_build
+    trace_directory = store.artifacts.read(selected.trace_dataset.artifact_id).directory
+    trace_path = trace_directory / "traces.jsonl"
+    trace_path.write_text("corrupt\n", encoding="utf-8")
+
+    with pytest.raises(ArtifactCorruptionError, match="digest mismatch"):
+        store.artifacts.read(selected.trace_dataset.artifact_id)
+
+
+def test_build_package_upgrade_decline_preserves_selected_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Declining replacement spend leaves the selected build and review handoff together.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and project root.
+        monkeypatch: Pytest patch fixture forcing a paid-build decline.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    first_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "a" * 40},
+    )
+    assert first_result.exit_code == 0, first_result.output
+    store = ProjectStore(root, "support")
+    first_build = store.load_project().build
+    first_review = store.read_review()
+    assert first_build is not None
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 1.0)
+    monkeypatch.setattr(build_command, "require_spend_consent", lambda *_args, **_kwargs: False)
+
+    declined = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+
+    assert declined.exit_code == 0, declined.output
+    assert store.load_project().build == first_build
+    assert store.read_review() == first_review
+
+
+def test_build_package_upgrade_recovers_selection_before_review_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart repairs review after completed-build selection without rebuilding providers.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and project root.
+        monkeypatch: Pytest patch fixture injecting and recovering a final review-write failure.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    first_result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "a" * 40},
+    )
+    assert first_result.exit_code == 0, first_result.output
+    store = ProjectStore(root, "support")
+    first_build = store.load_project().build
+    first_review = store.read_review()
+    assert first_build is not None
+    original_select_review = simulation_build.select_build_review
+
+    def fail_review_selection(*_args: object, **_kwargs: object) -> None:
+        """Inject a crash after completed-build selection and before review advancement.
+
+        Raises:
+            ValueError: Always, to simulate interrupted coordination.
+        """
+        raise ValueError("injected final review failure")
+
+    monkeypatch.setattr(simulation_build, "select_build_review", fail_review_selection)
+    interrupted = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+    assert interrupted.exit_code == 2
+    assert "injected final review failure" in interrupted.output
+    selected_build = store.load_project().build
+    assert selected_build is not None
+    assert selected_build != first_build
+    assert store.read_review() == first_review
+
+    monkeypatch.setattr(simulation_build, "select_build_review", original_select_review)
+
+    def forbid_rebuild(*_args: object, **_kwargs: object) -> None:
+        """Fail if recovery reconstructs already selected provider-backed artifacts.
+
+        Raises:
+            AssertionError: Always, because restart must reuse the selected immutable graph.
+        """
+        raise AssertionError("review recovery must not rebuild provider-backed artifacts")
+
+    monkeypatch.setattr(build_command, "_build_grounded_artifacts", forbid_rebuild)
+    recovered = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "b" * 40},
+    )
+
+    assert recovered.exit_code == 0, recovered.output
+    assert store.load_project().build == selected_build
+    recovered_review = store.read_review()
+    assert isinstance(recovered_review, dict)
+    assert recovered_review["build_review"]["trace_dataset"] == (
+        selected_build.trace_dataset.model_dump(mode="json")
+    )
 
 
 @pytest.mark.parametrize("count", [2, 100, 1_001])

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -520,6 +520,59 @@ def test_build_package_upgrade_decline_preserves_selected_review(
     assert store.read_review() == first_review
 
 
+@pytest.mark.parametrize("failure_mode", ["cost", "decline", "grounded"])
+def test_first_build_failure_does_not_publish_review_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+) -> None:
+    """No first-build readiness is visible until its completed graph is selected.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and project root.
+        monkeypatch: Pytest patch fixture selecting the pre-selection failure boundary.
+        failure_mode: Cost rejection, explicit spend decline, or grounded construction failure.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    if failure_mode == "cost":
+        monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 6.0)
+    elif failure_mode == "decline":
+        monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 1.0)
+        monkeypatch.setattr(
+            build_command,
+            "require_spend_consent",
+            lambda *_args, **_kwargs: False,
+        )
+    else:
+
+        def fail_grounded_build(*_args: object, **_kwargs: object) -> None:
+            """Simulate grounded artifact construction failing before selection.
+
+            Raises:
+                ValueError: Always, at the provider-backed construction boundary.
+            """
+            raise ValueError("injected first grounded build failure")
+
+        monkeypatch.setattr(build_command, "_build_grounded_artifacts", fail_grounded_build)
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        env={"WMO_RELEASE_REVISION": "a" * 40},
+    )
+
+    if failure_mode == "decline":
+        assert result.exit_code == 0, result.output
+    else:
+        assert result.exit_code == 2
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
 def test_build_package_upgrade_recovers_selection_before_review_crash(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from click import unstyle
+from pydantic import JsonValue
 from typer.testing import CliRunner
 
 import wmo.cli.build_cmd as build_command
@@ -543,6 +544,28 @@ def test_build_package_upgrade_recovers_selection_before_review_crash(
     first_build = store.load_project().build
     first_review = store.read_review()
     assert first_build is not None
+    assert isinstance(first_review, dict)
+
+    def add_build_scoped_review_state(current: JsonValue | None) -> JsonValue:
+        """Attach graph-A judge namespaces and unrelated review state.
+
+        Args:
+            current: Current project review value.
+
+        Returns:
+            Review state with stale build-scoped fixtures and an unrelated marker.
+        """
+        assert isinstance(current, dict)
+        return {
+            **current,
+            "manual_judge": {"build": "a"},
+            "rubric_review": {"build": "a"},
+            "human_score_history": [{"build": "a"}],
+            "human_score_submissions": [{"build": "a"}],
+            "unrelated_review_state": {"preserve": True},
+        }
+
+    first_review = store.update_review(add_build_scoped_review_state)
     original_select_review = simulation_build.select_build_review
 
     def fail_review_selection(*_args: object, **_kwargs: object) -> None:
@@ -590,6 +613,11 @@ def test_build_package_upgrade_recovers_selection_before_review_crash(
     assert recovered_review["build_review"]["trace_dataset"] == (
         selected_build.trace_dataset.model_dump(mode="json")
     )
+    assert "manual_judge" not in recovered_review
+    assert "rubric_review" not in recovered_review
+    assert "human_score_history" not in recovered_review
+    assert "human_score_submissions" not in recovered_review
+    assert recovered_review["unrelated_review_state"] == {"preserve": True}
 
 
 @pytest.mark.parametrize("count", [2, 100, 1_001])

--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -16,6 +15,7 @@ from wmo.common.judging import Rubric, RubricDimension
 from wmo.common.judging.provenance import read_artifact_json
 from wmo.common.models import load_model_catalog
 from wmo.common.project import ProjectStore
+from wmo.common.release_revision import installed_release_revision
 from wmo.runtime.models.registry import RuntimeModelCatalog
 from wmo.workflow.manual_judge import (
     DEFAULT_JUDGE_TEMPLATE,
@@ -90,6 +90,7 @@ def judge_setup(
         typer.BadParameter: Local files, build evidence, or confirmation are invalid.
     """
     try:
+        revision = installed_release_revision()
         store = ProjectStore(root, project)
         dimensions = _load_rubric_dimensions(rubric_file)
         template = _load_prompt_template(template_file)
@@ -101,7 +102,7 @@ def judge_setup(
             prompt_template=template,
             preview_count=preview_count,
             created_at=datetime.now(UTC),
-            code_revision=_current_revision(),
+            code_revision=revision,
         )
         _render_setup(plan)
         confirmed = approve or _confirm(
@@ -161,10 +162,10 @@ def judge_calibrate(
     Raises:
         typer.BadParameter: Evidence, labels, budget, consent, or approval is invalid.
     """
-    store = ProjectStore(root, project)
-    now = datetime.now(UTC)
-    revision = _current_revision()
     try:
+        revision = installed_release_revision()
+        store = ProjectStore(root, project)
+        now = datetime.now(UTC)
         plan = prepare_manual_judge_calibration(store, sample_size=sample_size)
         rubric = _load_setup_rubric(store, plan.setup)
         _render_calibration_previews(plan.previews)
@@ -536,20 +537,3 @@ def _confirm(question: str, *, non_interactive: bool, required_flag: str) -> boo
     if non_interactive or not can_prompt(_console):
         raise ValueError(f"noninteractive judge review requires {required_flag}")
     return Confirm.ask(question, default=False)
-
-
-def _current_revision() -> str:
-    """Return the local Git revision without provider or project state changes.
-
-    Returns:
-        Current Git commit, or a stable local marker outside a repository.
-    """
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=Path(__file__).resolve().parents[2],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    revision = result.stdout.strip()
-    return revision if result.returncode == 0 and revision else "local-unversioned"

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -2,10 +2,51 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["config", "judge", "setup", "support"],
+        [
+            "config",
+            "judge",
+            "calibrate",
+            "support",
+            "--input-usd-per-million",
+            "0",
+            "--output-usd-per-million",
+            "0",
+        ],
+    ],
+)
+def test_malformed_release_revision_fails_before_judge_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: list[str],
+) -> None:
+    """Reject malformed producer identity before judge project or artifact writes.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped invalid release revision override.
+        arguments: Exact nested judge command invocation.
+    """
+    root = tmp_path / ".wmo"
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "HEAD")
+
+    result = CliRunner().invoke(app, [*arguments, "--root", str(root)])
+
+    assert result.exit_code == 2
+    assert "full lowercase 40-hex" in result.output
+    assert not root.exists()
 
 
 def test_judge_commands_render_as_nested_config_commands() -> None:

--- a/wmo/common/judging/labels.py
+++ b/wmo/common/judging/labels.py
@@ -17,7 +17,11 @@ from wmo.common.core.artifacts import (
 )
 from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
 from wmo.common.judging.rubric import Rubric
-from wmo.common.project import ArtifactAlreadyExistsError, ProjectStore
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ProjectStore,
+    coordinate_completed_build_selection,
+)
 
 
 class HumanScore(ContractModel):
@@ -190,7 +194,8 @@ class HumanScoreReview:
             selected.append((root, history))
             return root
 
-        store.update_review(initialize)
+        with coordinate_completed_build_selection(store):
+            store.update_review(initialize)
         root, history = selected[0]
         return cls(store, root, history)
 
@@ -205,7 +210,7 @@ class HumanScoreReview:
         Args:
             score: New score with no correction predecessor.
         """
-        self._mutate(lambda history: history.append(score))
+        self._mutate(lambda history: history.append(score), rubric_id=score.rubric_id)
 
     def correct(self, score: HumanScore) -> None:
         """Persist one correction while retaining its superseded historical label.
@@ -213,7 +218,7 @@ class HumanScoreReview:
         Args:
             score: New score that names the earlier label it supersedes.
         """
-        self._mutate(lambda history: history.correct(score))
+        self._mutate(lambda history: history.correct(score), rubric_id=score.rubric_id)
 
     def upsert(
         self,
@@ -317,7 +322,9 @@ class HumanScoreReview:
             return root
 
         selected: list[tuple[JsonObject, HumanScoreHistory]] = []
-        self._store.update_review(update)
+        with coordinate_completed_build_selection(self._store):
+            _require_rubric_matches_selected_build(self._store, rubric_id)
+            self._store.update_review(update)
         self._root_review, self._history = selected[0]
         return result[0]
 
@@ -351,7 +358,7 @@ class HumanScoreReview:
             )
             return history
 
-        self._mutate(transition)
+        self._mutate(transition, rubric_id=rubric_id)
         return result[0]
 
     def _finalize(
@@ -434,8 +441,15 @@ class HumanScoreReview:
     def _mutate(
         self,
         transition: Callable[[HumanScoreHistory], HumanScoreHistory],
+        *,
+        rubric_id: ArtifactId,
     ) -> None:
-        """Reload and apply one score-history transition while the review lock is held."""
+        """Apply one score transition while build selection and review state are locked.
+
+        Args:
+            transition: Pure history transition to apply to the latest persisted namespace.
+            rubric_id: Immutable rubric whose source task set must remain selected.
+        """
         selected: list[tuple[JsonObject, HumanScoreHistory]] = []
 
         def update(current: JsonValue | None) -> JsonObject:
@@ -445,8 +459,43 @@ class HumanScoreReview:
             selected.append((root, history))
             return root
 
-        self._store.update_review(update)
+        with coordinate_completed_build_selection(self._store):
+            _require_rubric_matches_selected_build(self._store, rubric_id)
+            self._store.update_review(update)
         self._root_review, self._history = selected[0]
+
+
+def _require_rubric_matches_selected_build(
+    store: ProjectStore,
+    rubric_id: ArtifactId,
+) -> None:
+    """Reject a score writer whose rubric belongs to an older selected task set.
+
+    Args:
+        store: Project whose completed build is stable under the caller's coordination lock.
+        rubric_id: Immutable rubric used by the score transition.
+
+    Raises:
+        ValueError: The rubric is unavailable or names a task set other than the selected build.
+    """
+    completed = store.load_project().build
+    if completed is None:
+        return
+    try:
+        rubric, _rubric_input = read_artifact_json(
+            store,
+            artifact_id=rubric_id,
+            expected_artifact_type="rubric",
+            relative_path="rubric.json",
+            model_type=Rubric,
+        )
+    except JudgingProvenanceError as exc:
+        raise ValueError("human scores require a completed immutable finalized rubric") from exc
+    if rubric.source_task_set_id != completed.task_set.artifact_id:
+        raise ValueError(
+            "human score rubric differs from the selected completed build; reopen labels from "
+            "the current project build"
+        )
 
 
 def _root_review_from_value(review: JsonValue | None) -> JsonObject:

--- a/wmo/common/judging/review.py
+++ b/wmo/common/judging/review.py
@@ -20,7 +20,11 @@ from wmo.common.judging.provenance import (
     sorted_verified_inputs,
 )
 from wmo.common.judging.rubric import Rubric, RubricDimension, ScoreAnchor
-from wmo.common.project import ArtifactAlreadyExistsError, ProjectStore
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ProjectStore,
+    coordinate_completed_build_selection,
+)
 
 
 class RubricReviewError(RuntimeError):
@@ -170,7 +174,8 @@ class RubricReview:
             selected.append(draft)
             return root
 
-        store.update_review(initialize)
+        with coordinate_completed_build_selection(store, task_set_id=source_task_set_id):
+            store.update_review(initialize)
         return cls(store, selected[0], supplied_proposals, code_revision, now)
 
     @property
@@ -595,7 +600,11 @@ class RubricReview:
             selected.append(working._draft)
             return root
 
-        self._store.update_review(update)
+        with coordinate_completed_build_selection(
+            self._store,
+            task_set_id=self._draft.source_task_set_id,
+        ):
+            self._store.update_review(update)
         self._draft = selected[0]
 
     def _event(

--- a/wmo/common/project/__init__.py
+++ b/wmo/common/project/__init__.py
@@ -21,6 +21,7 @@ from wmo.common.project.store import (
     ProjectStore,
     ProjectStoreError,
     StoredArtifact,
+    coordinate_completed_build_selection,
 )
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     "ProjectStoreError",
     "StoredArtifact",
     "artifact_input",
+    "coordinate_completed_build_selection",
     "load_project_config",
     "write_project_config",
 ]

--- a/wmo/common/project/store.py
+++ b/wmo/common/project/store.py
@@ -7,7 +7,9 @@ import logging
 import os
 import shutil
 import stat
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
@@ -16,6 +18,7 @@ from pydantic import BaseModel, JsonValue, TypeAdapter, ValidationError
 
 from wmo.common.core.artifacts import (
     ArtifactEnvelope,
+    ArtifactId,
     ArtifactInput,
     SecretBoundaryError,
     assert_secret_free,
@@ -37,6 +40,10 @@ from wmo.common.project.project import (
 logger = logging.getLogger(__name__)
 
 _JSON_VALUE_ADAPTER = TypeAdapter(JsonValue)
+_ACTIVE_COMPLETED_BUILD_COORDINATION: ContextVar[str | None] = ContextVar(
+    "active_completed_build_coordination",
+    default=None,
+)
 
 
 class ArtifactStoreError(RuntimeError):
@@ -571,6 +578,74 @@ class ProjectStore:
             return _JSON_VALUE_ADAPTER.validate_json(self.paths.review_json.read_bytes())
         except (OSError, ValidationError) as exc:
             raise ProjectStoreError("review.json is not valid JSON") from exc
+
+
+@contextmanager
+def coordinate_completed_build_selection(
+    store: ProjectStore,
+    *,
+    task_set_id: ArtifactId | None = None,
+) -> Iterator[None]:
+    """Serialize build selection with mutable review writers for the selected task set.
+
+    The coordination lock is reentrant only for the same project inside one execution context.
+    This lets a workflow hold the transaction across common review services without reacquiring
+    the non-reentrant filesystem lock. A task-set-bound writer verifies the current selection
+    after acquiring the lock, so a service opened for an older build cannot restore its namespace
+    after a replacement commits.
+
+    Args:
+        store: Project whose completed build and review namespaces must change atomically.
+        task_set_id: Optional immutable task-set identity required by the review mutation.
+
+    Yields:
+        None while completed-build replacement is excluded.
+
+    Raises:
+        ProjectStoreError: Nested coordination targets another project, or the selected build uses
+            a different task set from the review writer.
+    """
+    project_key = str(store.paths.project_directory.absolute())
+    active = _ACTIVE_COMPLETED_BUILD_COORDINATION.get()
+    if active is not None:
+        if active != project_key:
+            raise ProjectStoreError(
+                "nested completed-build coordination cannot target another project"
+            )
+        _require_selected_task_set(store, task_set_id)
+        yield
+        return
+    coordination_path = store.paths.project_directory / "completed-build-selection"
+    with file_write_lock(coordination_path, what="completed build and review state"):
+        token = _ACTIVE_COMPLETED_BUILD_COORDINATION.set(project_key)
+        try:
+            _require_selected_task_set(store, task_set_id)
+            yield
+        finally:
+            _ACTIVE_COMPLETED_BUILD_COORDINATION.reset(token)
+
+
+def _require_selected_task_set(
+    store: ProjectStore,
+    task_set_id: ArtifactId | None,
+) -> None:
+    """Reject a build-scoped writer whose task set is no longer selected.
+
+    Args:
+        store: Project containing the optional completed-build selection.
+        task_set_id: Task-set identity required by the writer, or None for the selector itself.
+
+    Raises:
+        ProjectStoreError: A completed build selects a different task set.
+    """
+    if task_set_id is None:
+        return
+    completed = store.load_project().build
+    if completed is not None and completed.task_set.artifact_id != task_set_id:
+        raise ProjectStoreError(
+            "review evidence differs from the selected completed build; reopen the review from "
+            "the current project build"
+        )
 
 
 def _assert_payload_secret_free(relative_path: str, payload: bytes) -> None:

--- a/wmo/simulation/build.py
+++ b/wmo/simulation/build.py
@@ -32,6 +32,13 @@ from wmo.simulation.ingest.otlp import TraceNormalizationResult
 from wmo.simulation.mining.descriptors import DescriptorEmbedder, HashingDescriptorEmbedder
 from wmo.simulation.mining.service import MiningSpec, TaskMiningResult, mine_tasks, persist_task_set
 
+_BUILD_SCOPED_REVIEW_KEYS = (
+    "manual_judge",
+    "rubric_review",
+    "human_score_history",
+    "human_score_submissions",
+)
+
 
 @dataclass(frozen=True)
 class TaskSetBuild:
@@ -331,16 +338,7 @@ def select_build_review(store: ProjectStore, review: BuildReviewReadiness) -> No
             )
         except ValueError as exc:
             raise ValueError("review.json contains invalid build readiness") from exc
-        if prior != review:
-            for key in (
-                "manual_judge",
-                "rubric_review",
-                "human_score_history",
-                "human_score_submissions",
-            ):
-                root_review.pop(key, None)
-        root_review["build_review"] = review.model_dump(mode="json")
-        return root_review
+        return _advance_build_review(root_review, prior=prior, review=review)
 
     store.update_review(update)
 
@@ -371,20 +369,45 @@ def _prepare_build_review(store: ProjectStore, review: BuildReviewReadiness) -> 
         root_review = _review_object(current)
         prior = root_review.get("build_review")
         if prior is None:
-            root_review["build_review"] = review.model_dump(mode="json")
-            return root_review
+            return _advance_build_review(root_review, prior=None, review=review)
         try:
             existing = BuildReviewReadiness.model_validate(prior)
         except ValueError as exc:
             raise ValueError("review.json contains invalid build readiness") from exc
-        if existing == review or _completed_build_matches_review(store, review):
-            root_review["build_review"] = review.model_dump(mode="json")
+        if existing == review:
             return root_review
+        if _completed_build_matches_review(store, review):
+            return _advance_build_review(root_review, prior=existing, review=review)
         if _completed_build_matches_review(store, existing):
             return root_review
         raise ValueError("review.json already binds a different completed build")
 
-    store.update_review(update)
+    with _build_review_coordination(store):
+        store.update_review(update)
+
+
+def _advance_build_review(
+    root_review: JsonObject,
+    *,
+    prior: BuildReviewReadiness | None,
+    review: BuildReviewReadiness,
+) -> JsonObject:
+    """Advance the build binding and remove only namespaces owned by replaced evidence.
+
+    Args:
+        root_review: Mutable complete project review object.
+        prior: Previous build binding, or None before the first build.
+        review: Selected build binding that will replace it.
+
+    Returns:
+        Review state with the selected build binding, unrelated members preserved, and judge
+        namespaces removed only when their prior build binding was replaced.
+    """
+    if prior != review:
+        for key in _BUILD_SCOPED_REVIEW_KEYS:
+            root_review.pop(key, None)
+    root_review["build_review"] = review.model_dump(mode="json")
+    return root_review
 
 
 def _review_object(current: JsonValue | None) -> JsonObject:

--- a/wmo/simulation/build.py
+++ b/wmo/simulation/build.py
@@ -18,13 +18,13 @@ from wmo.common.core.artifacts import (
     SourceIdentity,
     stable_id,
 )
-from wmo.common.core.locks import file_write_lock
 from wmo.common.project import (
     ArtifactStore,
     ProjectBuildArtifacts,
     ProjectConfig,
     ProjectStore,
     artifact_input,
+    coordinate_completed_build_selection,
 )
 from wmo.common.tasks import TaskSet
 from wmo.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_dataset
@@ -223,7 +223,6 @@ def build_project(
         descriptor_dimensions=descriptor_dimensions,
         code_revision=code_revision,
     )
-    _prepare_build_review(store, review)
     return ProjectBuild(artifacts=artifacts, review=review)
 
 
@@ -298,8 +297,7 @@ def _build_review_coordination(store: ProjectStore) -> Iterator[None]:
     Yields:
         None while the project-local cross-process lock is held.
     """
-    coordination_path = store.paths.project_directory / "completed-build-selection"
-    with file_write_lock(coordination_path, what="completed build and review state"):
+    with coordinate_completed_build_selection(store):
         yield
 
 
@@ -341,49 +339,6 @@ def select_build_review(store: ProjectStore, review: BuildReviewReadiness) -> No
         return _advance_build_review(root_review, prior=prior, review=review)
 
     store.update_review(update)
-
-
-def _prepare_build_review(store: ProjectStore, review: BuildReviewReadiness) -> None:
-    """Persist first-build readiness or defer replacement until completed-build selection.
-
-    Args:
-        store: Project store owning review and completed-build state.
-        review: Readiness record for the deterministic trace and task build.
-
-    Raises:
-        ValueError: Existing review state is invalid or is not bound to a selected build.
-    """
-
-    def update(current: JsonValue | None) -> JsonObject:
-        """Validate and transition the build-review member under the review lock.
-
-        Args:
-            current: Current complete review JSON value.
-
-        Returns:
-            Current or updated object-shaped review state.
-
-        Raises:
-            ValueError: Existing build-review state is invalid or unselected.
-        """
-        root_review = _review_object(current)
-        prior = root_review.get("build_review")
-        if prior is None:
-            return _advance_build_review(root_review, prior=None, review=review)
-        try:
-            existing = BuildReviewReadiness.model_validate(prior)
-        except ValueError as exc:
-            raise ValueError("review.json contains invalid build readiness") from exc
-        if existing == review:
-            return root_review
-        if _completed_build_matches_review(store, review):
-            return _advance_build_review(root_review, prior=existing, review=review)
-        if _completed_build_matches_review(store, existing):
-            return root_review
-        raise ValueError("review.json already binds a different completed build")
-
-    with _build_review_coordination(store):
-        store.update_review(update)
 
 
 def _advance_build_review(

--- a/wmo/simulation/build.py
+++ b/wmo/simulation/build.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
@@ -239,10 +241,59 @@ def select_completed_build(
     """
     if build.trace_dataset != review.trace_dataset or build.task_set != review.task_set:
         raise ValueError("completed build does not match proposed build review")
-    coordination_path = store.paths.project_directory / "completed-build-selection"
-    with file_write_lock(coordination_path, what="completed build selection"):
+    with _build_review_coordination(store):
         store.bind_completed_build(build)
         select_build_review(store, review)
+
+
+@contextmanager
+def coordinate_selected_build_review(
+    store: ProjectStore,
+    *,
+    trace_dataset: ArtifactInput,
+    task_set: ArtifactInput,
+) -> Iterator[BuildReviewReadiness]:
+    """Hold the build-review transaction while a dependent review mutation completes.
+
+    Args:
+        store: Project store whose selected build and review state must remain aligned.
+        trace_dataset: Exact trace artifact required by the dependent mutation.
+        task_set: Exact task artifact required by the dependent mutation.
+
+    Yields:
+        The verified selected-build readiness while replacement selection is excluded.
+
+    Raises:
+        ValueError: Review state is absent, malformed, stale, or names different evidence.
+    """
+    with _build_review_coordination(store):
+        current = store.read_review()
+        if not isinstance(current, dict) or "build_review" not in current:
+            raise ValueError("project has no completed build review")
+        try:
+            review = BuildReviewReadiness.model_validate(current["build_review"])
+        except ValueError as exc:
+            raise ValueError("project build review is invalid") from exc
+        if review.trace_dataset != trace_dataset or review.task_set != task_set:
+            raise ValueError("manual judge evidence differs from the selected build review")
+        if not _completed_build_matches_review(store, review):
+            raise ValueError("selected completed build and review state are not synchronized")
+        yield review
+
+
+@contextmanager
+def _build_review_coordination(store: ProjectStore) -> Iterator[None]:
+    """Serialize completed-build selection with dependent mutable review transactions.
+
+    Args:
+        store: Project store whose build and review state share the coordination boundary.
+
+    Yields:
+        None while the project-local cross-process lock is held.
+    """
+    coordination_path = store.paths.project_directory / "completed-build-selection"
+    with file_write_lock(coordination_path, what="completed build and review state"):
+        yield
 
 
 def select_build_review(store: ProjectStore, review: BuildReviewReadiness) -> None:
@@ -262,15 +313,32 @@ def select_build_review(store: ProjectStore, review: BuildReviewReadiness) -> No
         raise ValueError("selected completed build does not match proposed build review")
 
     def update(current: JsonValue | None) -> JsonObject:
-        """Replace only the build-review member while preserving unrelated review state.
+        """Advance build review and discard judge state bound to replaced evidence.
 
         Args:
             current: Current complete review JSON value.
 
         Returns:
-            Updated object with the selected build-review handoff.
+            Updated object with the selected build-review handoff and compatible judge state.
         """
         root_review = _review_object(current)
+        prior_value = root_review.get("build_review")
+        try:
+            prior = (
+                BuildReviewReadiness.model_validate(prior_value)
+                if prior_value is not None
+                else None
+            )
+        except ValueError as exc:
+            raise ValueError("review.json contains invalid build readiness") from exc
+        if prior != review:
+            for key in (
+                "manual_judge",
+                "rubric_review",
+                "human_score_history",
+                "human_score_submissions",
+            ):
+                root_review.pop(key, None)
         root_review["build_review"] = review.model_dump(mode="json")
         return root_review
 

--- a/wmo/simulation/build.py
+++ b/wmo/simulation/build.py
@@ -6,16 +6,24 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, JsonValue, model_validator
 
 from wmo.common.core.artifacts import (
     ArtifactId,
     ArtifactInput,
     ContractModel,
+    JsonObject,
     SourceIdentity,
     stable_id,
 )
-from wmo.common.project import ArtifactStore, ProjectConfig, ProjectStore, artifact_input
+from wmo.common.core.locks import file_write_lock
+from wmo.common.project import (
+    ArtifactStore,
+    ProjectBuildArtifacts,
+    ProjectConfig,
+    ProjectStore,
+    artifact_input,
+)
 from wmo.common.tasks import TaskSet
 from wmo.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_dataset
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
@@ -206,25 +214,171 @@ def build_project(
         descriptor_dimensions=descriptor_dimensions,
         code_revision=code_revision,
     )
-    current = store.read_review()
-    if current is None:
-        root_review: dict[str, object] = {}
-    elif isinstance(current, dict):
-        root_review = dict(current)
-    else:
-        raise ValueError("review.json must be an object before build readiness can be recorded")
-    prior = root_review.get("build_review")
-    serialized = review.model_dump(mode="json")
-    if prior is not None:
+    _prepare_build_review(store, review)
+    return ProjectBuild(artifacts=artifacts, review=review)
+
+
+def select_completed_build(
+    store: ProjectStore,
+    build: ProjectBuildArtifacts,
+    review: BuildReviewReadiness,
+) -> None:
+    """Select a completed graph before advancing its recoverable review handoff.
+
+    Official build writers share one cross-process coordination lock. The immutable build is
+    selected first, then review readiness advances. If execution stops between those writes, an
+    exact restart verifies the selected graph and repairs the review handoff without provider work.
+
+    Args:
+        store: Project store receiving the completed-build selection.
+        build: Verified immutable trace, task, RAG, and world-model graph.
+        review: Exact readiness record derived from the graph's trace and task artifacts.
+
+    Raises:
+        ValueError: The proposed graph and review name different trace or task artifacts.
+    """
+    if build.trace_dataset != review.trace_dataset or build.task_set != review.task_set:
+        raise ValueError("completed build does not match proposed build review")
+    coordination_path = store.paths.project_directory / "completed-build-selection"
+    with file_write_lock(coordination_path, what="completed build selection"):
+        store.bind_completed_build(build)
+        select_build_review(store, review)
+
+
+def select_build_review(store: ProjectStore, review: BuildReviewReadiness) -> None:
+    """Advance review readiness after the exact completed build has been selected.
+
+    The completed-build selection is written first. If execution stops before this function
+    finishes, a later identical build verifies the selected graph and repairs the review pointer.
+
+    Args:
+        store: Project store owning the selected build and mutable review handoff.
+        review: Exact readiness record derived from the selected trace and task artifacts.
+
+    Raises:
+        ValueError: The selected completed build does not match the proposed review.
+    """
+    if not _completed_build_matches_review(store, review):
+        raise ValueError("selected completed build does not match proposed build review")
+
+    def update(current: JsonValue | None) -> JsonObject:
+        """Replace only the build-review member while preserving unrelated review state.
+
+        Args:
+            current: Current complete review JSON value.
+
+        Returns:
+            Updated object with the selected build-review handoff.
+        """
+        root_review = _review_object(current)
+        root_review["build_review"] = review.model_dump(mode="json")
+        return root_review
+
+    store.update_review(update)
+
+
+def _prepare_build_review(store: ProjectStore, review: BuildReviewReadiness) -> None:
+    """Persist first-build readiness or defer replacement until completed-build selection.
+
+    Args:
+        store: Project store owning review and completed-build state.
+        review: Readiness record for the deterministic trace and task build.
+
+    Raises:
+        ValueError: Existing review state is invalid or is not bound to a selected build.
+    """
+
+    def update(current: JsonValue | None) -> JsonObject:
+        """Validate and transition the build-review member under the review lock.
+
+        Args:
+            current: Current complete review JSON value.
+
+        Returns:
+            Current or updated object-shaped review state.
+
+        Raises:
+            ValueError: Existing build-review state is invalid or unselected.
+        """
+        root_review = _review_object(current)
+        prior = root_review.get("build_review")
+        if prior is None:
+            root_review["build_review"] = review.model_dump(mode="json")
+            return root_review
         try:
             existing = BuildReviewReadiness.model_validate(prior)
         except ValueError as exc:
             raise ValueError("review.json contains invalid build readiness") from exc
-        if existing != review:
-            raise ValueError("review.json already binds a different completed build")
-    root_review["build_review"] = serialized
-    store.write_review(root_review)
-    return ProjectBuild(artifacts=artifacts, review=review)
+        if existing == review or _completed_build_matches_review(store, review):
+            root_review["build_review"] = review.model_dump(mode="json")
+            return root_review
+        if _completed_build_matches_review(store, existing):
+            return root_review
+        raise ValueError("review.json already binds a different completed build")
+
+    store.update_review(update)
+
+
+def _review_object(current: JsonValue | None) -> JsonObject:
+    """Return mutable object-shaped review state.
+
+    Args:
+        current: Current parsed review value, or ``None`` before any review exists.
+
+    Returns:
+        Mutable copy of the current object-shaped review state.
+
+    Raises:
+        ValueError: Existing review state is not an object.
+    """
+    if current is None:
+        return {}
+    if isinstance(current, dict):
+        return dict(current)
+    raise ValueError("review.json must be an object before build readiness can be recorded")
+
+
+def _completed_build_matches_review(store: ProjectStore, review: BuildReviewReadiness) -> bool:
+    """Verify that the selected completed build authorizes advancing its review handoff.
+
+    Args:
+        store: Project store containing the mutable completed-build selection.
+        review: Existing review handoff that a subsequent build would replace.
+
+    Returns:
+        Whether the selected build and verified immutable manifests match the review handoff.
+    """
+    completed = store.load_project().build
+    if completed is None:
+        return False
+    if completed.trace_dataset != review.trace_dataset or completed.task_set != review.task_set:
+        return False
+    expected_types = {
+        "trace_dataset": "trace-dataset",
+        "task_set": "task-set",
+        "serving_rag": "trace-rag-index",
+        "fit_rag": "trace-rag-index",
+        "world_model": "grounded-world-model",
+    }
+    manifests = {}
+    for field_name, artifact_type in expected_types.items():
+        pointer = getattr(completed, field_name)
+        stored = store.artifacts.read(pointer.artifact_id)
+        if stored.manifest.artifact_type != artifact_type:
+            return False
+        if artifact_input(stored.manifest) != pointer:
+            return False
+        manifests[field_name] = stored.manifest
+    expected_inputs = {
+        "task_set": (completed.trace_dataset,),
+        "serving_rag": (completed.trace_dataset,),
+        "fit_rag": (completed.trace_dataset,),
+        "world_model": (completed.serving_rag,),
+    }
+    for field_name, inputs in expected_inputs.items():
+        if manifests[field_name].inputs != inputs:
+            return False
+    return True
 
 
 def _task_set_id(dataset_input: ArtifactInput, mining: TaskMiningResult) -> str:

--- a/wmo/simulation/build_test.py
+++ b/wmo/simulation/build_test.py
@@ -74,8 +74,10 @@ def test_build_task_set_uses_only_the_persisted_trace_dataset_as_task_set_input(
     assert store.read(built.task_set.task_set_id).manifest.inputs == (dataset_input,)
 
 
-def test_build_project_resumes_and_records_provider_free_review_readiness(tmp_path: Path) -> None:
-    """A repeated local build reuses immutable IDs and never invents rubric proposals."""
+def test_build_project_resumes_without_publishing_unselected_review_readiness(
+    tmp_path: Path,
+) -> None:
+    """A repeated local build returns one handoff without publishing it before selection."""
     store = ProjectStore(tmp_path, "project-a")
     store.initialize(ProjectConfig(project_id="project-a"))
     normalized = TraceNormalizationResult(
@@ -106,26 +108,14 @@ def test_build_project_resumes_and_records_provider_free_review_readiness(tmp_pa
     assert replay.review.source == _trace(0).source.identity
     assert replay.review.mining_spec == MiningSpec(fit_task_budget=1, held_out_task_budget=1)
     assert replay.review.code_revision == "test-revision"
-    assert store.read_review() == {"build_review": replay.review.model_dump(mode="json")}
+    assert store.read_review() is None
     assert len(store.artifacts.list_ids()) == 2
 
-    corrupt_review = replay.review.model_dump(mode="json")
-    corrupt_review["readiness_id"] = "build-review-00000000000000000000"
-    store.write_review({"build_review": corrupt_review})
-    with pytest.raises(ValueError, match="invalid build readiness"):
-        build_project(
-            normalized,
-            store,
-            created_at=datetime(2026, 8, 12, tzinfo=UTC),
-            code_revision="test-revision",
-            mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
-        )
 
-
-def test_build_project_refuses_unselected_revision_and_corrupt_replay_payload(
+def test_build_project_keeps_unselected_candidates_local_and_verifies_replay_payload(
     tmp_path: Path,
 ) -> None:
-    """An incomplete build cannot replace review state, and replay verifies stored bytes."""
+    """Candidate revisions do not publish readiness, and exact replay verifies stored bytes."""
     store = ProjectStore(tmp_path, "project-a")
     store.initialize(ProjectConfig(project_id="project-a"))
     normalized = TraceNormalizationResult(
@@ -138,17 +128,15 @@ def test_build_project_refuses_unselected_revision_and_corrupt_replay_payload(
         code_revision="test-revision",
         mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
     )
-    first_review = store.read_review()
-
-    with pytest.raises(ValueError, match="already binds a different completed build"):
-        build_project(
-            normalized,
-            store,
-            created_at=datetime(2026, 8, 12, tzinfo=UTC),
-            code_revision="changed-revision",
-            mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
-        )
-    assert store.read_review() == first_review
+    changed = build_project(
+        normalized,
+        store,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        code_revision="changed-revision",
+        mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
+    )
+    assert changed.review != first.review
+    assert store.read_review() is None
 
     trace_directory = store.artifacts.read(first.review.trace_dataset.artifact_id).directory
     (trace_directory / "traces.jsonl").write_text("corrupt\n", encoding="utf-8")

--- a/wmo/simulation/build_test.py
+++ b/wmo/simulation/build_test.py
@@ -122,8 +122,10 @@ def test_build_project_resumes_and_records_provider_free_review_readiness(tmp_pa
         )
 
 
-def test_build_project_refuses_changed_revision_and_corrupt_replay_payload(tmp_path: Path) -> None:
-    """Resume verifies the exact artifact envelope and bytes before returning readiness."""
+def test_build_project_refuses_unselected_revision_and_corrupt_replay_payload(
+    tmp_path: Path,
+) -> None:
+    """An incomplete build cannot replace review state, and replay verifies stored bytes."""
     store = ProjectStore(tmp_path, "project-a")
     store.initialize(ProjectConfig(project_id="project-a"))
     normalized = TraceNormalizationResult(
@@ -136,8 +138,9 @@ def test_build_project_refuses_changed_revision_and_corrupt_replay_payload(tmp_p
         code_revision="test-revision",
         mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
     )
+    first_review = store.read_review()
 
-    with pytest.raises(ValueError, match="differs from replayed normalized evidence"):
+    with pytest.raises(ValueError, match="already binds a different completed build"):
         build_project(
             normalized,
             store,
@@ -145,6 +148,7 @@ def test_build_project_refuses_changed_revision_and_corrupt_replay_payload(tmp_p
             code_revision="changed-revision",
             mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=1),
         )
+    assert store.read_review() == first_review
 
     trace_directory = store.artifacts.read(first.review.trace_dataset.artifact_id).directory
     (trace_directory / "traces.jsonl").write_text("corrupt\n", encoding="utf-8")

--- a/wmo/simulation/ingest/dataset.py
+++ b/wmo/simulation/ingest/dataset.py
@@ -71,6 +71,7 @@ def persist_trace_dataset(
             "semantic_convention_version": semantic_convention_version,
             "traces_sha256": hashlib.sha256(traces_payload).hexdigest(),
             "issues_sha256": hashlib.sha256(issues_payload).hexdigest(),
+            "code_revision": code_revision,
         },
     )
     dataset = TraceDataset(

--- a/wmo/simulation/ingest/dataset_test.py
+++ b/wmo/simulation/ingest/dataset_test.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 import pytest
 
-from wmo.common.core.artifacts import SourceIdentity
+from wmo.common.core.artifacts import SourceIdentity, stable_id
 from wmo.common.project import ArtifactStore, artifact_input
 from wmo.common.project.paths import ProjectPaths
-from wmo.common.traces import Trace, TraceDataset, TraceSource, TraceSpan
+from wmo.common.traces import Trace, TraceDataset, TraceSource, TraceSpan, load_trace_dataset
 from wmo.simulation.ingest.dataset import persist_trace_dataset
 from wmo.simulation.ingest.otlp import TraceNormalizationIssue, TraceNormalizationResult
 
@@ -111,10 +111,10 @@ def test_persist_trace_dataset_is_content_addressed_despite_input_order(tmp_path
     assert first_persisted.manifest == second_persisted.manifest
 
 
-def test_persist_trace_dataset_returns_exact_replay_and_refuses_changed_envelope(
+def test_persist_trace_dataset_returns_exact_replay_and_versions_producer_revision(
     tmp_path: Path,
 ) -> None:
-    """A completed dataset resumes exactly but rejects changed provenance under the same ID."""
+    """A completed dataset resumes exactly and a new producer revision gets a new identity."""
     result = TraceNormalizationResult(traces=(_trace(1),), issues=())
     store = _store(tmp_path, "project-a")
     first = persist_trace_dataset(
@@ -132,15 +132,73 @@ def test_persist_trace_dataset_returns_exact_replay_and_refuses_changed_envelope
     )
     assert replay == first
 
+    changed_revision = persist_trace_dataset(
+        result,
+        store,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        code_revision="changed-revision",
+    )
+
+    assert changed_revision.dataset.dataset_id != first.dataset.dataset_id
+    assert changed_revision.dataset.code_revision == "changed-revision"
+    assert store.read(first.dataset.dataset_id).manifest == first.manifest
+
+
+def test_persist_trace_dataset_rejects_changed_evidence_under_explicit_id(
+    tmp_path: Path,
+) -> None:
+    """An explicit immutable dataset identity cannot be reused for changed evidence."""
+    store = _store(tmp_path, "project-a")
+    persist_trace_dataset(
+        TraceNormalizationResult(traces=(_trace(1),), issues=()),
+        store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+        dataset_id="trace-dataset-explicit",
+    )
+
     with pytest.raises(ValueError, match="differs from replayed normalized evidence"):
         persist_trace_dataset(
-            result,
+            TraceNormalizationResult(traces=(_trace(2),), issues=()),
             store,
             created_at=datetime(2026, 8, 12, tzinfo=UTC),
-            code_revision="changed-revision",
+            code_revision="test-revision",
+            dataset_id="trace-dataset-explicit",
         )
 
-    assert store.read(first.dataset.dataset_id).manifest == first.manifest
+
+def test_load_trace_dataset_accepts_pre_revision_identity(tmp_path: Path) -> None:
+    """The loader keeps accepting artifacts whose historical ID omitted producer revision."""
+    result = TraceNormalizationResult(traces=(_trace(1),), issues=())
+    probe = persist_trace_dataset(
+        result,
+        _store(tmp_path / "probe", "project-a"),
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+    )
+    assert probe.dataset.source is not None
+    legacy_id = stable_id(
+        "trace-dataset",
+        {
+            "source": probe.dataset.source.model_dump(mode="json"),
+            "semantic_convention_version": probe.dataset.semantic_convention_version,
+            "traces_sha256": probe.dataset.traces_sha256,
+            "issues_sha256": probe.dataset.issues_sha256,
+        },
+    )
+    legacy_store = _store(tmp_path / "legacy", "project-a")
+    legacy = persist_trace_dataset(
+        result,
+        legacy_store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+        dataset_id=legacy_id,
+    )
+
+    loaded = load_trace_dataset(legacy_store, legacy_id)
+
+    assert loaded.dataset == legacy.dataset
+    assert loaded.traces == legacy.traces
 
 
 def test_persist_trace_dataset_rejects_mixed_raw_source_provenance(tmp_path: Path) -> None:

--- a/wmo/workflow/automatic_router_test.py
+++ b/wmo/workflow/automatic_router_test.py
@@ -53,7 +53,7 @@ from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.runtime.agents import ChatAgentRuntime
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router.application import RouterApplicationError, load_project_router
-from wmo.simulation.build import build_project
+from wmo.simulation.build import build_project, select_completed_build
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
 from wmo.simulation.mining.service import MiningSpec
 from wmo.workflow.automatic_router import (
@@ -904,7 +904,7 @@ def _completed_project(
         resolved_embedder=runtime.resolve("embedder"),
         top_k=2,
     )
-    store.bind_completed_build(completed)
+    select_completed_build(store, completed, built.review)
     return store, catalog, state
 
 

--- a/wmo/workflow/manual_judge.py
+++ b/wmo/workflow/manual_judge.py
@@ -35,11 +35,19 @@ from wmo.runtime.models.providers.retry import RetryPolicy
 from wmo.runtime.models.registry import RuntimeModelCatalog
 from wmo.simulation.build import BuildReviewReadiness
 from wmo.workflow.manual_judge_artifacts import (
+    coordinate_manual_judge_calibration,
+    coordinate_manual_judge_setup,
     find_provisional_calibration,
     replay_or_approve,
     write_audit,
     write_production_rollout,
     write_review_state,
+)
+from wmo.workflow.manual_judge_artifacts import (
+    load_build_review as _load_build_review,
+)
+from wmo.workflow.manual_judge_artifacts import (
+    require_exact_build_inputs as _require_exact_build_inputs,
 )
 from wmo.workflow.manual_judge_contracts import (
     JudgeCalibrationBudget,
@@ -220,6 +228,7 @@ def prepare_manual_judge_setup(
     )
 
 
+@coordinate_manual_judge_setup
 def commit_manual_judge_setup(
     store: ProjectStore,
     plan: ManualJudgeSetupPlan,
@@ -407,6 +416,7 @@ def estimate_manual_judge_budget(
     )
 
 
+@coordinate_manual_judge_calibration
 def calibrate_manual_judge(
     store: ProjectStore,
     runtime_catalog: RuntimeModelCatalog,
@@ -606,46 +616,6 @@ def calibrate_manual_judge(
         approved_at=created_at,
         provider_calls_made=provider_calls,
     )
-
-
-def _load_build_review(store: ProjectStore) -> BuildReviewReadiness:
-    """Load the exact completed-build handoff from mutable review state.
-
-    Args:
-        store: Project-local review store.
-
-    Returns:
-        Validated completed-build readiness.
-
-    Raises:
-        ManualJudgeError: The build handoff is absent or malformed.
-    """
-    review = store.read_review()
-    if not isinstance(review, dict) or "build_review" not in review:
-        raise ManualJudgeError("project has no completed build; run wmo build first")
-    try:
-        return BuildReviewReadiness.model_validate(review["build_review"])
-    except ValueError as exc:
-        raise ManualJudgeError("project build review is invalid") from exc
-
-
-def _require_exact_build_inputs(store: ProjectStore, build: BuildReviewReadiness) -> None:
-    """Verify build trace and task manifests before preview or persistence.
-
-    Args:
-        store: Project-local immutable artifact store.
-        build: Build handoff naming exact trace and task inputs.
-
-    Raises:
-        ManualJudgeError: Either manifest changed or the task set is not trace-bound.
-    """
-    trace_input = artifact_input(store.artifacts.read(build.trace_dataset.artifact_id).manifest)
-    task_input = artifact_input(store.artifacts.read(build.task_set.artifact_id).manifest)
-    if trace_input != build.trace_dataset or task_input != build.task_set:
-        raise ManualJudgeError("completed build artifact manifest changed")
-    task_set = load_task_set(store.artifacts, build.task_set.artifact_id).task_set
-    if task_set.inputs != (trace_input,):
-        raise ManualJudgeError("completed task set does not bind the exact trace dataset")
 
 
 def _write_setup(store: ProjectStore, setup: ManualJudgeSetupArtifact) -> ArtifactInput:

--- a/wmo/workflow/manual_judge_artifacts.py
+++ b/wmo/workflow/manual_judge_artifacts.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime
-from typing import TYPE_CHECKING
+from functools import wraps
+from typing import Concatenate, Protocol
 
 from pydantic import JsonValue
 
 from wmo.common.core.artifacts import ArtifactInput, JsonObject, stable_id
+from wmo.common.core.locks import FileLockTimeout
 from wmo.common.judging import (
     CalibrationReport,
     JudgeCalibration,
@@ -15,11 +20,18 @@ from wmo.common.judging import (
 )
 from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
 from wmo.common.models import AssistantAction, OperationEconomics, Usage
-from wmo.common.project import ArtifactAlreadyExistsError, ProjectStore, artifact_input
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactStoreError,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
 from wmo.common.rollouts import RolloutArtifact, SimulationMode, StopReason
 from wmo.common.rollouts.otel import ProductionSimulatorSnapshot, RolloutEventKind, RolloutSpan
-from wmo.common.tasks import TaskCase
+from wmo.common.tasks import TaskCase, load_task_set
 from wmo.common.traces import Trace, TraceSpan
+from wmo.simulation.build import BuildReviewReadiness, coordinate_selected_build_review
 from wmo.workflow.manual_judge_contracts import (
     JudgeCalibrationBudget,
     JudgeRunEvidence,
@@ -30,8 +42,198 @@ from wmo.workflow.manual_judge_contracts import (
     ManualJudgeSetupArtifact,
 )
 
-if TYPE_CHECKING:
-    pass
+
+class _BuildEvidence(Protocol):
+    """Structural trace and task binding required by coordinated judge plans."""
+
+    @property
+    def trace_dataset(self) -> ArtifactInput:
+        """Return the exact trace dataset pointer."""
+        ...
+
+    @property
+    def task_set(self) -> ArtifactInput:
+        """Return the exact task-set pointer."""
+        ...
+
+
+class _SetupMutationPlan(Protocol):
+    """Structural setup plan exposing its completed-build evidence."""
+
+    @property
+    def build(self) -> _BuildEvidence:
+        """Return the reviewed completed-build binding."""
+        ...
+
+
+class _CalibrationMutationPlan(Protocol):
+    """Structural calibration plan exposing its finalized setup evidence."""
+
+    @property
+    def setup(self) -> _BuildEvidence:
+        """Return the finalized setup build binding."""
+        ...
+
+
+_ACTIVE_BUILD_BINDING: ContextVar[tuple[str, ArtifactInput, ArtifactInput] | None] = ContextVar(
+    "manual_judge_active_build_binding",
+    default=None,
+)
+
+
+def coordinate_manual_judge_setup[SetupPlanT: _SetupMutationPlan, **P, R](
+    operation: Callable[Concatenate[ProjectStore, SetupPlanT, P], R],
+) -> Callable[Concatenate[ProjectStore, SetupPlanT, P], R]:
+    """Wrap a setup mutation in the plan's stable selected-build transaction.
+
+    Args:
+        operation: Setup mutation whose first arguments are the project store and setup plan.
+
+    Returns:
+        Signature-preserving operation serialized with completed-build replacement.
+    """
+
+    @wraps(operation)
+    def coordinated(
+        store: ProjectStore,
+        plan: SetupPlanT,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
+        """Run the setup mutation against one stable selected build."""
+        with coordinate_manual_judge_review(
+            store,
+            trace_dataset=plan.build.trace_dataset,
+            task_set=plan.build.task_set,
+        ):
+            return operation(store, plan, *args, **kwargs)
+
+    return coordinated
+
+
+def coordinate_manual_judge_calibration[
+    CatalogT,
+    CalibrationPlanT: _CalibrationMutationPlan,
+    **P,
+    R,
+](
+    operation: Callable[
+        Concatenate[ProjectStore, CatalogT, CalibrationPlanT, P],
+        R,
+    ],
+) -> Callable[Concatenate[ProjectStore, CatalogT, CalibrationPlanT, P], R]:
+    """Wrap calibration in the finalized setup's stable selected-build transaction.
+
+    Args:
+        operation: Calibration mutation beginning with store, runtime catalog, and plan.
+
+    Returns:
+        Signature-preserving operation serialized with completed-build replacement.
+    """
+
+    @wraps(operation)
+    def coordinated(
+        store: ProjectStore,
+        catalog: CatalogT,
+        plan: CalibrationPlanT,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
+        """Run calibration against one stable selected build."""
+        with coordinate_manual_judge_review(
+            store,
+            trace_dataset=plan.setup.trace_dataset,
+            task_set=plan.setup.task_set,
+        ):
+            return operation(store, catalog, plan, *args, **kwargs)
+
+    return coordinated
+
+
+@contextmanager
+def coordinate_manual_judge_review(
+    store: ProjectStore,
+    *,
+    trace_dataset: ArtifactInput,
+    task_set: ArtifactInput,
+) -> Iterator[None]:
+    """Keep one manual-judge operation bound to a stable selected build.
+
+    Nested review-state writes reuse the outer operation lock only when they name the same exact
+    trace and task inputs. Independent operations contend through the project-local build-review
+    coordination lock.
+
+    Args:
+        store: Project whose selected build supplies the judge evidence.
+        trace_dataset: Exact trace artifact consumed by the judge operation.
+        task_set: Exact task artifact consumed by the judge operation.
+
+    Yields:
+        None while completed-build replacement is excluded.
+
+    Raises:
+        ManualJudgeError: The nested or selected build binding differs from the requested inputs.
+    """
+    requested = (str(store.paths.project_directory.absolute()), trace_dataset, task_set)
+    active = _ACTIVE_BUILD_BINDING.get()
+    if active is not None:
+        if active != requested:
+            raise ManualJudgeError("nested manual judge state names a different project or build")
+        yield
+        return
+    try:
+        with coordinate_selected_build_review(
+            store,
+            trace_dataset=trace_dataset,
+            task_set=task_set,
+        ):
+            token = _ACTIVE_BUILD_BINDING.set(requested)
+            try:
+                yield
+            finally:
+                _ACTIVE_BUILD_BINDING.reset(token)
+    except (ArtifactStoreError, FileLockTimeout, ProjectStoreError, ValueError) as exc:
+        raise ManualJudgeError(str(exc)) from exc
+
+
+def load_build_review(store: ProjectStore) -> BuildReviewReadiness:
+    """Load the exact completed-build handoff from mutable review state.
+
+    Args:
+        store: Project-local review store.
+
+    Returns:
+        Validated completed-build readiness.
+
+    Raises:
+        ManualJudgeError: The build handoff is absent or malformed.
+    """
+    review = store.read_review()
+    if not isinstance(review, dict) or "build_review" not in review:
+        raise ManualJudgeError("project has no completed build; run wmo build first")
+    try:
+        return BuildReviewReadiness.model_validate(review["build_review"])
+    except ValueError as exc:
+        raise ManualJudgeError("project build review is invalid") from exc
+
+
+def require_exact_build_inputs(store: ProjectStore, build: BuildReviewReadiness) -> None:
+    """Verify build trace and task manifests before preview or persistence.
+
+    Args:
+        store: Project-local immutable artifact store.
+        build: Build handoff naming exact trace and task inputs.
+
+    Raises:
+        ManualJudgeError: Either manifest changed or the task set is not trace-bound.
+    """
+    trace_input = artifact_input(store.artifacts.read(build.trace_dataset.artifact_id).manifest)
+    task_input = artifact_input(store.artifacts.read(build.task_set.artifact_id).manifest)
+    if trace_input != build.trace_dataset or task_input != build.task_set:
+        raise ManualJudgeError("completed build artifact manifest changed")
+    task_set = load_task_set(store.artifacts, build.task_set.artifact_id).task_set
+    if task_set.inputs != (trace_input,):
+        raise ManualJudgeError("completed task set does not bind the exact trace dataset")
 
 
 def rollout_id(task: TaskCase, trace: Trace) -> str:
@@ -55,15 +257,27 @@ def rollout_id(task: TaskCase, trace: Trace) -> str:
 
 
 def write_review_state(store: ProjectStore, state: ManualJudgeReviewState) -> None:
-    """Update only the manual judge namespace under the project review lock.
+    """Update manual judge state only while its selected build remains current.
 
     Args:
         store: Project-local review store.
         state: Complete replacement manual judge state.
 
     Raises:
-        ManualJudgeError: Existing review state is not an object.
+        ManualJudgeError: Setup provenance, selected build, or review state is invalid.
     """
+    try:
+        setup, setup_input = read_artifact_json(
+            store,
+            artifact_id=state.setup.artifact_id,
+            expected_artifact_type="manual-judge-setup",
+            relative_path="setup.json",
+            model_type=ManualJudgeSetupArtifact,
+        )
+    except JudgingProvenanceError as exc:
+        raise ManualJudgeError("manual judge setup is unavailable for review update") from exc
+    if setup_input != state.setup:
+        raise ManualJudgeError("manual judge setup manifest differs from review state")
 
     def update(current: JsonValue | None) -> JsonObject:
         """Preserve unrelated review namespaces while replacing manual judge state.
@@ -86,7 +300,12 @@ def write_review_state(store: ProjectStore, state: ManualJudgeReviewState) -> No
         root["manual_judge"] = state.model_dump(mode="json")
         return root
 
-    store.update_review(update)
+    with coordinate_manual_judge_review(
+        store,
+        trace_dataset=setup.trace_dataset,
+        task_set=setup.task_set,
+    ):
+        store.update_review(update)
 
 
 def find_provisional_calibration(

--- a/wmo/workflow/manual_judge_test.py
+++ b/wmo/workflow/manual_judge_test.py
@@ -21,7 +21,14 @@ from wmo.common.core.artifacts import (
     sha256_json,
     stable_id,
 )
-from wmo.common.judging import PromptDefinition
+from wmo.common.judging import (
+    HumanScore,
+    HumanScoreHistory,
+    HumanScoreReview,
+    PromptDefinition,
+    RubricDimension,
+    RubricReview,
+)
 from wmo.common.judging.judgment import Judgment
 from wmo.common.models import (
     AssistantAction,
@@ -35,7 +42,13 @@ from wmo.common.models import (
     ModelSnapshot,
     OperationEconomics,
 )
-from wmo.common.project import ProjectBuildArtifacts, ProjectConfig, ProjectStore, artifact_input
+from wmo.common.project import (
+    ProjectBuildArtifacts,
+    ProjectConfig,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.runtime.models.registry import ResolvedModel, RuntimeModelCatalog
 from wmo.simulation.build import ProjectBuild, build_project, select_completed_build
@@ -633,6 +646,209 @@ def test_build_replacement_crash_blocks_stale_judge_commit_and_recovers(
     final_review = store.read_review()
     assert isinstance(final_review, dict)
     assert final_review["manual_judge"]["setup"]["artifact_id"] == current_setup.setup_id
+
+
+def test_build_replacement_serializes_direct_rubric_writer_and_removes_stale_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct rubric writer finishes before selection cleanup and cannot restore A later.
+
+    Args:
+        tmp_path: Isolated project and immutable artifact root.
+        monkeypatch: Patch fixture pausing the rubric transition inside both coordination locks.
+    """
+    store = _built_store(tmp_path)
+    selected_a = store.load_project().build
+    assert selected_a is not None
+    plan = prepare_manual_judge_setup(
+        store,
+        _catalog(),
+        created_at=_TIME,
+        code_revision="test-revision",
+    )
+    stale = RubricReview.open(
+        store,
+        source_task_set_id=selected_a.task_set.artifact_id,
+        code_revision="test-revision",
+        clock=lambda: _TIME,
+    )
+    stale.replace_all(plan.dimensions)
+    replacement = build_project(
+        TraceNormalizationResult(traces=tuple(_trace(index) for index in range(100)), issues=()),
+        store,
+        created_at=_TIME + timedelta(seconds=1),
+        code_revision="replacement-revision",
+        mining_spec=MiningSpec(fit_task_budget=3, held_out_task_budget=1),
+    )
+    completed_b = _persist_grounded_build(store, replacement, select=False)
+    writer_paused = Event()
+    release_writer = Event()
+    writer_errors: list[BaseException] = []
+    selector_errors: list[BaseException] = []
+    original_replace = RubricReview._replace
+
+    def pause_replace(
+        review: RubricReview,
+        *,
+        dimensions: tuple[RubricDimension, ...],
+        event_kind: Literal["accept", "reject", "edit", "add", "replace_all", "order"],
+        event_dimension_ids: tuple[str, ...],
+        rejected_dimension_ids: tuple[str, ...] | None = None,
+    ) -> None:
+        """Pause one rubric mutation while it owns build and review coordination.
+
+        Args:
+            review: Working rubric service applying the locked transition.
+            dimensions: Complete active rubric dimensions after the transition.
+            event_kind: Exact transition kind recorded in the review history.
+            event_dimension_ids: Dimension identities affected by the transition.
+            rejected_dimension_ids: Optional complete rejected-dimension replacement.
+        """
+        writer_paused.set()
+        assert release_writer.wait(timeout=5)
+        original_replace(
+            review,
+            dimensions=dimensions,
+            event_kind=event_kind,
+            event_dimension_ids=event_dimension_ids,
+            rejected_dimension_ids=rejected_dimension_ids,
+        )
+
+    def run_writer() -> None:
+        """Record any unexpected direct rubric-writer failure."""
+        try:
+            stale.order(tuple(item.dimension_id for item in plan.dimensions))
+        except BaseException as exc:  # noqa: BLE001 - thread reports its terminal result
+            writer_errors.append(exc)
+
+    def run_selector() -> None:
+        """Select build B after the rubric writer releases coordination."""
+        try:
+            select_completed_build(store, completed_b, replacement.review)
+        except BaseException as exc:  # noqa: BLE001 - thread reports its terminal result
+            selector_errors.append(exc)
+
+    monkeypatch.setattr(RubricReview, "_replace", pause_replace)
+    writer = Thread(target=run_writer, daemon=True)
+    writer.start()
+    assert writer_paused.wait(timeout=5)
+    selector = Thread(target=run_selector, daemon=True)
+    selector.start()
+    selector.join(timeout=0.1)
+    assert selector.is_alive()
+    release_writer.set()
+    writer.join(timeout=5)
+    selector.join(timeout=5)
+
+    assert not writer.is_alive()
+    assert not selector.is_alive()
+    assert writer_errors == []
+    assert selector_errors == []
+    saved = store.read_review()
+    assert isinstance(saved, dict)
+    assert saved["build_review"]["readiness_id"] == replacement.review.readiness_id
+    assert "rubric_review" not in saved
+    with pytest.raises(ProjectStoreError, match="selected completed build"):
+        stale.order(tuple(item.dimension_id for item in plan.dimensions))
+
+
+def test_build_replacement_serializes_human_score_writer_and_removes_stale_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct score writer cannot race build cleanup or restore build-A labels afterward.
+
+    Args:
+        tmp_path: Isolated project and immutable artifact root.
+        monkeypatch: Patch fixture pausing score history mutation inside both coordination locks.
+    """
+    store = _built_store(tmp_path)
+    setup = _setup(store)
+    selected_a = store.load_project().build
+    assert selected_a is not None
+    stale = HumanScoreReview.open(store)
+    replacement = build_project(
+        TraceNormalizationResult(traces=tuple(_trace(index) for index in range(100)), issues=()),
+        store,
+        created_at=_TIME + timedelta(seconds=1),
+        code_revision="replacement-revision",
+        mining_spec=MiningSpec(fit_task_budget=3, held_out_task_budget=1),
+    )
+    completed_b = _persist_grounded_build(store, replacement, select=False)
+    writer_paused = Event()
+    release_writer = Event()
+    writer_errors: list[BaseException] = []
+    selector_errors: list[BaseException] = []
+    original_append = HumanScoreHistory.append
+
+    def pause_append(history: HumanScoreHistory, score: HumanScore) -> HumanScoreHistory:
+        """Pause one score mutation while it owns build and review coordination.
+
+        Args:
+            history: Latest persisted score history.
+            score: Human score being appended.
+
+        Returns:
+            Updated score history after the selector has begun waiting.
+        """
+        writer_paused.set()
+        assert release_writer.wait(timeout=5)
+        return original_append(history, score)
+
+    def run_writer() -> None:
+        """Record any unexpected direct score-writer failure."""
+        try:
+            stale.upsert(
+                rubric_id=setup.rubric.artifact_id,
+                rollout_id="rollout-a",
+                lineage_id="lineage-a",
+                dimension_id="task-success",
+                score=3,
+                submission_id="submission-a",
+                created_at=_TIME,
+            )
+        except BaseException as exc:  # noqa: BLE001 - thread reports its terminal result
+            writer_errors.append(exc)
+
+    def run_selector() -> None:
+        """Select build B after the score writer releases coordination."""
+        try:
+            select_completed_build(store, completed_b, replacement.review)
+        except BaseException as exc:  # noqa: BLE001 - thread reports its terminal result
+            selector_errors.append(exc)
+
+    monkeypatch.setattr(HumanScoreHistory, "append", pause_append)
+    writer = Thread(target=run_writer, daemon=True)
+    writer.start()
+    assert writer_paused.wait(timeout=5)
+    selector = Thread(target=run_selector, daemon=True)
+    selector.start()
+    selector.join(timeout=0.1)
+    assert selector.is_alive()
+    release_writer.set()
+    writer.join(timeout=5)
+    selector.join(timeout=5)
+
+    assert not writer.is_alive()
+    assert not selector.is_alive()
+    assert writer_errors == []
+    assert selector_errors == []
+    saved = store.read_review()
+    assert isinstance(saved, dict)
+    assert saved["build_review"]["readiness_id"] == replacement.review.readiness_id
+    assert "human_score_history" not in saved
+    assert "human_score_submissions" not in saved
+    with pytest.raises(ValueError, match="selected completed build"):
+        stale.upsert(
+            rubric_id=setup.rubric.artifact_id,
+            rollout_id="rollout-a",
+            lineage_id="lineage-a",
+            dimension_id="task-success",
+            score=4,
+            submission_id="submission-b",
+            created_at=_TIME + timedelta(seconds=2),
+        )
 
 
 def test_calibration_refuses_before_resolution_write_or_model_call(tmp_path: Path) -> None:

--- a/wmo/workflow/manual_judge_test.py
+++ b/wmo/workflow/manual_judge_test.py
@@ -7,12 +7,20 @@ import re
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from threading import Event, Thread
 from typing import Literal, cast
 
 import pytest
 
+import wmo.simulation.build as simulation_build
 import wmo.workflow.manual_judge as manual_judge_workflow
-from wmo.common.core.artifacts import JsonObject, SourceIdentity, sha256_json
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    JsonObject,
+    SourceIdentity,
+    sha256_json,
+    stable_id,
+)
 from wmo.common.judging import PromptDefinition
 from wmo.common.judging.judgment import Judgment
 from wmo.common.models import (
@@ -27,10 +35,10 @@ from wmo.common.models import (
     ModelSnapshot,
     OperationEconomics,
 )
-from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.common.project import ProjectBuildArtifacts, ProjectConfig, ProjectStore, artifact_input
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.runtime.models.registry import ResolvedModel, RuntimeModelCatalog
-from wmo.simulation.build import build_project
+from wmo.simulation.build import ProjectBuild, build_project, select_completed_build
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
 from wmo.simulation.mining.service import MiningSpec
 from wmo.workflow.manual_judge import (
@@ -275,6 +283,83 @@ def _unique_task_trace(index: int) -> Trace:
     return _trace(index).model_copy(update={"task": f"Handle unique request {suffix}"})
 
 
+def _persist_grounded_build(
+    store: ProjectStore,
+    built: ProjectBuild,
+    *,
+    select: bool,
+) -> ProjectBuildArtifacts:
+    """Persist a complete immutable graph and optionally select it for judge mutations.
+
+    Args:
+        store: Initialized project receiving the grounded graph.
+        built: Deterministic trace and task build awaiting grounded artifacts.
+        select: Whether to bind the graph and advance its build review immediately.
+
+    Returns:
+        Complete grounded artifact pointers, selected when requested.
+    """
+    trace_input = artifact_input(built.artifacts.trace_dataset.manifest)
+    created_at = built.artifacts.trace_dataset.dataset.created_at
+    revision = built.review.code_revision
+    serving_id = stable_id(
+        "test-serving-rag",
+        {"trace_dataset": trace_input.model_dump(mode="json")},
+    )
+    serving_manifest = store.artifacts.write_json(
+        artifact_id=serving_id,
+        artifact_type="trace-rag-index",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=created_at,
+            inputs=(trace_input,),
+            code_revision=revision,
+        ),
+        files={"fixture.json": {"partition": "serving"}},
+    )
+    fit_id = stable_id(
+        "test-fit-rag",
+        {"trace_dataset": trace_input.model_dump(mode="json")},
+    )
+    fit_manifest = store.artifacts.write_json(
+        artifact_id=fit_id,
+        artifact_type="trace-rag-index",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=created_at,
+            inputs=(trace_input,),
+            code_revision=revision,
+        ),
+        files={"fixture.json": {"partition": "fit"}},
+    )
+    serving_input = artifact_input(serving_manifest)
+    world_id = stable_id(
+        "test-grounded-world-model",
+        {"serving_rag": serving_input.model_dump(mode="json")},
+    )
+    world_manifest = store.artifacts.write_json(
+        artifact_id=world_id,
+        artifact_type="grounded-world-model",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=created_at,
+            inputs=(serving_input,),
+            code_revision=revision,
+        ),
+        files={"fixture.json": {"model_alias": "judge-main"}},
+    )
+    completed = ProjectBuildArtifacts(
+        trace_dataset=trace_input,
+        task_set=built.review.task_set,
+        serving_rag=serving_input,
+        fit_rag=artifact_input(fit_manifest),
+        world_model=artifact_input(world_manifest),
+    )
+    if select:
+        select_completed_build(store, completed, built.review)
+    return completed
+
+
 def _built_store(tmp_path: Path) -> ProjectStore:
     """Create a completed build with three fit lineages and one held-out lineage.
 
@@ -286,13 +371,14 @@ def _built_store(tmp_path: Path) -> ProjectStore:
     """
     store = ProjectStore(tmp_path / ".wmo", "support")
     store.initialize(ProjectConfig(project_id="support"))
-    build_project(
+    built = build_project(
         TraceNormalizationResult(traces=tuple(_trace(index) for index in range(100)), issues=()),
         store,
         created_at=_TIME,
         code_revision="test-revision",
         mining_spec=MiningSpec(fit_task_budget=3, held_out_task_budget=1),
     )
+    _persist_grounded_build(store, built, select=True)
     return store
 
 
@@ -307,7 +393,7 @@ def _unpaired_trace_store(tmp_path: Path) -> ProjectStore:
     """
     store = ProjectStore(tmp_path / ".wmo", "support")
     store.initialize(ProjectConfig(project_id="support"))
-    build_project(
+    built = build_project(
         TraceNormalizationResult(
             traces=tuple(_unique_task_trace(index) for index in range(100)), issues=()
         ),
@@ -320,6 +406,7 @@ def _unpaired_trace_store(tmp_path: Path) -> ProjectStore:
             semantic_duplicate_threshold=1.0,
         ),
     )
+    _persist_grounded_build(store, built, select=True)
     return store
 
 
@@ -418,6 +505,134 @@ def test_setup_failure_is_read_only_and_setup_never_calls_a_model(tmp_path: Path
         commit_manual_judge_setup(store, plan, confirmed=False)
     assert store.read_review() == before_review
     assert store.artifacts.list_ids() == before_artifacts
+
+
+def test_build_replacement_crash_blocks_stale_judge_commit_and_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale judge setup cannot cross an interrupted replacement selection.
+
+    Args:
+        tmp_path: Isolated project and immutable artifact root.
+        monkeypatch: Patch fixture controlling the bind-to-review interruption.
+    """
+    store = _built_store(tmp_path)
+    selected_a = store.load_project().build
+    assert selected_a is not None
+    old_manifests = {
+        pointer.artifact_id: store.artifacts.read(pointer.artifact_id).manifest
+        for pointer in (
+            selected_a.trace_dataset,
+            selected_a.task_set,
+            selected_a.serving_rag,
+            selected_a.fit_rag,
+            selected_a.world_model,
+        )
+    }
+    stale_plan = prepare_manual_judge_setup(
+        store,
+        _catalog(),
+        created_at=_TIME,
+        code_revision="test-revision",
+    )
+    selected_setup = commit_manual_judge_setup(store, stale_plan, confirmed=True)
+    selected_review = store.read_review()
+    assert isinstance(selected_review, dict)
+    assert selected_review["manual_judge"]["setup"]["artifact_id"] == selected_setup.setup_id
+    assert "rubric_review" in selected_review
+    replacement = build_project(
+        TraceNormalizationResult(traces=tuple(_trace(index) for index in range(100)), issues=()),
+        store,
+        created_at=_TIME + timedelta(seconds=1),
+        code_revision="replacement-revision",
+        mining_spec=MiningSpec(fit_task_budget=3, held_out_task_budget=1),
+    )
+    completed_b = _persist_grounded_build(store, replacement, select=False)
+    selection_paused = Event()
+    release_selection = Event()
+    judge_started = Event()
+    builder_errors: list[BaseException] = []
+    judge_errors: list[BaseException] = []
+    original_select_review = simulation_build.select_build_review
+
+    def interrupt_after_bind(*_args: object, **_kwargs: object) -> None:
+        """Pause after selecting graph B, then simulate interruption before review B.
+
+        Raises:
+            RuntimeError: Always after the test releases the paused selection.
+        """
+        selection_paused.set()
+        assert release_selection.wait(timeout=5)
+        raise RuntimeError("injected interruption after completed-build selection")
+
+    def run_builder() -> None:
+        """Capture the expected interrupted replacement result."""
+        try:
+            select_completed_build(store, completed_b, replacement.review)
+        except BaseException as exc:  # noqa: BLE001 - thread must report every terminal result
+            builder_errors.append(exc)
+
+    def run_stale_judge() -> None:
+        """Capture the stale judge commit result without terminating the test process."""
+        judge_started.set()
+        try:
+            commit_manual_judge_setup(store, stale_plan, confirmed=True)
+        except BaseException as exc:  # noqa: BLE001 - thread must report every terminal result
+            judge_errors.append(exc)
+
+    monkeypatch.setattr(simulation_build, "select_build_review", interrupt_after_bind)
+    builder = Thread(target=run_builder, daemon=True)
+    builder.start()
+    assert selection_paused.wait(timeout=5)
+    assert store.load_project().build == completed_b
+    stale_review = store.read_review()
+    assert isinstance(stale_review, dict)
+    assert stale_review["build_review"]["readiness_id"] == stale_plan.build.readiness_id
+
+    judge = Thread(target=run_stale_judge, daemon=True)
+    judge.start()
+    assert judge_started.wait(timeout=5)
+    judge.join(timeout=0.1)
+    assert judge.is_alive()
+    release_selection.set()
+    builder.join(timeout=5)
+    judge.join(timeout=5)
+    assert not builder.is_alive()
+    assert not judge.is_alive()
+    assert len(builder_errors) == 1
+    assert "injected interruption" in str(builder_errors[0])
+    assert len(judge_errors) == 1
+    assert isinstance(judge_errors[0], ManualJudgeError)
+    assert "not synchronized" in str(judge_errors[0])
+    assert store.load_project().build == completed_b
+    assert store.read_review() == stale_review
+
+    monkeypatch.setattr(simulation_build, "select_build_review", original_select_review)
+    select_completed_build(store, completed_b, replacement.review)
+    recovered_review = store.read_review()
+    assert isinstance(recovered_review, dict)
+    assert recovered_review["build_review"]["readiness_id"] == replacement.review.readiness_id
+    for stale_key in (
+        "manual_judge",
+        "rubric_review",
+        "human_score_history",
+        "human_score_submissions",
+    ):
+        assert stale_key not in recovered_review
+    for artifact_id, manifest in old_manifests.items():
+        assert store.artifacts.read(artifact_id).manifest == manifest
+
+    current_plan = prepare_manual_judge_setup(
+        store,
+        _catalog(),
+        created_at=_TIME + timedelta(seconds=2),
+        code_revision="replacement-revision",
+    )
+    current_setup = commit_manual_judge_setup(store, current_plan, confirmed=True)
+    final_review = store.read_review()
+    assert isinstance(final_review, dict)
+    assert final_review["manual_judge"]["setup"]["artifact_id"] == current_setup.setup_id
 
 
 def test_calibration_refuses_before_resolution_write_or_model_call(tmp_path: Path) -> None:

--- a/wmo/workflow/router_test.py
+++ b/wmo/workflow/router_test.py
@@ -49,7 +49,7 @@ from wmo.common.tasks import load_task_set
 from wmo.optimize.router.workflow_test import _persist_embeddings, _persist_pricing
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router.runtime_test import _Client, _request
-from wmo.simulation.build import ProjectBuild, build_project
+from wmo.simulation.build import ProjectBuild, build_project, select_completed_build
 from wmo.simulation.engines.text.simulator import WorldModelSimulator
 from wmo.simulation.engines.text.simulator_test import (
     _OneTurnAgent,
@@ -140,7 +140,7 @@ def _bind_completed_build(
         fit_rag=artifact_input(fit.manifest),
         world_model=artifact_input(world.manifest),
     )
-    project.bind_completed_build(completed)
+    select_completed_build(project, completed, built.review)
     return completed
 
 


### PR DESCRIPTION
## Summary

- replace host Git and local-unversioned producer identity in build and judge commands with the installed package revision contract
- resolve revision metadata before catalog, project, credential, or artifact work and translate failures into actionable CLI errors
- bind trace dataset identity to its producer revision so an installed upgrade creates a new immutable build graph while exact revision replay remains zero-dispatch
- serialize completed-build selection and manual-judge mutations through one project-local transaction boundary
- recover interrupted graph replacement without committing stale judge state or redispatching providers
- publish build review readiness only after the complete immutable graph is selected
- serialize direct rubric and human-score writers with build replacement and reject stale task-set bindings

## Dependency and exact identity

This PR is based on the merged #445 tree in `main`.

- Base: `main` at `96badb4581e27f4a8824db269202b15b36a562cb`
- Head: `agent/package-revision-cli-20260814` at `b15791e9820346e01bc40f28800a9b498f332bd3`
- Exact range: `96badb4581e27f4a8824db269202b15b36a562cb..b15791e9820346e01bc40f28800a9b498f332bd3`

The first three commits are patch-identical to the reviewed package-revision, coordinated review-state, and interrupted build-recovery repairs. The final commit closes first-build readiness and concurrent direct review-writer boundaries.

## Validation

- full pytest on exact repaired head: 866 passed, 1 skipped
- exact restack range-diff: 3 of 3 commits patch-identical
- post-restack build, judge, release-revision matrix: 48 passed
- build-readiness and direct review-writer race matrix: 46 passed
- affected automatic-router and public-router fixtures: 10 passed
- independent transaction, reentrancy, cross-project release, and writer-serialization audit: passed
- W16 evidence on exact repaired head: 1 passed
- Ruff format and check: passed
- Ty: passed
- wheel build: passed
- isolated installed-wheel import and `wmo --help`: passed

README, AGENTS, and repository policy files are unchanged.
