### PR TITLE
Remove the build Proceed? prompt and add a cost preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,12 @@ uv run pytest -q
 - `wmo/simulation/` owns trace ingestion, representative-task mining, typed simulation specs,
   current engines, orchestration, artifact construction, and comparisons. New modules for those
   responsibilities go inside `wmo/simulation/`, never at the flat `wmo/` root.
-- `wmo build TRACE_FILE --source otlp|posthog --project PROJECT --root ROOT` is the only CLI path
+- `wmo build PROJECT TRACES --source otlp|posthog --root ROOT` is the only CLI path
   from local traces to immutable task evidence. It accepts 100 through 1000 normalized traces,
-  writes manifest-bound fit and held-out tasks plus `proposals_pending` review state, and makes no
-  model, provider, or judge calls. Route each corpus through an explicit canonical source loader.
+  writes manifest-bound fit and held-out tasks plus `proposals_pending` review state, and
+  authorizes build-time embeddings when the conservative estimate is within
+  `--max-build-cost-usd`. It makes no judge or completion calls. Route each corpus through an
+  explicit canonical source loader.
 - New trace sources belong in `wmo/simulation/ingest/`, normalize into the `Trace` and `TraceSpan`
   contracts in `wmo/common/traces/`, support file ingestion, and register from
   `wmo/simulation/ingest/__init__.py`.

--- a/docs/cookbook/router.md
+++ b/docs/cookbook/router.md
@@ -6,20 +6,22 @@ online request.
 ## 1. Build deterministic task evidence
 
 ```bash
-wmo build traces.otel.jsonl --source otlp --project support-agent --root .wmo
+wmo build support-agent traces.otel.jsonl --source otlp --root .wmo
 ```
 
-The command requires 100 through 1000 valid normalized traces. It reads the raw file once,
-persists normalized traces and representative fit and held-out tasks, then records a
-manifest-bound readiness state with rubric proposals pending. It makes zero model, provider, or
-judge paid calls. Anonymous aggregate PostHog product telemetry may send after persistence unless
-disabled. Repeating the command with identical source content and code revision verifies and
-reuses the exact artifact manifests and payloads.
+The command reads the raw file once, persists normalized traces and representative fit and
+held-out tasks, then grounds serving and fit-only retrieval when the conservative embedding
+estimate is within `--max-build-cost-usd`. It records a manifest-bound readiness state with rubric
+proposals pending. It makes no judge or completion calls. `--dry-run` prints the complete
+preflight without credentials or a completed-build selection. Anonymous aggregate PostHog product
+telemetry may send after persistence unless disabled. Repeating the command with identical source
+content and code revision verifies and reuses the exact artifact manifests and payloads.
 
 ## 2. Complete review and evaluation explicitly
 
-The CLI keeps provider consent out of `build`, so its next input remains a reviewed completed
-evidence config. Python applications can use `wmo.compose_router` for actual WMO composition. They
+`wmo build` authorizes only build-time embeddings under `--max-build-cost-usd`. Router
+optimization still requires its own reviewed completed evidence and spend consent. Python
+applications can use `wmo.compose_router` for actual WMO composition. They
 inject an approved-review supplier, reviewed setup supplier, plan-bound simulator factory, judge,
 runtime catalog, finite simulation-dollar ceiling, and finite judgment-call ceiling. WMO creates
 the plan and phase-scoped simulation specs, runs only fidelity and fit cells, persists judgments

--- a/docs/cookbook/router.md
+++ b/docs/cookbook/router.md
@@ -11,9 +11,11 @@ wmo build support-agent traces.otel.jsonl --source otlp --root .wmo
 
 The command reads the raw file once, persists normalized traces and representative fit and
 held-out tasks, then grounds serving and fit-only retrieval when the conservative embedding
-estimate is within `--max-build-cost-usd`. It records a manifest-bound readiness state with rubric
-proposals pending. It makes no judge or completion calls. `--dry-run` prints the complete
-preflight without credentials or a completed-build selection. Anonymous aggregate PostHog product
+estimate is within `--max-build-cost-usd`. An interactive terminal confirms after the preflight
+with a ``Proceed`` prompt that names the estimate and defaults to yes. It records a
+manifest-bound readiness state with rubric proposals pending. It makes no judge or completion
+calls. `--dry-run` prints the complete preflight without credentials or a completed-build
+selection. Anonymous aggregate PostHog product
 telemetry may send after persistence unless disabled. Repeating the command with identical source
 content and code revision verifies and reuses the exact artifact manifests and payloads.
 

--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -5,21 +5,21 @@
 - `--source otlp` reads OpenTelemetry JSON or JSONL using the supported GenAI span mapping.
 - `--source posthog` reads a local PostHog LLM-observability export.
 
-The positional `TRACE_FILE` and `--project` are required. Raw exports remain at the customer path.
-WMO stores a normalized immutable snapshot and explicit normalization issues under the selected
-project. Public build accepts 100 through 1000 valid normalized traces after validation and source
-deduplication. The limit applies to normalized traces, not to the smaller representative task count
-that semantic deduplication and mining produce.
+The positional `PROJECT` and `TRACES` arguments are required. Raw exports remain at the customer
+path. WMO stores a normalized immutable snapshot and explicit normalization issues under the
+selected project. Public build accepts 100 through 1000 valid normalized traces after validation
+and source deduplication. The limit applies to normalized traces, not to the smaller
+representative task count that semantic deduplication and mining produce.
 
 No generic vendor-adapter registry is part of the command. Build does not pull a remote source,
-resolve a provider, propose a rubric, run a judge, or call an embedding API. Representative task
-selection uses the deterministic local hashing embedder unless a Python caller supplies another
-explicit descriptor embedder.
+propose a rubric, or run a judge. Representative task selection uses the deterministic local
+hashing embedder unless a Python caller supplies another explicit descriptor embedder. After
+preflight, `wmo build` may call the configured embedder when the conservative estimate is within
+`--max-build-cost-usd`. `--dry-run` stops after that preflight without credentials or spend.
 
-Build makes zero model, provider, or judge paid calls. The CLI preserves anonymous aggregate
-PostHog product telemetry, which may send after successful persistence unless the user runs
-`wmo config telemetry disable`. Telemetry does not include prompts, traces, paths, model names, or
-customer content.
+The CLI preserves anonymous aggregate PostHog product telemetry, which may send after successful
+persistence unless the user runs `wmo config telemetry disable`. Telemetry does not include
+prompts, traces, paths, model names, or customer content.
 
 ## Authorized PostHog HogQL pull
 

--- a/docs/reference/router_optimization_config.md
+++ b/docs/reference/router_optimization_config.md
@@ -1,7 +1,8 @@
 # Router optimization configuration
 
-`wmo build` stops with `proposals_pending`. It does not create simulation, judgment, fidelity,
-embedding, or pricing artifacts. The completed-evidence CLI path requires these inputs. A Python
+`wmo build` stops with `proposals_pending` after grounding retrieval. It does not create
+simulation, judgment, fidelity, router embedding-set, or pricing artifacts. The completed-evidence
+CLI path requires these inputs. A Python
 application may instead use `wmo.compose_router` with explicit suppliers, simulator, judge, runtime
 catalog, and finite budgets to have WMO create and verify the remaining artifact chain. Before
 either path, the application must provide these approved inputs with explicit user consent:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,9 @@ The root surface is deliberately small:
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
 `build` authorizes provider embeddings when the conservative estimate is within
