### PR TITLE
Add ghost mode for unsaved router traffic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,12 +53,13 @@ uv run pytest -q
   world model, approved manual judge calibration, and confirmed router candidates from the
   project. It freezes one shared provider ceiling before calls, simulates and judges missing
   evidence, locks the fit policy before held-out execution, and exactly replays completed work.
-- `wmo run PROJECT --root ROOT --port PORT` loads one frozen policy and exposes OpenAI Chat
+- `wmo run PROJECT --root ROOT --port PORT [--ghost]` loads one frozen policy and exposes OpenAI Chat
   Completions, Responses, and Models routes on loopback. Public request and response types come
   from the official OpenAI SDK. Chat retries use the standard `Idempotency-Key`; Responses
   continuations use `previous_response_id`. WMO never joins unrelated Chat callers by transcript
-  prefix and requires no proprietary request fields or headers. Request-time embedding failure
-  uses the frozen conservative baseline, and neither path mutates policy or evidence.
+  prefix and requires no proprietary request fields or headers. Durable journaling is the default;
+  ghost mode performs routed calls without saving traffic or replay state. Request-time embedding
+  failure uses the frozen conservative baseline, and neither path mutates policy or evidence.
 
 ## Worker-agent execution
 

--- a/docs/cookbook/router.md
+++ b/docs/cookbook/router.md
@@ -64,15 +64,25 @@ identity fails instead of overwriting evidence.
 wmo run support-agent --root .wmo --port 8000
 ```
 
-This development adapter binds only to `127.0.0.1`. Send a caller-owned episode ID with every
-request:
+This development adapter binds only to `127.0.0.1`. Send a standard OpenAI request:
 
 ```bash
 curl http://127.0.0.1:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -H 'X-WMO-Episode-ID: customer-conversation-42' \
   -d '{"model":"support-agent","messages":[{"role":"user","content":"Help me"}]}'
 ```
 
-The first decision is sticky for that episode. Request-time embedding failure falls back to the
-frozen conservative baseline. Neither path updates the policy or evidence bank.
+Chat requests are stateless. Responses continuations preserve routing affinity through the official
+`previous_response_id` field. Request-time embedding failure falls back to the frozen conservative
+baseline. Neither path updates the policy or evidence bank.
+
+By default, completed traffic enters the durable project journal and can later feed runtime RAG and
+SFT preparation. Use ghost mode when traffic must not be saved:
+
+```bash
+wmo run support-agent --root .wmo --ghost
+```
+
+Python applications use the same boundary with `wmo.load_router("support-agent", ghost=True)`.
+Ghost mode still performs routed provider calls, but it writes no interaction, replay, RAG, or SFT
+state. Caller idempotency keys are accepted but cannot replay, so a retry may dispatch again.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@ The root surface is deliberately small:
 | `wmo build TRACE_FILE --project PROJECT --root ROOT` | Normalize 100 through 1000 local OTLP or PostHog traces and mine representative tasks. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
 | `wmo optimize router PROJECT --config FILE --root ROOT` | Fit, freeze, then report from explicit completed evidence. | Fit evaluation, bank, policy, held-out evaluation, and router report. |
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
-| `wmo run PROJECT --root ROOT` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint requiring `X-WMO-Episode-ID`. |
+| `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
 `build` makes zero model, provider, or judge paid calls. Successful build, router, simulation, and
@@ -17,7 +17,8 @@ positive cost ceiling, a finite conservative full-schedule estimate, explicit co
 project evidence before Tinker can open. Unknown cost or incomplete provenance fails before
 dispatch. `run` makes no provider call at startup.
 An HTTP completion or direct `RouterRuntime.complete` call is the explicit online model-call
-boundary. The router remains frozen for the process lifetime.
+boundary. The router remains frozen for the process lifetime. `run --ghost` still permits provider
+calls but disables durable interaction, replay, RAG, and SFT state for that process.
 
 Build stops at review readiness. Simulation, judgment, fidelity, embedding, and pricing artifacts
 must be completed through a separately authorized workflow before creating the exact

--- a/wmo/__init__.py
+++ b/wmo/__init__.py
@@ -30,6 +30,23 @@ if TYPE_CHECKING:
     from wmo.simulation.build import TaskSetBuild as TaskSetBuild
     from wmo.simulation.build import build_project as build_project
     from wmo.simulation.build import build_task_set as build_task_set
+    from wmo.simulation.world_model.application import WorldModel as WorldModel
+    from wmo.simulation.world_model.application import (
+        WorldModelLoadError as WorldModelLoadError,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelObservation as WorldModelObservation,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelSession as WorldModelSession,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelSessionError as WorldModelSessionError,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelSessionLimits as WorldModelSessionLimits,
+    )
+    from wmo.simulation.world_model.application import load_world_model as load_world_model
     from wmo.workflow.router import (
         ApprovedRouterReview as ApprovedRouterReview,
     )
@@ -53,6 +70,13 @@ _EXPORT_MODULES = {
     "TaskSetBuild": "wmo.simulation.build",
     "build_project": "wmo.simulation.build",
     "build_task_set": "wmo.simulation.build",
+    "WorldModel": "wmo.simulation.world_model.application",
+    "WorldModelLoadError": "wmo.simulation.world_model.application",
+    "WorldModelObservation": "wmo.simulation.world_model.application",
+    "WorldModelSession": "wmo.simulation.world_model.application",
+    "WorldModelSessionError": "wmo.simulation.world_model.application",
+    "WorldModelSessionLimits": "wmo.simulation.world_model.application",
+    "load_world_model": "wmo.simulation.world_model.application",
     "EvaluationInputs": "wmo.optimize.router.workflow",
     "RouterFitConfig": "wmo.optimize.router.workflow",
     "RouterFitWorkflowResult": "wmo.optimize.router.workflow",

--- a/wmo/api_test.py
+++ b/wmo/api_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from inspect import signature
 
 import wmo
 from wmo.optimize.router.workflow import fit_router, optimize_router, report_router
@@ -40,6 +41,7 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.compose_router is compose_router
     assert wmo.load_project_router is load_project_router
     assert wmo.load_router is load_router
+    assert "ghost" in signature(wmo.load_router).parameters
     assert wmo.create_project_router_app is create_project_router_app
     assert wmo.load_world_model is load_world_model
     assert wmo.WorldModel is WorldModel

--- a/wmo/api_test.py
+++ b/wmo/api_test.py
@@ -14,11 +14,24 @@ from wmo.runtime.router.application import (
 )
 from wmo.runtime.router.runtime import RouterRuntime
 from wmo.simulation.build import build_project
+from wmo.simulation.world_model.application import (
+    WorldModel,
+    WorldModelLoadError,
+    WorldModelObservation,
+    WorldModelSession,
+    WorldModelSessionError,
+    WorldModelSessionLimits,
+    load_world_model,
+)
 from wmo.workflow.router import compose_router
 
 
 def test_public_api_matches_quickstart() -> None:
-    """The customer workflow uses only deliberate package-root service exports."""
+    """The quickstart uses only deliberate package-root services.
+
+    Every supported build, optimization, router, and world-model entrypoint resolves to its owning
+    implementation while unsupported conveniences remain absent.
+    """
     assert wmo.build_project is build_project
     assert wmo.optimize_router is optimize_router
     assert wmo.fit_router is fit_router
@@ -28,6 +41,13 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.load_project_router is load_project_router
     assert wmo.load_router is load_router
     assert wmo.create_project_router_app is create_project_router_app
+    assert wmo.load_world_model is load_world_model
+    assert wmo.WorldModel is WorldModel
+    assert wmo.WorldModelLoadError is WorldModelLoadError
+    assert wmo.WorldModelSession is WorldModelSession
+    assert wmo.WorldModelSessionError is WorldModelSessionError
+    assert wmo.WorldModelSessionLimits is WorldModelSessionLimits
+    assert wmo.WorldModelObservation is WorldModelObservation
     assert "ActionKind" not in wmo.__all__
 
 

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -46,7 +46,8 @@ from wmo.simulation.retrieval import (
     persist_trace_rag,
 )
 from wmo.simulation.retrieval.transitions import extract_real_transitions
-from wmo.simulation.world_model import load_grounded_world_model, persist_grounded_world_model
+from wmo.simulation.world_model.artifact import persist_grounded_world_model
+from wmo.simulation.world_model.runtime import load_grounded_world_model
 
 _console = Console()
 _CANONICAL_SOURCES = ("otlp", "posthog")

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -30,7 +30,9 @@ from wmo.common.models import (
     write_model_catalog,
 )
 from wmo.common.project import ArtifactCorruptionError, ProjectStore, ProjectStoreError
+from wmo.common.traces import load_trace_dataset
 from wmo.runtime.models import ResolvedModel
+from wmo.simulation.ingest.dataset import read_trace_model_identity_evidence
 from wmo.simulation.retrieval import load_rag_index
 from wmo.simulation.world_model import GroundedWorldModelArtifact
 
@@ -302,6 +304,13 @@ def test_build_positional_happy_path_creates_two_rags_and_executable_artifact(
     assert config.models.candidates == ()
     assert config.build is not None
     assert config.build.serving_rag != config.build.fit_rag
+    loaded_traces = load_trace_dataset(store.artifacts, config.build.trace_dataset.artifact_id)
+    identity_evidence = read_trace_model_identity_evidence(store.artifacts, loaded_traces)
+    assert identity_evidence is not None
+    assert identity_evidence.records
+    assert {(record.capabilities, record.connection) for record in identity_evidence.records} == {
+        ("inferred", "inferred")
+    }
     serving = load_rag_index(store.artifacts, config.build.serving_rag.artifact_id)
     fit = load_rag_index(store.artifacts, config.build.fit_rag.artifact_id)
     assert serving.index.transition_count == 1

--- a/wmo/cli/model_optimize.py
+++ b/wmo/cli/model_optimize.py
@@ -35,6 +35,7 @@ from wmo.optimize.model.sft import (
     TinkerSFTDependencyError,
     TinkerTrainerBackend,
     TrainerBackend,
+    accept_runtime_sft_model_optimization,
     load_sft_model_optimization_config,
     preflight_sft_model_optimization,
     prepare_runtime_sft_model_optimization,
@@ -153,6 +154,20 @@ def optimize_model(
             _LocalPreflightBackend(),
             code_revision=code_revision,
         )
+        if local_preflight.completed_result is None and not preparation.accepted:
+            preparation = prepare_runtime_sft_model_optimization(
+                store,
+                created_at=created_at,
+                code_revision=code_revision,
+            )
+            config = preparation.config
+            config_id = config.config_id
+            local_preflight = preflight_sft_model_optimization(
+                store,
+                config_id,
+                _LocalPreflightBackend(),
+                code_revision=code_revision,
+            )
         backend: TrainerBackend = _LocalPreflightBackend()
         preflight = local_preflight
     except (
@@ -166,7 +181,7 @@ def optimize_model(
     ) as exc:
         raise typer.BadParameter(str(exc)) from None
 
-    if preflight.completed_result is None:
+    if preflight.completed_result is None and not preparation.accepted:
         assert config.training.maximum_cost_usd is not None
         assert preflight.conservative_schedule_cost_usd is not None
         spend = (
@@ -182,6 +197,16 @@ def optimize_model(
         ):
             _console.print("Managed Tinker SFT was not started.")
             return
+        try:
+            accept_runtime_sft_model_optimization(
+                store,
+                preparation,
+                created_at=created_at,
+                code_revision=code_revision,
+            )
+        except AutomaticSFTPreparationError as exc:
+            raise typer.BadParameter(str(exc)) from None
+    if preflight.completed_result is None:
         try:
             backend = _compose_tinker_backend(
                 store,

--- a/wmo/cli/model_optimize.py
+++ b/wmo/cli/model_optimize.py
@@ -1,19 +1,35 @@
-"""Minimal ``wmo optimize model`` composition over persisted W12 and W13 artifacts."""
+"""Automatic routed-interaction W12 preparation and bounded managed W13 SFT."""
 
 from __future__ import annotations
 
-import subprocess
+import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Never
 
 import typer
 from rich.console import Console
+from rich.prompt import Confirm, FloatPrompt, Prompt
 
 from wmo.cli.consent import require_spend_consent
+from wmo.common.core.artifacts import Sha256, sha256_json
+from wmo.common.core.locks import file_write_lock
+from wmo.common.models import (
+    ConnectionConfig,
+    ModelCatalog,
+    ModelCatalogError,
+    ModelRecord,
+    NumericMeasurement,
+    load_model_catalog,
+    write_model_catalog,
+)
 from wmo.common.observability.telemetry import capture_completion_once
 from wmo.common.project import ProjectStore, ProjectStoreError
+from wmo.common.release_revision import installed_release_revision
 from wmo.optimize.model.sft import (
+    AutomaticSFTPreparationError,
+    InitialSFTModelOptimizationSettings,
     SFTModelOptimizationError,
     SFTModelOptimizationPreflightError,
     TinkerSFTDependencyError,
@@ -21,11 +37,26 @@ from wmo.optimize.model.sft import (
     TrainerBackend,
     load_sft_model_optimization_config,
     preflight_sft_model_optimization,
+    prepare_runtime_sft_model_optimization,
+    require_completed_runtime_interactions,
     run_sft_model_optimization,
 )
+from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
+from wmo.optimize.model.sft.training_contracts import (
+    TinkerSFTSpec,
+    conservative_training_step_cost,
+)
+from wmo.runtime.models.credentials import ModelCredentialError, read_connection_api_key
 
 _console = Console()
 _ROOT_OPTION = typer.Option(Path(".wmo"), "--root", help="Local .wmo project root.")
+_DEFAULT_LORA_RANK = 32
+_DEFAULT_LEARNING_RATE = 0.0001
+_DEFAULT_BATCH_SIZE = 4
+_DEFAULT_EPOCHS = 1
+_DEFAULT_CHECKPOINT_EVERY_STEPS = 10
+_DEFAULT_MAXIMUM_DATUM_TOKENS = 4096
+_DEFAULT_MAXIMUM_COST_USD = 25.0
 
 
 def optimize_model(
@@ -36,46 +67,101 @@ def optimize_model(
         "--yes",
         help="Confirm managed Tinker execution after all validation and risk gates pass.",
     ),
+    tinker_connection: str | None = typer.Option(
+        None,
+        "--tinker-connection",
+        help="Existing or new local name for the explicit native Tinker connection.",
+    ),
+    tinker_api_key_env: str | None = typer.Option(
+        None,
+        "--tinker-api-key-env",
+        help="Environment-variable name containing the Tinker key. The key is never persisted.",
+    ),
+    base_model_alias: str | None = typer.Option(
+        None,
+        "--base-model-alias",
+        help="Existing or new local alias for the exact Tinker base model.",
+    ),
+    base_model: str | None = typer.Option(
+        None,
+        "--base-model",
+        help="Exact Tinker model ID, required when the base alias is not configured.",
+    ),
+    maximum_cost_usd: float | None = typer.Option(
+        None,
+        "--maximum-cost-usd",
+        min=0.01,
+        help="Immutable managed training cost cap. First-run default: $25.00.",
+    ),
+    training_usd_per_million_tokens: float | None = typer.Option(
+        None,
+        "--training-usd-per-million-tokens",
+        min=0,
+        help="Explicit Tinker training price used for conservative local reservation.",
+    ),
 ) -> None:
-    """Run W13 SFT from the project's explicit persisted W12 dataset configuration.
+    """Build routed interactions into W12 and run bounded W13 SFT automatically.
 
-    This command never builds a dataset, generates teacher rollouts, launches a simulator, or
-    changes routing roles.  It validates the complete local input graph before consent, then
-    registers a trained alias only after recursively verifying W13's completed result and opaque
-    sampling handle.
+    The command seals the current validated runtime journal prefix, reuses or creates its
+    immutable W12 dataset and bounded config, then validates the complete local input graph before
+    consent. Failed and disconnected interactions never become training targets. A trained alias
+    is registered only after recursively verifying W13's completed result and opaque sampling
+    handle.
 
     Args:
         project: Local project ID below ``<root>/projects``.
         root: Local ``.wmo`` root containing the project and ``models.toml``.
         yes: Explicit consent for managed execution only, never a validation or risk bypass.
+        tinker_connection: Native Tinker connection name used for first-run setup.
+        tinker_api_key_env: Environment-variable name used by training and later sampling.
+        base_model_alias: Local alias for the exact first-run Tinker base model.
+        base_model: Exact Tinker model ID when the alias is not already configured.
+        maximum_cost_usd: Optional first-run or consistency-checked managed-training cost cap.
+        training_usd_per_million_tokens: Explicit model-specific training price. Zero is accepted
+            only when supplied by the user or entered during interactive setup.
 
     Raises:
         typer.BadParameter: Local configuration, preflight, W13, or registration is unsafe.
     """
     started = time.monotonic()
-    code_revision = _current_revision()
+    created_at = datetime.now(UTC)
     try:
+        code_revision = _current_revision()
         store = ProjectStore(root, project)
-        project_config = store.load_project()
-        config_input = project_config.model_optimization_config
-        if config_input is None:
-            raise SFTModelOptimizationPreflightError(
-                "project has no immutable SFT model optimization config artifact binding. "
-                "Persist a verified W12 SFT dataset and bind an immutable config first."
-            )
-        config_id = config_input.artifact_id
-        config = load_sft_model_optimization_config(store, config_id)
-        backend = _compose_tinker_backend()
-        preflight = preflight_sft_model_optimization(
+        require_completed_runtime_interactions(store)
+        initial_settings = _initial_settings(
+            store,
+            project=project,
+            tinker_connection=tinker_connection,
+            tinker_api_key_env=tinker_api_key_env,
+            base_model_alias=base_model_alias,
+            base_model=base_model,
+            maximum_cost_usd=maximum_cost_usd,
+            training_usd_per_million_tokens=training_usd_per_million_tokens,
+        )
+        preparation = prepare_runtime_sft_model_optimization(
+            store,
+            created_at=created_at,
+            code_revision=code_revision,
+            initial_settings=initial_settings,
+        )
+        config = preparation.config
+        config_id = config.config_id
+        local_preflight = preflight_sft_model_optimization(
             store,
             config_id,
-            backend,
+            _LocalPreflightBackend(),
             code_revision=code_revision,
         )
+        backend: TrainerBackend = _LocalPreflightBackend()
+        preflight = local_preflight
     except (
         ProjectStoreError,
+        ModelCatalogError,
+        AutomaticSFTPreparationError,
         SFTModelOptimizationError,
         TinkerSFTDependencyError,
+        ModelCredentialError,
         ValueError,
     ) as exc:
         raise typer.BadParameter(str(exc)) from None
@@ -96,12 +182,32 @@ def optimize_model(
         ):
             _console.print("Managed Tinker SFT was not started.")
             return
+        try:
+            backend = _compose_tinker_backend(
+                store,
+                config.tinker_connection,
+                config.connection_config_sha256,
+            )
+            preflight = preflight_sft_model_optimization(
+                store,
+                config_id,
+                backend,
+                code_revision=code_revision,
+            )
+        except (
+            ModelCatalogError,
+            ModelCredentialError,
+            SFTModelOptimizationError,
+            TinkerSFTDependencyError,
+            ValueError,
+        ) as exc:
+            raise typer.BadParameter(str(exc)) from None
     try:
         completed = run_sft_model_optimization(
             store,
             config_id,
             backend,
-            created_at=datetime.now(UTC),
+            created_at=created_at,
             code_revision=code_revision,
             preflight=preflight,
         )
@@ -131,32 +237,362 @@ def optimize_model(
         )
 
 
-def _compose_tinker_backend() -> TrainerBackend:
-    """Compose the one concrete Tinker SDK adapter without a factory or fallback backend.
+def _initial_settings(
+    store: ProjectStore,
+    *,
+    project: str,
+    tinker_connection: str | None,
+    tinker_api_key_env: str | None,
+    base_model_alias: str | None,
+    base_model: str | None,
+    maximum_cost_usd: float | None,
+    training_usd_per_million_tokens: float | None,
+) -> InitialSFTModelOptimizationSettings | None:
+    """Collect and persist only missing first-run Tinker catalog selections.
+
+    Args:
+        store: Project whose catalog and selection state are inspected.
+        project: Project ID used for the deterministic trained-model alias prefix.
+        tinker_connection: Optional explicit connection name from the CLI.
+        tinker_api_key_env: Optional environment-variable name for the Tinker credential.
+        base_model_alias: Optional explicit local base-model alias from the CLI.
+        base_model: Optional exact Tinker model ID for a new alias.
+        maximum_cost_usd: Optional finite immutable training cap shown before provider consent.
+        training_usd_per_million_tokens: Optional explicit model-specific training price.
+
+    Returns:
+        Confirmed first-run settings, or ``None`` when an immutable selection already exists.
+
+    Raises:
+        typer.BadParameter: Required noninteractive values are missing or catalog selections
+            conflict with existing provider metadata.
+        typer.Abort: An interactive user declines the complete setup summary.
+    """
+    latest = load_latest_sft_model_optimization(store)
+    bootstrap = store.load_project().model_optimization_config
+    selected = latest.config if latest is not None else bootstrap
+    if selected is not None:
+        config = load_sft_model_optimization_config(store, selected.artifact_id)
+        _require_replay_settings_match(
+            config.training,
+            maximum_cost_usd=maximum_cost_usd,
+            training_usd_per_million_tokens=training_usd_per_million_tokens,
+        )
+        return None
+    catalog = load_model_catalog(store.model_catalog_path)
+    catalog_sha256 = sha256_json(catalog)
+    interactive = sys.stdin.isatty()
+    connection_name = tinker_connection
+    alias = base_model_alias
+    if interactive:
+        _console.print("[bold]Tinker model optimization setup[/bold]")
+        if connection_name is None:
+            connection_name = Prompt.ask("Tinker connection name", console=_console).strip()
+        if alias is None:
+            alias = Prompt.ask("Tinker base model alias", console=_console).strip()
+    connection = catalog.connections.get(connection_name) if connection_name is not None else None
+    api_key_env = tinker_api_key_env
+    if connection is not None and connection.api_key_env is not None:
+        if api_key_env is not None and api_key_env != connection.api_key_env:
+            raise typer.BadParameter(
+                f"Tinker connection {connection_name!r} already names a different api_key_env"
+            )
+        api_key_env = connection.api_key_env
+    if interactive and api_key_env is None:
+        api_key_env = Prompt.ask("Tinker API key environment variable", console=_console).strip()
+    missing = []
+    if connection_name is None:
+        missing.append("--tinker-connection")
+    if api_key_env is None:
+        missing.append("--tinker-api-key-env")
+    if alias is None:
+        missing.append("--base-model-alias")
+    if training_usd_per_million_tokens is None and not interactive:
+        missing.append("--training-usd-per-million-tokens")
+    if missing:
+        raise typer.BadParameter(
+            "first `wmo optimize model` in noninteractive mode requires "
+            + ", ".join(missing)
+            + "; add those flags, plus --base-model when the alias is new; an explicit zero "
+            "training price is allowed"
+        )
+    assert connection_name is not None
+    assert api_key_env is not None
+    assert alias is not None
+    if connection is not None and connection.provider != "tinker":
+        raise typer.BadParameter(
+            f"connection {connection_name!r} uses provider {connection.provider!r}, not 'tinker'"
+        )
+    record = catalog.models.get(alias)
+    if record is not None:
+        if record.connection != connection_name:
+            raise typer.BadParameter(
+                f"base model alias {alias!r} uses connection {record.connection!r}, not "
+                f"{connection_name!r}"
+            )
+        if base_model is not None and record.model != base_model:
+            raise typer.BadParameter(
+                f"base model alias {alias!r} already names a different exact model ID"
+            )
+        resolved_model = record.model
+    else:
+        resolved_model = base_model
+        if interactive and resolved_model is None:
+            resolved_model = Prompt.ask("Exact Tinker base model ID", console=_console).strip()
+        if resolved_model is None:
+            raise typer.BadParameter(
+                f"base model alias {alias!r} is not configured; add --base-model with its exact "
+                "Tinker model ID"
+            )
+    if interactive and training_usd_per_million_tokens is None:
+        training_usd_per_million_tokens = FloatPrompt.ask(
+            "Training USD per million tokens",
+            console=_console,
+        )
+    if training_usd_per_million_tokens is None:
+        raise typer.BadParameter(
+            "first model optimization requires --training-usd-per-million-tokens; use an "
+            "explicit 0 only when training is known to be free"
+        )
+    if training_usd_per_million_tokens < 0:
+        raise typer.BadParameter("training price must be nonnegative")
+    selected_maximum_cost_usd = (
+        _DEFAULT_MAXIMUM_COST_USD if maximum_cost_usd is None else maximum_cost_usd
+    )
+    training = TinkerSFTSpec(
+        base_model=resolved_model,
+        lora_rank=_DEFAULT_LORA_RANK,
+        learning_rate=_DEFAULT_LEARNING_RATE,
+        batch_size=_DEFAULT_BATCH_SIZE,
+        epochs=_DEFAULT_EPOCHS,
+        checkpoint_every_steps=_DEFAULT_CHECKPOINT_EVERY_STEPS,
+        maximum_datum_tokens=_DEFAULT_MAXIMUM_DATUM_TOKENS,
+        maximum_cost_usd=selected_maximum_cost_usd,
+        training_usd_per_million_tokens=training_usd_per_million_tokens,
+    )
+    if interactive:
+        _console.print(
+            "[dim]Training defaults: LoRA rank 32, learning rate 0.0001, batch size 4, "
+            "1 epoch, checkpoint every 10 steps, 4096 tokens per datum, maximum cost "
+            f"${selected_maximum_cost_usd:.2f}; confirmed training price "
+            f"${training_usd_per_million_tokens:.6f} per million tokens.[/dim]"
+        )
+        if not Confirm.ask(
+            f"Use Tinker connection {connection_name!r}, credential variable {api_key_env!r}, "
+            f"and base model {resolved_model!r}?",
+            default=True,
+            console=_console,
+        ):
+            raise typer.Abort()
+    _persist_tinker_selection(
+        store,
+        observed_catalog_sha256=catalog_sha256,
+        connection_name=connection_name,
+        api_key_env=api_key_env,
+        alias=alias,
+        resolved_model=resolved_model,
+    )
+    return InitialSFTModelOptimizationSettings(
+        model_alias_prefix=f"{project}-sft",
+        tinker_connection=connection_name,
+        base_model_alias=alias,
+        training=training,
+    )
+
+
+def _require_replay_settings_match(
+    training: TinkerSFTSpec,
+    *,
+    maximum_cost_usd: float | None,
+    training_usd_per_million_tokens: float | None,
+) -> None:
+    """Reject explicit CLI settings that drift from the selected immutable graph.
+
+    Args:
+        training: Previously selected immutable training settings.
+        maximum_cost_usd: Optional cap supplied for this invocation.
+        training_usd_per_million_tokens: Optional price supplied for this invocation.
+
+    Raises:
+        typer.BadParameter: Either supplied value differs from the immutable selection.
+    """
+    if maximum_cost_usd is not None and maximum_cost_usd != training.maximum_cost_usd:
+        raise typer.BadParameter(
+            "--maximum-cost-usd differs from the selected immutable model-optimization config"
+        )
+    if (
+        training_usd_per_million_tokens is not None
+        and training_usd_per_million_tokens != training.training_usd_per_million_tokens
+    ):
+        raise typer.BadParameter(
+            "--training-usd-per-million-tokens differs from the selected immutable "
+            "model-optimization config"
+        )
+
+
+def _persist_tinker_selection(
+    store: ProjectStore,
+    *,
+    observed_catalog_sha256: Sha256,
+    connection_name: str,
+    api_key_env: str,
+    alias: str,
+    resolved_model: str,
+) -> None:
+    """Merge confirmed Tinker entries under a cross-process catalog lock.
+
+    Unrelated concurrent catalog additions are retained. Drift in either confirmed target fails
+    closed, while another process persisting the exact same selection is idempotent.
+
+    Args:
+        store: Project whose shared model catalog receives the confirmed selection.
+        observed_catalog_sha256: Digest of the catalog shown and validated before confirmation.
+        connection_name: Confirmed native Tinker connection name.
+        api_key_env: Confirmed credential environment-variable name. No secret value is read.
+        alias: Confirmed local base-model alias.
+        resolved_model: Confirmed exact Tinker base-model ID.
+
+    Raises:
+        typer.BadParameter: A concurrent writer changed a confirmed connection or alias.
+    """
+    desired_connection = ConnectionConfig(provider="tinker", api_key_env=api_key_env)
+    desired_record = ModelRecord(connection=connection_name, model=resolved_model)
+    with file_write_lock(store.model_catalog_path, what="the local model catalog"):
+        current = load_model_catalog(store.model_catalog_path)
+        drifted = sha256_json(current) != observed_catalog_sha256
+        existing_connection = current.connections.get(connection_name)
+        connection_conflicts = existing_connection is not None and (
+            existing_connection.provider != "tinker"
+            or existing_connection.base_url != desired_connection.base_url
+            or existing_connection.api_key_env not in {None, api_key_env}
+        )
+        if connection_conflicts:
+            qualifier = "concurrently " if drifted else ""
+            raise typer.BadParameter(
+                f"Tinker connection {connection_name!r} {qualifier}changed before setup commit"
+            )
+        existing_record = current.models.get(alias)
+        record_conflicts = existing_record is not None and (
+            existing_record.connection != connection_name or existing_record.model != resolved_model
+        )
+        if record_conflicts:
+            qualifier = "concurrently " if drifted else ""
+            raise typer.BadParameter(
+                f"base model alias {alias!r} {qualifier}changed before setup commit"
+            )
+        if (
+            existing_connection == desired_connection
+            and existing_record is not None
+            and not record_conflicts
+        ):
+            return
+        connections = dict(current.connections)
+        models = dict(current.models)
+        connections[connection_name] = desired_connection
+        models.setdefault(alias, desired_record)
+        write_model_catalog(
+            store.model_catalog_path,
+            ModelCatalog(
+                schema_version=current.schema_version,
+                connections=connections,
+                models=models,
+                roles=current.roles,
+            ),
+        )
+
+
+class _LocalPreflightBackend:
+    """Backend seam that permits local graph validation but cannot open a trainer."""
+
+    def conservative_step_cost(
+        self, spec: TinkerSFTSpec, *, batch_example_count: int
+    ) -> NumericMeasurement | None:
+        """Calculate the immutable caller-priced step bound without constructing an SDK.
+
+        Args:
+            spec: Frozen settings containing an explicit price and token ceiling.
+            batch_example_count: Exact planned batch size.
+
+        Returns:
+            The conservative local estimate, or ``None`` when price inputs are incomplete.
+        """
+        return conservative_training_step_cost(spec, batch_example_count=batch_example_count)
+
+    def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> Never:
+        """Reject any attempt to dispatch through the local-only validation seam.
+
+        Args:
+            spec: Frozen settings that must never reach a provider through this seam.
+            resume_state_path: Optional resume handle that must never be used here.
+
+        Raises:
+            SFTModelOptimizationPreflightError: Always, because this backend is non-dispatching.
+        """
+        del spec, resume_state_path
+        raise SFTModelOptimizationPreflightError(
+            "local model-optimization preflight cannot dispatch trainer work"
+        )
+
+
+def _compose_tinker_backend(
+    store: ProjectStore,
+    connection_name: str,
+    expected_connection_config_sha256: Sha256,
+) -> TrainerBackend:
+    """Resolve the selected credential and compose the concrete Tinker SDK adapter.
+
+    Args:
+        store: Project whose secret-free catalog selects the authorized credential name.
+        connection_name: Exact Tinker connection frozen into the optimization config.
+        expected_connection_config_sha256: Frozen full connection metadata digest that must match
+            before credential or SDK access.
 
     Returns:
         Concrete backend that does not call Tinker until W13 invokes ``open``.
 
     Raises:
-        SFTModelOptimizationPreflightError: The optional local Tinker SDK is unavailable.
+        ModelCredentialError: The selected credential environment variable is absent.
+        SFTModelOptimizationPreflightError: The selected connection or optional SDK is invalid.
     """
+    catalog = load_model_catalog(store.model_catalog_path)
+    connection = catalog.connections.get(connection_name)
+    if connection is None or connection.provider != "tinker":
+        raise SFTModelOptimizationPreflightError(
+            f"selected connection {connection_name!r} is not a configured native Tinker connection"
+        )
+    current_connection_config_sha256 = sha256_json(
+        {
+            "provider": connection.provider,
+            "base_url": connection.base_url,
+            "api_key_env": connection.api_key_env,
+        }
+    )
+    if current_connection_config_sha256 != expected_connection_config_sha256:
+        raise SFTModelOptimizationPreflightError(
+            "selected Tinker connection metadata drifted before credential resolution"
+        )
+    api_key = read_connection_api_key(connection)
     try:
         import tinker
     except ImportError as exc:
         raise SFTModelOptimizationPreflightError(
             "Tinker SFT requires the optional sft dependencies; run `uv sync --extra sft`"
         ) from exc
-    return TinkerTrainerBackend(tinker.ServiceClient())
+    service = (
+        tinker.ServiceClient(api_key=api_key)
+        if connection.base_url is None
+        else tinker.ServiceClient(api_key=api_key, base_url=connection.base_url)
+    )
+    return TinkerTrainerBackend(service)
 
 
 def _current_revision() -> str:
-    """Return the local Git revision without changing repository or provider state."""
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=Path(__file__).resolve().parents[2],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    revision = result.stdout.strip()
-    return revision if result.returncode == 0 and revision else "local-unversioned"
+    """Resolve package-owned producer identity without consulting host Git.
+
+    Returns:
+        Exact configured release revision or installed distribution identity.
+
+    Raises:
+        ReleaseRevisionError: Release metadata is unavailable or malformed.
+    """
+    return installed_release_revision()

--- a/wmo/cli/model_optimize_test.py
+++ b/wmo/cli/model_optimize_test.py
@@ -30,6 +30,9 @@ from wmo.optimize.model.sft import (
     SFTModelOptimizationConfig,
     TinkerSFTSpec,
     create_sft_model_optimization_config,
+    load_sft_model_optimization_config,
+    load_verified_sft_dataset,
+    sft_model_optimization_output_dir,
     write_sft_model_optimization_config,
 )
 from wmo.optimize.model.sft.runtime_source_test import _complete, _request
@@ -717,6 +720,319 @@ def test_declined_spend_consent_does_not_resolve_credentials_or_construct_sdk(
     assert result.exit_code == 0, result.output
     assert "was not started" in result.output
     assert backend_calls == []
+
+
+def test_completion_before_consent_refreshes_the_schedule_and_trains_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Include a completion that lands after the first snapshot but before consent.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped race injection, consent, backend, and revision replacements.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    original_preflight = command.preflight_sft_model_optimization
+    preflight_calls = 0
+    consented_row_counts: list[int] = []
+    backend = _FakeBackend(conservative_cost_per_batch=0.10)
+
+    def preflight_then_complete(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        """Append one completion after the first local preflight returns.
+
+        Args:
+            args: Positional preflight inputs forwarded unchanged.
+            kwargs: Keyword preflight inputs forwarded unchanged.
+
+        Returns:
+            The original recursively verified preflight result.
+        """
+        nonlocal preflight_calls
+        result = original_preflight(*args, **kwargs)
+        preflight_calls += 1
+        if preflight_calls == 1:
+            _complete(
+                RuntimeInteractionJournal(configured.store.paths),
+                key="completion-before-consent",
+                conversation="runtime-sft-conversation",
+                request=_request(ModelMessage(role="user", content="Second routed request")),
+                output=AssistantAction(content="Second routed response"),
+                now=_TIME,
+            )
+        return result
+
+    def approve_refreshed_schedule(*args: object, **kwargs: object) -> bool:
+        """Record the exact refreshed W12 denominator shown for consent.
+
+        Args:
+            args: Consent positional inputs accepted without inspection.
+            kwargs: Consent keyword inputs accepted without inspection.
+
+        Returns:
+            ``True`` to authorize the refreshed immutable schedule.
+        """
+        del args, kwargs
+        latest = load_latest_sft_model_optimization(configured.store)
+        assert latest is not None
+        config = load_sft_model_optimization_config(configured.store, latest.config.artifact_id)
+        dataset = load_verified_sft_dataset(configured.store, config.dataset.artifact_id)
+        consented_row_counts.append(len(dataset.rows))
+        return True
+
+    monkeypatch.setattr(command, "preflight_sft_model_optimization", preflight_then_complete)
+    monkeypatch.setattr(command, "require_spend_consent", approve_refreshed_schedule)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "pre-consent-refresh-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert consented_row_counts == [2]
+    assert len(backend.trained_example_ids) == 2
+    assert len(set(backend.trained_example_ids)) == 2
+
+
+def test_completion_during_consent_fails_before_run_acceptance_and_reconsents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject stale consent before credentials, then train the refreshed graph once.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped consent-race, backend, and revision replacements.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls: list[bool] = []
+    consent_calls: list[str] = []
+
+    def consent_then_complete(*args: object, **kwargs: object) -> bool:
+        """Append a durable completion inside the first consent boundary.
+
+        Args:
+            args: Consent positional inputs accepted without inspection.
+            kwargs: Consent keyword inputs accepted without inspection.
+
+        Returns:
+            ``True`` after the journal advances beyond the consented snapshot.
+        """
+        del args, kwargs
+        consent_calls.append("stale")
+        _complete(
+            RuntimeInteractionJournal(configured.store.paths),
+            key="completion-during-consent",
+            conversation="runtime-sft-conversation",
+            request=_request(ModelMessage(role="user", content="Second routed request")),
+            output=AssistantAction(content="Second routed response"),
+            now=_TIME,
+        )
+        return True
+
+    def forbidden_backend(*args: object, **kwargs: object) -> Never:
+        """Fail if stale consent reaches credential or trainer composition.
+
+        Args:
+            args: Unexpected positional backend inputs.
+            kwargs: Unexpected keyword backend inputs.
+        """
+        del args, kwargs
+        backend_calls.append(True)
+        raise AssertionError("stale consent must fail before backend composition")
+
+    monkeypatch.setattr(command, "require_spend_consent", consent_then_complete)
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "consent-race-test")
+    arguments = [
+        "optimize",
+        "model",
+        configured.store.paths.project_id,
+        "--root",
+        str(configured.store.paths.root),
+    ]
+
+    stale = CliRunner().invoke(app, arguments)
+
+    assert stale.exit_code == 2
+    assert "everydurablecompletion" in _flat_cli_output(stale.output)
+    assert backend_calls == []
+    latest = load_latest_sft_model_optimization(configured.store)
+    assert latest is not None
+    assert not sft_model_optimization_output_dir(
+        configured.store, latest.config.artifact_id
+    ).exists()
+
+    refreshed_backend = _FakeBackend(conservative_cost_per_batch=0.10)
+
+    def approve_retry(*args: object, **kwargs: object) -> bool:
+        """Record and approve the refreshed retry schedule.
+
+        Args:
+            args: Consent positional inputs accepted without inspection.
+            kwargs: Consent keyword inputs accepted without inspection.
+
+        Returns:
+            ``True`` for the refreshed second consent.
+        """
+        del args, kwargs
+        consent_calls.append("refreshed")
+        return True
+
+    monkeypatch.setattr(command, "require_spend_consent", approve_retry)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: refreshed_backend)
+
+    retry = CliRunner().invoke(app, arguments)
+
+    assert retry.exit_code == 0, retry.output
+    assert consent_calls == ["stale", "refreshed"]
+    assert len(refreshed_backend.trained_example_ids) == 2
+    assert len(set(refreshed_backend.trained_example_ids)) == 2
+
+
+def test_accepted_prefix_resumes_after_crash_and_defers_later_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resume one accepted prefix without reconsent and train later appends next.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped consent, crash, backend, and revision replacements.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    consent_calls: list[str] = []
+    compose_calls: list[str] = []
+    runner = CliRunner()
+    arguments = [
+        "optimize",
+        "model",
+        configured.store.paths.project_id,
+        "--root",
+        str(configured.store.paths.root),
+    ]
+
+    def approve_initial(*args: object, **kwargs: object) -> bool:
+        """Approve the initial one-row immutable schedule.
+
+        Args:
+            args: Consent positional inputs accepted without inspection.
+            kwargs: Consent keyword inputs accepted without inspection.
+
+        Returns:
+            ``True`` to create the durable W13 acceptance manifest.
+        """
+        del args, kwargs
+        consent_calls.append("initial")
+        return True
+
+    def crash_before_backend(*args: object, **kwargs: object) -> Never:
+        """Simulate a crash after acceptance but before trainer construction.
+
+        Args:
+            args: Backend positional inputs accepted without inspection.
+            kwargs: Backend keyword inputs accepted without inspection.
+
+        Raises:
+            ModelCredentialError: Always, after recording the composition attempt.
+        """
+        del args, kwargs
+        compose_calls.append("crash")
+        raise command.ModelCredentialError("simulated crash after local W13 acceptance")
+
+    monkeypatch.setattr(command, "require_spend_consent", approve_initial)
+    monkeypatch.setattr(command, "_compose_tinker_backend", crash_before_backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "accepted-prefix-resume-test")
+
+    crashed = runner.invoke(app, arguments)
+
+    assert crashed.exit_code == 2
+    assert consent_calls == ["initial"]
+    latest_before_append = load_latest_sft_model_optimization(configured.store)
+    assert latest_before_append is not None
+    accepted_config = load_sft_model_optimization_config(
+        configured.store, latest_before_append.config.artifact_id
+    )
+    accepted_dataset = load_verified_sft_dataset(
+        configured.store, accepted_config.dataset.artifact_id
+    )
+    assert len(accepted_dataset.rows) == 1
+    assert (
+        sft_model_optimization_output_dir(configured.store, accepted_config.config_id)
+        / "manifest.json"
+    ).is_file()
+    _complete(
+        RuntimeInteractionJournal(configured.store.paths),
+        key="completion-after-acceptance",
+        conversation="runtime-sft-conversation",
+        request=_request(ModelMessage(role="user", content="Deferred routed request")),
+        output=AssistantAction(content="Deferred routed response"),
+        now=_TIME,
+    )
+
+    def reject_repeat_consent(*args: object, **kwargs: object) -> Never:
+        """Fail if recovery asks again for consent already bound to the accepted prefix.
+
+        Args:
+            args: Unexpected consent positional inputs.
+            kwargs: Unexpected consent keyword inputs.
+        """
+        del args, kwargs
+        raise AssertionError("accepted incomplete W13 run must resume without new consent")
+
+    resumed_backend = _FakeBackend(conservative_cost_per_batch=0.10)
+    monkeypatch.setattr(command, "require_spend_consent", reject_repeat_consent)
+    monkeypatch.setattr(
+        command,
+        "_compose_tinker_backend",
+        lambda *_args: compose_calls.append("resume") or resumed_backend,
+    )
+
+    resumed = runner.invoke(app, arguments)
+
+    assert resumed.exit_code == 0, resumed.output
+    assert compose_calls == ["crash", "resume"]
+    assert len(resumed_backend.trained_example_ids) == 1
+    assert load_latest_sft_model_optimization(configured.store) == latest_before_append
+
+    next_consent_calls: list[int] = []
+    next_backend = _FakeBackend(conservative_cost_per_batch=0.10)
+
+    def approve_next_prefix(*args: object, **kwargs: object) -> bool:
+        """Approve the new graph that includes the deferred completion.
+
+        Args:
+            args: Consent positional inputs accepted without inspection.
+            kwargs: Consent keyword inputs accepted without inspection.
+
+        Returns:
+            ``True`` after recording the exact new W12 denominator.
+        """
+        del args, kwargs
+        latest = load_latest_sft_model_optimization(configured.store)
+        assert latest is not None
+        config = load_sft_model_optimization_config(configured.store, latest.config.artifact_id)
+        dataset = load_verified_sft_dataset(configured.store, config.dataset.artifact_id)
+        next_consent_calls.append(len(dataset.rows))
+        return True
+
+    monkeypatch.setattr(command, "require_spend_consent", approve_next_prefix)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: next_backend)
+
+    next_run = runner.invoke(app, arguments)
+
+    assert next_run.exit_code == 0, next_run.output
+    assert next_consent_calls == [2]
+    assert len(next_backend.trained_example_ids) == 2
+    assert len(set(next_backend.trained_example_ids)) == 2
 
 
 def test_connection_drift_after_consent_fails_before_credential_or_sdk(

--- a/wmo/cli/model_optimize_test.py
+++ b/wmo/cli/model_optimize_test.py
@@ -9,6 +9,7 @@ from typing import Never
 
 import pytest
 import typer
+from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -64,6 +65,22 @@ class _RestartSampler:
             output=AssistantAction(content="resolved after restart"),
             served_model_id="tinker://trained-handle",
         )
+
+
+def _flat_cli_output(output: str) -> str:
+    """Remove terminal styling, whitespace, and table borders from CLI output.
+
+    Args:
+        output: Rich-formatted text captured by the CLI test runner.
+
+    Returns:
+        Stable text suitable for cross-platform substring assertions.
+    """
+    return "".join(
+        character
+        for character in unstyle(output)
+        if not character.isspace() and character not in "│┃"
+    )
 
 
 def _configured_project(tmp_path: Path, training: TinkerSFTSpec) -> _ConfiguredProject:
@@ -334,11 +351,7 @@ def test_cli_first_run_noninteractive_reports_all_required_tinker_flags(
         ],
     )
 
-    flat = "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    flat = _flat_cli_output(result.output)
     assert result.exit_code == 2
     assert "--tinker-connection" in flat
     assert "--tinker-api-key-env" in flat
@@ -600,11 +613,7 @@ def test_cli_yes_does_not_bypass_the_unsupported_budget_estimate_gate(
     )
 
     assert result.exit_code == 2
-    assert "nosupportedconservativecostestimate" in "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    assert "nosupportedconservativecostestimate" in _flat_cli_output(result.output)
     assert backend.open_resume_paths == []
 
 
@@ -662,11 +671,7 @@ def test_cli_empty_journal_fails_before_backend_or_consent(
     )
 
     assert result.exit_code == 2
-    assert "nointeractions" in "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    assert "nointeractions" in _flat_cli_output(result.output)
     assert backend_calls == []
     assert consent_calls == []
 
@@ -792,11 +797,7 @@ def test_connection_drift_after_consent_fails_before_credential_or_sdk(
     )
 
     assert result.exit_code == 2
-    assert "metadatadriftedbeforecredentialresolution" in "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    assert "metadatadriftedbeforecredentialresolution" in _flat_cli_output(result.output)
     assert credential_reads == []
     assert service_calls == []
 
@@ -926,11 +927,7 @@ def test_schedule_ceiling_refuses_before_tinker_backend_construction(
     )
 
     assert result.exit_code == 2
-    assert "exceedsmaximum_cost_usd" in "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    assert "exceedsmaximum_cost_usd" in _flat_cli_output(result.output)
     assert backend_calls == []
 
 
@@ -974,11 +971,7 @@ def test_selected_price_replay_rejects_explicit_drift_before_backend(
     )
 
     assert result.exit_code == 2
-    assert "differsfromtheselectedimmutable" in "".join(
-        character
-        for character in result.output
-        if not character.isspace() and character not in "│┃"
-    )
+    assert "differsfromtheselectedimmutable" in _flat_cli_output(result.output)
     assert backend_calls == []
 
 

--- a/wmo/cli/model_optimize_test.py
+++ b/wmo/cli/model_optimize_test.py
@@ -5,12 +5,25 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Never
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
-from wmo.common.models import ConnectionConfig, ModelCatalog, ModelRecord, write_model_catalog
+from wmo.common.core.artifacts import sha256_json
+from wmo.common.models import (
+    AssistantAction,
+    ConnectionConfig,
+    ModelCapabilities,
+    ModelCatalog,
+    ModelMessage,
+    ModelRecord,
+    ModelRequest,
+    load_model_catalog,
+    write_model_catalog,
+)
 from wmo.common.project import ProjectStore
 from wmo.optimize.model.sft import (
     SFTModelOptimizationConfig,
@@ -18,7 +31,12 @@ from wmo.optimize.model.sft import (
     create_sft_model_optimization_config,
     write_sft_model_optimization_config,
 )
+from wmo.optimize.model.sft.runtime_source_test import _complete, _request
+from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
 from wmo.optimize.model.sft.training_test import _TIME, _FakeBackend, _persisted_dataset, _spec
+from wmo.runtime.models import ModelConnectionError, RuntimeModelCatalog
+from wmo.runtime.models.providers.tinker_sampling import TinkerSample
+from wmo.runtime.router import RuntimeInteractionJournal
 
 
 @dataclass(frozen=True)
@@ -29,13 +47,44 @@ class _ConfiguredProject:
     config: SFTModelOptimizationConfig
 
 
+class _RestartSampler:
+    """Deterministic sampling seam used to prove a registered alias resolves after restart."""
+
+    def sample(self, request: ModelRequest) -> TinkerSample:
+        """Return a fixed response through the runtime's Tinker client adapter.
+
+        Args:
+            request: Typed request accepted by the completed trained alias.
+
+        Returns:
+            One deterministic sampling result.
+        """
+        del request
+        return TinkerSample(
+            output=AssistantAction(content="resolved after restart"),
+            served_model_id="tinker://trained-handle",
+        )
+
+
 def _configured_project(tmp_path: Path, training: TinkerSFTSpec) -> _ConfiguredProject:
-    """Persist W12 evidence, a native Tinker connection, and one selected W14M config."""
+    """Persist W12 evidence, a native Tinker connection, and one selected config.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        training: Frozen settings to bind into the selected config.
+
+    Returns:
+        Project fixture with runtime evidence and a selected immutable config.
+    """
     fixture = _persisted_dataset(tmp_path)
+    if training.training_usd_per_million_tokens is None:
+        training = training.model_copy(update={"training_usd_per_million_tokens": 100.0})
     write_model_catalog(
         fixture.store.model_catalog_path,
         ModelCatalog(
-            connections={"tinker": ConnectionConfig(provider="tinker")},
+            connections={
+                "tinker": ConnectionConfig(provider="tinker", api_key_env="TINKER_API_KEY")
+            },
             models={"base": ModelRecord(connection="tinker", model="test-base-model")},
         ),
     )
@@ -50,7 +99,329 @@ def _configured_project(tmp_path: Path, training: TinkerSFTSpec) -> _ConfiguredP
         code_revision="w14m-test",
     )
     write_sft_model_optimization_config(fixture.store, config)
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="runtime-sft-source",
+        conversation="runtime-sft-conversation",
+        request=_request(ModelMessage(role="user", content="Train on this routed request")),
+        output=AssistantAction(content="Completed routed response"),
+        now=_TIME,
+    )
     return _ConfiguredProject(store=fixture.store, config=config)
+
+
+def _seed_catalog(store: ProjectStore) -> ModelCatalog:
+    """Persist one unrelated provider entry as the shared setup starting point.
+
+    Args:
+        store: Project whose catalog is initialized.
+
+    Returns:
+        The exact catalog persisted for a stale setup proposal.
+    """
+    catalog = ModelCatalog(
+        connections={"openai": ConnectionConfig(provider="openai")},
+        models={"judge": ModelRecord(connection="openai", model="judge-model")},
+    )
+    write_model_catalog(store.model_catalog_path, catalog)
+    return catalog
+
+
+def test_cli_rejects_malformed_release_revision_before_project_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail closed on invalid producer identity before creating project state.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped malformed release revision override.
+    """
+    root = tmp_path / ".wmo"
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "HEAD")
+
+    result = CliRunner().invoke(
+        app,
+        ["optimize", "model", "support", "--root", str(root)],
+    )
+
+    assert result.exit_code == 2
+    assert "full lowercase 40-hex" in result.output
+    assert not root.exists()
+
+
+def test_cli_first_run_builds_runtime_w12_and_config_without_bootstrap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Collect explicit noninteractive Tinker settings and train from routed interactions.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped fake backend and revision replacements.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"openai": ConnectionConfig(provider="openai")},
+            models={"judge": ModelRecord(connection="openai", model="judge-model")},
+        ),
+    )
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="first-runtime-source",
+        conversation="first-runtime-conversation",
+        request=_request(ModelMessage(role="user", content="First routed training request")),
+        output=AssistantAction(content="First routed training response"),
+        now=_TIME,
+    )
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend = _FakeBackend(conservative_cost_per_batch=0.10)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "automatic-cli-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            fixture.store.paths.project_id,
+            "--root",
+            str(fixture.store.paths.root),
+            "--tinker-connection",
+            "tinker-local",
+            "--tinker-api-key-env",
+            "TINKER_API_KEY",
+            "--base-model-alias",
+            "base",
+            "--base-model",
+            "test-base-model",
+            "--maximum-cost-usd",
+            "1.0",
+            "--training-usd-per-million-tokens",
+            "100",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert backend.open_resume_paths == [None]
+    assert fixture.store.load_project().model_optimization_config is None
+    latest = load_latest_sft_model_optimization(fixture.store)
+    assert latest is not None
+    catalog = load_model_catalog(fixture.store.model_catalog_path)
+    assert catalog.connections["tinker-local"].provider == "tinker"
+    assert catalog.connections["tinker-local"].api_key_env == "TINKER_API_KEY"
+    assert catalog.models["base"] == ModelRecord(connection="tinker-local", model="test-base-model")
+    config = command.load_sft_model_optimization_config(fixture.store, latest.config.artifact_id)
+    constructed = []
+
+    def sampler_factory(model, api_key, base_url):  # noqa: ANN001, ANN202
+        """Record the restarted resolver's exact selected connection inputs.
+
+        Args:
+            model: Immutable registered trained-model snapshot.
+            api_key: Credential resolved from the persisted environment-variable name.
+            base_url: Optional endpoint from the selected Tinker connection.
+
+        Returns:
+            Deterministic sampling seam for the restarted runtime.
+        """
+        constructed.append((model.model_id, api_key, base_url))
+        return _RestartSampler()
+
+    resolver = RuntimeModelCatalog(
+        load_model_catalog(fixture.store.model_catalog_path),
+        environment={"TINKER_API_KEY": "runtime-secret"},
+        tinker_sampler_factory=sampler_factory,
+    )
+    resolved = resolver.resolve(config.model_alias)
+
+    assert constructed == [(catalog.models[config.model_alias].model, "runtime-secret", None)]
+    assert (
+        resolved.client.complete(
+            ModelRequest(messages=(ModelMessage(role="user", content="Hello"),))
+        ).output.content
+        == "resolved after restart"
+    )
+    drifted_connections = dict(catalog.connections)
+    drifted_connections["tinker-local"] = catalog.connections["tinker-local"].model_copy(
+        update={"api_key_env": "OTHER_TINKER_API_KEY"}
+    )
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        catalog.model_copy(update={"connections": drifted_connections}),
+    )
+    credential_reads = []
+
+    def forbidden_credential_read(*args: object, **kwargs: object) -> Never:
+        """Fail if connection drift reaches the credential boundary.
+
+        Args:
+            args: Unexpected positional credential lookup inputs.
+            kwargs: Unexpected keyword credential lookup inputs.
+        """
+        del args, kwargs
+        credential_reads.append(True)
+        raise AssertionError("credential lookup must follow provenance verification")
+
+    monkeypatch.setattr(
+        "wmo.runtime.models.registry.read_connection_api_key",
+        forbidden_credential_read,
+    )
+    restarted_after_drift = RuntimeModelCatalog(
+        load_model_catalog(fixture.store.model_catalog_path),
+        environment={"OTHER_TINKER_API_KEY": "drifted-secret"},
+        tinker_sampler_factory=sampler_factory,
+    )
+
+    with pytest.raises(ModelConnectionError, match="connection metadata drifted"):
+        restarted_after_drift.resolve(config.model_alias)
+    assert credential_reads == []
+    assert len(constructed) == 1
+
+
+def test_cli_first_run_noninteractive_reports_all_required_tinker_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Report complete setup remediation before backend composition or consent.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped replacement that fails if backend composition is reached.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"openai": ConnectionConfig(provider="openai")},
+            models={"judge": ModelRecord(connection="openai", model="judge-model")},
+        ),
+    )
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="missing-setup",
+        conversation="missing-setup-conversation",
+        request=_request(ModelMessage(role="user", content="Completed request")),
+        output=AssistantAction(content="Completed response"),
+        now=_TIME,
+    )
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls = []
+    artifact_ids = fixture.store.artifacts.list_ids()
+    catalog_bytes = fixture.store.model_catalog_path.read_bytes()
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if incomplete first-run setup reaches backend composition.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("backend composition must not run")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            fixture.store.paths.project_id,
+            "--root",
+            str(fixture.store.paths.root),
+        ],
+    )
+
+    flat = "".join(
+        character
+        for character in result.output
+        if not character.isspace() and character not in "│┃"
+    )
+    assert result.exit_code == 2
+    assert "--tinker-connection" in flat
+    assert "--tinker-api-key-env" in flat
+    assert "--base-model-alias" in flat
+    assert "--base-model" in flat
+    assert "--training-usd-per-million-tokens" in flat
+    assert backend_calls == []
+    assert load_latest_sft_model_optimization(fixture.store) is None
+    assert fixture.store.artifacts.list_ids() == artifact_ids
+    assert fixture.store.model_catalog_path.read_bytes() == catalog_bytes
+
+
+def test_first_run_setup_cancellation_writes_no_catalog_or_training_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Leave catalog, artifacts, and latest selection unchanged when setup is declined.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped interactive prompt replacements.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"openai": ConnectionConfig(provider="openai")},
+            models={"judge": ModelRecord(connection="openai", model="judge-model")},
+        ),
+    )
+    command = importlib.import_module("wmo.cli.model_optimize")
+    catalog_bytes = fixture.store.model_catalog_path.read_bytes()
+    artifact_ids = fixture.store.artifacts.list_ids()
+    answers = iter(("tinker-local", "base", "TINKER_API_KEY", "test-base-model"))
+    backend_calls = []
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="cancelled-setup",
+        conversation="cancelled-setup-conversation",
+        request=_request(ModelMessage(role="user", content="Completed request")),
+        output=AssistantAction(content="Completed response"),
+        now=_TIME,
+    )
+
+    class _TTY:
+        """Minimal stdin contract used only to select interactive setup behavior."""
+
+        def isatty(self) -> bool:
+            """Report that setup may prompt interactively."""
+            return True
+
+    monkeypatch.setattr(command.sys, "stdin", _TTY())
+    monkeypatch.setattr(command.Prompt, "ask", lambda *args, **kwargs: next(answers))
+    monkeypatch.setattr(command.Confirm, "ask", lambda *args, **kwargs: False)
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if declined setup imports or constructs the Tinker backend.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("backend composition must not run")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+
+    with pytest.raises(typer.Abort):
+        command.optimize_model(
+            project=fixture.store.paths.project_id,
+            root=fixture.store.paths.root,
+            yes=False,
+            tinker_connection=None,
+            tinker_api_key_env=None,
+            base_model_alias=None,
+            base_model=None,
+            maximum_cost_usd=25.0,
+            training_usd_per_million_tokens=100.0,
+        )
+
+    assert fixture.store.model_catalog_path.read_bytes() == catalog_bytes
+    assert fixture.store.artifacts.list_ids() == artifact_ids
+    assert load_latest_sft_model_optimization(fixture.store) is None
+    assert backend_calls == []
 
 
 def test_cli_runs_fake_w13_then_idempotently_resumes_without_consent(
@@ -60,13 +431,24 @@ def test_cli_runs_fake_w13_then_idempotently_resumes_without_consent(
     configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
     command = importlib.import_module("wmo.cli.model_optimize")
     first_backend = _FakeBackend(conservative_cost_per_batch=0.10)
-    monkeypatch.setattr(command, "_compose_tinker_backend", lambda: first_backend)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: first_backend)
     monkeypatch.setattr(command, "_current_revision", lambda: "w14m-test")
     attempts = []
     emitted = []
     receipts: set[str] = set()
 
     def capture(event, completion_id, properties, *, root):  # noqa: ANN001, ANN202
+        """Record one telemetry attempt while emitting each completion identity once.
+
+        Args:
+            event: Telemetry event name.
+            completion_id: Durable completion identity used for deduplication.
+            properties: Aggregate completion properties.
+            root: Project root receiving the local telemetry receipt.
+
+        Returns:
+            Whether this completion identity emitted for the first time.
+        """
         attempt = (event, completion_id, properties, root)
         attempts.append(attempt)
         if completion_id in receipts:
@@ -95,7 +477,7 @@ def test_cli_runs_fake_w13_then_idempotently_resumes_without_consent(
     assert first_backend.cost_calls > 0
     assert first_backend.open_resume_paths == [None]
     second_backend = _FakeBackend(conservative_cost_per_batch=0.10)
-    monkeypatch.setattr(command, "_compose_tinker_backend", lambda: second_backend)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: second_backend)
 
     second = runner.invoke(
         app,
@@ -109,7 +491,8 @@ def test_cli_runs_fake_w13_then_idempotently_resumes_without_consent(
     )
 
     assert second.exit_code == 0, second.output
-    assert "already registered" in second.output
+    assert "was already" in second.output
+    assert "registered." in second.output
     assert second_backend.open_resume_paths == []
     assert len(attempts) == 2
     assert len(emitted) == 1
@@ -120,11 +503,11 @@ def test_cli_runs_fake_w13_then_idempotently_resumes_without_consent(
         for _event, _completion_id, _properties, event_root in attempts
     )
     assert all(
-        properties["training_step_count"] == 2
+        properties["training_step_count"] == 1
         for _event, _completion_id, properties, _root in attempts
     )
     assert all(
-        properties["cost_usd"] == pytest.approx(0.2)
+        properties["cost_usd"] == pytest.approx(0.1)
         for _event, _completion_id, properties, _root in attempts
     )
 
@@ -136,13 +519,27 @@ def test_cli_crash_after_sft_receipt_replays_without_duplicate_event_or_dispatch
     configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
     command = importlib.import_module("wmo.cli.model_optimize")
     first_backend = _FakeBackend(conservative_cost_per_batch=0.10)
-    monkeypatch.setattr(command, "_compose_tinker_backend", lambda: first_backend)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: first_backend)
     monkeypatch.setattr(command, "_current_revision", lambda: "w14m-test")
     attempts = []
     emitted = []
     receipts: set[str] = set()
 
     def crash_once(event, completion_id, properties, *, root):  # noqa: ANN001, ANN202
+        """Persist one telemetry receipt, then simulate a crash on its first emission.
+
+        Args:
+            event: Telemetry event name.
+            completion_id: Durable completion identity used for deduplication.
+            properties: Aggregate completion properties.
+            root: Project root receiving the local telemetry receipt.
+
+        Returns:
+            False when the receipt already exists.
+
+        Raises:
+            RuntimeError: The first unique receipt simulates a post-write process crash.
+        """
         attempt = (event, completion_id, properties, root)
         attempts.append(attempt)
         if completion_id in receipts:
@@ -169,11 +566,12 @@ def test_cli_crash_after_sft_receipt_replays_without_duplicate_event_or_dispatch
     assert first_backend.open_resume_paths == [None]
 
     replay_backend = _FakeBackend(conservative_cost_per_batch=0.10)
-    monkeypatch.setattr(command, "_compose_tinker_backend", lambda: replay_backend)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: replay_backend)
     replay = runner.invoke(app, arguments[:-1])
 
     assert replay.exit_code == 0, replay.output
-    assert "already registered" in replay.output
+    assert "was already" in replay.output
+    assert "registered." in replay.output
     assert replay_backend.open_resume_paths == []
     assert len(attempts) == 2
     assert len(emitted) == 1
@@ -186,7 +584,7 @@ def test_cli_yes_does_not_bypass_the_unsupported_budget_estimate_gate(
     configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
     command = importlib.import_module("wmo.cli.model_optimize")
     backend = _FakeBackend(conservative_cost_per_batch=None)
-    monkeypatch.setattr(command, "_compose_tinker_backend", lambda: backend)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: backend)
     monkeypatch.setattr(command, "_current_revision", lambda: "w14m-test")
 
     result = CliRunner().invoke(
@@ -208,3 +606,559 @@ def test_cli_yes_does_not_bypass_the_unsupported_budget_estimate_gate(
         if not character.isspace() and character not in "│┃"
     )
     assert backend.open_resume_paths == []
+
+
+def test_cli_empty_journal_fails_before_backend_or_consent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject an empty runtime source before SDK composition or user spend consent.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped replacements that fail if later execution boundaries are reached.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    configured.store.paths.runtime_journal.unlink()
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls = []
+    consent_calls = []
+
+    def forbidden_backend(*args: object) -> Never:
+        """Record and fail any backend composition after empty-source validation.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("backend composition must not run")
+
+    def forbidden_consent(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        """Record and fail any consent prompt after empty-source validation.
+
+        Args:
+            args: Unexpected positional consent inputs.
+            kwargs: Unexpected keyword consent inputs.
+
+        Raises:
+            AssertionError: Always, because empty input must fail before consent.
+        """
+        consent_calls.append((args, kwargs))
+        raise AssertionError("consent must not run")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+    monkeypatch.setattr(command, "require_spend_consent", forbidden_consent)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "nointeractions" in "".join(
+        character
+        for character in result.output
+        if not character.isspace() and character not in "│┃"
+    )
+    assert backend_calls == []
+    assert consent_calls == []
+
+
+def test_declined_spend_consent_does_not_resolve_credentials_or_construct_sdk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep credential lookup, SDK import, and ServiceClient construction after consent.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped consent and backend-boundary replacements.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls = []
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if declined spend consent reaches credential or SDK composition.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("backend composition must follow consent")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+    monkeypatch.setattr(command, "require_spend_consent", lambda *args, **kwargs: False)
+    monkeypatch.setattr(command, "_current_revision", lambda: "declined-consent-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "was not started" in result.output
+    assert backend_calls == []
+
+
+def test_connection_drift_after_consent_fails_before_credential_or_sdk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recheck frozen connection metadata after consent and before external construction.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped consent, credential, and SDK constructor replacements.
+    """
+    import tinker
+
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    credential_reads = []
+    service_calls = []
+
+    def consent_with_connection_drift(*args: object, **kwargs: object) -> bool:
+        """Mutate only the selected credential reference at the consent boundary.
+
+        Args:
+            args: Consent inputs accepted without inspection.
+            kwargs: Consent inputs accepted without inspection.
+
+        Returns:
+            ``True`` after persisting the adversarial drift.
+        """
+        del args, kwargs
+        catalog = load_model_catalog(configured.store.model_catalog_path)
+        connections = dict(catalog.connections)
+        connections["tinker"] = connections["tinker"].model_copy(
+            update={"api_key_env": "DRIFTED_TINKER_API_KEY"}
+        )
+        write_model_catalog(
+            configured.store.model_catalog_path,
+            catalog.model_copy(update={"connections": connections}),
+        )
+        return True
+
+    def forbidden_credential_read(*args: object, **kwargs: object) -> Never:
+        """Fail if drift validation occurs after credential lookup.
+
+        Args:
+            args: Unexpected positional credential inputs.
+            kwargs: Unexpected keyword credential inputs.
+        """
+        del args, kwargs
+        credential_reads.append(True)
+        raise AssertionError("credential lookup must follow drift validation")
+
+    def forbidden_service_client(*args: object, **kwargs: object) -> Never:
+        """Fail if drift validation occurs after ServiceClient construction.
+
+        Args:
+            args: Unexpected positional SDK inputs.
+            kwargs: Unexpected keyword SDK inputs.
+        """
+        del args, kwargs
+        service_calls.append(True)
+        raise AssertionError("ServiceClient construction must follow drift validation")
+
+    monkeypatch.setattr(command, "require_spend_consent", consent_with_connection_drift)
+    monkeypatch.setattr(command, "read_connection_api_key", forbidden_credential_read)
+    monkeypatch.setattr(tinker, "ServiceClient", forbidden_service_client)
+    monkeypatch.setattr(command, "_current_revision", lambda: "post-consent-drift-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "metadatadriftedbeforecredentialresolution" in "".join(
+        character
+        for character in result.output
+        if not character.isspace() and character not in "│┃"
+    )
+    assert credential_reads == []
+    assert service_calls == []
+
+
+def test_first_run_explicit_zero_training_price_is_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Accept zero only through the explicit price flag and persist it in immutable settings.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped backend and revision replacements.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"openai": ConnectionConfig(provider="openai")},
+            models={"judge": ModelRecord(connection="openai", model="judge-model")},
+        ),
+    )
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="free-training",
+        conversation="free-training-conversation",
+        request=_request(ModelMessage(role="user", content="Train this request")),
+        output=AssistantAction(content="Train this response"),
+        now=_TIME,
+    )
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend = _FakeBackend(cost_per_batch=0.0, conservative_cost_per_batch=0.0)
+    monkeypatch.setattr(command, "_compose_tinker_backend", lambda *_args: backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "explicit-zero-price-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            fixture.store.paths.project_id,
+            "--root",
+            str(fixture.store.paths.root),
+            "--tinker-connection",
+            "tinker-local",
+            "--tinker-api-key-env",
+            "TINKER_API_KEY",
+            "--base-model-alias",
+            "base",
+            "--base-model",
+            "test-base-model",
+            "--training-usd-per-million-tokens",
+            "0",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    latest = load_latest_sft_model_optimization(fixture.store)
+    assert latest is not None
+    config = command.load_sft_model_optimization_config(fixture.store, latest.config.artifact_id)
+    assert config.training.training_usd_per_million_tokens == 0.0
+
+
+def test_schedule_ceiling_refuses_before_tinker_backend_construction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject the full local token-price reservation before importing or constructing Tinker.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped backend replacement proving the SDK boundary is not reached.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"openai": ConnectionConfig(provider="openai")},
+            models={"judge": ModelRecord(connection="openai", model="judge-model")},
+        ),
+    )
+    _complete(
+        RuntimeInteractionJournal(fixture.store.paths),
+        key="over-budget",
+        conversation="over-budget-conversation",
+        request=_request(ModelMessage(role="user", content="Expensive request")),
+        output=AssistantAction(content="Expensive response"),
+        now=_TIME,
+    )
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls = []
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if an over-budget local schedule reaches Tinker construction.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("Tinker backend must not be constructed")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "local-price-ceiling-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            fixture.store.paths.project_id,
+            "--root",
+            str(fixture.store.paths.root),
+            "--tinker-connection",
+            "tinker-local",
+            "--tinker-api-key-env",
+            "TINKER_API_KEY",
+            "--base-model-alias",
+            "base",
+            "--base-model",
+            "test-base-model",
+            "--maximum-cost-usd",
+            "1",
+            "--training-usd-per-million-tokens",
+            "1000000",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "exceedsmaximum_cost_usd" in "".join(
+        character
+        for character in result.output
+        if not character.isspace() and character not in "│┃"
+    )
+    assert backend_calls == []
+
+
+def test_selected_price_replay_rejects_explicit_drift_before_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject an invocation price that differs from the selected immutable config.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped backend replacement proving drift fails locally.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls = []
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if immutable price drift reaches Tinker construction.
+
+        Args:
+            args: Unexpected project and connection arguments from backend composition.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("Tinker backend must not be constructed")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+            "--training-usd-per-million-tokens",
+            "101",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "differsfromtheselectedimmutable" in "".join(
+        character
+        for character in result.output
+        if not character.isspace() and character not in "│┃"
+    )
+    assert backend_calls == []
+
+
+def test_tinker_backend_uses_the_selected_credential_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Construct training with the exact cataloged key name at the authorized boundary.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        monkeypatch: Scoped environment and SDK constructor replacements.
+    """
+    import tinker
+
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    command = importlib.import_module("wmo.cli.model_optimize")
+    constructed = []
+
+    def service_client(*, api_key: str, base_url: str | None = None) -> object:
+        """Capture only whether the named credential reaches the exact SDK constructor.
+
+        Args:
+            api_key: Credential resolved from the selected environment-variable name.
+            base_url: Optional selected endpoint.
+
+        Returns:
+            Opaque caller-owned service seam accepted by the backend wrapper.
+        """
+        constructed.append((api_key, base_url))
+        return object()
+
+    monkeypatch.setenv("TINKER_API_KEY", "training-secret")
+    monkeypatch.setattr(tinker, "ServiceClient", service_client)
+
+    backend = command._compose_tinker_backend(
+        configured.store,
+        "tinker",
+        configured.config.connection_config_sha256,
+    )
+
+    assert isinstance(backend, command.TinkerTrainerBackend)
+    assert constructed == [("training-secret", None)]
+
+
+def test_catalog_setup_preserves_unrelated_concurrent_additions(tmp_path: Path) -> None:
+    """Merge a confirmed Tinker selection without erasing unrelated catalog drift.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    command = importlib.import_module("wmo.cli.model_optimize")
+    observed = _seed_catalog(fixture.store)
+    concurrent = observed.model_copy(
+        update={
+            "connections": {
+                **observed.connections,
+                "other": ConnectionConfig(provider="openai"),
+            },
+            "models": {
+                **observed.models,
+                "other-model": ModelRecord(connection="other", model="other-model-id"),
+            },
+        }
+    )
+    write_model_catalog(fixture.store.model_catalog_path, concurrent)
+
+    command._persist_tinker_selection(
+        fixture.store,
+        observed_catalog_sha256=sha256_json(observed),
+        connection_name="tinker-local",
+        api_key_env="TINKER_API_KEY",
+        alias="base",
+        resolved_model="test-base-model",
+    )
+
+    updated = load_model_catalog(fixture.store.model_catalog_path)
+    assert updated.connections["other"] == concurrent.connections["other"]
+    assert updated.models["other-model"] == concurrent.models["other-model"]
+    assert updated.connections["tinker-local"] == ConnectionConfig(
+        provider="tinker", api_key_env="TINKER_API_KEY"
+    )
+    assert updated.models["base"] == ModelRecord(connection="tinker-local", model="test-base-model")
+
+
+@pytest.mark.parametrize("conflict", ["connection", "alias"])
+def test_catalog_setup_rejects_concurrent_target_drift(tmp_path: Path, conflict: str) -> None:
+    """Reject a stale setup when a concurrent writer changes either confirmed target.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        conflict: Confirmed catalog entry changed by the simulated concurrent writer.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    command = importlib.import_module("wmo.cli.model_optimize")
+    observed = _seed_catalog(fixture.store)
+    connections = dict(observed.connections)
+    models = dict(observed.models)
+    if conflict == "connection":
+        connections["tinker-local"] = ConnectionConfig(provider="openai")
+    else:
+        connections["tinker-local"] = ConnectionConfig(
+            provider="tinker", api_key_env="TINKER_API_KEY"
+        )
+        models["base"] = ModelRecord(connection="tinker-local", model="different-model")
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        observed.model_copy(update={"connections": connections, "models": models}),
+    )
+
+    with pytest.raises(typer.BadParameter, match="changed before setup commit"):
+        command._persist_tinker_selection(
+            fixture.store,
+            observed_catalog_sha256=sha256_json(observed),
+            connection_name="tinker-local",
+            api_key_env="TINKER_API_KEY",
+            alias="base",
+            resolved_model="test-base-model",
+        )
+
+
+def test_catalog_setup_is_idempotent_for_same_concurrent_selection(tmp_path: Path) -> None:
+    """Allow two stale first-run proposals to commit the exact same Tinker selection.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    command = importlib.import_module("wmo.cli.model_optimize")
+    observed = _seed_catalog(fixture.store)
+    observed_sha256 = sha256_json(observed)
+    arguments = {
+        "observed_catalog_sha256": observed_sha256,
+        "connection_name": "tinker-local",
+        "api_key_env": "TINKER_API_KEY",
+        "alias": "base",
+        "resolved_model": "test-base-model",
+    }
+
+    command._persist_tinker_selection(fixture.store, **arguments)
+    first_bytes = fixture.store.model_catalog_path.read_bytes()
+    command._persist_tinker_selection(fixture.store, **arguments)
+
+    assert fixture.store.model_catalog_path.read_bytes() == first_bytes
+
+
+def test_catalog_setup_preserves_compatible_base_model_metadata(tmp_path: Path) -> None:
+    """Retain harmless revision and capability metadata on an already matching base alias.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    command = importlib.import_module("wmo.cli.model_optimize")
+    existing_record = ModelRecord(
+        connection="tinker-local",
+        model="test-base-model",
+        revision="provider-revision-1",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            context_window_tokens=32_768,
+        ),
+    )
+    catalog = ModelCatalog(
+        connections={
+            "tinker-local": ConnectionConfig(provider="tinker", api_key_env="TINKER_API_KEY")
+        },
+        models={"base": existing_record},
+    )
+    write_model_catalog(fixture.store.model_catalog_path, catalog)
+    catalog_bytes = fixture.store.model_catalog_path.read_bytes()
+
+    command._persist_tinker_selection(
+        fixture.store,
+        observed_catalog_sha256=sha256_json(catalog),
+        connection_name="tinker-local",
+        api_key_env="TINKER_API_KEY",
+        alias="base",
+        resolved_model="test-base-model",
+    )
+
+    assert fixture.store.model_catalog_path.read_bytes() == catalog_bytes
+    assert load_model_catalog(fixture.store.model_catalog_path).models["base"] == existing_record

--- a/wmo/cli/optimize_app.py
+++ b/wmo/cli/optimize_app.py
@@ -3,7 +3,7 @@
 """`wmo optimize`: the one switch over the product optimizers.
 
 The group is exactly two commands: `router` (the guarded offline kNN path) and
-`model` (offline SFT from persisted artifacts). This module owns the switch only,
+`model` (automatic routed-interaction SFT). This module owns the switch only,
 so no optimization logic lives here.
 """
 
@@ -24,5 +24,5 @@ optimize_app.command(
     help="Optimize a guarded router automatically from one completed project build.",
 )(router)
 optimize_app.command(
-    "model", help="Run W13 Tinker SFT from an explicit persisted W12 dataset configuration."
+    "model", help="Build routed interactions into W12 and run bounded W13 Tinker SFT."
 )(optimize_model)

--- a/wmo/cli/run_cmd.py
+++ b/wmo/cli/run_cmd.py
@@ -14,6 +14,11 @@ _POLICY_OPTION = typer.Option(
     help="Exact frozen policy ID; required only when the project contains several.",
 )
 _PORT_OPTION = typer.Option(8000, "--port", min=1, max=65_535)
+_GHOST_OPTION = typer.Option(
+    False,
+    "--ghost",
+    help="Route traffic without durable interaction journals or replay state.",
+)
 
 
 def run(
@@ -21,6 +26,7 @@ def run(
     root: Path = _ROOT_OPTION,
     policy: str | None = _POLICY_OPTION,
     port: int = _PORT_OPTION,
+    ghost: bool = _GHOST_OPTION,
 ) -> None:
     """Start a development-only loopback adapter over one frozen router.
 
@@ -33,6 +39,7 @@ def run(
         root: Local artifact and model-catalog root.
         policy: Optional exact policy identity for an otherwise ambiguous project.
         port: Local loopback TCP port.
+        ghost: Whether completed traffic must bypass durable journal and replay state.
 
     Raises:
         typer.BadParameter: Project runtime activation fails before the server starts.
@@ -49,12 +56,18 @@ def run(
     try:
         runtime = load_project_router(project, root, policy_id=policy)
         project_store = ProjectStore(root, project)
-        completion_service = create_project_completion_service(project_store, runtime)
+        completion_service = create_project_completion_service(
+            project_store,
+            runtime,
+            ghost=ghost,
+        )
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from None
     typer.echo(
         f"loaded policy {runtime.policy.policy_id} with {runtime.policy.judgment_status} judgment"
     )
+    if ghost:
+        typer.echo("ghost mode enabled: durable interaction journaling is disabled")
     typer.echo(f"OpenAI API router at http://{_LOOPBACK_HOST}:{port}/v1")
     uvicorn.run(
         create_project_router_app(

--- a/wmo/cli/run_cmd_test.py
+++ b/wmo/cli/run_cmd_test.py
@@ -12,8 +12,17 @@ from wmo.cli.app import app
 from wmo.common.project import ProjectStore
 
 
-def test_run_loads_once_and_can_only_bind_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The CLI activates locally without a request and never accepts a remote host."""
+@pytest.mark.parametrize("ghost", [False, True])
+def test_run_loads_once_and_can_only_bind_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+    ghost: bool,
+) -> None:
+    """The CLI activates locally, supports ghost mode, and only binds loopback.
+
+    Args:
+        monkeypatch: Scoped replacements for runtime and server boundaries.
+        ghost: Whether the invocation disables durable interaction state.
+    """
     runtime = SimpleNamespace(
         policy=SimpleNamespace(policy_id="policy-a", judgment_status="provisional")
     )
@@ -36,13 +45,15 @@ def test_run_loads_once_and_can_only_bind_loopback(monkeypatch: pytest.MonkeyPat
         return runtime
 
     services: list[object] = []
+    ghost_modes: list[bool] = []
 
-    def compose(store: ProjectStore, selected: object) -> object:
-        """Capture project-scoped durable composition without dispatching the runtime.
+    def compose(store: ProjectStore, selected: object, *, ghost: bool = False) -> object:
+        """Capture project-scoped traffic composition without dispatching the runtime.
 
         Args:
             store: Project store created for the requested root and project.
             selected: Previously loaded frozen runtime.
+            ghost: Whether durable interaction state is disabled.
 
         Returns:
             Opaque completion service passed to application composition.
@@ -50,6 +61,7 @@ def test_run_loads_once_and_can_only_bind_loopback(monkeypatch: pytest.MonkeyPat
         assert store.paths.project_id == "project-a"
         assert store.paths.root == Path("/tmp/local-wmo")
         assert selected is runtime
+        ghost_modes.append(ghost)
         service = object()
         services.append(service)
         return service
@@ -89,15 +101,26 @@ def test_run_loads_once_and_can_only_bind_loopback(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("wmo.runtime.router.application.create_project_router_app", create)
     monkeypatch.setattr("uvicorn.run", serve)
 
-    result = CliRunner().invoke(
-        app,
-        ["run", "project-a", "--root", "/tmp/local-wmo", "--policy", "policy-a", "--port", "8123"],
-    )
+    arguments = [
+        "run",
+        "project-a",
+        "--root",
+        "/tmp/local-wmo",
+        "--policy",
+        "policy-a",
+        "--port",
+        "8123",
+    ]
+    if ghost:
+        arguments.append("--ghost")
+    result = CliRunner().invoke(app, arguments)
 
     assert result.exit_code == 0, result.output
     assert loaded == [("project-a", Path("/tmp/local-wmo"), "policy-a")]
     assert len(services) == 1
+    assert ghost_modes == [ghost]
     assert served == [(application, "127.0.0.1", 8123)]
     assert "provisional judgment" in result.output
     assert "OpenAI API router at http://127.0.0.1:8123/v1" in result.output
+    assert ("ghost mode enabled" in result.output) is ghost
     assert "--host" not in CliRunner().invoke(app, ["run", "--help"]).output

--- a/wmo/cli/startup_test.py
+++ b/wmo/cli/startup_test.py
@@ -119,3 +119,50 @@ assert callable(load_world_model)
 assert load_world_model.__module__ == "wmo.simulation.world_model.application"
 """
     )
+
+
+def test_router_server_public_imports_resolve_after_lazy_package_import() -> None:
+    """Resolve public router application and endpoint services through lazy exports."""
+    _run(
+        """
+import wmo.runtime.router as router
+assert {"create_router_endpoint", "load_router"}.issubset(dir(router))
+try:
+    getattr(router, "p17_unknown_router_export")
+except AttributeError:
+    pass
+else:
+    raise AssertionError("unknown router export resolved")
+from wmo.runtime.router import create_router_endpoint, load_router
+from wmo.runtime.router.application import load_router as nested_load_router
+from wmo.runtime.router.endpoint import create_router_endpoint as nested_endpoint
+assert create_router_endpoint.__module__ == "wmo.runtime.router.endpoint"
+assert load_router.__module__ == "wmo.runtime.router.application"
+assert create_router_endpoint is nested_endpoint
+assert load_router is nested_load_router
+"""
+    )
+
+
+def test_runtime_rag_refresh_public_imports_resolve_after_lazy_package_import() -> None:
+    """Resolve public runtime refresh services through lazy retrieval exports."""
+    _run(
+        """
+import sys
+import wmo.simulation.retrieval as retrieval
+names = {"RuntimeRAGRefresh", "RuntimeTraceStitchingError", "refresh_runtime_trace_rag"}
+assert names.issubset(dir(retrieval))
+assert "wmo.runtime.router" not in sys.modules
+try:
+    getattr(retrieval, "p17_unknown_retrieval_export")
+except AttributeError:
+    pass
+else:
+    raise AssertionError("unknown retrieval export resolved")
+from wmo.simulation.retrieval import RuntimeRAGRefresh, refresh_runtime_trace_rag
+from wmo.simulation.retrieval.refresh import RuntimeRAGRefresh as nested_refresh_type
+from wmo.simulation.retrieval.refresh import refresh_runtime_trace_rag as nested_refresh
+assert RuntimeRAGRefresh is nested_refresh_type
+assert refresh_runtime_trace_rag is nested_refresh
+"""
+    )

--- a/wmo/cli/startup_test.py
+++ b/wmo/cli/startup_test.py
@@ -108,3 +108,14 @@ assert RuntimeRAGRefresh is nested_refresh_type
 assert refresh_runtime_trace_rag is nested_refresh
 """
     )
+
+
+def test_world_model_public_import_resolves_after_lazy_package_import() -> None:
+    """Resolve the public world-model loader through the lazy package export."""
+    _run(
+        """
+from wmo.simulation.world_model import load_world_model
+assert callable(load_world_model)
+assert load_world_model.__module__ == "wmo.simulation.world_model.application"
+"""
+    )

--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -1,5 +1,12 @@
 """Frozen, leakage-safe SFT datasets and managed offline Tinker SFT behavior."""
 
+from wmo.optimize.model.sft.automatic import (
+    AutomaticSFTPreparation,
+    AutomaticSFTPreparationError,
+    InitialSFTModelOptimizationSettings,
+    prepare_runtime_sft_model_optimization,
+    require_completed_runtime_interactions,
+)
 from wmo.optimize.model.sft.builder import (
     SFTBuildError,
     SFTBuildSpec,
@@ -75,6 +82,9 @@ from wmo.optimize.model.sft.training import (
 
 __all__ = [
     "AssistantActionEvent",
+    "AutomaticSFTPreparation",
+    "AutomaticSFTPreparationError",
+    "InitialSFTModelOptimizationSettings",
     "CanonicalSFTTurn",
     "HumanApproval",
     "InfrastructureFailureEvent",
@@ -123,6 +133,8 @@ __all__ = [
     "load_sft_model_optimization_config",
     "load_verified_sft_dataset",
     "parse_rendered_turn",
+    "prepare_runtime_sft_model_optimization",
+    "require_completed_runtime_interactions",
     "preflight_sft_model_optimization",
     "render_context_target",
     "resolve_runtime_source",

--- a/wmo/optimize/model/sft/__init__.py
+++ b/wmo/optimize/model/sft/__init__.py
@@ -4,6 +4,7 @@ from wmo.optimize.model.sft.automatic import (
     AutomaticSFTPreparation,
     AutomaticSFTPreparationError,
     InitialSFTModelOptimizationSettings,
+    accept_runtime_sft_model_optimization,
     prepare_runtime_sft_model_optimization,
     require_completed_runtime_interactions,
 )
@@ -125,6 +126,7 @@ __all__ = [
     "TinkerTrainerSession",
     "ToolEvent",
     "TrainerBackend",
+    "accept_runtime_sft_model_optimization",
     "build_sft_dataset",
     "create_sft_model_optimization_config",
     "context_target_fingerprint",

--- a/wmo/optimize/model/sft/automatic.py
+++ b/wmo/optimize/model/sft/automatic.py
@@ -1,0 +1,383 @@
+"""Automatic immutable runtime-dataset preparation for managed model optimization."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+
+from wmo.common.core.artifacts import ArtifactId, ArtifactInput, ContractModel, canonical_json_bytes
+from wmo.common.models import ModelCatalogError, load_model_catalog
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
+from wmo.optimize.model.sft.builder import (
+    SFTBuildError,
+    build_sft_dataset,
+    load_verified_sft_dataset,
+    write_sft_dataset,
+)
+from wmo.optimize.model.sft.composition import (
+    SFTModelOptimizationConfig,
+    SFTModelOptimizationError,
+    create_sft_model_optimization_config,
+    load_sft_model_optimization_config,
+    write_sft_model_optimization_config,
+)
+from wmo.optimize.model.sft.contracts import RuntimeSFTSource, SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.selection import (
+    LatestSFTModelOptimization,
+    SFTModelOptimizationSelectionError,
+    load_latest_sft_model_optimization,
+    versioned_sft_model_alias,
+    write_latest_sft_model_optimization,
+)
+from wmo.optimize.model.sft.training_contracts import TinkerSFTSpec
+from wmo.runtime.router.journal import (
+    RuntimeCompletedEvent,
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    RuntimeJournalEvent,
+)
+from wmo.runtime.router.snapshot import (
+    RuntimeTraceSnapshot,
+    RuntimeTraceSnapshotError,
+    load_runtime_trace_snapshot,
+    seal_runtime_trace_snapshot,
+)
+
+
+class AutomaticSFTPreparationError(ValueError):
+    """Runtime evidence cannot safely select an immutable SFT dataset and config."""
+
+
+class InitialSFTModelOptimizationSettings(ContractModel):
+    """Confirmed first-run Tinker selections and bounded training schedule."""
+
+    model_alias_prefix: ArtifactId
+    tinker_connection: ArtifactId
+    base_model_alias: ArtifactId
+    training: TinkerSFTSpec
+
+
+@dataclass(frozen=True)
+class AutomaticSFTPreparation:
+    """Verified artifacts selected before consent or trainer-backend composition.
+
+    Attributes:
+        snapshot: Exact sealed runtime journal prefix used as the SFT source.
+        dataset: Recursively verified immutable W12 runtime dataset.
+        config: Latest immutable bounded Tinker model-optimization config.
+        created: Whether this call advanced the selected immutable graph.
+    """
+
+    snapshot: RuntimeTraceSnapshot
+    dataset: SFTDatasetArtifact
+    config: SFTModelOptimizationConfig
+    created: bool
+
+
+def prepare_runtime_sft_model_optimization(
+    store: ProjectStore,
+    *,
+    created_at: datetime,
+    code_revision: str,
+    initial_settings: InitialSFTModelOptimizationSettings | None = None,
+) -> AutomaticSFTPreparation:
+    """Seal completed routed interactions and select their deterministic W12 and config.
+
+    A latest config supplies previously confirmed Tinker settings. The first run instead requires
+    explicit confirmed settings from the caller. Runtime journal content supplies every example.
+    The function performs no trainer-backend construction, consent, credential read, or provider
+    call.
+
+    Args:
+        store: Initialized project containing the runtime journal and local model catalog.
+        created_at: Time recorded by newly materialized immutable artifacts and latest pointer.
+        code_revision: Exact revision recorded by newly materialized artifacts.
+        initial_settings: Confirmed settings required only when no prior config is selected.
+
+    Returns:
+        The reused or newly selected snapshot, W12 dataset, and bounded optimization config.
+
+    Raises:
+        AutomaticSFTPreparationError: The journal has no completed interaction, diverges from the
+            selected prefix, or any source, dataset, config, catalog, or pointer cannot be
+            verified without dispatch.
+    """
+    journal = RuntimeInteractionJournal(store.paths)
+    events = _completed_runtime_events(journal)
+    try:
+        latest = load_latest_sft_model_optimization(store)
+        if latest is not None:
+            selected_input = latest.config
+            selected_config = load_sft_model_optimization_config(store, selected_input.artifact_id)
+            selected_dataset = load_verified_sft_dataset(store, selected_config.dataset.artifact_id)
+            reused = _reuse_or_require_append(
+                store,
+                events=events,
+                latest=latest,
+                config=selected_config,
+                dataset=selected_dataset,
+            )
+            if reused is not None:
+                return reused
+            settings = InitialSFTModelOptimizationSettings(
+                model_alias_prefix=latest.model_alias_prefix,
+                tinker_connection=selected_config.tinker_connection,
+                base_model_alias=selected_config.base_model_alias,
+                training=selected_config.training,
+            )
+        else:
+            selected_input, bootstrap = _optional_bootstrap_config(store)
+            if bootstrap is not None:
+                settings = InitialSFTModelOptimizationSettings(
+                    model_alias_prefix=bootstrap.model_alias,
+                    tinker_connection=bootstrap.tinker_connection,
+                    base_model_alias=bootstrap.base_model_alias,
+                    training=bootstrap.training,
+                )
+            elif initial_settings is not None:
+                settings = initial_settings
+            else:
+                raise AutomaticSFTPreparationError(
+                    "first model optimization needs confirmed Tinker connection, base model, "
+                    "model alias, and bounded training settings"
+                )
+        return _materialize_appended_prefix(
+            store,
+            journal=journal,
+            selected_input=selected_input,
+            settings=settings,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+    except AutomaticSFTPreparationError:
+        raise
+    except (
+        ArtifactCorruptionError,
+        ModelCatalogError,
+        ProjectStoreError,
+        RuntimeTraceSnapshotError,
+        SFTBuildError,
+        SFTModelOptimizationError,
+        SFTModelOptimizationSelectionError,
+        ValueError,
+    ) as exc:
+        raise AutomaticSFTPreparationError(
+            f"cannot prepare routed interactions for model optimization: {exc}"
+        ) from exc
+
+
+def require_completed_runtime_interactions(store: ProjectStore) -> None:
+    """Validate that a project has at least one completed routed SFT target.
+
+    Args:
+        store: Project whose journal is checked before any setup, consent, or backend work.
+
+    Raises:
+        AutomaticSFTPreparationError: The journal is corrupt, empty, or has no completion.
+    """
+    _completed_runtime_events(RuntimeInteractionJournal(store.paths))
+
+
+def _completed_runtime_events(
+    journal: RuntimeInteractionJournal,
+) -> tuple[RuntimeJournalEvent, ...]:
+    """Return a valid journal containing at least one completed routed interaction.
+
+    Args:
+        journal: Project journal read through its complete event validation boundary.
+
+    Returns:
+        Every current durable event in global journal order.
+
+    Raises:
+        AutomaticSFTPreparationError: The journal is corrupt, empty, or contains no completion.
+    """
+    try:
+        events = journal.read_events()
+    except RuntimeJournalError as exc:
+        raise AutomaticSFTPreparationError(f"runtime journal is invalid: {exc}") from exc
+    if not events:
+        raise AutomaticSFTPreparationError(
+            "runtime journal has no interactions; run the router and complete at least one "
+            "request before `wmo optimize model`"
+        )
+    if not any(isinstance(event, RuntimeCompletedEvent) for event in events):
+        raise AutomaticSFTPreparationError(
+            "runtime journal has no completed routed interactions; failed or disconnected "
+            "requests are not SFT targets"
+        )
+    return events
+
+
+def _optional_bootstrap_config(
+    store: ProjectStore,
+) -> tuple[ArtifactInput | None, SFTModelOptimizationConfig | None]:
+    """Load an optional project-bound config as compatible first-run settings.
+
+    Args:
+        store: Project that may retain an explicit bootstrap config binding.
+
+    Returns:
+        The exact config manifest input and verified config, or two ``None`` values.
+    """
+    bound = store.load_project().model_optimization_config
+    if bound is None:
+        return None, None
+    return bound, load_sft_model_optimization_config(store, bound.artifact_id)
+
+
+def _reuse_or_require_append(
+    store: ProjectStore,
+    *,
+    events: tuple[RuntimeJournalEvent, ...],
+    latest: LatestSFTModelOptimization,
+    config: SFTModelOptimizationConfig,
+    dataset: SFTDatasetArtifact,
+) -> AutomaticSFTPreparation | None:
+    """Reuse an unchanged selected prefix or require a strict append-only continuation.
+
+    Args:
+        store: Project containing the selected snapshot.
+        events: Complete currently validated runtime journal.
+        latest: Recursively verified latest graph pointer.
+        config: Config selected by the pointer.
+        dataset: Dataset selected by the config.
+
+    Returns:
+        A reuse result when the journal is unchanged, otherwise ``None`` for a valid append.
+
+    Raises:
+        AutomaticSFTPreparationError: The current journal removed or changed selected events.
+    """
+    loaded = load_runtime_trace_snapshot(store.artifacts, latest.runtime_snapshot.artifact_id)
+    snapshot = loaded.snapshot
+    if len(events) < snapshot.last_ordinal:
+        raise AutomaticSFTPreparationError(
+            "runtime journal is shorter than the latest selected immutable prefix"
+        )
+    selected_prefix = events[: snapshot.last_ordinal]
+    if _events_sha256(selected_prefix) != snapshot.prefix_sha256:
+        raise AutomaticSFTPreparationError(
+            "runtime journal changed inside the latest selected immutable prefix"
+        )
+    if len(events) == snapshot.last_ordinal:
+        return AutomaticSFTPreparation(
+            snapshot=snapshot,
+            dataset=dataset,
+            config=config,
+            created=False,
+        )
+    return None
+
+
+def _materialize_appended_prefix(
+    store: ProjectStore,
+    *,
+    journal: RuntimeInteractionJournal,
+    selected_input: ArtifactInput | None,
+    settings: InitialSFTModelOptimizationSettings,
+    created_at: datetime,
+    code_revision: str,
+) -> AutomaticSFTPreparation:
+    """Persist a new full journal prefix, W12 dataset, config, and latest pointer.
+
+    Args:
+        store: Project receiving immutable artifacts and the coordination update.
+        journal: Validated project runtime journal.
+        selected_input: Exact prior config selection, or ``None`` on a first run.
+        settings: Confirmed Tinker selections and bounded deterministic schedule.
+        created_at: Time recorded on new artifacts and coordination state.
+        code_revision: Exact revision recorded on new artifacts.
+
+    Returns:
+        Newly selected recursively verified artifacts.
+
+    Raises:
+        AutomaticSFTPreparationError: The deterministic alias selection collides.
+    """
+    exported = seal_runtime_trace_snapshot(
+        journal,
+        store.artifacts,
+        created_at=created_at,
+        code_revision=code_revision,
+    )
+    dataset = write_sft_dataset(
+        store,
+        build_sft_dataset(
+            store=store,
+            production_sources=(),
+            teacher_sources=(),
+            runtime_sources=(RuntimeSFTSource(snapshot_id=exported.snapshot.snapshot_id),),
+            spec=SFTBuildSpec(held_out_fraction=0.0),
+            created_at=created_at,
+            code_revision=code_revision,
+        ),
+    )
+    alias_prefix = settings.model_alias_prefix
+    model_alias = versioned_sft_model_alias(alias_prefix, dataset.dataset.dataset_id)
+    catalog = load_model_catalog(store.model_catalog_path)
+    if model_alias in catalog.models:
+        raise AutomaticSFTPreparationError(
+            f"automatic SFT model alias {model_alias!r} already names another catalog record"
+        )
+    config = write_sft_model_optimization_config(
+        store,
+        create_sft_model_optimization_config(
+            store,
+            dataset_id=dataset.dataset.dataset_id,
+            model_alias=model_alias,
+            tinker_connection=settings.tinker_connection,
+            base_model_alias=settings.base_model_alias,
+            training=settings.training,
+            created_at=created_at,
+            code_revision=code_revision,
+        ),
+        bind_project=False,
+    )
+    snapshot_input = artifact_input(exported.snapshot_manifest)
+    dataset_input = artifact_input(store.artifacts.read(dataset.dataset.dataset_id).manifest)
+    config_input = artifact_input(store.artifacts.read(config.config_id).manifest)
+    pointer = write_latest_sft_model_optimization(
+        store,
+        LatestSFTModelOptimization(
+            project_id=store.paths.project_id,
+            config=config_input,
+            dataset=dataset_input,
+            runtime_snapshot=snapshot_input,
+            model_alias_prefix=alias_prefix,
+            updated_at=created_at,
+        ),
+        expected_current=selected_input,
+    )
+    selected = load_sft_model_optimization_config(store, pointer.config.artifact_id)
+    verified_dataset = load_verified_sft_dataset(store, pointer.dataset.artifact_id)
+    verified_snapshot = load_runtime_trace_snapshot(
+        store.artifacts, pointer.runtime_snapshot.artifact_id
+    ).snapshot
+    return AutomaticSFTPreparation(
+        snapshot=verified_snapshot,
+        dataset=verified_dataset,
+        config=selected,
+        created=True,
+    )
+
+
+def _events_sha256(events: tuple[RuntimeJournalEvent, ...]) -> str:
+    """Return the canonical newline-framed digest for a validated journal prefix.
+
+    Args:
+        events: Ordered validated journal events in the selected prefix.
+
+    Returns:
+        SHA-256 digest matching the runtime snapshot prefix contract.
+    """
+    payload = b"\n".join(canonical_json_bytes(event) for event in events)
+    if payload:
+        payload += b"\n"
+    return hashlib.sha256(payload).hexdigest()

--- a/wmo/optimize/model/sft/automatic.py
+++ b/wmo/optimize/model/sft/automatic.py
@@ -6,7 +6,14 @@ import hashlib
 from dataclasses import dataclass
 from datetime import datetime
 
-from wmo.common.core.artifacts import ArtifactId, ArtifactInput, ContractModel, canonical_json_bytes
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    canonical_json_bytes,
+    sha256_json,
+)
+from wmo.common.core.locks import file_write_lock
 from wmo.common.models import ModelCatalogError, load_model_catalog
 from wmo.common.project import (
     ArtifactCorruptionError,
@@ -25,23 +32,41 @@ from wmo.optimize.model.sft.composition import (
     SFTModelOptimizationError,
     create_sft_model_optimization_config,
     load_sft_model_optimization_config,
+    sft_model_optimization_output_dir,
     write_sft_model_optimization_config,
 )
 from wmo.optimize.model.sft.contracts import RuntimeSFTSource, SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.run_manifest import (
+    AutomaticSFTRunAcceptance,
+    AutomaticSFTRunAcceptanceSelection,
+    initialize_automatic_sft_acceptance,
+    initialize_tinker_sft_run,
+    load_automatic_sft_acceptance,
+    load_automatic_sft_acceptance_selection,
+    load_tinker_sft_run,
+    require_automatic_sft_acceptance_binding,
+    write_automatic_sft_acceptance_selection_unlocked,
+)
 from wmo.optimize.model.sft.selection import (
     LatestSFTModelOptimization,
     SFTModelOptimizationSelectionError,
+    latest_sft_model_optimization_path,
     load_latest_sft_model_optimization,
     versioned_sft_model_alias,
     write_latest_sft_model_optimization,
 )
-from wmo.optimize.model.sft.training_contracts import TinkerSFTSpec
+from wmo.optimize.model.sft.training_contracts import (
+    TinkerSFTError,
+    TinkerSFTRunManifest,
+    TinkerSFTSpec,
+)
 from wmo.runtime.router.journal import (
     RuntimeCompletedEvent,
     RuntimeInteractionJournal,
     RuntimeJournalError,
     RuntimeJournalEvent,
 )
+from wmo.runtime.router.journal_handoff import commit_runtime_journal_prefix
 from wmo.runtime.router.snapshot import (
     RuntimeTraceSnapshot,
     RuntimeTraceSnapshotError,
@@ -72,12 +97,14 @@ class AutomaticSFTPreparation:
         dataset: Recursively verified immutable W12 runtime dataset.
         config: Latest immutable bounded Tinker model-optimization config.
         created: Whether this call advanced the selected immutable graph.
+        accepted: Whether explicit consent already durably accepted this graph for W13.
     """
 
     snapshot: RuntimeTraceSnapshot
     dataset: SFTDatasetArtifact
     config: SFTModelOptimizationConfig
     created: bool
+    accepted: bool
 
 
 def prepare_runtime_sft_model_optimization(
@@ -122,6 +149,7 @@ def prepare_runtime_sft_model_optimization(
                 latest=latest,
                 config=selected_config,
                 dataset=selected_dataset,
+                code_revision=code_revision,
             )
             if reused is not None:
                 return reused
@@ -165,6 +193,7 @@ def prepare_runtime_sft_model_optimization(
         SFTBuildError,
         SFTModelOptimizationError,
         SFTModelOptimizationSelectionError,
+        TinkerSFTError,
         ValueError,
     ) as exc:
         raise AutomaticSFTPreparationError(
@@ -182,6 +211,321 @@ def require_completed_runtime_interactions(store: ProjectStore) -> None:
         AutomaticSFTPreparationError: The journal is corrupt, empty, or has no completion.
     """
     _completed_runtime_events(RuntimeInteractionJournal(store.paths))
+
+
+def accept_runtime_sft_model_optimization(
+    store: ProjectStore,
+    preparation: AutomaticSFTPreparation,
+    *,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTRunManifest:
+    """Atomically bind the current journal prefix to one durable local W13 run.
+
+    The exact prepared prefix is checked under the runtime journal append lock. The callback then
+    initializes only the local W13 run manifest before the lock is released. Credential reads,
+    trainer construction, and provider work remain outside the journal lock.
+
+    Args:
+        store: Project containing the prepared graph and runtime journal.
+        preparation: Exact snapshot, W12 dataset, and config approved for managed execution.
+        created_at: Time recorded if the W13 run is first accepted.
+        code_revision: Exact release revision recorded or required by the W13 run.
+
+    Returns:
+        The new or exactly matching durable W13 run manifest.
+
+    Raises:
+        AutomaticSFTPreparationError: The selected graph or runtime journal changed before local
+            W13 acceptance, or the run manifest cannot be initialized safely.
+    """
+    try:
+        _require_preparation_matches_latest(store, preparation)
+
+        def initialize_run() -> TinkerSFTRunManifest:
+            """CAS-select config-bound acceptance while journal appends are excluded.
+
+            Returns:
+                The new or exactly matching W13 run manifest.
+            """
+            coordination_path = latest_sft_model_optimization_path(store)
+            with file_write_lock(
+                coordination_path,
+                what="model optimization and automatic SFT acceptance",
+            ):
+                latest = _require_preparation_matches_latest(store, preparation)
+                selected = load_automatic_sft_acceptance_selection(store)
+                previous_acceptance: ArtifactInput | None = None
+                if selected is not None:
+                    prior, prior_input = _load_selected_acceptance(store, selected)
+                    if prior.config == latest.config:
+                        manifest = _load_selected_run_manifest(
+                            store,
+                            preparation=preparation,
+                            code_revision=code_revision,
+                        )
+                        _require_current_acceptance_binding(
+                            store,
+                            prior,
+                            manifest=manifest,
+                            latest=latest,
+                            preparation=preparation,
+                            code_revision=code_revision,
+                        )
+                        return manifest
+                    _require_terminal_registered_acceptance(store, prior)
+                    previous_acceptance = prior_input
+                manifest = initialize_tinker_sft_run(
+                    store,
+                    preparation.dataset.dataset.dataset_id,
+                    preparation.config.training,
+                    sft_model_optimization_output_dir(store, preparation.config.config_id),
+                    created_at=created_at,
+                    code_revision=code_revision,
+                )
+                _receipt, acceptance_input = initialize_automatic_sft_acceptance(
+                    store,
+                    manifest=manifest,
+                    previous_acceptance=previous_acceptance,
+                    config=latest.config,
+                    dataset=latest.dataset,
+                    runtime_snapshot=latest.runtime_snapshot,
+                    model_alias=preparation.config.model_alias,
+                    tinker_connection=preparation.config.tinker_connection,
+                    base_model=preparation.config.base_model,
+                    connection_config_sha256=preparation.config.connection_config_sha256,
+                    training_spec_sha256=sha256_json(preparation.config.training),
+                    runtime_last_ordinal=preparation.snapshot.last_ordinal,
+                    runtime_prefix_sha256=preparation.snapshot.prefix_sha256,
+                    created_at=created_at,
+                    code_revision=code_revision,
+                )
+                write_automatic_sft_acceptance_selection_unlocked(
+                    store,
+                    AutomaticSFTRunAcceptanceSelection(
+                        schema_version=1,
+                        project_id=store.paths.project_id,
+                        acceptance=acceptance_input,
+                        previous_acceptance=previous_acceptance,
+                        config=latest.config,
+                        updated_at=created_at,
+                    ),
+                    expected_current=previous_acceptance,
+                )
+                return manifest
+
+        return commit_runtime_journal_prefix(
+            RuntimeInteractionJournal(store.paths),
+            last_ordinal=preparation.snapshot.last_ordinal,
+            prefix_sha256=preparation.snapshot.prefix_sha256,
+            commit=initialize_run,
+        )
+    except AutomaticSFTPreparationError:
+        raise
+    except RuntimeJournalError as exc:
+        raise AutomaticSFTPreparationError(
+            "runtime journal changed before managed training acceptance; rerun "
+            "`wmo optimize model` so every durable completion is included in the immutable "
+            "schedule and spend consent"
+        ) from exc
+    except (
+        ArtifactCorruptionError,
+        ProjectStoreError,
+        RuntimeTraceSnapshotError,
+        SFTBuildError,
+        SFTModelOptimizationError,
+        SFTModelOptimizationSelectionError,
+        TinkerSFTError,
+        ValueError,
+    ) as exc:
+        raise AutomaticSFTPreparationError(
+            f"cannot accept routed interactions for managed training: {exc}"
+        ) from exc
+
+
+def _require_preparation_matches_latest(
+    store: ProjectStore,
+    preparation: AutomaticSFTPreparation,
+) -> LatestSFTModelOptimization:
+    """Recursively require one preparation to equal the selected immutable graph.
+
+    Args:
+        store: Project containing the selected graph.
+        preparation: Exact snapshot, W12 dataset, and config proposed for acceptance.
+
+    Returns:
+        Recursively verified latest pointer matching every preparation component.
+
+    Raises:
+        AutomaticSFTPreparationError: Selection or any immutable artifact differs.
+    """
+    latest = load_latest_sft_model_optimization(store)
+    if latest is None or (
+        latest.config.artifact_id != preparation.config.config_id
+        or latest.dataset.artifact_id != preparation.dataset.dataset.dataset_id
+        or latest.runtime_snapshot.artifact_id != preparation.snapshot.snapshot_id
+    ):
+        raise AutomaticSFTPreparationError(
+            "selected model-optimization graph changed before managed training acceptance"
+        )
+    selected_config = load_sft_model_optimization_config(store, preparation.config.config_id)
+    selected_dataset = load_verified_sft_dataset(store, preparation.dataset.dataset.dataset_id)
+    selected_snapshot = load_runtime_trace_snapshot(
+        store.artifacts, preparation.snapshot.snapshot_id
+    ).snapshot
+    if (
+        selected_config != preparation.config
+        or selected_dataset != preparation.dataset
+        or selected_snapshot != preparation.snapshot
+    ):
+        raise AutomaticSFTPreparationError(
+            "prepared model-optimization graph differs from recursive verification"
+        )
+    return latest
+
+
+def _load_selected_acceptance(
+    store: ProjectStore,
+    selection: AutomaticSFTRunAcceptanceSelection,
+) -> tuple[AutomaticSFTRunAcceptance, ArtifactInput]:
+    """Load the selected receipt and verify its prior chain and pointer bindings.
+
+    Args:
+        store: Project owning the selection and immutable acceptance artifacts.
+        selection: Canonical mutable selection pointer.
+
+    Returns:
+        Selected receipt and exact immutable artifact input.
+
+    Raises:
+        AutomaticSFTPreparationError: Pointer fields, prior chain, or terminal provenance differ.
+    """
+    receipt, receipt_input = load_automatic_sft_acceptance(store, selection.acceptance.artifact_id)
+    if (
+        receipt_input != selection.acceptance
+        or receipt.config != selection.config
+        or receipt.previous_acceptance != selection.previous_acceptance
+    ):
+        raise AutomaticSFTPreparationError(
+            "automatic SFT acceptance pointer differs from its immutable receipt"
+        )
+    previous = receipt.previous_acceptance
+    while previous is not None:
+        prior, prior_input = load_automatic_sft_acceptance(store, previous.artifact_id)
+        if prior_input != previous:
+            raise AutomaticSFTPreparationError(
+                "automatic SFT acceptance prior input differs from its manifest"
+            )
+        _require_terminal_registered_acceptance(store, prior)
+        previous = prior.previous_acceptance
+    return receipt, receipt_input
+
+
+def _require_terminal_registered_acceptance(
+    store: ProjectStore,
+    acceptance: AutomaticSFTRunAcceptance,
+) -> None:
+    """Require an earlier selected acceptance to have exact registered terminal provenance.
+
+    Args:
+        store: Project owning the local model catalog.
+        acceptance: Earlier immutable receipt that must be terminal before a successor.
+
+    Raises:
+        AutomaticSFTPreparationError: Registration is absent or differs from the accepted graph.
+    """
+    catalog = load_model_catalog(store.model_catalog_path)
+    record = catalog.models.get(acceptance.model_alias)
+    provenance = None if record is None else record.sft_provenance
+    if (
+        record is None
+        or record.connection != acceptance.tinker_connection
+        or provenance is None
+        or provenance.source_dataset != acceptance.dataset
+        or provenance.optimization_config != acceptance.config
+        or provenance.training_spec_sha256 != acceptance.training_spec_sha256
+        or provenance.run_id != acceptance.tinker_run_id
+        or provenance.base_model != acceptance.base_model
+        or provenance.connection_config_sha256 != acceptance.connection_config_sha256
+    ):
+        raise AutomaticSFTPreparationError(
+            "a newer automatic SFT acceptance cannot replace an incomplete or differently "
+            "registered prior accepted run"
+        )
+
+
+def _load_selected_run_manifest(
+    store: ProjectStore,
+    *,
+    preparation: AutomaticSFTPreparation,
+    code_revision: str,
+) -> TinkerSFTRunManifest:
+    """Load the exact generic W13 manifest required by a selected automatic receipt.
+
+    Args:
+        store: Project owning the W12 dataset and local W13 run.
+        preparation: Current recursively verified selected graph.
+        code_revision: Exact release revision required from the run.
+
+    Returns:
+        Recursively verified existing generic W13 manifest.
+
+    Raises:
+        AutomaticSFTPreparationError: The selected receipt has no matching W13 manifest.
+    """
+    manifest = load_tinker_sft_run(
+        store,
+        preparation.dataset.dataset.dataset_id,
+        preparation.config.training,
+        sft_model_optimization_output_dir(store, preparation.config.config_id),
+        code_revision=code_revision,
+    )
+    if manifest is None:
+        raise AutomaticSFTPreparationError(
+            "selected automatic SFT acceptance has no recursively verified W13 manifest"
+        )
+    return manifest
+
+
+def _require_current_acceptance_binding(
+    store: ProjectStore,
+    acceptance: AutomaticSFTRunAcceptance,
+    *,
+    manifest: TinkerSFTRunManifest,
+    latest: LatestSFTModelOptimization,
+    preparation: AutomaticSFTPreparation,
+    code_revision: str,
+) -> None:
+    """Require one selected receipt to bind every current immutable graph component.
+
+    Args:
+        store: Project owning the selected graph.
+        acceptance: Selected immutable automatic acceptance receipt.
+        manifest: Recursively verified generic W13 run manifest.
+        latest: Current recursively verified graph pointer.
+        preparation: Current exact snapshot, W12 dataset, and config.
+        code_revision: Exact release revision required by the receipt.
+
+    Raises:
+        TinkerSFTError: Any receipt or graph field differs.
+    """
+    require_automatic_sft_acceptance_binding(
+        acceptance,
+        manifest=manifest,
+        project_id=store.paths.project_id,
+        previous_acceptance=acceptance.previous_acceptance,
+        config=latest.config,
+        dataset=latest.dataset,
+        runtime_snapshot=latest.runtime_snapshot,
+        model_alias=preparation.config.model_alias,
+        tinker_connection=preparation.config.tinker_connection,
+        base_model=preparation.config.base_model,
+        connection_config_sha256=preparation.config.connection_config_sha256,
+        training_spec_sha256=sha256_json(preparation.config.training),
+        runtime_last_ordinal=preparation.snapshot.last_ordinal,
+        runtime_prefix_sha256=preparation.snapshot.prefix_sha256,
+        code_revision=code_revision,
+    )
 
 
 def _completed_runtime_events(
@@ -239,6 +583,7 @@ def _reuse_or_require_append(
     latest: LatestSFTModelOptimization,
     config: SFTModelOptimizationConfig,
     dataset: SFTDatasetArtifact,
+    code_revision: str,
 ) -> AutomaticSFTPreparation | None:
     """Reuse an unchanged selected prefix or require a strict append-only continuation.
 
@@ -248,6 +593,7 @@ def _reuse_or_require_append(
         latest: Recursively verified latest graph pointer.
         config: Config selected by the pointer.
         dataset: Dataset selected by the config.
+        code_revision: Exact release revision required by any accepted W13 run.
 
     Returns:
         A reuse result when the journal is unchanged, otherwise ``None`` for a valid append.
@@ -266,14 +612,96 @@ def _reuse_or_require_append(
         raise AutomaticSFTPreparationError(
             "runtime journal changed inside the latest selected immutable prefix"
         )
-    if len(events) == snapshot.last_ordinal:
+    manifest = load_tinker_sft_run(
+        store,
+        dataset.dataset.dataset_id,
+        config.training,
+        sft_model_optimization_output_dir(store, config.config_id),
+        code_revision=code_revision,
+    )
+    automatic_acceptance: AutomaticSFTRunAcceptance | None = None
+    selected = load_automatic_sft_acceptance_selection(store)
+    if selected is not None:
+        selected_acceptance, _selected_input = _load_selected_acceptance(store, selected)
+        if selected_acceptance.config == latest.config:
+            if manifest is None:
+                raise AutomaticSFTPreparationError(
+                    "selected automatic SFT acceptance has no recursively verified W13 manifest"
+                )
+            preparation = AutomaticSFTPreparation(
+                snapshot=snapshot,
+                dataset=dataset,
+                config=config,
+                created=False,
+                accepted=True,
+            )
+            _require_current_acceptance_binding(
+                store,
+                selected_acceptance,
+                manifest=manifest,
+                latest=latest,
+                preparation=preparation,
+                code_revision=code_revision,
+            )
+            automatic_acceptance = selected_acceptance
+        else:
+            _require_terminal_registered_acceptance(store, selected_acceptance)
+    accepted_incomplete = automatic_acceptance is not None and _accepted_run_needs_resume(
+        store, latest=latest, config=config
+    )
+    if accepted_incomplete or len(events) == snapshot.last_ordinal:
         return AutomaticSFTPreparation(
             snapshot=snapshot,
             dataset=dataset,
             config=config,
             created=False,
+            accepted=accepted_incomplete,
         )
     return None
+
+
+def _accepted_run_needs_resume(
+    store: ProjectStore,
+    *,
+    latest: LatestSFTModelOptimization,
+    config: SFTModelOptimizationConfig,
+) -> bool:
+    """Return whether a durably accepted W13 run still lacks catalog registration.
+
+    A registered alias is the existing durable terminal boundary: composition writes it only
+    after recursively verifying the completed W13 result and sampling handle. Any alias that does
+    not bind the selected W12/config inputs fails before a newer journal prefix is materialized.
+
+    Args:
+        store: Project owning the selected graph and local model catalog.
+        latest: Exact selected immutable graph pointer.
+        config: Recursively verified config selected by the pointer.
+
+    Returns:
+        ``True`` while an accepted run must resume its original prefix, otherwise ``False``.
+
+    Raises:
+        AutomaticSFTPreparationError: The registered alias has missing or conflicting provenance.
+    """
+    catalog = load_model_catalog(store.model_catalog_path)
+    record = catalog.models.get(config.model_alias)
+    if record is None:
+        return True
+    provenance = record.sft_provenance
+    if (
+        record.connection != config.tinker_connection
+        or provenance is None
+        or provenance.source_dataset != latest.dataset
+        or provenance.optimization_config != latest.config
+        or provenance.training_spec_sha256 != sha256_json(config.training)
+        or provenance.base_model != config.base_model
+        or provenance.connection_config_sha256 != config.connection_config_sha256
+    ):
+        raise AutomaticSFTPreparationError(
+            f"registered automatic SFT alias {config.model_alias!r} does not bind the selected "
+            "immutable W12/W13 graph"
+        )
+    return False
 
 
 def _materialize_appended_prefix(
@@ -365,6 +793,7 @@ def _materialize_appended_prefix(
         dataset=verified_dataset,
         config=selected,
         created=True,
+        accepted=False,
     )
 
 

--- a/wmo/optimize/model/sft/automatic_test.py
+++ b/wmo/optimize/model/sft/automatic_test.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import shutil
+import threading
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
+from typing import Never
 
 import pytest
 
 import wmo.optimize.model.sft.automatic as automatic_module
-from wmo.common.core.artifacts import canonical_json_bytes
+import wmo.optimize.model.sft.run_manifest as run_manifest_module
+from wmo.common.core.artifacts import canonical_json_bytes, sha256_json
 from wmo.common.models import (
     AssistantAction,
     ConnectionConfig,
@@ -22,12 +26,14 @@ from wmo.common.project import ProjectStore, artifact_input
 from wmo.optimize.model.sft.automatic import (
     AutomaticSFTPreparationError,
     InitialSFTModelOptimizationSettings,
+    accept_runtime_sft_model_optimization,
     prepare_runtime_sft_model_optimization,
 )
 from wmo.optimize.model.sft.composition import (
     SFTModelOptimizationConfig,
     create_sft_model_optimization_config,
     preflight_sft_model_optimization,
+    sft_model_optimization_output_dir,
     write_sft_model_optimization_config,
 )
 from wmo.optimize.model.sft.contracts import SFTBuildSpec
@@ -36,8 +42,10 @@ from wmo.optimize.model.sft.selection import (
     SFTModelOptimizationSelectionError,
     latest_sft_model_optimization_path,
     load_latest_sft_model_optimization,
+    versioned_sft_model_alias,
     write_latest_sft_model_optimization,
 )
+from wmo.optimize.model.sft.training_contracts import TinkerSFTResumeError
 from wmo.optimize.model.sft.training_test import _TIME, _FakeBackend, _persisted_dataset, _spec
 from wmo.runtime.router import RuntimeInteractionJournal
 
@@ -299,6 +307,434 @@ def test_appended_interaction_creates_new_graph_without_mutating_old_artifacts(
             first_pointer.model_copy(update={"updated_at": _TIME + timedelta(hours=3)}),
             expected_current=bootstrap_input,
         )
+
+
+def test_run_acceptance_rejects_an_advanced_journal_before_manifest_write(
+    tmp_path: Path,
+) -> None:
+    """Require a new graph and consent when a completion precedes W13 acceptance.
+
+    Args:
+        tmp_path: Pytest-owned project and artifact directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    output_dir = sft_model_optimization_output_dir(bootstrap.store, prepared.config.config_id)
+    _append_completed(bootstrap.store, key="second", minute=2)
+
+    with pytest.raises(AutomaticSFTPreparationError, match="rerun.*every durable completion"):
+        accept_runtime_sft_model_optimization(
+            bootstrap.store,
+            prepared,
+            created_at=_TIME + timedelta(hours=1),
+            code_revision="automatic-sft-test",
+        )
+
+    assert not output_dir.exists()
+    refreshed = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    manifest = accept_runtime_sft_model_optimization(
+        bootstrap.store,
+        refreshed,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+
+    assert len(refreshed.dataset.rows) == 2
+    assert manifest.dataset_id == refreshed.dataset.dataset.dataset_id
+    assert (
+        sft_model_optimization_output_dir(bootstrap.store, refreshed.config.config_id)
+        / "manifest.json"
+    ).is_file()
+
+
+def test_run_acceptance_holds_journal_lock_through_w13_manifest_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Serialize concurrent appends until the config-bound W13 manifest is durable.
+
+    Args:
+        tmp_path: Pytest-owned project and artifact directory.
+        monkeypatch: Scoped W13 initializer wrapper used to expose the lock boundary.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    output_dir = sft_model_optimization_output_dir(bootstrap.store, prepared.config.config_id)
+    original_initialize = automatic_module.initialize_tinker_sft_run
+    writer_started = threading.Event()
+    writer_finished = threading.Event()
+    manifest_committed_before_writer: list[bool] = []
+
+    def append_concurrently() -> None:
+        """Attempt one append while the acceptance callback owns the journal lock."""
+        writer_started.set()
+        _append_completed(bootstrap.store, key="second", minute=2)
+        writer_finished.set()
+
+    def initialize_while_writer_waits(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        """Expose that W13 initialization runs before a queued append can finish.
+
+        Args:
+            args: Positional W13 initializer inputs forwarded unchanged.
+            kwargs: Keyword W13 initializer inputs forwarded unchanged.
+
+        Returns:
+            The original initializer's durable run manifest.
+        """
+        writer = threading.Thread(target=append_concurrently)
+        writer.start()
+        assert writer_started.wait(timeout=1.0)
+        assert not writer_finished.wait(timeout=0.05)
+        manifest = original_initialize(*args, **kwargs)
+        manifest_committed_before_writer.append((output_dir / "manifest.json").is_file())
+        assert not writer_finished.is_set()
+        return manifest
+
+    monkeypatch.setattr(
+        automatic_module,
+        "initialize_tinker_sft_run",
+        initialize_while_writer_waits,
+    )
+
+    accepted = accept_runtime_sft_model_optimization(
+        bootstrap.store,
+        prepared,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+
+    assert writer_finished.wait(timeout=1.0)
+    assert manifest_committed_before_writer == [True]
+    assert accepted.dataset_id == prepared.dataset.dataset.dataset_id
+    refreshed = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    assert refreshed.config == prepared.config
+    assert refreshed.accepted is True
+    assert len(refreshed.dataset.rows) == 1
+
+
+def test_crash_before_acceptance_pointer_leaves_orphan_inert_and_reconsents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Treat a crash after the immutable receipt but before its CAS pointer as unaccepted.
+
+    Args:
+        tmp_path: Pytest-owned project and artifact directory.
+        monkeypatch: Scoped acceptance-pointer crash replacement.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    original_select = automatic_module.write_automatic_sft_acceptance_selection_unlocked
+
+    def crash_before_pointer(*args: object, **kwargs: object) -> Never:
+        """Interrupt after immutable acceptance persistence but before pointer selection.
+
+        Args:
+            args: Unexpected selection positional inputs.
+            kwargs: Unexpected selection keyword inputs.
+
+        Raises:
+            RuntimeError: Always, at the selected crash boundary.
+        """
+        del args, kwargs
+        raise RuntimeError("simulated crash before acceptance pointer")
+
+    monkeypatch.setattr(
+        automatic_module,
+        "write_automatic_sft_acceptance_selection_unlocked",
+        crash_before_pointer,
+    )
+    with pytest.raises(RuntimeError, match="before acceptance pointer"):
+        accept_runtime_sft_model_optimization(
+            bootstrap.store,
+            prepared,
+            created_at=_TIME + timedelta(hours=1),
+            code_revision="automatic-sft-test",
+        )
+
+    assert run_manifest_module.load_automatic_sft_acceptance_selection(bootstrap.store) is None
+    retry = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    assert retry.config == prepared.config
+    assert retry.accepted is False
+
+    monkeypatch.setattr(
+        automatic_module,
+        "write_automatic_sft_acceptance_selection_unlocked",
+        original_select,
+    )
+    accept_runtime_sft_model_optimization(
+        bootstrap.store,
+        retry,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    selected = run_manifest_module.load_automatic_sft_acceptance_selection(bootstrap.store)
+    assert selected is not None
+    resumed = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=3),
+        code_revision="automatic-sft-test",
+    )
+    assert resumed.accepted is True
+
+
+def test_copied_w13_acceptance_cannot_authorize_another_selected_config(
+    tmp_path: Path,
+) -> None:
+    """Reject a manifest and acceptance copied into a different config namespace.
+
+    Args:
+        tmp_path: Pytest-owned project and artifact directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    accept_runtime_sft_model_optimization(
+        bootstrap.store,
+        prepared,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    latest_a = load_latest_sft_model_optimization(bootstrap.store)
+    assert latest_a is not None
+    selected_a = run_manifest_module.load_automatic_sft_acceptance_selection(bootstrap.store)
+    assert selected_a is not None
+    with pytest.raises(TinkerSFTResumeError, match="changed before consent commit"):
+        run_manifest_module.write_automatic_sft_acceptance_selection_unlocked(
+            bootstrap.store,
+            selected_a.model_copy(
+                update={
+                    "acceptance": selected_a.acceptance.model_copy(
+                        update={"artifact_id": "forged-automatic-acceptance"}
+                    ),
+                    "updated_at": _TIME + timedelta(hours=2),
+                }
+            ),
+            expected_current=None,
+        )
+    pointer_path = run_manifest_module.automatic_sft_acceptance_path(bootstrap.store)
+    pointer_bytes = pointer_path.read_bytes()
+    bootstrap_config_input = artifact_input(
+        bootstrap.store.artifacts.read(bootstrap.config.config_id).manifest
+    )
+    pointer_path.write_bytes(
+        canonical_json_bytes(selected_a.model_copy(update={"config": bootstrap_config_input}))
+    )
+    with pytest.raises(AutomaticSFTPreparationError, match="pointer differs"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=2),
+            code_revision="automatic-sft-test",
+        )
+    pointer_path.write_bytes(pointer_bytes)
+    alias_prefix_b = "alternate-trained"
+    config_b = create_sft_model_optimization_config(
+        bootstrap.store,
+        dataset_id=prepared.dataset.dataset.dataset_id,
+        model_alias=versioned_sft_model_alias(alias_prefix_b, prepared.dataset.dataset.dataset_id),
+        tinker_connection=prepared.config.tinker_connection,
+        base_model_alias=prepared.config.base_model_alias,
+        training=prepared.config.training,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    write_sft_model_optimization_config(bootstrap.store, config_b, bind_project=False)
+    config_b_input = artifact_input(bootstrap.store.artifacts.read(config_b.config_id).manifest)
+    output_a = sft_model_optimization_output_dir(bootstrap.store, prepared.config.config_id)
+    latest_b = latest_a.model_copy(
+        update={
+            "config": config_b_input,
+            "model_alias_prefix": alias_prefix_b,
+            "updated_at": _TIME + timedelta(hours=2),
+        }
+    )
+    write_latest_sft_model_optimization(
+        bootstrap.store,
+        latest_b,
+        expected_current=latest_a.config,
+    )
+    output_b = sft_model_optimization_output_dir(bootstrap.store, config_b.config_id)
+    output_b.mkdir(parents=True)
+    shutil.copyfile(output_a / "manifest.json", output_b / "manifest.json")
+
+    with pytest.raises(AutomaticSFTPreparationError, match="incomplete"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=3),
+            code_revision="automatic-sft-test",
+        )
+
+    manifest_b = run_manifest_module.load_tinker_sft_run(
+        bootstrap.store,
+        prepared.dataset.dataset.dataset_id,
+        config_b.training,
+        output_b,
+        code_revision="automatic-sft-test",
+    )
+    assert manifest_b is not None
+    _receipt_b, acceptance_b_input = run_manifest_module.initialize_automatic_sft_acceptance(
+        bootstrap.store,
+        manifest=manifest_b,
+        previous_acceptance=selected_a.acceptance,
+        config=config_b_input,
+        dataset=latest_b.dataset,
+        runtime_snapshot=latest_b.runtime_snapshot,
+        model_alias=config_b.model_alias,
+        tinker_connection=config_b.tinker_connection,
+        base_model=config_b.base_model,
+        connection_config_sha256=config_b.connection_config_sha256,
+        training_spec_sha256=sha256_json(config_b.training),
+        runtime_last_ordinal=prepared.snapshot.last_ordinal,
+        runtime_prefix_sha256=prepared.snapshot.prefix_sha256,
+        created_at=_TIME + timedelta(hours=3),
+        code_revision="automatic-sft-test",
+    )
+    run_manifest_module.write_automatic_sft_acceptance_selection_unlocked(
+        bootstrap.store,
+        run_manifest_module.AutomaticSFTRunAcceptanceSelection(
+            schema_version=1,
+            project_id=bootstrap.store.paths.project_id,
+            acceptance=acceptance_b_input,
+            previous_acceptance=selected_a.acceptance,
+            config=config_b_input,
+            updated_at=_TIME + timedelta(hours=3),
+        ),
+        expected_current=selected_a.acceptance,
+    )
+
+    with pytest.raises(AutomaticSFTPreparationError, match="incomplete"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=4),
+            code_revision="automatic-sft-test",
+        )
+
+
+@pytest.mark.parametrize("target_exists", [False, True])
+def test_automatic_acceptance_pointer_rejects_broken_and_live_symlinks_before_write(
+    tmp_path: Path,
+    *,
+    target_exists: bool,
+) -> None:
+    """Reject a redirected acceptance pointer without creating or changing its target.
+
+    Args:
+        tmp_path: Pytest-owned project and external target directory.
+        target_exists: Whether the redirect names an existing external file.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    pointer_path = run_manifest_module.automatic_sft_acceptance_path(bootstrap.store)
+    external_target = tmp_path / "external-automatic-acceptance.json"
+    original_external_bytes = b"external pointer must remain unchanged"
+    if target_exists:
+        external_target.write_bytes(original_external_bytes)
+    pointer_path.symlink_to(external_target)
+
+    with pytest.raises(TinkerSFTResumeError, match="not a safe file"):
+        run_manifest_module.load_automatic_sft_acceptance_selection(bootstrap.store)
+    with pytest.raises(AutomaticSFTPreparationError, match="not a safe file"):
+        accept_runtime_sft_model_optimization(
+            bootstrap.store,
+            prepared,
+            created_at=_TIME + timedelta(hours=1),
+            code_revision="automatic-sft-test",
+        )
+
+    if target_exists:
+        assert external_target.read_bytes() == original_external_bytes
+    else:
+        assert not external_target.exists()
+
+
+@pytest.mark.parametrize("target_exists", [False, True])
+def test_automatic_acceptance_pointer_replaces_a_symlink_swapped_at_write_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    target_exists: bool,
+) -> None:
+    """Replace a raced pointer link itself without following or changing its target.
+
+    Args:
+        tmp_path: Pytest-owned project and external target directory.
+        monkeypatch: Pytest mutation helper used at the exact atomic-replace boundary.
+        target_exists: Whether the raced redirect names an existing external file.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepared = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    pointer_path = run_manifest_module.automatic_sft_acceptance_path(bootstrap.store)
+    external_target = tmp_path / "raced-external-automatic-acceptance.json"
+    original_external_bytes = b"raced external pointer must remain unchanged"
+    if target_exists:
+        external_target.write_bytes(original_external_bytes)
+    real_replace = run_manifest_module.os.replace
+
+    def swap_pointer_before_replace(source: str | Path, destination: str | Path) -> None:
+        """Install the adversarial link immediately before the production replace.
+
+        Args:
+            source: Exclusive sibling staging path.
+            destination: Canonical acceptance pointer path.
+        """
+        if Path(destination) == pointer_path:
+            pointer_path.symlink_to(external_target)
+        real_replace(source, destination)
+
+    monkeypatch.setattr(run_manifest_module.os, "replace", swap_pointer_before_replace)
+    accept_runtime_sft_model_optimization(
+        bootstrap.store,
+        prepared,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+
+    assert pointer_path.is_file()
+    assert not pointer_path.is_symlink()
+    assert run_manifest_module.load_automatic_sft_acceptance_selection(bootstrap.store) is not None
+    if target_exists:
+        assert external_target.read_bytes() == original_external_bytes
+    else:
+        assert not external_target.exists()
 
 
 def test_empty_or_incomplete_journal_fails_without_materializing_runtime_artifacts(

--- a/wmo/optimize/model/sft/automatic_test.py
+++ b/wmo/optimize/model/sft/automatic_test.py
@@ -1,0 +1,636 @@
+"""Automatic runtime SFT composition tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+import wmo.optimize.model.sft.automatic as automatic_module
+from wmo.common.core.artifacts import canonical_json_bytes
+from wmo.common.models import (
+    AssistantAction,
+    ConnectionConfig,
+    ModelCatalog,
+    ModelMessage,
+    ModelRecord,
+    write_model_catalog,
+)
+from wmo.common.project import ProjectStore, artifact_input
+from wmo.optimize.model.sft.automatic import (
+    AutomaticSFTPreparationError,
+    InitialSFTModelOptimizationSettings,
+    prepare_runtime_sft_model_optimization,
+)
+from wmo.optimize.model.sft.composition import (
+    SFTModelOptimizationConfig,
+    create_sft_model_optimization_config,
+    preflight_sft_model_optimization,
+    write_sft_model_optimization_config,
+)
+from wmo.optimize.model.sft.contracts import SFTBuildSpec
+from wmo.optimize.model.sft.runtime_source_test import _accept, _complete, _request
+from wmo.optimize.model.sft.selection import (
+    SFTModelOptimizationSelectionError,
+    latest_sft_model_optimization_path,
+    load_latest_sft_model_optimization,
+    write_latest_sft_model_optimization,
+)
+from wmo.optimize.model.sft.training_test import _TIME, _FakeBackend, _persisted_dataset, _spec
+from wmo.runtime.router import RuntimeInteractionJournal
+
+
+@dataclass(frozen=True)
+class _Bootstrap:
+    """Project with explicit bounded Tinker settings but no automatic runtime dataset."""
+
+    store: ProjectStore
+    config: SFTModelOptimizationConfig
+
+
+def _bootstrap(tmp_path: Path) -> _Bootstrap:
+    """Persist one accepted seed W12 and user-selected bounded Tinker configuration.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+
+    Returns:
+        Initialized project ready to accumulate runtime interactions.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"tinker": ConnectionConfig(provider="tinker")},
+            models={"base": ModelRecord(connection="tinker", model="test-base-model")},
+        ),
+    )
+    config = create_sft_model_optimization_config(
+        fixture.store,
+        dataset_id=fixture.artifact.dataset.dataset_id,
+        model_alias="trained",
+        tinker_connection="tinker",
+        base_model_alias="base",
+        training=_spec(maximum_cost_usd=1.0),
+        created_at=_TIME,
+        code_revision="automatic-sft-test",
+    )
+    write_sft_model_optimization_config(fixture.store, config)
+    return _Bootstrap(store=fixture.store, config=config)
+
+
+def _append_completed(
+    store: ProjectStore,
+    *,
+    key: str,
+    minute: int,
+) -> None:
+    """Append one completed routed interaction to the project's durable journal.
+
+    Args:
+        store: Project receiving the interaction.
+        key: Unique idempotency identity and visible fixture tag.
+        minute: Timestamp offset that preserves global journal order.
+    """
+    _complete(
+        RuntimeInteractionJournal(store.paths),
+        key=key,
+        conversation="automatic-sft-conversation",
+        request=_request(ModelMessage(role="user", content=f"Request {key}")),
+        output=AssistantAction(content=f"Response {key}"),
+        now=_TIME + timedelta(minutes=minute),
+    )
+
+
+def test_first_runtime_prefix_needs_no_bootstrap_dataset_or_config(tmp_path: Path) -> None:
+    """Create the first W12 and config directly from confirmed settings and runtime data.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"tinker": ConnectionConfig(provider="tinker")},
+            models={"base": ModelRecord(connection="tinker", model="test-base-model")},
+        ),
+    )
+    _append_completed(fixture.store, key="first", minute=1)
+
+    prepared = prepare_runtime_sft_model_optimization(
+        fixture.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+        initial_settings=InitialSFTModelOptimizationSettings(
+            model_alias_prefix="support-project-sft",
+            tinker_connection="tinker",
+            base_model_alias="base",
+            training=_spec(maximum_cost_usd=25.0),
+        ),
+    )
+    latest = load_latest_sft_model_optimization(fixture.store)
+
+    assert prepared.created is True
+    assert prepared.dataset.build_spec == SFTBuildSpec(held_out_fraction=0.0)
+    assert len(prepared.dataset.rows) == 1
+    assert fixture.store.load_project().model_optimization_config is None
+    assert latest is not None
+    assert latest.config.artifact_id == prepared.config.config_id
+
+
+def test_automatic_runtime_sft_schedules_every_lineage_and_retains_duplicates(
+    tmp_path: Path,
+) -> None:
+    """Train every completed target while leakage-linking duplicate cross-lineage rows.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"tinker": ConnectionConfig(provider="tinker")},
+            models={"base": ModelRecord(connection="tinker", model="test-base-model")},
+        ),
+    )
+    journal = RuntimeInteractionJournal(fixture.store.paths)
+    request = _request(ModelMessage(role="user", content="Retain this duplicate"))
+    target = AssistantAction(content="Retained target")
+    _complete(
+        journal,
+        key="first-lineage",
+        conversation="conversation-one",
+        request=request,
+        output=target,
+        now=_TIME + timedelta(minutes=1),
+    )
+    _complete(
+        journal,
+        key="second-lineage",
+        conversation="conversation-two",
+        request=request,
+        output=target,
+        now=_TIME + timedelta(minutes=2),
+    )
+    prepared = prepare_runtime_sft_model_optimization(
+        fixture.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-all-target-test",
+        initial_settings=InitialSFTModelOptimizationSettings(
+            model_alias_prefix="support-project-sft",
+            tinker_connection="tinker",
+            base_model_alias="base",
+            training=_spec(maximum_cost_usd=25.0),
+        ),
+    )
+    preflight = preflight_sft_model_optimization(
+        fixture.store,
+        prepared.config.config_id,
+        _FakeBackend(conservative_cost_per_batch=0.1),
+        code_revision="automatic-all-target-test",
+    )
+
+    assert len(prepared.dataset.rows) == 2
+    assert {row.partition for row in prepared.dataset.rows} == {"train"}
+    assert len({row.example.example_id for row in prepared.dataset.rows}) == 2
+    assert len({row.fingerprint for row in prepared.dataset.rows}) == 1
+    lineage_ids = {row.example.leakage_group_id for row in prepared.dataset.rows}
+    assert len(lineage_ids) == 2
+    assert len(prepared.dataset.partitions) == 1
+    assert set(prepared.dataset.partitions[0].leakage_group_ids) == lineage_ids
+    assert sum(preflight.planned_batch_counts) == 2
+
+
+def test_unchanged_prefix_reuses_snapshot_dataset_config_and_pointer_bytes(
+    tmp_path: Path,
+) -> None:
+    """Replay an unchanged journal without creating or rewriting any selected state.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    first = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    artifact_ids = bootstrap.store.artifacts.list_ids()
+    pointer_path = latest_sft_model_optimization_path(bootstrap.store)
+    pointer_bytes = pointer_path.read_bytes()
+
+    replay = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(days=1),
+        code_revision="different-replay-revision",
+    )
+
+    assert first.created is True
+    assert replay.created is False
+    assert replay.snapshot == first.snapshot
+    assert replay.dataset == first.dataset
+    assert replay.config == first.config
+    assert bootstrap.store.artifacts.list_ids() == artifact_ids
+    assert pointer_path.read_bytes() == pointer_bytes
+
+
+def test_appended_interaction_creates_new_graph_without_mutating_old_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Advance to a full appended prefix while retaining every prior immutable artifact.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    first = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    first_pointer = load_latest_sft_model_optimization(bootstrap.store)
+    assert first_pointer is not None
+    old_config_bytes = bootstrap.store.artifacts.read_bytes(first.config.config_id, "config.json")
+    old_dataset_bytes = bootstrap.store.artifacts.read_bytes(
+        first.dataset.dataset.dataset_id, "examples.jsonl"
+    )
+    _append_completed(bootstrap.store, key="second", minute=2)
+
+    appended = prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+    )
+    latest = load_latest_sft_model_optimization(bootstrap.store)
+
+    assert appended.created is True
+    assert appended.snapshot.snapshot_id != first.snapshot.snapshot_id
+    assert appended.dataset.dataset.dataset_id != first.dataset.dataset.dataset_id
+    assert appended.config.config_id != first.config.config_id
+    assert len(appended.dataset.rows) == 2
+    assert {row.example.target.content for row in appended.dataset.rows} == {
+        "Response first",
+        "Response second",
+    }
+    assert (
+        bootstrap.store.artifacts.read_bytes(first.config.config_id, "config.json")
+        == old_config_bytes
+    )
+    assert (
+        bootstrap.store.artifacts.read_bytes(first.dataset.dataset.dataset_id, "examples.jsonl")
+        == old_dataset_bytes
+    )
+    assert latest is not None
+    assert latest.config.artifact_id == appended.config.config_id
+    assert latest.dataset.artifact_id == appended.dataset.dataset.dataset_id
+    assert latest.runtime_snapshot.artifact_id == appended.snapshot.snapshot_id
+    bootstrap_input = artifact_input(
+        bootstrap.store.artifacts.read(bootstrap.config.config_id).manifest
+    )
+    with pytest.raises(SFTModelOptimizationSelectionError, match="changed before commit"):
+        write_latest_sft_model_optimization(
+            bootstrap.store,
+            first_pointer.model_copy(update={"updated_at": _TIME + timedelta(hours=3)}),
+            expected_current=bootstrap_input,
+        )
+
+
+def test_empty_or_incomplete_journal_fails_without_materializing_runtime_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Reject missing completed targets before creating snapshot, dataset, or config artifacts.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    original_ids = bootstrap.store.artifacts.list_ids()
+
+    with pytest.raises(AutomaticSFTPreparationError, match="no interactions"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=1),
+            code_revision="automatic-sft-test",
+        )
+
+    assert bootstrap.store.artifacts.list_ids() == original_ids
+    assert not latest_sft_model_optimization_path(bootstrap.store).exists()
+
+    _accept(
+        RuntimeInteractionJournal(bootstrap.store.paths),
+        key="disconnected",
+        conversation="automatic-sft-conversation",
+        request=_request(ModelMessage(role="user", content="Disconnected request")),
+        now=_TIME + timedelta(minutes=1),
+    )
+    with pytest.raises(AutomaticSFTPreparationError, match="no completed routed interactions"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=1),
+            code_revision="automatic-sft-test",
+        )
+
+    assert bootstrap.store.artifacts.list_ids() == original_ids
+    assert not latest_sft_model_optimization_path(bootstrap.store).exists()
+
+
+def test_corrupt_latest_pointer_fails_closed_before_new_materialization(tmp_path: Path) -> None:
+    """Reject a malformed coordination pointer without replacing its selected artifacts.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    original_ids = bootstrap.store.artifacts.list_ids()
+    latest_sft_model_optimization_path(bootstrap.store).write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(AutomaticSFTPreparationError, match="pointer is invalid"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=2),
+            code_revision="automatic-sft-test",
+        )
+
+    assert bootstrap.store.artifacts.list_ids() == original_ids
+
+
+def test_crash_after_immutable_graph_reuses_artifacts_before_pointer_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recover a first-run crash after config persistence without duplicating artifacts.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped failure injected at the mutable pointer commit.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"tinker": ConnectionConfig(provider="tinker")},
+            models={"base": ModelRecord(connection="tinker", model="test-base-model")},
+        ),
+    )
+    _append_completed(fixture.store, key="first", minute=1)
+    settings = InitialSFTModelOptimizationSettings(
+        model_alias_prefix="support-project-sft",
+        tinker_connection="tinker",
+        base_model_alias="base",
+        training=_spec(maximum_cost_usd=25.0),
+    )
+
+    def crash_before_pointer(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        """Fail after immutable artifacts exist but before mutable selection commits.
+
+        Args:
+            *args: Positional pointer-write inputs, deliberately unused.
+            **kwargs: Keyword pointer-write inputs, deliberately unused.
+
+        Raises:
+            SFTModelOptimizationSelectionError: Always, to simulate the crash boundary.
+        """
+        del args, kwargs
+        raise SFTModelOptimizationSelectionError("injected pointer crash")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            automatic_module,
+            "write_latest_sft_model_optimization",
+            crash_before_pointer,
+        )
+        with pytest.raises(AutomaticSFTPreparationError, match="injected pointer crash"):
+            prepare_runtime_sft_model_optimization(
+                fixture.store,
+                created_at=_TIME + timedelta(hours=1),
+                code_revision="automatic-sft-test",
+                initial_settings=settings,
+            )
+    artifact_ids_after_crash = fixture.store.artifacts.list_ids()
+    assert load_latest_sft_model_optimization(fixture.store) is None
+
+    recovered = prepare_runtime_sft_model_optimization(
+        fixture.store,
+        created_at=_TIME + timedelta(hours=2),
+        code_revision="automatic-sft-test",
+        initial_settings=settings,
+    )
+
+    assert recovered.created is True
+    assert fixture.store.artifacts.list_ids() == artifact_ids_after_crash
+    assert load_latest_sft_model_optimization(fixture.store) is not None
+
+
+def test_two_first_run_pointer_proposals_allow_only_one_compare_and_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Allow only one of two valid concurrent first-run graphs to become latest.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        monkeypatch: Scoped capture of independently materialized pointer proposals.
+    """
+    fixture = _persisted_dataset(tmp_path)
+    write_model_catalog(
+        fixture.store.model_catalog_path,
+        ModelCatalog(
+            connections={"tinker": ConnectionConfig(provider="tinker")},
+            models={
+                "base-a": ModelRecord(connection="tinker", model="test-base-model"),
+                "base-b": ModelRecord(connection="tinker", model="test-base-model"),
+            },
+        ),
+    )
+    _append_completed(fixture.store, key="first", minute=1)
+    proposals = []
+
+    def capture_pointer(store, pointer, *, expected_current):  # noqa: ANN001, ANN202
+        """Capture one complete graph proposal and interrupt before pointer mutation.
+
+        Args:
+            store: Project store that would receive the pointer.
+            pointer: Fully verified proposed latest graph.
+            expected_current: Compare-and-swap predecessor observed by the attempt.
+
+        Raises:
+            SFTModelOptimizationSelectionError: Always, after recording the proposal.
+        """
+        del store
+        proposals.append((pointer, expected_current))
+        raise SFTModelOptimizationSelectionError("captured proposal")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            automatic_module,
+            "write_latest_sft_model_optimization",
+            capture_pointer,
+        )
+        for base_alias in ("base-a", "base-b"):
+            with pytest.raises(AutomaticSFTPreparationError, match="captured proposal"):
+                prepare_runtime_sft_model_optimization(
+                    fixture.store,
+                    created_at=_TIME + timedelta(hours=1),
+                    code_revision="automatic-sft-test",
+                    initial_settings=InitialSFTModelOptimizationSettings(
+                        model_alias_prefix=f"{base_alias}-trained",
+                        tinker_connection="tinker",
+                        base_model_alias=base_alias,
+                        training=_spec(maximum_cost_usd=25.0),
+                    ),
+                )
+    assert len(proposals) == 2
+    first_pointer, first_expected = proposals[0]
+    second_pointer, second_expected = proposals[1]
+    write_latest_sft_model_optimization(
+        fixture.store, first_pointer, expected_current=first_expected
+    )
+    with pytest.raises(SFTModelOptimizationSelectionError, match="changed before commit"):
+        write_latest_sft_model_optimization(
+            fixture.store, second_pointer, expected_current=second_expected
+        )
+
+
+def test_latest_pointer_rejects_symlink_and_wrong_project(tmp_path: Path) -> None:
+    """Fail closed when latest coordination is redirected or claims another project.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    path = latest_sft_model_optimization_path(bootstrap.store)
+    pointer = load_latest_sft_model_optimization(bootstrap.store)
+    assert pointer is not None
+    target = tmp_path / "redirected-latest.json"
+    target.write_bytes(path.read_bytes())
+    path.unlink()
+    path.symlink_to(target)
+
+    with pytest.raises(SFTModelOptimizationSelectionError, match="not a safe file"):
+        load_latest_sft_model_optimization(bootstrap.store)
+
+    path.unlink()
+    path.write_bytes(
+        canonical_json_bytes(pointer.model_copy(update={"project_id": "another-project"}))
+    )
+    with pytest.raises(SFTModelOptimizationSelectionError, match="another project"):
+        load_latest_sft_model_optimization(bootstrap.store)
+
+
+def test_latest_pointer_rejects_symlinked_coordination_directory_for_read_and_write(
+    tmp_path: Path,
+) -> None:
+    """Reject a parent-directory redirect before pointer read, lock, or write.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    path = latest_sft_model_optimization_path(bootstrap.store)
+    pointer = load_latest_sft_model_optimization(bootstrap.store)
+    assert pointer is not None
+    coordination_directory = path.parent
+    external_directory = tmp_path / "external-model-optimization"
+    coordination_directory.rename(external_directory)
+    coordination_directory.symlink_to(external_directory, target_is_directory=True)
+    external_pointer_bytes = (external_directory / path.name).read_bytes()
+
+    with pytest.raises(SFTModelOptimizationSelectionError, match="directory is not safe"):
+        load_latest_sft_model_optimization(bootstrap.store)
+    with pytest.raises(SFTModelOptimizationSelectionError, match="directory is not safe"):
+        write_latest_sft_model_optimization(
+            bootstrap.store,
+            pointer,
+            expected_current=pointer.config,
+        )
+    _append_completed(bootstrap.store, key="second", minute=2)
+    with pytest.raises(AutomaticSFTPreparationError, match="directory is not safe"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=2),
+            code_revision="automatic-sft-test",
+        )
+    assert (external_directory / path.name).read_bytes() == external_pointer_bytes
+
+
+def test_latest_pointer_rejects_model_alias_prefix_rewrite(tmp_path: Path) -> None:
+    """Bind the mutable alias prefix to the selected immutable config and dataset.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    path = latest_sft_model_optimization_path(bootstrap.store)
+    pointer = load_latest_sft_model_optimization(bootstrap.store)
+    assert pointer is not None
+    artifact_ids = bootstrap.store.artifacts.list_ids()
+    path.write_bytes(
+        canonical_json_bytes(pointer.model_copy(update={"model_alias_prefix": "attacker-prefix"}))
+    )
+
+    with pytest.raises(SFTModelOptimizationSelectionError, match="does not derive"):
+        load_latest_sft_model_optimization(bootstrap.store)
+    _append_completed(bootstrap.store, key="second", minute=2)
+    with pytest.raises(AutomaticSFTPreparationError, match="does not derive"):
+        prepare_runtime_sft_model_optimization(
+            bootstrap.store,
+            created_at=_TIME + timedelta(hours=2),
+            code_revision="automatic-sft-test",
+        )
+    assert bootstrap.store.artifacts.list_ids() == artifact_ids
+
+
+@pytest.mark.parametrize("schema_version", [0, 2])
+def test_latest_pointer_rejects_unsupported_canonical_schema_versions(
+    tmp_path: Path, schema_version: int
+) -> None:
+    """Reject canonically encoded pointer versions outside the exact supported contract.
+
+    Args:
+        tmp_path: Pytest-owned state directory.
+        schema_version: Unsupported lower or higher coordination schema version.
+    """
+    bootstrap = _bootstrap(tmp_path)
+    _append_completed(bootstrap.store, key="first", minute=1)
+    prepare_runtime_sft_model_optimization(
+        bootstrap.store,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="automatic-sft-test",
+    )
+    path = latest_sft_model_optimization_path(bootstrap.store)
+    pointer = load_latest_sft_model_optimization(bootstrap.store)
+    assert pointer is not None
+    payload = pointer.model_dump(mode="json", exclude_none=False)
+    payload["schema_version"] = schema_version
+    path.write_bytes(canonical_json_bytes(payload))
+
+    with pytest.raises(SFTModelOptimizationSelectionError, match="pointer is invalid"):
+        load_latest_sft_model_optimization(bootstrap.store)

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -567,7 +567,15 @@ def _scan_source_actions(
 def _build_partitions(
     scanned_actions: Sequence[_ScannedAction], spec: SFTBuildSpec
 ) -> tuple[dict[ArtifactId, Literal["train", "held_out"]], tuple[SFTPartition, ...]]:
-    """Union shared fingerprints, then split only complete leakage components."""
+    """Union shared fingerprints, then assign components by held-out fraction.
+
+    Args:
+        scanned_actions: Eligible targets with their lineage and normalized fingerprint identity.
+        spec: Frozen partition sizing and fingerprint contract.
+
+    Returns:
+        Per-lineage partition assignments and complete leakage components.
+    """
     group_ids = tuple(sorted({action.source.leakage_group_id for action in scanned_actions}))
     if not group_ids:
         return {}, ()
@@ -629,8 +637,16 @@ def _build_partitions(
 
 
 def _held_out_component_count(component_count: int, held_out_fraction: float) -> int:
-    """Choose a deterministic nonempty held-out component set when splitting is possible."""
-    if component_count < 2:
+    """Choose the deterministic held-out count, including an explicit all-train mode.
+
+    Args:
+        component_count: Number of complete leakage components eligible for partitioning.
+        held_out_fraction: Persisted fraction, where exactly zero explicitly selects all training.
+
+    Returns:
+        Held-out component count that preserves at least one training component.
+    """
+    if component_count < 2 or held_out_fraction == 0:
         return 0
     target = math.floor(component_count * held_out_fraction + 0.5)
     return min(component_count - 1, max(1, target))

--- a/wmo/optimize/model/sft/builder_test.py
+++ b/wmo/optimize/model/sft/builder_test.py
@@ -699,6 +699,45 @@ def _build(
     )
 
 
+def test_default_build_spec_reloads_and_rebuilds_without_identity_drift(tmp_path: Path) -> None:
+    """Preserve the canonical default W12 spec and artifact identity across all-train support.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    store = _store(tmp_path)
+    source = _write_production_source(store, "default-spec-compatibility")
+    pre_change_payload = {
+        "held_out_fraction": 0.2,
+        "representative_sample_count": 3,
+        "split_salt": "wmo-sft-split-v1",
+    }
+    spec = SFTBuildSpec.model_validate(pre_change_payload)
+    first = build_sft_dataset(
+        store=store,
+        production_sources=(source,),
+        teacher_sources=(),
+        spec=spec,
+        created_at=_TIME,
+        code_revision="w12-default-compatibility-test",
+    )
+    write_sft_dataset(store, first)
+    loaded = load_sft_dataset(store, first.dataset.dataset_id)
+    rebuilt = build_sft_dataset(
+        store=store,
+        production_sources=(source,),
+        teacher_sources=(),
+        spec=spec,
+        created_at=_TIME,
+        code_revision="w12-default-compatibility-test",
+    )
+
+    assert spec.model_dump(mode="json", exclude_none=False) == pre_change_payload
+    assert loaded.build_spec == spec
+    assert rebuilt.dataset.dataset_id == first.dataset.dataset_id
+    assert rebuilt.dataset.build_sha256 == first.dataset.build_sha256
+
+
 def test_store_backed_sources_hydrate_transcripts_and_preserve_full_actions(tmp_path: Path) -> None:
     """Production and teacher rows come from verified evidence, not caller-owned transcripts."""
     store = _store(tmp_path)

--- a/wmo/optimize/model/sft/composition.py
+++ b/wmo/optimize/model/sft/composition.py
@@ -92,6 +92,10 @@ from wmo.common.project import (
 from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
 from wmo.optimize.model.sft.contracts import PartitionedSFTExample
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
+from wmo.optimize.model.sft.selection import (
+    SFTModelOptimizationSelectionError,
+    require_selected_sft_model_optimization_config,
+)
 from wmo.optimize.model.sft.training import TinkerSFTOptimizer, train_tinker_sft
 from wmo.optimize.model.sft.training_contracts import (
     TinkerSFTError,
@@ -292,13 +296,19 @@ def create_sft_model_optimization_config(
 
 
 def write_sft_model_optimization_config(
-    store: ProjectStore, config: SFTModelOptimizationConfig
+    store: ProjectStore,
+    config: SFTModelOptimizationConfig,
+    *,
+    bind_project: bool = True,
 ) -> SFTModelOptimizationConfig:
-    """Persist W14M intent and bind its ID to the project exactly once.
+    """Persist W14M intent and optionally establish the bootstrap project binding.
 
     Args:
         store: Project store that owns the config artifact and project pointer.
         config: Immutable config produced by ``create_sft_model_optimization_config``.
+        bind_project: Whether to establish or verify the project's bootstrap config binding.
+            Automatic journal composition persists later immutable configs with this disabled,
+            then advances the separately verified latest pointer.
 
     Returns:
         The persisted config.
@@ -316,23 +326,26 @@ def write_sft_model_optimization_config(
         )
     except ArtifactAlreadyExistsError:
         existing, stored = _load_sft_model_optimization_config_artifact(store, config.config_id)
-        if existing != config:
+        replay = config.model_copy(update={"created_at": existing.created_at})
+        if existing != replay:
             raise SFTModelOptimizationError(
                 "existing SFT model optimization config does not match its content-addressed ID"
             ) from None
+        config = existing
         config_manifest = stored.manifest
     except (ArtifactCorruptionError, ValueError) as exc:
         raise SFTModelOptimizationError(
             f"cannot persist SFT model optimization config {config.config_id}: {exc}"
         ) from exc
-    try:
-        store.bind_model_optimization_config(
-            artifact_input(config_manifest), artifact_type=_CONFIG_ARTIFACT_TYPE
-        )
-    except ProjectStoreError as exc:
-        raise SFTModelOptimizationError(
-            f"cannot bind SFT model optimization config to the project: {exc}"
-        ) from exc
+    if bind_project:
+        try:
+            store.bind_model_optimization_config(
+                artifact_input(config_manifest), artifact_type=_CONFIG_ARTIFACT_TYPE
+            )
+        except ProjectStoreError as exc:
+            raise SFTModelOptimizationError(
+                f"cannot bind SFT model optimization config to the project: {exc}"
+            ) from exc
     return config
 
 
@@ -353,23 +366,9 @@ def load_sft_model_optimization_config(
     """
     config, manifest = _load_sft_model_optimization_config_artifact(store, config_id)
     try:
-        bound = store.load_project().model_optimization_config
-    except ProjectStoreError as exc:
-        raise SFTModelOptimizationError(
-            f"cannot load project binding for SFT model optimization config {config_id}: {exc}"
-        ) from exc
-    if bound is None:
-        raise SFTModelOptimizationError(
-            "project has no immutable SFT model optimization config artifact binding"
-        )
-    if bound.artifact_id != config_id:
-        raise SFTModelOptimizationError(
-            "requested SFT model optimization config is not the project-bound config artifact"
-        )
-    if bound != artifact_input(manifest.manifest):
-        raise SFTModelOptimizationError(
-            "project SFT model optimization binding does not match the config artifact manifest"
-        )
+        require_selected_sft_model_optimization_config(store, artifact_input(manifest.manifest))
+    except SFTModelOptimizationSelectionError as exc:
+        raise SFTModelOptimizationError(str(exc)) from exc
     return config
 
 

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -375,7 +375,7 @@ class SFTPartition(ContractModel):
 class SFTBuildSpec(ContractModel):
     """Deterministic controls persisted with one frozen SFT dataset build."""
 
-    held_out_fraction: float = Field(default=0.20, gt=0, lt=1)
+    held_out_fraction: float = Field(default=0.20, ge=0, lt=1)
     representative_sample_count: int = Field(default=3, ge=0)
     split_salt: str = Field(default="wmo-sft-split-v1", min_length=1, max_length=256)
 

--- a/wmo/optimize/model/sft/run_manifest.py
+++ b/wmo/optimize/model/sft/run_manifest.py
@@ -1,0 +1,892 @@
+"""Local acceptance and recursive verification for one managed W13 run manifest."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    assert_secret_free,
+    canonical_json_bytes,
+    sha256_json,
+    stable_id,
+)
+from wmo.common.core.files import write_bytes_atomic
+from wmo.common.core.locks import file_write_lock
+from wmo.common.models import ModelSnapshot
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactStoreError,
+    ProjectStore,
+    artifact_input,
+)
+from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
+from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+from wmo.optimize.model.sft.training_contracts import (
+    TinkerSFTError,
+    TinkerSFTResumeError,
+    TinkerSFTRunManifest,
+    TinkerSFTSpec,
+)
+
+MANIFEST_FILE = "manifest.json"
+AUTOMATIC_ACCEPTANCE_FILE = "acceptance.json"
+AUTOMATIC_ACCEPTANCE_TYPE = "automatic-sft-acceptance"
+AUTOMATIC_ACCEPTANCE_POINTER_FILE = "automatic-acceptance.json"
+
+
+class AutomaticSFTRunAcceptance(ArtifactEnvelope):
+    """Exact automatic W12 selection durably authorized for one local W13 run."""
+
+    schema_version: Literal[1] = 1
+    acceptance_id: ArtifactId
+    project_id: ArtifactId
+    previous_acceptance: ArtifactInput | None = None
+    config: ArtifactInput
+    dataset: ArtifactInput
+    runtime_snapshot: ArtifactInput
+    model_alias: ArtifactId
+    tinker_connection: ArtifactId
+    base_model: ModelSnapshot
+    connection_config_sha256: Sha256
+    training_spec_sha256: Sha256
+    runtime_last_ordinal: int = Field(ge=1)
+    runtime_prefix_sha256: Sha256
+    tinker_run_id: str = Field(min_length=1, max_length=128)
+    tinker_manifest_sha256: Sha256
+
+
+class AutomaticSFTRunAcceptanceSelection(ContractModel):
+    """Mutable CAS pointer selecting the only automatic acceptance authorized to replay."""
+
+    schema_version: Literal[1] = 1
+    project_id: ArtifactId
+    acceptance: ArtifactInput
+    previous_acceptance: ArtifactInput | None = None
+    config: ArtifactInput
+    updated_at: datetime
+
+    @field_validator("updated_at")
+    @classmethod
+    def _require_updated_at_timezone(cls, value: datetime) -> datetime:
+        """Require explicit time-zone evidence for the acceptance selection."""
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("automatic SFT acceptance update time must include a timezone")
+        return value
+
+
+def automatic_sft_acceptance_path(store: ProjectStore) -> Path:
+    """Return the canonical project-local automatic-acceptance selection path.
+
+    Args:
+        store: Project whose managed run acceptance is coordinated.
+
+    Returns:
+        Mutable pointer path sharing the model-optimization coordination directory.
+    """
+    return store.paths.project_directory / "model-optimization" / AUTOMATIC_ACCEPTANCE_POINTER_FILE
+
+
+def initialize_automatic_sft_acceptance(
+    store: ProjectStore,
+    *,
+    manifest: TinkerSFTRunManifest,
+    previous_acceptance: ArtifactInput | None,
+    config: ArtifactInput,
+    dataset: ArtifactInput,
+    runtime_snapshot: ArtifactInput,
+    model_alias: ArtifactId,
+    tinker_connection: ArtifactId,
+    base_model: ModelSnapshot,
+    connection_config_sha256: Sha256,
+    training_spec_sha256: Sha256,
+    runtime_last_ordinal: int,
+    runtime_prefix_sha256: Sha256,
+    created_at: datetime,
+    code_revision: str,
+) -> tuple[AutomaticSFTRunAcceptance, ArtifactInput]:
+    """Persist or verify automatic consent bound to an exact selected W12/W13 graph.
+
+    Args:
+        store: Project receiving the immutable acceptance artifact.
+        manifest: Recursively verified generic W13 run manifest created under the journal lock.
+        previous_acceptance: Exact prior selected acceptance, or ``None`` at genesis.
+        config: Exact immutable model-optimization config artifact input.
+        dataset: Exact immutable W12 dataset artifact input.
+        runtime_snapshot: Exact immutable runtime-prefix snapshot artifact input.
+        model_alias: Versioned trained-model alias frozen by the selected config.
+        tinker_connection: Secret-free local Tinker connection name.
+        base_model: Exact provider model snapshot used as the training base.
+        connection_config_sha256: Exact secret-free Tinker connection digest.
+        training_spec_sha256: Exact immutable training-spec digest.
+        runtime_last_ordinal: Final journal ordinal authorized by consent.
+        runtime_prefix_sha256: Canonical digest of every authorized journal event.
+        created_at: Time recorded only when acceptance is first persisted.
+        code_revision: Exact release revision authorizing the automatic run.
+
+    Returns:
+        New or exactly matching immutable receipt and its exact artifact input.
+
+    Raises:
+        TinkerSFTError: The proposed binding conflicts with the W13 manifest or prior receipt.
+    """
+    acceptance = _automatic_acceptance(
+        manifest=manifest,
+        project_id=store.paths.project_id,
+        previous_acceptance=previous_acceptance,
+        config=config,
+        dataset=dataset,
+        runtime_snapshot=runtime_snapshot,
+        model_alias=model_alias,
+        tinker_connection=tinker_connection,
+        base_model=base_model,
+        connection_config_sha256=connection_config_sha256,
+        training_spec_sha256=training_spec_sha256,
+        runtime_last_ordinal=runtime_last_ordinal,
+        runtime_prefix_sha256=runtime_prefix_sha256,
+        created_at=created_at,
+        code_revision=code_revision,
+    )
+    try:
+        manifest_record = store.artifacts.write_json(
+            artifact_id=acceptance.acceptance_id,
+            artifact_type=AUTOMATIC_ACCEPTANCE_TYPE,
+            envelope=acceptance,
+            files={AUTOMATIC_ACCEPTANCE_FILE: acceptance},
+        )
+    except ArtifactAlreadyExistsError:
+        existing, existing_input = load_automatic_sft_acceptance(store, acceptance.acceptance_id)
+        _validate_automatic_acceptance(
+            existing,
+            expected=acceptance.model_copy(update={"created_at": existing.created_at}),
+        )
+        return existing, existing_input
+    except (ArtifactCorruptionError, ArtifactStoreError, ValueError) as exc:
+        raise TinkerSFTError(f"cannot persist automatic SFT acceptance: {exc}") from exc
+    return acceptance, artifact_input(manifest_record)
+
+
+def load_automatic_sft_acceptance(
+    store: ProjectStore,
+    acceptance_id: ArtifactId,
+) -> tuple[AutomaticSFTRunAcceptance, ArtifactInput]:
+    """Load one immutable acceptance artifact with exact manifest and canonical-byte checks.
+
+    Args:
+        store: Project owning the immutable acceptance artifact.
+        acceptance_id: Exact content-addressed acceptance identity.
+
+    Returns:
+        Verified receipt and exact artifact-manifest input.
+
+    Raises:
+        TinkerSFTResumeError: The artifact type, files, envelope, bytes, or identity differ.
+    """
+    try:
+        stored = store.artifacts.read(acceptance_id)
+        if stored.manifest.artifact_type != AUTOMATIC_ACCEPTANCE_TYPE:
+            raise TinkerSFTResumeError("automatic SFT acceptance has the wrong artifact type")
+        if tuple(file.path for file in stored.manifest.files) != (AUTOMATIC_ACCEPTANCE_FILE,):
+            raise TinkerSFTResumeError("automatic SFT acceptance has unexpected artifact files")
+        payload = store.artifacts.read_bytes(acceptance_id, AUTOMATIC_ACCEPTANCE_FILE)
+        receipt = AutomaticSFTRunAcceptance.model_validate_json(payload)
+    except (ArtifactCorruptionError, OSError, ValueError) as exc:
+        raise TinkerSFTResumeError(f"cannot verify automatic SFT acceptance: {exc}") from exc
+    if payload != canonical_json_bytes(receipt):
+        raise TinkerSFTResumeError("automatic SFT acceptance payload is not canonical")
+    if (
+        receipt.acceptance_id != acceptance_id
+        or receipt.acceptance_id != _automatic_acceptance_id(receipt)
+        or receipt.project_id != store.paths.project_id
+        or receipt.source is not None
+        or stored.manifest.schema_version != receipt.schema_version
+        or stored.manifest.created_at != receipt.created_at
+        or stored.manifest.inputs != receipt.inputs
+        or stored.manifest.code_revision != receipt.code_revision
+        or stored.manifest.source is not None
+    ):
+        raise TinkerSFTResumeError("automatic SFT acceptance manifest differs from its receipt")
+    return receipt, artifact_input(stored.manifest)
+
+
+def require_automatic_sft_acceptance_binding(
+    acceptance: AutomaticSFTRunAcceptance,
+    *,
+    manifest: TinkerSFTRunManifest,
+    project_id: ArtifactId,
+    previous_acceptance: ArtifactInput | None,
+    config: ArtifactInput,
+    dataset: ArtifactInput,
+    runtime_snapshot: ArtifactInput,
+    model_alias: ArtifactId,
+    tinker_connection: ArtifactId,
+    base_model: ModelSnapshot,
+    connection_config_sha256: Sha256,
+    training_spec_sha256: Sha256,
+    runtime_last_ordinal: int,
+    runtime_prefix_sha256: Sha256,
+    code_revision: str,
+) -> None:
+    """Require a selected receipt to match the exact recursively verified current graph.
+
+    Args:
+        acceptance: Immutable receipt selected by project coordination.
+        manifest: Recursively verified generic W13 run manifest.
+        project_id: Project authorized to replay the managed run.
+        previous_acceptance: Exact prior selected acceptance, or ``None`` at genesis.
+        config: Exact immutable model-optimization config artifact input.
+        dataset: Exact immutable W12 dataset artifact input.
+        runtime_snapshot: Exact immutable runtime-prefix snapshot artifact input.
+        model_alias: Versioned trained-model alias frozen by the selected config.
+        tinker_connection: Secret-free local Tinker connection name.
+        base_model: Exact provider model snapshot used as the training base.
+        connection_config_sha256: Exact secret-free Tinker connection digest.
+        training_spec_sha256: Exact immutable training-spec digest.
+        runtime_last_ordinal: Final journal ordinal authorized by consent.
+        runtime_prefix_sha256: Canonical digest of every authorized journal event.
+        code_revision: Exact release revision required by the receipt.
+
+    Raises:
+        TinkerSFTResumeError: Any receipt identity or selected-graph binding differs.
+    """
+    expected = _automatic_acceptance(
+        manifest=manifest,
+        project_id=project_id,
+        previous_acceptance=previous_acceptance,
+        config=config,
+        dataset=dataset,
+        runtime_snapshot=runtime_snapshot,
+        model_alias=model_alias,
+        tinker_connection=tinker_connection,
+        base_model=base_model,
+        connection_config_sha256=connection_config_sha256,
+        training_spec_sha256=training_spec_sha256,
+        runtime_last_ordinal=runtime_last_ordinal,
+        runtime_prefix_sha256=runtime_prefix_sha256,
+        created_at=acceptance.created_at,
+        code_revision=code_revision,
+    )
+    _validate_automatic_acceptance(acceptance, expected=expected)
+
+
+def load_automatic_sft_acceptance_selection(
+    store: ProjectStore,
+) -> AutomaticSFTRunAcceptanceSelection | None:
+    """Read the selected automatic acceptance without acquiring its external coordination lock.
+
+    Callers that mutate the pointer must already hold the model-optimization coordination lock.
+    Read-only preparation relies on atomic replacement and verifies the immutable target.
+
+    Args:
+        store: Project whose selected automatic acceptance is loaded.
+
+    Returns:
+        Canonical selected acceptance pointer, or ``None`` before the first consent commit.
+
+    Raises:
+        TinkerSFTResumeError: The pointer is malformed, noncanonical, or belongs elsewhere.
+    """
+    path = automatic_sft_acceptance_path(store)
+    _require_safe_automatic_acceptance_path(store, path)
+    if not path.exists():
+        return None
+    if not path.is_file() or path.is_symlink():
+        raise TinkerSFTResumeError("automatic SFT acceptance pointer is not a safe file")
+    try:
+        payload = path.read_bytes()
+        selection = AutomaticSFTRunAcceptanceSelection.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise TinkerSFTResumeError(f"cannot read automatic SFT acceptance pointer: {exc}") from exc
+    if payload != canonical_json_bytes(selection):
+        raise TinkerSFTResumeError("automatic SFT acceptance pointer is not canonical")
+    if selection.project_id != store.paths.project_id:
+        raise TinkerSFTResumeError("automatic SFT acceptance pointer belongs to another project")
+    return selection
+
+
+def write_automatic_sft_acceptance_selection_unlocked(
+    store: ProjectStore,
+    selection: AutomaticSFTRunAcceptanceSelection,
+    *,
+    expected_current: ArtifactInput | None,
+) -> AutomaticSFTRunAcceptanceSelection:
+    """CAS-select one immutable acceptance while the caller owns the coordination lock.
+
+    Args:
+        store: Project receiving the selected acceptance pointer.
+        selection: New exact acceptance and prior-selection binding.
+        expected_current: Exact acceptance selected before consent, or ``None`` at genesis.
+
+    Returns:
+        Stored selection or a byte-equivalent concurrent replay.
+
+    Raises:
+        TinkerSFTResumeError: Project identity, prior selection, or stored bytes conflict.
+    """
+    if selection.project_id != store.paths.project_id:
+        raise TinkerSFTResumeError("cannot select automatic SFT acceptance for another project")
+    current = load_automatic_sft_acceptance_selection(store)
+    if current is not None and current == selection:
+        return current
+    current_input = None if current is None else current.acceptance
+    if current_input != expected_current or selection.previous_acceptance != expected_current:
+        raise TinkerSFTResumeError(
+            "automatic SFT acceptance selection changed before consent commit"
+        )
+    path = automatic_sft_acceptance_path(store)
+    _require_safe_automatic_acceptance_path(store, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _require_safe_automatic_acceptance_path(store, path)
+    _write_automatic_acceptance_pointer_atomic(path, canonical_json_bytes(selection))
+    stored = load_automatic_sft_acceptance_selection(store)
+    if stored is None or stored != selection:
+        raise TinkerSFTResumeError("automatic SFT acceptance pointer did not preserve selection")
+    return stored
+
+
+def initialize_tinker_sft_run(
+    store: ProjectStore,
+    dataset_id: ArtifactId,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    *,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTRunManifest:
+    """Durably accept one verified W12 dataset without composing a trainer backend.
+
+    Args:
+        store: Project store owning the immutable W12 dataset.
+        dataset_id: Persisted W12 dataset selected for the managed run.
+        spec: Frozen base model, schedule, and spend settings.
+        output_dir: Stable append-only W13 run directory for the selected config.
+        created_at: Time recorded only when the run is first accepted.
+        code_revision: Exact release revision recorded or required by the run.
+
+    Returns:
+        The new or exactly matching immutable W13 run manifest.
+
+    Raises:
+        TinkerSFTError: Dataset verification or run-manifest acceptance is unsafe.
+    """
+    dataset, dataset_input = verified_training_inputs(store, dataset_id)
+    validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
+    manifest_path = output_dir / MANIFEST_FILE
+    with file_write_lock(manifest_path, what="the Tinker SFT run"):
+        return load_or_create_manifest(
+            dataset=dataset,
+            dataset_input=dataset_input,
+            spec=spec,
+            output_dir=output_dir,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+
+
+def load_tinker_sft_run(
+    store: ProjectStore,
+    dataset_id: ArtifactId,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    *,
+    code_revision: str,
+) -> TinkerSFTRunManifest | None:
+    """Load an accepted W13 run manifest without creating local state.
+
+    Args:
+        store: Project store owning the immutable W12 dataset.
+        dataset_id: Persisted W12 dataset selected for the managed run.
+        spec: Frozen base model, schedule, and spend settings.
+        output_dir: Stable append-only W13 run directory for the selected config.
+        code_revision: Exact release revision required by the existing run.
+
+    Returns:
+        The recursively verified run manifest, or ``None`` when no run was accepted.
+
+    Raises:
+        TinkerSFTError: The dataset or existing manifest cannot be verified exactly.
+    """
+    dataset, dataset_input = verified_training_inputs(store, dataset_id)
+    path = output_dir / MANIFEST_FILE
+    if not path.exists():
+        return None
+    with file_write_lock(path, what="the Tinker SFT run"):
+        if not path.exists():
+            return None
+        manifest = _read_model(path, TinkerSFTRunManifest, "Tinker SFT manifest")
+        validate_manifest(
+            manifest,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            spec=spec,
+            code_revision=code_revision,
+        )
+        return manifest
+
+
+def verified_training_inputs(
+    store: ProjectStore,
+    dataset_id: ArtifactId,
+    *,
+    legacy_build_spec: SFTBuildSpec | None = None,
+) -> tuple[SFTDatasetArtifact, ArtifactInput]:
+    """Load one recursively verified W12 dataset and its exact manifest input.
+
+    Args:
+        store: Project store owning the immutable dataset.
+        dataset_id: Persisted W12 dataset identity.
+        legacy_build_spec: Explicit settings required only for a legacy dataset.
+
+    Returns:
+        The verified dataset and exact manifest input used by W13.
+
+    Raises:
+        TinkerSFTError: The W12 artifact graph cannot be verified for training.
+    """
+    try:
+        dataset = load_verified_sft_dataset(
+            store,
+            dataset_id,
+            legacy_build_spec=legacy_build_spec,
+        )
+        dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
+    except (ArtifactCorruptionError, SFTBuildError) as exc:
+        raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc
+    return dataset, dataset_input
+
+
+def validate_run_inputs(
+    dataset: SFTDatasetArtifact, *, created_at: datetime, code_revision: str
+) -> None:
+    """Validate immutable W12 rows and local producer facts before W13 acceptance.
+
+    Args:
+        dataset: Recursively verified W12 dataset artifact.
+        created_at: Time proposed for a new run manifest.
+        code_revision: Exact release revision proposed or required for the run.
+
+    Raises:
+        TinkerSFTError: Dataset rows or producer facts are not safe for managed training.
+    """
+    if created_at.tzinfo is None or created_at.utcoffset() is None:
+        raise TinkerSFTError("Tinker SFT creation time must include a timezone")
+    if not code_revision:
+        raise TinkerSFTError("Tinker SFT code_revision must be non-empty")
+    if dataset.dataset.status != "accepted":
+        raise TinkerSFTError("Tinker SFT only accepts an accepted frozen W12 dataset")
+    if dataset.dataset.examples_sha256 != partitioned_rows_sha256(dataset.rows):
+        raise TinkerSFTError("Tinker SFT dataset rows do not match the W12 examples digest")
+    train_rows = tuple(row for row in dataset.rows if row.partition == "train")
+    held_out_rows = tuple(row for row in dataset.rows if row.partition == "held_out")
+    if not train_rows:
+        raise TinkerSFTError("an accepted W12 dataset needs at least one train example")
+    if dataset.dataset.train_example_ids != tuple(
+        sorted(row.example.example_id for row in train_rows)
+    ):
+        raise TinkerSFTError("Tinker SFT train rows do not match the W12 manifest")
+    if dataset.dataset.held_out_example_ids != tuple(
+        sorted(row.example.example_id for row in held_out_rows)
+    ):
+        raise TinkerSFTError("Tinker SFT held-out rows do not match the W12 manifest")
+
+
+def load_or_create_manifest(
+    *,
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    spec: TinkerSFTSpec,
+    output_dir: Path,
+    created_at: datetime,
+    code_revision: str,
+) -> TinkerSFTRunManifest:
+    """Load an exact run manifest or create it once from verified immutable inputs.
+
+    Args:
+        dataset: Recursively verified W12 dataset artifact.
+        dataset_input: Exact W12 artifact manifest input.
+        spec: Frozen base model, schedule, and spend settings.
+        output_dir: Stable append-only W13 run directory.
+        created_at: Time recorded only for a new manifest.
+        code_revision: Exact release revision recorded or required by the run.
+
+    Returns:
+        The new or recursively verified existing manifest.
+
+    Raises:
+        TinkerSFTError: The dataset input or existing manifest differs from the run contract.
+    """
+    path = output_dir / MANIFEST_FILE
+    if path.exists():
+        manifest = _read_model(path, TinkerSFTRunManifest, "Tinker SFT manifest")
+        validate_manifest(
+            manifest,
+            dataset=dataset,
+            dataset_input=dataset_input,
+            spec=spec,
+            code_revision=code_revision,
+        )
+        return manifest
+    if dataset_input.artifact_id != dataset.dataset.dataset_id:
+        raise TinkerSFTError("canonical W12 manifest names a different dataset")
+    spec_sha256 = sha256_json(spec)
+    run_id = stable_id(
+        "tinker-sft-run",
+        {
+            "dataset_id": dataset.dataset.dataset_id,
+            "dataset_manifest_sha256": dataset_input.sha256,
+            "dataset_build_sha256": dataset.dataset.build_sha256,
+            "dataset_examples_sha256": dataset.dataset.examples_sha256,
+            "spec_sha256": spec_sha256,
+        },
+    )
+    manifest = TinkerSFTRunManifest(
+        schema_version=1,
+        created_at=created_at,
+        inputs=(dataset_input,),
+        code_revision=code_revision,
+        run_id=run_id,
+        dataset_id=dataset.dataset.dataset_id,
+        dataset_manifest_sha256=dataset_input.sha256,
+        dataset_build_sha256=dataset.dataset.build_sha256,
+        dataset_examples_sha256=dataset.dataset.examples_sha256,
+        spec=spec,
+        spec_sha256=spec_sha256,
+    )
+    _write_new_json(path, manifest, "Tinker SFT manifest")
+    return manifest
+
+
+def validate_manifest(
+    manifest: TinkerSFTRunManifest,
+    *,
+    dataset: SFTDatasetArtifact,
+    dataset_input: ArtifactInput,
+    spec: TinkerSFTSpec,
+    code_revision: str,
+) -> None:
+    """Require one existing run manifest to match every immutable W12 input.
+
+    Args:
+        manifest: Existing local W13 run manifest.
+        dataset: Recursively verified W12 dataset artifact.
+        dataset_input: Exact W12 artifact manifest input.
+        spec: Frozen base model, schedule, and spend settings.
+        code_revision: Exact release revision required by the run.
+
+    Raises:
+        TinkerSFTResumeError: Any existing run field differs from the selected W12 graph.
+    """
+    if manifest.dataset_id != dataset.dataset.dataset_id:
+        raise TinkerSFTResumeError("existing Tinker SFT run belongs to a different W12 dataset")
+    if manifest.inputs != (dataset_input,):
+        raise TinkerSFTResumeError(
+            "existing Tinker SFT run does not name the canonical W12 artifact manifest"
+        )
+    if manifest.dataset_manifest_sha256 != dataset_input.sha256:
+        raise TinkerSFTResumeError(
+            "existing Tinker SFT run has a different W12 artifact manifest digest"
+        )
+    if manifest.dataset_build_sha256 != dataset.dataset.build_sha256:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different W12 dataset build")
+    if manifest.dataset_examples_sha256 != dataset.dataset.examples_sha256:
+        raise TinkerSFTResumeError("existing Tinker SFT run has different W12 example rows")
+    if manifest.spec != spec:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different training spec")
+    if manifest.code_revision != code_revision:
+        raise TinkerSFTResumeError("existing Tinker SFT run has a different code revision")
+
+
+def _automatic_acceptance(
+    *,
+    manifest: TinkerSFTRunManifest,
+    project_id: ArtifactId,
+    previous_acceptance: ArtifactInput | None,
+    config: ArtifactInput,
+    dataset: ArtifactInput,
+    runtime_snapshot: ArtifactInput,
+    model_alias: ArtifactId,
+    tinker_connection: ArtifactId,
+    base_model: ModelSnapshot,
+    connection_config_sha256: Sha256,
+    training_spec_sha256: Sha256,
+    runtime_last_ordinal: int,
+    runtime_prefix_sha256: Sha256,
+    created_at: datetime,
+    code_revision: str,
+) -> AutomaticSFTRunAcceptance:
+    """Build the content-addressed automatic acceptance for one selected graph.
+
+    Args:
+        manifest: Recursively verified generic W13 run manifest.
+        project_id: Project authorized to replay the managed run.
+        previous_acceptance: Exact prior selected acceptance, or ``None`` at genesis.
+        config: Exact immutable model-optimization config artifact input.
+        dataset: Exact immutable W12 dataset artifact input.
+        runtime_snapshot: Exact immutable runtime-prefix snapshot artifact input.
+        model_alias: Versioned trained-model alias frozen by the selected config.
+        tinker_connection: Secret-free local Tinker connection name.
+        base_model: Exact provider model snapshot used as the training base.
+        connection_config_sha256: Exact secret-free Tinker connection digest.
+        training_spec_sha256: Exact immutable training-spec digest.
+        runtime_last_ordinal: Final journal ordinal authorized by consent.
+        runtime_prefix_sha256: Canonical digest of every authorized journal event.
+        created_at: Materialization time for a new receipt or existing receipt verification.
+        code_revision: Exact release revision authorizing the automatic run.
+
+    Returns:
+        Fully bound automatic acceptance receipt.
+    """
+    inputs = tuple(
+        sorted(
+            (
+                config,
+                dataset,
+                runtime_snapshot,
+                *((previous_acceptance,) if previous_acceptance is not None else ()),
+            ),
+            key=lambda item: (item.artifact_id, item.sha256),
+        )
+    )
+    manifest_sha256 = sha256_json(manifest)
+    material = {
+        "schema_version": 1,
+        "code_revision": code_revision,
+        "project_id": project_id,
+        "previous_acceptance": (
+            None if previous_acceptance is None else previous_acceptance.model_dump(mode="json")
+        ),
+        "inputs": tuple(item.model_dump(mode="json") for item in inputs),
+        "config": config.model_dump(mode="json"),
+        "dataset": dataset.model_dump(mode="json"),
+        "runtime_snapshot": runtime_snapshot.model_dump(mode="json"),
+        "model_alias": model_alias,
+        "tinker_connection": tinker_connection,
+        "base_model": base_model.model_dump(mode="json"),
+        "connection_config_sha256": connection_config_sha256,
+        "training_spec_sha256": training_spec_sha256,
+        "runtime_last_ordinal": runtime_last_ordinal,
+        "runtime_prefix_sha256": runtime_prefix_sha256,
+        "tinker_run_id": manifest.run_id,
+        "tinker_manifest_sha256": manifest_sha256,
+    }
+    return AutomaticSFTRunAcceptance(
+        schema_version=1,
+        created_at=created_at,
+        code_revision=code_revision,
+        source=None,
+        acceptance_id=stable_id("automatic-sft-acceptance", material),
+        project_id=project_id,
+        previous_acceptance=previous_acceptance,
+        inputs=inputs,
+        config=config,
+        dataset=dataset,
+        runtime_snapshot=runtime_snapshot,
+        model_alias=model_alias,
+        tinker_connection=tinker_connection,
+        base_model=base_model,
+        connection_config_sha256=connection_config_sha256,
+        training_spec_sha256=training_spec_sha256,
+        runtime_last_ordinal=runtime_last_ordinal,
+        runtime_prefix_sha256=runtime_prefix_sha256,
+        tinker_run_id=manifest.run_id,
+        tinker_manifest_sha256=manifest_sha256,
+    )
+
+
+def _automatic_acceptance_id(acceptance: AutomaticSFTRunAcceptance) -> ArtifactId:
+    """Recompute one receipt's content identity from every semantic authorization field.
+
+    Args:
+        acceptance: Immutable automatic acceptance receipt to verify.
+
+    Returns:
+        Stable identity excluding only materialization time and redundant stored identity.
+    """
+    material = {
+        "schema_version": acceptance.schema_version,
+        "code_revision": acceptance.code_revision,
+        "project_id": acceptance.project_id,
+        "previous_acceptance": (
+            None
+            if acceptance.previous_acceptance is None
+            else acceptance.previous_acceptance.model_dump(mode="json")
+        ),
+        "inputs": tuple(item.model_dump(mode="json") for item in acceptance.inputs),
+        "config": acceptance.config.model_dump(mode="json"),
+        "dataset": acceptance.dataset.model_dump(mode="json"),
+        "runtime_snapshot": acceptance.runtime_snapshot.model_dump(mode="json"),
+        "model_alias": acceptance.model_alias,
+        "tinker_connection": acceptance.tinker_connection,
+        "base_model": acceptance.base_model.model_dump(mode="json"),
+        "connection_config_sha256": acceptance.connection_config_sha256,
+        "training_spec_sha256": acceptance.training_spec_sha256,
+        "runtime_last_ordinal": acceptance.runtime_last_ordinal,
+        "runtime_prefix_sha256": acceptance.runtime_prefix_sha256,
+        "tinker_run_id": acceptance.tinker_run_id,
+        "tinker_manifest_sha256": acceptance.tinker_manifest_sha256,
+    }
+    return stable_id("automatic-sft-acceptance", material)
+
+
+def _validate_automatic_acceptance(
+    acceptance: AutomaticSFTRunAcceptance,
+    *,
+    expected: AutomaticSFTRunAcceptance,
+) -> None:
+    """Require every semantic field of an existing acceptance to match exactly.
+
+    Args:
+        acceptance: Existing canonical automatic acceptance receipt.
+        expected: Receipt rebuilt from the recursively verified selected graph.
+
+    Raises:
+        TinkerSFTResumeError: Existing acceptance belongs to any different graph or producer.
+    """
+    if acceptance != expected:
+        raise TinkerSFTResumeError(
+            "existing automatic SFT acceptance does not bind the selected config, runtime "
+            "snapshot, W12 dataset, connection, alias, and W13 manifest"
+        )
+
+
+def _write_new_json(path: Path, value: BaseModel, label: str) -> None:
+    """Persist one secret-free canonical JSON contract without replacement.
+
+    Args:
+        path: New append-only file path.
+        value: Validated contract to serialize canonically.
+        label: User-facing artifact label used by failures.
+
+    Raises:
+        TinkerSFTResumeError: The append-only path already exists.
+    """
+    if path.exists():
+        raise TinkerSFTResumeError(
+            f"{label} already exists at {path}; append-only runs do not replace it"
+        )
+    assert_secret_free(value)
+    write_bytes_atomic(path, canonical_json_bytes(value) + b"\n")
+
+
+def _read_model[ModelT: BaseModel](path: Path, model_type: type[ModelT], label: str) -> ModelT:
+    """Read one validated local contract with a contextual resume failure.
+
+    Args:
+        path: Existing local contract path.
+        model_type: Pydantic model class used for exact validation.
+        label: User-facing artifact label used by failures.
+
+    Returns:
+        The validated contract instance.
+
+    Raises:
+        TinkerSFTResumeError: The file is absent, unreadable, or malformed.
+    """
+    try:
+        return model_type.model_validate_json(path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise TinkerSFTResumeError(f"cannot read {label} at {path}: {exc}") from exc
+
+
+def _read_canonical_model[ModelT: BaseModel](
+    path: Path, model_type: type[ModelT], label: str
+) -> ModelT:
+    """Read one validated model and require exact canonical builder serialization.
+
+    Args:
+        path: Existing local contract path.
+        model_type: Pydantic model class used for exact validation.
+        label: User-facing artifact label used by failures.
+
+    Returns:
+        Validated model whose stored bytes match the current canonical serializer.
+
+    Raises:
+        TinkerSFTResumeError: The file is malformed or not canonical current output.
+    """
+    try:
+        payload = path.read_bytes()
+        model = model_type.model_validate_json(payload)
+    except (OSError, ValueError) as exc:
+        raise TinkerSFTResumeError(f"cannot read {label} at {path}: {exc}") from exc
+    if payload != canonical_json_bytes(model) + b"\n":
+        raise TinkerSFTResumeError(f"{label} at {path} is not canonical current output")
+    return model
+
+
+def _require_safe_automatic_acceptance_path(store: ProjectStore, path: Path) -> None:
+    """Reject a pointer path escaping through any project-relative symlinked ancestor.
+
+    Args:
+        store: Project that owns the coordination path.
+        path: Expected automatic-acceptance pointer below the project directory.
+
+    Raises:
+        TinkerSFTResumeError: The path escapes the project or an ancestor is a symlink.
+    """
+    project_directory = store.paths.project_directory
+    try:
+        path.relative_to(project_directory)
+    except ValueError as exc:
+        raise TinkerSFTResumeError(
+            "automatic SFT acceptance pointer escapes its project directory"
+        ) from exc
+    if path.is_symlink():
+        raise TinkerSFTResumeError("automatic SFT acceptance pointer is not a safe file")
+    current = path.parent
+    while True:
+        if current.is_symlink():
+            raise TinkerSFTResumeError(
+                f"automatic SFT acceptance coordination directory is not safe: {current}"
+            )
+        if current == project_directory:
+            break
+        current = current.parent
+
+
+def _write_automatic_acceptance_pointer_atomic(path: Path, payload: bytes) -> None:
+    """Replace the acceptance pointer without following a swapped destination symlink.
+
+    Args:
+        path: Already validated pointer path whose parent coordination directory exists.
+        payload: Complete canonical pointer bytes.
+
+    Raises:
+        OSError: Exclusive staging, payload durability, or atomic replacement fails.
+    """
+    staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(staging, flags, 0o644)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(staging, path)
+    except BaseException:
+        staging.unlink(missing_ok=True)
+        raise
+    try:
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(directory_descriptor)

--- a/wmo/optimize/model/sft/run_manifest_test.py
+++ b/wmo/optimize/model/sft/run_manifest_test.py
@@ -1,0 +1,1 @@
+"""Adjacent test owner for W13 run-manifest acceptance exercised by composition suites."""

--- a/wmo/optimize/model/sft/selection.py
+++ b/wmo/optimize/model/sft/selection.py
@@ -1,0 +1,395 @@
+"""Verified mutable selection of the latest immutable model-optimization config."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    assert_secret_free,
+    canonical_json_bytes,
+)
+from wmo.common.core.files import write_bytes_atomic
+from wmo.common.core.locks import file_write_lock
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
+from wmo.runtime.router.snapshot import load_runtime_trace_snapshot
+
+_CONFIG_ARTIFACT_TYPE = "sft-model-optimization-config"
+_DATASET_ARTIFACT_TYPE = "sft-dataset"
+_SNAPSHOT_ARTIFACT_TYPE = "runtime-trace-snapshot"
+_LATEST_DIRECTORY = "model-optimization"
+_LATEST_FILE = "latest.json"
+
+
+class SFTModelOptimizationSelectionError(ValueError):
+    """The selected model-optimization artifact graph is missing or inconsistent."""
+
+
+class LatestSFTModelOptimization(ContractModel):
+    """Mutable coordination pointer to one verified immutable runtime SFT graph."""
+
+    schema_version: Literal[1] = 1
+    project_id: ArtifactId
+    config: ArtifactInput
+    dataset: ArtifactInput
+    runtime_snapshot: ArtifactInput
+    model_alias_prefix: ArtifactId
+    updated_at: datetime
+
+    @field_validator("updated_at")
+    @classmethod
+    def _require_timezone(cls, value: datetime) -> datetime:
+        """Require an explicit timezone for the coordination update."""
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("latest model-optimization update time must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _require_distinct_artifacts(self) -> LatestSFTModelOptimization:
+        """Require the pointer to name three distinct artifact identities."""
+        artifact_ids = {
+            self.config.artifact_id,
+            self.dataset.artifact_id,
+            self.runtime_snapshot.artifact_id,
+        }
+        if len(artifact_ids) != 3:
+            raise ValueError("latest model-optimization artifacts must have distinct IDs")
+        return self
+
+
+def latest_sft_model_optimization_path(store: ProjectStore) -> Path:
+    """Return the project-local coordination path for the latest verified config.
+
+    Args:
+        store: Project whose selected model-optimization graph is addressed.
+
+    Returns:
+        Canonical mutable pointer path outside the immutable artifact directory.
+    """
+    return store.paths.project_directory / _LATEST_DIRECTORY / _LATEST_FILE
+
+
+def load_latest_sft_model_optimization(
+    store: ProjectStore,
+) -> LatestSFTModelOptimization | None:
+    """Load and recursively verify the latest coordination pointer when present.
+
+    Args:
+        store: Project whose pointer and immutable artifacts are verified.
+
+    Returns:
+        The verified pointer, or ``None`` before automatic runtime SFT materialization.
+
+    Raises:
+        SFTModelOptimizationSelectionError: The pointer is unsafe, malformed, secret-bearing,
+            belongs to another project, or names an inconsistent artifact graph.
+    """
+    path = latest_sft_model_optimization_path(store)
+    _require_safe_coordination_path(store, path)
+    if not path.exists():
+        return None
+    if not path.is_file() or path.is_symlink():
+        raise SFTModelOptimizationSelectionError(
+            f"latest model-optimization pointer is not a safe file: {path}"
+        )
+    try:
+        pointer = LatestSFTModelOptimization.model_validate_json(path.read_bytes())
+        assert_secret_free(pointer)
+    except (OSError, ValueError) as exc:
+        raise SFTModelOptimizationSelectionError(
+            f"latest model-optimization pointer is invalid: {path}"
+        ) from exc
+    if pointer.project_id != store.paths.project_id:
+        raise SFTModelOptimizationSelectionError(
+            "latest model-optimization pointer belongs to another project"
+        )
+    _verify_pointer_artifacts(store, pointer)
+    return pointer
+
+
+def selected_sft_model_optimization_config_input(store: ProjectStore) -> ArtifactInput:
+    """Return the latest verified config input or the project's bootstrap binding.
+
+    Args:
+        store: Project containing immutable model-optimization state.
+
+    Returns:
+        Exact manifest input selected for the next preflight or replay.
+
+    Raises:
+        SFTModelOptimizationSelectionError: Neither a valid latest pointer nor a bootstrap
+            project binding is available.
+    """
+    latest = load_latest_sft_model_optimization(store)
+    if latest is not None:
+        return latest.config
+    try:
+        bootstrap = store.load_project().model_optimization_config
+    except ProjectStoreError as exc:
+        raise SFTModelOptimizationSelectionError(str(exc)) from exc
+    if bootstrap is None:
+        raise SFTModelOptimizationSelectionError(
+            "project has no model-optimization settings; configure a bounded Tinker SFT "
+            "template before running `wmo optimize model`"
+        )
+    _require_artifact_input(store, bootstrap, artifact_type=_CONFIG_ARTIFACT_TYPE)
+    return bootstrap
+
+
+def require_selected_sft_model_optimization_config(
+    store: ProjectStore, config: ArtifactInput
+) -> None:
+    """Require an exact config manifest to be the project's current verified selection.
+
+    Args:
+        store: Project containing the selection state.
+        config: Config manifest input requested by a caller.
+
+    Raises:
+        SFTModelOptimizationSelectionError: Another config is selected or the selection is
+            invalid.
+    """
+    if selected_sft_model_optimization_config_input(store) != config:
+        raise SFTModelOptimizationSelectionError(
+            "requested SFT model-optimization config is not the latest verified selection"
+        )
+
+
+def write_latest_sft_model_optimization(
+    store: ProjectStore,
+    pointer: LatestSFTModelOptimization,
+    *,
+    expected_current: ArtifactInput | None,
+) -> LatestSFTModelOptimization:
+    """Atomically advance the verified latest pointer with compare-and-swap semantics.
+
+    Args:
+        store: Project receiving the coordination update.
+        pointer: New pointer whose complete immutable graph already exists.
+        expected_current: Exact config input observed before creating the new graph, or ``None``
+            when no model-optimization graph has ever been selected.
+
+    Returns:
+        The newly stored pointer, or a byte-equivalent pointer written by a concurrent replay.
+
+    Raises:
+        SFTModelOptimizationSelectionError: The proposed graph is invalid or another process
+            selected a different config before commit.
+    """
+    if pointer.project_id != store.paths.project_id:
+        raise SFTModelOptimizationSelectionError(
+            "cannot select a model-optimization graph for another project"
+        )
+    _verify_pointer_artifacts(store, pointer)
+    path = latest_sft_model_optimization_path(store)
+    _require_safe_coordination_path(store, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _require_safe_coordination_path(store, path)
+    with file_write_lock(path, what="latest model-optimization selection"):
+        _require_safe_coordination_path(store, path)
+        existing = load_latest_sft_model_optimization(store)
+        if existing is not None and _same_selected_graph(existing, pointer):
+            return existing
+        current = existing.config if existing is not None else _bootstrap_config_input(store)
+        if current != expected_current:
+            raise SFTModelOptimizationSelectionError(
+                "latest model-optimization selection changed before commit"
+            )
+        try:
+            write_bytes_atomic(path, canonical_json_bytes(pointer))
+        except OSError as exc:
+            raise SFTModelOptimizationSelectionError(
+                f"cannot persist latest model-optimization pointer: {path}"
+            ) from exc
+    stored = load_latest_sft_model_optimization(store)
+    if stored is None or not _same_selected_graph(stored, pointer):
+        raise SFTModelOptimizationSelectionError(
+            "latest model-optimization pointer did not preserve the selected graph"
+        )
+    return stored
+
+
+def _verify_pointer_artifacts(store: ProjectStore, pointer: LatestSFTModelOptimization) -> None:
+    """Verify pointer manifests and their exact config-to-dataset-to-snapshot edges.
+
+    Args:
+        store: Project owning every selected immutable artifact.
+        pointer: Coordination record whose complete graph is checked.
+
+    Raises:
+        SFTModelOptimizationSelectionError: An artifact, digest, edge, or project identity differs.
+    """
+    config_manifest = _require_artifact_input(
+        store, pointer.config, artifact_type=_CONFIG_ARTIFACT_TYPE
+    )
+    dataset_manifest = _require_artifact_input(
+        store, pointer.dataset, artifact_type=_DATASET_ARTIFACT_TYPE
+    )
+    _require_artifact_input(store, pointer.runtime_snapshot, artifact_type=_SNAPSHOT_ARTIFACT_TYPE)
+    if config_manifest.inputs != (pointer.dataset,):
+        raise SFTModelOptimizationSelectionError(
+            "selected model-optimization config does not bind the selected dataset"
+        )
+    try:
+        config_payload = json.loads(
+            store.artifacts.read_bytes(pointer.config.artifact_id, "config.json")
+        )
+        config_alias = config_payload["model_alias"]
+    except (ArtifactCorruptionError, KeyError, TypeError, ValueError) as exc:
+        raise SFTModelOptimizationSelectionError(
+            "selected model-optimization config has no verified model alias"
+        ) from exc
+    if not isinstance(config_alias, str):
+        raise SFTModelOptimizationSelectionError(
+            "selected model-optimization config has no verified model alias"
+        )
+    expected_alias = versioned_sft_model_alias(
+        pointer.model_alias_prefix,
+        pointer.dataset.artifact_id,
+    )
+    if config_alias != expected_alias:
+        raise SFTModelOptimizationSelectionError(
+            "latest model alias prefix does not derive the selected immutable config alias"
+        )
+    if pointer.runtime_snapshot not in dataset_manifest.inputs:
+        raise SFTModelOptimizationSelectionError(
+            "selected SFT dataset does not bind the selected runtime snapshot"
+        )
+    try:
+        snapshot = load_runtime_trace_snapshot(
+            store.artifacts, pointer.runtime_snapshot.artifact_id
+        ).snapshot
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTModelOptimizationSelectionError(
+            "selected runtime snapshot cannot be recursively verified"
+        ) from exc
+    if snapshot.project_id != store.paths.project_id:
+        raise SFTModelOptimizationSelectionError(
+            "selected runtime snapshot belongs to another project"
+        )
+
+
+def _bootstrap_config_input(store: ProjectStore) -> ArtifactInput | None:
+    """Return and verify the optional project-bound bootstrap config input.
+
+    Args:
+        store: Project that may contain a compatibility bootstrap binding.
+
+    Returns:
+        Exact verified config manifest input, or ``None`` when absent.
+
+    Raises:
+        SFTModelOptimizationSelectionError: Project configuration or its artifact is invalid.
+    """
+    try:
+        bootstrap = store.load_project().model_optimization_config
+    except ProjectStoreError as exc:
+        raise SFTModelOptimizationSelectionError(str(exc)) from exc
+    if bootstrap is not None:
+        _require_artifact_input(store, bootstrap, artifact_type=_CONFIG_ARTIFACT_TYPE)
+    return bootstrap
+
+
+def _require_artifact_input(
+    store: ProjectStore, expected: ArtifactInput, *, artifact_type: str
+) -> ArtifactManifest:
+    """Return a verified manifest after checking its exact input and domain type.
+
+    Args:
+        store: Project containing the expected immutable artifact.
+        expected: Exact artifact ID and manifest digest required by the pointer.
+        artifact_type: Required domain type for the artifact manifest.
+
+    Returns:
+        Fully verified immutable manifest.
+
+    Raises:
+        SFTModelOptimizationSelectionError: The artifact is unavailable, wrong-typed, or changed.
+    """
+    try:
+        stored = store.artifacts.read(expected.artifact_id)
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise SFTModelOptimizationSelectionError(
+            f"selected {artifact_type} artifact is unavailable: {expected.artifact_id}"
+        ) from exc
+    if stored.manifest.artifact_type != artifact_type:
+        raise SFTModelOptimizationSelectionError(
+            f"selected artifact {expected.artifact_id} is not {artifact_type}"
+        )
+    if artifact_input(stored.manifest) != expected:
+        raise SFTModelOptimizationSelectionError(
+            f"selected {artifact_type} manifest digest changed"
+        )
+    return stored.manifest
+
+
+def _same_selected_graph(
+    left: LatestSFTModelOptimization, right: LatestSFTModelOptimization
+) -> bool:
+    """Return whether two coordination records select the same immutable graph."""
+    return left.model_copy(update={"updated_at": right.updated_at}) == right
+
+
+def versioned_sft_model_alias(prefix: str, dataset_id: str) -> ArtifactId:
+    """Derive the immutable-dataset-specific catalog alias from its selected prefix.
+
+    Args:
+        prefix: Persisted user-selected alias prefix.
+        dataset_id: Immutable W12 dataset identity for this trained version.
+
+    Returns:
+        Artifact-safe local alias no longer than the catalog contract permits.
+
+    Raises:
+        SFTModelOptimizationSelectionError: The prefix cannot retain a valid leading identifier.
+    """
+    suffix = dataset_id.rsplit("-", maxsplit=1)[-1][:12]
+    maximum_prefix_length = 128 - len(suffix) - 1
+    normalized_prefix = prefix[:maximum_prefix_length].rstrip("._-")
+    if not normalized_prefix:
+        raise SFTModelOptimizationSelectionError(
+            "configured SFT model alias cannot form a versioned runtime alias"
+        )
+    return f"{normalized_prefix}-{suffix}"
+
+
+def _require_safe_coordination_path(store: ProjectStore, path: Path) -> None:
+    """Reject symlinked coordination directories before reading, locking, or writing.
+
+    Args:
+        store: Project that owns the coordination path.
+        path: Expected latest pointer below the project directory.
+
+    Raises:
+        SFTModelOptimizationSelectionError: The path escapes the project or an ancestor is a
+            symlink.
+    """
+    project_directory = store.paths.project_directory
+    try:
+        path.relative_to(project_directory)
+    except ValueError as exc:
+        raise SFTModelOptimizationSelectionError(
+            "latest model-optimization pointer escapes its project directory"
+        ) from exc
+    current = path.parent
+    while True:
+        if current.is_symlink():
+            raise SFTModelOptimizationSelectionError(
+                f"latest model-optimization coordination directory is not safe: {current}"
+            )
+        if current == project_directory:
+            break
+        current = current.parent

--- a/wmo/optimize/model/sft/selection_test.py
+++ b/wmo/optimize/model/sft/selection_test.py
@@ -1,0 +1,1 @@
+"""Regression coverage for latest model-optimization selection lives with composition tests."""

--- a/wmo/optimize/model/sft/tinker.py
+++ b/wmo/optimize/model/sft/tinker.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 from wmo.common.core.artifacts import canonical_json_bytes
-from wmo.common.models import AssistantAction, ToolCall
+from wmo.common.models import AssistantAction, NumericMeasurement, ToolCall
 from wmo.optimize.model.sft.contracts import (
     AssistantActionEvent,
     SFTExample,
@@ -26,6 +26,7 @@ from wmo.optimize.model.sft.training_contracts import (
     TrainerBatchResult,
     TrainerDatum,
     TrainerSession,
+    conservative_training_step_cost,
 )
 
 if TYPE_CHECKING:
@@ -92,17 +93,25 @@ class TinkerTrainerBackend:
         """
         self._service = service
 
-    def conservative_step_cost(self, spec: TinkerSFTSpec, *, batch_example_count: int) -> None:
-        """Return no cost bound because the pinned SDK exposes no supported estimator.
+    def conservative_step_cost(
+        self, spec: TinkerSFTSpec, *, batch_example_count: int
+    ) -> NumericMeasurement | None:
+        """Bound one logical training step from explicit price and maximum token settings.
 
         Args:
-            spec: Frozen training settings, unused because no SDK estimate exists.
-            batch_example_count: Planned row count, also insufficient for an SDK-backed bound.
+            spec: Frozen training settings containing the caller-confirmed token price and datum
+                token ceiling.
+            batch_example_count: Exact number of examples scheduled for this logical step.
 
         Returns:
-            None. A run with ``maximum_cost_usd`` therefore fails before opening this backend.
+            A conservative caller-priced bound, or ``None`` when either required setting is
+            unknown. Each logical step has one durable pre-dispatch intent, so a failed or
+            ambiguous dispatch cannot be retried as another billable step.
         """
-        return None
+        return conservative_training_step_cost(
+            spec,
+            batch_example_count=batch_example_count,
+        )
 
     def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> TrainerSession:
         """Create a managed LoRA client and restore a durable state before rendering any datum.

--- a/wmo/optimize/model/sft/tinker_test.py
+++ b/wmo/optimize/model/sft/tinker_test.py
@@ -143,6 +143,7 @@ class _DatumRenderer:
     """Return fixed local token and weight tensors without fetching a tokenizer or model."""
 
     def __init__(self) -> None:
+        """Initialize empty call journals for deterministic renderer assertions."""
         self.conversations: list[list[TinkerConversationMessage]] = []
         self.train_on_what: list[TrainOnWhat] = []
 
@@ -167,6 +168,7 @@ class _Future[ValueT]:
     """A synchronous local stand-in for the small Tinker future surface used by the adapter."""
 
     def __init__(self, value: ValueT) -> None:
+        """Store one already-computed local response."""
         self._value = value
 
     def result(self) -> ValueT:
@@ -178,6 +180,7 @@ class _TrainingClient:
     """Record local concrete training calls without creating a Tinker service session."""
 
     def __init__(self) -> None:
+        """Initialize empty forward, backward, and optimizer call journals."""
         self.forward_backward_calls: list[tuple[Sequence[tinker.Datum], str]] = []
         self.optim_steps: list[tinker.AdamParams] = []
 
@@ -315,6 +318,18 @@ def test_context_truncation_retains_the_complete_two_token_target() -> None:
     assert datum.datum.model_input.to_ints() == [11, 12]
     assert datum.datum.loss_fn_inputs["target_tokens"].data == [12, 13]
     assert datum.datum.loss_fn_inputs["weights"].data == [1.0, 1.0]
+
+
+def test_backend_cost_bound_uses_explicit_price_and_maximum_tokens() -> None:
+    """Calculate a model-specific full-datum bound without accessing the service client."""
+    backend = TinkerTrainerBackend(cast("tinker.ServiceClient", object()))
+    spec = _spec().model_copy(update={"training_usd_per_million_tokens": 250.0})
+
+    cost = backend.conservative_step_cost(spec, batch_example_count=3)
+
+    assert cost is not None
+    assert cost.value == 250.0 * 32 * 3 / 1_000_000
+    assert cost.provenance == "estimated"
 
 
 def test_datum_limit_rejects_instead_of_truncating_the_two_token_target() -> None:

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -21,11 +21,14 @@ from wmo.common.core.artifacts import (
 from wmo.common.core.files import write_bytes_atomic
 from wmo.common.core.locks import file_write_lock
 from wmo.common.models import NumericMeasurement
-from wmo.common.project import ArtifactCorruptionError, ProjectStore, artifact_input
-from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
+from wmo.common.project import ProjectStore
 from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
-from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
+from wmo.optimize.model.sft.run_manifest import (
+    load_or_create_manifest,
+    validate_run_inputs,
+    verified_training_inputs,
+)
 from wmo.optimize.model.sft.training_contracts import (
     TINKER_SFT_EVENT_ADAPTER,
     TinkerSFTAmbiguousStepError,
@@ -127,16 +130,12 @@ def train_tinker_sft(
     Raises:
         TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
     """
-    try:
-        dataset = load_verified_sft_dataset(
-            store,
-            dataset_id,
-            legacy_build_spec=legacy_build_spec,
-        )
-        dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
-    except (ArtifactCorruptionError, SFTBuildError) as exc:
-        raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc
-    _validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
+    dataset, dataset_input = verified_training_inputs(
+        store,
+        dataset_id,
+        legacy_build_spec=legacy_build_spec,
+    )
+    validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
     manifest_path = output_dir / _MANIFEST_FILE
     with file_write_lock(manifest_path, what="the Tinker SFT run"):
         return _train_locked(
@@ -160,7 +159,7 @@ def _train_locked(
     created_at: datetime,
     code_revision: str,
 ) -> TinkerSFTResult:
-    manifest = _load_or_create_manifest(
+    manifest = load_or_create_manifest(
         dataset=dataset,
         dataset_input=dataset_input,
         spec=spec,
@@ -326,109 +325,6 @@ def _train_locked(
         dataset_input=dataset_input,
         expected_schedule=expected_schedule,
     )
-
-
-def _validate_run_inputs(
-    dataset: SFTDatasetArtifact, *, created_at: datetime, code_revision: str
-) -> None:
-    if created_at.tzinfo is None or created_at.utcoffset() is None:
-        raise TinkerSFTError("Tinker SFT creation time must include a timezone")
-    if not code_revision:
-        raise TinkerSFTError("Tinker SFT code_revision must be non-empty")
-    if dataset.dataset.status != "accepted":
-        raise TinkerSFTError("Tinker SFT only accepts an accepted frozen W12 dataset")
-    if dataset.dataset.examples_sha256 != partitioned_rows_sha256(dataset.rows):
-        raise TinkerSFTError("Tinker SFT dataset rows do not match the W12 examples digest")
-    train_rows = tuple(row for row in dataset.rows if row.partition == "train")
-    held_out_rows = tuple(row for row in dataset.rows if row.partition == "held_out")
-    if not train_rows:
-        raise TinkerSFTError("an accepted W12 dataset needs at least one train example")
-    if dataset.dataset.train_example_ids != tuple(
-        sorted(row.example.example_id for row in train_rows)
-    ):
-        raise TinkerSFTError("Tinker SFT train rows do not match the W12 manifest")
-    if dataset.dataset.held_out_example_ids != tuple(
-        sorted(row.example.example_id for row in held_out_rows)
-    ):
-        raise TinkerSFTError("Tinker SFT held-out rows do not match the W12 manifest")
-
-
-def _load_or_create_manifest(
-    *,
-    dataset: SFTDatasetArtifact,
-    dataset_input: ArtifactInput,
-    spec: TinkerSFTSpec,
-    output_dir: Path,
-    created_at: datetime,
-    code_revision: str,
-) -> TinkerSFTRunManifest:
-    path = output_dir / _MANIFEST_FILE
-    if path.exists():
-        manifest = _read_model(path, TinkerSFTRunManifest, "Tinker SFT manifest")
-        _validate_manifest(
-            manifest,
-            dataset=dataset,
-            dataset_input=dataset_input,
-            spec=spec,
-            code_revision=code_revision,
-        )
-        return manifest
-    if dataset_input.artifact_id != dataset.dataset.dataset_id:
-        raise TinkerSFTError("canonical W12 manifest names a different dataset")
-    spec_sha256 = sha256_json(spec)
-    run_id = stable_id(
-        "tinker-sft-run",
-        {
-            "dataset_id": dataset.dataset.dataset_id,
-            "dataset_manifest_sha256": dataset_input.sha256,
-            "dataset_build_sha256": dataset.dataset.build_sha256,
-            "dataset_examples_sha256": dataset.dataset.examples_sha256,
-            "spec_sha256": spec_sha256,
-        },
-    )
-    manifest = TinkerSFTRunManifest(
-        schema_version=1,
-        created_at=created_at,
-        inputs=(dataset_input,),
-        code_revision=code_revision,
-        run_id=run_id,
-        dataset_id=dataset.dataset.dataset_id,
-        dataset_manifest_sha256=dataset_input.sha256,
-        dataset_build_sha256=dataset.dataset.build_sha256,
-        dataset_examples_sha256=dataset.dataset.examples_sha256,
-        spec=spec,
-        spec_sha256=spec_sha256,
-    )
-    _write_new_json(path, manifest, "Tinker SFT manifest")
-    return manifest
-
-
-def _validate_manifest(
-    manifest: TinkerSFTRunManifest,
-    *,
-    dataset: SFTDatasetArtifact,
-    dataset_input: ArtifactInput,
-    spec: TinkerSFTSpec,
-    code_revision: str,
-) -> None:
-    if manifest.dataset_id != dataset.dataset.dataset_id:
-        raise TinkerSFTResumeError("existing Tinker SFT run belongs to a different W12 dataset")
-    if manifest.inputs != (dataset_input,):
-        raise TinkerSFTResumeError(
-            "existing Tinker SFT run does not name the canonical W12 artifact manifest"
-        )
-    if manifest.dataset_manifest_sha256 != dataset_input.sha256:
-        raise TinkerSFTResumeError(
-            "existing Tinker SFT run has a different W12 artifact manifest digest"
-        )
-    if manifest.dataset_build_sha256 != dataset.dataset.build_sha256:
-        raise TinkerSFTResumeError("existing Tinker SFT run has a different W12 dataset build")
-    if manifest.dataset_examples_sha256 != dataset.dataset.examples_sha256:
-        raise TinkerSFTResumeError("existing Tinker SFT run has different W12 example rows")
-    if manifest.spec != spec:
-        raise TinkerSFTResumeError("existing Tinker SFT run has a different training spec")
-    if manifest.code_revision != code_revision:
-        raise TinkerSFTResumeError("existing Tinker SFT run has a different code revision")
 
 
 def _read_events(output_dir: Path, run_id: ArtifactId) -> tuple[TinkerSFTEvent, ...]:

--- a/wmo/optimize/model/sft/training_contracts.py
+++ b/wmo/optimize/model/sft/training_contracts.py
@@ -50,13 +50,57 @@ class TinkerSFTSpec(ContractModel):
     maximum_steps: int | None = Field(default=None, gt=0)
     maximum_datum_tokens: int | None = Field(default=None, gt=1)
     maximum_cost_usd: float | None = Field(default=None, gt=0)
+    training_usd_per_million_tokens: float | None = Field(default=None, ge=0)
 
-    @field_validator("learning_rate", "maximum_cost_usd")
+    @field_validator(
+        "learning_rate",
+        "maximum_cost_usd",
+        "training_usd_per_million_tokens",
+    )
     @classmethod
     def _require_finite_float(cls, value: float | None) -> float | None:
+        """Reject nonfinite prices, caps, and learning rates.
+
+        Args:
+            value: Optional numeric setting validated by Pydantic.
+
+        Returns:
+            The unchanged finite value or ``None``.
+
+        Raises:
+            ValueError: ``value`` is nonfinite.
+        """
         if value is not None and not math.isfinite(value):
             raise ValueError("Tinker SFT numeric settings must be finite")
         return value
+
+
+def conservative_training_step_cost(
+    spec: TinkerSFTSpec, *, batch_example_count: int
+) -> NumericMeasurement | None:
+    """Bound one logical training step from explicit price and maximum token settings.
+
+    Args:
+        spec: Frozen settings containing a caller-confirmed price and per-datum token ceiling.
+        batch_example_count: Exact positive number of examples scheduled for the step.
+
+    Returns:
+        The maximum caller-priced cost for the step, or ``None`` when price or token ceiling is
+        unknown.
+
+    Raises:
+        ValueError: ``batch_example_count`` is not positive.
+    """
+    if batch_example_count <= 0:
+        raise ValueError("batch_example_count must be positive")
+    price = spec.training_usd_per_million_tokens
+    maximum_tokens = spec.maximum_datum_tokens
+    if price is None or maximum_tokens is None:
+        return None
+    return NumericMeasurement(
+        value=price * maximum_tokens * batch_example_count / 1_000_000,
+        provenance="estimated",
+    )
 
 
 class TrainerBatchResult(ContractModel):
@@ -70,6 +114,17 @@ class TrainerBatchResult(ContractModel):
     @field_validator("loss", "gradient_norm")
     @classmethod
     def _require_finite_metric(cls, value: float | None) -> float | None:
+        """Reject nonfinite backend loss or gradient observations.
+
+        Args:
+            value: Optional backend metric validated by Pydantic.
+
+        Returns:
+            The unchanged finite value or ``None``.
+
+        Raises:
+            ValueError: ``value`` is nonfinite.
+        """
         if value is not None and not math.isfinite(value):
             raise ValueError("Tinker SFT backend metrics must be finite")
         return value
@@ -138,6 +193,14 @@ class TinkerSFTRunManifest(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_exact_dataset_and_spec_bindings(self) -> TinkerSFTRunManifest:
+        """Verify the run identity binds the exact dataset and training settings.
+
+        Returns:
+            This verified immutable run manifest.
+
+        Raises:
+            ValueError: Any input, digest, or content-addressed identity differs.
+        """
         expected_inputs = (
             ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_manifest_sha256),
         )
@@ -181,6 +244,17 @@ class TinkerSFTMetric(ContractModel):
     @field_validator("loss", "gradient_norm")
     @classmethod
     def _require_finite_metric(cls, value: float | None) -> float | None:
+        """Reject nonfinite persisted loss or gradient observations.
+
+        Args:
+            value: Optional metric validated by Pydantic.
+
+        Returns:
+            The unchanged finite value or ``None``.
+
+        Raises:
+            ValueError: ``value`` is nonfinite.
+        """
         if value is not None and not math.isfinite(value):
             raise ValueError("Tinker SFT metrics must be finite")
         return value
@@ -257,6 +331,14 @@ class TinkerSFTModelArtifact(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_exact_dataset_binding(self) -> TinkerSFTModelArtifact:
+        """Verify the terminal model binds its dataset and provider handle.
+
+        Returns:
+            This verified immutable model artifact.
+
+        Raises:
+            ValueError: Inputs or content-addressed model identity differ.
+        """
         expected_inputs = (
             ArtifactInput(artifact_id=self.dataset_id, sha256=self.dataset_manifest_sha256),
         )
@@ -294,6 +376,14 @@ class TinkerSFTResult(ArtifactEnvelope):
 
     @model_validator(mode="after")
     def _require_exact_terminal_inputs(self) -> TinkerSFTResult:
+        """Verify the terminal result binds its exact dataset and model artifacts.
+
+        Returns:
+            This verified immutable result artifact.
+
+        Raises:
+            ValueError: Inputs or content-addressed result identity differ.
+        """
         expected_inputs = tuple(
             sorted(
                 (

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -56,9 +56,18 @@ class _FakeSession:
     """Record deterministic training calls without creating a Tinker client."""
 
     def __init__(self, backend: _FakeBackend) -> None:
+        """Bind the shared fake backend call journal."""
         self._backend = backend
 
     def render_examples(self, examples: Sequence[SFTExample]) -> tuple[_FakeDatum, ...]:
+        """Render deterministic datum identities and supervised-token counts.
+
+        Args:
+            examples: Frozen W12 examples supplied to the trainer.
+
+        Returns:
+            One fake datum for each example in the original order.
+        """
         self._backend.rendered_example_ids.extend(example.example_id for example in examples)
         return tuple(
             _FakeDatum(example_id=example.example_id, supervised_token_count=index + 3)
@@ -68,6 +77,19 @@ class _FakeSession:
     def train_batch(
         self, datums: Sequence[TrainerDatum], *, learning_rate: float
     ) -> TrainerBatchResult:
+        """Record one batch and return deterministic metrics or an injected failure.
+
+        Args:
+            datums: Rendered examples scheduled for this optimizer step.
+            learning_rate: Frozen learning rate accepted by the backend seam.
+
+        Returns:
+            Deterministic loss, gradient, and observed cost facts.
+
+        Raises:
+            RuntimeError: The configured failure boundary is reached.
+        """
+        del learning_rate
         self._backend.train_calls += 1
         if self._backend.fail_on_train_call == self._backend.train_calls:
             raise RuntimeError("injected training failure")
@@ -85,10 +107,26 @@ class _FakeSession:
         return result
 
     def save_state(self, checkpoint_name: str) -> str:
+        """Record a checkpoint request and return its deterministic provider handle.
+
+        Args:
+            checkpoint_name: Stable checkpoint name selected by the trainer.
+
+        Returns:
+            Configured or derived fake provider state handle.
+        """
         self._backend.saved_state_names.append(checkpoint_name)
         return self._backend.state_resource or f"fake://state/{checkpoint_name}"
 
     def save_sampling_handle(self, model_name: str) -> str:
+        """Record terminal model persistence and return a fake sampling handle.
+
+        Args:
+            model_name: Stable terminal model name selected by the trainer.
+
+        Returns:
+            Deterministic fake sampling handle.
+        """
         self._backend.saved_model_names.append(model_name)
         return f"fake://model/{model_name}"
 
@@ -106,6 +144,16 @@ class _FakeBackend:
         fail_on_cost_call: int | None = None,
         state_resource: str | None = None,
     ) -> None:
+        """Configure deterministic costs, failures, state, and empty call journals.
+
+        Args:
+            cost_per_batch: Observed cost returned after each completed batch.
+            conservative_cost_per_batch: Pre-dispatch upper bound, or ``None`` when unknown.
+            fail_on_train_call: Batch number that fails before a result is returned.
+            fail_after_train_call: Batch number that fails after simulated provider work.
+            fail_on_cost_call: Estimate call number that raises a planning failure.
+            state_resource: Optional fixed provider checkpoint handle.
+        """
         self.cost_per_batch = cost_per_batch
         self.conservative_cost_per_batch = conservative_cost_per_batch
         self.fail_on_train_call = fail_on_train_call
@@ -123,6 +171,19 @@ class _FakeBackend:
     def conservative_step_cost(
         self, spec: TinkerSFTSpec, *, batch_example_count: int
     ) -> NumericMeasurement | None:
+        """Return the configured batch bound or an injected planning failure.
+
+        Args:
+            spec: Frozen training settings accepted by the backend seam.
+            batch_example_count: Exact examples in the planned batch.
+
+        Returns:
+            Configured conservative measurement, or ``None`` when unknown.
+
+        Raises:
+            RuntimeError: The configured estimate failure boundary is reached.
+        """
+        del spec, batch_example_count
         self.cost_calls += 1
         if self.fail_on_cost_call == self.cost_calls:
             raise RuntimeError("injected pre-dispatch planning failure")
@@ -134,6 +195,16 @@ class _FakeBackend:
         )
 
     def open(self, spec: TinkerSFTSpec, resume_state_path: str | None) -> _FakeSession:
+        """Record the resume handle and return a session sharing this call journal.
+
+        Args:
+            spec: Frozen training settings accepted without provider access.
+            resume_state_path: Optional durable checkpoint handle.
+
+        Returns:
+            A deterministic fake training session.
+        """
+        del spec
         self.open_resume_paths.append(resume_state_path)
         return _FakeSession(self)
 
@@ -192,6 +263,7 @@ def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
         "maximum_steps": None,
         "maximum_datum_tokens": 128,
         "maximum_cost_usd": None,
+        "training_usd_per_million_tokens": None,
     }
     return TinkerSFTSpec.model_validate(fields | overrides)
 

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import errno
 import os
+import pty
 import re
+import select
 import shutil
+import signal
 import subprocess
 import sys
 import tarfile
+import termios
+import time
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -188,6 +194,129 @@ def _run_checked(
     return result
 
 
+def _run_tty_child(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    answers: list[tuple[str, str]],
+    completion_marker: str | None = None,
+    timeout: float = 30,
+) -> str:
+    """Drive one interactive child and require a clean bounded exit.
+
+    Args:
+        command: Exact executable and argument vector.
+        cwd: Isolated working directory for the child.
+        environment: Complete child environment.
+        answers: Ordered prompt substring and terminal answer pairs.
+        completion_marker: Optional output required before terminal input closes.
+        timeout: Maximum total child lifetime in seconds.
+
+    Returns:
+        Combined terminal transcript.
+
+    Raises:
+        AssertionError: The child times out, exits unsuccessfully, omits a prompt, or omits the
+            required completion marker.
+        OSError: The pseudo-terminal fails for a reason other than normal slave closure.
+    """
+    master, slave = pty.openpty()
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=environment,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+    )
+    os.close(slave)
+    transcript = ""
+    search_from = 0
+    pending = list(answers)
+    input_closed = False
+    completion_seen = completion_marker is None
+    terminal_closed = False
+    deadline = time.monotonic() + timeout
+    try:
+        while process.poll() is None and time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(master, 65_536)
+                except OSError as error:
+                    if error.errno != errno.EIO:
+                        raise
+                    terminal_closed = True
+                    break
+                if not chunk:
+                    terminal_closed = True
+                    break
+                transcript += chunk.decode(errors="replace")
+            if pending and (prompt_position := transcript.find(pending[0][0], search_from)) >= 0:
+                prompt, answer = pending[0]
+                search_from = prompt_position + len(prompt)
+                try:
+                    os.write(master, (answer + "\n").encode())
+                except OSError as error:
+                    if error.errno != errno.EIO:
+                        raise
+                    terminal_closed = True
+                    break
+                pending.pop(0)
+            if completion_marker is not None and completion_marker in transcript:
+                completion_seen = True
+            if not pending and completion_seen and not input_closed:
+                try:
+                    canonical_input = bool(termios.tcgetattr(master)[3] & termios.ICANON)
+                except termios.error as error:
+                    if error.args and error.args[0] == errno.EIO:
+                        terminal_closed = True
+                        break
+                    if process.poll() is None and not terminal_closed:
+                        raise
+                    continue
+                if canonical_input:
+                    try:
+                        os.write(master, b"\x04")
+                    except OSError as error:
+                        if error.errno != errno.EIO:
+                            raise
+                        terminal_closed = True
+                        break
+                    input_closed = True
+        if terminal_closed and process.poll() is None:
+            try:
+                process.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                pass
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+            process.wait(timeout=5)
+            raise AssertionError(f"interactive CLI timed out:\n{transcript}")
+        if not terminal_closed:
+            while True:
+                readable, _, _ = select.select([master], [], [], 0)
+                if not readable:
+                    break
+                try:
+                    chunk = os.read(master, 65_536)
+                except OSError as error:
+                    if error.errno != errno.EIO:
+                        raise
+                    break
+                if not chunk:
+                    break
+                transcript += chunk.decode(errors="replace")
+    finally:
+        os.close(master)
+    assert process.returncode == 0, transcript
+    assert not pending, f"unanswered prompts {pending}:\n{transcript}"
+    assert completion_seen, f"missing completion marker {completion_marker!r}:\n{transcript}"
+    return transcript
+
+
 def _installed_release_driver() -> None:
     """Execute the isolated installed-wheel no-spend release evidence flow.
 
@@ -197,13 +326,8 @@ def _installed_release_driver() -> None:
     import hashlib
     import json
     import math
-    import pty
-    import select
-    import signal
     import socket
-    import termios
     import threading
-    import time
     from collections import Counter
     from datetime import UTC, datetime
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -657,71 +781,13 @@ def _installed_release_driver() -> None:
         Returns:
             Combined terminal transcript.
         """
-        master, slave = pty.openpty()
-        process = subprocess.Popen(
+        return _run_tty_child(
             [str(executable), *arguments],
             cwd=execution_root,
-            env=child_environment,
-            stdin=slave,
-            stdout=slave,
-            stderr=slave,
-            close_fds=True,
+            environment=child_environment,
+            answers=answers,
+            completion_marker=completion_marker,
         )
-        os.close(slave)
-        transcript = ""
-        search_from = 0
-        pending = list(answers)
-        input_closed = False
-        completion_seen = completion_marker is None
-        deadline = time.monotonic() + 30
-        try:
-            while process.poll() is None and time.monotonic() < deadline:
-                readable, _, _ = select.select([master], [], [], 0.1)
-                if readable:
-                    try:
-                        transcript += os.read(master, 65_536).decode(errors="replace")
-                    except OSError:
-                        break
-                if (
-                    pending
-                    and (prompt_position := transcript.find(pending[0][0], search_from)) >= 0
-                ):
-                    prompt, answer = pending.pop(0)
-                    search_from = prompt_position + len(prompt)
-                    os.write(master, (answer + "\n").encode())
-                if completion_marker is not None and completion_marker in transcript:
-                    completion_seen = True
-                if not pending and completion_seen and not input_closed:
-                    try:
-                        canonical_input = bool(termios.tcgetattr(master)[3] & termios.ICANON)
-                    except termios.error:
-                        if process.poll() is None:
-                            raise
-                        continue
-                    if canonical_input:
-                        os.write(master, b"\x04")
-                        input_closed = True
-            if process.poll() is None:
-                process.send_signal(signal.SIGTERM)
-                process.wait(timeout=5)
-                raise AssertionError(f"interactive CLI timed out:\n{transcript}")
-            while True:
-                readable, _, _ = select.select([master], [], [], 0)
-                if not readable:
-                    break
-                try:
-                    chunk = os.read(master, 65_536)
-                except OSError:
-                    break
-                if not chunk:
-                    break
-                transcript += chunk.decode(errors="replace")
-        finally:
-            os.close(master)
-        assert process.returncode == 0, transcript
-        assert not pending, f"unanswered prompts {pending}:\n{transcript}"
-        assert completion_seen, f"missing completion marker {completion_marker!r}:\n{transcript}"
-        return transcript
 
     def model_answers(
         alias: str,
@@ -1289,6 +1355,47 @@ def _installed_release_driver() -> None:
         server.server_close()
         server_thread.join(timeout=5)
         assert not server_thread.is_alive()
+
+
+def test_tty_child_exit_survives_terminal_close_races(tmp_path: Path) -> None:
+    """Treat terminal closure before child reaping as a clean bounded exit.
+
+    Args:
+        tmp_path: Pytest-owned working directory shared by isolated child processes.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    child = (
+        "import os, sys, time; "
+        "answer = input('Prompt: '); "
+        "assert answer == 'yes'; "
+        "print('COMPLETE', flush=True); "
+        "os.close(0); os.close(1); os.close(2); "
+        "time.sleep(0.02)"
+    )
+
+    def invoke(_: int) -> str:
+        """Run one child that closes its terminal before its process exits.
+
+        Args:
+            _: Unused invocation index supplied by the concurrent map.
+
+        Returns:
+            Complete prompt and completion-marker transcript.
+        """
+        return _run_tty_child(
+            [sys.executable, "-c", child],
+            cwd=tmp_path,
+            environment=os.environ.copy(),
+            answers=[("Prompt:", "yes")],
+            completion_marker="COMPLETE",
+            timeout=2,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        transcripts = tuple(executor.map(invoke, range(32)))
+    assert all("Prompt:" in transcript for transcript in transcripts)
+    assert all("COMPLETE" in transcript for transcript in transcripts)
 
 
 def test_installed_wheel_no_spend_release_evidence(tmp_path: Path) -> None:

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -201,6 +201,7 @@ def _installed_release_driver() -> None:
     import select
     import signal
     import socket
+    import termios
     import threading
     import time
     from collections import Counter
@@ -691,8 +692,15 @@ def _installed_release_driver() -> None:
                 if completion_marker is not None and completion_marker in transcript:
                     completion_seen = True
                 if not pending and completion_seen and not input_closed:
-                    os.write(master, b"\x04")
-                    input_closed = True
+                    try:
+                        canonical_input = bool(termios.tcgetattr(master)[3] & termios.ICANON)
+                    except termios.error:
+                        if process.poll() is None:
+                            raise
+                        continue
+                    if canonical_input:
+                        os.write(master, b"\x04")
+                        input_closed = True
             if process.poll() is None:
                 process.send_signal(signal.SIGTERM)
                 process.wait(timeout=5)

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
+import sys
 import tarfile
 import zipfile
 from pathlib import Path, PurePosixPath
+from typing import cast
 
-import pytest
+if os.environ.get("WMO_INSTALLED_RELEASE_EVIDENCE") != "1":
+    import pytest
 
 BUILT_DIST_ENV = "WMO_BUILT_DIST_DIR"
 FORBIDDEN_REQUIREMENT = re.compile(
@@ -49,6 +53,7 @@ REQUIRED_WHEEL_MODULES = frozenset(
 REQUIRED_SDIST_MEMBERS = frozenset(
     {"README.md", "assets/wmo-workflow.png", "pyproject.toml", "wmo/workflow/router.py"}
 )
+_RELEASE_REVISION = "1" * 40
 
 
 def _normalized_path(member_name: str) -> str:
@@ -146,6 +151,1177 @@ def _tracked_wheel_members() -> frozenset[str]:
     )
 
 
+def _run_checked(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str] | None = None,
+    timeout: float = 300,
+) -> subprocess.CompletedProcess[str]:
+    """Run one release-evidence subprocess and retain readable failure output.
+
+    Args:
+        command: Exact executable and argument vector.
+        cwd: Isolated working directory for the subprocess.
+        environment: Optional complete child environment.
+        timeout: Maximum subprocess duration in seconds.
+
+    Returns:
+        Completed successful subprocess result.
+
+    Raises:
+        AssertionError: The subprocess exits unsuccessfully.
+    """
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"command failed ({result.returncode}): {' '.join(command)}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _installed_release_driver() -> None:
+    """Execute the isolated installed-wheel no-spend release evidence flow.
+
+    Raises:
+        AssertionError: Any package, CLI, API, artifact, replay, or no-spend invariant fails.
+    """
+    import hashlib
+    import json
+    import math
+    import pty
+    import select
+    import signal
+    import socket
+    import threading
+    import time
+    from collections import Counter
+    from datetime import UTC, datetime
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    from openai import OpenAI
+    from openai.types.responses import FunctionToolParam
+
+    import wmo
+    from wmo.common.models import EmbeddingCostReservation, load_model_catalog
+    from wmo.common.project import ProjectStore, artifact_input
+    from wmo.optimize.model.sft import (
+        RuntimeInteractionExampleSource,
+        load_sft_model_optimization_config,
+        load_verified_sft_dataset,
+        prepare_runtime_sft_model_optimization,
+    )
+    from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
+    from wmo.runtime.models import CapabilityRequirement, RuntimeModelCatalog
+    from wmo.runtime.router import (
+        RuntimeAcceptedEvent,
+        RuntimeCompletedEvent,
+        RuntimeInteractionJournal,
+    )
+    from wmo.simulation.retrieval import (
+        RAGEmbedderBinding,
+        load_completed_build_rag_lineage_bindings,
+        refresh_runtime_trace_rag,
+    )
+    from wmo.workflow.manual_judge import prepare_manual_judge_calibration
+
+    execution_root = Path.cwd().resolve()
+    source_checkout = Path(os.environ["WMO_SOURCE_CHECKOUT"]).resolve()
+    assert execution_root != source_checkout
+    assert not execution_root.is_relative_to(source_checkout)
+    assert source_checkout not in tuple(Path(item).resolve() for item in sys.path if item)
+    package_path = Path(wmo.__file__).resolve()
+    assert "site-packages" in package_path.parts, package_path
+    assert not any(part == "world-model-optimizer" for part in package_path.parts)
+
+    class ProviderState:
+        """Thread-safe deterministic request log for the loopback fake provider."""
+
+        def __init__(self) -> None:
+            """Initialize an empty provider request log."""
+            self._lock = threading.Lock()
+            self.requests: list[dict[str, object]] = []
+
+        def append(self, path: str, payload: dict[str, object]) -> int:
+            """Record one provider request and return its stable ordinal.
+
+            Args:
+                path: Loopback HTTP request path.
+                payload: Decoded JSON request body.
+
+            Returns:
+                One-based request ordinal.
+            """
+            with self._lock:
+                self.requests.append({"path": path, "payload": payload})
+                return len(self.requests)
+
+        def counts(self) -> Counter[str]:
+            """Return request counts grouped by HTTP path."""
+            with self._lock:
+                return Counter(str(item["path"]) for item in self.requests)
+
+        def snapshot(self) -> tuple[dict[str, object], ...]:
+            """Return a detached ordered copy of recorded provider requests."""
+            with self._lock:
+                return tuple(dict(item) for item in self.requests)
+
+    state = ProviderState()
+
+    class ProviderHandler(BaseHTTPRequestHandler):
+        """Minimal OpenAI-compatible handler for deterministic zero-price evidence."""
+
+        protocol_version = "HTTP/1.0"
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            """Suppress nondeterministic HTTP server logs."""
+            del format, args
+
+        def do_POST(self) -> None:
+            """Serve deterministic embeddings and chat completions on loopback only.
+
+            Raises:
+                AssertionError: A structured judge request contains no real evidence span.
+            """
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            if not isinstance(payload, dict):
+                self.send_error(400)
+                return
+            ordinal = state.append(self.path, payload)
+            if self.path == "/v1/embeddings":
+                values = payload.get("input", [])
+                texts = [values] if isinstance(values, str) else list(values)
+                data = []
+                for index, text in enumerate(texts):
+                    digest = hashlib.sha256(str(text).encode()).digest()
+                    raw = [float(value + 1) for value in digest[:8]]
+                    norm = math.sqrt(sum(value * value for value in raw))
+                    data.append(
+                        {
+                            "object": "embedding",
+                            "index": index,
+                            "embedding": [value / norm for value in raw],
+                        }
+                    )
+                response = {
+                    "object": "list",
+                    "data": data,
+                    "model": payload.get("model"),
+                    "usage": {
+                        "prompt_tokens": max(len(texts), 1),
+                        "total_tokens": max(len(texts), 1),
+                    },
+                }
+            else:
+                prompt = json.dumps(payload, sort_keys=True)
+                model = str(payload.get("model"))
+                if model == "core-model" and "evidence_span_ids" in prompt:
+                    messages = payload.get("messages")
+                    assert isinstance(messages, list) and messages, prompt
+                    user_content = messages[-1].get("content")
+                    assert isinstance(user_content, str), prompt
+                    rollout_text = user_content.partition("ROLLOUT:\n")[2].partition(
+                        "\n\nRUBRIC:\n"
+                    )[0]
+                    rollout = json.loads(rollout_text)
+                    spans = rollout.get("spans")
+                    assert isinstance(spans, list) and spans, prompt
+                    span_id = spans[0].get("span_id")
+                    assert isinstance(span_id, str) and span_id, prompt
+                    content = json.dumps(
+                        {
+                            "dimensions": [
+                                {
+                                    "dimension_id": "task-success",
+                                    "raw_score": 5,
+                                    "evidence_span_ids": [span_id],
+                                    "feedback": "Deterministic loopback evidence.",
+                                }
+                            ]
+                        }
+                    )
+                    message: dict[str, object] = {"role": "assistant", "content": content}
+                    finish_reason = "stop"
+                elif model == "core-model" and "terminal" in prompt:
+                    message = {
+                        "role": "assistant",
+                        "content": json.dumps(
+                            {
+                                "message": "P17 generated world observation",
+                                "terminal": True,
+                            }
+                        ),
+                    }
+                    finish_reason = "stop"
+                elif payload.get("tools"):
+                    tool = payload["tools"][0]
+                    function = tool["function"]
+                    message = {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": f"call-{ordinal}",
+                                "type": "function",
+                                "function": {
+                                    "name": function["name"],
+                                    "arguments": json.dumps({"ticket_id": "42"}),
+                                },
+                            }
+                        ],
+                    }
+                    finish_reason = "tool_calls"
+                else:
+                    content = (
+                        "Duplicate routed target"
+                        if "Duplicate routed example" in prompt
+                        else f"Deterministic loopback response {ordinal}"
+                    )
+                    message = {
+                        "role": "assistant",
+                        "content": content,
+                    }
+                    finish_reason = "stop"
+                response = {
+                    "id": f"chatcmpl-{ordinal}",
+                    "object": "chat.completion",
+                    "created": 1_760_000_000,
+                    "model": model,
+                    "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+                    "usage": {
+                        "prompt_tokens": 8,
+                        "completion_tokens": 4,
+                        "total_tokens": 12,
+                    },
+                }
+            body = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ProviderHandler)
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    provider_url = f"http://127.0.0.1:{server.server_port}/v1"
+
+    root = execution_root / ".wmo"
+    traces = execution_root / "support.otel.jsonl"
+    one_trace = execution_root / "one.otel.jsonl"
+    executable = Path(sys.executable).with_name("wmo")
+    child_environment = os.environ.copy()
+    child_environment.update(
+        {
+            "WMO_RELEASE_REVISION": _RELEASE_REVISION,
+            "WMO_INSTALLED_RELEASE_EVIDENCE": "0",
+            "P17_PROVIDER_KEY": "deterministic-loopback-placeholder",
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+            "HTTP_PROXY": "http://127.0.0.1:9",
+            "HTTPS_PROXY": "http://127.0.0.1:9",
+            "ALL_PROXY": "http://127.0.0.1:9",
+            "http_proxy": "http://127.0.0.1:9",
+            "https_proxy": "http://127.0.0.1:9",
+            "all_proxy": "http://127.0.0.1:9",
+        }
+    )
+
+    def attribute(key: str, value: str) -> dict[str, object]:
+        """Encode one text OTLP attribute.
+
+        Args:
+            key: Semantic-convention attribute name.
+            value: Text attribute value.
+
+        Returns:
+            OTLP JSON attribute envelope.
+        """
+        return {"key": key, "value": {"stringValue": value}}
+
+    def write_traces(
+        path: Path,
+        count: int,
+        *,
+        terminal_last_trace: bool = False,
+    ) -> tuple[str, ...]:
+        """Write observed traces attributed across router candidates.
+
+        Args:
+            path: Destination OTLP JSONL file.
+            count: Number of distinct source lineages.
+            terminal_last_trace: Whether the final trace lacks a later real observation.
+
+        Returns:
+            Ordered trace identities written to the file.
+        """
+        records: list[dict[str, object]] = []
+        trace_ids = []
+        for index in range(count):
+            trace_id = f"{index + 1:032x}"
+            trace_ids.append(trace_id)
+            model = "core-model" if index % 2 == 0 else "candidate-b-model"
+            base = 1_760_000_000_000_000_000 + index * 10_000_000_000
+            common = [
+                attribute("gen_ai.operation.name", "chat"),
+                attribute("gen_ai.provider.name", "openai-compatible"),
+                attribute("gen_ai.request.model", model),
+                attribute("wmo.customer.id", f"customer-{index}"),
+                attribute("wmo.conversation.id", f"conversation-{index}"),
+            ]
+            records.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{index * 2 + 1:016x}",
+                    "name": "agent.model_call",
+                    "startTimeUnixNano": str(base),
+                    "endTimeUnixNano": str(base + 1_000_000_000),
+                    "attributes": common
+                    + [
+                        attribute(
+                            "gen_ai.input.messages",
+                            json.dumps([{"role": "user", "content": f"Support request {index}"}]),
+                        ),
+                        attribute(
+                            "gen_ai.output.messages",
+                            json.dumps(
+                                [
+                                    {
+                                        "role": "assistant",
+                                        "content": "What account email?",
+                                    }
+                                ]
+                            ),
+                        ),
+                    ],
+                }
+            )
+            if terminal_last_trace and index == count - 1:
+                continue
+            records.append(
+                {
+                    "traceId": trace_id,
+                    "spanId": f"{index * 2 + 2:016x}",
+                    "name": "agent.model_call",
+                    "startTimeUnixNano": str(base + 2_000_000_000),
+                    "endTimeUnixNano": str(base + 3_000_000_000),
+                    "attributes": common
+                    + [
+                        attribute(
+                            "gen_ai.input.messages",
+                            json.dumps(
+                                [
+                                    {
+                                        "role": "assistant",
+                                        "content": "What account email?",
+                                    },
+                                    {
+                                        "role": "user",
+                                        "content": f"customer-{index}@example.test",
+                                    },
+                                ]
+                            ),
+                        ),
+                        attribute(
+                            "gen_ai.output.messages",
+                            json.dumps(
+                                [
+                                    {
+                                        "role": "assistant",
+                                        "content": "Reset instructions sent.",
+                                    }
+                                ]
+                            ),
+                        ),
+                    ],
+                }
+            )
+        path.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n",
+            encoding="utf-8",
+        )
+        return tuple(trace_ids)
+
+    support_trace_ids = write_traces(traces, 10, terminal_last_trace=True)
+    write_traces(one_trace, 1)
+
+    def run_cli(*arguments: str, expected: int = 0) -> subprocess.CompletedProcess[str]:
+        """Run the installed CLI without a terminal and validate its exit status.
+
+        Args:
+            arguments: CLI arguments after the installed executable.
+            expected: Required process exit code.
+
+        Returns:
+            Completed CLI subprocess.
+        """
+        result = subprocess.run(
+            [str(executable), *arguments],
+            cwd=execution_root,
+            env=child_environment,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        assert result.returncode == expected, (
+            f"CLI exit {result.returncode}, expected {expected}: {arguments}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        return result
+
+    def directory_digest(path: Path) -> str:
+        """Hash every regular file below a directory in relative-path order.
+
+        Args:
+            path: Directory containing immutable evidence.
+
+        Returns:
+            SHA-256 digest of relative paths and file bytes.
+        """
+        digest = hashlib.sha256()
+        for item in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+            digest.update(item.relative_to(path).as_posix().encode())
+            digest.update(b"\0")
+            digest.update(item.read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    def assert_embedded_revision(value: object) -> None:
+        """Require every recursively present code revision to match the installed release.
+
+        Args:
+            value: Decoded artifact JSON value to inspect recursively.
+        """
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key == "code_revision":
+                    assert item == _RELEASE_REVISION
+                assert_embedded_revision(item)
+        elif isinstance(value, list):
+            for item in value:
+                assert_embedded_revision(item)
+
+    def unused_loopback_port() -> int:
+        """Reserve and release one currently unused loopback TCP port."""
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            return int(probe.getsockname()[1])
+
+    def wait_for_loopback(port: int, process: subprocess.Popen[str]) -> None:
+        """Wait for one local server without allowing an unbounded startup hang.
+
+        Args:
+            port: Expected loopback TCP port.
+            process: Server process that must remain live.
+
+        Raises:
+            AssertionError: The process exits or does not listen before the deadline.
+        """
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                output = process.stdout.read() if process.stdout is not None else ""
+                raise AssertionError(f"wmo run exited before startup:\n{output}")
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    return
+            except OSError:
+                time.sleep(0.05)
+        raise AssertionError(f"wmo run did not listen on port {port}")
+
+    def run_tty(arguments: list[str], answers: list[tuple[str, str]]) -> str:
+        """Drive one installed interactive CLI process through ordered prompt matches.
+
+        Args:
+            arguments: CLI arguments after the installed executable.
+            answers: Ordered prompt substring and terminal answer pairs.
+
+        Returns:
+            Combined terminal transcript.
+        """
+        master, slave = pty.openpty()
+        process = subprocess.Popen(
+            [str(executable), *arguments],
+            cwd=execution_root,
+            env=child_environment,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+        )
+        os.close(slave)
+        transcript = ""
+        search_from = 0
+        pending = list(answers)
+        input_closed = False
+        deadline = time.monotonic() + 30
+        try:
+            while process.poll() is None and time.monotonic() < deadline:
+                readable, _, _ = select.select([master], [], [], 0.1)
+                if readable:
+                    try:
+                        transcript += os.read(master, 65_536).decode(errors="replace")
+                    except OSError:
+                        break
+                if (
+                    pending
+                    and (prompt_position := transcript.find(pending[0][0], search_from)) >= 0
+                ):
+                    prompt, answer = pending.pop(0)
+                    search_from = prompt_position + len(prompt)
+                    os.write(master, (answer + "\n").encode())
+                    if not pending and not input_closed:
+                        os.write(master, b"\x04")
+                        input_closed = True
+            if process.poll() is None:
+                process.send_signal(signal.SIGTERM)
+                process.wait(timeout=5)
+                raise AssertionError(f"interactive CLI timed out:\n{transcript}")
+            while True:
+                readable, _, _ = select.select([master], [], [], 0)
+                if not readable:
+                    break
+                try:
+                    chunk = os.read(master, 65_536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                transcript += chunk.decode(errors="replace")
+        finally:
+            os.close(master)
+        assert process.returncode == 0, transcript
+        assert not pending, f"unanswered prompts {pending}:\n{transcript}"
+        return transcript
+
+    def model_answers(
+        alias: str,
+        model: str,
+        *,
+        embeddings: bool,
+        add_another: bool,
+    ) -> list[tuple[str, str]]:
+        """Return ordered interactive answers for one explicit model declaration.
+
+        Args:
+            alias: Stable local model alias.
+            model: Provider model identifier.
+            embeddings: Whether the alias supports embeddings.
+            add_another: Whether setup should collect another model afterward.
+
+        Returns:
+            Ordered prompt and answer pairs.
+        """
+        answers = [
+            ("Connection", "loopback"),
+            ("Model alias", alias),
+            ("Provider model ID", model),
+            ("Supports tools?", "y"),
+            ("Supports embeddings?", "y" if embeddings else "n"),
+            ("Supports structured output?", "y"),
+            ("Supports chat completions?", "y"),
+            ("Record context window tokens?", "y"),
+            ("Context window tokens", "128000"),
+            ("Record maximum output tokens?", "y"),
+            ("Maximum output tokens", "16000"),
+            ("Input cost per million tokens in USD", "0"),
+            ("Output cost per million tokens in USD", "0"),
+            ("Cached input cost per million tokens in USD", "0"),
+            ("Cache write cost per million tokens in USD", "0"),
+            ("Add another available model?", "y" if add_another else "n"),
+        ]
+        return answers
+
+    setup_answers = [
+        ("Add a OpenAI connection?", "n"),
+        ("Add a OpenRouter connection?", "n"),
+        ("Add a Anthropic connection?", "n"),
+        ("Add a Gemini connection?", "n"),
+        ("Add a OpenAI-compatible connection?", "y"),
+        ("Connection name", "loopback"),
+        ("API key environment variable", "P17_PROVIDER_KEY"),
+        ("Base URL", provider_url),
+        ("Add another OpenAI-compatible connection?", "n"),
+        *model_answers("core", "core-model", embeddings=True, add_another=False),
+        ("World model alias", "core"),
+        ("Use 'core' as the judge?", "y"),
+        ("Embedder alias", "core"),
+        ("Save this configuration?", "y"),
+    ]
+    try:
+        assert not root.exists()
+        build_output = run_tty(
+            ["build", "support-agent", str(traces), "--root", str(root)],
+            setup_answers,
+        )
+        assert "Model setup is required" in build_output
+        assert "Candidate aliases" not in build_output
+        support_store = ProjectStore(root, "support-agent")
+        support_project = support_store.load_project()
+        assert support_project.build is not None
+        assert support_project.models is not None
+        assert support_project.models.candidates == ()
+        catalog_text = (root / "models.toml").read_text(encoding="utf-8")
+        assert "deterministic-loopback-placeholder" not in catalog_text
+        assert "P17_PROVIDER_KEY" in catalog_text
+        build_counts = state.counts()
+        assert build_counts["/v1/embeddings"] > 0
+        assert build_counts["/v1/chat/completions"] == 0
+        world_model = wmo.load_world_model(
+            "support-agent",
+            root=root,
+            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+        )
+        session = world_model.new_session(task="Help a customer reset their password")
+        observation = world_model.step(
+            session.id,
+            {"role": "assistant", "content": "What account email is associated?"},
+        )
+        assert observation.message == {
+            "role": "user",
+            "content": "P17 generated world observation",
+        }
+        assert observation.terminal is True
+        world_requests = state.snapshot()[sum(build_counts.values()) :]
+        assert [item["path"] for item in world_requests] == [
+            "/v1/embeddings",
+            "/v1/chat/completions",
+        ]
+        world_prompt = json.dumps(world_requests[-1]["payload"], sort_keys=True)
+        assert "What account email?" in world_prompt
+        assert "customer-" in world_prompt
+        setup_call_count = sum(state.counts().values())
+        setup_result = run_cli(
+            "config",
+            "judge",
+            "setup",
+            "support-agent",
+            "--root",
+            str(root),
+            "--preview-count",
+            "10",
+            "--approve",
+            "--non-interactive",
+        )
+        assert "Saved judge setup" in setup_result.stdout
+        assert sum(state.counts().values()) == setup_call_count
+        calibration_plan = prepare_manual_judge_calibration(support_store, sample_size=10)
+        assert len(calibration_plan.previews) >= 2
+        calibration_arguments = [
+            "config",
+            "judge",
+            "calibrate",
+            "support-agent",
+            "--root",
+            str(root),
+            "--sample-size",
+            "10",
+        ]
+        for preview in calibration_plan.previews:
+            calibration_arguments.extend(["--label", f"{preview.trace_id}:task-success=5"])
+        calibration_arguments.extend(
+            [
+                "--input-usd-per-million",
+                "0",
+                "--output-usd-per-million",
+                "0",
+                "--maximum-cost-usd",
+                "0.000001",
+                "--yes",
+                "--approve",
+                "--accept-insufficient-labels",
+                "--non-interactive",
+            ]
+        )
+        calibration_result = run_cli(*calibration_arguments)
+        assert "Approved judge calibration" in calibration_result.stdout
+        assert sum(state.counts().values()) - setup_call_count == len(calibration_plan.previews)
+        review = support_store.read_review()
+        assert isinstance(review, dict)
+        manual_judge = review.get("manual_judge")
+        assert isinstance(manual_judge, dict)
+        assert manual_judge.get("approved_calibration") is not None
+        optimize_arguments = [
+            "optimize",
+            "router",
+            "support-agent",
+            "--root",
+            str(root),
+            "--maximum-provider-cost-usd",
+            "0.000001",
+            "--maximum-judgments",
+            "100",
+            "--preferred-fidelity-overlaps",
+            "2",
+            "--maximum-model-calls",
+            "1",
+            "--simulation-maximum-output-tokens",
+            "8000",
+            "--maximum-concurrency",
+            "1",
+            "--yes",
+            "--approve-fidelity",
+        ]
+        optimization_output = run_tty(
+            optimize_arguments,
+            [
+                ("Candidate alias", "candidate-b"),
+                ("Provider connection", "loopback"),
+                ("Provider model ID", "candidate-b-model"),
+                ("Supports tools?", "y"),
+                ("Context window tokens", "128000"),
+                ("Maximum output tokens", "16000"),
+                ("Input USD per million tokens", "0"),
+                ("Output USD per million tokens", "0"),
+                ("Cached input USD per million tokens", "0"),
+                ("Cache write USD per million tokens", "0"),
+                ("Candidate aliases (comma separated)", "core,candidate-b"),
+                ("Incumbent alias", "core"),
+                ("Save these router candidates?", "y"),
+            ],
+        )
+        assert optimization_output.count("Candidate aliases (comma separated)") == 1
+        assert "policy:" in optimization_output
+        assert "report:" in optimization_output
+        optimized_artifacts = directory_digest(support_store.paths.artifacts_directory)
+        optimized_catalog = (root / "models.toml").read_bytes()
+        optimized_project = support_store.paths.project_toml.read_bytes()
+        optimized_review = support_store.paths.review_json.read_bytes()
+        optimized_provider_requests = state.snapshot()
+        replay_result = run_cli(
+            *optimize_arguments[:-2],
+            "--non-interactive",
+        )
+        assert "replay: verified completed optimization" in replay_result.stdout
+        assert state.snapshot() == optimized_provider_requests
+        assert (root / "models.toml").read_bytes() == optimized_catalog
+        assert support_store.paths.project_toml.read_bytes() == optimized_project
+        assert support_store.paths.review_json.read_bytes() == optimized_review
+        assert directory_digest(support_store.paths.artifacts_directory) == optimized_artifacts
+
+        router_port = unused_loopback_port()
+        provider_calls_before_run = state.snapshot()
+        router_process = subprocess.Popen(
+            [
+                str(executable),
+                "run",
+                "support-agent",
+                "--root",
+                str(root),
+                "--port",
+                str(router_port),
+            ],
+            cwd=execution_root,
+            env=child_environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_for_loopback(router_port, router_process)
+            assert state.snapshot() == provider_calls_before_run
+            client = OpenAI(
+                base_url=f"http://127.0.0.1:{router_port}/v1",
+                api_key="unused-loopback-client-key",
+            )
+            chat = client.chat.completions.create(
+                model="support-agent",
+                messages=[{"role": "user", "content": "Look up ticket 42"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_ticket",
+                            "description": "Look up one support ticket.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"ticket_id": {"type": "string"}},
+                                "required": ["ticket_id"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+            )
+            assert chat.choices[0].message.tool_calls
+            response_calls_before = state.counts()
+            response_tool = FunctionToolParam(
+                type="function",
+                name="lookup_ticket",
+                description="Look up one support ticket.",
+                parameters={
+                    "type": "object",
+                    "properties": {"ticket_id": {"type": "string"}},
+                    "required": ["ticket_id"],
+                    "additionalProperties": False,
+                },
+                strict=None,
+            )
+            first_response = client.responses.create(
+                model="support-agent",
+                input="Look up ticket 42 through the Responses API",
+                tools=[response_tool],
+            )
+            function_call = next(
+                item for item in first_response.output if item.type == "function_call"
+            )
+            first_response_counts = state.counts()
+            second_response = client.responses.create(
+                model="support-agent",
+                previous_response_id=first_response.id,
+                input=[
+                    {
+                        "type": "function_call_output",
+                        "call_id": function_call.call_id,
+                        "output": "Ticket 42 is ready for reset.",
+                    }
+                ],
+                tools=[response_tool],
+            )
+            assert second_response.previous_response_id == first_response.id
+            second_response_counts = state.counts()
+            assert first_response_counts["/v1/embeddings"] == (
+                response_calls_before["/v1/embeddings"] + 1
+            )
+            assert (
+                second_response_counts["/v1/embeddings"] == first_response_counts["/v1/embeddings"]
+            )
+            keyed_chat = client.chat.completions.create(
+                model="support-agent",
+                messages=[{"role": "user", "content": "Durable keyed request"}],
+                extra_headers={"Idempotency-Key": "p17-durable-request"},
+            )
+            client.close()
+        finally:
+            router_process.terminate()
+            try:
+                router_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                router_process.kill()
+                router_process.wait(timeout=5)
+        journal = RuntimeInteractionJournal(support_store.paths)
+        events_before_public_replay = journal.read_events()
+        provider_before_public_replay = state.snapshot()
+        with wmo.load_router(
+            "support-agent",
+            root=root,
+            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+        ) as loaded_router:
+            replayed_chat = loaded_router.chat.completions.create(
+                model="support-agent",
+                messages=[{"role": "user", "content": "Durable keyed request"}],
+                extra_headers={"Idempotency-Key": "p17-durable-request"},
+            )
+            assert replayed_chat.id == keyed_chat.id
+            public_response = loaded_router.responses.create(
+                model="support-agent",
+                input="Programmatic router response",
+            )
+            assert public_response.output
+            duplicate_first = loaded_router.chat.completions.create(
+                model="support-agent",
+                messages=[{"role": "user", "content": "Duplicate routed example"}],
+            )
+            duplicate_second = loaded_router.chat.completions.create(
+                model="support-agent",
+                messages=[{"role": "user", "content": "Duplicate routed example"}],
+            )
+            assert duplicate_first.choices[0].message.content == "Duplicate routed target"
+            assert duplicate_second.choices[0].message.content == "Duplicate routed target"
+        events = journal.read_events()
+        assert state.snapshot() != provider_before_public_replay
+        accepted = tuple(event for event in events if isinstance(event, RuntimeAcceptedEvent))
+        completed = tuple(event for event in events if isinstance(event, RuntimeCompletedEvent))
+        prior_completed = tuple(
+            event
+            for event in events_before_public_replay
+            if isinstance(event, RuntimeCompletedEvent)
+        )
+        assert len(completed) == len(prior_completed) + 3
+        assert len({event.interaction_id for event in completed}) == len(completed)
+        assert accepted[1].lineage_id == accepted[2].lineage_id
+        assert accepted[1].selected_alias == accepted[2].selected_alias
+        current_project = support_store.load_project()
+        assert current_project.build is not None
+        assert current_project.models is not None
+        completed_build = current_project.build
+        completed_build_digests = {
+            pointer.artifact_id: directory_digest(
+                support_store.paths.artifacts_directory / pointer.artifact_id
+            )
+            for pointer in (
+                completed_build.trace_dataset,
+                completed_build.task_set,
+                completed_build.serving_rag,
+                completed_build.fit_rag,
+                completed_build.world_model,
+            )
+        }
+        imported_bindings = load_completed_build_rag_lineage_bindings(
+            support_store.artifacts,
+            completed_build,
+        )
+        assert {binding.trace_id for binding in imported_bindings} == set(support_trace_ids)
+        catalog = load_model_catalog(root / "models.toml")
+        resolved_embedder = RuntimeModelCatalog(
+            catalog,
+            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+        ).preflight(
+            current_project.models.embedder,
+            CapabilityRequirement(requires_embeddings=True),
+        )
+        assert resolved_embedder.embedding_client is not None
+        embedding_price = resolved_embedder.capabilities.input_cost_per_million_tokens_usd
+        assert embedding_price == 0
+        embedding_binding = RAGEmbedderBinding(
+            client=resolved_embedder.embedding_client,
+            snapshot=resolved_embedder.snapshot,
+            maximum_attempts=3,
+            input_usd_per_million_tokens=embedding_price,
+        )
+        embedding_reservation = EmbeddingCostReservation(
+            model=resolved_embedder.snapshot,
+            input_usd_per_million_tokens=embedding_price,
+            maximum_attempts=embedding_binding.maximum_attempts,
+            maximum_input_tokens=1_000_000,
+        )
+        refresh_time = datetime.now(UTC)
+        provider_before_refresh = state.snapshot()
+        refresh = refresh_runtime_trace_rag(
+            journal,
+            support_store.artifacts,
+            (completed_build.trace_dataset,),
+            imported_bindings,
+            embedder=embedding_binding,
+            embedding_reservation=embedding_reservation,
+            maximum_embedding_cost_usd=0,
+            created_at=refresh_time,
+            code_revision=_RELEASE_REVISION,
+        )
+        provider_after_refresh = state.snapshot()
+        assert len(provider_after_refresh) > len(provider_before_refresh)
+        assert all(
+            request["path"] == "/v1/embeddings"
+            for request in provider_after_refresh[len(provider_before_refresh) :]
+        )
+        assert refresh.snapshot_export.snapshot.completed_target_count == len(completed)
+        assert refresh.retrieval.index.rag_id not in {
+            completed_build.serving_rag.artifact_id,
+            completed_build.fit_rag.artifact_id,
+        }
+        assert refresh.dataset.dataset.dataset_id != completed_build.trace_dataset.artifact_id
+        response_acceptances = tuple(
+            event for event in accepted if event.lineage_id == accepted[1].lineage_id
+        )
+        assert len(response_acceptances) == 2
+        observed_response = response_acceptances[0]
+        terminal_response = response_acceptances[1]
+        tool_transitions = tuple(
+            transition
+            for transition in refresh.retrieval.transitions
+            if transition.trace_id == observed_response.interaction_id
+            and transition.action.kind == "tool_call"
+            and transition.observation.kind == "tool_result"
+        )
+        assert len(tool_transitions) == 1
+        assert tool_transitions[0].action.tool_name == "lookup_ticket"
+        assert tool_transitions[0].observation.content == "Ticket 42 is ready for reset."
+        assert terminal_response.interaction_id not in {
+            transition.trace_id for transition in refresh.retrieval.transitions
+        }
+        refresh_payload = json.dumps(
+            [trace.model_dump(mode="json") for trace in refresh.dataset.traces],
+            sort_keys=True,
+        )
+        assert "P17 generated world observation" not in refresh_payload
+        assert support_store.load_project().build == completed_build
+        assert {
+            artifact_id: directory_digest(support_store.paths.artifacts_directory / artifact_id)
+            for artifact_id in completed_build_digests
+        } == completed_build_digests
+        replayed_refresh = refresh_runtime_trace_rag(
+            journal,
+            support_store.artifacts,
+            (completed_build.trace_dataset,),
+            imported_bindings,
+            embedder=embedding_binding,
+            embedding_reservation=embedding_reservation,
+            maximum_embedding_cost_usd=0,
+            created_at=refresh_time,
+            code_revision=_RELEASE_REVISION,
+        )
+        assert replayed_refresh.refresh.refresh_id == refresh.refresh.refresh_id
+        assert replayed_refresh.retrieval.index.rag_id == refresh.retrieval.index.rag_id
+        assert state.snapshot() == provider_after_refresh
+        provider_before_model_optimization = state.snapshot()
+        model_optimization_output = run_tty(
+            [
+                "optimize",
+                "model",
+                "support-agent",
+                "--root",
+                str(root),
+                "--tinker-connection",
+                "tinker-local",
+                "--tinker-api-key-env",
+                "P17_MISSING_TINKER_KEY",
+                "--base-model-alias",
+                "tinker-base",
+                "--base-model",
+                "fake-base-model",
+                "--maximum-cost-usd",
+                "1",
+                "--training-usd-per-million-tokens",
+                "0",
+            ],
+            [
+                ("Use Tinker connection 'tinker-local'", "y"),
+                ("Proceed?", "n"),
+            ],
+        )
+        assert "Managed Tinker SFT was not started." in model_optimization_output
+        assert state.snapshot() == provider_before_model_optimization
+        assert "P17_MISSING_TINKER_KEY" not in child_environment
+        latest = load_latest_sft_model_optimization(support_store)
+        assert latest is not None
+        config = load_sft_model_optimization_config(
+            support_store,
+            latest.config.artifact_id,
+        )
+        dataset = load_verified_sft_dataset(support_store, latest.dataset.artifact_id)
+        assert config.dataset == latest.dataset
+        assert dataset.build_spec is not None
+        assert dataset.build_spec.held_out_fraction == 0
+        assert dataset.rows
+        assert all(row.partition == "train" for row in dataset.rows)
+        runtime_rows = tuple(
+            row
+            for row in dataset.rows
+            if isinstance(row.example.source, RuntimeInteractionExampleSource)
+        )
+        assert len(runtime_rows) == len(completed)
+        assert {
+            cast(RuntimeInteractionExampleSource, row.example.source).interaction_id
+            for row in runtime_rows
+        } == {event.interaction_id for event in completed}
+        duplicate_rows = tuple(
+            row for row in runtime_rows if row.example.target.content == "Duplicate routed target"
+        )
+        assert len(duplicate_rows) == 2
+        assert len({row.example.example_id for row in duplicate_rows}) == 2
+        assert len({row.fingerprint for row in duplicate_rows}) == 1
+        duplicate_groups = {row.example.leakage_group_id for row in duplicate_rows}
+        assert len(duplicate_groups) == 2
+        assert any(
+            duplicate_groups.issubset(set(partition.leakage_group_ids))
+            for partition in dataset.partitions
+        )
+        assert any(row.example.target.tool_calls for row in runtime_rows)
+        assert "P17 generated world observation" not in json.dumps(
+            [row.model_dump(mode="json") for row in dataset.rows],
+            sort_keys=True,
+        )
+        replayed_preparation = prepare_runtime_sft_model_optimization(
+            support_store,
+            created_at=dataset.dataset.created_at,
+            code_revision=_RELEASE_REVISION,
+        )
+        assert replayed_preparation.created is False
+        assert replayed_preparation.dataset.dataset.dataset_id == dataset.dataset.dataset_id
+        one_result = run_cli(
+            "build",
+            "one-trace",
+            str(one_trace),
+            "--root",
+            str(root),
+            "--no-interactive",
+        )
+        assert "100 to 1,000 traces is the usual starting range" in one_result.stdout
+        one_store = ProjectStore(root, "one-trace")
+        assert one_store.load_project().build is not None
+        assert support_trace_ids
+        for project_store in (support_store, one_store):
+            for artifact_id in project_store.artifacts.list_ids():
+                manifest = project_store.artifacts.read(artifact_id).manifest
+                assert manifest.code_revision == _RELEASE_REVISION
+                for file in manifest.files:
+                    if not (file.path.endswith(".json") or file.path.endswith(".jsonl")):
+                        continue
+                    payload = project_store.artifacts.read_bytes(artifact_id, file.path)
+                    for line in payload.decode("utf-8").splitlines():
+                        if line.strip():
+                            assert_embedded_revision(json.loads(line))
+                for input_item in manifest.inputs:
+                    input_manifest = project_store.artifacts.read(input_item.artifact_id).manifest
+                    assert artifact_input(input_manifest) == input_item
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+        assert not server_thread.is_alive()
+
+
+def test_installed_wheel_no_spend_release_evidence(tmp_path: Path) -> None:
+    """Prove the installed release happy path with deterministic loopback providers.
+
+    Args:
+        tmp_path: Pytest-owned build, virtual environment, and execution root.
+    """
+    repository = Path(__file__).resolve().parent.parent
+    distribution = tmp_path / "dist"
+    virtual_environment = tmp_path / "venv"
+    execution = tmp_path / "execution"
+    distribution.mkdir()
+    execution.mkdir()
+    uv = shutil.which("uv")
+    assert uv is not None, "release evidence requires the repository's uv toolchain"
+    environment = os.environ.copy()
+    environment["UV_CACHE_DIR"] = str(tmp_path / "uv-cache")
+    _run_checked(
+        [uv, "build", "--wheel", "--out-dir", str(distribution)],
+        cwd=repository,
+        environment=environment,
+    )
+    wheel = tuple(distribution.glob("*.whl"))
+    assert len(wheel) == 1
+    _run_checked([uv, "venv", str(virtual_environment)], cwd=execution, environment=environment)
+    installed_python = virtual_environment / "bin" / "python"
+    _run_checked(
+        [uv, "pip", "install", "--python", str(installed_python), str(wheel[0])],
+        cwd=execution,
+        environment=environment,
+    )
+    driver = execution / "installed_release_evidence.py"
+    driver.write_text(Path(__file__).read_text(encoding="utf-8"), encoding="utf-8")
+    driver_environment = environment.copy()
+    driver_environment.update(
+        {
+            "WMO_INSTALLED_RELEASE_EVIDENCE": "1",
+            "WMO_RELEASE_REVISION": _RELEASE_REVISION,
+            "WMO_TELEMETRY": "0",
+            "PYTHONNOUSERSITE": "1",
+            "WMO_SOURCE_CHECKOUT": str(repository),
+        }
+    )
+    _run_checked(
+        [str(installed_python), str(driver)],
+        cwd=execution,
+        environment=driver_environment,
+        timeout=600,
+    )
+
+
 def test_built_archives_match_current_package_contract() -> None:
     """Prove fresh wheel and sdist match the current package contract.
 
@@ -240,3 +1416,7 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
     ingest = (docs / "reference" / "ingest.md").read_text(encoding="utf-8")
     assert "PostHogPullRequest" in ingest
     assert "pull_posthog_traces" in ingest
+
+
+if __name__ == "__main__" and os.environ.get("WMO_INSTALLED_RELEASE_EVIDENCE") == "1":
+    _installed_release_driver()

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -640,12 +640,18 @@ def _installed_release_driver() -> None:
                 time.sleep(0.05)
         raise AssertionError(f"wmo run did not listen on port {port}")
 
-    def run_tty(arguments: list[str], answers: list[tuple[str, str]]) -> str:
+    def run_tty(
+        arguments: list[str],
+        answers: list[tuple[str, str]],
+        *,
+        completion_marker: str | None = None,
+    ) -> str:
         """Drive one installed interactive CLI process through ordered prompt matches.
 
         Args:
             arguments: CLI arguments after the installed executable.
             answers: Ordered prompt substring and terminal answer pairs.
+            completion_marker: Optional output that must appear before terminal input closes.
 
         Returns:
             Combined terminal transcript.
@@ -665,6 +671,7 @@ def _installed_release_driver() -> None:
         search_from = 0
         pending = list(answers)
         input_closed = False
+        completion_seen = completion_marker is None
         deadline = time.monotonic() + 30
         try:
             while process.poll() is None and time.monotonic() < deadline:
@@ -681,9 +688,11 @@ def _installed_release_driver() -> None:
                     prompt, answer = pending.pop(0)
                     search_from = prompt_position + len(prompt)
                     os.write(master, (answer + "\n").encode())
-                    if not pending and not input_closed:
-                        os.write(master, b"\x04")
-                        input_closed = True
+                if completion_marker is not None and completion_marker in transcript:
+                    completion_seen = True
+                if not pending and completion_seen and not input_closed:
+                    os.write(master, b"\x04")
+                    input_closed = True
             if process.poll() is None:
                 process.send_signal(signal.SIGTERM)
                 process.wait(timeout=5)
@@ -703,6 +712,7 @@ def _installed_release_driver() -> None:
             os.close(master)
         assert process.returncode == 0, transcript
         assert not pending, f"unanswered prompts {pending}:\n{transcript}"
+        assert completion_seen, f"missing completion marker {completion_marker!r}:\n{transcript}"
         return transcript
 
     def model_answers(
@@ -1189,6 +1199,7 @@ def _installed_release_driver() -> None:
                 ("Use Tinker connection 'tinker-local'", "y"),
                 ("Proceed?", "n"),
             ],
+            completion_marker="Managed Tinker SFT was not started.",
         )
         assert "Managed Tinker SFT was not started." in model_optimization_output
         assert state.snapshot() == provider_before_model_optimization

--- a/wmo/runtime/models/registry.py
+++ b/wmo/runtime/models/registry.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
+from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
     EmbeddingClient,
     ModelCapabilities,
@@ -145,6 +146,20 @@ class RuntimeModelCatalog:
             raise ModelConnectionError(f"unknown model alias {alias!r}")
         connection = self._catalog.connections[record.connection]
         snapshot, capabilities = self.snapshot(alias)
+        provenance = record.sft_provenance
+        if provenance is not None:
+            current_connection_sha256 = sha256_json(
+                {
+                    "provider": connection.provider,
+                    "base_url": connection.base_url,
+                    "api_key_env": connection.api_key_env,
+                }
+            )
+            if provenance.connection_config_sha256 != current_connection_sha256:
+                raise ModelConnectionError(
+                    f"trained model alias {alias!r} connection metadata drifted from its "
+                    "verified SFT provenance"
+                )
         api_key = read_connection_api_key(connection, environment=self._environment)
         provider = connection.provider
         if provider == "openai":

--- a/wmo/runtime/router/__init__.py
+++ b/wmo/runtime/router/__init__.py
@@ -1,12 +1,24 @@
 """Frozen online router runtime and loopback HTTP adapter."""
 
-from wmo.runtime.router.application import (
-    RouterApplicationError,
-    create_project_completion_service,
-    create_project_router_app,
-    load_project_router,
-    load_router,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wmo.runtime.router.application import (
+        RouterApplicationError as RouterApplicationError,
+    )
+    from wmo.runtime.router.application import (
+        create_project_completion_service as create_project_completion_service,
+    )
+    from wmo.runtime.router.application import (
+        create_project_router_app as create_project_router_app,
+    )
+    from wmo.runtime.router.application import load_project_router as load_project_router
+    from wmo.runtime.router.application import load_router as load_router
+    from wmo.runtime.router.endpoint import create_router_endpoint as create_router_endpoint
+
 from wmo.runtime.router.completion import (
     JournaledRouterCompletionService,
     RouterCompletionConflictError,
@@ -14,7 +26,6 @@ from wmo.runtime.router.completion import (
     RouterCompletionInProgressError,
     RouterCompletionService,
 )
-from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.journal import (
     JournaledRouterRuntime,
     RuntimeAcceptedEvent,
@@ -44,6 +55,15 @@ from wmo.runtime.router.snapshot import (
     load_runtime_trace_snapshot,
     seal_runtime_trace_snapshot,
 )
+
+_SERVER_EXPORT_MODULES = {
+    "RouterApplicationError": "wmo.runtime.router.application",
+    "create_project_completion_service": "wmo.runtime.router.application",
+    "create_project_router_app": "wmo.runtime.router.application",
+    "create_router_endpoint": "wmo.runtime.router.endpoint",
+    "load_project_router": "wmo.runtime.router.application",
+    "load_router": "wmo.runtime.router.application",
+}
 
 __all__ = [
     "RoutedModelResponse",
@@ -81,3 +101,28 @@ __all__ = [
     "load_router",
     "load_project_router",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve one server-facing router service without loading FastAPI at package import.
+
+    Args:
+        name: Package attribute requested by Python.
+
+    Returns:
+        The supported public server object loaded from its owning module.
+
+    Raises:
+        AttributeError: The name is not a lazy server-facing export.
+    """
+    module_name = _SERVER_EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return module globals plus supported lazy server exports."""
+    return sorted(set(globals()) | set(_SERVER_EXPORT_MODULES))

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from openai import OpenAI
 
 from wmo.common.core.artifacts import ArtifactId
-from wmo.common.models import load_model_catalog
+from wmo.common.models import ModelRequest, load_model_catalog
 from wmo.common.project import (
     ArtifactStore,
     ArtifactStoreError,
@@ -31,11 +31,39 @@ from wmo.runtime.router.completion import (
 )
 from wmo.runtime.router.endpoint import create_router_endpoint
 from wmo.runtime.router.journal import JournaledRouterRuntime, RuntimeInteractionJournal
-from wmo.runtime.router.runtime import DecisionSink, RouterRuntime
+from wmo.runtime.router.runtime import DecisionSink, RoutedModelResponse, RouterRuntime
 
 
 class RouterApplicationError(ValueError):
     """A project cannot select one verified frozen router for local execution."""
+
+
+class _GhostRouterCompletionService:
+    """Route requests without creating durable interaction state."""
+
+    def __init__(self, runtime: RouterRuntime) -> None:
+        """Bind the stateless completion adapter to one verified runtime."""
+        self._runtime = runtime
+
+    def complete(
+        self,
+        request: ModelRequest,
+        *,
+        idempotency_key: str,
+        conversation_id: str | None = None,
+    ) -> RoutedModelResponse:
+        """Dispatch directly while accepting but not persisting caller identity.
+
+        Args:
+            request: Provider-neutral request to route and execute.
+            idempotency_key: Caller key intentionally ignored in ghost mode.
+            conversation_id: Optional in-memory Responses affinity identity.
+
+        Returns:
+            Newly routed provider response with no durable replay record.
+        """
+        del idempotency_key
+        return self._runtime.complete(request, episode_id=conversation_id)
 
 
 def load_project_router(
@@ -136,15 +164,19 @@ def create_project_router_app(
 def create_project_completion_service(
     store: ProjectStore,
     runtime: RouterRuntime,
+    *,
+    ghost: bool = False,
 ) -> RouterCompletionService:
-    """Compose one project's durable completion boundary without provider dispatch.
+    """Compose one project's selected durable or ghost completion boundary.
 
     Args:
-        store: Initialized project whose canonical runtime journal receives interactions.
-        runtime: Loaded frozen router wrapped by the durable journal service.
+        store: Initialized project that owns the selected runtime policy.
+        runtime: Loaded frozen router wrapped by the selected traffic service.
+        ghost: Whether requests must bypass all durable interaction state.
 
     Returns:
-        Neutral completion service shared by every endpoint request in one application.
+        Neutral completion service shared by every endpoint request in one application. Ghost
+        services accept caller keys but never provide durable idempotent replay.
 
     Raises:
         RouterApplicationError: The store does not own the runtime's exact verified policy.
@@ -157,8 +189,12 @@ def create_project_completion_service(
         ) from exc
     if stored_policy != runtime.policy:
         raise RouterApplicationError(
-            "project router policy content differs from the runtime selected for journaling"
+            "project router policy content differs from the runtime selected for completion"
         )
+    if ghost:
+        if runtime.records_decisions:
+            raise RouterApplicationError("ghost mode cannot use a routing decision sink")
+        return _GhostRouterCompletionService(runtime)
     return JournaledRouterCompletionService(
         JournaledRouterRuntime(runtime, RuntimeInteractionJournal(store.paths))
     )
@@ -172,6 +208,7 @@ def load_router(
     environment: Mapping[str, str] | None = None,
     runtime_catalog: RuntimeModelCatalog | None = None,
     decision_sink: DecisionSink | None = None,
+    ghost: bool = False,
 ) -> OpenAI:
     """Load one local project as an official synchronous OpenAI client.
 
@@ -182,12 +219,15 @@ def load_router(
         environment: Optional credential mapping for runtime client construction.
         runtime_catalog: Optional explicit catalog for deterministic applications and tests.
         decision_sink: Optional aggregate-safe routing-decision recorder.
+        ghost: Whether completed traffic must bypass durable journal and replay state.
 
     Returns:
         Official OpenAI client whose Chat Completions and Responses resources call the local
-        verified router in process and durably journal every completed interaction. Close it or
-        use it as a context manager when finished.
+        verified router in process. By default every completion is journaled; ghost mode keeps no
+        durable traffic or replay state. Close it or use it as a context manager when finished.
     """
+    if ghost and decision_sink is not None:
+        raise RouterApplicationError("ghost mode cannot use a routing decision sink")
     runtime = load_project_router(
         project,
         root,
@@ -197,7 +237,7 @@ def load_router(
         decision_sink=decision_sink,
     )
     store = ProjectStore(root, project)
-    completion_service = create_project_completion_service(store, runtime)
+    completion_service = create_project_completion_service(store, runtime, ghost=ghost)
     application = create_project_router_app(
         project,
         runtime,

--- a/wmo/runtime/router/application_test.py
+++ b/wmo/runtime/router/application_test.py
@@ -18,6 +18,7 @@ from openai.types.responses import Response
 
 from wmo.common.core.artifacts import ArtifactId, FailureCode
 from wmo.common.project import ProjectStore
+from wmo.common.routing import RoutingDecision
 from wmo.runtime.models import RuntimeModelCatalog
 from wmo.runtime.router.application import (
     RouterApplicationError,
@@ -175,6 +176,101 @@ def test_load_router_exposes_official_chat_and_responses_resources(
     assert model_client.complete_calls == 2
     events = RuntimeInteractionJournal(store.paths).read_events()
     assert sum(isinstance(event, RuntimeCompletedEvent) for event in events) == 2
+
+
+@pytest.mark.parametrize("api", ["chat", "responses"])
+def test_ghost_router_dispatches_without_durable_traffic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    api: Literal["chat", "responses"],
+) -> None:
+    """Ghost calls accept caller keys but never create replay or training state.
+
+    Args:
+        tmp_path: Pytest-owned local artifact root.
+        monkeypatch: Scoped loaded-runtime replacement.
+        api: Official OpenAI resource exercised by the parameterized regression.
+    """
+    runtime, model_client = _runtime()
+    root = tmp_path / ".wmo"
+    store = _store_with_policy(root, "support-agent", runtime)
+
+    def load_selected_runtime(
+        _project: str,
+        _root: Path,
+        *,
+        policy_id: ArtifactId | None = None,
+        environment: Mapping[str, str] | None = None,
+        runtime_catalog: RuntimeModelCatalog | None = None,
+        decision_sink: DecisionSink | None = None,
+    ) -> RouterRuntime:
+        """Return the already verified runtime without reconstructing providers."""
+        del policy_id, environment, runtime_catalog, decision_sink
+        return runtime
+
+    monkeypatch.setattr(
+        "wmo.runtime.router.application.load_project_router",
+        load_selected_runtime,
+    )
+    before = {
+        path.relative_to(store.paths.project_directory): path.read_bytes()
+        for path in store.paths.project_directory.rglob("*")
+        if path.is_file()
+    }
+    headers = {"Idempotency-Key": "ghost-request"}
+
+    with load_router("support-agent", root=root, ghost=True) as router:
+        for content in ("first", "changed"):
+            if api == "responses":
+                router.responses.create(
+                    model="support-agent",
+                    input=content,
+                    extra_headers=headers,
+                )
+            else:
+                router.chat.completions.create(
+                    model="support-agent",
+                    messages=[{"role": "user", "content": content}],
+                    extra_headers=headers,
+                )
+
+    assert model_client.complete_calls == 2
+    assert not store.paths.runtime_journal.exists()
+    after = {
+        path.relative_to(store.paths.project_directory): path.read_bytes()
+        for path in store.paths.project_directory.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_ghost_router_rejects_a_persistent_decision_sink(
+    tmp_path: Path,
+) -> None:
+    """Fail before activation when ghost mode is paired with a decision recorder.
+
+    Args:
+        tmp_path: Pytest-owned local artifact root.
+    """
+
+    def decision_sink(_decision: RoutingDecision) -> None:
+        """Accept a routing decision for the rejected option combination."""
+
+    runtime, model_client = _runtime()
+    store = _store_with_policy(tmp_path / ".wmo", "support-agent", runtime)
+    runtime._decision_sink = decision_sink  # noqa: SLF001 - adversarial composition regression
+
+    with pytest.raises(RouterApplicationError, match="ghost mode cannot use"):
+        create_project_completion_service(store, runtime, ghost=True)
+
+    with pytest.raises(RouterApplicationError, match="ghost mode cannot use"):
+        load_router(
+            "support-agent",
+            root=tmp_path / ".wmo",
+            ghost=True,
+            decision_sink=decision_sink,
+        )
+    assert model_client.complete_calls == 0
 
 
 def test_load_and_close_are_provider_and_journal_idle(

--- a/wmo/runtime/router/completion.py
+++ b/wmo/runtime/router/completion.py
@@ -34,7 +34,7 @@ class RouterCompletionFailedError(RuntimeError):
 
 
 class RouterCompletionService(Protocol):
-    """Durable idempotent completion boundary used by public router adapters."""
+    """Completion boundary used by public router adapters in a selected traffic mode."""
 
     def complete(
         self,
@@ -43,15 +43,15 @@ class RouterCompletionService(Protocol):
         idempotency_key: str,
         conversation_id: str | None = None,
     ) -> RoutedModelResponse:
-        """Complete or replay one durable caller-keyed interaction.
+        """Complete one caller-keyed interaction under the service's traffic mode.
 
         Args:
             request: Provider-neutral request to route and execute.
-            idempotency_key: Caller key that identifies the logical interaction.
+            idempotency_key: Caller key used for replay only by durable implementations.
             conversation_id: Optional stable identity for sticky conversation routing.
 
         Returns:
-            The original or replayed routed model response.
+            Newly completed or durably replayed routed model response.
 
         Raises:
             RouterCompletionConflictError: The key names different request state.

--- a/wmo/runtime/router/endpoint.py
+++ b/wmo/runtime/router/endpoint.py
@@ -354,7 +354,7 @@ def create_router_endpoint(
 
     Args:
         endpoints: Public model names mapped to activated local runtimes.
-        completion_services: Optional durable idempotent services for standard keyed requests.
+        completion_services: Optional traffic-mode services for standard keyed requests.
 
     Returns:
         Loopback-hostable OpenAI API router.

--- a/wmo/runtime/router/journal_handoff.py
+++ b/wmo/runtime/router/journal_handoff.py
@@ -1,0 +1,67 @@
+"""Atomic local work handoff bound to one exact runtime-journal prefix."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+
+from wmo.common.core.artifacts import Sha256, canonical_json_bytes
+from wmo.common.core.locks import file_write_lock
+from wmo.runtime.router.journal import (
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    RuntimeJournalEvent,
+)
+
+
+def commit_runtime_journal_prefix[ResultT](
+    journal: RuntimeInteractionJournal,
+    *,
+    last_ordinal: int,
+    prefix_sha256: Sha256,
+    commit: Callable[[], ResultT],
+) -> ResultT:
+    """Commit one local handoff only while an exact journal prefix remains current.
+
+    The callback runs under the journal's append lock and must only perform a bounded local
+    durable write. Provider access, credential reads, and other unbounded work do not belong
+    inside this boundary.
+
+    Args:
+        journal: Validated project journal whose append lock defines the handoff boundary.
+        last_ordinal: Exact final event ordinal approved by the caller.
+        prefix_sha256: Canonical newline-framed digest of every approved event.
+        commit: Bounded local callback that durably accepts work bound to the prefix.
+
+    Returns:
+        The callback result after the exact prefix is verified and accepted.
+
+    Raises:
+        RuntimeJournalError: The journal changed before the local handoff committed.
+    """
+    with file_write_lock(journal.path, what="the routed-interaction journal"):
+        events = journal._read_unlocked()  # noqa: SLF001
+        if (
+            not events
+            or events[-1].ordinal != last_ordinal
+            or _events_sha256(events) != prefix_sha256
+        ):
+            raise RuntimeJournalError(
+                "runtime journal changed before the approved prefix was accepted"
+            )
+        return commit()
+
+
+def _events_sha256(events: tuple[RuntimeJournalEvent, ...]) -> str:
+    """Return the canonical newline-framed digest of validated journal events.
+
+    Args:
+        events: Ordered journal events read under the append lock.
+
+    Returns:
+        SHA-256 digest matching the runtime snapshot prefix contract.
+    """
+    payload = b"\n".join(canonical_json_bytes(event) for event in events)
+    if payload:
+        payload += b"\n"
+    return hashlib.sha256(payload, usedforsecurity=False).hexdigest()

--- a/wmo/runtime/router/journal_handoff_test.py
+++ b/wmo/runtime/router/journal_handoff_test.py
@@ -1,0 +1,1 @@
+"""Tests for exact runtime-journal prefix handoff."""

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -90,6 +90,11 @@ class RouterRuntime:
             raise RouterRuntimeIntegrityError("frozen router embedder lacks embedding capability")
         self._embedder = embedder.embedding_client
 
+    @property
+    def records_decisions(self) -> bool:
+        """Return whether selections are sent to an injected decision recorder."""
+        return self._decision_sink is not None
+
     @classmethod
     def load(
         cls,

--- a/wmo/simulation/build.py
+++ b/wmo/simulation/build.py
@@ -29,6 +29,10 @@ from wmo.common.project import (
 from wmo.common.tasks import TaskSet
 from wmo.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_dataset
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
+from wmo.simulation.mining.bindings import (
+    bindings_for_mining,
+    task_set_content_id,
+)
 from wmo.simulation.mining.descriptors import DescriptorEmbedder, HashingDescriptorEmbedder
 from wmo.simulation.mining.service import MiningSpec, TaskMiningResult, mine_tasks, persist_task_set
 
@@ -429,13 +433,11 @@ def _completed_build_matches_review(store: ProjectStore, review: BuildReviewRead
 
 def _task_set_id(dataset_input: ArtifactInput, mining: TaskMiningResult) -> str:
     """Return the content-addressed task-set ID for one immutable dataset and selection result."""
-    return stable_id(
-        "task-set",
-        {
-            "trace_dataset": dataset_input.model_dump(mode="json"),
-            "tasks": [task.model_dump(mode="json") for task in mining.tasks],
-            "coverage": mining.coverage.model_dump(mode="json"),
-        },
+    return task_set_content_id(
+        dataset_input,
+        mining.tasks,
+        mining.coverage,
+        bindings_for_mining(mining),
     )
 
 

--- a/wmo/simulation/ingest/dataset.py
+++ b/wmo/simulation/ingest/dataset.py
@@ -7,15 +7,28 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-from wmo.common.core.artifacts import SourceIdentity, canonical_json_bytes, stable_id
-from wmo.common.project import ArtifactAlreadyExistsError, ArtifactManifest, ArtifactStore
-from wmo.common.traces import Trace, TraceDataset, TraceSource
+from pydantic import Field, ValidationError, model_validator
+
+from wmo.common.core.artifacts import (
+    ContractModel,
+    SourceIdentity,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ArtifactStore,
+)
+from wmo.common.traces import LoadedTraceDataset, Trace, TraceDataset, TraceSource
 from wmo.simulation.ingest.otlp import TraceNormalizationIssue, TraceNormalizationResult
 
 _TRACE_DATASET_ARTIFACT_TYPE = "trace-dataset"
 _TRACES_PATH = "traces.jsonl"
 _ISSUES_PATH = "normalization-issues.json"
 _TRACE_DATASET_PATH = "trace-dataset.json"
+_TRACE_DATASET_FILES = frozenset({_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH})
 
 
 @dataclass(frozen=True)
@@ -31,6 +44,34 @@ class PersistedTraceDataset:
     dataset: TraceDataset
     manifest: ArtifactManifest
     traces: tuple[Trace, ...]
+
+
+class NormalizationIssueRecord(ContractModel):
+    """One exact persisted normalization exclusion."""
+
+    source_record: str
+    message: str
+
+
+class NormalizationIssuesPayload(ContractModel):
+    """Complete exact normalization issue list and matching exclusion count."""
+
+    invalid_trace_count: int = Field(ge=0)
+    issues: tuple[NormalizationIssueRecord, ...]
+
+    @model_validator(mode="after")
+    def _require_exact_issue_count(self) -> NormalizationIssuesPayload:
+        """Require the declared exclusion count to equal the exact issue list.
+
+        Returns:
+            The validated exact issue payload.
+
+        Raises:
+            ValueError: The declared count differs from the issue-list length.
+        """
+        if self.invalid_trace_count != len(self.issues):
+            raise ValueError("normalization issue count must equal the exact issue list")
+        return self
 
 
 def persist_trace_dataset(
@@ -64,15 +105,12 @@ def persist_trace_dataset(
     source, semantic_convention_version = _shared_source(traces)
     traces_payload = _jsonl_bytes(traces)
     issues_payload = _issues_bytes(result.issues)
-    resolved_dataset_id = dataset_id or stable_id(
-        "trace-dataset",
-        {
-            "source": source.model_dump(mode="json"),
-            "semantic_convention_version": semantic_convention_version,
-            "traces_sha256": hashlib.sha256(traces_payload).hexdigest(),
-            "issues_sha256": hashlib.sha256(issues_payload).hexdigest(),
-            "code_revision": code_revision,
-        },
+    resolved_dataset_id = dataset_id or current_trace_dataset_id(
+        source=source,
+        semantic_convention_version=semantic_convention_version,
+        traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
+        issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
+        code_revision=code_revision,
     )
     dataset = TraceDataset(
         schema_version=1,
@@ -117,6 +155,126 @@ def persist_trace_dataset(
             issues_payload=issues_payload,
         )
     return PersistedTraceDataset(dataset=dataset, manifest=manifest, traces=traces)
+
+
+def current_trace_dataset_id(
+    *,
+    source: SourceIdentity,
+    semantic_convention_version: str,
+    traces_sha256: str,
+    issues_sha256: str,
+    code_revision: str,
+) -> str:
+    """Return the current automatic trace-dataset content identity.
+
+    Args:
+        source: Exact normalized raw-source identity.
+        semantic_convention_version: Convention used to interpret source model spans.
+        traces_sha256: Digest of canonical normalized trace JSONL.
+        issues_sha256: Digest of the complete normalization issue report.
+        code_revision: Exact producer revision.
+
+    Returns:
+        Stable current trace-dataset artifact identity.
+    """
+    return stable_id(
+        "trace-dataset",
+        {
+            "source": source.model_dump(mode="json"),
+            "semantic_convention_version": semantic_convention_version,
+            "traces_sha256": traces_sha256,
+            "issues_sha256": issues_sha256,
+            "code_revision": code_revision,
+        },
+    )
+
+
+def verify_current_trace_dataset(
+    store: ArtifactStore,
+    loaded: LoadedTraceDataset,
+) -> None:
+    """Verify the exact current automatic dataset shape and content identity.
+
+    Generic trace-dataset loading remains compatible with older and explicitly named artifacts.
+    Completed build lineage evidence uses this stricter boundary because its parent dataset must be
+    reproducible from current canonical source evidence.
+
+    Args:
+        store: Project-local immutable artifact store.
+        loaded: Already verified trace-dataset envelope and records.
+
+    Raises:
+        ArtifactCorruptionError: The dataset is not a current automatic content-addressed build
+            artifact or its source, convention, issue evidence, paths, or files disagree.
+    """
+    dataset = loaded.dataset
+    stored = store.read(dataset.dataset_id)
+    if dataset.inputs:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} must not have artifact inputs"
+        )
+    paths = {entry.path for entry in stored.manifest.files}
+    if paths != _TRACE_DATASET_FILES:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} does not have the exact current-build file set"
+        )
+    if dataset.traces_path != _TRACES_PATH or dataset.issues_path != _ISSUES_PATH:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} uses noncanonical current-build paths"
+        )
+    if dataset.source is None:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} has no normalized source identity"
+        )
+    traces_payload = store.read_bytes(dataset.dataset_id, _TRACES_PATH)
+    issues_payload = store.read_bytes(dataset.dataset_id, _ISSUES_PATH)
+    dataset_payload = store.read_bytes(dataset.dataset_id, _TRACE_DATASET_PATH)
+    if dataset_payload != canonical_json_bytes(dataset):
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} envelope is not canonical current-build JSON"
+        )
+    if traces_payload != _jsonl_bytes(loaded.traces):
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} records are not canonical current-build JSONL"
+        )
+    if hashlib.sha256(issues_payload).hexdigest() != dataset.issues_sha256:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} issue digest does not match its envelope"
+        )
+    try:
+        issues = NormalizationIssuesPayload.model_validate_json(issues_payload)
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} has invalid normalization issues"
+        ) from exc
+    if issues_payload != canonical_json_bytes(issues):
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} issues are not canonical current-build JSON"
+        )
+    if issues.invalid_trace_count != dataset.invalid_trace_count:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} exclusion count differs from its issue evidence"
+        )
+    for trace in loaded.traces:
+        if (
+            trace.source.identity != dataset.source
+            or trace.source.semantic_convention_version != dataset.semantic_convention_version
+        ):
+            raise ArtifactCorruptionError(
+                f"trace dataset {dataset.dataset_id} source or convention differs from its records"
+            )
+    expected_id = current_trace_dataset_id(
+        source=dataset.source,
+        semantic_convention_version=dataset.semantic_convention_version,
+        traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
+        issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
+        code_revision=dataset.code_revision,
+    )
+    if dataset.dataset_id != expected_id:
+        raise ArtifactCorruptionError(
+            f"trace dataset {dataset.dataset_id} is not a current content-addressed build dataset; "
+            "rebuild the project before refreshing runtime retrieval evidence"
+        )
 
 
 def _load_exact_replay(
@@ -182,11 +340,14 @@ def _jsonl_bytes(traces: Sequence[Trace]) -> bytes:
 
 def _issues_bytes(issues: Sequence[TraceNormalizationIssue]) -> bytes:
     """Serialize every normalization exclusion as a stable immutable audit record."""
-    return canonical_json_bytes(
-        {
-            "invalid_trace_count": len(issues),
-            "issues": [
-                {"source_record": issue.source_record, "message": issue.message} for issue in issues
-            ],
-        }
+    payload = NormalizationIssuesPayload(
+        invalid_trace_count=len(issues),
+        issues=tuple(
+            NormalizationIssueRecord(
+                source_record=issue.source_record,
+                message=issue.message,
+            )
+            for issue in issues
+        ),
     )
+    return canonical_json_bytes(payload)

--- a/wmo/simulation/ingest/dataset.py
+++ b/wmo/simulation/ingest/dataset.py
@@ -22,13 +22,20 @@ from wmo.common.project import (
     ArtifactStore,
 )
 from wmo.common.traces import LoadedTraceDataset, Trace, TraceDataset, TraceSource
+from wmo.simulation.ingest.model_identity import (
+    TraceModelIdentityEvidenceSet,
+    complete_model_identity_evidence,
+    require_model_identity_evidence_matches_traces,
+)
 from wmo.simulation.ingest.otlp import TraceNormalizationIssue, TraceNormalizationResult
 
 _TRACE_DATASET_ARTIFACT_TYPE = "trace-dataset"
 _TRACES_PATH = "traces.jsonl"
 _ISSUES_PATH = "normalization-issues.json"
 _TRACE_DATASET_PATH = "trace-dataset.json"
-_TRACE_DATASET_FILES = frozenset({_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH})
+MODEL_IDENTITY_EVIDENCE_PATH = "model-identity-evidence.json"
+_LEGACY_TRACE_DATASET_FILES = frozenset({_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH})
+_TRACE_DATASET_FILES = frozenset((*_LEGACY_TRACE_DATASET_FILES, MODEL_IDENTITY_EVIDENCE_PATH))
 
 
 @dataclass(frozen=True)
@@ -105,11 +112,26 @@ def persist_trace_dataset(
     source, semantic_convention_version = _shared_source(traces)
     traces_payload = _jsonl_bytes(traces)
     issues_payload = _issues_bytes(result.issues)
+    identity_evidence = (
+        complete_model_identity_evidence(traces, result.identity_evidence)
+        if result.include_identity_evidence
+        else None
+    )
+    if identity_evidence is not None:
+        require_model_identity_evidence_matches_traces(traces, identity_evidence)
+    identity_payload = (
+        None if identity_evidence is None else canonical_json_bytes(identity_evidence)
+    )
+    if not result.include_identity_evidence and result.identity_evidence is not None:
+        raise ValueError("identity evidence cannot be supplied when persistence is disabled")
     resolved_dataset_id = dataset_id or current_trace_dataset_id(
         source=source,
         semantic_convention_version=semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
+        identity_evidence_sha256=(
+            None if identity_payload is None else hashlib.sha256(identity_payload).hexdigest()
+        ),
         code_revision=code_revision,
     )
     dataset = TraceDataset(
@@ -134,17 +156,21 @@ def persist_trace_dataset(
             traces,
             traces_payload=traces_payload,
             issues_payload=issues_payload,
+            identity_payload=identity_payload,
         )
     try:
+        files = {
+            _TRACES_PATH: traces_payload,
+            _ISSUES_PATH: issues_payload,
+            _TRACE_DATASET_PATH: canonical_json_bytes(dataset),
+        }
+        if identity_payload is not None:
+            files[MODEL_IDENTITY_EVIDENCE_PATH] = identity_payload
         manifest = store.write(
             artifact_id=dataset.dataset_id,
             artifact_type=_TRACE_DATASET_ARTIFACT_TYPE,
             envelope=dataset,
-            files={
-                _TRACES_PATH: traces_payload,
-                _ISSUES_PATH: issues_payload,
-                _TRACE_DATASET_PATH: canonical_json_bytes(dataset),
-            },
+            files=files,
         )
     except ArtifactAlreadyExistsError:
         return _load_exact_replay(
@@ -153,6 +179,7 @@ def persist_trace_dataset(
             traces,
             traces_payload=traces_payload,
             issues_payload=issues_payload,
+            identity_payload=identity_payload,
         )
     return PersistedTraceDataset(dataset=dataset, manifest=manifest, traces=traces)
 
@@ -163,6 +190,7 @@ def current_trace_dataset_id(
     semantic_convention_version: str,
     traces_sha256: str,
     issues_sha256: str,
+    identity_evidence_sha256: str | None = None,
     code_revision: str,
 ) -> str:
     """Return the current automatic trace-dataset content identity.
@@ -172,21 +200,23 @@ def current_trace_dataset_id(
         semantic_convention_version: Convention used to interpret source model spans.
         traces_sha256: Digest of canonical normalized trace JSONL.
         issues_sha256: Digest of the complete normalization issue report.
+        identity_evidence_sha256: Optional digest of complete model-span provenance. Omission
+            selects the compatible identity form without a provenance component.
         code_revision: Exact producer revision.
 
     Returns:
         Stable current trace-dataset artifact identity.
     """
-    return stable_id(
-        "trace-dataset",
-        {
-            "source": source.model_dump(mode="json"),
-            "semantic_convention_version": semantic_convention_version,
-            "traces_sha256": traces_sha256,
-            "issues_sha256": issues_sha256,
-            "code_revision": code_revision,
-        },
-    )
+    semantic = {
+        "source": source.model_dump(mode="json"),
+        "semantic_convention_version": semantic_convention_version,
+        "traces_sha256": traces_sha256,
+        "issues_sha256": issues_sha256,
+        "code_revision": code_revision,
+    }
+    if identity_evidence_sha256 is not None:
+        semantic["identity_evidence_sha256"] = identity_evidence_sha256
+    return stable_id("trace-dataset", semantic)
 
 
 def verify_current_trace_dataset(
@@ -214,7 +244,7 @@ def verify_current_trace_dataset(
             f"trace dataset {dataset.dataset_id} must not have artifact inputs"
         )
     paths = {entry.path for entry in stored.manifest.files}
-    if paths != _TRACE_DATASET_FILES:
+    if paths not in {_LEGACY_TRACE_DATASET_FILES, _TRACE_DATASET_FILES}:
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} does not have the exact current-build file set"
         )
@@ -255,6 +285,7 @@ def verify_current_trace_dataset(
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} exclusion count differs from its issue evidence"
         )
+    identity_evidence = read_trace_model_identity_evidence(store, loaded)
     for trace in loaded.traces:
         if (
             trace.source.identity != dataset.source
@@ -268,6 +299,13 @@ def verify_current_trace_dataset(
         semantic_convention_version=dataset.semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
+        identity_evidence_sha256=(
+            None
+            if identity_evidence is None
+            else hashlib.sha256(
+                store.read_bytes(dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
+            ).hexdigest()
+        ),
         code_revision=dataset.code_revision,
     )
     if dataset.dataset_id != expected_id:
@@ -277,6 +315,45 @@ def verify_current_trace_dataset(
         )
 
 
+def read_trace_model_identity_evidence(
+    store: ArtifactStore,
+    loaded: LoadedTraceDataset,
+) -> TraceModelIdentityEvidenceSet | None:
+    """Read and verify optional model-span provenance from a loaded trace dataset.
+
+    Args:
+        store: Project-local immutable artifact store.
+        loaded: Digest-verified trace dataset and records.
+
+    Returns:
+        Complete current provenance, or ``None`` for a compatible dataset without the payload.
+
+    Raises:
+        ArtifactCorruptionError: The payload is malformed, noncanonical, incomplete, extra, or
+            differs from its exact trace span snapshots.
+    """
+    stored = store.read(loaded.dataset.dataset_id)
+    paths = {entry.path for entry in stored.manifest.files}
+    if MODEL_IDENTITY_EVIDENCE_PATH not in paths:
+        return None
+    payload_bytes = store.read_bytes(
+        loaded.dataset.dataset_id,
+        MODEL_IDENTITY_EVIDENCE_PATH,
+    )
+    try:
+        payload = TraceModelIdentityEvidenceSet.model_validate_json(payload_bytes)
+        require_model_identity_evidence_matches_traces(loaded.traces, payload)
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"trace dataset {loaded.dataset.dataset_id} has invalid model identity evidence"
+        ) from exc
+    if payload_bytes != canonical_json_bytes(payload):
+        raise ArtifactCorruptionError(
+            f"trace dataset {loaded.dataset.dataset_id} model identity evidence is not canonical"
+        )
+    return payload
+
+
 def _load_exact_replay(
     store: ArtifactStore,
     expected: TraceDataset,
@@ -284,6 +361,7 @@ def _load_exact_replay(
     *,
     traces_payload: bytes,
     issues_payload: bytes,
+    identity_payload: bytes | None,
 ) -> PersistedTraceDataset:
     """Return an existing content-identical dataset for a safe build resume."""
     stored = store.read(expected.dataset_id)
@@ -299,6 +377,14 @@ def _load_exact_replay(
         raise ValueError("existing trace dataset records differ from replayed evidence")
     if store.read_bytes(expected.dataset_id, _ISSUES_PATH) != issues_payload:
         raise ValueError("existing trace dataset issues differ from replayed evidence")
+    manifest_paths = {entry.path for entry in stored.manifest.files}
+    existing_identity = (
+        store.read_bytes(expected.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
+        if MODEL_IDENTITY_EVIDENCE_PATH in manifest_paths
+        else None
+    )
+    if existing_identity != identity_payload:
+        raise ValueError("existing trace dataset model identity differs from replayed evidence")
     manifest = stored.manifest
     if (
         manifest.schema_version,

--- a/wmo/simulation/ingest/dataset_test.py
+++ b/wmo/simulation/ingest/dataset_test.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
-from wmo.common.core.artifacts import SourceIdentity, stable_id
-from wmo.common.project import ArtifactStore, artifact_input
+from wmo.common.core.artifacts import SourceIdentity, canonical_json_bytes, stable_id
+from wmo.common.models import ModelSnapshot
+from wmo.common.project import ArtifactCorruptionError, ArtifactStore, artifact_input
 from wmo.common.project.paths import ProjectPaths
 from wmo.common.traces import Trace, TraceDataset, TraceSource, TraceSpan, load_trace_dataset
-from wmo.simulation.ingest.dataset import persist_trace_dataset
+from wmo.simulation.ingest.dataset import (
+    MODEL_IDENTITY_EVIDENCE_PATH,
+    current_trace_dataset_id,
+    persist_trace_dataset,
+    read_trace_model_identity_evidence,
+    verify_current_trace_dataset,
+)
+from wmo.simulation.ingest.model_identity import (
+    IdentityComponentProvenance,
+    TraceModelIdentityEvidence,
+)
 from wmo.simulation.ingest.otlp import TraceNormalizationIssue, TraceNormalizationResult
 
 _SOURCE_DIGEST = "a" * 64
@@ -46,6 +58,59 @@ def _trace(index: int, *, source_id: str = "fixture.otlp") -> Trace:
             semantic_convention_version="1.37.0",
         ),
     )
+
+
+def _modeled_trace() -> Trace:
+    """Return one direct trace carrying a complete but origin-unspecified model snapshot."""
+    trace = _trace(1)
+    model = ModelSnapshot(
+        provider="openai",
+        model_id="gpt-test",
+        capabilities_sha256="b" * 64,
+        connection_sha256="c" * 64,
+    )
+    return trace.model_copy(update={"spans": (trace.spans[0].model_copy(update={"model": model}),)})
+
+
+def _write_reidentified_evidence(
+    store: ArtifactStore,
+    dataset: TraceDataset,
+    identity_bytes: bytes,
+) -> str:
+    """Write one self-consistently reidentified dataset with forged identity evidence.
+
+    Args:
+        store: Test artifact store containing the source dataset.
+        dataset: Original current dataset envelope.
+        identity_bytes: Mutated model-identity payload bytes.
+
+    Returns:
+        Newly written current content-addressed dataset identity.
+    """
+    assert dataset.source is not None
+    traces_bytes = store.read_bytes(dataset.dataset_id, "traces.jsonl")
+    issues_bytes = store.read_bytes(dataset.dataset_id, "normalization-issues.json")
+    forged_id = current_trace_dataset_id(
+        source=dataset.source,
+        semantic_convention_version=dataset.semantic_convention_version,
+        traces_sha256=dataset.traces_sha256,
+        issues_sha256=dataset.issues_sha256 or hashlib.sha256(issues_bytes).hexdigest(),
+        identity_evidence_sha256=hashlib.sha256(identity_bytes).hexdigest(),
+        code_revision=dataset.code_revision,
+    )
+    forged = dataset.model_copy(update={"dataset_id": forged_id})
+    store.write(
+        artifact_id=forged_id,
+        artifact_type="trace-dataset",
+        envelope=forged,
+        files={
+            "traces.jsonl": traces_bytes,
+            "normalization-issues.json": issues_bytes,
+            MODEL_IDENTITY_EVIDENCE_PATH: identity_bytes,
+            "trace-dataset.json": canonical_json_bytes(forged),
+        },
+    )
+    return forged_id
 
 
 def test_persist_trace_dataset_writes_trace_and_issue_evidence(tmp_path: Path) -> None:
@@ -85,6 +150,190 @@ def test_persist_trace_dataset_writes_trace_and_issue_evidence(tmp_path: Path) -
         "invalid_trace_count": 1,
         "issues": [{"message": "invalid JSONL record", "source_record": "line-4"}],
     }
+
+
+def test_direct_model_spans_persist_explicit_unspecified_provenance(tmp_path: Path) -> None:
+    """Programmatic traces never gain inferred telemetry provenance during persistence."""
+    trace = _modeled_trace()
+    store = _store(tmp_path, "project-a")
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(trace,), issues=()),
+        store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+    )
+    loaded = load_trace_dataset(store, persisted.dataset.dataset_id)
+
+    verify_current_trace_dataset(store, loaded)
+    evidence = read_trace_model_identity_evidence(store, loaded)
+
+    assert evidence is not None
+    assert evidence.records[0].capabilities == "unspecified"
+    assert evidence.records[0].connection == "unspecified"
+
+
+def test_strict_loader_preserves_legacy_dataset_without_identity_payload(tmp_path: Path) -> None:
+    """A verified legacy current dataset remains readable with no inferred provenance."""
+    trace = _modeled_trace()
+    store = _store(tmp_path, "project-a")
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(
+            traces=(trace,),
+            issues=(),
+            include_identity_evidence=False,
+        ),
+        store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+    )
+    loaded = load_trace_dataset(store, persisted.dataset.dataset_id)
+
+    verify_current_trace_dataset(store, loaded)
+
+    assert read_trace_model_identity_evidence(store, loaded) is None
+    assert MODEL_IDENTITY_EVIDENCE_PATH not in {item.path for item in persisted.manifest.files}
+
+
+def test_persist_rejects_incomplete_or_extra_supplied_model_identity(tmp_path: Path) -> None:
+    """Supplied normalizer evidence must cover exactly every model span before artifact writes."""
+    trace = _modeled_trace()
+    model = trace.spans[0].model
+    assert model is not None
+    store = _store(tmp_path, "project-a")
+
+    with pytest.raises(ValueError, match="cover every model span exactly"):
+        persist_trace_dataset(
+            TraceNormalizationResult(traces=(trace,), issues=(), identity_evidence=()),
+            store,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="test-revision",
+        )
+    with pytest.raises(ValueError, match="cover every model span exactly"):
+        persist_trace_dataset(
+            TraceNormalizationResult(
+                traces=(trace,),
+                issues=(),
+                identity_evidence=(
+                    TraceModelIdentityEvidence(
+                        trace_id=trace.trace_id,
+                        span_id="extra-span",
+                        model=model,
+                        capabilities="unspecified",
+                        connection="unspecified",
+                    ),
+                ),
+            ),
+            store,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="test-revision",
+        )
+
+    assert not store.project_directory.exists()
+
+
+@pytest.mark.parametrize("provenance", ["declared", "inferred"])
+def test_persist_rejects_provenance_that_disagrees_with_canonical_span(
+    tmp_path: Path,
+    provenance: IdentityComponentProvenance,
+) -> None:
+    """Rehashed provenance cannot contradict declaration presence or fallback arithmetic.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        provenance: Incorrect component classification to attempt.
+    """
+    trace = _modeled_trace()
+    model = trace.spans[0].model
+    assert model is not None
+    evidence = TraceModelIdentityEvidence(
+        trace_id=trace.trace_id,
+        span_id=trace.spans[0].span_id,
+        model=model,
+        capabilities=provenance,
+        connection="unspecified",
+    )
+    store = _store(tmp_path, "project-a")
+
+    with pytest.raises(ValueError, match=f"{provenance} wmo.model.capabilities_sha256"):
+        persist_trace_dataset(
+            TraceNormalizationResult(
+                traces=(trace,),
+                issues=(),
+                identity_evidence=(evidence,),
+            ),
+            store,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            code_revision="test-revision",
+        )
+
+    assert not store.project_directory.exists()
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra", "duplicate"])
+def test_current_dataset_rejects_rehashed_identity_coverage_drift(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    """A self-consistent current ID cannot hide missing, extra, or duplicate span evidence.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        mutation: Evidence coverage mutation to apply before rehashing every parent.
+    """
+    store = _store(tmp_path, "project-a")
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(_modeled_trace(),), issues=()),
+        store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+    )
+    value = json.loads(store.read_bytes(persisted.dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH))
+    record = value["records"][0]
+    if mutation == "missing":
+        value["records"] = []
+    elif mutation == "extra":
+        value["records"].append({**record, "span_id": "extra-span"})
+    else:
+        value["records"].append(record)
+    forged_id = _write_reidentified_evidence(store, persisted.dataset, canonical_json_bytes(value))
+
+    loaded = load_trace_dataset(store, forged_id)
+    with pytest.raises(ArtifactCorruptionError, match="invalid model identity evidence"):
+        verify_current_trace_dataset(store, loaded)
+
+
+@pytest.mark.parametrize("mutation", ["noncanonical", "schema-v0", "schema-v2"])
+def test_current_dataset_rejects_rehashed_identity_serialization_or_schema(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    """Canonical rehashing cannot authorize unsupported or noncanonical identity evidence.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        mutation: Serialization or schema mutation to apply.
+    """
+    store = _store(tmp_path, "project-a")
+    persisted = persist_trace_dataset(
+        TraceNormalizationResult(traces=(_modeled_trace(),), issues=()),
+        store,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        code_revision="test-revision",
+    )
+    original = store.read_bytes(persisted.dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
+    if mutation == "noncanonical":
+        identity_bytes = b" " + original
+        match = "not canonical"
+    else:
+        value = json.loads(original)
+        value["schema_version"] = 0 if mutation == "schema-v0" else 2
+        identity_bytes = canonical_json_bytes(value)
+        match = "invalid model identity evidence"
+    forged_id = _write_reidentified_evidence(store, persisted.dataset, identity_bytes)
+
+    loaded = load_trace_dataset(store, forged_id)
+    with pytest.raises(ArtifactCorruptionError, match=match):
+        verify_current_trace_dataset(store, loaded)
 
 
 def test_persist_trace_dataset_is_content_addressed_despite_input_order(tmp_path: Path) -> None:

--- a/wmo/simulation/ingest/model_identity.py
+++ b/wmo/simulation/ingest/model_identity.py
@@ -1,0 +1,271 @@
+"""Versioned provenance for model identities extracted from normalized telemetry."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from typing import Literal
+
+from pydantic import field_validator
+
+from wmo.common.core.artifacts import ContractModel, JsonObject, Sha256
+from wmo.common.models import ConnectionConfig, ModelSnapshot
+from wmo.common.traces import Trace
+
+IdentityComponentProvenance = Literal["declared", "inferred", "unspecified"]
+
+CAPABILITIES_DIGEST_ATTRIBUTE = "wmo.model.capabilities_sha256"
+CONNECTION_DIGEST_ATTRIBUTE = "wmo.model.connection_sha256"
+
+
+class TraceModelIdentityEvidence(ContractModel):
+    """Provenance for the model identity retained on one normalized model span."""
+
+    trace_id: str
+    span_id: str
+    model: ModelSnapshot
+    capabilities: IdentityComponentProvenance
+    connection: IdentityComponentProvenance
+
+
+class TraceModelIdentityEvidenceSet(ContractModel):
+    """Complete deterministic model-identity provenance for one trace dataset."""
+
+    schema_version: Literal[1] = 1
+    records: tuple[TraceModelIdentityEvidence, ...]
+
+    @field_validator("records")
+    @classmethod
+    def _require_sorted_unique_records(
+        cls,
+        value: tuple[TraceModelIdentityEvidence, ...],
+    ) -> tuple[TraceModelIdentityEvidence, ...]:
+        """Require one deterministically ordered record per model span.
+
+        Args:
+            value: Model-span provenance records.
+
+        Returns:
+            The unchanged validated tuple.
+
+        Raises:
+            ValueError: Record keys repeat or are not sorted.
+        """
+        keys = tuple((item.trace_id, item.span_id) for item in value)
+        if len(set(keys)) != len(keys):
+            raise ValueError("model identity evidence must not repeat trace and span IDs")
+        if keys != tuple(sorted(keys)):
+            raise ValueError("model identity evidence must be sorted by trace and span ID")
+        return value
+
+
+def normalized_connection_sha256(
+    attributes: JsonObject,
+    provider: str,
+    *,
+    error_type: type[ValueError],
+) -> Sha256:
+    """Return declared endpoint evidence or an explicitly inferred standard endpoint.
+
+    Args:
+        attributes: Source telemetry attributes or properties.
+        provider: Exact provider name retained by normalization.
+        error_type: Source-specific validation exception type.
+
+    Returns:
+        Declared connection digest or the provider standard-endpoint digest.
+
+    Raises:
+        ValueError: The declared extension value is not a SHA-256 digest.
+    """
+    declared = attributes.get(CONNECTION_DIGEST_ATTRIBUTE)
+    if declared is not None:
+        if not isinstance(declared, str) or not re.fullmatch(r"[0-9a-f]{64}", declared):
+            raise error_type(f"{CONNECTION_DIGEST_ATTRIBUTE} must be a SHA-256 digest")
+        return declared
+    return ConnectionConfig(provider=provider).identity_sha256()
+
+
+def normalized_capabilities_sha256(
+    attributes: JsonObject,
+    provider: str,
+    model_id: str,
+    revision: str | None,
+    *,
+    error_type: type[ValueError],
+) -> Sha256:
+    """Return declared capability evidence or an explicitly inferred model digest.
+
+    Args:
+        attributes: Source telemetry attributes or properties.
+        provider: Exact provider name retained by normalization.
+        model_id: Exact provider model identifier retained by normalization.
+        revision: Exact optional model revision retained by normalization.
+        error_type: Source-specific validation exception type.
+
+    Returns:
+        Declared capability digest or the deterministic telemetry fallback.
+
+    Raises:
+        ValueError: The declared extension value is not a SHA-256 digest.
+    """
+    declared = attributes.get(CAPABILITIES_DIGEST_ATTRIBUTE)
+    if declared is not None:
+        if not isinstance(declared, str) or not re.fullmatch(r"[0-9a-f]{64}", declared):
+            raise error_type(f"{CAPABILITIES_DIGEST_ATTRIBUTE} must be a SHA-256 digest")
+        return declared
+    return hashlib.sha256(f"{provider}\0{model_id}\0{revision or ''}".encode()).hexdigest()
+
+
+def normalized_model_identity_evidence(
+    traces: Sequence[Trace],
+) -> tuple[TraceModelIdentityEvidence, ...]:
+    """Classify digest components retained by an OTLP or PostHog normalizer.
+
+    Model provider, model ID, and revision are copied directly from the source telemetry.
+    Capabilities and connection digests are declared only when their WMO extension attributes
+    were present. Otherwise their normalized fallback values are explicitly inferred.
+
+    Args:
+        traces: Traces produced by a telemetry-aware normalizer.
+
+    Returns:
+        Complete ordered provenance for every normalized model span.
+    """
+    records = []
+    for trace in traces:
+        for span in trace.spans:
+            if span.model is None:
+                continue
+            records.append(
+                TraceModelIdentityEvidence(
+                    trace_id=trace.trace_id,
+                    span_id=span.span_id,
+                    model=span.model,
+                    capabilities=(
+                        "declared"
+                        if CAPABILITIES_DIGEST_ATTRIBUTE in span.attributes
+                        else "inferred"
+                    ),
+                    connection=(
+                        "declared" if CONNECTION_DIGEST_ATTRIBUTE in span.attributes else "inferred"
+                    ),
+                )
+            )
+    return tuple(sorted(records, key=lambda item: (item.trace_id, item.span_id)))
+
+
+def complete_model_identity_evidence(
+    traces: Sequence[Trace],
+    supplied: Sequence[TraceModelIdentityEvidence] | None,
+) -> TraceModelIdentityEvidenceSet:
+    """Validate supplied normalization evidence or classify direct records as unspecified.
+
+    Args:
+        traces: Exact normalized trace records being persisted.
+        supplied: Telemetry-normalizer evidence, or ``None`` for direct/programmatic records.
+
+    Returns:
+        Complete ordered evidence for every span carrying a model snapshot.
+
+    Raises:
+        ValueError: Supplied evidence is incomplete, duplicated, extra, or differs from a span.
+    """
+    expected = {
+        (trace.trace_id, span.span_id): span.model
+        for trace in traces
+        for span in trace.spans
+        if span.model is not None
+    }
+    if supplied is None:
+        records = tuple(
+            TraceModelIdentityEvidence(
+                trace_id=trace_id,
+                span_id=span_id,
+                model=model,
+                capabilities="unspecified",
+                connection="unspecified",
+            )
+            for (trace_id, span_id), model in sorted(expected.items())
+        )
+    else:
+        records = tuple(sorted(supplied, key=lambda item: (item.trace_id, item.span_id)))
+    payload = TraceModelIdentityEvidenceSet(records=records)
+    actual = {(item.trace_id, item.span_id): item.model for item in payload.records}
+    if actual != expected:
+        raise ValueError(
+            "model identity evidence must cover every model span exactly and preserve its snapshot"
+        )
+    return payload
+
+
+def require_model_identity_evidence_matches_traces(
+    traces: Sequence[Trace],
+    payload: TraceModelIdentityEvidenceSet,
+) -> None:
+    """Verify persisted identity evidence against exact normalized model spans.
+
+    Args:
+        traces: Recursively verified trace records.
+        payload: Parsed versioned identity evidence.
+
+    Raises:
+        ValueError: Coverage, uniqueness, or snapshot identity differs.
+    """
+    complete_model_identity_evidence(traces, payload.records)
+    spans = {
+        (trace.trace_id, span.span_id): span
+        for trace in traces
+        for span in trace.spans
+        if span.model is not None
+    }
+    for item in payload.records:
+        span = spans[(item.trace_id, item.span_id)]
+        _require_component_provenance(
+            span.attributes,
+            CAPABILITIES_DIGEST_ATTRIBUTE,
+            item.capabilities,
+            item.model.capabilities_sha256,
+            normalized_capabilities_sha256(
+                {},
+                item.model.provider,
+                item.model.model_id,
+                item.model.revision,
+                error_type=ValueError,
+            ),
+        )
+        _require_component_provenance(
+            span.attributes,
+            CONNECTION_DIGEST_ATTRIBUTE,
+            item.connection,
+            item.model.connection_sha256,
+            ConnectionConfig(provider=item.model.provider).identity_sha256(),
+        )
+
+
+def _require_component_provenance(
+    attributes: JsonObject,
+    key: str,
+    provenance: IdentityComponentProvenance,
+    recorded_digest: Sha256,
+    inferred_digest: Sha256,
+) -> None:
+    """Verify one declared or inferred digest against canonical span attributes.
+
+    Args:
+        attributes: Exact normalized span attributes.
+        key: WMO digest extension key.
+        provenance: Persisted declared, inferred, or unspecified classification.
+        recorded_digest: Digest retained in the span's model snapshot.
+        inferred_digest: Deterministic normalizer fallback digest.
+
+    Raises:
+        ValueError: Declared or inferred provenance disagrees with the canonical span.
+    """
+    attribute = attributes.get(key)
+    if provenance == "declared":
+        if attribute != recorded_digest:
+            raise ValueError(f"declared {key} is absent or differs from its model snapshot")
+    elif provenance == "inferred" and (attribute is not None or recorded_digest != inferred_digest):
+        raise ValueError(f"inferred {key} differs from the canonical telemetry fallback")

--- a/wmo/simulation/ingest/model_identity_test.py
+++ b/wmo/simulation/ingest/model_identity_test.py
@@ -1,0 +1,1 @@
+"""Tests for normalized model-identity provenance contracts."""

--- a/wmo/simulation/ingest/otlp.py
+++ b/wmo/simulation/ingest/otlp.py
@@ -19,9 +19,15 @@ from pydantic import JsonValue
 
 from wmo.common.core.artifacts import FailureCode, JsonObject, SourceIdentity, StructuredFailure
 from wmo.common.core.text import normalize_durable_text
-from wmo.common.models import ConnectionConfig, ModelSnapshot, Usage
+from wmo.common.models import ModelSnapshot, Usage
 from wmo.common.tasks import ToolSchema
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.simulation.ingest.model_identity import (
+    TraceModelIdentityEvidence,
+    normalized_capabilities_sha256,
+    normalized_connection_sha256,
+    normalized_model_identity_evidence,
+)
 
 GENAI_SEMANTIC_CONVENTION_VERSION = "1.37.0"
 
@@ -65,10 +71,16 @@ class TraceNormalizationResult:
     Args:
         traces: Valid normalized production traces in deterministic order.
         issues: Corrupt or incomplete source records that were excluded without repair.
+        identity_evidence: Exact model-span provenance from a telemetry-aware normalizer. ``None``
+            marks direct or programmatic records whose digest origin is unspecified.
+        include_identity_evidence: Whether persistence materializes the provenance payload. Only
+            exact reconstruction of a verified legacy dataset should disable it.
     """
 
     traces: tuple[Trace, ...]
     issues: tuple[TraceNormalizationIssue, ...]
+    identity_evidence: tuple[TraceModelIdentityEvidence, ...] | None = None
+    include_identity_evidence: bool = True
 
     @property
     def invalid_trace_count(self) -> int:
@@ -220,7 +232,12 @@ def normalize_otlp_payloads(
         else:
             traces.append(trace)
     traces.sort(key=lambda trace: (trace.spans[0].started_at, trace.trace_id))
-    return TraceNormalizationResult(traces=tuple(traces), issues=tuple(issues))
+    normalized_traces = tuple(traces)
+    return TraceNormalizationResult(
+        traces=normalized_traces,
+        issues=tuple(issues),
+        identity_evidence=normalized_model_identity_evidence(normalized_traces),
+    )
 
 
 def _normalize_jsonl(
@@ -463,18 +480,18 @@ def _model_snapshot(attributes: JsonObject, operation: str) -> ModelSnapshot | N
     revision = _first_text(
         attributes, ("gen_ai.response.model.version", "gen_ai.request.model.version")
     )
-    declared_capabilities = attributes.get("wmo.model.capabilities_sha256")
-    if declared_capabilities is not None:
-        if not isinstance(declared_capabilities, str) or not re.fullmatch(
-            r"[0-9a-f]{64}", declared_capabilities
-        ):
-            raise OtlpTraceFormatError("wmo.model.capabilities_sha256 must be a SHA-256 digest")
-        capabilities_sha256 = declared_capabilities
-    else:
-        capabilities_sha256 = hashlib.sha256(
-            f"{provider}\0{model_id}\0{revision or ''}".encode()
-        ).hexdigest()
-    connection_sha256 = _connection_sha256(attributes, provider)
+    capabilities_sha256 = normalized_capabilities_sha256(
+        attributes,
+        provider,
+        model_id,
+        revision,
+        error_type=OtlpTraceFormatError,
+    )
+    connection_sha256 = normalized_connection_sha256(
+        attributes,
+        provider,
+        error_type=OtlpTraceFormatError,
+    )
     return ModelSnapshot(
         provider=provider,
         model_id=model_id,
@@ -482,23 +499,6 @@ def _model_snapshot(attributes: JsonObject, operation: str) -> ModelSnapshot | N
         capabilities_sha256=capabilities_sha256,
         connection_sha256=connection_sha256,
     )
-
-
-def _connection_sha256(attributes: JsonObject, provider: str) -> str:
-    """Return declared connection evidence or the provider's standard endpoint identity.
-
-    An imported trace cannot safely infer an endpoint from arbitrary telemetry attributes. An
-    exporter may therefore provide the secret-free canonical digest explicitly. When it does
-    not, the provider-only connection identity represents that provider's standard endpoint.
-    """
-    declared_connection = attributes.get("wmo.model.connection_sha256")
-    if declared_connection is not None:
-        if not isinstance(declared_connection, str) or not re.fullmatch(
-            r"[0-9a-f]{64}", declared_connection
-        ):
-            raise OtlpTraceFormatError("wmo.model.connection_sha256 must be a SHA-256 digest")
-        return declared_connection
-    return ConnectionConfig(provider=provider).identity_sha256()
 
 
 def _usage(attributes: JsonObject) -> Usage | None:

--- a/wmo/simulation/ingest/otlp_test.py
+++ b/wmo/simulation/ingest/otlp_test.py
@@ -174,6 +174,9 @@ def test_normalizes_w3c_genai_trace_and_wmo_outcome_extensions() -> None:
     result = normalize_otlp_payload(_payload(), source=_source())
 
     assert result.issues == ()
+    assert result.identity_evidence is not None
+    assert result.identity_evidence[0].capabilities == "inferred"
+    assert result.identity_evidence[0].connection == "inferred"
     assert len(result.traces) == 1
     trace = result.traces[0]
     assert trace.trace_id == _TRACE_ID
@@ -202,6 +205,30 @@ def test_otlp_retains_a_declared_model_connection_digest() -> None:
     assert result.issues == ()
     assert result.traces[0].spans[0].model is not None
     assert result.traces[0].spans[0].model.connection_sha256 == "d" * 64
+    assert result.identity_evidence is not None
+    assert result.identity_evidence[0].capabilities == "inferred"
+    assert result.identity_evidence[0].connection == "declared"
+
+
+def test_otlp_retains_independent_declared_model_identity_components() -> None:
+    """Capability and connection provenance remain independently declared."""
+    payload = _payload()
+    attributes = cast(list[dict[str, object]], _span(payload, 0)["attributes"])
+    attributes.extend(
+        (
+            _attribute("wmo.model.capabilities_sha256", "c" * 64),
+            _attribute("wmo.model.connection_sha256", "d" * 64),
+        )
+    )
+
+    result = normalize_otlp_payload(payload, source=_source())
+
+    assert result.issues == ()
+    assert result.identity_evidence is not None
+    assert result.identity_evidence[0].capabilities == "declared"
+    assert result.identity_evidence[0].connection == "declared"
+    assert result.traces[0].spans[0].model is not None
+    assert result.traces[0].spans[0].model.capabilities_sha256 == "c" * 64
 
 
 def test_otlp_rejects_an_invalid_declared_model_connection_digest() -> None:

--- a/wmo/simulation/ingest/posthog_canonical.py
+++ b/wmo/simulation/ingest/posthog_canonical.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from collections import defaultdict, deque
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -21,17 +20,23 @@ from wmo.common.core.artifacts import (
     canonical_json_bytes,
 )
 from wmo.common.core.text import normalize_durable_text
-from wmo.common.models import ConnectionConfig, ModelSnapshot
+from wmo.common.models import ModelSnapshot
 from wmo.common.tasks import ToolSchema
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.simulation.ingest.model_identity import (
+    CAPABILITIES_DIGEST_ATTRIBUTE,
+    CONNECTION_DIGEST_ATTRIBUTE,
+    normalized_capabilities_sha256,
+    normalized_connection_sha256,
+    normalized_model_identity_evidence,
+)
 from wmo.simulation.ingest.otlp import (
     GENAI_SEMANTIC_CONVENTION_VERSION,
     TraceNormalizationIssue,
     TraceNormalizationResult,
 )
+from wmo.simulation.ingest.posthog_ids import posthog_w3c_id
 
-_TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
-_SPAN_ID_PATTERN = re.compile(r"^[0-9a-f]{16}$")
 _OUTCOME_STATUS_KEY = "wmo.outcome.status"
 _OUTCOME_NAME_KEY = "wmo.outcome.name"
 _OUTCOME_FAILURE_CODE_KEY = "wmo.outcome.failure.code"
@@ -170,7 +175,12 @@ def normalize_posthog_payload(
         except PostHogPullError as exc:
             issues.append(TraceNormalizationIssue(f"trace-{source_trace_id}", str(exc)))
     traces.sort(key=lambda trace: (trace.spans[0].started_at, trace.trace_id))
-    return TraceNormalizationResult(traces=tuple(traces), issues=tuple(issues))
+    normalized_traces = tuple(traces)
+    return TraceNormalizationResult(
+        traces=normalized_traces,
+        issues=tuple(issues),
+        identity_evidence=normalized_model_identity_evidence(normalized_traces),
+    )
 
 
 def _normalize_jsonl(
@@ -241,7 +251,7 @@ def _normalize_trace_events(
     semantic_convention_version: str,
 ) -> Trace:
     """Convert ordered PostHog root, generation, tool, and error events to one canonical trace."""
-    trace_id = _w3c_trace_id(source_trace_id, kind="trace", namespace="trace")
+    trace_id = posthog_w3c_id(source_trace_id, kind="trace", namespace="trace")
     ordered = sorted(
         events,
         key=lambda event: (_event_timestamp(event.event), event.source_order_key, event.ordinal),
@@ -490,7 +500,7 @@ def _span(
     """Build one canonical span with deterministic W3C-shaped IDs and PostHog error mapping."""
     properties = _properties(event.event)
     source_span_id = _source_span_id(event)
-    span_id = _w3c_trace_id(
+    span_id = posthog_w3c_id(
         f"{source_trace_id}\0{source_span_id}\0{suffix}", kind="span", namespace="span"
     )
     failure = _event_failure(properties)
@@ -666,6 +676,8 @@ def _mapped_extensions(properties: JsonObject) -> JsonObject:
         "wmo.request.context",
         "wmo.request.tags",
         "wmo.request.tools",
+        CAPABILITIES_DIGEST_ATTRIBUTE,
+        CONNECTION_DIGEST_ATTRIBUTE,
         "wmo.outcome.escalated",
         _OUTCOME_STATUS_KEY,
         _OUTCOME_NAME_KEY,
@@ -821,8 +833,18 @@ def _model_snapshot(properties: JsonObject) -> ModelSnapshot | None:
     if provider is None:
         raise PostHogPullError("PostHog model identity has a model but no provider")
     revision = _first_property_text(properties, ("$ai_model_revision", "model_revision"))
-    digest = hashlib.sha256(f"{provider}\0{model_id}\0{revision or ''}".encode()).hexdigest()
-    connection_sha256 = _connection_sha256(properties, provider)
+    digest = normalized_capabilities_sha256(
+        properties,
+        provider,
+        model_id,
+        revision,
+        error_type=PostHogPullError,
+    )
+    connection_sha256 = normalized_connection_sha256(
+        properties,
+        provider,
+        error_type=PostHogPullError,
+    )
     return ModelSnapshot(
         provider=provider,
         model_id=model_id,
@@ -830,23 +852,6 @@ def _model_snapshot(properties: JsonObject) -> ModelSnapshot | None:
         capabilities_sha256=digest,
         connection_sha256=connection_sha256,
     )
-
-
-def _connection_sha256(properties: JsonObject, provider: str) -> str:
-    """Return declared connection evidence or the provider's standard endpoint identity.
-
-    PostHog exports do not reliably retain a safe endpoint spelling. Producers can include the
-    canonical digest directly. Otherwise the provider-only identity records that the trace used
-    the provider's standard endpoint without copying a credential or raw endpoint into WMO.
-    """
-    declared_connection = properties.get("wmo.model.connection_sha256")
-    if declared_connection is not None:
-        if not isinstance(declared_connection, str) or not re.fullmatch(
-            r"[0-9a-f]{64}", declared_connection
-        ):
-            raise PostHogPullError("wmo.model.connection_sha256 must be a SHA-256 digest")
-        return declared_connection
-    return ConnectionConfig(provider=provider).identity_sha256()
 
 
 def _event_failure(properties: JsonObject) -> StructuredFailure | None:
@@ -984,13 +989,3 @@ def _first_property_text(properties: JsonObject, keys: tuple[str, ...]) -> str |
         if isinstance(value, str) and value.strip():
             return normalize_durable_text(value.strip())
     return None
-
-
-def _w3c_trace_id(value: str, *, kind: str, namespace: str) -> str:
-    """Keep valid W3C IDs and deterministically hash PostHog opaque IDs into W3C width."""
-    normalized = value.casefold()
-    pattern = _TRACE_ID_PATTERN if kind == "trace" else _SPAN_ID_PATTERN
-    if pattern.fullmatch(normalized) and set(normalized) != {"0"}:
-        return normalized
-    width = 32 if kind == "trace" else 16
-    return hashlib.sha256(f"posthog\0{namespace}\0{value}".encode()).hexdigest()[:width]

--- a/wmo/simulation/ingest/posthog_canonical_test.py
+++ b/wmo/simulation/ingest/posthog_canonical_test.py
@@ -246,6 +246,29 @@ def test_posthog_retains_a_declared_model_connection_digest() -> None:
     assert result.issues == ()
     assert result.traces[0].spans[0].model is not None
     assert result.traces[0].spans[0].model.connection_sha256 == "d" * 64
+    assert result.identity_evidence is not None
+    assert result.identity_evidence[0].capabilities == "inferred"
+    assert result.identity_evidence[0].connection == "declared"
+    assert result.traces[0].spans[0].attributes["wmo.model.connection_sha256"] == "d" * 64
+
+
+def test_posthog_retains_independent_declared_model_identity_components() -> None:
+    """PostHog capability and connection digests remain safe canonical span extensions."""
+    events = _posthog_events()
+    properties = _event_properties(events[0])
+    properties["wmo.model.capabilities_sha256"] = "c" * 64
+    properties["wmo.model.connection_sha256"] = "d" * 64
+
+    result = normalize_posthog_payload(events, source=_source())
+
+    assert result.issues == ()
+    assert result.identity_evidence is not None
+    assert result.identity_evidence[0].capabilities == "declared"
+    assert result.identity_evidence[0].connection == "declared"
+    model_span = result.traces[0].spans[0]
+    assert model_span.model is not None
+    assert model_span.model.capabilities_sha256 == "c" * 64
+    assert model_span.attributes["wmo.model.capabilities_sha256"] == "c" * 64
 
 
 def test_posthog_rejects_an_invalid_declared_model_connection_digest() -> None:
@@ -257,6 +280,17 @@ def test_posthog_rejects_an_invalid_declared_model_connection_digest() -> None:
 
     assert result.traces == ()
     assert "connection_sha256" in result.issues[0].message
+
+
+def test_posthog_rejects_an_invalid_declared_model_capability_digest() -> None:
+    """Malformed capability provenance excludes the complete source trace."""
+    events = _posthog_events()
+    _event_properties(events[0])["wmo.model.capabilities_sha256"] = "not-a-digest"
+
+    result = normalize_posthog_payload(events, source=_source())
+
+    assert result.traces == ()
+    assert "capabilities_sha256" in result.issues[0].message
 
 
 def test_posthog_error_and_jsonl_export_are_retained_as_canonical_failure_evidence(

--- a/wmo/simulation/ingest/posthog_ids.py
+++ b/wmo/simulation/ingest/posthog_ids.py
@@ -1,0 +1,28 @@
+"""Deterministic W3C identifiers for PostHog's opaque trace and span keys."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+_TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_PATTERN = re.compile(r"^[0-9a-f]{16}$")
+
+
+def posthog_w3c_id(value: str, *, kind: str, namespace: str) -> str:
+    """Preserve valid W3C IDs or deterministically map an opaque PostHog ID.
+
+    Args:
+        value: Source trace or span identity.
+        kind: ``trace`` for a 32-character identity, otherwise ``span``.
+        namespace: Stable source-role namespace preventing cross-role collisions.
+
+    Returns:
+        Lowercase nonzero W3C-shaped trace or span identity.
+    """
+    normalized = value.casefold()
+    pattern = _TRACE_ID_PATTERN if kind == "trace" else _SPAN_ID_PATTERN
+    if pattern.fullmatch(normalized) and set(normalized) != {"0"}:
+        return normalized
+    width = 32 if kind == "trace" else 16
+    return hashlib.sha256(f"posthog\0{namespace}\0{value}".encode()).hexdigest()[:width]

--- a/wmo/simulation/ingest/posthog_ids_test.py
+++ b/wmo/simulation/ingest/posthog_ids_test.py
@@ -1,0 +1,1 @@
+"""Tests for deterministic PostHog trace and span identifiers."""

--- a/wmo/simulation/mining/__init__.py
+++ b/wmo/simulation/mining/__init__.py
@@ -1,5 +1,10 @@
 """Canonical representative-task mining from normalized production traces."""
 
+from wmo.simulation.mining.bindings import (
+    TaskSetLineageBindings,
+    TaskTraceLineageBinding,
+    load_task_set_lineage_bindings,
+)
 from wmo.simulation.mining.cleanup import (
     InstructionCleanupModel,
     InstructionCleanupResult,
@@ -26,10 +31,13 @@ __all__ = [
     "MiningSpec",
     "RoutingDescriptor",
     "TaskMiningResult",
+    "TaskSetLineageBindings",
+    "TaskTraceLineageBinding",
     "assign_source_lineages",
     "clean_instruction",
     "coverage_descriptor",
     "mine_tasks",
+    "load_task_set_lineage_bindings",
     "persist_task_set",
     "routing_descriptor",
 ]

--- a/wmo/simulation/mining/bindings.py
+++ b/wmo/simulation/mining/bindings.py
@@ -1,0 +1,424 @@
+"""Complete immutable trace lineage assignments owned by a built task set."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.tasks import TaskCase, TaskSet, load_task_set
+from wmo.common.traces import load_trace_dataset
+from wmo.simulation.ingest.dataset import verify_current_trace_dataset
+from wmo.simulation.mining.coverage import CoverageReport
+
+if TYPE_CHECKING:
+    from wmo.simulation.mining.service import TaskMiningResult
+
+LINEAGE_BINDINGS_PATH = "lineage-bindings.json"
+_TASK_SET_FILES = frozenset(
+    {"coverage.json", LINEAGE_BINDINGS_PATH, "task-set.json", "tasks.jsonl"}
+)
+
+
+class TaskTraceLineageBinding(ContractModel):
+    """Frozen leakage lineage and partition for one imported trace."""
+
+    trace_id: str = Field(min_length=1, max_length=512)
+    lineage_id: ArtifactId
+    partition: Literal["fit", "held_out"]
+
+
+class TaskSetLineageBindings(ContractModel):
+    """Complete build-owned lineage assignments for a task set's source dataset."""
+
+    schema_version: Literal[1] = 1
+    binding_set_id: ArtifactId
+    task_set_id: ArtifactId
+    trace_dataset: ArtifactInput
+    bindings: tuple[TaskTraceLineageBinding, ...] = Field(min_length=1)
+
+    @field_validator("bindings")
+    @classmethod
+    def _require_sorted_unique_bindings(
+        cls, value: tuple[TaskTraceLineageBinding, ...]
+    ) -> tuple[TaskTraceLineageBinding, ...]:
+        """Require exactly one deterministically ordered assignment per trace.
+
+        Args:
+            value: Complete trace lineage assignments.
+
+        Returns:
+            The validated assignments without modification.
+
+        Raises:
+            ValueError: Trace IDs repeat or are not sorted.
+        """
+        trace_ids = tuple(binding.trace_id for binding in value)
+        if len(set(trace_ids)) != len(trace_ids):
+            raise ValueError("task-set lineage bindings must not repeat trace IDs")
+        if trace_ids != tuple(sorted(trace_ids)):
+            raise ValueError("task-set lineage bindings must be sorted by trace ID")
+        return value
+
+    @model_validator(mode="after")
+    def _require_content_identity(self) -> TaskSetLineageBindings:
+        """Verify that the binding-set identity covers every semantic field.
+
+        Returns:
+            The validated content-addressed payload.
+
+        Raises:
+            ValueError: The stored identity differs from the canonical binding content.
+        """
+        expected = task_set_lineage_binding_id(
+            self.task_set_id,
+            self.trace_dataset,
+            self.bindings,
+        )
+        if self.binding_set_id != expected:
+            raise ValueError("task-set lineage binding ID differs from its complete content")
+        return self
+
+
+def bindings_for_mining(result: TaskMiningResult) -> tuple[TaskTraceLineageBinding, ...]:
+    """Derive complete assignments for every trace in frozen leakage groups.
+
+    Args:
+        result: Completed mining evidence with leakage groups and a frozen partition.
+
+    Returns:
+        One sorted binding for every imported trace.
+
+    Raises:
+        ValueError: Mining evidence repeats a trace or omits a partitioned lineage.
+    """
+    bindings: list[TaskTraceLineageBinding] = []
+    seen: set[str] = set()
+    for group in result.analysis.leakage_groups:
+        partition = result.partition.partition_for(group.lineage_group_id)
+        for trace_id in group.source_trace_ids:
+            if trace_id in seen:
+                raise ValueError(
+                    f"mining evidence repeats trace {trace_id!r} across leakage groups"
+                )
+            seen.add(trace_id)
+            bindings.append(
+                TaskTraceLineageBinding(
+                    trace_id=trace_id,
+                    lineage_id=group.lineage_group_id,
+                    partition=partition,
+                )
+            )
+    return tuple(sorted(bindings, key=lambda item: item.trace_id))
+
+
+def task_set_lineage_binding_material(
+    bindings: tuple[TaskTraceLineageBinding, ...],
+) -> dict[str, object]:
+    """Return canonical versioned material used by the parent task-set identity.
+
+    Args:
+        bindings: Complete sorted assignments derived from mining.
+
+    Returns:
+        JSON-compatible versioned identity material.
+    """
+    return {
+        "version": "task-set-lineage-bindings-v1",
+        "bindings": [binding.model_dump(mode="json") for binding in bindings],
+    }
+
+
+def task_set_content_id(
+    trace_dataset: ArtifactInput,
+    tasks: tuple[TaskCase, ...],
+    coverage: CoverageReport,
+    bindings: tuple[TaskTraceLineageBinding, ...],
+) -> str:
+    """Return the content identity for a build-owned task set and complete bindings.
+
+    Args:
+        trace_dataset: Exact source trace-dataset manifest input.
+        tasks: Ordered representative tasks.
+        coverage: Complete mining coverage report.
+        bindings: Complete sorted imported-trace assignments.
+
+    Returns:
+        Stable task-set artifact identity.
+    """
+    return stable_id(
+        "task-set",
+        {
+            "trace_dataset": trace_dataset.model_dump(mode="json"),
+            "tasks": [task.model_dump(mode="json") for task in tasks],
+            "coverage": coverage.model_dump(mode="json"),
+            "lineage_bindings": task_set_lineage_binding_material(bindings),
+        },
+    )
+
+
+def task_set_lineage_binding_id(
+    task_set_id: str,
+    trace_dataset: ArtifactInput,
+    bindings: tuple[TaskTraceLineageBinding, ...],
+) -> str:
+    """Return the content identity for one complete lineage-binding payload.
+
+    Args:
+        task_set_id: Parent task-set artifact identity.
+        trace_dataset: Exact source trace-dataset manifest input.
+        bindings: Complete sorted trace assignments.
+
+    Returns:
+        Stable lineage-binding payload identity.
+    """
+    return stable_id(
+        "task-set-lineage-bindings",
+        {
+            "task_set_id": task_set_id,
+            "trace_dataset": trace_dataset.model_dump(mode="json"),
+            **task_set_lineage_binding_material(bindings),
+        },
+    )
+
+
+def build_task_set_lineage_bindings(
+    task_set_id: str,
+    trace_dataset: ArtifactInput,
+    result: TaskMiningResult,
+) -> TaskSetLineageBindings:
+    """Materialize a complete typed binding payload from mining evidence.
+
+    Args:
+        task_set_id: Parent task-set artifact identity.
+        trace_dataset: Exact source trace-dataset manifest input.
+        result: Completed mining evidence.
+
+    Returns:
+        Content-addressed lineage-binding payload.
+    """
+    bindings = bindings_for_mining(result)
+    return TaskSetLineageBindings(
+        binding_set_id=task_set_lineage_binding_id(task_set_id, trace_dataset, bindings),
+        task_set_id=task_set_id,
+        trace_dataset=trace_dataset,
+        bindings=bindings,
+    )
+
+
+def load_task_set_lineage_bindings(
+    store: ArtifactStore,
+    task_set_id: str,
+) -> TaskSetLineageBindings:
+    """Load and recursively verify complete lineage assignments for a built task set.
+
+    Args:
+        store: Project-local immutable artifact store.
+        task_set_id: Task-set artifact whose build-owned bindings are required.
+
+    Returns:
+        Verified complete lineage assignments.
+
+    Raises:
+        ArtifactCorruptionError: The payload is missing, corrupt, incomplete, or disagrees with
+            its task set or source trace dataset.
+    """
+    stored = store.read(task_set_id)
+    if stored.manifest.artifact_type != "task-set":
+        raise ArtifactCorruptionError(f"artifact {task_set_id} is not a task-set")
+    if stored.manifest.schema_version != 1:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} uses unsupported schema version "
+            f"{stored.manifest.schema_version}"
+        )
+    paths = {entry.path for entry in stored.manifest.files}
+    if LINEAGE_BINDINGS_PATH not in paths:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} has no complete lineage bindings; rebuild the project "
+            "before refreshing runtime retrieval evidence"
+        )
+    loaded_tasks = load_task_set(store, task_set_id)
+    _require_task_set_manifest_matches_envelope(stored.manifest, loaded_tasks.task_set)
+    if loaded_tasks.task_set.tasks_path != "tasks.jsonl":
+        raise ArtifactCorruptionError(f"task set {task_set_id} uses a noncanonical task path")
+    if loaded_tasks.task_set.coverage_path != "coverage.json":
+        raise ArtifactCorruptionError(f"task set {task_set_id} uses a noncanonical coverage path")
+    if paths != _TASK_SET_FILES:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} does not have the exact complete-lineage file set"
+        )
+    if store.read_bytes(task_set_id, "task-set.json") != canonical_json_bytes(
+        loaded_tasks.task_set
+    ):
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} envelope is not canonical current-build JSON"
+        )
+    task_bytes = store.read_bytes(task_set_id, "tasks.jsonl")
+    expected_task_bytes = b"\n".join(canonical_json_bytes(task) for task in loaded_tasks.tasks)
+    if expected_task_bytes:
+        expected_task_bytes += b"\n"
+    if task_bytes != expected_task_bytes:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} records are not canonical current-build JSONL"
+        )
+    lineage_bytes = store.read_bytes(task_set_id, LINEAGE_BINDINGS_PATH)
+    try:
+        payload = TaskSetLineageBindings.model_validate_json(lineage_bytes)
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} has invalid complete lineage bindings"
+        ) from exc
+    if lineage_bytes != canonical_json_bytes(payload):
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} lineage bindings are not canonical current-build JSON"
+        )
+    if payload.task_set_id != task_set_id:
+        raise ArtifactCorruptionError(
+            f"task-set lineage bindings name {payload.task_set_id}, expected {task_set_id}"
+        )
+    if len(stored.manifest.inputs) != 1:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} must have exactly one source trace-dataset input"
+        )
+    trace_input = stored.manifest.inputs[0]
+    if payload.trace_dataset != trace_input:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} lineage bindings differ from its source dataset input"
+        )
+    trace_stored = store.read(trace_input.artifact_id)
+    if trace_stored.manifest.schema_version != 1:
+        raise ArtifactCorruptionError(
+            f"trace dataset {trace_input.artifact_id} uses unsupported schema version "
+            f"{trace_stored.manifest.schema_version}"
+        )
+    source = load_trace_dataset(store, trace_input.artifact_id)
+    verify_current_trace_dataset(store, source)
+    if artifact_input(trace_stored.manifest) != trace_input:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} source trace-dataset manifest digest differs"
+        )
+    if loaded_tasks.task_set.code_revision != source.dataset.code_revision:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} producer revision differs from its source trace dataset"
+        )
+    if loaded_tasks.task_set.created_at != source.dataset.created_at:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} build timestamp differs from its source trace dataset"
+        )
+    if loaded_tasks.task_set.source is not None:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} must derive source provenance from its trace-dataset input"
+        )
+    expected_trace_ids = tuple(sorted(trace.trace_id for trace in source.traces))
+    actual_trace_ids = tuple(binding.trace_id for binding in payload.bindings)
+    if actual_trace_ids != expected_trace_ids:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} lineage bindings do not cover its exact source traces"
+        )
+    if loaded_tasks.task_set.coverage_path is None:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} has no coverage evidence for lineage verification"
+        )
+    coverage_bytes = store.read_bytes(task_set_id, loaded_tasks.task_set.coverage_path)
+    if hashlib.sha256(coverage_bytes).hexdigest() != loaded_tasks.task_set.coverage_sha256:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} coverage digest does not match its envelope"
+        )
+    try:
+        coverage = CoverageReport.model_validate_json(coverage_bytes)
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} has invalid coverage evidence"
+        ) from exc
+    if coverage_bytes != canonical_json_bytes(coverage):
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} coverage is not canonical current-build JSON"
+        )
+    expected_task_set_id = task_set_content_id(
+        trace_input,
+        loaded_tasks.tasks,
+        coverage,
+        payload.bindings,
+    )
+    if task_set_id != expected_task_set_id:
+        raise ArtifactCorruptionError(
+            f"task set {task_set_id} identity does not bind its complete lineage evidence"
+        )
+    _require_selected_tasks_match_bindings(loaded_tasks.task_set, loaded_tasks.tasks, payload)
+    return payload
+
+
+def _require_task_set_manifest_matches_envelope(
+    manifest: ArtifactManifest,
+    task_set: TaskSet,
+) -> None:
+    """Verify task-set envelope provenance against its artifact manifest.
+
+    Args:
+        manifest: Immutable artifact manifest surrounding the task-set envelope.
+        task_set: Parsed task-set envelope.
+
+    Raises:
+        ArtifactCorruptionError: The envelope inputs differ from the manifest.
+    """
+    if (
+        task_set.schema_version,
+        task_set.created_at,
+        task_set.inputs,
+        task_set.code_revision,
+        task_set.source,
+    ) != (
+        manifest.schema_version,
+        manifest.created_at,
+        manifest.inputs,
+        manifest.code_revision,
+        manifest.source,
+    ):
+        raise ArtifactCorruptionError(
+            f"task set {task_set.task_set_id} envelope differs from its artifact manifest"
+        )
+
+
+def _require_selected_tasks_match_bindings(
+    task_set: TaskSet,
+    tasks: tuple[TaskCase, ...],
+    payload: TaskSetLineageBindings,
+) -> None:
+    """Verify representative tasks agree with complete source assignments.
+
+    Args:
+        task_set: Verified task-set envelope used for actionable error context.
+        tasks: Verified ordered task records.
+        payload: Complete source-trace assignments.
+
+    Raises:
+        ArtifactCorruptionError: A task source is absent or crosses lineage or partition boundaries.
+    """
+    by_trace = {binding.trace_id: binding for binding in payload.bindings}
+    for task in tasks:
+        for trace_id in task.source_trace_ids:
+            binding = by_trace.get(trace_id)
+            if binding is None:
+                raise ArtifactCorruptionError(
+                    f"task set {task_set.task_set_id} task source {trace_id!r} has no lineage "
+                    "binding"
+                )
+            if binding.lineage_id != task.lineage_group_id or binding.partition != task.partition:
+                raise ArtifactCorruptionError(
+                    f"task set {task_set.task_set_id} task source {trace_id!r} disagrees with its "
+                    "lineage binding"
+                )

--- a/wmo/simulation/mining/bindings_test.py
+++ b/wmo/simulation/mining/bindings_test.py
@@ -1,0 +1,1 @@
+"""Tests for build-owned complete lineage assignments."""

--- a/wmo/simulation/mining/service.py
+++ b/wmo/simulation/mining/service.py
@@ -16,9 +16,13 @@ from wmo.common.core.artifacts import (
     canonical_json_bytes,
     stable_id,
 )
-from wmo.common.project import ArtifactAlreadyExistsError, ArtifactStore
+from wmo.common.project import ArtifactAlreadyExistsError, ArtifactStore, artifact_input
 from wmo.common.tasks import TaskCase, TaskSet, load_task_set
-from wmo.common.traces import Trace
+from wmo.common.traces import Trace, load_trace_dataset
+from wmo.simulation.mining.bindings import (
+    TaskSetLineageBindings,
+    build_task_set_lineage_bindings,
+)
 from wmo.simulation.mining.cleanup import (
     InstructionCleanupModel,
     InstructionCleanupResult,
@@ -236,6 +240,13 @@ def persist_task_set(
     """
     task_payload = _jsonl_bytes(result.tasks)
     coverage_payload = canonical_json_bytes(result.coverage)
+    lineage_payload = None
+    if inputs:
+        if len(inputs) != 1:
+            raise ValueError("built task sets require exactly one source trace-dataset input")
+        lineage_bindings = build_task_set_lineage_bindings(task_set_id, inputs[0], result)
+        _require_complete_source_bindings(store, inputs[0], lineage_bindings)
+        lineage_payload = canonical_json_bytes(lineage_bindings)
     task_set = TaskSet(
         schema_version=1,
         created_at=created_at,
@@ -257,17 +268,21 @@ def persist_task_set(
             raise ValueError("existing task set differs from replayed mining evidence")
         if store.read_bytes(task_set_id, "coverage.json") != coverage_payload:
             raise ValueError("existing task-set coverage differs from replayed mining evidence")
+        _require_lineage_replay(store, task_set_id, lineage_payload)
         return loaded.task_set
+    files = {
+        "tasks.jsonl": task_payload,
+        "coverage.json": coverage_payload,
+        "task-set.json": canonical_json_bytes(task_set),
+    }
+    if lineage_payload is not None:
+        files["lineage-bindings.json"] = lineage_payload
     try:
         store.write(
             artifact_id=task_set_id,
             artifact_type="task-set",
             envelope=task_set,
-            files={
-                "tasks.jsonl": task_payload,
-                "coverage.json": coverage_payload,
-                "task-set.json": canonical_json_bytes(task_set),
-            },
+            files=files,
         )
     except ArtifactAlreadyExistsError:
         loaded = load_task_set(store, task_set_id)
@@ -278,8 +293,66 @@ def persist_task_set(
             raise ValueError(
                 "existing task-set coverage differs from replayed mining evidence"
             ) from None
+        _require_lineage_replay(store, task_set_id, lineage_payload)
         return loaded.task_set
     return task_set
+
+
+def _require_lineage_replay(
+    store: ArtifactStore,
+    task_set_id: str,
+    expected_payload: bytes | None,
+) -> None:
+    """Verify that replay preserves the complete optional lineage payload.
+
+    Args:
+        store: Project artifact store owning the existing task set.
+        task_set_id: Existing immutable task-set identity.
+        expected_payload: Canonical payload expected for a built task set, or None for legacy
+            source-free persistence.
+
+    Raises:
+        ValueError: Existing lineage evidence differs from the replay.
+    """
+    paths = {entry.path for entry in store.read(task_set_id).manifest.files}
+    has_payload = "lineage-bindings.json" in paths
+    if expected_payload is None:
+        if has_payload:
+            raise ValueError("existing task set unexpectedly contains lineage bindings")
+        return
+    if (
+        not has_payload
+        or store.read_bytes(task_set_id, "lineage-bindings.json") != expected_payload
+    ):
+        raise ValueError("existing task-set lineage bindings differ from replayed mining evidence")
+
+
+def _require_complete_source_bindings(
+    store: ArtifactStore,
+    trace_dataset_input: ArtifactInput,
+    payload: TaskSetLineageBindings,
+) -> None:
+    """Reject incomplete mining lineage evidence before task-set publication.
+
+    Args:
+        store: Project artifact store owning the exact source trace dataset.
+        trace_dataset_input: Claimed immutable source dataset manifest input.
+        payload: Typed complete lineage payload produced from mining.
+
+    Raises:
+        ValueError: Bindings omit or add traces relative to the exact source dataset.
+        ArtifactCorruptionError: The source artifact or manifest input cannot be verified.
+    """
+    stored = store.read(trace_dataset_input.artifact_id)
+    if artifact_input(stored.manifest) != trace_dataset_input:
+        raise ValueError("task-set source trace-dataset manifest digest differs")
+    source = load_trace_dataset(store, trace_dataset_input.artifact_id)
+    source_trace_ids = tuple(sorted(trace.trace_id for trace in source.traces))
+    binding_trace_ids = tuple(binding.trace_id for binding in payload.bindings)
+    if binding_trace_ids != source_trace_ids:
+        raise ValueError(
+            "task-set lineage bindings must cover every exact source trace once and only once"
+        )
 
 
 def _materialize_tasks(

--- a/wmo/simulation/retrieval/__init__.py
+++ b/wmo/simulation/retrieval/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     )
 
 from wmo.simulation.retrieval.build import PersistedRAGIndex, persist_trace_rag
+from wmo.simulation.retrieval.build_inputs import load_completed_build_rag_lineage_bindings
 from wmo.simulation.retrieval.contracts import (
     RAGAction,
     RAGIndex,
@@ -87,6 +88,7 @@ __all__ = [
     "load_runtime_rag_refresh",
     "load_rag_index",
     "load_fit_rag_retriever",
+    "load_completed_build_rag_lineage_bindings",
     "persist_trace_rag",
     "refresh_runtime_trace_rag",
 ]

--- a/wmo/simulation/retrieval/build_inputs.py
+++ b/wmo/simulation/retrieval/build_inputs.py
@@ -1,0 +1,62 @@
+"""Verified build-owned lineage inputs for runtime retrieval refresh."""
+
+from __future__ import annotations
+
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactStore,
+    ProjectBuildArtifacts,
+    artifact_input,
+)
+from wmo.simulation.mining.bindings import load_task_set_lineage_bindings
+from wmo.simulation.retrieval.contracts import RAGLineageBinding
+
+
+def load_completed_build_rag_lineage_bindings(
+    store: ArtifactStore,
+    completed: ProjectBuildArtifacts,
+) -> tuple[RAGLineageBinding, ...]:
+    """Derive exact refresh bindings from a recursively verified completed build.
+
+    Args:
+        store: Project-local immutable artifact store.
+        completed: Exact immutable outputs selected as the project's completed build.
+
+    Returns:
+        One sorted retrieval binding for every imported source trace.
+
+    Raises:
+        ArtifactCorruptionError: Build pointers, source inputs, or complete bindings are missing or
+            disagree with their immutable artifacts.
+    """
+    task_stored = store.read(completed.task_set.artifact_id)
+    if task_stored.manifest.artifact_type != "task-set":
+        raise ArtifactCorruptionError(
+            f"completed build task-set pointer names {task_stored.manifest.artifact_type}"
+        )
+    if artifact_input(task_stored.manifest) != completed.task_set:
+        raise ArtifactCorruptionError("completed build task-set manifest digest differs")
+    trace_stored = store.read(completed.trace_dataset.artifact_id)
+    if trace_stored.manifest.artifact_type != "trace-dataset":
+        raise ArtifactCorruptionError(
+            f"completed build trace pointer names {trace_stored.manifest.artifact_type}"
+        )
+    if artifact_input(trace_stored.manifest) != completed.trace_dataset:
+        raise ArtifactCorruptionError("completed build trace-dataset manifest digest differs")
+    if task_stored.manifest.inputs != (completed.trace_dataset,):
+        raise ArtifactCorruptionError(
+            "completed build task set does not depend on its exact trace dataset"
+        )
+    payload = load_task_set_lineage_bindings(store, completed.task_set.artifact_id)
+    if payload.trace_dataset != completed.trace_dataset:
+        raise ArtifactCorruptionError(
+            "completed build lineage bindings name a different trace dataset"
+        )
+    return tuple(
+        RAGLineageBinding(
+            trace_id=binding.trace_id,
+            lineage_id=binding.lineage_id,
+            partition=binding.partition,
+        )
+        for binding in payload.bindings
+    )

--- a/wmo/simulation/retrieval/build_inputs_test.py
+++ b/wmo/simulation/retrieval/build_inputs_test.py
@@ -1,0 +1,869 @@
+"""Tests for completed-build retrieval lineage inputs."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmo.common.core.artifacts import ArtifactInput, SourceIdentity, canonical_json_bytes
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactManifest,
+    ArtifactStore,
+    ProjectBuildArtifacts,
+    ProjectConfig,
+    ProjectStore,
+    artifact_input,
+)
+from wmo.common.project.manifests import file_digest
+from wmo.common.project.paths import ProjectPaths
+from wmo.common.tasks import TaskSet
+from wmo.common.traces import Trace, TraceDataset, TraceSource, TraceSpan
+from wmo.simulation.build import TaskSetBuild, build_task_set
+from wmo.simulation.ingest.dataset import current_trace_dataset_id, persist_trace_dataset
+from wmo.simulation.ingest.otlp import TraceNormalizationResult
+from wmo.simulation.mining.bindings import (
+    LINEAGE_BINDINGS_PATH,
+    TaskSetLineageBindings,
+    bindings_for_mining,
+    load_task_set_lineage_bindings,
+    task_set_content_id,
+    task_set_lineage_binding_id,
+)
+from wmo.simulation.mining.service import MiningSpec, persist_task_set
+from wmo.simulation.retrieval.build_inputs import load_completed_build_rag_lineage_bindings
+
+_TIME = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def _trace(
+    trace_id: str,
+    *,
+    conversation_id: str,
+    task: str = "Resolve the same support request",
+    terminal: bool = False,
+) -> Trace:
+    """Create one canonical source trace, optionally without a later observation.
+
+    Args:
+        trace_id: Unique source trace identity.
+        conversation_id: Source conversation used for initial lineage assignment.
+        task: Request-visible task text.
+        terminal: Whether the trace contains only a terminal model action.
+
+    Returns:
+        Canonical OTLP source trace.
+    """
+    spans = [
+        TraceSpan(
+            span_id=f"{trace_id}-action",
+            name="agent.model_call",
+            started_at=_TIME,
+            ended_at=_TIME + timedelta(seconds=1),
+            attributes={
+                "gen_ai.output.messages": [{"role": "assistant", "content": "Resolved response"}]
+            },
+        )
+    ]
+    if not terminal:
+        spans.append(
+            TraceSpan(
+                span_id=f"{trace_id}-observation",
+                parent_span_id=f"{trace_id}-action",
+                name="user",
+                started_at=_TIME + timedelta(seconds=2),
+                ended_at=_TIME + timedelta(seconds=2),
+                attributes={"gen_ai.input.messages": [{"role": "user", "content": "Continue"}]},
+            )
+        )
+    return Trace(
+        trace_id=trace_id,
+        conversation_id=conversation_id,
+        task=task,
+        spans=tuple(spans),
+        source=TraceSource(
+            identity=SourceIdentity(
+                kind="otlp",
+                source_id="fixture.otlp",
+                sha256="a" * 64,
+            ),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def _build(store: ArtifactStore) -> TaskSetBuild:
+    """Build a fixture containing duplicates and a terminal trace.
+
+    Args:
+        store: Project artifact store receiving the build.
+
+    Returns:
+        Completed trace-dataset and task-set artifacts.
+    """
+    return build_task_set(
+        TraceNormalizationResult(
+            traces=(
+                _trace("trace-a", conversation_id="conversation-shared"),
+                _trace("trace-b", conversation_id="conversation-shared"),
+                _trace(
+                    "trace-terminal",
+                    conversation_id="conversation-terminal",
+                    task="Terminal only request",
+                    terminal=True,
+                ),
+            ),
+            issues=(),
+        ),
+        store,
+        created_at=_TIME,
+        code_revision="test-revision",
+        mining_spec=MiningSpec(fit_task_budget=2, held_out_task_budget=1),
+    )
+
+
+def _completed(store: ArtifactStore, build: TaskSetBuild) -> ProjectBuildArtifacts:
+    """Create completed-build pointers around the real trace and task artifacts.
+
+    Args:
+        store: Artifact store owning the task-set manifest.
+        build: Real fixture build outputs.
+
+    Returns:
+        Typed completed build with unrelated unique placeholder outputs.
+    """
+    return ProjectBuildArtifacts(
+        trace_dataset=artifact_input(build.trace_dataset.manifest),
+        task_set=artifact_input(store.read(build.task_set.task_set_id).manifest),
+        serving_rag=ArtifactInput(artifact_id="serving-rag-placeholder", sha256="1" * 64),
+        fit_rag=ArtifactInput(artifact_id="fit-rag-placeholder", sha256="2" * 64),
+        world_model=ArtifactInput(artifact_id="world-model-placeholder", sha256="3" * 64),
+    )
+
+
+def _rebind_task_set_to_dataset_manifest(
+    store: ArtifactStore,
+    build: TaskSetBuild,
+    manifest: ArtifactManifest,
+) -> ProjectBuildArtifacts:
+    """Persist a self-consistent dependent task set over a rewritten source manifest.
+
+    Args:
+        store: Project artifact store owning both graph levels.
+        build: Original mining result and unrelated completed-build placeholders.
+        manifest: Rehashed source trace-dataset manifest.
+
+    Returns:
+        Completed-build pointers naming the rewritten parent and newly identified task set.
+    """
+    trace_input = artifact_input(manifest)
+    bindings = bindings_for_mining(build.mining)
+    task_set_id = task_set_content_id(
+        trace_input,
+        build.mining.tasks,
+        build.mining.coverage,
+        bindings,
+    )
+    task_set = persist_task_set(
+        build.mining,
+        store,
+        task_set_id=task_set_id,
+        created_at=build.trace_dataset.dataset.created_at,
+        code_revision=build.trace_dataset.dataset.code_revision,
+        inputs=(trace_input,),
+    )
+    completed = _completed(store, build)
+    return completed.model_copy(
+        update={
+            "trace_dataset": trace_input,
+            "task_set": artifact_input(store.read(task_set.task_set_id).manifest),
+        }
+    )
+
+
+def test_completed_build_bindings_cover_terminal_and_duplicate_traces(tmp_path: Path) -> None:
+    """Retain every imported trace even when it yields no transition or shares leakage.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+
+    bindings = load_completed_build_rag_lineage_bindings(store, _completed(store, build))
+
+    assert tuple(binding.trace_id for binding in bindings) == (
+        "trace-a",
+        "trace-b",
+        "trace-terminal",
+    )
+    by_trace = {binding.trace_id: binding for binding in bindings}
+    assert by_trace["trace-a"].lineage_id == by_trace["trace-b"].lineage_id
+    assert by_trace["trace-a"].partition == by_trace["trace-b"].partition
+    assert by_trace["trace-terminal"].partition in {"fit", "held_out"}
+
+
+def test_binding_loader_rejects_tamper_and_wrong_completed_pointer(tmp_path: Path) -> None:
+    """Fail closed on changed payload bytes or a stale completed-build digest.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    completed = _completed(store, build)
+    tampered_pointer = completed.model_copy(
+        update={"task_set": completed.task_set.model_copy(update={"sha256": "f" * 64})}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="task-set manifest digest"):
+        load_completed_build_rag_lineage_bindings(store, tampered_pointer)
+
+    lineage_path = (
+        store.project_directory / "artifacts" / build.task_set.task_set_id / LINEAGE_BINDINGS_PATH
+    )
+    lineage_path.write_bytes(lineage_path.read_bytes() + b" ")
+    with pytest.raises(ArtifactCorruptionError, match="digest"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_semantic_tamper(tmp_path: Path) -> None:
+    """Reject a canonical rehash whose changed assignments no longer match the task-set ID.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    payload = TaskSetLineageBindings.model_validate_json(
+        store.read_bytes(task_set_id, LINEAGE_BINDINGS_PATH)
+    )
+    changed = tuple(
+        binding.model_copy(
+            update={"partition": "held_out" if binding.partition == "fit" else "fit"}
+        )
+        if binding.trace_id == "trace-terminal"
+        else binding
+        for binding in payload.bindings
+    )
+    tampered = payload.model_copy(
+        update={
+            "binding_set_id": task_set_lineage_binding_id(
+                task_set_id,
+                payload.trace_dataset,
+                changed,
+            ),
+            "bindings": changed,
+        }
+    )
+    tampered_bytes = canonical_json_bytes(tampered)
+    directory = stored.directory
+    (directory / LINEAGE_BINDINGS_PATH).write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == LINEAGE_BINDINGS_PATH else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(update={"files": files})
+    (directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="identity does not bind"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_task_set_coverage_digest(tmp_path: Path) -> None:
+    """Reject a canonical envelope rehash that lies about the verified coverage bytes.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    envelope = TaskSet.model_validate_json(store.read_bytes(task_set_id, "task-set.json"))
+    tampered = envelope.model_copy(update={"coverage_sha256": "f" * 64})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "task-set.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "task-set.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(update={"files": files})
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="coverage digest"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_task_set_producer_revision(tmp_path: Path) -> None:
+    """Reject a dependent task set whose producer revision differs from its source dataset.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    envelope = TaskSet.model_validate_json(store.read_bytes(task_set_id, "task-set.json"))
+    tampered = envelope.model_copy(update={"code_revision": "different-revision"})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "task-set.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "task-set.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(
+        update={"code_revision": "different-revision", "files": files}
+    )
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="producer revision"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_unsupported_task_set_schema(tmp_path: Path) -> None:
+    """Reject a self-consistent envelope and manifest using an unsupported TaskSet schema.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    envelope = TaskSet.model_validate_json(store.read_bytes(task_set_id, "task-set.json"))
+    tampered = envelope.model_copy(update={"schema_version": 2})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "task-set.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "task-set.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(update={"schema_version": 2, "files": files})
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="unsupported schema version 2"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_unsupported_trace_dataset_schema(
+    tmp_path: Path,
+) -> None:
+    """Reject a self-consistent source envelope and manifest using an unsupported schema.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    dataset_id = build.trace_dataset.dataset.dataset_id
+    stored = store.read(dataset_id)
+    envelope = TraceDataset.model_validate_json(store.read_bytes(dataset_id, "trace-dataset.json"))
+    tampered = envelope.model_copy(update={"schema_version": 2})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "trace-dataset.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "trace-dataset.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(update={"schema_version": 2, "files": files})
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+
+    with pytest.raises(ArtifactCorruptionError, match="unsupported schema version 2"):
+        load_task_set_lineage_bindings(store, build.task_set.task_set_id)
+
+
+@pytest.mark.parametrize("changed_field", ["semantic_convention_version", "source"])
+def test_binding_loader_rejects_rehashed_trace_source_contract(
+    tmp_path: Path,
+    changed_field: str,
+) -> None:
+    """Reject source or convention drift propagated through a reidentified dependent task set.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        changed_field: TraceDataset source-contract field to rewrite.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    dataset_id = build.trace_dataset.dataset.dataset_id
+    stored = store.read(dataset_id)
+    envelope = TraceDataset.model_validate_json(store.read_bytes(dataset_id, "trace-dataset.json"))
+    if changed_field == "semantic_convention_version":
+        update: dict[str, object] = {changed_field: "9.9.9"}
+        manifest_update: dict[str, object] = {}
+    else:
+        changed_source = SourceIdentity(
+            kind="otlp",
+            source_id="different.otlp",
+            sha256="b" * 64,
+        )
+        update = {changed_field: changed_source}
+        manifest_update = {changed_field: changed_source}
+    tampered = envelope.model_copy(update=update)
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "trace-dataset.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "trace-dataset.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(update={**manifest_update, "files": files})
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _rebind_task_set_to_dataset_manifest(store, build, tampered_manifest)
+
+    with pytest.raises(ArtifactCorruptionError, match="source or convention"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_explicit_non_content_trace_dataset_id(tmp_path: Path) -> None:
+    """Require current automatic source identity instead of guessing an explicit dataset ID.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    automatic = _build(store)
+    explicit = persist_trace_dataset(
+        TraceNormalizationResult(traces=automatic.trace_dataset.traces, issues=()),
+        store,
+        created_at=_TIME,
+        code_revision="test-revision",
+        dataset_id="explicit-trace-dataset",
+    )
+    completed = _rebind_task_set_to_dataset_manifest(store, automatic, explicit.manifest)
+
+    with pytest.raises(ArtifactCorruptionError, match="not a current content-addressed"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+@pytest.mark.parametrize(
+    "issues_value",
+    [
+        {"invalid_trace_count": 0},
+        {"invalid_trace_count": 0, "issues": "not-a-list"},
+        {"invalid_trace_count": 1, "issues": [{"source_record": "line-1"}]},
+        {
+            "invalid_trace_count": 1,
+            "issues": [{"source_record": 1, "message": "bad record"}],
+        },
+        {
+            "invalid_trace_count": 1,
+            "issues": [{"source_record": "line-1", "message": "bad record", "extra": True}],
+        },
+        {"invalid_trace_count": 0, "issues": [], "extra": True},
+        {
+            "invalid_trace_count": 0,
+            "issues": [{"source_record": "line-1", "message": "bad record"}],
+        },
+    ],
+)
+def test_binding_loader_rejects_malformed_normalization_issue_payloads(
+    tmp_path: Path,
+    issues_value: dict[str, object],
+) -> None:
+    """Require the exact issue schema and count before accepting lineage parents.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        issues_value: Malformed or internally inconsistent issue payload.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    original = build.trace_dataset.dataset
+    assert original.source is not None
+    traces_bytes = store.read_bytes(original.dataset_id, "traces.jsonl")
+    issues_bytes = canonical_json_bytes(issues_value)
+    malicious_id = current_trace_dataset_id(
+        source=original.source,
+        semantic_convention_version=original.semantic_convention_version,
+        traces_sha256=hashlib.sha256(traces_bytes).hexdigest(),
+        issues_sha256=hashlib.sha256(issues_bytes).hexdigest(),
+        code_revision=original.code_revision,
+    )
+    malicious = original.model_copy(
+        update={
+            "dataset_id": malicious_id,
+            "issues_sha256": hashlib.sha256(issues_bytes).hexdigest(),
+        }
+    )
+    malicious_manifest = store.write(
+        artifact_id=malicious_id,
+        artifact_type="trace-dataset",
+        envelope=malicious,
+        files={
+            "traces.jsonl": traces_bytes,
+            "normalization-issues.json": issues_bytes,
+            "trace-dataset.json": canonical_json_bytes(malicious),
+        },
+    )
+    completed = _rebind_task_set_to_dataset_manifest(store, build, malicious_manifest)
+
+    with pytest.raises(ArtifactCorruptionError, match="invalid normalization issues"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_trace_dataset_input(tmp_path: Path) -> None:
+    """Reject a raw-source dataset that claims a forged upstream artifact input.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    dataset_id = build.trace_dataset.dataset.dataset_id
+    stored = store.read(dataset_id)
+    envelope = TraceDataset.model_validate_json(store.read_bytes(dataset_id, "trace-dataset.json"))
+    forged_input = ArtifactInput(artifact_id="forged-parent", sha256="e" * 64)
+    tampered = envelope.model_copy(update={"inputs": (forged_input,)})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "trace-dataset.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "trace-dataset.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(
+        update={"inputs": (forged_input,), "files": files}
+    )
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _rebind_task_set_to_dataset_manifest(store, build, tampered_manifest)
+
+    with pytest.raises(ArtifactCorruptionError, match="must not have artifact inputs"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["trace-dataset.json", "traces.jsonl", "normalization-issues.json"],
+)
+def test_binding_loader_rejects_noncanonical_trace_dataset_payloads(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    """Reject equivalent noncanonical bytes across every current trace payload class.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        relative_path: Trace artifact payload to rewrite with valid leading whitespace.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    original = build.trace_dataset.dataset
+    assert original.source is not None
+    traces_bytes = store.read_bytes(original.dataset_id, "traces.jsonl")
+    issues_bytes = store.read_bytes(original.dataset_id, "normalization-issues.json")
+    if relative_path == "traces.jsonl":
+        traces_bytes = b" " + traces_bytes
+    elif relative_path == "normalization-issues.json":
+        issues_bytes = b" " + issues_bytes
+    resolved_id = current_trace_dataset_id(
+        source=original.source,
+        semantic_convention_version=original.semantic_convention_version,
+        traces_sha256=hashlib.sha256(traces_bytes).hexdigest(),
+        issues_sha256=hashlib.sha256(issues_bytes).hexdigest(),
+        code_revision=original.code_revision,
+    )
+    rewritten = original.model_copy(
+        update={
+            "dataset_id": resolved_id,
+            "traces_sha256": hashlib.sha256(traces_bytes).hexdigest(),
+            "issues_sha256": hashlib.sha256(issues_bytes).hexdigest(),
+        }
+    )
+    envelope_bytes = canonical_json_bytes(rewritten)
+    if relative_path == "trace-dataset.json":
+        envelope_bytes = b" " + envelope_bytes
+        stored = store.read(original.dataset_id)
+        (stored.directory / "trace-dataset.json").write_bytes(envelope_bytes)
+        files = tuple(
+            file_digest(entry.path, envelope_bytes) if entry.path == "trace-dataset.json" else entry
+            for entry in stored.manifest.files
+        )
+        manifest = stored.manifest.model_copy(update={"files": files})
+        (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(manifest))
+    else:
+        manifest = store.write(
+            artifact_id=resolved_id,
+            artifact_type="trace-dataset",
+            envelope=rewritten,
+            files={
+                "traces.jsonl": traces_bytes,
+                "normalization-issues.json": issues_bytes,
+                "trace-dataset.json": envelope_bytes,
+            },
+        )
+    completed = _rebind_task_set_to_dataset_manifest(store, build, manifest)
+
+    with pytest.raises(ArtifactCorruptionError, match="not canonical current-build"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["task-set.json", "tasks.jsonl", "coverage.json", LINEAGE_BINDINGS_PATH],
+)
+def test_binding_loader_rejects_noncanonical_task_set_payloads(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    """Reject equivalent noncanonical bytes across every current task payload class.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        relative_path: Task artifact payload to rewrite with valid leading whitespace.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    payloads = {
+        entry.path: store.read_bytes(task_set_id, entry.path) for entry in stored.manifest.files
+    }
+    payloads[relative_path] = b" " + payloads[relative_path]
+    envelope = TaskSet.model_validate_json(payloads["task-set.json"])
+    updates: dict[str, object] = {}
+    if relative_path == "tasks.jsonl":
+        updates["tasks_sha256"] = hashlib.sha256(payloads[relative_path]).hexdigest()
+    elif relative_path == "coverage.json":
+        updates["coverage_sha256"] = hashlib.sha256(payloads[relative_path]).hexdigest()
+    if updates:
+        envelope = envelope.model_copy(update=updates)
+        payloads["task-set.json"] = canonical_json_bytes(envelope)
+    files = tuple(file_digest(path, payload) for path, payload in sorted(payloads.items()))
+    tampered_manifest = stored.manifest.model_copy(update={"files": files})
+    for path, payload in payloads.items():
+        (stored.directory / path).write_bytes(payload)
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="not canonical current-build"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_task_set_build_timestamp(tmp_path: Path) -> None:
+    """Reject a task-set materialization time that differs from its source dataset.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    envelope = TaskSet.model_validate_json(store.read_bytes(task_set_id, "task-set.json"))
+    changed_time = envelope.created_at + timedelta(days=1)
+    tampered = envelope.model_copy(update={"created_at": changed_time})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / "task-set.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest(entry.path, tampered_bytes) if entry.path == "task-set.json" else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(
+        update={"created_at": changed_time, "files": files}
+    )
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="build timestamp"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+@pytest.mark.parametrize(
+    ("envelope_field", "canonical_path", "alternate_path", "message"),
+    [
+        ("tasks_path", "tasks.jsonl", "alternate-tasks.jsonl", "noncanonical task path"),
+        (
+            "coverage_path",
+            "coverage.json",
+            "alternate-coverage.json",
+            "noncanonical coverage path",
+        ),
+    ],
+)
+def test_binding_loader_rejects_rehashed_noncanonical_task_set_paths(
+    tmp_path: Path,
+    envelope_field: str,
+    canonical_path: str,
+    alternate_path: str,
+    message: str,
+) -> None:
+    """Reject path relocation even when envelope, bytes, and manifest agree.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        envelope_field: TaskSet path field to replace.
+        canonical_path: Current canonical artifact-relative file path.
+        alternate_path: Self-consistent noncanonical replacement path.
+        message: Expected actionable loader error.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    envelope = TaskSet.model_validate_json(store.read_bytes(task_set_id, "task-set.json"))
+    tampered = envelope.model_copy(update={envelope_field: alternate_path})
+    tampered_bytes = canonical_json_bytes(tampered)
+    (stored.directory / canonical_path).rename(stored.directory / alternate_path)
+    (stored.directory / "task-set.json").write_bytes(tampered_bytes)
+    files = tuple(
+        file_digest("task-set.json", tampered_bytes)
+        if entry.path == "task-set.json"
+        else entry.model_copy(update={"path": alternate_path})
+        if entry.path == canonical_path
+        else entry
+        for entry in stored.manifest.files
+    )
+    tampered_manifest = stored.manifest.model_copy(
+        update={"files": tuple(sorted(files, key=lambda item: item.path))}
+    )
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match=message):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_binding_loader_rejects_rehashed_extra_task_set_file(tmp_path: Path) -> None:
+    """Reject an unrecognized file even when its bytes are manifest-digested.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    task_set_id = build.task_set.task_set_id
+    stored = store.read(task_set_id)
+    extra_bytes = b"{}"
+    (stored.directory / "extra.json").write_bytes(extra_bytes)
+    files = tuple(
+        sorted(
+            (*stored.manifest.files, file_digest("extra.json", extra_bytes)),
+            key=lambda item: item.path,
+        )
+    )
+    tampered_manifest = stored.manifest.model_copy(update={"files": files})
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(tampered_manifest))
+    completed = _completed(store, build).model_copy(
+        update={"task_set": artifact_input(tampered_manifest)}
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="exact complete-lineage file set"):
+        load_completed_build_rag_lineage_bindings(store, completed)
+
+
+def test_legacy_task_set_loads_but_complete_binding_loader_is_actionable(tmp_path: Path) -> None:
+    """Preserve legacy TaskSet loading while requiring rebuild for refresh bindings.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    legacy = persist_task_set(
+        build.mining,
+        store,
+        task_set_id="legacy-task-set",
+        created_at=_TIME,
+        code_revision="legacy-revision",
+    )
+
+    assert legacy.task_set_id == "legacy-task-set"
+    with pytest.raises(ArtifactCorruptionError, match="rebuild the project"):
+        load_task_set_lineage_bindings(store, legacy.task_set_id)
+
+
+@pytest.mark.parametrize("replacement_trace_ids", [(), ("trace-terminal", "extra-trace")])
+def test_task_set_persistence_rejects_incomplete_or_extra_bindings_before_write(
+    tmp_path: Path,
+    replacement_trace_ids: tuple[str, ...],
+) -> None:
+    """Compare mining assignments to the exact source dataset before artifact publication.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+        replacement_trace_ids: Tampered source membership for the terminal leakage group.
+    """
+    store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
+    build = _build(store)
+    groups = tuple(
+        replace(group, source_trace_ids=replacement_trace_ids)
+        if "trace-terminal" in group.source_trace_ids
+        else group
+        for group in build.mining.analysis.leakage_groups
+    )
+    tampered = replace(
+        build.mining,
+        analysis=replace(build.mining.analysis, leakage_groups=groups),
+    )
+    before_ids = store.list_ids()
+
+    with pytest.raises(ValueError, match="cover every exact source trace"):
+        persist_task_set(
+            tampered,
+            store,
+            task_set_id="tampered-task-set",
+            created_at=_TIME,
+            code_revision="test-revision",
+            inputs=(artifact_input(build.trace_dataset.manifest),),
+        )
+
+    assert store.list_ids() == before_ids
+
+
+def test_exact_build_replay_reuses_binding_payload_and_does_not_mutate_project(
+    tmp_path: Path,
+) -> None:
+    """Reuse exact binding bytes and leave mutable project selection untouched.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+    """
+    project = ProjectStore(tmp_path, "support")
+    project.initialize(ProjectConfig(project_id="support"))
+    before_project = project.paths.project_toml.read_bytes()
+    first = _build(project.artifacts)
+    first_payload = project.artifacts.read_bytes(
+        first.task_set.task_set_id,
+        LINEAGE_BINDINGS_PATH,
+    )
+    first_ids = project.artifacts.list_ids()
+
+    replay = _build(project.artifacts)
+    bindings = load_completed_build_rag_lineage_bindings(
+        project.artifacts,
+        _completed(project.artifacts, replay),
+    )
+
+    assert replay.task_set.task_set_id == first.task_set.task_set_id
+    assert project.artifacts.list_ids() == first_ids
+    assert (
+        project.artifacts.read_bytes(replay.task_set.task_set_id, LINEAGE_BINDINGS_PATH)
+        == first_payload
+    )
+    assert len(bindings) == 3
+    assert project.paths.project_toml.read_bytes() == before_project

--- a/wmo/simulation/retrieval/build_inputs_test.py
+++ b/wmo/simulation/retrieval/build_inputs_test.py
@@ -24,7 +24,11 @@ from wmo.common.project.paths import ProjectPaths
 from wmo.common.tasks import TaskSet
 from wmo.common.traces import Trace, TraceDataset, TraceSource, TraceSpan
 from wmo.simulation.build import TaskSetBuild, build_task_set
-from wmo.simulation.ingest.dataset import current_trace_dataset_id, persist_trace_dataset
+from wmo.simulation.ingest.dataset import (
+    MODEL_IDENTITY_EVIDENCE_PATH,
+    current_trace_dataset_id,
+    persist_trace_dataset,
+)
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
 from wmo.simulation.mining.bindings import (
     LINEAGE_BINDINGS_PATH,
@@ -492,11 +496,13 @@ def test_binding_loader_rejects_malformed_normalization_issue_payloads(
     assert original.source is not None
     traces_bytes = store.read_bytes(original.dataset_id, "traces.jsonl")
     issues_bytes = canonical_json_bytes(issues_value)
+    identity_bytes = store.read_bytes(original.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
     malicious_id = current_trace_dataset_id(
         source=original.source,
         semantic_convention_version=original.semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_bytes).hexdigest(),
         issues_sha256=hashlib.sha256(issues_bytes).hexdigest(),
+        identity_evidence_sha256=hashlib.sha256(identity_bytes).hexdigest(),
         code_revision=original.code_revision,
     )
     malicious = original.model_copy(
@@ -512,6 +518,7 @@ def test_binding_loader_rejects_malformed_normalization_issue_payloads(
         files={
             "traces.jsonl": traces_bytes,
             "normalization-issues.json": issues_bytes,
+            MODEL_IDENTITY_EVIDENCE_PATH: identity_bytes,
             "trace-dataset.json": canonical_json_bytes(malicious),
         },
     )
@@ -570,6 +577,7 @@ def test_binding_loader_rejects_noncanonical_trace_dataset_payloads(
     assert original.source is not None
     traces_bytes = store.read_bytes(original.dataset_id, "traces.jsonl")
     issues_bytes = store.read_bytes(original.dataset_id, "normalization-issues.json")
+    identity_bytes = store.read_bytes(original.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
     if relative_path == "traces.jsonl":
         traces_bytes = b" " + traces_bytes
     elif relative_path == "normalization-issues.json":
@@ -579,6 +587,7 @@ def test_binding_loader_rejects_noncanonical_trace_dataset_payloads(
         semantic_convention_version=original.semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_bytes).hexdigest(),
         issues_sha256=hashlib.sha256(issues_bytes).hexdigest(),
+        identity_evidence_sha256=hashlib.sha256(identity_bytes).hexdigest(),
         code_revision=original.code_revision,
     )
     rewritten = original.model_copy(
@@ -607,6 +616,7 @@ def test_binding_loader_rejects_noncanonical_trace_dataset_payloads(
             files={
                 "traces.jsonl": traces_bytes,
                 "normalization-issues.json": issues_bytes,
+                MODEL_IDENTITY_EVIDENCE_PATH: identity_bytes,
                 "trace-dataset.json": envelope_bytes,
             },
         )

--- a/wmo/simulation/retrieval/refresh.py
+++ b/wmo/simulation/retrieval/refresh.py
@@ -114,20 +114,20 @@ class RuntimeRAGRefresh(ArtifactEnvelope):
     @field_validator("maximum_embedding_cost_usd", "reserved_embedding_cost_usd")
     @classmethod
     def _require_finite_cost(cls, value: float) -> float:
-        """Reject non-finite refresh costs.
+        """Canonicalize finite refresh costs stored in the receipt.
 
         Args:
             value: Nonnegative cost supplied for validation.
 
         Returns:
-            The unchanged finite value.
+            The finite value with every signed zero represented as ``0.0``.
 
         Raises:
             ValueError: The cost is infinite or NaN.
         """
         if not math.isfinite(value):
             raise ValueError("runtime RAG refresh costs must be finite")
-        return value
+        return 0.0 if value == 0.0 else value
 
     @model_validator(mode="after")
     def _require_receipt_identity(self) -> RuntimeRAGRefresh:
@@ -227,7 +227,7 @@ def refresh_runtime_trace_rag(
             cannot be proven before or after dispatch.
         RuntimeTraceSnapshotError: The selected journal prefix cannot be sealed.
     """
-    _require_finite_nonnegative_cost(maximum_embedding_cost_usd)
+    maximum_embedding_cost_usd = _normalize_finite_nonnegative_cost(maximum_embedding_cost_usd)
     imports = tuple(sorted(imported_trace_datasets, key=lambda item: item.artifact_id))
     if len({item.artifact_id for item in imports}) != len(imports):
         raise RuntimeRAGRefreshError("imported runtime RAG datasets must not repeat")
@@ -794,14 +794,19 @@ def _envelope_identity(
     )
 
 
-def _require_finite_nonnegative_cost(value: float) -> None:
-    """Reject an unknown or negative refresh cost ceiling.
+def _normalize_finite_nonnegative_cost(value: float) -> float:
+    """Normalize one caller-authorized refresh ceiling before observable work.
 
     Args:
         value: Caller-authorized maximum USD spend.
 
+    Returns:
+        A finite nonnegative float with every signed zero represented as ``0.0``.
+
     Raises:
-        RuntimeRAGRefreshError: The ceiling is negative, infinite, or NaN.
+        RuntimeRAGRefreshError: The ceiling is boolean, negative, infinite, or NaN.
     """
-    if not math.isfinite(value) or value < 0:
+    if isinstance(value, bool) or not math.isfinite(value) or value < 0:
         raise RuntimeRAGRefreshError("maximum_embedding_cost_usd must be finite and nonnegative")
+    normalized = float(value)
+    return 0.0 if normalized == 0.0 else normalized

--- a/wmo/simulation/retrieval/refresh_test.py
+++ b/wmo/simulation/retrieval/refresh_test.py
@@ -35,6 +35,7 @@ from wmo.common.models import (
 from wmo.common.project import (
     ArtifactCorruptionError,
     ArtifactStore,
+    ProjectBuildArtifacts,
     ProjectPaths,
     artifact_input,
 )
@@ -42,8 +43,10 @@ from wmo.common.routing import RouterFeatureExtractor, RoutingDecision
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.runtime.router import RuntimeAcceptedEvent, RuntimeInteractionJournal
 from wmo.runtime.router.journal import RuntimeAcceptance, _interaction_identity
+from wmo.simulation.build import build_task_set
 from wmo.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_dataset
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
+from wmo.simulation.mining.service import MiningSpec
 from wmo.simulation.retrieval import (
     PersistedRuntimeRAGRefresh,
     RAGAction,
@@ -54,6 +57,7 @@ from wmo.simulation.retrieval import (
     RuntimeRAGRefreshError,
     RuntimeTraceStitchingError,
     TraceRAGRetriever,
+    load_completed_build_rag_lineage_bindings,
     load_rag_index,
     load_runtime_rag_refresh,
     refresh_runtime_trace_rag,
@@ -855,21 +859,30 @@ def test_real_import_and_runtime_snapshot_build_one_new_union_and_index(tmp_path
         tmp_path: Pytest-owned project directory.
     """
     journal, store, first = _two_turn_journal(tmp_path)
-    imported = _persist_imported_trace(store, source_kind="otlp")
+    built = build_task_set(
+        TraceNormalizationResult(traces=(_imported_trace(source_kind="otlp"),), issues=()),
+        store,
+        created_at=_TIME,
+        code_revision="test-revision",
+        mining_spec=MiningSpec(fit_task_budget=1, held_out_task_budget=0),
+    )
+    imported = built.trace_dataset
     imported_input = artifact_input(imported.manifest)
+    completed = ProjectBuildArtifacts(
+        trace_dataset=imported_input,
+        task_set=artifact_input(store.read(built.task_set.task_set_id).manifest),
+        serving_rag=ArtifactInput(artifact_id="serving-rag-placeholder", sha256="1" * 64),
+        fit_rag=ArtifactInput(artifact_id="fit-rag-placeholder", sha256="2" * 64),
+        world_model=ArtifactInput(artifact_id="world-model-placeholder", sha256="3" * 64),
+    )
+    imported_bindings = load_completed_build_rag_lineage_bindings(store, completed)
     binding = _binding(CountingEmbedder())
 
     result = refresh_runtime_trace_rag(
         journal,
         store,
         (imported_input,),
-        (
-            RAGLineageBinding(
-                trace_id=imported.traces[0].trace_id,
-                lineage_id="imported-lineage",
-                partition="fit",
-            ),
-        ),
+        imported_bindings,
         embedder=binding,
         embedding_reservation=_reservation(binding),
         maximum_embedding_cost_usd=1.0,
@@ -890,7 +903,7 @@ def test_real_import_and_runtime_snapshot_build_one_new_union_and_index(tmp_path
     assert {
         (transition.trace_id, transition.lineage_id) for transition in result.retrieval.transitions
     } == {
-        (imported.traces[0].trace_id, "imported-lineage"),
+        (imported.traces[0].trace_id, imported_bindings[0].lineage_id),
         (first.interaction_id, first.lineage_id),
     }
 
@@ -1101,6 +1114,27 @@ def _persist_imported_trace(
     Returns:
         Completed canonical imported dataset.
     """
+    trace = _imported_trace(source_kind=source_kind)
+    return persist_trace_dataset(
+        TraceNormalizationResult(traces=(trace,), issues=()),
+        store,
+        created_at=_TIME - timedelta(minutes=1),
+        code_revision="import-revision",
+    )
+
+
+def _imported_trace(
+    *,
+    source_kind: Literal["file", "otlp", "production", "simulation", "manual", "generated"],
+) -> Trace:
+    """Create one imported trace with selectable source provenance.
+
+    Args:
+        source_kind: SourceIdentity kind used for trace provenance.
+
+    Returns:
+        Canonical imported trace with one observed transition.
+    """
     source = TraceSource(
         identity=SourceIdentity(
             kind=source_kind,
@@ -1109,7 +1143,7 @@ def _persist_imported_trace(
         ),
         semantic_convention_version="1.0",
     )
-    trace = Trace(
+    return Trace(
         trace_id=f"{source_kind}-trace",
         conversation_id="imported-lineage",
         task="Imported task",
@@ -1136,10 +1170,4 @@ def _persist_imported_trace(
         ),
         outcome=TraceOutcome(status="success"),
         source=source,
-    )
-    return persist_trace_dataset(
-        TraceNormalizationResult(traces=(trace,), issues=()),
-        store,
-        created_at=_TIME - timedelta(minutes=1),
-        code_revision="import-revision",
     )

--- a/wmo/simulation/retrieval/refresh_test.py
+++ b/wmo/simulation/retrieval/refresh_test.py
@@ -366,6 +366,7 @@ def _refresh(
     binding: RAGEmbedderBinding,
     *,
     created_at: datetime = _TIME + timedelta(hours=1),
+    maximum_embedding_cost_usd: float = 1.0,
 ) -> PersistedRuntimeRAGRefresh:
     """Run one fixture refresh with no imported source datasets.
 
@@ -374,6 +375,7 @@ def _refresh(
         store: Same-project immutable artifact store.
         binding: Explicit configured embedder.
         created_at: Materialization time for new artifacts.
+        maximum_embedding_cost_usd: Caller-authorized total embedding ceiling.
 
     Returns:
         Completed runtime retrieval refresh result.
@@ -385,10 +387,85 @@ def _refresh(
         (),
         embedder=binding,
         embedding_reservation=_reservation(binding),
-        maximum_embedding_cost_usd=1.0,
+        maximum_embedding_cost_usd=maximum_embedding_cost_usd,
         created_at=created_at,
         code_revision="test-revision",
     )
+
+
+def test_zero_cost_int_and_float_share_identity_and_replay_without_dispatch(
+    tmp_path: Path,
+) -> None:
+    """Canonicalize a public integer zero before identity and durable materialization.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    journal, store, _first = _two_turn_journal(tmp_path)
+    client = CountingEmbedder()
+    configured = _binding(client)
+    binding = RAGEmbedderBinding(
+        client=client,
+        snapshot=configured.snapshot,
+        maximum_attempts=configured.maximum_attempts,
+        input_usd_per_million_tokens=0.0,
+    )
+
+    first = _refresh(
+        journal,
+        store,
+        binding,
+        maximum_embedding_cost_usd=0,
+    )
+    completed_artifacts = {path.name for path in (store.project_directory / "artifacts").iterdir()}
+    replay = _refresh(
+        journal,
+        store,
+        binding,
+        created_at=_TIME + timedelta(days=1),
+        maximum_embedding_cost_usd=0.0,
+    )
+
+    assert first.refresh.maximum_embedding_cost_usd == 0.0
+    assert isinstance(first.refresh.maximum_embedding_cost_usd, float)
+    assert replay.refresh == first.refresh
+    assert replay.retrieval.index == first.retrieval.index
+    assert client.calls == 1
+    assert {
+        path.name for path in (store.project_directory / "artifacts").iterdir()
+    } == completed_artifacts
+
+
+@pytest.mark.parametrize(
+    "ceiling",
+    (True, -0.01, float("nan"), float("inf"), float("-inf")),
+)
+def test_invalid_cost_ceiling_fails_before_artifact_or_embedding(
+    tmp_path: Path,
+    ceiling: float,
+) -> None:
+    """Reject invalid public ceilings before sealing evidence or spending.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+        ceiling: Boolean, negative, or non-finite caller input.
+    """
+    journal, store, _first = _two_turn_journal(tmp_path)
+    client = CountingEmbedder()
+
+    with pytest.raises(
+        RuntimeRAGRefreshError,
+        match="maximum_embedding_cost_usd must be finite and nonnegative",
+    ):
+        _refresh(
+            journal,
+            store,
+            _binding(client),
+            maximum_embedding_cost_usd=ceiling,
+        )
+
+    assert client.calls == 0
+    assert not (store.project_directory / "artifacts").exists()
 
 
 def test_two_turn_refresh_indexes_observed_turn_and_excludes_terminal_output(

--- a/wmo/simulation/world_model/__init__.py
+++ b/wmo/simulation/world_model/__init__.py
@@ -1,5 +1,14 @@
 """Persisted grounded world-model build artifacts and executable runtime."""
 
+from wmo.simulation.world_model.application import (
+    WorldModel,
+    WorldModelLoadError,
+    WorldModelObservation,
+    WorldModelSession,
+    WorldModelSessionError,
+    WorldModelSessionLimits,
+    load_world_model,
+)
 from wmo.simulation.world_model.artifact import (
     GROUNDED_WORLD_MODEL_ARTIFACT_TYPE,
     GroundedWorldModelArtifact,
@@ -17,7 +26,14 @@ __all__ = [
     "GroundedWorldModel",
     "GroundedWorldModelArtifact",
     "PersistedGroundedWorldModel",
+    "WorldModel",
+    "WorldModelLoadError",
+    "WorldModelObservation",
+    "WorldModelSession",
+    "WorldModelSessionError",
+    "WorldModelSessionLimits",
     "bind_fit_grounded_world_model",
     "load_grounded_world_model",
+    "load_world_model",
     "persist_grounded_world_model",
 ]

--- a/wmo/simulation/world_model/__init__.py
+++ b/wmo/simulation/world_model/__init__.py
@@ -1,14 +1,26 @@
 """Persisted grounded world-model build artifacts and executable runtime."""
 
-from wmo.simulation.world_model.application import (
-    WorldModel,
-    WorldModelLoadError,
-    WorldModelObservation,
-    WorldModelSession,
-    WorldModelSessionError,
-    WorldModelSessionLimits,
-    load_world_model,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wmo.simulation.world_model.application import WorldModel as WorldModel
+    from wmo.simulation.world_model.application import (
+        WorldModelLoadError as WorldModelLoadError,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelObservation as WorldModelObservation,
+    )
+    from wmo.simulation.world_model.application import WorldModelSession as WorldModelSession
+    from wmo.simulation.world_model.application import (
+        WorldModelSessionError as WorldModelSessionError,
+    )
+    from wmo.simulation.world_model.application import (
+        WorldModelSessionLimits as WorldModelSessionLimits,
+    )
+    from wmo.simulation.world_model.application import load_world_model as load_world_model
 from wmo.simulation.world_model.artifact import (
     GROUNDED_WORLD_MODEL_ARTIFACT_TYPE,
     GroundedWorldModelArtifact,
@@ -19,6 +31,18 @@ from wmo.simulation.world_model.runtime import (
     GroundedWorldModel,
     bind_fit_grounded_world_model,
     load_grounded_world_model,
+)
+
+_APPLICATION_EXPORTS = frozenset(
+    {
+        "WorldModel",
+        "WorldModelLoadError",
+        "WorldModelObservation",
+        "WorldModelSession",
+        "WorldModelSessionError",
+        "WorldModelSessionLimits",
+        "load_world_model",
+    }
 )
 
 __all__ = [
@@ -37,3 +61,27 @@ __all__ = [
     "load_world_model",
     "persist_grounded_world_model",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve one public application service without loading it during package import.
+
+    Args:
+        name: Package attribute requested by Python.
+
+    Returns:
+        The supported public application object loaded from its owning module.
+
+    Raises:
+        AttributeError: The name is not a lazy public application export.
+    """
+    if name not in _APPLICATION_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module("wmo.simulation.world_model.application"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return module globals plus supported lazy application exports."""
+    return sorted(set(globals()) | _APPLICATION_EXPORTS)

--- a/wmo/simulation/world_model/application.py
+++ b/wmo/simulation/world_model/application.py
@@ -1,0 +1,477 @@
+"""Public project-name loader and bounded sessions for grounded world models."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+import uuid
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock, RLock
+from typing import cast
+
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionUserMessageParam,
+)
+
+from wmo.common.core.artifacts import ArtifactInput, JsonObject, canonical_json_bytes, stable_id
+from wmo.common.models import AssistantAction, ModelMessage, load_model_catalog
+from wmo.common.project import ProjectStore, ProjectStoreError
+from wmo.common.tasks import TaskCase
+from wmo.runtime.models import CapabilityRequirement, RuntimeModelCatalog
+from wmo.runtime.models.providers.retry import RetryPolicy
+from wmo.simulation.retrieval import RAGEmbedderBinding
+from wmo.simulation.world_model.runtime import (
+    GroundedWorldModel,
+    load_grounded_world_model,
+)
+
+
+class WorldModelLoadError(ValueError):
+    """A named project cannot load one exact executable serving world model."""
+
+
+class WorldModelSessionError(ValueError):
+    """A public world-model session request violates its bounded text contract."""
+
+
+@dataclass(frozen=True)
+class WorldModelSessionLimits:
+    """Explicit resource limits for one in-memory public world-model runtime."""
+
+    maximum_sessions: int = 256
+    session_ttl_seconds: float = 3_600.0
+    maximum_messages_per_session: int = 128
+    maximum_transcript_bytes: int = 1_048_576
+    maximum_observation_bytes: int = 65_536
+    maximum_task_bytes: int = 65_536
+    maximum_initial_context_bytes: int = 262_144
+
+    def __post_init__(self) -> None:
+        """Validate every count, time, and byte ceiling.
+
+        Raises:
+            ValueError: A limit is nonpositive or the TTL is not finite.
+        """
+        integer_limits = (
+            self.maximum_sessions,
+            self.maximum_messages_per_session,
+            self.maximum_transcript_bytes,
+            self.maximum_observation_bytes,
+            self.maximum_task_bytes,
+            self.maximum_initial_context_bytes,
+        )
+        if any(value <= 0 for value in integer_limits):
+            raise ValueError("world-model session count and byte limits must be positive")
+        if not math.isfinite(self.session_ttl_seconds) or self.session_ttl_seconds <= 0:
+            raise ValueError("world-model session TTL must be finite and positive")
+        if self.maximum_observation_bytes > self.maximum_transcript_bytes:
+            raise ValueError("world-model observation bytes cannot exceed transcript bytes")
+
+
+@dataclass(frozen=True)
+class WorldModelSession:
+    """One opaque public session identity and its request-visible starting state."""
+
+    id: str
+    task: str
+    _initial_context_json: bytes = field(repr=False)
+
+    @property
+    def initial_context(self) -> JsonObject:
+        """Return a detached copy of the session's canonical initial context.
+
+        Returns:
+            JSON object whose mutation cannot change the active session.
+        """
+        return cast(JsonObject, json.loads(self._initial_context_json))
+
+
+@dataclass(frozen=True)
+class WorldModelObservation:
+    """One OpenAI-shaped user message predicted by a grounded world model."""
+
+    message: ChatCompletionUserMessageParam
+    terminal: bool
+
+
+@dataclass
+class _SessionState:
+    """Mutable transcript and lifecycle bookkeeping for one public session."""
+
+    session: WorldModelSession
+    task_case: TaskCase
+    messages: tuple[ModelMessage, ...]
+    transcript_bytes: int
+    expires_at: float
+    lock: Lock = field(default_factory=Lock)
+    closed: bool = False
+
+
+def _new_session_id() -> str:
+    """Return one opaque random session identity."""
+    return uuid.uuid4().hex
+
+
+class WorldModel:
+    """Expose one verified serving-RAG world model through bounded text sessions."""
+
+    def __init__(
+        self,
+        runtime: GroundedWorldModel,
+        *,
+        limits: WorldModelSessionLimits | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        session_id_factory: Callable[[], str] = _new_session_id,
+    ) -> None:
+        """Bind session state to one already verified grounded runtime.
+
+        Args:
+            runtime: Exact executable world model over the project's serving RAG.
+            limits: Optional explicit resource ceilings. Stable safe defaults are used when
+                omitted.
+            monotonic: Monotonic clock injectable for deterministic expiry tests.
+            session_id_factory: Opaque session identity supplier.
+        """
+        self._runtime = runtime
+        self.limits = limits or WorldModelSessionLimits()
+        self._monotonic = monotonic
+        self._session_id_factory = session_id_factory
+        self._sessions: OrderedDict[str, _SessionState] = OrderedDict()
+        self._registry_lock = RLock()
+
+    def new_session(
+        self,
+        *,
+        task: str,
+        initial_context: JsonObject | None = None,
+    ) -> WorldModelSession:
+        """Create one bounded in-memory session without model or embedder dispatch.
+
+        Args:
+            task: Nonempty request-visible scenario instruction.
+            initial_context: Optional safe JSON context rendered into every grounded step.
+
+        Returns:
+            Opaque session handle accepted by ``step`` and ``end_session``.
+
+        Raises:
+            WorldModelSessionError: Input or active-session capacity exceeds a fixed limit.
+        """
+        if not task.strip():
+            raise WorldModelSessionError("world-model session task must not be empty")
+        if len(task.encode("utf-8")) > self.limits.maximum_task_bytes:
+            raise WorldModelSessionError("world-model session task exceeds the byte limit")
+        context: JsonObject = {} if initial_context is None else dict(initial_context)
+        try:
+            context_json = canonical_json_bytes(context)
+        except (TypeError, ValueError) as exc:
+            raise WorldModelSessionError("world-model initial context must be JSON") from exc
+        if len(context_json) > self.limits.maximum_initial_context_bytes:
+            raise WorldModelSessionError("world-model initial context exceeds the byte limit")
+        now = self._monotonic()
+        with self._registry_lock:
+            self._expire_sessions(now)
+            if len(self._sessions) >= self.limits.maximum_sessions:
+                raise WorldModelSessionError(
+                    "world-model session capacity reached; end a session or wait for expiry"
+                )
+            session_id = self._session_id_factory()
+            if not session_id or session_id in self._sessions:
+                raise WorldModelSessionError("world-model session identity is empty or repeated")
+            session = WorldModelSession(
+                id=session_id,
+                task=task,
+                _initial_context_json=context_json,
+            )
+            self._sessions[session_id] = _SessionState(
+                session=session,
+                task_case=_session_task(session),
+                messages=(),
+                transcript_bytes=0,
+                expires_at=now + self.limits.session_ttl_seconds,
+            )
+            return session
+
+    def step(
+        self,
+        session_id: str,
+        action: ChatCompletionAssistantMessageParam,
+    ) -> WorldModelObservation:
+        """Predict and append one user turn from an official OpenAI assistant message.
+
+        The persisted artifact is text-only. Any tool call, legacy function call, audio payload,
+        non-text content, or non-assistant role is rejected before retrieval or provider dispatch.
+
+        Args:
+            session_id: Opaque identity returned by ``new_session``.
+            action: Official OpenAI assistant-message input containing visible text only.
+
+        Returns:
+            Official OpenAI user-message shape and the world-model terminal flag.
+
+        Raises:
+            WorldModelSessionError: The session is absent, expired, closed, unsupported, or would
+                exceed a transcript limit.
+        """
+        action_text = _assistant_text(action)
+        action_message = ModelMessage(role="assistant", content=action_text)
+        now = self._monotonic()
+        with self._registry_lock:
+            self._expire_sessions(now)
+            state = self._sessions.get(session_id)
+            if state is None:
+                raise WorldModelSessionError("world-model session is unknown or expired")
+            state.lock.acquire()
+            if state.closed:
+                state.lock.release()
+                raise WorldModelSessionError("world-model session is closed")
+            self._sessions.move_to_end(session_id)
+        try:
+            self._require_step_capacity(state, action_message)
+            prepared = self._runtime.prepare_turn(
+                task=state.task_case,
+                visible_messages=state.messages,
+                candidate_response=AssistantAction(content=action_text),
+                excluded_lineage_ids=(),
+                maximum_output_tokens=1_024,
+            )
+            dispatched = self._runtime.complete_turn(prepared)
+            if dispatched.response.model != self._runtime.artifact.model:
+                raise WorldModelSessionError(
+                    "world-model response identity differs from its build artifact"
+                )
+            transition = self._runtime.parse_turn(dispatched).transition
+            user_message = ModelMessage(role="user", content=transition.message)
+            user_bytes = _message_bytes(user_message)
+            if user_bytes > self.limits.maximum_observation_bytes:
+                raise WorldModelSessionError(
+                    "world-model observation exceeds the provider-output byte limit"
+                )
+            final_bytes = state.transcript_bytes + _message_bytes(action_message) + user_bytes
+            if final_bytes > self.limits.maximum_transcript_bytes:
+                raise WorldModelSessionError("world-model transcript exceeds the byte limit")
+            state.messages = (*state.messages, action_message, user_message)
+            state.transcript_bytes = final_bytes
+            state.expires_at = self._monotonic() + self.limits.session_ttl_seconds
+            state.closed = transition.terminal
+            return WorldModelObservation(
+                message=ChatCompletionUserMessageParam(
+                    role="user",
+                    content=transition.message,
+                ),
+                terminal=transition.terminal,
+            )
+        finally:
+            state.lock.release()
+
+    def end_session(self, session_id: str) -> None:
+        """Remove one session and its complete transcript immediately.
+
+        Args:
+            session_id: Opaque identity returned by ``new_session``.
+
+        Raises:
+            WorldModelSessionError: The session is absent or already expired.
+        """
+        with self._registry_lock:
+            self._expire_sessions(self._monotonic())
+            state = self._sessions.get(session_id)
+            if state is None:
+                raise WorldModelSessionError("world-model session is unknown or expired")
+            with state.lock:
+                state.closed = True
+                self._sessions.pop(session_id)
+
+    def _require_step_capacity(self, state: _SessionState, action: ModelMessage) -> None:
+        """Reject a known transcript overflow before retrieval or provider dispatch.
+
+        Args:
+            state: Locked active session state.
+            action: Validated text-only assistant message.
+
+        Raises:
+            WorldModelSessionError: The next assistant and reserved observation exceed a limit.
+        """
+        if len(state.messages) + 2 > self.limits.maximum_messages_per_session:
+            raise WorldModelSessionError("world-model transcript exceeds the message-count limit")
+        reserved_bytes = (
+            state.transcript_bytes + _message_bytes(action) + self.limits.maximum_observation_bytes
+        )
+        if reserved_bytes > self.limits.maximum_transcript_bytes:
+            raise WorldModelSessionError("world-model transcript exceeds the byte limit")
+
+    def _expire_sessions(self, now: float) -> None:
+        """Remove idle sessions without interrupting a step already in progress.
+
+        Args:
+            now: Current monotonic time under the registry lock.
+        """
+        for session_id, state in tuple(self._sessions.items()):
+            if state.expires_at > now or not state.lock.acquire(blocking=False):
+                continue
+            try:
+                if state.expires_at <= now:
+                    state.closed = True
+                    self._sessions.pop(session_id, None)
+            finally:
+                state.lock.release()
+
+
+def load_world_model(
+    project: str,
+    root: Path = Path(".wmo"),
+    *,
+    environment: Mapping[str, str] | None = None,
+    runtime_catalog: RuntimeModelCatalog | None = None,
+    limits: WorldModelSessionLimits | None = None,
+) -> WorldModel:
+    """Load one named project's verified serving-RAG world model.
+
+    Loading verifies immutable project pointers, model and embedder snapshots, the serving RAG,
+    and the grounded prompt without making a provider or embedder call.
+
+    Args:
+        project: Canonical local project identifier.
+        root: Local ``.wmo`` root. Defaults to the happy-path project location.
+        environment: Optional credential mapping used only to construct runtime clients.
+        runtime_catalog: Optional explicit runtime catalog for deterministic applications.
+        limits: Optional explicit in-memory session ceilings.
+
+    Returns:
+        Public bounded world model over the project's exact serving RAG.
+
+    Raises:
+        WorldModelLoadError: Project, build, catalog, model, embedder, or artifact identity is
+            absent, malformed, or inconsistent.
+    """
+    try:
+        store = ProjectStore(root, project)
+        config = store.load_project()
+        if config.models is None:
+            raise WorldModelLoadError("project has no model roles; run wmo build first")
+        if config.build is None:
+            raise WorldModelLoadError("project has no completed world model; run wmo build first")
+        catalog = runtime_catalog
+        if catalog is None:
+            catalog = RuntimeModelCatalog(
+                load_model_catalog(store.model_catalog_path),
+                environment=environment,
+            )
+        resolved_world = catalog.resolve(config.models.world_model)
+        resolved_embedder = catalog.preflight(
+            config.models.embedder,
+            CapabilityRequirement(requires_embeddings=True),
+        )
+        if resolved_embedder.embedding_client is None:
+            raise WorldModelLoadError("project embedder alias has no embedding client")
+        embedding_price = resolved_embedder.capabilities.input_cost_per_million_tokens_usd
+        if embedding_price is None:
+            raise WorldModelLoadError("project embedder alias has no explicit input price")
+        runtime = load_grounded_world_model(
+            store.artifacts,
+            config.build.world_model.artifact_id,
+            client=resolved_world.client,
+            embedder=RAGEmbedderBinding(
+                client=resolved_embedder.embedding_client,
+                snapshot=resolved_embedder.snapshot,
+                maximum_attempts=RetryPolicy().maximum_attempts,
+                input_usd_per_million_tokens=embedding_price,
+            ),
+        )
+        _require_project_binding(runtime, config.build.world_model, config.build.serving_rag)
+        if runtime.artifact.model_alias != config.models.world_model:
+            raise WorldModelLoadError("project world-model alias differs from its build artifact")
+        if runtime.artifact.model != resolved_world.snapshot:
+            raise WorldModelLoadError("project world-model snapshot differs from its runtime")
+        if runtime.retriever.rag_input != config.build.serving_rag:
+            raise WorldModelLoadError("project world model is not bound to its exact serving RAG")
+        return WorldModel(runtime, limits=limits)
+    except WorldModelLoadError:
+        raise
+    except (OSError, ProjectStoreError, ValueError) as exc:
+        raise WorldModelLoadError(str(exc)) from exc
+
+
+def _assistant_text(action: ChatCompletionAssistantMessageParam) -> str:
+    """Return one supported assistant text action before any runtime work.
+
+    Args:
+        action: Official OpenAI assistant-message parameter.
+
+    Returns:
+        Nonempty visible assistant text.
+
+    Raises:
+        WorldModelSessionError: The action is not one plain text-only assistant message.
+    """
+    if action.get("role") != "assistant":
+        raise WorldModelSessionError("world-model actions must use role='assistant'")
+    if action.get("tool_calls") is not None or action.get("function_call") is not None:
+        raise WorldModelSessionError(
+            "this text-only world model does not accept assistant tool_calls"
+        )
+    if action.get("audio") is not None:
+        raise WorldModelSessionError("this text-only world model does not accept assistant audio")
+    content = action.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise WorldModelSessionError(
+            "this text-only world model requires nonempty assistant text content"
+        )
+    return content
+
+
+def _message_bytes(message: ModelMessage) -> int:
+    """Return visible UTF-8 content bytes charged to one text transcript message."""
+    assert message.content is not None
+    return len(message.content.encode("utf-8"))
+
+
+def _session_task(session: WorldModelSession) -> TaskCase:
+    """Build the canonical prompt task for one public session.
+
+    Args:
+        session: Public session with validated task and initial context.
+
+    Returns:
+        Stable synthetic task case accepted by the artifact's pinned prompt builder.
+    """
+    task_identity = {
+        "task": session.task,
+        "initial_context": session.initial_context,
+    }
+    task_id = stable_id("public-world-model-task", task_identity)
+    return TaskCase(
+        task_id=task_id,
+        lineage_group_id=stable_id("public-world-model-lineage", task_identity),
+        partition="held_out",
+        instruction=session.task,
+        initial_context=session.initial_context,
+        workload_weight=1.0,
+        source_trace_ids=(task_id,),
+    )
+
+
+def _require_project_binding(
+    runtime: GroundedWorldModel,
+    world_model_input: ArtifactInput,
+    serving_rag_input: ArtifactInput,
+) -> None:
+    """Require exact project pointers without accepting a fit-RAG substitution.
+
+    Args:
+        runtime: Fully verified grounded runtime.
+        world_model_input: Project's exact grounded-world-model manifest input.
+        serving_rag_input: Project's exact serving-RAG manifest input.
+
+    Raises:
+        WorldModelLoadError: Runtime inputs differ from either project pointer.
+    """
+    if runtime.artifact_input != world_model_input:
+        raise WorldModelLoadError("project world-model manifest differs from its build pointer")
+    if runtime.artifact.serving_rag != serving_rag_input:
+        raise WorldModelLoadError("project world model does not name its serving RAG")

--- a/wmo/simulation/world_model/application_test.py
+++ b/wmo/simulation/world_model/application_test.py
@@ -1,0 +1,562 @@
+"""Public project-name world-model loader and bounded-session tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+from openai.types.chat import ChatCompletionAssistantMessageParam
+
+from wmo.common.core.artifacts import ArtifactInput, JsonObject, sha256_json
+from wmo.common.models import (
+    AssistantAction,
+    Embedding,
+    ModelCapabilities,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+)
+from wmo.common.project import (
+    ProjectBuildArtifacts,
+    ProjectConfig,
+    ProjectModelConfiguration,
+    ProjectStore,
+)
+from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
+from wmo.simulation.engines.text.prompt import WORLD_MODEL_TEXT_SYSTEM_PROMPT
+from wmo.simulation.retrieval import RAGEmbedderBinding, RAGMatch, RAGQuery, TraceRAGRetriever
+from wmo.simulation.world_model.application import (
+    WorldModel,
+    WorldModelLoadError,
+    WorldModelSessionError,
+    WorldModelSessionLimits,
+    load_world_model,
+)
+from wmo.simulation.world_model.artifact import (
+    GROUNDED_WORLD_MODEL_PROMPT_VERSION,
+    GroundedWorldModelArtifact,
+    grounded_world_model_prompt_sha256,
+)
+from wmo.simulation.world_model.runtime import GroundedWorldModel
+
+_TIME = datetime(2026, 8, 13, tzinfo=UTC)
+
+
+class _Retriever:
+    """Capture public session queries without contacting an embedder."""
+
+    def __init__(self, rag_input: ArtifactInput) -> None:
+        """Bind the fake retriever to one serving-RAG pointer.
+
+        Args:
+            rag_input: Exact serving-RAG manifest reference.
+        """
+        self.rag_input = rag_input
+        self.queries: list[RAGQuery] = []
+
+    def retrieve(self, query: RAGQuery) -> tuple[RAGMatch, ...]:
+        """Record one query and return no demonstrations.
+
+        Args:
+            query: Canonical serving-RAG query.
+
+        Returns:
+            Empty immutable retrieval result.
+        """
+        self.queries.append(query)
+        return ()
+
+
+class _WorldClient:
+    """Capture canonical requests and return queued strict transitions."""
+
+    def __init__(
+        self,
+        snapshot: ModelSnapshot,
+        outputs: Sequence[str] = ('{"message":"Next","terminal":false}',),
+    ) -> None:
+        """Configure one exact response identity and output sequence.
+
+        Args:
+            snapshot: Provider identity returned with every response.
+            outputs: Strict transition payloads returned in order.
+        """
+        self.snapshot = snapshot
+        self.outputs = list(outputs)
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Record a request and return the next configured transition.
+
+        Args:
+            request: Canonical artifact-bound request.
+
+        Returns:
+            Model response under the configured identity.
+        """
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(content=self.outputs.pop(0)),
+            model=self.snapshot,
+            economics=OperationEconomics(),
+        )
+
+
+class _Embedder:
+    """Minimal embedding client used only to prove loader composition."""
+
+    def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Return one fixed vector for each input.
+
+        Args:
+            texts: Texts submitted for embedding.
+
+        Returns:
+            Stable one-dimensional unit vectors.
+        """
+        return tuple(Embedding(values=(1.0,)) for _ in texts)
+
+
+class _Catalog:
+    """Resolve the exact world-model and embedder aliases selected by a project."""
+
+    def __init__(self, world: ResolvedModel, embedder: ResolvedModel) -> None:
+        """Store exact resolved fixtures.
+
+        Args:
+            world: Completion-capable world-model resolution.
+            embedder: Embedding-capable resolution.
+        """
+        self.world = world
+        self.embedder = embedder
+        self.resolved: list[str] = []
+
+    def resolve(self, alias: str) -> ResolvedModel:
+        """Resolve only the configured world-model alias.
+
+        Args:
+            alias: Project-selected alias.
+
+        Returns:
+            Exact world-model fixture.
+        """
+        self.resolved.append(alias)
+        return self.world
+
+    def preflight(self, alias: str, requirement: object) -> ResolvedModel:
+        """Resolve the configured embedder after recording capability preflight.
+
+        Args:
+            alias: Project-selected embedder alias.
+            requirement: Explicit embedding capability requirement.
+
+        Returns:
+            Exact embedder fixture.
+        """
+        del requirement
+        self.resolved.append(alias)
+        return self.embedder
+
+
+def test_session_uses_canonical_prompt_and_exact_prior_transcript() -> None:
+    """Every public step uses artifact framing.
+
+    The second request contains each prior visible turn exactly once and preserves the detached
+    initial context even after callers mutate both input and returned objects.
+    """
+    runtime, retriever, client = _runtime(
+        outputs=(
+            '{"message":"First observation","terminal":false}',
+            '{"message":"Finished","terminal":true}',
+        )
+    )
+    world_model = WorldModel(runtime, session_id_factory=lambda: "session-a")
+    initial_context: JsonObject = {"tenant": {"name": "support"}}
+    session = world_model.new_session(
+        task="Reset the password",
+        initial_context=initial_context,
+    )
+    cast(dict[str, object], initial_context["tenant"])["name"] = "mutated"
+    detached = session.initial_context
+    cast(dict[str, object], detached["tenant"])["name"] = "also-mutated"
+
+    first = world_model.step(session.id, _action("Ask for the account email"))
+    second = world_model.step(session.id, _action("Send the reset link"))
+
+    assert first.message == {"role": "user", "content": "First observation"}
+    assert first.terminal is False
+    assert second.message == {"role": "user", "content": "Finished"}
+    assert second.terminal is True
+    assert len(retriever.queries) == 2
+    assert len(client.requests) == 2
+    assert client.requests[0].messages[0].content == WORLD_MODEL_TEXT_SYSTEM_PROMPT
+    first_payload = _request_payload(client.requests[0])
+    second_payload = _request_payload(client.requests[1])
+    assert first_payload["visible_conversation"] == []
+    assert second_payload["visible_conversation"] == [
+        {"role": "assistant", "content": "Ask for the account email"},
+        {"role": "user", "content": "First observation"},
+    ]
+    assert second_payload["candidate_response"] == "Send the reset link"
+    task_payload = cast(dict[str, object], second_payload["task"])
+    assert task_payload["instruction"] == "Reset the password"
+    assert task_payload["initial_context"] == {"tenant": {"name": "support"}}
+    assert session.initial_context == {"tenant": {"name": "support"}}
+    with pytest.raises(WorldModelSessionError, match="closed"):
+        world_model.step(session.id, _action("This must not dispatch"))
+    assert len(retriever.queries) == 2
+    assert len(client.requests) == 2
+    world_model.end_session(session.id)
+    with pytest.raises(WorldModelSessionError, match="unknown or expired"):
+        world_model.step(session.id, _action("This must not dispatch either"))
+
+
+def test_unsupported_action_and_preflight_overflow_dispatch_nothing() -> None:
+    """Unsupported actions and known overflow dispatch nothing.
+
+    Both failures occur before serving-RAG retrieval and world-model provider execution.
+    """
+    runtime, retriever, client = _runtime()
+    limits = WorldModelSessionLimits(
+        maximum_sessions=1,
+        session_ttl_seconds=60,
+        maximum_messages_per_session=2,
+        maximum_transcript_bytes=200,
+        maximum_observation_bytes=150,
+    )
+    world_model = WorldModel(runtime, limits=limits, session_id_factory=lambda: "session-a")
+    session = world_model.new_session(task="Task")
+    tool_action = cast(
+        ChatCompletionAssistantMessageParam,
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(WorldModelSessionError, match="tool_calls"):
+        world_model.step(session.id, tool_action)
+    with pytest.raises(WorldModelSessionError, match="byte limit"):
+        world_model.step(session.id, _action("x" * 100))
+
+    assert retriever.queries == []
+    assert client.requests == []
+
+
+def test_failed_response_identity_or_size_never_advances_transcript() -> None:
+    """Rejected provider results never advance the transcript.
+
+    Oversized output leaves the next canonical request empty, while mismatched model identity is
+    rejected before the invalid provider payload can reach protocol parsing.
+    """
+    runtime, _, client = _runtime(
+        outputs=(
+            '{"message":"This observation is too large","terminal":false}',
+            '{"message":"ok","terminal":false}',
+        )
+    )
+    limits = WorldModelSessionLimits(
+        maximum_observation_bytes=10,
+        maximum_transcript_bytes=1_000,
+    )
+    world_model = WorldModel(runtime, limits=limits, session_id_factory=lambda: "session-a")
+    session = world_model.new_session(task="Task")
+
+    with pytest.raises(WorldModelSessionError, match="provider-output byte limit"):
+        world_model.step(session.id, _action("first"))
+    result = world_model.step(session.id, _action("second"))
+
+    assert result.message == {"role": "user", "content": "ok"}
+    assert _request_payload(client.requests[1])["visible_conversation"] == []
+
+    wrong_runtime, wrong_retriever, wrong_client = _runtime(
+        response_snapshot=_snapshot("different"),
+        outputs=("not-json",),
+    )
+    wrong_world = WorldModel(wrong_runtime, session_id_factory=lambda: "session-b")
+    wrong_session = wrong_world.new_session(task="Task")
+    with pytest.raises(WorldModelSessionError, match="response identity"):
+        wrong_world.step(wrong_session.id, _action("ask"))
+    assert len(wrong_retriever.queries) == 1
+    assert len(wrong_client.requests) == 1
+
+
+def test_session_capacity_expiry_and_end_remove_all_state() -> None:
+    """Capacity, TTL, and explicit end bound retained session state.
+
+    Expired and ended identities become unavailable, and released capacity can be reused without
+    retrieval or provider execution.
+    """
+    now = [10.0]
+    runtime, retriever, client = _runtime()
+    world_model = WorldModel(
+        runtime,
+        limits=WorldModelSessionLimits(maximum_sessions=1, session_ttl_seconds=5),
+        monotonic=lambda: now[0],
+        session_id_factory=iter(("session-a", "session-b", "session-c")).__next__,
+    )
+    first = world_model.new_session(task="First")
+    with pytest.raises(WorldModelSessionError, match="capacity"):
+        world_model.new_session(task="Blocked")
+
+    now[0] = 16.0
+    second = world_model.new_session(task="Second")
+    with pytest.raises(WorldModelSessionError, match="unknown or expired"):
+        world_model.step(first.id, _action("ask"))
+    world_model.end_session(second.id)
+    third = world_model.new_session(task="Third")
+    with pytest.raises(WorldModelSessionError, match="unknown or expired"):
+        world_model.step(second.id, _action("ask"))
+
+    assert third.id == "session-c"
+    assert retriever.queries == []
+    assert client.requests == []
+
+
+def test_failed_provider_result_does_not_refresh_session_ttl() -> None:
+    """A rejected provider result preserves the original expiry boundary.
+
+    Advancing beyond that boundary removes the failed session without another retrieval or model
+    dispatch.
+    """
+    now = [10.0]
+    runtime, retriever, client = _runtime(outputs=('{"message":"too large","terminal":false}',))
+    world_model = WorldModel(
+        runtime,
+        limits=WorldModelSessionLimits(
+            session_ttl_seconds=5,
+            maximum_observation_bytes=2,
+            maximum_transcript_bytes=1_000,
+        ),
+        monotonic=lambda: now[0],
+        session_id_factory=lambda: "session-a",
+    )
+    session = world_model.new_session(task="Task")
+
+    with pytest.raises(WorldModelSessionError, match="provider-output byte limit"):
+        world_model.step(session.id, _action("ask"))
+    now[0] = 16.0
+    with pytest.raises(WorldModelSessionError, match="unknown or expired"):
+        world_model.step(session.id, _action("ask again"))
+
+    assert len(retriever.queries) == 1
+    assert len(client.requests) == 1
+
+
+def test_loader_resolves_exact_serving_artifact_without_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Project-name load verifies serving pointers and constructs no paid operation.
+
+    Args:
+        tmp_path: Temporary local project root.
+        monkeypatch: Fixture replacing only immutable artifact loading.
+    """
+    pointers = _build_pointers()
+    store = ProjectStore(tmp_path / ".wmo", "support")
+    store.initialize(
+        ProjectConfig(
+            project_id="support",
+            models=ProjectModelConfiguration(
+                world_model="world",
+                judge="judge",
+                embedder="embedder",
+            ),
+            build=pointers,
+        )
+    )
+    runtime, retriever, client = _runtime(
+        artifact_input=pointers.world_model,
+        serving_rag=pointers.serving_rag,
+    )
+    embedder_snapshot = _snapshot(
+        "embedder",
+        capabilities=ModelCapabilities(
+            supports_embeddings=True,
+            input_cost_per_million_tokens_usd=0.0,
+        ),
+    )
+    embedder_client = _Embedder()
+    catalog = _Catalog(
+        ResolvedModel(
+            alias="world",
+            snapshot=runtime.artifact.model,
+            capabilities=ModelCapabilities(),
+            client=client,
+            embedding_client=None,
+        ),
+        ResolvedModel(
+            alias="embedder",
+            snapshot=embedder_snapshot,
+            capabilities=ModelCapabilities(
+                supports_embeddings=True,
+                input_cost_per_million_tokens_usd=0.0,
+            ),
+            client=client,
+            embedding_client=embedder_client,
+        ),
+    )
+    loaded: list[str] = []
+
+    def fake_load(*args: object, **kwargs: object) -> GroundedWorldModel:
+        """Capture the exact artifact ID selected by the project.
+
+        Args:
+            args: Positional artifact loader inputs.
+            kwargs: Explicit client and embedder bindings.
+
+        Returns:
+            Verified serving-bound fixture runtime.
+        """
+        loaded.append(cast(str, args[1]))
+        assert kwargs["client"] is client
+        binding = cast(RAGEmbedderBinding, kwargs["embedder"])
+        assert binding.client is embedder_client
+        assert binding.snapshot == embedder_snapshot
+        return runtime
+
+    monkeypatch.setattr(
+        "wmo.simulation.world_model.application.load_grounded_world_model",
+        fake_load,
+    )
+
+    public = load_world_model(
+        "support",
+        root=tmp_path / ".wmo",
+        runtime_catalog=cast(RuntimeModelCatalog, catalog),
+    )
+
+    assert isinstance(public, WorldModel)
+    assert loaded == [pointers.world_model.artifact_id]
+    assert catalog.resolved == ["world", "embedder"]
+    assert retriever.queries == []
+    assert client.requests == []
+    assert store.artifacts.list_ids() == ()
+
+    retriever.rag_input = pointers.fit_rag
+    with pytest.raises(WorldModelLoadError, match="exact serving RAG"):
+        load_world_model(
+            "support",
+            root=tmp_path / ".wmo",
+            runtime_catalog=cast(RuntimeModelCatalog, catalog),
+        )
+
+
+def _runtime(
+    *,
+    artifact_input: ArtifactInput | None = None,
+    serving_rag: ArtifactInput | None = None,
+    response_snapshot: ModelSnapshot | None = None,
+    outputs: Sequence[str] = ('{"message":"Next","terminal":false}',),
+) -> tuple[GroundedWorldModel, _Retriever, _WorldClient]:
+    """Build one serving-bound grounded runtime with observable local seams.
+
+    Args:
+        artifact_input: Optional completed world-model manifest pointer.
+        serving_rag: Optional exact serving-RAG pointer.
+        response_snapshot: Optional provider response identity override.
+        outputs: Strict transition payloads returned in order.
+
+    Returns:
+        Runtime, fake retriever, and fake provider client.
+    """
+    rag_input = serving_rag or ArtifactInput(artifact_id="serving-rag", sha256="a" * 64)
+    snapshot = _snapshot("world")
+    retriever = _Retriever(rag_input)
+    client = _WorldClient(response_snapshot or snapshot, outputs)
+    runtime = GroundedWorldModel(
+        artifact_input=artifact_input or ArtifactInput(artifact_id="world-model", sha256="b" * 64),
+        artifact=GroundedWorldModelArtifact(
+            schema_version=1,
+            created_at=_TIME,
+            inputs=(rag_input,),
+            code_revision="test-revision",
+            world_model_id="world-model",
+            serving_rag=rag_input,
+            model_alias="world",
+            model=snapshot,
+            prompt_version=GROUNDED_WORLD_MODEL_PROMPT_VERSION,
+            prompt_sha256=grounded_world_model_prompt_sha256(),
+            top_k=5,
+        ),
+        retriever=cast(TraceRAGRetriever, retriever),
+        client=client,
+    )
+    return runtime, retriever, client
+
+
+def _snapshot(
+    model_id: str,
+    *,
+    capabilities: ModelCapabilities | None = None,
+) -> ModelSnapshot:
+    """Return one exact fixture model identity.
+
+    Args:
+        model_id: Stable provider model identifier.
+        capabilities: Optional explicit capability snapshot.
+
+    Returns:
+        Secret-free immutable model snapshot.
+    """
+    resolved_capabilities = capabilities or ModelCapabilities()
+    return ModelSnapshot(
+        provider="fixture",
+        model_id=model_id,
+        capabilities_sha256=sha256_json(resolved_capabilities),
+        connection_sha256=sha256_json({"connection": model_id}),
+    )
+
+
+def _action(content: str) -> ChatCompletionAssistantMessageParam:
+    """Return one official OpenAI text assistant message.
+
+    Args:
+        content: Visible assistant text.
+
+    Returns:
+        Official assistant-message parameter.
+    """
+    return {"role": "assistant", "content": content}
+
+
+def _request_payload(request: ModelRequest) -> dict[str, object]:
+    """Decode the canonical user prompt from one grounded request.
+
+    Args:
+        request: Artifact-bound world-model request.
+
+    Returns:
+        Decoded canonical prompt object.
+    """
+    content = request.messages[1].content
+    assert content is not None
+    return cast(dict[str, object], json.loads(content))
+
+
+def _build_pointers() -> ProjectBuildArtifacts:
+    """Return distinct completed-build pointers for loader tests.
+
+    Returns:
+        Exact immutable project build references.
+    """
+    return ProjectBuildArtifacts(
+        trace_dataset=ArtifactInput(artifact_id="traces", sha256="1" * 64),
+        task_set=ArtifactInput(artifact_id="tasks", sha256="2" * 64),
+        serving_rag=ArtifactInput(artifact_id="serving-rag", sha256="3" * 64),
+        fit_rag=ArtifactInput(artifact_id="fit-rag", sha256="4" * 64),
+        world_model=ArtifactInput(artifact_id="world-model", sha256="5" * 64),
+    )

--- a/wmo/workflow/automatic_router.py
+++ b/wmo/workflow/automatic_router.py
@@ -49,6 +49,7 @@ from wmo.workflow.router import (
     RouterWorkflowServices,
     compose_router,
 )
+from wmo.workflow.router_attribution import persist_router_observed_attribution_set
 
 
 class AutomaticRouterError(ValueError):
@@ -145,6 +146,17 @@ def optimize_project_router(
         project.model_catalog_path,
         candidate_plan.expected_catalog_sha256,
     )
+    _attribution, attribution_input = persist_router_observed_attribution_set(
+        project.artifacts,
+        trace_dataset=preflight.completed_build.trace_dataset,
+        task_set=preflight.completed_build.task_set,
+        catalog_sha256=preflight.catalog_sha256,
+        candidates=preflight.candidates,
+        preferred_overlap_limit=preflight.preferred_fidelity_overlaps,
+        records=tuple(item.attribution for item in preflight.observed_traces),
+        created_at=created_at,
+        code_revision=code_revision,
+    )
     resolved_catalog = runtime_catalog.with_catalog(candidate_plan.prospective_catalog)
     agent_factory = _resolve_agent_factory(preflight, options)
     resolved = _resolve_all_models(preflight, resolved_catalog, options)
@@ -160,6 +172,7 @@ def optimize_project_router(
         project,
         preflight,
         resolved_catalog,
+        attribution_input=attribution_input,
         router_embedding_maximum_attempts=options.router_embedding_maximum_attempts,
         completion_maximum_attempts=options.completion_maximum_attempts,
         maximum_provider_cost_usd=options.maximum_provider_cost_usd,
@@ -180,7 +193,16 @@ def optimize_project_router(
     )
     composition = compose_router(
         project,
-        TraceNormalizationResult(traces=preflight.traces, issues=()),
+        TraceNormalizationResult(
+            traces=preflight.traces,
+            issues=(),
+            identity_evidence=(
+                None
+                if preflight.trace_identity_evidence is None
+                else preflight.trace_identity_evidence.records
+            ),
+            include_identity_evidence=preflight.trace_identity_evidence is not None,
+        ),
         services=services,
         budget=RouterCompositionBudget(
             maximum_simulation_cost_usd=preflight.remaining_simulation_cost_usd,
@@ -511,6 +533,7 @@ def _workflow_services(
         fidelity_approval=fidelity_approval,
         runtime_catalog=runtime_catalog,
         evaluation_plan_inputs=(
+            artifacts.attribution_input,
             artifacts.runtime_capability_input,
             artifacts.execution_contract_input,
         ),

--- a/wmo/workflow/automatic_router_artifacts.py
+++ b/wmo/workflow/automatic_router_artifacts.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from wmo.common.core.artifacts import ArtifactInput
 from wmo.common.evaluations import ObservedProductionCell
 from wmo.common.models import (
+    CandidateTokenPrice,
     PricingSnapshot,
     load_model_catalog,
     persist_pricing_snapshot,
@@ -105,7 +106,7 @@ def materialize_automatic_router_artifacts(
     )
     pricing = persist_pricing_snapshot(
         project.artifacts,
-        preflight.candidate_prices,
+        _canonical_candidate_prices(preflight),
         created_at=created_at,
         code_revision=code_revision,
     )
@@ -204,6 +205,27 @@ def materialize_automatic_router_artifacts(
         execution_contract=execution,
         execution_contract_input=execution_input,
     )
+
+
+def _canonical_candidate_prices(
+    preflight: AutomaticRouterPreflight,
+) -> tuple[CandidateTokenPrice, ...]:
+    """Align selected prices with the canonical candidate snapshot order.
+
+    Args:
+        preflight: Verified candidate snapshots and complete catalog-derived prices.
+
+    Returns:
+        Exact price rows ordered by canonical candidate alias.
+
+    Raises:
+        ValueError: Prices repeat, omit, or add a selected candidate alias.
+    """
+    prices = {item.candidate_alias: item for item in preflight.candidate_prices}
+    aliases = tuple(item.alias for item in preflight.candidates)
+    if len(prices) != len(preflight.candidate_prices) or set(prices) != set(aliases):
+        raise ValueError("candidate pricing differs from the canonical selected candidates")
+    return tuple(prices[alias] for alias in aliases)
 
 
 def _persist_observed_cells(

--- a/wmo/workflow/automatic_router_artifacts.py
+++ b/wmo/workflow/automatic_router_artifacts.py
@@ -40,6 +40,7 @@ class AutomaticRouterArtifacts:
     """Immutable evidence, pricing, embeddings, and execution reservations."""
 
     observed_cells: tuple[ObservedProductionCell, ...]
+    attribution_input: ArtifactInput
     pricing: PricingSnapshot
     router_embeddings: ReservedFrozenEmbeddingSet
     router_embedding_input: ArtifactInput
@@ -56,6 +57,7 @@ def materialize_automatic_router_artifacts(
     preflight: AutomaticRouterPreflight,
     runtime_catalog: RuntimeModelCatalog,
     *,
+    attribution_input: ArtifactInput,
     router_embedding_maximum_attempts: int,
     completion_maximum_attempts: int,
     maximum_provider_cost_usd: float,
@@ -68,6 +70,7 @@ def materialize_automatic_router_artifacts(
         project: Existing project whose completed build is being optimized.
         preflight: Aggregate read-only prerequisite and reservation result.
         runtime_catalog: Credential-capable resolver over the just-persisted catalog.
+        attribution_input: Immutable real-overlap attribution persisted after consent.
         router_embedding_maximum_attempts: Active embedding retry ceiling.
         completion_maximum_attempts: Active completion retry ceiling.
         maximum_provider_cost_usd: Exact operator-approved shared provider ceiling.
@@ -93,7 +96,13 @@ def materialize_automatic_router_artifacts(
     ):
         raise ValueError("resolved embedder differs from the completed-build preflight")
 
-    observed_cells = _persist_observed_cells(project, preflight, created_at, code_revision)
+    observed_cells = _persist_observed_cells(
+        project,
+        preflight,
+        attribution_input,
+        created_at,
+        code_revision,
+    )
     pricing = persist_pricing_snapshot(
         project.artifacts,
         preflight.candidate_prices,
@@ -148,6 +157,7 @@ def materialize_automatic_router_artifacts(
         preflight.setup_input,
         preflight.judge_audit_input,
         preflight.approved_calibration_input,
+        attribution_input,
         pricing_input,
         embedding_input,
         completion_input,
@@ -183,6 +193,7 @@ def materialize_automatic_router_artifacts(
     )
     return AutomaticRouterArtifacts(
         observed_cells=observed_cells,
+        attribution_input=attribution_input,
         pricing=pricing,
         router_embeddings=embeddings,
         router_embedding_input=embedding_input,
@@ -198,6 +209,7 @@ def materialize_automatic_router_artifacts(
 def _persist_observed_cells(
     project: ProjectStore,
     preflight: AutomaticRouterPreflight,
+    attribution_input: ArtifactInput,
     created_at: datetime,
     code_revision: str,
 ) -> tuple[ObservedProductionCell, ...]:
@@ -206,6 +218,7 @@ def _persist_observed_cells(
     Args:
         project: Project-local artifact store.
         preflight: Verified real task and trace overlaps.
+        attribution_input: Exact immutable attribution authorizing selected candidate snapshots.
         created_at: Artifact materialization time.
         code_revision: Exact producer revision.
 
@@ -221,6 +234,8 @@ def _persist_observed_cells(
             item.trace,
             created_at,
             code_revision,
+            attributed_candidate=item.attribution.candidate_model,
+            attribution_input=attribution_input,
         )
         cells.append(
             ObservedProductionCell(

--- a/wmo/workflow/automatic_router_preflight.py
+++ b/wmo/workflow/automatic_router_preflight.py
@@ -33,6 +33,11 @@ from wmo.common.tasks import TaskCase, load_task_set
 from wmo.common.traces import Trace, load_trace_dataset
 from wmo.runtime.agents import agent_factory_sha256
 from wmo.runtime.models import RuntimeModelCatalog
+from wmo.simulation.ingest.dataset import (
+    read_trace_model_identity_evidence,
+    verify_current_trace_dataset,
+)
+from wmo.simulation.ingest.model_identity import TraceModelIdentityEvidenceSet
 from wmo.simulation.specs import CandidateCompletionReservation
 from wmo.workflow.automatic_router_reservations import (
     judge_completion_reservation,
@@ -47,6 +52,11 @@ from wmo.workflow.manual_judge_contracts import (
     ManualJudgeReviewState,
     ManualJudgeSetupArtifact,
 )
+from wmo.workflow.router_attribution import (
+    RouterAttributionError,
+    RouterObservedAttribution,
+    resolve_router_observed_attributions,
+)
 
 
 class AutomaticRouterPreflightError(ValueError):
@@ -60,6 +70,7 @@ class ObservedRouterTrace:
     task: TaskCase
     trace: Trace
     candidate_alias: str
+    attribution: RouterObservedAttribution
 
 
 @dataclass(frozen=True)
@@ -69,6 +80,7 @@ class AutomaticRouterPreflight:
     project_config: ProjectConfig
     completed_build: ProjectBuildArtifacts
     catalog: ModelCatalog
+    catalog_sha256: Sha256
     candidates: tuple[RoutedCandidateSnapshot, ...]
     candidate_prices: tuple[CandidateTokenPrice, ...]
     incumbent_alias: str
@@ -86,6 +98,7 @@ class AutomaticRouterPreflight:
     approved_calibration_input: ArtifactInput
     tasks: tuple[TaskCase, ...]
     traces: tuple[Trace, ...]
+    trace_identity_evidence: TraceModelIdentityEvidenceSet | None
     observed_traces: tuple[ObservedRouterTrace, ...]
     fidelity_overlap_count: int
     preferred_fidelity_overlaps: int
@@ -195,9 +208,16 @@ def preflight_automatic_router(
         judge_alias,
         judge,
     )
-    tasks, traces = _build_evidence(problems, project, completed)
-    observed = _observed_traces(tasks, traces, candidates)
-    fidelity_overlap_count = min(len(observed), preferred_fidelity_overlaps)
+    tasks, traces, identity_evidence = _build_evidence(problems, project, completed)
+    observed = _observed_traces(
+        problems,
+        tasks,
+        traces,
+        identity_evidence,
+        candidates,
+        preferred_fidelity_overlaps,
+    )
+    fidelity_overlap_count = len(observed)
     if not observed:
         problems.append(
             "fidelity evidence: no real fit trace matches an exact selected candidate model; "
@@ -274,6 +294,7 @@ def preflight_automatic_router(
         project_config=config,
         completed_build=completed,
         catalog=catalog,
+        catalog_sha256=sha256_json(catalog.model_dump(mode="json")),
         candidates=candidates,
         candidate_prices=router_candidate_prices(
             catalog.model_copy(
@@ -302,6 +323,7 @@ def preflight_automatic_router(
         approved_calibration_input=approved_calibration_input,
         tasks=tasks,
         traces=traces,
+        trace_identity_evidence=identity_evidence,
         observed_traces=observed,
         fidelity_overlap_count=fidelity_overlap_count,
         preferred_fidelity_overlaps=preferred_fidelity_overlaps,
@@ -693,7 +715,11 @@ def _verify_manual_judge_chain(
 
 def _build_evidence(
     problems: list[str], project: ProjectStore, completed: ProjectBuildArtifacts | None
-) -> tuple[tuple[TaskCase, ...], tuple[Trace, ...]]:
+) -> tuple[
+    tuple[TaskCase, ...],
+    tuple[Trace, ...],
+    TraceModelIdentityEvidenceSet | None,
+]:
     """Load exact completed tasks and traces for overlap planning.
 
     Args:
@@ -702,63 +728,76 @@ def _build_evidence(
         completed: Completed build pointers, if available.
 
     Returns:
-        Verified task and trace tuples, or empty values after recording a failure.
+        Verified tasks, traces, and optional versioned identity evidence, or empty values after
+        recording a failure.
     """
     if completed is None:
-        return (), ()
+        return (), (), None
     try:
+        from wmo.simulation.mining.bindings import load_task_set_lineage_bindings
+
         tasks = load_task_set(project.artifacts, completed.task_set.artifact_id).tasks
-        traces = load_trace_dataset(project.artifacts, completed.trace_dataset.artifact_id).traces
-        return tasks, traces
+        load_task_set_lineage_bindings(project.artifacts, completed.task_set.artifact_id)
+        loaded_traces = load_trace_dataset(
+            project.artifacts,
+            completed.trace_dataset.artifact_id,
+        )
+        verify_current_trace_dataset(project.artifacts, loaded_traces)
+        identity_evidence = read_trace_model_identity_evidence(
+            project.artifacts,
+            loaded_traces,
+        )
+        return tasks, loaded_traces.traces, identity_evidence
     except (OSError, ValueError) as exc:
         problems.append(f"completed build evidence: {exc}")
-        return (), ()
+        return (), (), None
 
 
 def _observed_traces(
+    problems: list[str],
     tasks: tuple[TaskCase, ...],
     traces: tuple[Trace, ...],
+    identity_evidence: TraceModelIdentityEvidenceSet | None,
     candidates: tuple[RoutedCandidateSnapshot, ...],
+    preferred_overlap_limit: int,
 ) -> tuple[ObservedRouterTrace, ...]:
-    """Match all real fit lineages to exact selected candidate identities.
+    """Resolve real fit lineages through verified declared or unique inferred identity.
 
     Args:
+        problems: Mutable aggregate preflight failures.
         tasks: Verified representative tasks.
         traces: Verified normalized production traces.
+        identity_evidence: Verified model-span digest provenance, if the dataset carries it.
         candidates: Exact selected candidate identities.
+        preferred_overlap_limit: Maximum fidelity overlaps admitted to evaluation.
 
     Returns:
-        One deterministic matching trace per distinct fit lineage.
+        One deterministic attributed trace per admitted fit lineage.
     """
+    if not tasks or not traces or not candidates:
+        return ()
+    try:
+        attributions = resolve_router_observed_attributions(
+            tasks,
+            traces,
+            identity_evidence,
+            candidates,
+            preferred_overlap_limit=preferred_overlap_limit,
+        )
+    except RouterAttributionError as exc:
+        problems.append(f"fidelity identity attribution: {exc}")
+        return ()
+    tasks_by_id = {task.task_id: task for task in tasks}
     traces_by_id = {trace.trace_id: trace for trace in traces}
-    aliases_by_model = {candidate.model: candidate.alias for candidate in candidates}
-    selected = []
-    lineages = set()
-    for task in tasks:
-        if task.partition != "fit" or task.lineage_group_id in lineages:
-            continue
-        for trace_id in task.source_trace_ids:
-            trace = traces_by_id.get(trace_id)
-            model = _trace_model(trace) if trace is not None else None
-            alias = aliases_by_model.get(model) if model is not None else None
-            if trace is not None and alias is not None:
-                selected.append(ObservedRouterTrace(task=task, trace=trace, candidate_alias=alias))
-                lineages.add(task.lineage_group_id)
-                break
-    return tuple(selected)
-
-
-def _trace_model(trace: Trace) -> ModelSnapshot | None:
-    """Return the unique recorded candidate identity for one real trace.
-
-    Args:
-        trace: Normalized production trace.
-
-    Returns:
-        One exact model identity, or ``None`` for absent or ambiguous records.
-    """
-    models = {span.model for span in trace.spans if span.model is not None}
-    return next(iter(models)) if len(models) == 1 else None
+    return tuple(
+        ObservedRouterTrace(
+            task=tasks_by_id[item.task_id],
+            trace=traces_by_id[item.trace_id],
+            candidate_alias=item.candidate_alias,
+            attribution=item,
+        )
+        for item in attributions
+    )
 
 
 def _preflight_error(problems: list[str]) -> AutomaticRouterPreflightError:

--- a/wmo/workflow/automatic_router_preflight.py
+++ b/wmo/workflow/automatic_router_preflight.py
@@ -424,7 +424,7 @@ def _candidate_snapshots(
         selection: Explicit candidate aliases.
 
     Returns:
-        Successfully resolved candidate snapshots in selection order.
+        Successfully resolved candidate snapshots in canonical alias order.
     """
     resolved = []
     for alias in selection.candidates:
@@ -438,7 +438,7 @@ def _candidate_snapshots(
         problems.append(
             "selected candidate aliases must resolve to distinct exact model identities"
         )
-    return tuple(resolved)
+    return tuple(sorted(resolved, key=lambda item: item.alias))
 
 
 def _project_model_roles(

--- a/wmo/workflow/automatic_router_replay.py
+++ b/wmo/workflow/automatic_router_replay.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
-from wmo.common.core.artifacts import ArtifactId
+from wmo.common.core.artifacts import ArtifactId, ArtifactInput
 from wmo.common.evaluations.evidence import read_evaluation_plan
 from wmo.common.models import (
     Embedding,
@@ -26,6 +26,7 @@ from wmo.simulation.specs import SimulationSpec
 from wmo.workflow.automatic_router import AutomaticRouterOptions
 from wmo.workflow.automatic_router_preflight import AutomaticRouterPreflight
 from wmo.workflow.router import FidelityApprovalReceipt, RouterPolicyLock
+from wmo.workflow.router_attribution import load_router_observed_attribution_set
 from wmo.workflow.router_execution_contract import (
     RouterExecutionContract,
     load_router_execution_contract,
@@ -158,6 +159,8 @@ def find_completed_automatic_router_replay(
         execution = load_router_execution_contract(project.artifacts, execution_input.artifact_id)
         if not _execution_matches(execution, preflight, options, code_revision):
             continue
+        if not _attribution_matches(project, plan.inputs, execution, preflight, code_revision):
+            continue
         if not _simulation_specs_match(project, plan.plan_id, preflight, options, code_revision):
             continue
         approval_id = _matching_approval(project, policy)
@@ -187,6 +190,58 @@ def find_completed_automatic_router_replay(
             "multiple completed automatic router optimizations match these exact inputs"
         )
     return matches[0] if matches else None
+
+
+def _attribution_matches(
+    project: ProjectStore,
+    plan_inputs: tuple[ArtifactInput, ...],
+    execution: RouterExecutionContract,
+    preflight: AutomaticRouterPreflight,
+    code_revision: str,
+) -> bool:
+    """Verify the unique transitive observed-attribution input against current evidence.
+
+    Args:
+        project: Project-local immutable artifact store.
+        plan_inputs: Exact recursively verified evaluation-plan inputs.
+        execution: Current candidate execution contract.
+        preflight: Newly derived read-only attribution and catalog scope.
+        code_revision: Current package-owned producer identity.
+
+    Returns:
+        True only when plan and execution bind the same exact current attribution set.
+
+    Raises:
+        AutomaticRouterReplayError: Attribution inputs are ambiguous or corrupt.
+    """
+    attribution_inputs = tuple(
+        item
+        for item in execution.inputs
+        if project.artifacts.read(item.artifact_id).manifest.artifact_type
+        == "router-observed-attribution"
+    )
+    if not attribution_inputs:
+        return False
+    if len(attribution_inputs) != 1:
+        raise AutomaticRouterReplayError("automatic router execution has ambiguous attribution")
+    attribution_input = attribution_inputs[0]
+    if attribution_input not in plan_inputs:
+        return False
+    attribution, verified_input = load_router_observed_attribution_set(
+        project.artifacts,
+        attribution_input.artifact_id,
+    )
+    return (
+        verified_input == attribution_input
+        and attribution.code_revision == code_revision
+        and attribution.trace_dataset == preflight.completed_build.trace_dataset
+        and attribution.task_set == preflight.completed_build.task_set
+        and attribution.catalog_sha256 == preflight.catalog_sha256
+        and attribution.candidates
+        == tuple(sorted(preflight.candidates, key=lambda item: item.alias))
+        and attribution.preferred_overlap_limit == preflight.preferred_fidelity_overlaps
+        and attribution.records == tuple(item.attribution for item in preflight.observed_traces)
+    )
 
 
 def _execution_matches(

--- a/wmo/workflow/automatic_router_test.py
+++ b/wmo/workflow/automatic_router_test.py
@@ -284,20 +284,29 @@ class _FidelityApproval:
         )
 
 
+@pytest.mark.parametrize(
+    "candidate_order",
+    [
+        ("candidate-a", "candidate-b"),
+        ("candidate-b", "candidate-a"),
+    ],
+)
 def test_configless_automatic_router_composes_and_replays_without_dispatch(
     tmp_path: Path,
+    candidate_order: tuple[str, str],
 ) -> None:
     """Run the real happy path, then replay it through the CLI without approval or calls.
 
     Args:
         tmp_path: Isolated local WMO root.
+        candidate_order: User-selected aliases in lexical or reversed order.
     """
     store, catalog, state = _completed_project(tmp_path)
     _approve_manual_judge(store, catalog, state)
     plan = collect_router_candidate_setup(
         store.model_catalog_path,
         catalog,
-        candidates=("candidate-a", "candidate-b"),
+        candidates=candidate_order,
         incumbent="candidate-a",
         non_interactive=True,
         console=Console(file=StringIO(), force_terminal=False),
@@ -328,6 +337,23 @@ def test_configless_automatic_router_composes_and_replays_without_dispatch(
 
     assert result.composition.optimization.optimization.policy.policy_id
     assert result.composition.optimization.optimization.report.report_id
+    canonical_aliases = ("candidate-a", "candidate-b")
+    assert tuple(item.alias for item in result.preflight.candidates) == canonical_aliases
+    assert (
+        tuple(item.candidate_alias for item in result.artifacts.pricing.candidate_prices)
+        == canonical_aliases
+    )
+    assert (
+        tuple(item.candidate_alias for item in result.artifacts.execution_contract.candidates)
+        == canonical_aliases
+    )
+    assert tuple(item.alias for item in result.composition.plan.candidate_snapshots) == (
+        canonical_aliases
+    )
+    assert (
+        tuple(item.alias for item in result.composition.optimization.optimization.policy.candidates)
+        == canonical_aliases
+    )
     assert result.artifacts.execution_contract.maximum_provider_cost_usd == 25.0
     assert result.artifacts.attribution_input in result.artifacts.execution_contract.inputs
     assert result.artifacts.attribution_input in result.composition.plan.inputs

--- a/wmo/workflow/automatic_router_test.py
+++ b/wmo/workflow/automatic_router_test.py
@@ -42,6 +42,7 @@ from wmo.common.models import (
 )
 from wmo.common.project import (
     AgentConfiguration,
+    ArtifactCorruptionError,
     ProjectConfig,
     ProjectModelConfiguration,
     ProjectStore,
@@ -54,6 +55,10 @@ from wmo.runtime.agents import ChatAgentRuntime
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router.application import RouterApplicationError, load_project_router
 from wmo.simulation.build import build_project, select_completed_build
+from wmo.simulation.ingest.model_identity import (
+    normalized_capabilities_sha256,
+    normalized_model_identity_evidence,
+)
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
 from wmo.simulation.mining.service import MiningSpec
 from wmo.workflow.automatic_router import (
@@ -61,7 +66,10 @@ from wmo.workflow.automatic_router import (
     AutomaticRouterOptions,
     optimize_project_router,
 )
-from wmo.workflow.automatic_router_preflight import preflight_automatic_router
+from wmo.workflow.automatic_router_preflight import (
+    AutomaticRouterPreflightError,
+    preflight_automatic_router,
+)
 from wmo.workflow.automatic_router_replay import find_completed_automatic_router_replay
 from wmo.workflow.manual_judge import (
     calibrate_manual_judge,
@@ -73,6 +81,10 @@ from wmo.workflow.manual_judge import (
 from wmo.workflow.manual_judge_artifacts import read_audit, write_audit, write_review_state
 from wmo.workflow.manual_judge_contracts import ManualJudgeLabel, ManualJudgeReviewState
 from wmo.workflow.router import FidelityApprovalDecision, RouterCompositionBudget
+from wmo.workflow.router_attribution import (
+    RouterObservedAttributionSet,
+    persist_router_observed_attribution_set,
+)
 
 _TIME = datetime(2026, 8, 14, tzinfo=UTC)
 _REVISION = "a" * 40
@@ -317,6 +329,9 @@ def test_configless_automatic_router_composes_and_replays_without_dispatch(
     assert result.composition.optimization.optimization.policy.policy_id
     assert result.composition.optimization.optimization.report.report_id
     assert result.artifacts.execution_contract.maximum_provider_cost_usd == 25.0
+    assert result.artifacts.attribution_input in result.artifacts.execution_contract.inputs
+    assert result.artifacts.attribution_input in result.composition.plan.inputs
+    assert result.preflight.observed_traces[0].attribution.match_kind == "strict_snapshot"
     assert result.composition.plan.inputs
     assert approval.calls == 1
     assert len(state.completion_calls) > before_completion
@@ -366,6 +381,20 @@ def test_configless_automatic_router_composes_and_replays_without_dispatch(
             store,
             expanded_fidelity,
             options=replace(options, preferred_fidelity_overlaps=2),
+            code_revision=_REVISION,
+        )
+        is None
+    )
+    assert tuple(state.completion_calls) == completed_completion
+    assert tuple(state.embedding_calls) == completed_embedding
+    assert state.credential_resolutions == completed_credentials
+
+    catalog_drift = replace(result.preflight, catalog_sha256="0" * 64)
+    assert (
+        find_completed_automatic_router_replay(
+            store,
+            catalog_drift,
+            options=options,
             code_revision=_REVISION,
         )
         is None
@@ -552,6 +581,214 @@ def test_automatic_router_refuses_spend_before_credentials_calls_or_writes(
     assert store.artifacts.list_ids() == before_artifacts
     assert store.model_catalog_path.read_bytes() == before_catalog
     assert store.read_review() == before_review
+
+
+def test_provider_model_only_telemetry_composes_with_inferred_unique_attribution(
+    tmp_path: Path,
+) -> None:
+    """Normal provider/model OTLP evidence completes the configless production path.
+
+    Args:
+        tmp_path: Isolated local WMO root.
+    """
+    store, catalog, state = _completed_project(tmp_path, inferred_identity=True)
+    _approve_manual_judge(store, catalog, state)
+    plan = collect_router_candidate_setup(
+        store.model_catalog_path,
+        catalog,
+        candidates=("candidate-a", "candidate-b"),
+        incumbent="candidate-a",
+        non_interactive=True,
+        console=Console(file=StringIO(), force_terminal=False),
+    )
+
+    result = optimize_project_router(
+        store,
+        plan,
+        cast(RuntimeModelCatalog, _RuntimeCatalog(catalog, state)),
+        options=AutomaticRouterOptions(
+            maximum_judgments=20,
+            preferred_fidelity_overlaps=1,
+            maximum_model_calls=1,
+            simulation_maximum_output_tokens=8_000,
+        ),
+        provider_spend_consented=True,
+        fidelity_approval=_FidelityApproval(),
+        created_at=_TIME + timedelta(hours=1),
+        code_revision=_REVISION,
+    )
+
+    attribution = result.preflight.observed_traces[0].attribution
+    assert attribution.candidate_alias == "candidate-a"
+    assert attribution.match_kind == "inferred_unique"
+    assert result.artifacts.attribution_input in result.composition.plan.inputs
+
+
+def test_ambiguous_inferred_telemetry_fails_before_stateful_boundaries(tmp_path: Path) -> None:
+    """Candidate ambiguity is aggregated before writes, credentials, factories, or providers.
+
+    Args:
+        tmp_path: Isolated local WMO root.
+    """
+    store, catalog, state = _completed_project(tmp_path, inferred_identity=True)
+    _approve_manual_judge(store, catalog, state)
+    ambiguous = catalog.model_copy(
+        update={
+            "models": {
+                **catalog.models,
+                "candidate-b": catalog.models["candidate-b"].model_copy(
+                    update={"model": "candidate-a"}
+                ),
+            }
+        }
+    )
+    plan = collect_router_candidate_setup(
+        store.model_catalog_path,
+        ambiguous,
+        candidates=("candidate-a", "candidate-b"),
+        incumbent="candidate-a",
+        non_interactive=True,
+        console=Console(file=StringIO(), force_terminal=False),
+    )
+    before_artifacts = store.artifacts.list_ids()
+    before_catalog = store.model_catalog_path.read_bytes()
+    before_completion = tuple(state.completion_calls)
+    before_embedding = tuple(state.embedding_calls)
+    before_credentials = state.credential_resolutions
+
+    with pytest.raises(AutomaticRouterPreflightError, match="ambiguous"):
+        optimize_project_router(
+            store,
+            plan,
+            cast(RuntimeModelCatalog, _RuntimeCatalog(catalog, state)),
+            options=AutomaticRouterOptions(
+                maximum_judgments=20,
+                preferred_fidelity_overlaps=1,
+                maximum_model_calls=1,
+                simulation_maximum_output_tokens=8_000,
+            ),
+            provider_spend_consented=True,
+            fidelity_approval=_FidelityApproval(),
+            created_at=_TIME + timedelta(hours=1),
+            code_revision=_REVISION,
+        )
+
+    assert store.artifacts.list_ids() == before_artifacts
+    assert store.model_catalog_path.read_bytes() == before_catalog
+    assert tuple(state.completion_calls) == before_completion
+    assert tuple(state.embedding_calls) == before_embedding
+    assert state.credential_resolutions == before_credentials
+
+
+@pytest.mark.parametrize("tamper", ["payload", "source", "extra-file", "lineage-record"])
+def test_completed_replay_rejects_attribution_tamper_before_provider_access(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    """A manifest-valid changed attribution payload poisons replay before any provider call.
+
+    Args:
+        tmp_path: Isolated local WMO root.
+        tamper: Manifest-valid attribution mutation to apply.
+    """
+    store, catalog, state = _completed_project(tmp_path)
+    _approve_manual_judge(store, catalog, state)
+    plan = collect_router_candidate_setup(
+        store.model_catalog_path,
+        catalog,
+        candidates=("candidate-a", "candidate-b"),
+        incumbent="candidate-a",
+        non_interactive=True,
+        console=Console(file=StringIO(), force_terminal=False),
+    )
+    options = AutomaticRouterOptions(
+        maximum_judgments=20,
+        preferred_fidelity_overlaps=1,
+        maximum_model_calls=1,
+        simulation_maximum_output_tokens=8_000,
+    )
+    result = optimize_project_router(
+        store,
+        plan,
+        cast(RuntimeModelCatalog, _RuntimeCatalog(catalog, state)),
+        options=options,
+        provider_spend_consented=True,
+        fidelity_approval=_FidelityApproval(),
+        created_at=_TIME + timedelta(hours=1),
+        code_revision=_REVISION,
+    )
+    if tamper == "lineage-record":
+        before_artifacts = store.artifacts.list_ids()
+        record = result.preflight.observed_traces[0].attribution.model_copy(
+            update={"lineage_id": "forged-lineage"}
+        )
+        with pytest.raises(ArtifactCorruptionError, match="partition, or lineage"):
+            persist_router_observed_attribution_set(
+                store.artifacts,
+                trace_dataset=result.preflight.completed_build.trace_dataset,
+                task_set=result.preflight.completed_build.task_set,
+                catalog_sha256=result.preflight.catalog_sha256,
+                candidates=result.preflight.candidates,
+                preferred_overlap_limit=1,
+                records=(record,),
+                created_at=_TIME + timedelta(hours=2),
+                code_revision=_REVISION,
+            )
+        assert store.artifacts.list_ids() == before_artifacts
+        return
+    attribution_id = result.artifacts.attribution_input.artifact_id
+    stored = store.artifacts.read(attribution_id)
+    if tamper == "payload":
+        value = RouterObservedAttributionSet.model_validate_json(
+            store.artifacts.read_bytes(attribution_id, "attribution.json")
+        ).model_copy(update={"catalog_sha256": "0" * 64})
+        payload = canonical_json_bytes(value)
+        manifest = stored.manifest.model_copy(
+            update={"files": (file_digest("attribution.json", payload),)}
+        )
+        (stored.directory / "attribution.json").write_bytes(payload)
+        match = "content identity differs"
+    elif tamper == "source":
+        manifest = stored.manifest.model_copy(
+            update={
+                "source": SourceIdentity(
+                    kind="otlp",
+                    source_id="forged",
+                    sha256="0" * 64,
+                )
+            }
+        )
+        match = "must not have source"
+    else:
+        extra = b"{}"
+        (stored.directory / "extra.json").write_bytes(extra)
+        manifest = stored.manifest.model_copy(
+            update={
+                "files": tuple(
+                    sorted(
+                        (*stored.manifest.files, file_digest("extra.json", extra)),
+                        key=lambda item: item.path,
+                    )
+                )
+            }
+        )
+        match = "exact one-file shape"
+    (stored.directory / "manifest.json").write_bytes(canonical_json_bytes(manifest))
+    before_completion = tuple(state.completion_calls)
+    before_embedding = tuple(state.embedding_calls)
+    before_credentials = state.credential_resolutions
+
+    with pytest.raises(ArtifactCorruptionError, match=match):
+        find_completed_automatic_router_replay(
+            store,
+            result.preflight,
+            options=options,
+            code_revision=_REVISION,
+        )
+
+    assert tuple(state.completion_calls) == before_completion
+    assert tuple(state.embedding_calls) == before_embedding
+    assert state.credential_resolutions == before_credentials
 
 
 def test_completed_custom_agent_replay_does_not_import_or_construct_factory(
@@ -854,12 +1091,15 @@ def _completed_project(
     tmp_path: Path,
     *,
     agent: AgentConfiguration | None = None,
+    inferred_identity: bool = False,
 ) -> tuple[ProjectStore, ModelCatalog, _ProviderState]:
     """Create one exact completed build with candidate-attributed real traces.
 
     Args:
         tmp_path: Isolated local WMO root.
         agent: Optional exact custom agent configuration frozen during build.
+        inferred_identity: Whether source model digests use telemetry fallbacks rather than the
+            selected catalog snapshot.
 
     Returns:
         Completed project, catalog, and shared provider counters.
@@ -883,10 +1123,32 @@ def _completed_project(
     )
     runtime = _RuntimeCatalog(catalog, state)
     candidate_model, _capabilities = runtime.snapshot("candidate-a")
+    recorded_model = (
+        candidate_model.model_copy(
+            update={
+                "capabilities_sha256": normalized_capabilities_sha256(
+                    {},
+                    candidate_model.provider,
+                    candidate_model.model_id,
+                    candidate_model.revision,
+                    error_type=ValueError,
+                ),
+                "connection_sha256": ConnectionConfig(
+                    provider=candidate_model.provider
+                ).identity_sha256(),
+            }
+        )
+        if inferred_identity
+        else candidate_model
+    )
+    traces = tuple(_trace(index, recorded_model) for index in range(12))
     built = build_project(
         TraceNormalizationResult(
-            traces=tuple(_trace(index, candidate_model) for index in range(12)),
+            traces=traces,
             issues=(),
+            identity_evidence=(
+                normalized_model_identity_evidence(traces) if inferred_identity else None
+            ),
         ),
         store,
         created_at=_TIME,

--- a/wmo/workflow/manual_judge_artifacts.py
+++ b/wmo/workflow/manual_judge_artifacts.py
@@ -19,7 +19,7 @@ from wmo.common.judging import (
     JudgeCalibrationService,
 )
 from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
-from wmo.common.models import AssistantAction, OperationEconomics, Usage
+from wmo.common.models import AssistantAction, ModelSnapshot, OperationEconomics, Usage
 from wmo.common.project import (
     ArtifactAlreadyExistsError,
     ArtifactStoreError,
@@ -373,6 +373,9 @@ def write_production_rollout(
     trace: Trace,
     created_at: datetime,
     code_revision: str,
+    *,
+    attributed_candidate: ModelSnapshot | None = None,
+    attribution_input: ArtifactInput | None = None,
 ) -> ArtifactInput:
     """Persist one real trace as immutable production rollout evidence.
 
@@ -383,6 +386,8 @@ def write_production_rollout(
         trace: Real normalized trace to preserve.
         created_at: Artifact completion time.
         code_revision: Exact producer revision.
+        attributed_candidate: Selected candidate proven by immutable attribution evidence.
+        attribution_input: Exact attribution artifact authorizing the selected candidate.
 
     Returns:
         Exact rollout manifest pointer.
@@ -390,21 +395,54 @@ def write_production_rollout(
     Raises:
         ManualJudgeError: The trace has no recorded model identity or conflicts on replay.
     """
-    candidate = next((span.model for span in trace.spans if span.model is not None), None)
+    if (attributed_candidate is None) != (attribution_input is None):
+        raise ManualJudgeError(
+            "attributed production rollouts require both candidate and attribution input"
+        )
+    candidate = attributed_candidate or next(
+        (span.model for span in trace.spans if span.model is not None),
+        None,
+    )
     if candidate is None:
         raise ManualJudgeError(
             f"trace {trace.trace_id!r} has no recorded model identity and cannot be calibrated"
         )
-    artifact_id = rollout_id(task, trace)
+    base_rollout_id = rollout_id(task, trace)
+    artifact_id = (
+        base_rollout_id
+        if attribution_input is None
+        else stable_id(
+            "attributed-production-rollout",
+            {
+                "version": "attributed-production-rollout-v1",
+                "base_rollout_id": base_rollout_id,
+                "candidate": candidate.model_dump(mode="json"),
+                "attribution": attribution_input.model_dump(mode="json"),
+            },
+        )
+    )
+    inputs = tuple(
+        sorted(
+            (
+                setup.trace_dataset,
+                *((attribution_input,) if attribution_input is not None else ()),
+            ),
+            key=lambda item: item.artifact_id,
+        )
+    )
     failure = trace.outcome.failure if trace.outcome is not None else None
     rollout = RolloutArtifact(
         schema_version=1,
         created_at=created_at,
-        inputs=(setup.trace_dataset,),
+        inputs=inputs,
         code_revision=code_revision,
         source=trace.source.identity,
         artifact_id=artifact_id,
-        simulation_id="production-import-v1",
+        simulation_id=(
+            "production-import-v1"
+            if attribution_input is None
+            else "attributed-production-import-v1"
+        ),
         cell_id=stable_id("production-cell", {"rollout_id": artifact_id}),
         mode=SimulationMode.WORLD_MODEL,
         rollout_id=artifact_id,

--- a/wmo/workflow/router_attribution.py
+++ b/wmo/workflow/router_attribution.py
@@ -1,0 +1,611 @@
+"""Verified candidate attribution for real router fidelity overlaps."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    Sha256,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.models import ModelSnapshot, RoutedCandidateSnapshot
+from wmo.common.project import (
+    ArtifactAlreadyExistsError,
+    ArtifactCorruptionError,
+    ArtifactStore,
+    artifact_input,
+)
+from wmo.common.tasks import TaskCase, load_task_set
+from wmo.common.traces import Trace, load_trace_dataset
+from wmo.simulation.ingest.dataset import (
+    read_trace_model_identity_evidence,
+    verify_current_trace_dataset,
+)
+from wmo.simulation.ingest.model_identity import (
+    IdentityComponentProvenance,
+    TraceModelIdentityEvidence,
+    TraceModelIdentityEvidenceSet,
+    require_model_identity_evidence_matches_traces,
+)
+
+AttributionMatchKind = Literal["declared_exact", "inferred_unique", "strict_snapshot"]
+
+
+class RouterAttributionError(ValueError):
+    """Candidate attribution is absent, ambiguous, conflicting, or internally inconsistent."""
+
+
+class RouterAttributedSpan(ContractModel):
+    """One contributing model span and the provenance used to resolve its candidate."""
+
+    span_id: str
+    recorded_model: ModelSnapshot
+    capabilities: IdentityComponentProvenance
+    connection: IdentityComponentProvenance
+
+
+class RouterObservedAttribution(ContractModel):
+    """One admitted real fit lineage attributed to one selected candidate."""
+
+    task_id: ArtifactId
+    trace_id: str
+    lineage_id: ArtifactId
+    candidate_alias: ArtifactId
+    candidate_model: ModelSnapshot
+    match_kind: AttributionMatchKind
+    spans: tuple[RouterAttributedSpan, ...] = Field(min_length=1)
+
+    @field_validator("spans")
+    @classmethod
+    def _require_unique_ordered_spans(
+        cls,
+        value: tuple[RouterAttributedSpan, ...],
+    ) -> tuple[RouterAttributedSpan, ...]:
+        """Require deterministic unique contributing span identities.
+
+        Args:
+            value: Model spans contributing to candidate attribution.
+
+        Returns:
+            The unchanged validated tuple.
+
+        Raises:
+            ValueError: Span IDs repeat or are not sorted.
+        """
+        span_ids = tuple(item.span_id for item in value)
+        if len(set(span_ids)) != len(span_ids):
+            raise ValueError("router attribution must not repeat contributing span IDs")
+        if span_ids != tuple(sorted(span_ids)):
+            raise ValueError("router attribution spans must be sorted by span ID")
+        return value
+
+
+class RouterObservedAttributionSet(ArtifactEnvelope):
+    """Immutable exact real-overlap attribution and catalog selection evidence."""
+
+    schema_version: Literal[1] = 1
+    attribution_set_id: ArtifactId
+    trace_dataset: ArtifactInput
+    task_set: ArtifactInput
+    catalog_sha256: Sha256
+    candidates: tuple[RoutedCandidateSnapshot, ...] = Field(min_length=2)
+    preferred_overlap_limit: int = Field(gt=0)
+    records: tuple[RouterObservedAttribution, ...] = Field(min_length=1)
+
+    @field_validator("candidates")
+    @classmethod
+    def _require_unique_candidate_aliases(
+        cls,
+        value: tuple[RoutedCandidateSnapshot, ...],
+    ) -> tuple[RoutedCandidateSnapshot, ...]:
+        """Require deterministic unique selected aliases.
+
+        Args:
+            value: Selected candidate snapshots.
+
+        Returns:
+            The unchanged validated tuple.
+
+        Raises:
+            ValueError: Aliases repeat or are not sorted.
+        """
+        aliases = tuple(item.alias for item in value)
+        if len(set(aliases)) != len(aliases):
+            raise ValueError("router attribution candidates must not repeat aliases")
+        if aliases != tuple(sorted(aliases)):
+            raise ValueError("router attribution candidates must be sorted by alias")
+        return value
+
+    @model_validator(mode="after")
+    def _require_complete_record_scope(self) -> RouterObservedAttributionSet:
+        """Require unique admitted tasks, traces, and leakage lineages.
+
+        Returns:
+            The unchanged validated artifact.
+
+        Raises:
+            ValueError: Records repeat a task, trace, or leakage lineage or exceed the limit.
+        """
+        if len(self.records) > self.preferred_overlap_limit:
+            raise ValueError("router attribution records exceed the preferred overlap limit")
+        for label, values in (
+            ("task", tuple(item.task_id for item in self.records)),
+            ("trace", tuple(item.trace_id for item in self.records)),
+            ("lineage", tuple(item.lineage_id for item in self.records)),
+        ):
+            if len(set(values)) != len(values):
+                raise ValueError(f"router attribution must not repeat {label} identities")
+        aliases = {candidate.alias for candidate in self.candidates}
+        if any(item.candidate_alias not in aliases for item in self.records):
+            raise ValueError("router attribution record names an unselected candidate")
+        return self
+
+
+def resolve_router_observed_attributions(
+    tasks: Sequence[TaskCase],
+    traces: Sequence[Trace],
+    evidence: TraceModelIdentityEvidenceSet | None,
+    candidates: Sequence[RoutedCandidateSnapshot],
+    *,
+    preferred_overlap_limit: int,
+) -> tuple[RouterObservedAttribution, ...]:
+    """Resolve one real fit trace per leakage lineage without guessing model identity.
+
+    Args:
+        tasks: Exact completed representative tasks.
+        traces: Exact completed normalized traces.
+        evidence: Verified per-model-span provenance, or ``None`` when the dataset has none.
+        candidates: Explicit selected candidate snapshots.
+        preferred_overlap_limit: Positive maximum admitted fidelity-overlap count.
+
+    Returns:
+        Deterministic admitted real-overlap attributions.
+
+    Raises:
+        RouterAttributionError: No fit lineage resolves, or any unresolved lineage is zero-match,
+            ambiguous, conflicting, or crosses candidate aliases.
+    """
+    if preferred_overlap_limit <= 0:
+        raise RouterAttributionError("preferred overlap limit must be positive")
+    if evidence is not None:
+        try:
+            require_model_identity_evidence_matches_traces(traces, evidence)
+        except ValueError as exc:
+            raise RouterAttributionError(f"model identity evidence is inconsistent: {exc}") from exc
+    ordered_candidates = tuple(sorted(candidates, key=lambda item: item.alias))
+    if len(ordered_candidates) < 2 or len({item.alias for item in ordered_candidates}) != len(
+        ordered_candidates
+    ):
+        raise RouterAttributionError("candidate attribution needs at least two unique aliases")
+    traces_by_id = {trace.trace_id: trace for trace in traces}
+    if len(traces_by_id) != len(traces):
+        raise RouterAttributionError("candidate attribution traces repeat trace IDs")
+    evidence_by_key = (
+        None
+        if evidence is None
+        else {(item.trace_id, item.span_id): item for item in evidence.records}
+    )
+    selected: list[RouterObservedAttribution] = []
+    failures: list[str] = []
+    admitted_lineages: set[str] = set()
+    for task in tasks:
+        if task.partition != "fit" or task.lineage_group_id in admitted_lineages:
+            continue
+        resolved = None
+        trace_failures = []
+        for trace_id in task.source_trace_ids:
+            trace = traces_by_id.get(trace_id)
+            if trace is None:
+                trace_failures.append(f"trace {trace_id!r} is absent from the completed dataset")
+                continue
+            try:
+                resolved = _resolve_trace(task, trace, evidence_by_key, ordered_candidates)
+            except RouterAttributionError as exc:
+                trace_failures.append(str(exc))
+                continue
+            break
+        if resolved is None:
+            details = "; ".join(trace_failures) or "task has no source trace IDs"
+            failures.append(f"fit lineage {task.lineage_group_id!r}: {details}")
+            continue
+        selected.append(resolved)
+        admitted_lineages.add(task.lineage_group_id)
+    if failures or not selected:
+        if not selected:
+            failures.append("no real fit lineage resolved to a selected candidate")
+        raise RouterAttributionError("candidate attribution failed:\n- " + "\n- ".join(failures))
+    return tuple(selected[:preferred_overlap_limit])
+
+
+def persist_router_observed_attribution_set(
+    store: ArtifactStore,
+    *,
+    trace_dataset: ArtifactInput,
+    task_set: ArtifactInput,
+    catalog_sha256: Sha256,
+    candidates: Sequence[RoutedCandidateSnapshot],
+    preferred_overlap_limit: int,
+    records: Sequence[RouterObservedAttribution],
+    created_at: datetime,
+    code_revision: str,
+) -> tuple[RouterObservedAttributionSet, ArtifactInput]:
+    """Persist or exactly replay one post-consent real-overlap attribution set.
+
+    Args:
+        store: Project-local immutable artifact store.
+        trace_dataset: Exact completed trace-dataset manifest input.
+        task_set: Exact completed task-set manifest input.
+        catalog_sha256: Digest of the complete confirmed secret-free model catalog.
+        candidates: Selected candidate snapshots.
+        preferred_overlap_limit: Positive admission bound used by matching.
+        records: Exact preflight-resolved real overlaps.
+        created_at: Artifact materialization time.
+        code_revision: Exact producer revision.
+
+    Returns:
+        Verified immutable attribution payload and manifest input.
+
+    Raises:
+        ValueError: Inputs or existing immutable evidence differ from the semantic request.
+    """
+    inputs = tuple(sorted((trace_dataset, task_set), key=lambda item: item.artifact_id))
+    ordered_candidates = tuple(sorted(candidates, key=lambda item: item.alias))
+    resolved_records = tuple(records)
+    semantic = _attribution_semantic(
+        inputs=inputs,
+        trace_dataset=trace_dataset,
+        task_set=task_set,
+        catalog_sha256=catalog_sha256,
+        candidates=ordered_candidates,
+        preferred_overlap_limit=preferred_overlap_limit,
+        records=resolved_records,
+        code_revision=code_revision,
+    )
+    attribution_id = stable_id("router-observed-attribution", semantic)
+    value = RouterObservedAttributionSet(
+        schema_version=1,
+        created_at=created_at,
+        inputs=inputs,
+        code_revision=code_revision,
+        attribution_set_id=attribution_id,
+        trace_dataset=trace_dataset,
+        task_set=task_set,
+        catalog_sha256=catalog_sha256,
+        candidates=ordered_candidates,
+        preferred_overlap_limit=preferred_overlap_limit,
+        records=resolved_records,
+    )
+    _verify_attribution_inputs(store, value)
+    destination = store.project_directory / "artifacts" / attribution_id
+    if destination.exists():
+        existing, input_value = load_router_observed_attribution_set(store, attribution_id)
+        replay = value.model_copy(update={"created_at": existing.created_at})
+        if existing != replay:
+            raise ValueError("existing router attribution differs from exact replay")
+        return existing, input_value
+    try:
+        store.write_json(
+            artifact_id=attribution_id,
+            artifact_type="router-observed-attribution",
+            envelope=value,
+            files={"attribution.json": value},
+        )
+    except ArtifactAlreadyExistsError:
+        return load_router_observed_attribution_set(store, attribution_id)
+    return load_router_observed_attribution_set(store, attribution_id)
+
+
+def load_router_observed_attribution_set(
+    store: ArtifactStore,
+    attribution_set_id: ArtifactId,
+) -> tuple[RouterObservedAttributionSet, ArtifactInput]:
+    """Recursively load and verify one immutable observed-attribution set.
+
+    Args:
+        store: Project-local immutable artifact store.
+        attribution_set_id: Exact attribution artifact identity.
+
+    Returns:
+        Verified attribution payload and current manifest input.
+
+    Raises:
+        ArtifactCorruptionError: Type, schema, bytes, identity, inputs, catalog-independent
+            matching, or recursive trace/task evidence is inconsistent.
+    """
+    stored = store.read(attribution_set_id)
+    if stored.manifest.artifact_type != "router-observed-attribution":
+        raise ArtifactCorruptionError(f"artifact {attribution_set_id} is not router attribution")
+    if stored.manifest.source is not None:
+        raise ArtifactCorruptionError(
+            f"router attribution {attribution_set_id} must not have source"
+        )
+    if {entry.path for entry in stored.manifest.files} != {"attribution.json"}:
+        raise ArtifactCorruptionError("router attribution does not have its exact one-file shape")
+    payload_bytes = store.read_bytes(attribution_set_id, "attribution.json")
+    try:
+        value = RouterObservedAttributionSet.model_validate_json(payload_bytes)
+    except (ValidationError, ValueError) as exc:
+        raise ArtifactCorruptionError(
+            f"router attribution {attribution_set_id} is invalid"
+        ) from exc
+    if payload_bytes != canonical_json_bytes(value):
+        raise ArtifactCorruptionError(
+            f"router attribution {attribution_set_id} is not canonical JSON"
+        )
+    if value.attribution_set_id != attribution_set_id:
+        raise ArtifactCorruptionError("router attribution payload identity differs from its path")
+    if (
+        stored.manifest.schema_version,
+        stored.manifest.created_at,
+        stored.manifest.inputs,
+        stored.manifest.code_revision,
+        stored.manifest.source,
+    ) != (
+        value.schema_version,
+        value.created_at,
+        value.inputs,
+        value.code_revision,
+        value.source,
+    ):
+        raise ArtifactCorruptionError("router attribution manifest differs from its envelope")
+    expected_id = stable_id(
+        "router-observed-attribution",
+        _attribution_semantic(
+            inputs=value.inputs,
+            trace_dataset=value.trace_dataset,
+            task_set=value.task_set,
+            catalog_sha256=value.catalog_sha256,
+            candidates=value.candidates,
+            preferred_overlap_limit=value.preferred_overlap_limit,
+            records=value.records,
+            code_revision=value.code_revision,
+        ),
+    )
+    if expected_id != attribution_set_id:
+        raise ArtifactCorruptionError("router attribution content identity differs")
+    _verify_attribution_inputs(store, value)
+    return value, artifact_input(stored.manifest)
+
+
+def _resolve_trace(
+    task: TaskCase,
+    trace: Trace,
+    evidence_by_key: dict[tuple[str, str], TraceModelIdentityEvidence] | None,
+    candidates: tuple[RoutedCandidateSnapshot, ...],
+) -> RouterObservedAttribution:
+    """Resolve every model span in one trace to one common selected alias.
+
+    Args:
+        task: Fit task whose source trace is being admitted.
+        trace: Exact real production trace.
+        evidence_by_key: Verified model-span evidence, or ``None`` for strict snapshot matching.
+        candidates: Exact selected candidate snapshots.
+
+    Returns:
+        Complete trace attribution.
+
+    Raises:
+        RouterAttributionError: No model exists, a span is unresolved, or spans cross aliases.
+    """
+    resolved = []
+    modes: list[AttributionMatchKind] = []
+    attributed_spans: list[RouterAttributedSpan] = []
+    for span in trace.spans:
+        if span.model is None:
+            continue
+        if evidence_by_key is None:
+            evidence = None
+        else:
+            evidence = evidence_by_key.get((trace.trace_id, span.span_id))
+            if evidence is None:
+                raise RouterAttributionError(
+                    f"trace {trace.trace_id!r} span {span.span_id!r} has no identity evidence"
+                )
+        candidate, mode, attributed_span = _resolve_span(
+            span.model, span.span_id, evidence, candidates
+        )
+        resolved.append(candidate)
+        modes.append(mode)
+        attributed_spans.append(attributed_span)
+    if not resolved:
+        raise RouterAttributionError(f"trace {trace.trace_id!r} has no model span")
+    aliases = {item.alias for item in resolved}
+    if len(aliases) != 1:
+        raise RouterAttributionError(
+            f"trace {trace.trace_id!r} model spans resolve across selected aliases: "
+            + ", ".join(sorted(aliases))
+        )
+    candidate = resolved[0]
+    match_kind: AttributionMatchKind
+    if "inferred_unique" in modes:
+        match_kind = "inferred_unique"
+    elif "strict_snapshot" in modes:
+        match_kind = "strict_snapshot"
+    else:
+        match_kind = "declared_exact"
+    return RouterObservedAttribution(
+        task_id=task.task_id,
+        trace_id=trace.trace_id,
+        lineage_id=task.lineage_group_id,
+        candidate_alias=candidate.alias,
+        candidate_model=candidate.model,
+        match_kind=match_kind,
+        spans=tuple(sorted(attributed_spans, key=lambda item: item.span_id)),
+    )
+
+
+def _resolve_span(
+    model: ModelSnapshot,
+    span_id: str,
+    evidence: TraceModelIdentityEvidence | None,
+    candidates: tuple[RoutedCandidateSnapshot, ...],
+) -> tuple[RoutedCandidateSnapshot, AttributionMatchKind, RouterAttributedSpan]:
+    """Resolve one recorded model span under its exact provenance classification.
+
+    Args:
+        model: Recorded immutable model snapshot.
+        span_id: Contributing source span identity.
+        evidence: Verified component provenance, or ``None`` when the dataset has none.
+        candidates: Exact selected candidate snapshots.
+
+    Returns:
+        Unique candidate, non-relabeled match kind, and persisted contributing span evidence.
+
+    Raises:
+        RouterAttributionError: Declared evidence conflicts or zero/multiple candidates remain.
+    """
+    capabilities: IdentityComponentProvenance = (
+        "unspecified" if evidence is None else evidence.capabilities
+    )
+    connection: IdentityComponentProvenance = (
+        "unspecified" if evidence is None else evidence.connection
+    )
+    if evidence is not None and evidence.model != model:
+        raise RouterAttributionError(f"span {span_id!r} evidence differs from its model snapshot")
+    if "unspecified" in {capabilities, connection}:
+        matches = tuple(item for item in candidates if item.model == model)
+        mode: AttributionMatchKind = "strict_snapshot"
+    elif capabilities == connection == "declared":
+        matches = tuple(item for item in candidates if item.model == model)
+        mode = "declared_exact"
+    else:
+        matches = tuple(
+            item
+            for item in candidates
+            if (
+                item.model.provider,
+                item.model.model_id,
+                item.model.revision,
+            )
+            == (model.provider, model.model_id, model.revision)
+            and (
+                capabilities != "declared"
+                or item.model.capabilities_sha256 == model.capabilities_sha256
+            )
+            and (
+                connection != "declared" or item.model.connection_sha256 == model.connection_sha256
+            )
+        )
+        mode = "inferred_unique"
+    if len(matches) != 1:
+        declared = capabilities == "declared" or connection == "declared"
+        reason = "conflicts with declared identity" if declared and not matches else "is ambiguous"
+        if not matches and not declared:
+            reason = "matches no selected candidate"
+        raise RouterAttributionError(f"model span {span_id!r} {reason}")
+    attributed = RouterAttributedSpan(
+        span_id=span_id,
+        recorded_model=model,
+        capabilities=capabilities,
+        connection=connection,
+    )
+    return matches[0], mode, attributed
+
+
+def _verify_attribution_inputs(
+    store: ArtifactStore,
+    value: RouterObservedAttributionSet,
+) -> None:
+    """Recursively verify trace/task inputs and recompute exact admitted attributions.
+
+    Args:
+        store: Project-local immutable artifact store.
+        value: Parsed attribution payload.
+
+    Raises:
+        ArtifactCorruptionError: Recursive manifests or recomputed attribution differ.
+    """
+    from wmo.simulation.mining.bindings import load_task_set_lineage_bindings
+
+    if tuple(sorted((value.trace_dataset, value.task_set), key=lambda item: item.artifact_id)) != (
+        value.inputs
+    ):
+        raise ArtifactCorruptionError("router attribution inputs differ from trace and task fields")
+    trace_stored = store.read(value.trace_dataset.artifact_id)
+    task_stored = store.read(value.task_set.artifact_id)
+    if artifact_input(trace_stored.manifest) != value.trace_dataset:
+        raise ArtifactCorruptionError("router attribution trace-dataset manifest changed")
+    if artifact_input(task_stored.manifest) != value.task_set:
+        raise ArtifactCorruptionError("router attribution task-set manifest changed")
+    loaded_traces = load_trace_dataset(store, value.trace_dataset.artifact_id)
+    verify_current_trace_dataset(store, loaded_traces)
+    evidence = read_trace_model_identity_evidence(store, loaded_traces)
+    tasks = load_task_set(store, value.task_set.artifact_id).tasks
+    lineage_payload = load_task_set_lineage_bindings(store, value.task_set.artifact_id)
+    bindings = {item.trace_id: item for item in lineage_payload.bindings}
+    tasks_by_id = {item.task_id: item for item in tasks}
+    for record in value.records:
+        binding = bindings.get(record.trace_id)
+        task = tasks_by_id.get(record.task_id)
+        if (
+            binding is None
+            or task is None
+            or binding.partition != "fit"
+            or binding.lineage_id != record.lineage_id
+            or task.partition != "fit"
+            or task.lineage_group_id != record.lineage_id
+            or record.trace_id not in task.source_trace_ids
+        ):
+            raise ArtifactCorruptionError(
+                "router attribution trace, task, partition, or lineage differs from build binding"
+            )
+    try:
+        expected = resolve_router_observed_attributions(
+            tasks,
+            loaded_traces.traces,
+            evidence,
+            value.candidates,
+            preferred_overlap_limit=value.preferred_overlap_limit,
+        )
+    except RouterAttributionError as exc:
+        raise ArtifactCorruptionError("router attribution cannot be recomputed") from exc
+    if expected != value.records:
+        raise ArtifactCorruptionError("router attribution records differ from recursive evidence")
+
+
+def _attribution_semantic(
+    *,
+    inputs: tuple[ArtifactInput, ...],
+    trace_dataset: ArtifactInput,
+    task_set: ArtifactInput,
+    catalog_sha256: Sha256,
+    candidates: tuple[RoutedCandidateSnapshot, ...],
+    preferred_overlap_limit: int,
+    records: tuple[RouterObservedAttribution, ...],
+    code_revision: str,
+) -> dict[str, object]:
+    """Return the canonical content identity for one attribution request.
+
+    Args:
+        inputs: Sorted trace and task manifest inputs.
+        trace_dataset: Exact completed trace-dataset input.
+        task_set: Exact completed task-set input.
+        catalog_sha256: Complete confirmed catalog digest.
+        candidates: Sorted selected candidate snapshots.
+        preferred_overlap_limit: Exact admitted-overlap ceiling.
+        records: Exact admitted attribution records.
+        code_revision: Exact producer revision.
+
+    Returns:
+        Canonical semantic identity payload.
+    """
+    return {
+        "version": "router-observed-attribution-v1",
+        "inputs": [item.model_dump(mode="json") for item in inputs],
+        "trace_dataset": trace_dataset.model_dump(mode="json"),
+        "task_set": task_set.model_dump(mode="json"),
+        "catalog_sha256": catalog_sha256,
+        "candidates": [item.model_dump(mode="json") for item in candidates],
+        "preferred_overlap_limit": preferred_overlap_limit,
+        "records": [item.model_dump(mode="json") for item in records],
+        "code_revision": code_revision,
+    }

--- a/wmo/workflow/router_attribution_test.py
+++ b/wmo/workflow/router_attribution_test.py
@@ -1,0 +1,392 @@
+"""Tests for immutable real-overlap candidate attribution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from wmo.common.core.artifacts import JsonObject, SourceIdentity
+from wmo.common.models import ConnectionConfig, ModelSnapshot, RoutedCandidateSnapshot
+from wmo.common.tasks import TaskCase
+from wmo.common.traces import Trace, TraceSource, TraceSpan
+from wmo.simulation.ingest.model_identity import (
+    CAPABILITIES_DIGEST_ATTRIBUTE,
+    IdentityComponentProvenance,
+    TraceModelIdentityEvidence,
+    TraceModelIdentityEvidenceSet,
+    normalized_capabilities_sha256,
+)
+from wmo.workflow.router_attribution import (
+    RouterAttributionError,
+    resolve_router_observed_attributions,
+)
+
+_TIME = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def test_unique_inferred_identity_maps_without_relabeling_fallback_digests() -> None:
+    """Provider/model/revision uniqueness admits inferred telemetry as inferred only."""
+    recorded = _fallback_model("openai", "gpt-test", None)
+    selected = recorded.model_copy(
+        update={"capabilities_sha256": "a" * 64, "connection_sha256": "b" * 64}
+    )
+    trace = _trace((recorded,))
+
+    records = resolve_router_observed_attributions(
+        (_task(trace),),
+        (trace,),
+        _evidence(trace, capabilities="inferred", connection="inferred"),
+        _candidates(selected, _model("anthropic", "other", None, "c", "d")),
+        preferred_overlap_limit=10,
+    )
+
+    assert records[0].candidate_alias == "candidate-a"
+    assert records[0].match_kind == "inferred_unique"
+
+
+def test_accidental_inferred_digest_equality_remains_inferred() -> None:
+    """Matching fallback bytes never upgrades inferred telemetry to declared exact evidence."""
+    recorded = _fallback_model("openai", "gpt-test", None)
+    trace = _trace((recorded,))
+
+    record = resolve_router_observed_attributions(
+        (_task(trace),),
+        (trace,),
+        _evidence(trace, capabilities="inferred", connection="inferred"),
+        _candidates(recorded, _model("anthropic", "other", None, "c", "d")),
+        preferred_overlap_limit=1,
+    )[0]
+
+    assert record.candidate_model == recorded
+    assert record.match_kind == "inferred_unique"
+
+
+def test_mixed_declared_component_is_a_hard_constraint() -> None:
+    """A declared capability digest cannot fall back through a unique base identity."""
+    recorded = _fallback_model("openai", "gpt-test", None).model_copy(
+        update={"capabilities_sha256": "a" * 64}
+    )
+    trace = _trace(
+        (recorded,),
+        attributes=({CAPABILITIES_DIGEST_ATTRIBUTE: "a" * 64},),
+    )
+    wrong = recorded.model_copy(
+        update={"capabilities_sha256": "b" * 64, "connection_sha256": "c" * 64}
+    )
+
+    with pytest.raises(RouterAttributionError, match="conflicts with declared identity"):
+        resolve_router_observed_attributions(
+            (_task(trace),),
+            (trace,),
+            _evidence(trace, capabilities="declared", connection="inferred"),
+            _candidates(wrong, _model("anthropic", "other", None, "d", "e")),
+            preferred_overlap_limit=1,
+        )
+
+
+def test_unique_inferred_mapping_rejects_ambiguous_aliases_and_revision_drift() -> None:
+    """Two selected base matches or an exact revision mismatch remain actionable failures."""
+    recorded = _fallback_model("openai", "gpt-test", "2026-08")
+    trace = _trace((recorded,))
+    evidence = _evidence(trace, capabilities="inferred", connection="inferred")
+
+    with pytest.raises(RouterAttributionError, match="ambiguous"):
+        resolve_router_observed_attributions(
+            (_task(trace),),
+            (trace,),
+            evidence,
+            _candidates(
+                _model("openai", "gpt-test", "2026-08", "a", "b"),
+                _model("openai", "gpt-test", "2026-08", "c", "d"),
+            ),
+            preferred_overlap_limit=1,
+        )
+    with pytest.raises(RouterAttributionError, match="matches no selected candidate"):
+        resolve_router_observed_attributions(
+            (_task(trace),),
+            (trace,),
+            evidence,
+            _candidates(
+                _model("openai", "gpt-test", None, "a", "b"),
+                _model("anthropic", "other", None, "c", "d"),
+            ),
+            preferred_overlap_limit=1,
+        )
+
+
+def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> None:
+    """Direct and legacy records never receive provider/model-only inference."""
+    recorded = _model("openai", "gpt-test", None, "a", "b")
+    trace = _trace((recorded,))
+    candidates = _candidates(recorded, _model("anthropic", "other", None, "c", "d"))
+
+    unspecified = resolve_router_observed_attributions(
+        (_task(trace),),
+        (trace,),
+        _evidence(trace, capabilities="unspecified", connection="unspecified"),
+        candidates,
+        preferred_overlap_limit=1,
+    )[0]
+    legacy = resolve_router_observed_attributions(
+        (_task(trace),),
+        (trace,),
+        None,
+        candidates,
+        preferred_overlap_limit=1,
+    )[0]
+
+    assert unspecified.match_kind == "strict_snapshot"
+    assert legacy.match_kind == "strict_snapshot"
+
+    changed = recorded.model_copy(update={"connection_sha256": "e" * 64})
+    with pytest.raises(RouterAttributionError, match="matches no selected candidate"):
+        resolve_router_observed_attributions(
+            (_task(trace),),
+            (trace,),
+            None,
+            _candidates(changed, _model("anthropic", "other", None, "c", "d")),
+            preferred_overlap_limit=1,
+        )
+
+
+def test_multi_span_trace_requires_one_candidate_alias() -> None:
+    """Multiple model spans may agree on one alias but can never cross aliases."""
+    first = _fallback_model("openai", "gpt-a", None)
+    second = _fallback_model("openai", "gpt-b", None)
+    same = _trace((first, first))
+    cross = _trace((first, second))
+
+    same_record = resolve_router_observed_attributions(
+        (_task(same),),
+        (same,),
+        _evidence(same, capabilities="inferred", connection="inferred"),
+        _candidates(first, second),
+        preferred_overlap_limit=1,
+    )[0]
+    assert len(same_record.spans) == 2
+
+    with pytest.raises(RouterAttributionError, match="resolve across selected aliases"):
+        resolve_router_observed_attributions(
+            (_task(cross),),
+            (cross,),
+            _evidence(cross, capabilities="inferred", connection="inferred"),
+            _candidates(first, second),
+            preferred_overlap_limit=1,
+        )
+
+
+def test_trace_summary_reports_inference_when_any_span_requires_it() -> None:
+    """Mixed exact and inferred spans retain inference in the trace-level summary."""
+    recorded = _fallback_model("openai", "gpt-a", None)
+    trace = _trace((recorded, recorded))
+    evidence = TraceModelIdentityEvidenceSet(
+        records=(
+            TraceModelIdentityEvidence(
+                trace_id=trace.trace_id,
+                span_id=trace.spans[0].span_id,
+                model=recorded,
+                capabilities="unspecified",
+                connection="unspecified",
+            ),
+            TraceModelIdentityEvidence(
+                trace_id=trace.trace_id,
+                span_id=trace.spans[1].span_id,
+                model=recorded,
+                capabilities="inferred",
+                connection="inferred",
+            ),
+        )
+    )
+
+    record = resolve_router_observed_attributions(
+        (_task(trace),),
+        (trace,),
+        evidence,
+        _candidates(recorded, _fallback_model("anthropic", "other", None)),
+        preferred_overlap_limit=1,
+    )[0]
+
+    assert record.match_kind == "inferred_unique"
+
+
+def test_trace_without_model_and_missing_evidence_are_typed_failures() -> None:
+    """Absent model calls or incomplete evidence never surface raw lookup errors."""
+    trace = _trace((None,))
+    candidates = _candidates(
+        _model("openai", "gpt-a", None, "a", "b"),
+        _model("openai", "gpt-b", None, "c", "d"),
+    )
+    with pytest.raises(RouterAttributionError, match="has no model span"):
+        resolve_router_observed_attributions(
+            (_task(trace),),
+            (trace,),
+            TraceModelIdentityEvidenceSet(records=()),
+            candidates,
+            preferred_overlap_limit=1,
+        )
+
+    modeled = _trace((candidates[0].model,))
+    with pytest.raises(RouterAttributionError, match="evidence is inconsistent"):
+        resolve_router_observed_attributions(
+            (_task(modeled),),
+            (modeled,),
+            TraceModelIdentityEvidenceSet(records=()),
+            candidates,
+            preferred_overlap_limit=1,
+        )
+
+
+def _fallback_model(provider: str, model_id: str, revision: str | None) -> ModelSnapshot:
+    """Return the exact fallback snapshot produced by telemetry normalization.
+
+    Args:
+        provider: Source provider name.
+        model_id: Source provider model identifier.
+        revision: Exact optional source revision.
+
+    Returns:
+        Inferred capability and standard-connection snapshot.
+    """
+    return ModelSnapshot(
+        provider=provider,
+        model_id=model_id,
+        revision=revision,
+        capabilities_sha256=normalized_capabilities_sha256(
+            {}, provider, model_id, revision, error_type=ValueError
+        ),
+        connection_sha256=ConnectionConfig(provider=provider).identity_sha256(),
+    )
+
+
+def _model(
+    provider: str,
+    model_id: str,
+    revision: str | None,
+    capabilities_prefix: str,
+    connection_prefix: str,
+) -> ModelSnapshot:
+    """Return one deterministic selected model snapshot.
+
+    Args:
+        provider: Provider name.
+        model_id: Provider model identifier.
+        revision: Exact optional revision.
+        capabilities_prefix: Character repeated into the capability digest.
+        connection_prefix: Character repeated into the connection digest.
+
+    Returns:
+        Exact test model snapshot.
+    """
+    return ModelSnapshot(
+        provider=provider,
+        model_id=model_id,
+        revision=revision,
+        capabilities_sha256=capabilities_prefix * 64,
+        connection_sha256=connection_prefix * 64,
+    )
+
+
+def _candidates(
+    first: ModelSnapshot,
+    second: ModelSnapshot,
+) -> tuple[RoutedCandidateSnapshot, RoutedCandidateSnapshot]:
+    """Return two explicitly selected candidate aliases.
+
+    Args:
+        first: Candidate A model snapshot.
+        second: Candidate B model snapshot.
+
+    Returns:
+        Ordered selected candidates.
+    """
+    return (
+        RoutedCandidateSnapshot(alias="candidate-a", model=first),
+        RoutedCandidateSnapshot(alias="candidate-b", model=second),
+    )
+
+
+def _trace(
+    models: tuple[ModelSnapshot | None, ...],
+    *,
+    attributes: tuple[JsonObject, ...] | None = None,
+) -> Trace:
+    """Return one fit-source trace with the requested model spans.
+
+    Args:
+        models: Optional model snapshot for each span.
+        attributes: Optional exact span attribute dictionaries.
+
+    Returns:
+        Canonical trace fixture.
+    """
+    span_attributes: tuple[JsonObject, ...] = attributes or tuple({} for _item in models)
+    return Trace(
+        trace_id="trace-1",
+        task="Resolve the support request",
+        spans=tuple(
+            TraceSpan(
+                span_id=f"span-{index}",
+                name="agent.model_call",
+                started_at=_TIME + timedelta(seconds=index),
+                ended_at=_TIME + timedelta(seconds=index + 1),
+                attributes=span_attributes[index],
+                model=model,
+            )
+            for index, model in enumerate(models)
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(kind="otlp", source_id="fixture", sha256="f" * 64),
+            semantic_convention_version="1.37.0",
+        ),
+    )
+
+
+def _task(trace: Trace) -> TaskCase:
+    """Return one fit task bound to a trace fixture.
+
+    Args:
+        trace: Source trace fixture.
+
+    Returns:
+        Canonical fit task.
+    """
+    return TaskCase(
+        task_id="task-1",
+        lineage_group_id="lineage-1",
+        partition="fit",
+        instruction=trace.task,
+        workload_weight=1.0,
+        source_trace_ids=(trace.trace_id,),
+    )
+
+
+def _evidence(
+    trace: Trace,
+    *,
+    capabilities: IdentityComponentProvenance,
+    connection: IdentityComponentProvenance,
+) -> TraceModelIdentityEvidenceSet:
+    """Return complete model-span evidence with one shared provenance classification.
+
+    Args:
+        trace: Exact source trace.
+        capabilities: Capability provenance literal.
+        connection: Connection provenance literal.
+
+    Returns:
+        Complete ordered identity evidence.
+    """
+    return TraceModelIdentityEvidenceSet(
+        records=tuple(
+            TraceModelIdentityEvidence(
+                trace_id=trace.trace_id,
+                span_id=span.span_id,
+                model=span.model,
+                capabilities=capabilities,
+                connection=connection,
+            )
+            for span in trace.spans
+            if span.model is not None
+        )
+    )


### PR DESCRIPTION
## Summary

Adds an explicit ghost mode for router-backed runs that executes routing normally without persisting traces, traffic, or request journals. The CLI and Python application API share the same runtime mode.

## Stack

- Base: #448 at `e29663d172a527d8f05be783988fc6ec85010ddb`
- Head: `19a1e053e36efb7d1c3059a05243463045b57c57`
- Ghost replay: 1 of 1 patch-identical
- Includes #448 atomic journal-prefix acceptance and PTY repairs
- Does not include workflow deletion or the #449 ownership refactor

## Validation

- whole Ruff format/check and Ty passed
- focused ghost, API, CLI, runtime, and import-boundary matrix: 122 passed
- exact range-diff: 1 of 1 patch-identical
- fresh CI and Greptile requested

Do not merge before #448.
