### PR TITLE
Make the public terminal OTLP dataset build directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ curl http://127.0.0.1:8000/v1/chat/completions \
   -d '{"model":"support-agent","messages":[{"role":"user","content":"Help me"}]}'
 ```
 
+To exercise the build path with a public trace export, download the
+[terminal-tasks OTLP dataset](https://huggingface.co/datasets/experiential-labs/wmo-terminal-tasks-traces)
+and pass it to the same command without a source adapter or conversion step:
+
+```bash
+curl -L -o traces.otel.jsonl \
+  https://huggingface.co/datasets/experiential-labs/wmo-terminal-tasks-traces/resolve/540883e451dc13d34fb50fdd36b143cb0f1fb0db/traces.otel.jsonl
+wmo build terminal-tasks traces.otel.jsonl
+```
+
 After collecting traces from your router, fine-tune an open source model you own using
 [Tinker](https://tinker.thinkingmachines.ai/).
 

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -148,6 +148,67 @@ def _otlp_export(tmp_path: Path, count: int = 1) -> Path:
     return path
 
 
+def _environment_capture_otlp_export(tmp_path: Path) -> Path:
+    """Write one exact environment-capture direct-span JSONL export.
+
+    Args:
+        tmp_path: Temporary directory receiving the trace export.
+
+    Returns:
+        Path to the completed JSONL export.
+    """
+    trace_id = "1" * 32
+    prefix = f"{trace_id[:12]}0000"
+    records = (
+        {
+            "traceId": trace_id,
+            "spanId": f"{prefix}a",
+            "parentSpanId": "",
+            "name": "chat terminal",
+            "startTimeUnixNano": 0,
+            "endTimeUnixNano": 1,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": [
+                _attribute("gen_ai.operation.name", "chat"),
+                _attribute("gen_ai.request.model", "terminal-agent"),
+                _attribute("gen_ai.tool.name", "bash"),
+                _attribute(
+                    "gen_ai.tool.call.arguments",
+                    json.dumps({"command": "printf ready"}),
+                ),
+                _attribute("gen_ai.prompt", "Print ready"),
+                _attribute(
+                    "wmh.trace.metadata",
+                    json.dumps(
+                        {
+                            "benchmark": "terminal-tasks",
+                            "returncode": 0,
+                            "task_category": "Filesystem + text processing",
+                        }
+                    ),
+                ),
+            ],
+        },
+        {
+            "traceId": trace_id,
+            "spanId": f"{prefix}b",
+            "parentSpanId": "",
+            "name": "execute_tool terminal",
+            "startTimeUnixNano": 2,
+            "endTimeUnixNano": 3,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": [
+                _attribute("gen_ai.operation.name", "execute_tool"),
+                _attribute("gen_ai.tool.name", "bash"),
+                _attribute("gen_ai.tool.message", "ready"),
+            ],
+        },
+    )
+    path = tmp_path / "traces.otel.jsonl"
+    path.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+    return path
+
+
 class _EmbeddingClient:
     """Deterministic semantic-shaped client for no-network build tests."""
 
@@ -343,6 +404,36 @@ def test_build_positional_happy_path_creates_two_rags_and_executable_artifact(
     with pytest.raises(ProjectStoreError, match="completed build graph"):
         store.bind_completed_build(swapped)
     assert store.load_project().build == config.build
+
+
+def test_build_accepts_environment_capture_jsonl_through_default_otlp_source(
+    tmp_path: Path,
+) -> None:
+    """The direct capture download shape completes the positional build path.
+
+    Args:
+        tmp_path: Temporary project and trace root.
+    """
+    source = _environment_capture_otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+
+    result = _RUNNER.invoke(app, ["build", "terminal", str(source), "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "built 1 accepted, 0 invalid" in result.output
+    store = ProjectStore(root, "terminal")
+    config = store.load_project()
+    assert config.build is not None
+    traces = load_trace_dataset(store.artifacts, config.build.trace_dataset.artifact_id)
+    assert len(traces.traces) == 1
+    assert traces.traces[0].conversation_id == traces.traces[0].trace_id
+    identity_evidence = read_trace_model_identity_evidence(store.artifacts, traces)
+    assert identity_evidence is not None
+    assert identity_evidence.records == ()
+    serving = load_rag_index(store.artifacts, config.build.serving_rag.artifact_id)
+    assert serving.index.transition_count == 1
 
 
 def test_build_package_upgrade_creates_new_immutable_graph(

--- a/wmo/simulation/ingest/environment_capture.py
+++ b/wmo/simulation/ingest/environment_capture.py
@@ -1,0 +1,438 @@
+"""Canonicalize the owned environment-capture action and observation profile."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+
+from pydantic import JsonValue
+
+from wmo.common.core.artifacts import JsonObject
+
+_TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+_ACTION_KEY_ORDER = (
+    "gen_ai.operation.name",
+    "gen_ai.request.model",
+    "gen_ai.tool.name",
+    "gen_ai.tool.call.arguments",
+)
+_FIRST_ACTION_KEY_ORDER = _ACTION_KEY_ORDER + ("gen_ai.prompt", "wmh.trace.metadata")
+_RESULT_KEY_ORDER = (
+    "gen_ai.operation.name",
+    "gen_ai.tool.name",
+    "gen_ai.tool.message",
+)
+_SPAN_KEYS = frozenset(
+    {
+        "traceId",
+        "spanId",
+        "parentSpanId",
+        "name",
+        "startTimeUnixNano",
+        "endTimeUnixNano",
+        "status",
+        "attributes",
+    }
+)
+_PROFILE_TIMESTAMP_OFFSET_NANOS = 1_000_000_000
+_PROFILE_TIMESTAMP_SCALE = 1_000
+_ACTION_NAME = "chat terminal"
+_RESULT_NAME = "execute_tool terminal"
+_BENCHMARK = "terminal-tasks"
+_MODEL = "terminal-agent"
+_TOOL = "bash"
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when embedded profile JSON repeats an object key."""
+
+
+def canonicalize_environment_capture_payloads(
+    payloads: Sequence[JsonValue],
+) -> tuple[JsonValue, ...] | None:
+    """Return canonical spans when every payload matches the owned capture profile.
+
+    Args:
+        payloads: Decoded JSONL records in their original source order.
+
+    Returns:
+        Canonical direct-span payloads, or ``None`` when any record falls outside the profile.
+    """
+    spans = _direct_spans(payloads)
+    if spans is None:
+        return None
+    groups = _contiguous_trace_groups(spans)
+    if groups is None:
+        return None
+    canonical: list[JsonValue] = []
+    for group in groups:
+        converted = _canonical_trace(group)
+        if converted is None:
+            return None
+        canonical.extend(converted)
+    return tuple(canonical)
+
+
+def _direct_spans(payloads: Sequence[JsonValue]) -> tuple[JsonObject, ...] | None:
+    """Return exact direct-span objects without accepting nested OTLP envelopes.
+
+    Args:
+        payloads: Decoded JSON records offered to the profile.
+
+    Returns:
+        Direct span objects, or ``None`` when the input uses another OTLP shape.
+    """
+    if not payloads:
+        return None
+    spans: list[JsonObject] = []
+    for payload in payloads:
+        if not isinstance(payload, dict) or set(payload) != _SPAN_KEYS:
+            return None
+        spans.append(payload)
+    return tuple(spans)
+
+
+def _contiguous_trace_groups(
+    spans: Sequence[JsonObject],
+) -> tuple[tuple[JsonObject, ...], ...] | None:
+    """Group source-contiguous spans while rejecting repeated trace blocks.
+
+    Args:
+        spans: Exact direct-span records in source order.
+
+    Returns:
+        Contiguous trace groups, or ``None`` for invalid or repeated identities.
+    """
+    groups: list[list[JsonObject]] = []
+    seen: set[str] = set()
+    current_trace_id: str | None = None
+    for span in spans:
+        trace_id = span.get("traceId")
+        if not isinstance(trace_id, str) or not _valid_trace_id(trace_id):
+            return None
+        if trace_id != current_trace_id:
+            if trace_id in seen:
+                return None
+            seen.add(trace_id)
+            groups.append([])
+            current_trace_id = trace_id
+        groups[-1].append(span)
+    return tuple(tuple(group) for group in groups)
+
+
+def _canonical_trace(spans: Sequence[JsonObject]) -> tuple[JsonObject, ...] | None:
+    """Validate and canonicalize one complete alternating action-result trace.
+
+    Args:
+        spans: Source-contiguous spans for one trace identity.
+
+    Returns:
+        Canonical spans, or ``None`` when the trace is incomplete or malformed.
+    """
+    if not spans or len(spans) % 2:
+        return None
+    trace_id = spans[0].get("traceId")
+    if not isinstance(trace_id, str):
+        return None
+    canonical: list[JsonObject] = []
+    for ordinal in range(len(spans) // 2):
+        action = spans[ordinal * 2]
+        result = spans[ordinal * 2 + 1]
+        converted = _canonical_pair(action, result, trace_id=trace_id, ordinal=ordinal)
+        if converted is None:
+            return None
+        canonical.extend(converted)
+    return tuple(canonical)
+
+
+def _canonical_pair(
+    action: JsonObject,
+    result: JsonObject,
+    *,
+    trace_id: str,
+    ordinal: int,
+) -> tuple[JsonObject, JsonObject] | None:
+    """Validate one exact pair and return its canonical direct OTLP spans.
+
+    Args:
+        action: Captured terminal action span.
+        result: Captured terminal observation span.
+        trace_id: Shared validated trace identity.
+        ordinal: Zero-based action and result pair position.
+
+    Returns:
+        Canonical action and result spans, or ``None`` for any profile mismatch.
+    """
+    if action.get("traceId") != trace_id or result.get("traceId") != trace_id:
+        return None
+    prefix = f"{trace_id[:12]}{ordinal:04x}"
+    if action.get("spanId") != f"{prefix}a" or result.get("spanId") != f"{prefix}b":
+        return None
+    if action.get("parentSpanId") != "" or result.get("parentSpanId") != "":
+        return None
+    if action.get("name") != _ACTION_NAME or result.get("name") != _RESULT_NAME:
+        return None
+    if not _exact_timestamps(action, ordinal * 10, ordinal * 10 + 1):
+        return None
+    if not _exact_timestamps(result, ordinal * 10 + 2, ordinal * 10 + 3):
+        return None
+    if action.get("status") != {"code": "STATUS_CODE_OK"}:
+        return None
+    if result.get("status") not in (
+        {"code": "STATUS_CODE_OK"},
+        {"code": "STATUS_CODE_ERROR"},
+    ):
+        return None
+    action_attributes = _string_attributes(action.get("attributes"))
+    result_attributes = _string_attributes(result.get("attributes"))
+    if action_attributes is None or result_attributes is None:
+        return None
+    expected_action_keys = _FIRST_ACTION_KEY_ORDER if ordinal == 0 else _ACTION_KEY_ORDER
+    if tuple(action_attributes) != expected_action_keys:
+        return None
+    if tuple(result_attributes) != _RESULT_KEY_ORDER:
+        return None
+    if action_attributes["gen_ai.operation.name"] != "chat":
+        return None
+    if result_attributes["gen_ai.operation.name"] != "execute_tool":
+        return None
+    if action_attributes["gen_ai.request.model"] != _MODEL:
+        return None
+    tool_name = action_attributes["gen_ai.tool.name"]
+    if tool_name != _TOOL or result_attributes["gen_ai.tool.name"] != tool_name:
+        return None
+    if not _command_arguments(action_attributes["gen_ai.tool.call.arguments"]):
+        return None
+    if ordinal == 0 and not _first_action_evidence(action_attributes):
+        return None
+    action_span_id = str(action["spanId"])[-16:]
+    result_span_id = str(result["spanId"])[-16:]
+    call_id = f"environment-capture-{trace_id}-{ordinal}"
+    return (
+        _canonical_span(
+            action,
+            span_id=action_span_id,
+            parent_span_id=None,
+            start=ordinal * 10,
+            end=ordinal * 10 + 1,
+            status_code=1,
+            attributes=_canonical_action_attributes(
+                action_attributes,
+                trace_id=trace_id,
+                call_id=call_id,
+                first=ordinal == 0,
+            ),
+        ),
+        _canonical_span(
+            result,
+            span_id=result_span_id,
+            parent_span_id=action_span_id,
+            start=ordinal * 10 + 2,
+            end=ordinal * 10 + 3,
+            status_code=2 if result["status"] == {"code": "STATUS_CODE_ERROR"} else 1,
+            attributes=(
+                _attribute("gen_ai.operation.name", "execute_tool"),
+                _attribute("gen_ai.tool.name", result_attributes["gen_ai.tool.name"]),
+                _attribute("gen_ai.tool.call.id", call_id),
+                _attribute("gen_ai.tool.message", result_attributes["gen_ai.tool.message"]),
+            ),
+        ),
+    )
+
+
+def _canonical_span(
+    raw: JsonObject,
+    *,
+    span_id: str,
+    parent_span_id: str | None,
+    start: int,
+    end: int,
+    status_code: int,
+    attributes: Sequence[JsonObject],
+) -> JsonObject:
+    """Build one direct span with canonical identity, time, status, and attributes.
+
+    Args:
+        raw: Validated source span supplying trace identity and name.
+        span_id: Canonical W3C span identity.
+        parent_span_id: Canonical parent identity, when present.
+        start: Relative source start ordinal.
+        end: Relative source end ordinal.
+        status_code: Canonical OTLP numeric status code.
+        attributes: Canonical semantic attributes.
+
+    Returns:
+        Strict direct OTLP span accepted by the shared normalizer.
+    """
+    span: JsonObject = {
+        "traceId": raw["traceId"],
+        "spanId": span_id,
+        "name": raw["name"],
+        "startTimeUnixNano": _canonical_timestamp(start),
+        "endTimeUnixNano": _canonical_timestamp(end),
+        "status": {"code": status_code},
+        "attributes": list(attributes),
+    }
+    if parent_span_id is not None:
+        span["parentSpanId"] = parent_span_id
+    return span
+
+
+def _canonical_action_attributes(
+    attributes: dict[str, str], *, trace_id: str, call_id: str, first: bool
+) -> tuple[JsonObject, ...]:
+    """Build provider-free invoke-agent attributes with stable episode lineage.
+
+    Args:
+        attributes: Validated source action attributes.
+        trace_id: Source trace identity used as episode lineage.
+        call_id: Deterministic action and result pairing identity.
+        first: Whether this action owns initial prompt and metadata evidence.
+
+    Returns:
+        Canonical invoke-agent attributes in deterministic order.
+    """
+    result = [
+        _attribute("gen_ai.operation.name", "invoke_agent"),
+        _attribute("gen_ai.tool.name", attributes["gen_ai.tool.name"]),
+        _attribute("gen_ai.tool.call.id", call_id),
+        _attribute("gen_ai.tool.call.arguments", attributes["gen_ai.tool.call.arguments"]),
+    ]
+    if first:
+        result.extend(
+            (
+                _attribute("gen_ai.prompt", attributes["gen_ai.prompt"]),
+                _attribute("wmh.trace.metadata", attributes["wmh.trace.metadata"]),
+                _attribute("wmo.conversation.id", trace_id),
+            )
+        )
+    return tuple(result)
+
+
+def _string_attributes(value: JsonValue | None) -> dict[str, str] | None:
+    """Decode an exact list of unique OTLP string attributes.
+
+    Args:
+        value: Candidate OTLP attribute-list value.
+
+    Returns:
+        Ordered decoded attributes, or ``None`` for any structural mismatch.
+    """
+    if not isinstance(value, list):
+        return None
+    decoded: dict[str, str] = {}
+    for item in value:
+        if not isinstance(item, dict) or set(item) != {"key", "value"}:
+            return None
+        key = item.get("key")
+        wrapped = item.get("value")
+        if (
+            not isinstance(key, str)
+            or key in decoded
+            or not isinstance(wrapped, dict)
+            or set(wrapped) != {"stringValue"}
+            or not isinstance(wrapped.get("stringValue"), str)
+        ):
+            return None
+        decoded[key] = wrapped["stringValue"]
+    return decoded
+
+
+def _first_action_evidence(attributes: dict[str, str]) -> bool:
+    """Return whether the first action carries exact terminal evidence.
+
+    Args:
+        attributes: Validated first-action string attributes.
+
+    Returns:
+        Whether prompt and metadata satisfy the terminal profile.
+    """
+    if not attributes["gen_ai.prompt"].strip():
+        return False
+    try:
+        metadata = json.loads(
+            attributes["wmh.trace.metadata"], object_pairs_hook=_reject_duplicate_json_keys
+        )
+    except (json.JSONDecodeError, _DuplicateJsonKeyError):
+        return False
+    return (
+        isinstance(metadata, dict)
+        and set(metadata) == {"benchmark", "returncode", "task_category"}
+        and metadata.get("benchmark") == _BENCHMARK
+        and isinstance(metadata.get("task_category"), str)
+        and bool(metadata["task_category"].strip())
+        and type(metadata.get("returncode")) is int
+    )
+
+
+def _command_arguments(value: str) -> bool:
+    """Return whether text contains the exact nonempty terminal command object.
+
+    Args:
+        value: JSON text from the captured tool-call arguments.
+
+    Returns:
+        Whether the decoded object contains only one nonempty command string.
+    """
+    try:
+        decoded = json.loads(value, object_pairs_hook=_reject_duplicate_json_keys)
+    except (json.JSONDecodeError, _DuplicateJsonKeyError):
+        return False
+    return (
+        isinstance(decoded, dict)
+        and set(decoded) == {"command"}
+        and isinstance(decoded.get("command"), str)
+        and bool(decoded["command"].strip())
+    )
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, JsonValue]]) -> JsonObject:
+    """Decode one embedded JSON object while rejecting repeated keys.
+
+    Args:
+        pairs: Object members in source order.
+
+    Returns:
+        Decoded object with unique keys.
+
+    Raises:
+        _DuplicateJsonKeyError: A key occurs more than once in the object.
+    """
+    result: JsonObject = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _exact_timestamps(span: JsonObject, start: int, end: int) -> bool:
+    """Return whether one span retains exact non-boolean ordinal timestamps.
+
+    Args:
+        span: Captured direct span.
+        start: Required relative start ordinal.
+        end: Required relative end ordinal.
+
+    Returns:
+        Whether both timestamp fields are exact integer matches.
+    """
+    raw_start = span.get("startTimeUnixNano")
+    raw_end = span.get("endTimeUnixNano")
+    return type(raw_start) is int and type(raw_end) is int and raw_start == start and raw_end == end
+
+
+def _canonical_timestamp(value: int) -> int:
+    """Map one relative ordinal to a positive, microsecond-distinct epoch value."""
+    return _PROFILE_TIMESTAMP_OFFSET_NANOS + value * _PROFILE_TIMESTAMP_SCALE
+
+
+def _valid_trace_id(value: str) -> bool:
+    """Return whether one trace ID is a non-zero lowercase W3C identity."""
+    return bool(_TRACE_ID_PATTERN.fullmatch(value)) and set(value) != {"0"}
+
+
+def _attribute(key: str, value: str) -> JsonObject:
+    """Encode one OTLP string attribute."""
+    return {"key": key, "value": {"stringValue": value}}

--- a/wmo/simulation/ingest/environment_capture_test.py
+++ b/wmo/simulation/ingest/environment_capture_test.py
@@ -1,0 +1,321 @@
+"""Tests for the owned environment-capture OTLP profile."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import cast
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.simulation.ingest.environment_capture import canonicalize_environment_capture_payloads
+
+_TRACE_ID = "1" * 32
+
+
+def _attribute(key: str, value: str) -> JsonObject:
+    """Encode one string attribute for a profile fixture."""
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _profile_payloads() -> list[JsonObject]:
+    """Build one exact two-step environment-capture trace fixture.
+
+    Returns:
+        Alternating terminal action and result records in source order.
+    """
+    records: list[JsonObject] = []
+    for ordinal, command, output in (
+        (0, "printf first", "first"),
+        (1, "printf second", "second"),
+    ):
+        action_attributes: list[JsonObject] = [
+            _attribute("gen_ai.operation.name", "chat"),
+            _attribute("gen_ai.request.model", "terminal-agent"),
+            _attribute("gen_ai.tool.name", "bash"),
+            _attribute("gen_ai.tool.call.arguments", json.dumps({"command": command})),
+        ]
+        if ordinal == 0:
+            action_attributes.extend(
+                (
+                    _attribute("gen_ai.prompt", "Run two commands"),
+                    _attribute(
+                        "wmh.trace.metadata",
+                        json.dumps(
+                            {
+                                "benchmark": "terminal-tasks",
+                                "returncode": 0,
+                                "task_category": "Filesystem + text processing",
+                            }
+                        ),
+                    ),
+                )
+            )
+        prefix = f"{_TRACE_ID[:12]}{ordinal:04x}"
+        action: JsonObject = {
+            "traceId": _TRACE_ID,
+            "spanId": f"{prefix}a",
+            "parentSpanId": "",
+            "name": "chat terminal",
+            "startTimeUnixNano": ordinal * 10,
+            "endTimeUnixNano": ordinal * 10 + 1,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": action_attributes,
+        }
+        result: JsonObject = {
+            "traceId": _TRACE_ID,
+            "spanId": f"{prefix}b",
+            "parentSpanId": "",
+            "name": "execute_tool terminal",
+            "startTimeUnixNano": ordinal * 10 + 2,
+            "endTimeUnixNano": ordinal * 10 + 3,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": [
+                _attribute("gen_ai.operation.name", "execute_tool"),
+                _attribute("gen_ai.tool.name", "bash"),
+                _attribute("gen_ai.tool.message", output),
+            ],
+        }
+        records.extend((action, result))
+    return records
+
+
+def _attributes(span: JsonObject) -> dict[str, str]:
+    """Decode a canonical fixture span's string attributes.
+
+    Args:
+        span: Canonical direct span emitted by the profile converter.
+
+    Returns:
+        Attribute values keyed by their semantic-convention names.
+    """
+    raw = cast(list[JsonObject], span["attributes"])
+    return {
+        cast(str, item["key"]): cast(str, cast(JsonObject, item["value"])["stringValue"])
+        for item in raw
+    }
+
+
+def test_exact_profile_canonicalizes_without_fabricating_model_identity() -> None:
+    """Canonicalize owned actions without fabricating model identity.
+
+    The conversion repairs wire identities and pairing while retaining provider-free
+    invoke-agent semantics and deterministic episode lineage.
+    """
+    canonical = canonicalize_environment_capture_payloads(_profile_payloads())
+
+    assert canonical is not None
+    assert len(canonical) == 4
+    action = cast(JsonObject, canonical[0])
+    result = cast(JsonObject, canonical[1])
+    assert action["spanId"] == "111111111110000a"
+    assert result["spanId"] == "111111111110000b"
+    assert "parentSpanId" not in action
+    assert result["parentSpanId"] == action["spanId"]
+    assert action["startTimeUnixNano"] == 1_000_000_000
+    assert action["endTimeUnixNano"] == 1_000_001_000
+    assert action["status"] == {"code": 1}
+    assert result["status"] == {"code": 1}
+    action_attributes = _attributes(action)
+    result_attributes = _attributes(result)
+    assert action_attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert "gen_ai.request.model" not in action_attributes
+    assert "gen_ai.provider.name" not in action_attributes
+    assert action_attributes["wmh.trace.metadata"]
+    assert action_attributes["wmo.conversation.id"] == _TRACE_ID
+    assert action_attributes["gen_ai.tool.call.id"] == result_attributes["gen_ai.tool.call.id"]
+
+
+def test_empty_tool_output_remains_exact_profile_evidence() -> None:
+    """Retain an empty environment observation as exact capture evidence.
+
+    Empty output is valid for terminal commands and must not make an otherwise exact
+    action-result pair ineligible for canonicalization.
+    """
+    payloads = _profile_payloads()
+    result_attributes = cast(list[JsonObject], payloads[1]["attributes"])
+    message = next(item for item in result_attributes if item["key"] == "gen_ai.tool.message")
+    cast(JsonObject, message["value"])["stringValue"] = ""
+
+    canonical = canonicalize_environment_capture_payloads(payloads)
+
+    assert canonical is not None
+    assert _attributes(cast(JsonObject, canonical[1]))["gen_ai.tool.message"] == ""
+
+
+def test_near_matches_do_not_enter_the_owned_profile() -> None:
+    """Reject every tested identity, structure, metadata, and pairing drift.
+
+    The compatibility boundary is the exact owned terminal grammar, so each mutation
+    must return control to the strict generic OTLP normalizer without partial repair.
+    """
+    wrong_id = _profile_payloads()
+    wrong_id[0]["spanId"] = "2" * 17
+    assert canonicalize_environment_capture_payloads(wrong_id) is None
+
+    wrong_name = _profile_payloads()
+    wrong_name[0]["name"] = "chat other"
+    assert canonicalize_environment_capture_payloads(wrong_name) is None
+
+    non_root = _profile_payloads()
+    non_root[1]["parentSpanId"] = cast(str, non_root[0]["spanId"])
+    assert canonicalize_environment_capture_payloads(non_root) is None
+
+    wrong_time = _profile_payloads()
+    wrong_time[0]["startTimeUnixNano"] = 1
+    assert canonicalize_environment_capture_payloads(wrong_time) is None
+
+    boolean_time = _profile_payloads()
+    boolean_time[0]["startTimeUnixNano"] = False
+    assert canonicalize_environment_capture_payloads(boolean_time) is None
+
+    provider = _profile_payloads()
+    cast(list[JsonObject], provider[0]["attributes"]).append(
+        _attribute("gen_ai.provider.name", "openai")
+    )
+    assert canonicalize_environment_capture_payloads(provider) is None
+
+    wrong_model = _profile_payloads()
+    model_attributes = cast(list[JsonObject], wrong_model[0]["attributes"])
+    model = next(item for item in model_attributes if item["key"] == "gen_ai.request.model")
+    cast(JsonObject, model["value"])["stringValue"] = "gpt-5.4"
+    assert canonicalize_environment_capture_payloads(wrong_model) is None
+
+    non_bash = _profile_payloads()
+    action_attributes = cast(list[JsonObject], non_bash[0]["attributes"])
+    action_tool = next(item for item in action_attributes if item["key"] == "gen_ai.tool.name")
+    cast(JsonObject, action_tool["value"])["stringValue"] = "python"
+    result_attributes = cast(list[JsonObject], non_bash[1]["attributes"])
+    result_tool = next(item for item in result_attributes if item["key"] == "gen_ai.tool.name")
+    cast(JsonObject, result_tool["value"])["stringValue"] = "python"
+    assert canonicalize_environment_capture_payloads(non_bash) is None
+
+    extra_argument = _profile_payloads()
+    action_attributes = cast(list[JsonObject], extra_argument[0]["attributes"])
+    arguments = next(
+        item for item in action_attributes if item["key"] == "gen_ai.tool.call.arguments"
+    )
+    cast(JsonObject, arguments["value"])["stringValue"] = json.dumps(
+        {"command": "printf ready", "timeout": 1}
+    )
+    assert canonicalize_environment_capture_payloads(extra_argument) is None
+
+    duplicate_command = _profile_payloads()
+    action_attributes = cast(list[JsonObject], duplicate_command[0]["attributes"])
+    arguments = next(
+        item for item in action_attributes if item["key"] == "gen_ai.tool.call.arguments"
+    )
+    cast(JsonObject, arguments["value"])["stringValue"] = (
+        '{"command":"printf first","command":"printf second"}'
+    )
+    assert canonicalize_environment_capture_payloads(duplicate_command) is None
+
+    empty_command = _profile_payloads()
+    action_attributes = cast(list[JsonObject], empty_command[0]["attributes"])
+    arguments = next(
+        item for item in action_attributes if item["key"] == "gen_ai.tool.call.arguments"
+    )
+    cast(JsonObject, arguments["value"])["stringValue"] = json.dumps({"command": ""})
+    assert canonicalize_environment_capture_payloads(empty_command) is None
+
+    capability_digest = _profile_payloads()
+    cast(list[JsonObject], capability_digest[0]["attributes"]).append(
+        _attribute("wmo.model.capabilities_sha256", "c" * 64)
+    )
+    assert canonicalize_environment_capture_payloads(capability_digest) is None
+
+    connection_digest = _profile_payloads()
+    cast(list[JsonObject], connection_digest[0]["attributes"]).append(
+        _attribute("wmo.model.connection_sha256", "d" * 64)
+    )
+    assert canonicalize_environment_capture_payloads(connection_digest) is None
+
+    wrong_tool = _profile_payloads()
+    result_attributes = cast(list[JsonObject], wrong_tool[1]["attributes"])
+    tool = next(item for item in result_attributes if item["key"] == "gen_ai.tool.name")
+    cast(JsonObject, tool["value"])["stringValue"] = "python"
+    assert canonicalize_environment_capture_payloads(wrong_tool) is None
+
+    no_metadata = _profile_payloads()
+    first_attributes = cast(list[JsonObject], no_metadata[0]["attributes"])
+    no_metadata[0]["attributes"] = [
+        item for item in first_attributes if item["key"] != "wmh.trace.metadata"
+    ]
+    assert canonicalize_environment_capture_payloads(no_metadata) is None
+
+    wrong_benchmark = _profile_payloads()
+    attributes = cast(list[JsonObject], wrong_benchmark[0]["attributes"])
+    metadata = next(item for item in attributes if item["key"] == "wmh.trace.metadata")
+    cast(JsonObject, metadata["value"])["stringValue"] = json.dumps(
+        {
+            "benchmark": "other",
+            "returncode": 0,
+            "task_category": "Filesystem + text processing",
+        }
+    )
+    assert canonicalize_environment_capture_payloads(wrong_benchmark) is None
+
+    duplicate_benchmark = _profile_payloads()
+    attributes = cast(list[JsonObject], duplicate_benchmark[0]["attributes"])
+    metadata = next(item for item in attributes if item["key"] == "wmh.trace.metadata")
+    cast(JsonObject, metadata["value"])["stringValue"] = (
+        '{"benchmark":"other","benchmark":"terminal-tasks",'
+        '"returncode":0,"task_category":"Filesystem + text processing"}'
+    )
+    assert canonicalize_environment_capture_payloads(duplicate_benchmark) is None
+
+    boolean_returncode = _profile_payloads()
+    attributes = cast(list[JsonObject], boolean_returncode[0]["attributes"])
+    metadata = next(item for item in attributes if item["key"] == "wmh.trace.metadata")
+    cast(JsonObject, metadata["value"])["stringValue"] = json.dumps(
+        {
+            "benchmark": "terminal-tasks",
+            "returncode": False,
+            "task_category": "Filesystem + text processing",
+        }
+    )
+    assert canonicalize_environment_capture_payloads(boolean_returncode) is None
+
+    empty_category = _profile_payloads()
+    attributes = cast(list[JsonObject], empty_category[0]["attributes"])
+    metadata = next(item for item in attributes if item["key"] == "wmh.trace.metadata")
+    cast(JsonObject, metadata["value"])["stringValue"] = json.dumps(
+        {"benchmark": "terminal-tasks", "returncode": 0, "task_category": ""}
+    )
+    assert canonicalize_environment_capture_payloads(empty_category) is None
+
+    extra_metadata = _profile_payloads()
+    attributes = cast(list[JsonObject], extra_metadata[0]["attributes"])
+    metadata = next(item for item in attributes if item["key"] == "wmh.trace.metadata")
+    cast(JsonObject, metadata["value"])["stringValue"] = json.dumps(
+        {
+            "benchmark": "terminal-tasks",
+            "extra": True,
+            "returncode": 0,
+            "task_category": "Filesystem + text processing",
+        }
+    )
+    assert canonicalize_environment_capture_payloads(extra_metadata) is None
+
+    reordered_attributes = _profile_payloads()
+    attributes = cast(list[JsonObject], reordered_attributes[0]["attributes"])
+    attributes[0], attributes[1] = attributes[1], attributes[0]
+    assert canonicalize_environment_capture_payloads(reordered_attributes) is None
+
+
+def test_repeated_noncontiguous_trace_block_fails_closed() -> None:
+    """Reject a trace identity repeated around another source trace block.
+
+    The producer emits each trace contiguously, so accepting a spliced block would make
+    the compatibility detector broader than the owned source grammar.
+    """
+    first = _profile_payloads()
+    second = copy.deepcopy(first)
+    second_trace_id = "2" * 32
+    for ordinal, span in enumerate(second):
+        pair_ordinal = ordinal // 2
+        suffix = "a" if ordinal % 2 == 0 else "b"
+        span["traceId"] = second_trace_id
+        span["spanId"] = f"{second_trace_id[:12]}{pair_ordinal:04x}{suffix}"
+    interleaved = first[:2] + second + first[2:]
+
+    assert canonicalize_environment_capture_payloads(interleaved) is None

--- a/wmo/simulation/ingest/otlp.py
+++ b/wmo/simulation/ingest/otlp.py
@@ -22,6 +22,7 @@ from wmo.common.core.text import normalize_durable_text
 from wmo.common.models import ModelSnapshot, Usage
 from wmo.common.tasks import ToolSchema
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.simulation.ingest.environment_capture import canonicalize_environment_capture_payloads
 from wmo.simulation.ingest.model_identity import (
     TraceModelIdentityEvidence,
     normalized_capabilities_sha256,
@@ -49,6 +50,10 @@ _CONVERSATION_KEYS = ("wmo.conversation.id", "gen_ai.conversation.id")
 
 class OtlpTraceFormatError(ValueError):
     """Raised when a trace upload cannot be decoded as OpenTelemetry JSON."""
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when profile-eligibility parsing finds an ambiguous JSON object."""
 
 
 @dataclass(frozen=True)
@@ -246,26 +251,71 @@ def _normalize_jsonl(
     source: SourceIdentity,
     semantic_convention_version: str,
 ) -> TraceNormalizationResult:
-    """Decode JSONL while retaining every malformed-line exclusion for review."""
+    """Decode JSONL and admit only an unambiguous complete capture profile.
+
+    Args:
+        text: UTF-8 JSONL source text.
+        source: Immutable identity of the original source bytes.
+        semantic_convention_version: Pinned GenAI convention used for normalization.
+
+    Returns:
+        Canonical traces plus every retained parse or validation exclusion.
+
+    Raises:
+        OtlpTraceFormatError: The source contains neither records nor parse issues.
+    """
     payloads: list[JsonValue] = []
+    profile_payloads: list[JsonValue] = []
+    profile_eligible = True
     issues: list[TraceNormalizationIssue] = []
     for line_number, line in enumerate(text.splitlines(), start=1):
         if not line.strip():
             continue
         try:
-            payloads.append(json.loads(line))
+            payload = json.loads(line)
         except json.JSONDecodeError as exc:
+            profile_eligible = False
             issues.append(
                 TraceNormalizationIssue(f"line-{line_number}", f"invalid JSONL record: {exc.msg}")
             )
+            continue
+        payloads.append(payload)
+        try:
+            profile_payloads.append(json.loads(line, object_pairs_hook=_reject_duplicate_json_keys))
+        except _DuplicateJsonKeyError:
+            profile_eligible = False
     if not payloads and not issues:
         raise OtlpTraceFormatError("OTLP JSONL file contains no records")
+    if profile_eligible and not issues:
+        canonical_payloads = canonicalize_environment_capture_payloads(profile_payloads)
+        if canonical_payloads is not None:
+            payloads = list(canonical_payloads)
     return normalize_otlp_payloads(
         payloads,
         source=source,
         semantic_convention_version=semantic_convention_version,
         initial_issues=issues,
     )
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, JsonValue]]) -> JsonObject:
+    """Decode one JSON object while rejecting repeated keys.
+
+    Args:
+        pairs: Object members in their original source order.
+
+    Returns:
+        Decoded JSON object with unique keys.
+
+    Raises:
+        _DuplicateJsonKeyError: A key occurs more than once in the object.
+    """
+    result: JsonObject = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
 
 
 def _extract_raw_spans(payload: JsonValue, ordinal: int) -> list[_RawSpan]:

--- a/wmo/simulation/ingest/otlp_test.py
+++ b/wmo/simulation/ingest/otlp_test.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from pathlib import Path
 from typing import cast
+
+import pytest
 
 from wmo.common.core.artifacts import SourceIdentity
 from wmo.common.models import ConnectionConfig
@@ -103,6 +106,63 @@ def _payload(trace_id: str = _TRACE_ID) -> dict[str, object]:
 
 def _source() -> SourceIdentity:
     return SourceIdentity(kind="otlp", source_id="fixture", sha256="a" * 64)
+
+
+def _environment_capture_payloads(trace_id: str = _TRACE_ID) -> list[dict[str, object]]:
+    """Return one exact environment-capture action and observation pair.
+
+    Args:
+        trace_id: W3C trace identity assigned to both records.
+
+    Returns:
+        Source action and result spans in JSONL order.
+    """
+    prefix = f"{trace_id[:12]}0000"
+    return [
+        {
+            "traceId": trace_id,
+            "spanId": f"{prefix}a",
+            "parentSpanId": "",
+            "name": "chat terminal",
+            "startTimeUnixNano": 0,
+            "endTimeUnixNano": 1,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": [
+                _attribute("gen_ai.operation.name", "chat"),
+                _attribute("gen_ai.request.model", "terminal-agent"),
+                _attribute("gen_ai.tool.name", "bash"),
+                _attribute(
+                    "gen_ai.tool.call.arguments",
+                    json.dumps({"command": "printf ready"}),
+                ),
+                _attribute("gen_ai.prompt", "Print ready"),
+                _attribute(
+                    "wmh.trace.metadata",
+                    json.dumps(
+                        {
+                            "benchmark": "terminal-tasks",
+                            "returncode": 0,
+                            "task_category": "Filesystem + text processing",
+                        }
+                    ),
+                ),
+            ],
+        },
+        {
+            "traceId": trace_id,
+            "spanId": f"{prefix}b",
+            "parentSpanId": "",
+            "name": "execute_tool terminal",
+            "startTimeUnixNano": 2,
+            "endTimeUnixNano": 3,
+            "status": {"code": "STATUS_CODE_OK"},
+            "attributes": [
+                _attribute("gen_ai.operation.name", "execute_tool"),
+                _attribute("gen_ai.tool.name", "bash"),
+                _attribute("gen_ai.tool.message", "ready"),
+            ],
+        },
+    ]
 
 
 def _payload_spans(payload: dict[str, object]) -> list[object]:
@@ -312,6 +372,145 @@ def test_jsonl_preserves_a_malformed_line_as_an_explicit_exclusion(tmp_path: Pat
     assert len(result.traces) == 1
     assert result.invalid_trace_count == 1
     assert result.traces[0].source.identity.sha256 == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_environment_capture_jsonl_normalizes_through_default_otlp_loader(tmp_path: Path) -> None:
+    """The exact owned profile loads without a converter or source override.
+
+    Args:
+        tmp_path: Temporary directory receiving the direct-span JSONL fixture.
+    """
+    path = tmp_path / "traces.otel.jsonl"
+    path.write_text(
+        "".join(f"{json.dumps(payload)}\n" for payload in _environment_capture_payloads()),
+        encoding="utf-8",
+    )
+
+    result = load_otlp_file(path)
+
+    assert result.issues == ()
+    assert len(result.traces) == 1
+    trace = result.traces[0]
+    assert trace.task == "Print ready"
+    assert trace.conversation_id == _TRACE_ID
+    assert tuple(span.span_id for span in trace.spans) == (
+        "111111111110000a",
+        "111111111110000b",
+    )
+    assert trace.spans[0].parent_span_id is None
+    assert trace.spans[1].parent_span_id == trace.spans[0].span_id
+    assert trace.spans[0].attributes["gen_ai.tool.call.id"]
+    assert (
+        trace.spans[1].attributes["gen_ai.tool.call.id"]
+        == trace.spans[0].attributes["gen_ai.tool.call.id"]
+    )
+    assert trace.spans[0].attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert trace.spans[0].model is None
+    assert result.identity_evidence == ()
+    assert trace.source.identity.sha256 == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_environment_capture_trace_ids_become_distinct_conversation_lineages(
+    tmp_path: Path,
+) -> None:
+    """Each source episode receives its own stable conversation lineage.
+
+    Args:
+        tmp_path: Temporary directory receiving a two-trace JSONL fixture.
+    """
+    second_trace_id = "5" * 32
+    payloads = _environment_capture_payloads() + _environment_capture_payloads(second_trace_id)
+    path = tmp_path / "two-traces.otel.jsonl"
+    path.write_text(
+        "".join(f"{json.dumps(payload)}\n" for payload in payloads),
+        encoding="utf-8",
+    )
+
+    result = load_otlp_file(path)
+
+    assert result.issues == ()
+    assert {trace.conversation_id for trace in result.traces} == {_TRACE_ID, second_trace_id}
+
+
+def test_environment_capture_near_match_remains_strict_otlp_failure(tmp_path: Path) -> None:
+    """A provider-bearing near-match cannot use profile identity repair.
+
+    Args:
+        tmp_path: Temporary directory receiving the near-match JSONL fixture.
+    """
+    payloads = copy.deepcopy(_environment_capture_payloads())
+    attributes = cast(list[dict[str, object]], payloads[0]["attributes"])
+    attributes.append(_attribute("gen_ai.provider.name", "openai"))
+    path = tmp_path / "near-match.otel.jsonl"
+    path.write_text(
+        "".join(f"{json.dumps(payload)}\n" for payload in payloads),
+        encoding="utf-8",
+    )
+
+    result = load_otlp_file(path)
+
+    assert result.traces == ()
+    assert len(result.issues) == 1
+    assert "span ID must be a non-zero lowercase 16-hex W3C ID" in result.issues[0].message
+
+
+def test_environment_capture_malformed_line_disables_whole_file_repair(tmp_path: Path) -> None:
+    """Do not repair surviving capture records after a JSONL parse failure.
+
+    Args:
+        tmp_path: Temporary directory receiving the malformed mixed JSONL file.
+    """
+    records = "".join(f"{json.dumps(payload)}\n" for payload in _environment_capture_payloads())
+    path = tmp_path / "malformed-profile.otel.jsonl"
+    path.write_text(f"{{broken\n{records}", encoding="utf-8")
+
+    result = load_otlp_file(path)
+
+    assert result.traces == ()
+    assert any(issue.source_record == "line-1" for issue in result.issues)
+    assert any(
+        "span ID must be a non-zero lowercase 16-hex W3C ID" in issue.message
+        for issue in result.issues
+    )
+
+
+@pytest.mark.parametrize("duplicate_target", ["span", "status"])
+def test_environment_capture_duplicate_json_key_disables_whole_file_repair(
+    tmp_path: Path,
+    duplicate_target: str,
+) -> None:
+    """Do not profile-repair a last-key-wins JSON object.
+
+    Args:
+        tmp_path: Temporary directory receiving the ambiguous JSONL file.
+        duplicate_target: Outer or nested object whose key is repeated.
+    """
+    payloads = _environment_capture_payloads()
+    action = json.dumps(payloads[0], separators=(",", ":"))
+    if duplicate_target == "span":
+        exact_span_id = cast(str, payloads[0]["spanId"])
+        action = action.replace(
+            f'"spanId":"{exact_span_id}"',
+            f'"spanId":"bad","spanId":"{exact_span_id}"',
+            1,
+        )
+    else:
+        action = action.replace(
+            '"status":{"code":"STATUS_CODE_OK"}',
+            '"status":{"code":"STATUS_CODE_ERROR","code":"STATUS_CODE_OK"}',
+            1,
+        )
+    result_line = json.dumps(payloads[1], separators=(",", ":"))
+    path = tmp_path / f"duplicate-{duplicate_target}.otel.jsonl"
+    path.write_text(f"{action}\n{result_line}\n", encoding="utf-8")
+
+    result = load_otlp_file(path)
+
+    assert result.traces == ()
+    assert any(
+        "span ID must be a non-zero lowercase 16-hex W3C ID" in issue.message
+        for issue in result.issues
+    )
 
 
 def test_otlp_sorts_unordered_export_before_selecting_the_initial_task() -> None:


### PR DESCRIPTION
## Summary

- recognize the exact owned terminal environment-capture JSONL grammar at the raw OTLP ingest boundary
- canonicalize its legacy wire IDs, timestamps, tool pairing, and conversation lineage without inventing provider or model identity
- keep generic OTLP strict and disable compatibility for any malformed line, duplicate key, mixed record, or profile drift
- document a pinned public Hugging Face dataset that works with the ordinary wmo build PROJECT TRACES command

## Direct happy path

The unmodified pinned Hugging Face file at revision 540883e451dc13d34fb50fdd36b143cb0f1fb0db now produces:

- 280 accepted traces
- 1,370 spans
- 0 normalization issues
- 280 distinct conversation lineages
- 0 model identity records
- 50 fit tasks and 20 held-out tasks

The original source SHA256 remains 21c62cba7e3372cbf03df051dc2408699fbf8ea3561ba661b599e4949f0e5d42.

## Validation

- full suite: 1004 passed, 1 skipped
- focused ingest, build, layout, and import boundaries: 63 passed
- whole Ruff format and check: passed
- whole Ty: passed
- wheel and sdist: built
- fresh Python 3.13 wheel install: imported from site-packages and loaded the exact public file as 280 traces, 1,370 spans, 0 issues
- direct positional build and exact replay: 280 accepted, 0 invalid, 50 fit, 20 held out

No merge performed.