-`--max-build-cost-usd`. It makes no judge or completion calls. `--dry-run` prints the complete
+`--max-build-cost-usd`. An interactive terminal confirms after the preflight with a ``Proceed``
+prompt that names the estimate and defaults to yes. Noninteractive sessions continue automatically
+under the ceiling. It makes no judge or completion calls. `--dry-run` prints the complete
 preflight without credentials, provider calls, or a completed-build selection. Successful build,
 router, simulation, and SFT operations preserve anonymous aggregate PostHog product telemetry,
 which may send unless disabled. `optimize router` does not make provider calls. `optimize model`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,22 +4,24 @@ The root surface is deliberately small:
 
 | Command | Purpose | Local result |
 |---|---|---|
-| `wmo build TRACE_FILE --project PROJECT --root ROOT` | Normalize 100 through 1000 local OTLP or PostHog traces and mine representative tasks. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
+| `wmo build PROJECT TRACES --root ROOT [--dry-run]` | Normalize local OTLP or PostHog traces, mine representative tasks, and ground serving plus fit-only retrieval when the embedding estimate is within `--max-build-cost-usd`. | Manifest-bound `TraceDataset`, `TaskSet`, serving RAG, fit-only RAG, grounded world model, and `proposals_pending` review state. |
 | `wmo optimize router PROJECT --config FILE --root ROOT` | Fit, freeze, then report from explicit completed evidence. | Fit evaluation, bank, policy, held-out evaluation, and router report. |
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
-`build` makes zero model, provider, or judge paid calls. Successful build, router, simulation, and
-SFT operations preserve anonymous aggregate PostHog product telemetry, which may send unless
-disabled. `optimize router` does not make provider calls. `optimize model` requires an immutable
-positive cost ceiling, a finite conservative full-schedule estimate, explicit consent, and complete
-project evidence before Tinker can open. Unknown cost or incomplete provenance fails before
-dispatch. `run` makes no provider call at startup.
+`build` authorizes provider embeddings when the conservative estimate is within
+`--max-build-cost-usd`. It makes no judge or completion calls. `--dry-run` prints the complete
+preflight without credentials, provider calls, or a completed-build selection. Successful build,
+router, simulation, and SFT operations preserve anonymous aggregate PostHog product telemetry,
+which may send unless disabled. `optimize router` does not make provider calls. `optimize model`
+requires an immutable positive cost ceiling, a finite conservative full-schedule estimate, explicit
+consent, and complete project evidence before Tinker can open. Unknown cost or incomplete
+provenance fails before dispatch. `run` makes no provider call at startup.
 An HTTP completion or direct `RouterRuntime.complete` call is the explicit online model-call
 boundary. The router remains frozen for the process lifetime. `run --ghost` still permits provider
 calls but disables durable interaction, replay, RAG, and SFT state for that process.
 
-Build stops at review readiness. Simulation, judgment, fidelity, embedding, and pricing artifacts
-must be completed through a separately authorized workflow before creating the exact
-[`router-optimization.json`](reference/router_optimization_config.md) input.
+Build stops at review readiness after grounding retrieval. Simulation, judgment, fidelity, and
+pricing artifacts must be completed through a separately authorized workflow before creating the
+exact [`router-optimization.json`](reference/router_optimization_config.md) input.

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.prompt import Confirm
 
 from wmo.cli.consent import can_prompt
 from wmo.cli.provider_setup import (
@@ -106,11 +107,13 @@ def build(
 ) -> None:
     """Build a reusable grounded world model and immutable fit evidence.
 
-    The explicit invocation plus ``--max-build-cost-usd`` authorizes embedding work. Model setup
-    runs first when required catalog state is absent and both terminal streams are interactive.
-    The shared catalog commits before project creation. Noninteractive missing state fails before
-    any project or artifact write. Provider credentials are read only after preflight and the
-    cost ceiling pass.
+    The explicit invocation plus ``--max-build-cost-usd`` authorizes embedding work. An
+    interactive terminal sees the preflight, then a ``Proceed`` prompt that names the conservative
+    estimate and defaults to yes. Noninteractive sessions continue automatically when the estimate
+    is within the ceiling. Model setup runs first when required catalog state is absent and both
+    terminal streams are interactive. The shared catalog commits before project creation.
+    Noninteractive missing state fails before any project or artifact write. Provider credentials
+    are read only after preflight, the cost ceiling pass, and any interactive confirmation.
 
     Args:
         project: Safe local project identifier below ``<root>/projects``.
@@ -215,6 +218,9 @@ def build(
                         top_k=top_k,
                     )
                 )
+            if not _confirm_embedding_spend(estimate):
+                _console.print("Build was not started.")
+                return
             resolved_embedder = runtime_catalog.preflight(
                 selected.embedder,
                 CapabilityRequirement(requires_embeddings=True),
@@ -706,6 +712,28 @@ def _rag_transition_count(store: ProjectStore, artifact_id: str) -> int:
         Count of persisted real transitions.
     """
     return load_rag_index(store.artifacts, artifact_id).index.transition_count
+
+
+def _confirm_embedding_spend(estimate: float) -> bool:
+    """Confirm under-ceiling embedding spend after the preflight is visible.
+
+    Interactive sessions ask ``Proceed`` with the conservative estimate and default to yes.
+    Noninteractive sessions treat the explicit ``wmo build`` invocation plus the configured
+    ceiling as authorization and do not prompt.
+
+    Args:
+        estimate: Conservative maximum embedding cost in USD.
+
+    Returns:
+        True when the run should continue, or False when the operator declined.
+    """
+    if not can_prompt(_console):
+        return True
+    prompt = f"Proceed with at most ${estimate:.6f} embedding spend?"
+    try:
+        return Confirm.ask(prompt, default=True, console=_console)
+    except EOFError:
+        return False
 
 
 def _render_preflight(

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -9,14 +9,20 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from wmo.cli.consent import can_prompt, require_spend_consent
+from wmo.cli.consent import can_prompt
 from wmo.cli.provider_setup import (
     ProviderSetupOptions,
     provider_setup_json_examples,
     run_provider_setup,
 )
 from wmo.common.config import ARTIFACT_DIR
-from wmo.common.models import ModelCatalog, ModelCatalogError, load_model_catalog
+from wmo.common.models import (
+    ModelCapabilities,
+    ModelCatalog,
+    ModelCatalogError,
+    ModelSnapshot,
+    load_model_catalog,
+)
 from wmo.common.observability.telemetry import BuildTelemetryStats, capture_build_completed
 from wmo.common.project import (
     ArtifactStoreError,
@@ -30,7 +36,14 @@ from wmo.common.project import (
     artifact_input,
 )
 from wmo.common.release_revision import installed_release_revision
-from wmo.runtime.models import CapabilityRequirement, ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.models import (
+    CapabilityRequirement,
+    ModelCapabilityError,
+    ModelConnectionError,
+    ResolvedModel,
+    RuntimeModelCatalog,
+)
+from wmo.runtime.models.preflight import preflight_capabilities
 from wmo.runtime.models.providers.retry import RetryPolicy
 from wmo.simulation.build import ProjectBuild, TaskSetBuild, build_project, select_completed_build
 from wmo.simulation.ingest.otlp import (
@@ -46,8 +59,11 @@ from wmo.simulation.retrieval import (
     persist_trace_rag,
 )
 from wmo.simulation.retrieval.transitions import extract_real_transitions
-from wmo.simulation.world_model.artifact import persist_grounded_world_model
-from wmo.simulation.world_model.runtime import load_grounded_world_model
+from wmo.simulation.world_model.artifact import (
+    WORLD_MODEL_ARTIFACT_PATH,
+    GroundedWorldModelArtifact,
+    persist_grounded_world_model,
+)
 
 _console = Console()
 _CANONICAL_SOURCES = ("otlp", "posthog")
@@ -75,7 +91,11 @@ def build(
         min=0.01,
         help="Strict embedding spend ceiling in USD.",
     ),
-    yes: bool = typer.Option(False, "--yes", help="Consent to the displayed embedding spend."),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show the complete preflight without credentials, provider calls, or spend.",
+    ),
     no_interactive: bool = typer.Option(
         False,
         "--no-interactive",
@@ -84,9 +104,11 @@ def build(
 ) -> None:
     """Build a reusable grounded world model and immutable fit evidence.
 
-    Model setup runs first when required catalog state is absent and both terminal streams are
-    interactive. The shared catalog commits before project creation. Noninteractive missing state
-    fails before any project or artifact write.
+    The explicit invocation plus ``--max-build-cost-usd`` authorizes embedding work. Model setup
+    runs first when required catalog state is absent and both terminal streams are interactive.
+    The shared catalog commits before project creation. Noninteractive missing state fails before
+    any project or artifact write. Provider credentials are read only after preflight and the
+    cost ceiling pass.
 
     Args:
         project: Safe local project identifier below ``<root>/projects``.
@@ -98,7 +120,7 @@ def build(
         embedder: Optional configured alias override for this project.
         top_k: Positive serving retrieval result limit.
         maximum_build_cost_usd: Strict ceiling for provider embedding calls.
-        yes: Explicit noninteractive or advance spend consent.
+        dry_run: Print the complete preflight and stop before credentials or spend.
         no_interactive: Disable inline setup even when a terminal is available.
 
     Raises:
@@ -116,12 +138,11 @@ def build(
             embedder=embedder,
         )
         runtime_catalog = RuntimeModelCatalog(catalog)
-        resolved_world = runtime_catalog.resolve(selected.world_model)
-        runtime_catalog.resolve(selected.judge)
-        resolved_embedder = runtime_catalog.preflight(
-            selected.embedder,
-            CapabilityRequirement(requires_embeddings=True),
+        world_snapshot, embedder_snapshot, embedder_capabilities = _validated_role_snapshots(
+            runtime_catalog,
+            selected,
         )
+        _console.print("Loading and normalizing traces...")
         path = _resolve_trace_file(trace_file)
         normalized = _load_canonical_traces(path, source)
         if not normalized.traces:
@@ -145,37 +166,74 @@ def build(
             created_at=datetime.now(UTC),
             code_revision=code_revision,
         )
+        tasks = completed.artifacts.mining.tasks
+        fit_count = sum(task.partition == "fit" for task in tasks)
+        held_out_count = sum(task.partition == "held_out" for task in tasks)
+        _console.print(f"Mined {len(tasks)} tasks: {fit_count} fit, {held_out_count} held out")
+        estimate = _embedding_cost_ceiling(completed, embedder_capabilities)
         built = _reuse_completed_grounded_artifacts(
             store,
             completed,
-            resolved_world=resolved_world,
-            resolved_embedder=resolved_embedder,
+            world_alias=selected.world_model,
+            world_snapshot=world_snapshot,
+            embedder_snapshot=embedder_snapshot,
             top_k=top_k,
         )
-        estimate = 0.0
+        reused = built is not None
+        _render_preflight(
+            accepted=len(completed.artifacts.trace_dataset.dataset.trace_ids),
+            invalid=completed.artifacts.trace_dataset.dataset.invalid_trace_count,
+            fit_count=fit_count,
+            held_out_count=held_out_count,
+            world_alias=selected.world_model,
+            world_model_id=world_snapshot.model_id,
+            embedder_alias=selected.embedder,
+            embedder_model_id=embedder_snapshot.model_id,
+            estimate=estimate,
+            ceiling=maximum_build_cost_usd,
+        )
+        if reused:
+            _console.print("Reusing completed grounded artifacts.")
+        if dry_run:
+            _console.print("Dry run complete. No provider calls or completed-build selection.")
+            return
         if built is None:
-            estimate = _embedding_cost_ceiling(completed, resolved_embedder)
             if estimate > maximum_build_cost_usd:
                 raise ValueError(
-                    f"conservative embedding estimate ${estimate:.6f} exceeds "
-                    f"--max-build-cost-usd ${maximum_build_cost_usd:.6f}"
+                    _over_ceiling_message(
+                        estimate=estimate,
+                        ceiling=maximum_build_cost_usd,
+                        project=project,
+                        trace_file=trace_file,
+                        source=source,
+                        root=root,
+                        world_model=world_model,
+                        judge=judge,
+                        embedder=embedder,
+                        top_k=top_k,
+                    )
                 )
-            if estimate > 0 and not require_spend_consent(
-                _console,
-                yes=yes,
-                spend=f"at most ${estimate:.6f} for provider embeddings",
-                command=f"wmo build {project} {trace_file}",
-            ):
-                return
+            resolved_embedder = runtime_catalog.preflight(
+                selected.embedder,
+                CapabilityRequirement(requires_embeddings=True),
+            )
             built = _build_grounded_artifacts(
                 store,
                 completed,
-                resolved_world=resolved_world,
+                world_alias=selected.world_model,
+                world_snapshot=world_snapshot,
                 resolved_embedder=resolved_embedder,
                 top_k=top_k,
             )
         select_completed_build(store, built, completed.review)
-    except (ArtifactStoreError, ModelCatalogError, ProjectStoreError, ValueError) as exc:
+    except (
+        ArtifactStoreError,
+        ModelCapabilityError,
+        ModelCatalogError,
+        ModelConnectionError,
+        ProjectStoreError,
+        ValueError,
+    ) as exc:
         raise typer.BadParameter(str(exc)) from None
     _capture_local_build_telemetry(
         completed.artifacts,
@@ -183,7 +241,12 @@ def build(
         indexed_steps=_rag_transition_count(store, built.serving_rag.artifact_id),
         duration_seconds=time.monotonic() - started,
     )
-    _render_completed_build(completed, built=built, estimate=estimate)
+    _render_completed_build(
+        completed,
+        built=built,
+        estimate=0.0 if reused else estimate,
+        project=project,
+    )
 
 
 def _load_or_setup_catalog(root: Path, *, no_interactive: bool) -> ModelCatalog:
@@ -254,6 +317,40 @@ def _missing_build_configuration(catalog: ModelCatalog | None) -> tuple[str, ...
     return tuple(missing)
 
 
+def _validated_role_snapshots(
+    runtime_catalog: RuntimeModelCatalog,
+    selected: ProjectModelConfiguration,
+) -> tuple[ModelSnapshot, ModelSnapshot, ModelCapabilities]:
+    """Validate build roles from catalog metadata without reading credentials.
+
+    Args:
+        runtime_catalog: Local catalog resolver used only for static snapshots.
+        selected: Frozen world-model, judge, and embedder aliases.
+
+    Returns:
+        World-model snapshot, embedder snapshot, and embedder capabilities.
+
+    Raises:
+        ModelCapabilityError: The embedder cannot prove embedding support.
+        ModelConnectionError: A selected alias is unknown or uses an unsupported provider.
+        ValueError: The embedder omits explicit input pricing.
+    """
+    world_snapshot, _world_capabilities = runtime_catalog.snapshot(selected.world_model)
+    runtime_catalog.snapshot(selected.judge)
+    embedder_snapshot, embedder_capabilities = runtime_catalog.snapshot(selected.embedder)
+    preflight_capabilities(
+        selected.embedder,
+        embedder_capabilities,
+        CapabilityRequirement(requires_embeddings=True),
+    )
+    if embedder_capabilities.input_cost_per_million_tokens_usd is None:
+        raise ValueError(
+            f"embedder alias {selected.embedder!r} has no input_cost_per_million_tokens_usd; "
+            "record explicit pricing before a provider-backed build"
+        )
+    return world_snapshot, embedder_snapshot, embedder_capabilities
+
+
 def _selected_roles(
     catalog: ModelCatalog,
     *,
@@ -298,13 +395,13 @@ def _selected_roles(
 
 def _embedding_cost_ceiling(
     completed: ProjectBuild,
-    embedder: ResolvedModel,
+    capabilities: ModelCapabilities,
 ) -> float:
     """Bound retry-inclusive embedding spend from the exact rendered retrieval inputs.
 
     Args:
         completed: Persisted trace and task build whose transitions will be embedded.
-        embedder: Exact resolved embedding model and price metadata.
+        capabilities: Catalog embedder capabilities that already include explicit input pricing.
 
     Returns:
         Conservative USD ceiling across serving and fit-only index construction.
@@ -312,10 +409,10 @@ def _embedding_cost_ceiling(
     Raises:
         ValueError: The selected embedder omits explicit input pricing.
     """
-    price = embedder.capabilities.input_cost_per_million_tokens_usd
+    price = capabilities.input_cost_per_million_tokens_usd
     if price is None:
         raise ValueError(
-            f"embedder alias {embedder.alias!r} has no input_cost_per_million_tokens_usd; "
+            "embedder has no input_cost_per_million_tokens_usd; "
             "record explicit pricing before a provider-backed build"
         )
     bindings = _lineage_bindings(completed)
@@ -362,7 +459,8 @@ def _build_grounded_artifacts(
     store: ProjectStore,
     completed: ProjectBuild,
     *,
-    resolved_world: ResolvedModel,
+    world_alias: str,
+    world_snapshot: ModelSnapshot,
     resolved_embedder: ResolvedModel,
     top_k: int,
 ) -> ProjectBuildArtifacts:
@@ -371,8 +469,9 @@ def _build_grounded_artifacts(
     Args:
         store: Project artifact store receiving immutable outputs.
         completed: Persisted trace and task build.
-        resolved_world: Exact world-model runtime binding.
-        resolved_embedder: Exact provider embedding binding.
+        world_alias: Configured world-model alias persisted on the artifact.
+        world_snapshot: Secret-free world-model identity.
+        resolved_embedder: Exact provider embedding binding after ceiling enforcement.
         top_k: Default number of retrieved transitions.
 
     Returns:
@@ -398,6 +497,8 @@ def _build_grounded_artifacts(
         maximum_attempts=RetryPolicy().maximum_attempts,
         input_usd_per_million_tokens=embedding_price,
     )
+    _console.print(f"Embedding transitions with {resolved_embedder.snapshot.model_id}...")
+    _console.print("Building serving retrieval index...")
     serving = persist_trace_rag(
         store.artifacts,
         (trace_input,),
@@ -408,6 +509,7 @@ def _build_grounded_artifacts(
         default_top_k=top_k,
         included_partitions=frozenset({"fit", "held_out"}),
     )
+    _console.print("Building fit-only retrieval index...")
     fit = persist_trace_rag(
         store.artifacts,
         (trace_input,),
@@ -418,11 +520,12 @@ def _build_grounded_artifacts(
         default_top_k=top_k,
         included_partitions=frozenset({"fit"}),
     )
+    _console.print(f"Binding world model {world_snapshot.model_id}...")
     world = persist_grounded_world_model(
         store.artifacts,
         artifact_input(serving.manifest),
-        model_alias=resolved_world.alias,
-        model=resolved_world.snapshot,
+        model_alias=world_alias,
+        model=world_snapshot,
         created_at=created_at,
         code_revision=revision,
         top_k=top_k,
@@ -440,24 +543,23 @@ def _reuse_completed_grounded_artifacts(
     store: ProjectStore,
     completed: ProjectBuild,
     *,
-    resolved_world: ResolvedModel,
-    resolved_embedder: ResolvedModel,
+    world_alias: str,
+    world_snapshot: ModelSnapshot,
+    embedder_snapshot: ModelSnapshot,
     top_k: int,
 ) -> ProjectBuildArtifacts | None:
-    """Reuse a completely matching verified build without another provider embedding call.
+    """Reuse a completely matching verified build without credentials or provider calls.
 
     Args:
         store: Project artifact store containing a possible completed build.
         completed: Current persisted trace and task build.
-        resolved_world: Exact world-model runtime binding.
-        resolved_embedder: Exact provider embedding binding.
+        world_alias: Configured world-model alias required by the existing artifact.
+        world_snapshot: Secret-free world-model identity required by the existing artifact.
+        embedder_snapshot: Secret-free embedder identity required by both RAG indexes.
         top_k: Requested retrieval result count.
 
     Returns:
         Verified existing build pointers, or ``None`` when any identity differs.
-
-    Raises:
-        ValueError: The selected embedder lacks an explicit catalog input price.
     """
     existing = store.load_project().build
     if existing is None:
@@ -470,35 +572,23 @@ def _reuse_completed_grounded_artifacts(
         return None
     serving = load_rag_index(store.artifacts, existing.serving_rag.artifact_id)
     fit = load_rag_index(store.artifacts, existing.fit_rag.artifact_id)
-    expected_embedder = resolved_embedder.snapshot
     if (
-        serving.index.embedder != expected_embedder
-        or fit.index.embedder != expected_embedder
+        serving.index.embedder != embedder_snapshot
+        or fit.index.embedder != embedder_snapshot
         or serving.index.default_top_k != top_k
         or fit.index.default_top_k != top_k
         or serving.index.included_partitions != ("fit", "held_out")
         or fit.index.included_partitions != ("fit",)
     ):
         return None
-    assert resolved_embedder.embedding_client is not None
-    embedding_price = resolved_embedder.capabilities.input_cost_per_million_tokens_usd
-    if embedding_price is None:  # pragma: no cover - setup and capability preflight require it
-        raise ValueError("the selected embedder has no explicit input price")
-    runtime = load_grounded_world_model(
-        store.artifacts,
-        existing.world_model.artifact_id,
-        client=resolved_world.client,
-        embedder=RAGEmbedderBinding(
-            client=resolved_embedder.embedding_client,
-            snapshot=resolved_embedder.snapshot,
-            maximum_attempts=RetryPolicy().maximum_attempts,
-            input_usd_per_million_tokens=embedding_price,
-        ),
+    world = GroundedWorldModelArtifact.model_validate_json(
+        store.artifacts.read_bytes(existing.world_model.artifact_id, WORLD_MODEL_ARTIFACT_PATH)
     )
     if (
-        runtime.artifact.model_alias != resolved_world.alias
-        or runtime.artifact.model != resolved_world.snapshot
-        or runtime.artifact.top_k != top_k
+        world.serving_rag != existing.serving_rag
+        or world.model_alias != world_alias
+        or world.model != world_snapshot
+        or world.top_k != top_k
     ):
         return None
     return existing
@@ -616,22 +706,111 @@ def _rag_transition_count(store: ProjectStore, artifact_id: str) -> int:
     return load_rag_index(store.artifacts, artifact_id).index.transition_count
 
 
+def _render_preflight(
+    *,
+    accepted: int,
+    invalid: int,
+    fit_count: int,
+    held_out_count: int,
+    world_alias: str,
+    world_model_id: str,
+    embedder_alias: str,
+    embedder_model_id: str,
+    estimate: float,
+    ceiling: float,
+) -> None:
+    """Print the complete build preflight before credentials or provider dispatch.
+
+    Args:
+        accepted: Count of valid normalized traces.
+        invalid: Count of rejected input traces.
+        fit_count: Representative fit-task count.
+        held_out_count: Representative held-out task count.
+        world_alias: Selected world-model catalog alias.
+        world_model_id: Provider model ID bound to that alias.
+        embedder_alias: Selected embedder catalog alias.
+        embedder_model_id: Provider embedding model ID bound to that alias.
+        estimate: Conservative maximum embedding cost in USD.
+        ceiling: Configured ``--max-build-cost-usd`` value.
+    """
+    _console.print(f"Accepted traces: {accepted}  Invalid traces: {invalid}")
+    _console.print(f"Fit tasks: {fit_count}  Held-out tasks: {held_out_count}")
+    _console.print(f"World model: {world_alias} ({world_model_id})")
+    _console.print(f"Embedder: {embedder_alias} ({embedder_model_id})")
+    _console.print(f"Conservative maximum embedding cost: ${estimate:.6f}")
+    _console.print(f"Configured build-cost ceiling: ${ceiling:.6f}")
+
+
+def _over_ceiling_message(
+    *,
+    estimate: float,
+    ceiling: float,
+    project: str,
+    trace_file: Path,
+    source: str,
+    root: Path,
+    world_model: str | None,
+    judge: str | None,
+    embedder: str | None,
+    top_k: int,
+) -> str:
+    """Describe an over-ceiling refusal and the exact command that raises the limit.
+
+    Args:
+        estimate: Conservative maximum embedding cost in USD.
+        ceiling: Configured ``--max-build-cost-usd`` value that the estimate exceeded.
+        project: Local project identifier from this invocation.
+        trace_file: Trace export path from this invocation.
+        source: Selected canonical source format.
+        root: Local ``.wmo`` artifact root.
+        world_model: Optional world-model alias override.
+        judge: Optional judge alias override.
+        embedder: Optional embedder alias override.
+        top_k: Requested retrieval result limit.
+
+    Returns:
+        Fail-closed message naming both amounts and a sufficient rebuild command.
+    """
+    command = ["wmo", "build", project, str(trace_file)]
+    if source.strip().casefold() != "otlp":
+        command.extend(["--source", source])
+    if root != Path(ARTIFACT_DIR):
+        command.extend(["--root", str(root)])
+    if world_model is not None:
+        command.extend(["--world-model", world_model])
+    if judge is not None:
+        command.extend(["--judge", judge])
+    if embedder is not None:
+        command.extend(["--embedder", embedder])
+    if top_k != 5:
+        command.extend(["--top-k", str(top_k)])
+    command.extend(["--max-build-cost-usd", f"{estimate:.6f}"])
+    return (
+        f"conservative embedding estimate ${estimate:.6f} exceeds "
+        f"--max-build-cost-usd ${ceiling:.6f}. "
+        f"Re-run with a higher ceiling: {' '.join(command)}"
+    )
+
+
 def _render_completed_build(
     completed: ProjectBuild,
     *,
     built: ProjectBuildArtifacts,
     estimate: float,
+    project: str,
 ) -> None:
     """Present exact accepted, excluded, split, and grounded artifact identities.
 
     Args:
         completed: Persisted project build and mining results.
         built: Exact completed grounded-artifact pointers.
-        estimate: Conservative provider embedding spend ceiling.
+        estimate: Conservative provider embedding spend for this invocation.
+        project: Local project identifier used in the next recommended command.
     """
     dataset = completed.artifacts.trace_dataset.dataset
     tasks = completed.artifacts.mining.tasks
     duplicate_count = len(dataset.trace_ids) - len(completed.artifacts.mining.analysis.candidates)
+    _console.print("Build complete")
     _console.print(
         f"[green]built[/green] {len(dataset.trace_ids)} accepted, "
         f"{dataset.invalid_trace_count} invalid, {duplicate_count} duplicate"
@@ -647,3 +826,4 @@ def _render_completed_build(
         f"fit RAG {built.fit_rag.artifact_id}, world model {built.world_model.artifact_id}"
     )
     _console.print(f"embedding spend ceiling: ${estimate:.6f}")
+    _console.print(f"next: wmo optimize router {project}")

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+import shlex
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -784,12 +786,29 @@ def _over_ceiling_message(
         command.extend(["--embedder", embedder])
     if top_k != 5:
         command.extend(["--top-k", str(top_k)])
-    command.extend(["--max-build-cost-usd", f"{estimate:.6f}"])
+    command.extend(["--max-build-cost-usd", _sufficient_ceiling_usd(estimate)])
     return (
         f"conservative embedding estimate ${estimate:.6f} exceeds "
         f"--max-build-cost-usd ${ceiling:.6f}. "
-        f"Re-run with a higher ceiling: {' '.join(command)}"
+        f"Re-run with a higher ceiling: {shlex.join(command)}"
     )
+
+
+def _sufficient_ceiling_usd(estimate: float) -> str:
+    """Return a six-decimal ceiling that still authorizes the full-precision estimate.
+
+    Args:
+        estimate: Conservative maximum embedding cost in USD.
+
+    Returns:
+        A ``--max-build-cost-usd`` value whose parsed float is at least ``estimate``.
+    """
+    micros = max(math.ceil(estimate * 1_000_000), 1)
+    while True:
+        text = f"{micros / 1_000_000:.6f}"
+        if float(text) >= estimate:
+            return text
+        micros += 1
 
 
 def _render_completed_build(

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -1178,6 +1178,33 @@ def test_exact_replay_performs_zero_provider_calls(
     assert ProjectStore(root, "support").load_project().build == first_build
 
 
+def test_over_ceiling_command_quotes_paths_and_covers_full_precision() -> None:
+    """The suggested rebuild command quotes paths and authorizes the exact estimate.
+
+    The regression constructs the message directly so it can use a spaced path and a
+    six-decimal-rounding edge without running a full build.
+    """
+    estimate = 1.2345674
+    message = build_command._over_ceiling_message(
+        estimate=estimate,
+        ceiling=0.01,
+        project="support",
+        trace_file=Path("/tmp/my traces/export.jsonl"),
+        source="otlp",
+        root=Path("/tmp/wmo root"),
+        world_model=None,
+        judge=None,
+        embedder=None,
+        top_k=5,
+    )
+    assert "conservative embedding estimate $1.234567 exceeds" in message
+    assert "'/tmp/my traces/export.jsonl'" in message
+    assert "'/tmp/wmo root'" in message
+    suggested = build_command._sufficient_ceiling_usd(estimate)
+    assert float(suggested) >= estimate
+    assert f"--max-build-cost-usd {suggested}" in message
+
+
 def test_other_spend_consent_commands_still_require_yes() -> None:
     """Removing build confirmation does not change other spend-consent command flags.
 

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -16,7 +16,6 @@ from typer.testing import CliRunner
 import wmo.cli.build_cmd as build_command
 import wmo.simulation.build as simulation_build
 from wmo.cli.app import app
-from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
     ConnectionConfig,
     Embedding,
@@ -245,20 +244,47 @@ class _CompletionClient:
         raise AssertionError(f"build must not dispatch completion: {request}")
 
 
+_RESOLVE_CALLS: list[str] = []
+
+
 class _RuntimeCatalog:
     """Resolve catalog aliases to deterministic no-network test clients."""
 
-    def __init__(self, _catalog: ModelCatalog) -> None:
+    def __init__(self, catalog: ModelCatalog) -> None:
         """Create deterministic embedding and completion clients.
 
         Args:
-            _catalog: Unused catalog accepted by the production constructor seam.
+            catalog: Fixture catalog used for secret-free snapshots.
         """
+        self._catalog = catalog
         self._embedding = _EmbeddingClient()
         self._completion = _CompletionClient()
 
+    def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+        """Return catalog identity and capabilities without recording a credential lookup.
+
+        Args:
+            alias: Configured fixture model alias.
+
+        Returns:
+            Secret-free snapshot and the alias-specific capability record.
+        """
+        record = self._catalog.models[alias]
+        connection = self._catalog.connections[record.connection]
+        capabilities = record.capabilities or ModelCapabilities()
+        return (
+            ModelSnapshot(
+                provider=connection.provider,
+                model_id=record.model,
+                revision=record.revision,
+                capabilities_sha256=capabilities.identity_sha256(),
+                connection_sha256=connection.identity_sha256(),
+            ),
+            capabilities,
+        )
+
     def preflight(self, alias: str, _requirement: object | None = None) -> ResolvedModel:
-        """Return exact static identities with alias-specific capabilities.
+        """Return exact static identities and record the credential-bearing construction.
 
         Args:
             alias: Configured fixture model alias.
@@ -267,21 +293,9 @@ class _RuntimeCatalog:
         Returns:
             Deterministic resolved fixture model.
         """
-        if alias == "embed":
-            capabilities = ModelCapabilities(
-                supports_embeddings=True,
-                input_cost_per_million_tokens_usd=0,
-            )
-            embedding = self._embedding
-        else:
-            capabilities = ModelCapabilities(maximum_output_tokens=16_000)
-            embedding = None
-        snapshot = ModelSnapshot(
-            provider="fixture",
-            model_id=f"fixture-{alias}",
-            capabilities_sha256=sha256_json(capabilities),
-            connection_sha256=sha256_json({"connection": alias}),
-        )
+        _RESOLVE_CALLS.append(alias)
+        snapshot, capabilities = self.snapshot(alias)
+        embedding = self._embedding if capabilities.supports_embeddings else None
         return ResolvedModel(alias, snapshot, capabilities, self._completion, embedding)
 
     def resolve(self, alias: str) -> ResolvedModel:
@@ -296,11 +310,12 @@ class _RuntimeCatalog:
         return self.preflight(alias)
 
 
-def _catalog(root: Path) -> None:
+def _catalog(root: Path, *, embedder_input_usd_per_million: float = 0) -> None:
     """Write complete secret-free build roles while leaving router candidates empty.
 
     Args:
         root: Temporary WMO root receiving ``models.toml``.
+        embedder_input_usd_per_million: Explicit embedder input price used for preflight.
     """
     write_model_catalog(
         root / "models.toml",
@@ -320,7 +335,7 @@ def _catalog(root: Path) -> None:
                     model="embed-id",
                     capabilities=ModelCapabilities(
                         supports_embeddings=True,
-                        input_cost_per_million_tokens_usd=0,
+                        input_cost_per_million_tokens_usd=embedder_input_usd_per_million,
                     ),
                 ),
             },
@@ -336,6 +351,7 @@ def _fake_runtime_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     Args:
         monkeypatch: Pytest patch fixture replacing provider-backed seams.
     """
+    _RESOLVE_CALLS.clear()
     monkeypatch.setattr("wmo.cli.build_cmd.RuntimeModelCatalog", _RuntimeCatalog)
     monkeypatch.setattr("wmo.cli.build_cmd.capture_build_completed", lambda **_kwargs: None)
 
@@ -358,6 +374,8 @@ def test_build_positional_happy_path_creates_two_rags_and_executable_artifact(
     result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
 
     assert result.exit_code == 0, result.output
+    assert "Proceed?" not in result.output
+    assert "World model: world (world-id)" in result.output
     assert "100 to 1,000 traces is the usual starting range" in result.output
     store = ProjectStore(root, "support")
     config = store.load_project()
@@ -582,15 +600,15 @@ def test_build_package_upgrade_graphs_remain_independently_verified(
         store.artifacts.read(selected.trace_dataset.artifact_id)
 
 
-def test_build_package_upgrade_decline_preserves_selected_review(
+def test_build_package_upgrade_over_ceiling_preserves_selected_review(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Declining replacement spend leaves the selected build and review handoff together.
+    """An over-ceiling replacement leaves the selected build and review handoff together.
 
     Args:
         tmp_path: Temporary trace, catalog, and project root.
-        monkeypatch: Pytest patch fixture forcing a paid-build decline.
+        monkeypatch: Pytest patch fixture forcing a paid-build ceiling failure.
     """
     source = _otlp_export(tmp_path)
     root = tmp_path / ".wmo"
@@ -606,21 +624,26 @@ def test_build_package_upgrade_decline_preserves_selected_review(
     first_build = store.load_project().build
     first_review = store.read_review()
     assert first_build is not None
-    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 1.0)
-    monkeypatch.setattr(build_command, "require_spend_consent", lambda *_args, **_kwargs: False)
+    _RESOLVE_CALLS.clear()
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 6.0)
 
-    declined = _RUNNER.invoke(
+    blocked = _RUNNER.invoke(
         app,
         ["build", "support", str(source), "--root", str(root)],
         env={"WMO_RELEASE_REVISION": "b" * 40},
     )
 
-    assert declined.exit_code == 0, declined.output
+    assert blocked.exit_code == 2
+    output = " ".join(unstyle(blocked.output).replace("│", " ").split())
+    assert "conservative embedding estimate $6.000000 exceeds" in output
+    assert "--max-build-cost-usd $5.000000" in output
+    assert "wmo build support" in output
+    assert _RESOLVE_CALLS == []
     assert store.load_project().build == first_build
     assert store.read_review() == first_review
 
 
-@pytest.mark.parametrize("failure_mode", ["cost", "decline", "grounded"])
+@pytest.mark.parametrize("failure_mode", ["cost", "grounded"])
 def test_first_build_failure_does_not_publish_review_readiness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -631,7 +654,7 @@ def test_first_build_failure_does_not_publish_review_readiness(
     Args:
         tmp_path: Temporary trace, catalog, and project root.
         monkeypatch: Pytest patch fixture selecting the pre-selection failure boundary.
-        failure_mode: Cost rejection, explicit spend decline, or grounded construction failure.
+        failure_mode: Cost rejection or grounded construction failure.
     """
     source = _otlp_export(tmp_path)
     root = tmp_path / ".wmo"
@@ -639,13 +662,6 @@ def test_first_build_failure_does_not_publish_review_readiness(
     _catalog(root)
     if failure_mode == "cost":
         monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 6.0)
-    elif failure_mode == "decline":
-        monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 1.0)
-        monkeypatch.setattr(
-            build_command,
-            "require_spend_consent",
-            lambda *_args, **_kwargs: False,
-        )
     else:
 
         def fail_grounded_build(*_args: object, **_kwargs: object) -> None:
@@ -664,10 +680,11 @@ def test_first_build_failure_does_not_publish_review_readiness(
         env={"WMO_RELEASE_REVISION": "a" * 40},
     )
 
-    if failure_mode == "decline":
-        assert result.exit_code == 0, result.output
-    else:
-        assert result.exit_code == 2
+    assert result.exit_code == 2
+    if failure_mode == "cost":
+        assert _RESOLVE_CALLS == []
+        output = " ".join(unstyle(result.output).replace("│", " ").split())
+        assert "conservative embedding estimate $6.000000 exceeds" in output
     store = ProjectStore(root, "support")
     assert store.load_project().build is None
     assert store.read_review() is None
@@ -938,6 +955,236 @@ def test_build_help_describes_the_completed_grounded_artifact() -> None:
     result = _RUNNER.invoke(app, ["build", "--help"])
 
     assert result.exit_code == 0, result.output
-    assert "Build a reusable grounded world model from local trace evidence." in unstyle(
-        result.output
+    help_text = unstyle(result.output)
+    assert "Build a reusable grounded world model from local trace evidence." in help_text
+    assert "--dry-run" in help_text
+    assert "--max-build-cost-usd" in help_text
+    assert "--yes" not in help_text
+
+
+def _forbid_proceed(prompt: str, **_kwargs: object) -> bool:
+    """Fail if build still reaches the shared spend-consent prompt.
+
+    Args:
+        prompt: Unexpected confirmation question.
+
+    Raises:
+        AssertionError: Always, because build must not ask ``Proceed?``.
+    """
+    raise AssertionError(f"build must not ask {prompt!r}")
+
+
+def test_interactive_build_never_asks_proceed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A terminal session continues automatically when the estimate is under the ceiling.
+
+    Args:
+        monkeypatch: Pytest patch fixture simulating an interactive session.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+    monkeypatch.setattr(build_command, "can_prompt", lambda _console: True)
+    monkeypatch.setattr("wmo.cli.consent.Confirm.ask", _forbid_proceed)
+    monkeypatch.setattr("rich.prompt.Confirm.ask", _forbid_proceed)
+
+    result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "Proceed?" not in result.output
+    assert ProjectStore(root, "support").load_project().build is not None
+
+
+def test_noninteractive_build_runs_under_ceiling_without_yes(tmp_path: Path) -> None:
+    """Scripted builds do not need ``--yes`` when the estimate is under the ceiling.
+
+    Args:
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+
+    result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "Proceed?" not in result.output
+    assert "cannot ask for spend consent" not in result.output
+    assert ProjectStore(root, "support").load_project().build is not None
+
+
+def test_preflight_names_models_and_shows_estimate_plus_ceiling(tmp_path: Path) -> None:
+    """The preflight names selected models and quotes estimate plus ceiling before spend.
+
+    Args:
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+
+    result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "World model: world (world-id)" in output
+    assert "Embedder: embed (embed-id)" in output
+    assert "Conservative maximum embedding cost: $" in output
+    assert "Configured build-cost ceiling: $5.000000" in output
+    assert "Accepted traces:" in output
+    assert "Fit tasks:" in output
+    assert "next: wmo optimize router support" in output
+
+
+def test_over_ceiling_build_fails_before_credentials(tmp_path: Path) -> None:
+    """An over-ceiling estimate fails before credential lookup or provider construction.
+
+    Args:
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1_000_000.0)
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "build",
+            "support",
+            str(source),
+            "--root",
+            str(root),
+            "--max-build-cost-usd",
+            "0.01",
+        ],
     )
+
+    assert result.exit_code == 2
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
+    assert "conservative embedding estimate $" in output
+    assert "exceeds --max-build-cost-usd $0.010000" in output
+    assert "wmo build support" in output
+    assert "--max-build-cost-usd" in output
+    assert _RESOLVE_CALLS == []
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
+def test_dry_run_performs_zero_calls_and_does_not_select_build(tmp_path: Path) -> None:
+    """``--dry-run`` prints the complete preflight without credentials or selection.
+
+    Args:
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "World model: world (world-id)" in output
+    assert "Embedder: embed (embed-id)" in output
+    assert "Conservative maximum embedding cost: $" in output
+    assert "Configured build-cost ceiling: $5.000000" in output
+    assert "Dry run complete" in output
+    assert "Proceed?" not in output
+    assert _RESOLVE_CALLS == []
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
+def test_provider_failure_does_not_publish_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A provider embedding failure leaves no completed-build selection.
+
+    Args:
+        monkeypatch: Pytest patch fixture injecting a provider failure.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+
+    def fail_embed(self: _EmbeddingClient, texts: Sequence[str]) -> tuple[object, ...]:
+        """Fail at the first provider embedding dispatch.
+
+        Args:
+            texts: Canonical RAG key texts that would have been embedded.
+
+        Raises:
+            ValueError: Always, to simulate a provider embedding failure.
+        """
+        del self, texts
+        raise ValueError("injected provider embedding failure")
+
+    monkeypatch.setattr(_EmbeddingClient, "embed", fail_embed)
+    result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert result.exit_code == 2
+    assert "injected provider embedding failure" in result.output
+    assert _RESOLVE_CALLS == ["embed"]
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
+def test_exact_replay_performs_zero_provider_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exact replay reuses grounded artifacts without credentials, prompts, or spend.
+
+    Args:
+        monkeypatch: Pytest patch fixture forbidding rebuilds and spend prompts.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+    first = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+    assert first.exit_code == 0, first.output
+    first_build = ProjectStore(root, "support").load_project().build
+    assert first_build is not None
+    _RESOLVE_CALLS.clear()
+    monkeypatch.setattr("wmo.cli.consent.Confirm.ask", _forbid_proceed)
+    monkeypatch.setattr(build_command, "_build_grounded_artifacts", lambda *_a, **_k: None)
+
+    replay = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert replay.exit_code == 0, replay.output
+    assert "Proceed?" not in replay.output
+    assert "Reusing completed grounded artifacts." in replay.output
+    assert "embedding spend ceiling: $0.000000" in replay.output
+    assert _RESOLVE_CALLS == []
+    assert ProjectStore(root, "support").load_project().build == first_build
+
+
+def test_other_spend_consent_commands_still_require_yes() -> None:
+    """Removing build confirmation does not change other spend-consent command flags.
+
+    The regression reads public help only and does not execute those commands.
+    """
+    model_help = unstyle(_RUNNER.invoke(app, ["optimize", "model", "--help"]).output)
+    router_help = unstyle(_RUNNER.invoke(app, ["optimize", "router", "--help"]).output)
+    assert "--yes" in model_help
+    assert "--yes" in router_help
+    assert "--yes" not in unstyle(_RUNNER.invoke(app, ["build", "--help"]).output)

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -963,22 +963,50 @@ def test_build_help_describes_the_completed_grounded_artifact() -> None:
 
 
 def _forbid_proceed(prompt: str, **_kwargs: object) -> bool:
-    """Fail if build still reaches the shared spend-consent prompt.
+    """Fail if a path that must not prompt still reaches a confirmation.
 
     Args:
         prompt: Unexpected confirmation question.
 
     Raises:
-        AssertionError: Always, because build must not ask ``Proceed?``.
+        AssertionError: Always, because this path must not ask to proceed.
     """
     raise AssertionError(f"build must not ask {prompt!r}")
 
 
-def test_interactive_build_never_asks_proceed(
+class _RecordedConfirm:
+    """Record one build confirmation and return a scripted answer."""
+
+    def __init__(self, answer: bool) -> None:
+        """Store the scripted answer.
+
+        Args:
+            answer: Value returned by ``ask``.
+        """
+        self.answer = answer
+        self.prompts: list[str] = []
+        self.defaults: list[bool] = []
+
+    def ask(self, prompt: str, *, default: bool = False, **_kwargs: object) -> bool:
+        """Record the prompt and default, then return the scripted answer.
+
+        Args:
+            prompt: Confirmation question shown after preflight.
+            default: Default used when the operator presses Enter.
+
+        Returns:
+            The scripted answer.
+        """
+        self.prompts.append(prompt)
+        self.defaults.append(default)
+        return self.answer
+
+
+def test_interactive_build_asks_proceed_with_cost_and_defaults_to_yes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A terminal session continues automatically when the estimate is under the ceiling.
+    """A terminal session names the estimate and continues when Enter accepts the default.
 
     Args:
         monkeypatch: Pytest patch fixture simulating an interactive session.
@@ -988,15 +1016,85 @@ def test_interactive_build_never_asks_proceed(
     root = tmp_path / ".wmo"
     root.mkdir()
     _catalog(root, embedder_input_usd_per_million=1.0)
+    confirm = _RecordedConfirm(True)
     monkeypatch.setattr(build_command, "can_prompt", lambda _console: True)
-    monkeypatch.setattr("wmo.cli.consent.Confirm.ask", _forbid_proceed)
-    monkeypatch.setattr("rich.prompt.Confirm.ask", _forbid_proceed)
+    monkeypatch.setattr(build_command, "Confirm", confirm)
 
     result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
 
     assert result.exit_code == 0, result.output
-    assert "Proceed?" not in result.output
+    assert len(confirm.prompts) == 1
+    assert confirm.prompts[0].startswith("Proceed with at most $")
+    assert confirm.prompts[0].endswith(" embedding spend?")
+    assert confirm.defaults == [True]
+    assert "Conservative maximum embedding cost: $" in unstyle(result.output)
     assert ProjectStore(root, "support").load_project().build is not None
+
+
+def test_interactive_build_decline_does_not_publish_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Declining the cost-aware prompt spends nothing and selects no completed build.
+
+    Args:
+        monkeypatch: Pytest patch fixture simulating an interactive decline.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1.0)
+    confirm = _RecordedConfirm(False)
+    monkeypatch.setattr(build_command, "can_prompt", lambda _console: True)
+    monkeypatch.setattr(build_command, "Confirm", confirm)
+
+    result = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "Build was not started." in result.output
+    assert confirm.defaults == [True]
+    assert _RESOLVE_CALLS == []
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
+def test_over_ceiling_interactive_fails_before_proceed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An over-ceiling estimate fails before the Proceed prompt or credentials.
+
+    Args:
+        monkeypatch: Pytest patch fixture simulating an interactive session.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root, embedder_input_usd_per_million=1_000_000.0)
+    confirm = _RecordedConfirm(True)
+    monkeypatch.setattr(build_command, "can_prompt", lambda _console: True)
+    monkeypatch.setattr(build_command, "Confirm", confirm)
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "build",
+            "support",
+            str(source),
+            "--root",
+            str(root),
+            "--max-build-cost-usd",
+            "0.01",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert confirm.prompts == []
+    assert _RESOLVE_CALLS == []
+    assert ProjectStore(root, "support").load_project().build is None
 
 
 def test_noninteractive_build_runs_under_ceiling_without_yes(tmp_path: Path) -> None:
@@ -1165,7 +1263,8 @@ def test_exact_replay_performs_zero_provider_calls(
     first_build = ProjectStore(root, "support").load_project().build
     assert first_build is not None
     _RESOLVE_CALLS.clear()
-    monkeypatch.setattr("wmo.cli.consent.Confirm.ask", _forbid_proceed)
+    monkeypatch.setattr(build_command, "can_prompt", lambda _console: True)
+    monkeypatch.setattr(build_command.Confirm, "ask", _forbid_proceed)
     monkeypatch.setattr(build_command, "_build_grounded_artifacts", lambda *_a, **_k: None)
 
     replay = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])

--- a/wmo/optimize/router/automatic/service_test.py
+++ b/wmo/optimize/router/automatic/service_test.py
@@ -1186,10 +1186,12 @@ def _completed_project(
             semantic_duplicate_threshold=1.0,
         ),
     )
+    resolved_world = runtime.resolve("world")
     completed = _build_grounded_artifacts(
         store,
         built,
-        resolved_world=runtime.resolve("world"),
+        world_alias=resolved_world.alias,
+        world_snapshot=resolved_world.snapshot,
         resolved_embedder=runtime.resolve("embedder"),
         top_k=2,
     )

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -910,6 +910,36 @@ def _installed_release_driver() -> None:
         build_counts = state.counts()
         assert build_counts["/v1/embeddings"] > 0
         assert build_counts["/v1/chat/completions"] == 0
+        assert "Proceed?" not in build_output
+        assert "World model:" in build_output
+        assert "core-model" in build_output
+        assert "Conservative maximum embedding cost:" in build_output
+        assert "Configured build-cost ceiling:" in build_output
+        dry_run = run_cli(
+            "build",
+            "support-agent",
+            str(traces),
+            "--root",
+            str(root),
+            "--dry-run",
+            "--no-interactive",
+        )
+        assert "Dry run complete" in dry_run.stdout
+        assert "Proceed?" not in dry_run.stdout
+        assert "Conservative maximum embedding cost:" in dry_run.stdout
+        assert state.counts()["/v1/embeddings"] == build_counts["/v1/embeddings"]
+        assert support_store.load_project().build is not None
+        replay_build = run_cli(
+            "build",
+            "support-agent",
+            str(traces),
+            "--root",
+            str(root),
+            "--no-interactive",
+        )
+        assert "Reusing completed grounded artifacts." in replay_build.stdout
+        assert "Proceed?" not in replay_build.stdout
+        assert state.counts()["/v1/embeddings"] == build_counts["/v1/embeddings"]
         world_model = wmo.load_world_model(
             "support-agent",
             root=root,

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -890,6 +890,7 @@ def _installed_release_driver() -> None:
         ("Use 'core' as the judge?", "y"),
         ("Embedder alias", "core"),
         ("Save this configuration?", "y"),
+        ("Proceed with at most", ""),
     ]
     try:
         assert not root.exists()
@@ -910,7 +911,8 @@ def _installed_release_driver() -> None:
         build_counts = state.counts()
         assert build_counts["/v1/embeddings"] > 0
         assert build_counts["/v1/chat/completions"] == 0
-        assert "Proceed?" not in build_output
+        assert "Proceed with at most $" in build_output
+        assert "embedding spend?" in build_output
         assert "World model:" in build_output
         assert "core-model" in build_output
         assert "Conservative maximum embedding cost:" in build_output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`wmo build` no longer stops at a context-free `Proceed?` after model setup. The explicit command plus `--max-build-cost-usd` is the spend gate.

## Behavior
- Print a concise preflight (accepted/invalid traces, fit/held-out counts, world-model and embedder identities, conservative embedding estimate, and the configured ceiling) before any credential lookup or provider call.
- On an interactive terminal, confirm with `Proceed with at most $X embedding spend?` and default to yes.
- Continue automatically in noninteractive sessions when the estimate is within the ceiling.
- Fail closed before the prompt or credentials when the estimate exceeds the ceiling, and print both amounts plus a copy-safe command that raises the limit.
- Add `--dry-run` for the complete preflight with zero provider calls and no completed-build selection.
- Exact replay reuses grounded artifacts with zero provider calls and no prompt.
- Interrupted, declined, or failed grounded construction does not publish readiness.
- `--yes` is not preserved. I searched WMO, packaged docs, and Platform and found no real `wmo build --yes` consumers.

Judge calibration, router optimization, and model training keep their existing `--yes` / `Proceed?` spend-consent behavior, including the fail-closed default.

## Tests
Regressions cover the cost-aware yes-default prompt, interactive decline, noninteractive auto-continue, preflight contents, over-ceiling refusal before credentials or Proceed, dry-run, provider failure, exact replay, unchanged spend-consent flags on other commands, and installed-wheel happy-path evidence.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://experientiallabs.slack.com/archives/D0BFY60R0H5/p1786750765213149?thread_ts=1786750765.213149&cid=D0BFY60R0H5)

<div><a href="https://cursor.com/agents/bc-b44c197a-2dc4-5178-9017-e4cc3743f564?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b44c197a-2dc4-5178-9017-e4cc3743f564&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

