### PR TITLE
Retain unverified configured model role bindings

### DIFF
--- a/wmo/cli/model_picker.py
+++ b/wmo/cli/model_picker.py
@@ -1,8 +1,9 @@
 """Model selection, role assignment, and confirmation screens for provider setup.
 
 These screens run after every selected provider has been prepared. They present the discovered and
-already-configured models as one searchable list, filter each build role to the models whose
-verified metadata can serve it, and render the single summary shown before setup saves anything.
+already-configured models as one searchable list, filter new build-role assignments to models whose
+verified metadata can serve them, preserve exact prior assignments as retain-only choices, and
+render the single summary shown before setup saves anything.
 """
 
 from __future__ import annotations
@@ -272,7 +273,7 @@ def _assign_one_role(
     Raises:
         SetupCancelled: The user cancelled setup.
     """
-    eligible = tuple(item for item in chosen if serves_role(item.capabilities, role))
+    eligible = tuple(item for item in chosen if _serves_or_retains(item, role))
     if not eligible:
         console.print(
             f"[yellow]No selected model can serve the {role_name} role. "
@@ -315,7 +316,7 @@ def _assign_candidates(
         SetupCancelled: The user cancelled setup.
     """
     eligible = tuple(
-        item for item in chosen if serves_role(item.capabilities, SetupRole.ROUTER_CANDIDATE)
+        item for item in chosen if _serves_or_retains(item, SetupRole.ROUTER_CANDIDATE)
     )
     if len(eligible) < 2:
         console.print(
@@ -414,6 +415,8 @@ def build_result(
 def model_selection(item: AvailableModel) -> ProviderModelSelection:
     """Convert one configurable model into its persisted setup selection."""
     capabilities = item.capabilities
+    if capabilities is None:
+        raise ValueError(f"new model alias {item.alias!r} needs explicit capabilities")
     return ProviderModelSelection(
         alias=item.alias,
         connection=item.connection,
@@ -439,20 +442,24 @@ def configured_models(
     existing_models: Mapping[str, ModelRecord],
     *,
     connection_providers: Mapping[str, str],
+    retainable_roles: Mapping[str, frozenset[SetupRole]] | None = None,
 ) -> tuple[AvailableModel, ...]:
     """Present already-configured catalog aliases as selectable models.
 
     Args:
         existing_models: Exact model records keyed by every persisted alias.
         connection_providers: Exact provider kind keyed by every persisted connection name.
+        retainable_roles: Exact existing role assignments that incomplete aliases may retain.
 
     Returns:
-        Configurable records for every configured alias with usable metadata.
+        Configurable records for aliases with usable metadata or an exact role to retain.
     """
+    retained = {} if retainable_roles is None else retainable_roles
     records = []
     for alias, model in sorted(existing_models.items()):
         capabilities = model.capabilities
-        if capabilities is None or not served_roles(capabilities):
+        roles = retained.get(alias, frozenset())
+        if (capabilities is None or not served_roles(capabilities)) and not roles:
             continue
         records.append(
             AvailableModel(
@@ -463,9 +470,25 @@ def configured_models(
                 capabilities=capabilities,
                 pricing_source=PricingSource.CONFIGURED,
                 configured=True,
+                retainable_roles=roles,
             )
         )
     return tuple(records)
+
+
+def _serves_or_retains(item: AvailableModel, role: SetupRole) -> bool:
+    """Report whether verified metadata serves a role or the exact prior binding retains it.
+
+    Args:
+        item: Selected model with optional verified capabilities and prior role bindings.
+        role: Role being assigned.
+
+    Returns:
+        ``True`` for verified compatibility or an exact retain-only prior assignment.
+    """
+    return (
+        item.capabilities is not None and serves_role(item.capabilities, role)
+    ) or role in item.retainable_roles
 
 
 def render_summary(
@@ -494,6 +517,19 @@ def render_summary(
         )
     for item in chosen:
         capabilities = item.capabilities
+        if capabilities is None:
+            retained = ", ".join(role.value for role in item.retainable_roles)
+            console.print(
+                f"model {item.alias}: {item.provider}/{item.model}, "
+                f"capabilities=unverified, retain_only={retained or 'none'}, "
+                f"pricing={item.pricing_source.value}"
+            )
+            continue
+        verified = frozenset(served_roles(capabilities))
+        retain_only = ", ".join(
+            role.value for role in SetupRole if role in item.retainable_roles - verified
+        )
+        retained = f", retain_only={retain_only}" if retain_only else ""
         console.print(
             f"model {item.alias}: {item.provider}/{item.model}, "
             f"tools={capabilities.supports_tools}, "
@@ -502,7 +538,7 @@ def render_summary(
             f"completions={capabilities.supports_completions}, "
             f"context={capabilities.context_window_tokens}, "
             f"max_output={capabilities.maximum_output_tokens}, "
-            f"pricing={item.pricing_source.value}"
+            f"pricing={item.pricing_source.value}{retained}"
         )
     setup = result.setup
     console.print(

--- a/wmo/cli/model_picker_test.py
+++ b/wmo/cli/model_picker_test.py
@@ -28,6 +28,7 @@ from wmo.common.models import (
     PricingSource,
     ProviderConnection,
     ProviderModelSelection,
+    SetupRole,
     resolve_discovered_model,
 )
 
@@ -272,6 +273,66 @@ def test_configured_catalog_entries_become_selectable_rows() -> None:
     assert rows[0].provider == "openai"
 
 
+def test_unverified_configured_alias_retains_only_its_exact_prior_role() -> None:
+    """Unknown metadata permits retention but not reassignment to a different role."""
+    record = ModelRecord(connection="tinker", model="tinker://sampling/run")
+    rows = configured_models(
+        {"legacy": record},
+        connection_providers={"tinker": "tinker"},
+        retainable_roles={"legacy": frozenset({SetupRole.WORLD_MODEL})},
+    )
+
+    assert len(rows) == 1
+    assert rows[0].capabilities is None
+    assert rows[0].retainable_roles == frozenset({SetupRole.WORLD_MODEL})
+    assert "retain only: world_model" in rows[0].detail()
+    console = ScriptedConsole("\nlegacy\n1\n\n")
+    roles = assign_roles(
+        (*rows, _CHAT, _EMBEDDER),
+        role_inputs=SetupRoleInputs(
+            world_model="legacy",
+            judge="legacy",
+            embedder="embedder",
+        ),
+        console=console,
+    )
+
+    assert roles is not None
+    assert roles.world_model == "legacy"
+    assert roles.judge == "luna"
+    assert roles.embedder == "embedder"
+    assert "No row matches 'legacy'" in console.output
+
+
+def test_unverified_router_candidates_and_incumbent_can_be_retained() -> None:
+    """Exact prior candidate bindings remain selectable without claiming compatibility."""
+    records = {
+        "legacy-a": ModelRecord(connection="tinker", model="tinker://sampling/a"),
+        "legacy-b": ModelRecord(connection="tinker", model="tinker://sampling/b"),
+    }
+    retained = frozenset({SetupRole.ROUTER_CANDIDATE})
+    rows = configured_models(
+        records,
+        connection_providers={"tinker": "tinker"},
+        retainable_roles={"legacy-a": retained, "legacy-b": retained},
+    )
+    roles = assign_roles(
+        (*rows, _CHAT, _EMBEDDER),
+        role_inputs=SetupRoleInputs(
+            world_model="luna",
+            judge="luna",
+            embedder="embedder",
+            candidates=("legacy-a", "legacy-b"),
+            incumbent="legacy-a",
+        ),
+        console=ScriptedConsole("\n\n\n\n\n"),
+    )
+
+    assert roles is not None
+    assert roles.candidates == ("legacy-a", "legacy-b")
+    assert roles.incumbent == "legacy-a"
+
+
 def test_manual_declaration_stays_behind_the_advanced_row() -> None:
     """A hand-declared model is only reachable from the explicit advanced row."""
     session = _session(_CHAT, advanced_models=True)
@@ -284,6 +345,7 @@ def test_manual_declaration_stays_behind_the_advanced_row() -> None:
     declared = session.manual[0]
     assert declared.alias == "private-model"
     assert declared.pricing_source is PricingSource.CONFIGURED
+    assert declared.capabilities is not None
     assert declared.capabilities.supports_tools
     assert declared.capabilities.input_cost_per_million_tokens_usd == 2.0
 

--- a/wmo/cli/provider_picker.py
+++ b/wmo/cli/provider_picker.py
@@ -22,6 +22,7 @@ from wmo.common.models import (
     PricingSource,
     ProviderConnection,
     ProviderSetup,
+    SetupRole,
     derive_connection_name,
     derive_model_alias,
     resolve_discovered_model,
@@ -95,9 +96,10 @@ class AvailableModel:
     connection: str
     provider: str
     model: str
-    capabilities: ModelCapabilities
+    capabilities: ModelCapabilities | None
     pricing_source: PricingSource
     configured: bool
+    retainable_roles: frozenset[SetupRole] = frozenset()
 
     def label(self) -> str:
         """Describe this model as one picker row."""
@@ -105,8 +107,17 @@ class AvailableModel:
 
     def detail(self) -> str:
         """Summarize the roles and price provenance behind this model."""
-        roles = ", ".join(role.value for role in served_roles(self.capabilities))
-        return f"roles: {roles or 'none'}; pricing: {self.pricing_source.value}"
+        verified = (
+            frozenset(served_roles(self.capabilities))
+            if self.capabilities is not None
+            else frozenset()
+        )
+        roles = ", ".join(role.value for role in SetupRole if role in verified)
+        retain_only = ", ".join(
+            role.value for role in SetupRole if role in self.retainable_roles - verified
+        )
+        retained = f"; retain only: {retain_only}" if retain_only else ""
+        return f"roles: {roles or 'unverified'}{retained}; pricing: {self.pricing_source.value}"
 
 
 @dataclass(frozen=True)

--- a/wmo/cli/provider_picker_test.py
+++ b/wmo/cli/provider_picker_test.py
@@ -363,6 +363,7 @@ def test_discovered_metadata_and_roles_come_from_the_maintained_table() -> None:
     _, models = prepared
     chat, embedder = models
     assert chat.pricing_source is PricingSource.WMO_CATALOG
+    assert chat.capabilities is not None
     assert chat.capabilities.supports_structured_output
     assert chat.capabilities.context_window_tokens == 1_050_000
     assert SetupRole.EMBEDDER.value in embedder.detail()

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -43,6 +43,7 @@ from wmo.common.models import (
     ProviderModelSelection,
     ProviderSetup,
     RouterCandidateSelection,
+    SetupRole,
     catalog_state_sha256,
     configure_provider_catalog,
     configure_router_candidates,
@@ -108,6 +109,7 @@ def run_provider_setup(
         existing_connection_providers=_existing_connection_providers(existing),
         existing_catalog_models={} if existing is None else existing.models,
         existing_models=_existing_models(existing),
+        retainable_roles=_retained_setup_roles(existing),
         role_inputs=_role_inputs(options, existing=existing),
         console=console,
         lister=lister if lister is not None else HttpProviderModelLister(),
@@ -124,6 +126,7 @@ def _interactive_setup(
     existing_connection_providers: Mapping[str, str],
     existing_catalog_models: Mapping[str, ModelRecord],
     existing_models: tuple[ProviderModelSelection, ...],
+    retainable_roles: Mapping[str, frozenset[SetupRole]],
     role_inputs: SetupRoleInputs,
     console: Console,
     lister: ProviderModelLister,
@@ -136,6 +139,7 @@ def _interactive_setup(
         existing_connection_providers: Exact provider kind for every persisted connection.
         existing_catalog_models: Exact record for every persisted model alias.
         existing_models: Model aliases already configured in the catalog.
+        retainable_roles: Exact prior roles each incomplete alias may retain.
         role_inputs: Role values supplied by flags or already persisted.
         console: Terminal used for every screen.
         lister: Provider listing seam, injected by tests so no live request is made.
@@ -149,6 +153,7 @@ def _interactive_setup(
     configured = configured_models(
         existing_catalog_models,
         connection_providers=existing_connection_providers,
+        retainable_roles=retainable_roles,
     )
     session = SetupSession(selected=tuple(model.alias for model in configured))
     try:
@@ -269,6 +274,11 @@ def _commit(
         expected_state_sha256=expected_state_sha256,
     )
     if not result.candidates or result.incumbent is None:
+        return catalog
+    if (
+        result.candidates == catalog.roles.candidates
+        and result.incumbent == catalog.roles.incumbent
+    ):
         return catalog
     return configure_router_candidates(
         path,
@@ -465,6 +475,31 @@ def _existing_connection_providers(existing: ModelCatalog | None) -> dict[str, s
     if existing is None:
         return {}
     return {name: connection.provider for name, connection in sorted(existing.connections.items())}
+
+
+def _retained_setup_roles(existing: ModelCatalog | None) -> dict[str, frozenset[SetupRole]]:
+    """Map persisted setup roles to the aliases allowed to retain them without metadata.
+
+    Args:
+        existing: Existing catalog, or ``None`` on first setup.
+
+    Returns:
+        Exact retain-only roles keyed by their currently assigned aliases.
+    """
+    if existing is None:
+        return {}
+    retained: dict[str, set[SetupRole]] = {}
+    assignments = (
+        (existing.roles.world_model, SetupRole.WORLD_MODEL),
+        (existing.roles.judge, SetupRole.JUDGE),
+        (existing.roles.embedder, SetupRole.EMBEDDER),
+    )
+    for alias, role in assignments:
+        if alias is not None:
+            retained.setdefault(alias, set()).add(role)
+    for alias in existing.roles.candidates:
+        retained.setdefault(alias, set()).add(SetupRole.ROUTER_CANDIDATE)
+    return {alias: frozenset(roles) for alias, roles in sorted(retained.items())}
 
 
 def _existing_role(existing: ModelCatalog | None, role: str) -> str | None:

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -525,7 +525,7 @@ def test_rerunning_setup_preserves_unrelated_models_and_router_state(
         ),
     )
 
-    _, catalog = _setup(root, "1\n\n1,3\n\n1\n1\n1\ny\n", monkeypatch=monkeypatch)
+    _, catalog = _setup(root, "2\n\n2,4\n\n1\n1\n1\n\ny\n", monkeypatch=monkeypatch)
 
     assert catalog is not None
     saved = load_model_catalog(root / "models.toml")
@@ -720,6 +720,113 @@ def test_offline_roles_include_models_on_tinker_without_provider_requests(tmp_pa
     assert set(catalog.connections) == {"custom", "openai"}
     assert set(catalog.models) == {"chat", "embed"}
     assert "tinker/chat-id" in unstyle(console.output)
+
+
+def test_offline_roles_retain_assigned_tinker_alias_without_capabilities(tmp_path: Path) -> None:
+    """A current role may retain an unverified alias without provider access or record changes.
+
+    Args:
+        tmp_path: Temporary WMO root containing an assigned legacy Tinker alias.
+    """
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    embedding = ModelCapabilities(
+        supports_embeddings=True,
+        input_cost_per_million_tokens_usd=0.02,
+    )
+    original = ModelCatalog(
+        connections={
+            "tinker": ConnectionConfig(provider="tinker", api_key_env="TINKER_API_KEY"),
+            "openai": ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY"),
+        },
+        models={
+            "legacy": ModelRecord(connection="tinker", model="tinker://sampling/run"),
+            "embed": ModelRecord(
+                connection="openai",
+                model="embed-id",
+                capabilities=embedding,
+            ),
+        },
+        roles=ModelRoles(world_model="legacy", judge="legacy", embedder="embed"),
+    )
+    write_model_catalog(root / "models.toml", original)
+    console = ScriptedConsole("1\n\n\n\n\n\n\ny\n")
+
+    saved = run_provider_setup(
+        root,
+        ProviderSetupOptions(),
+        non_interactive=False,
+        replace=False,
+        console=console,
+        lister=_UnavailableLister(),
+    )
+
+    assert saved == original
+    assert load_model_catalog(root / "models.toml") == original
+    printed = unstyle(console.output)
+    assert "tinker/tinker://sampling/run" in printed
+    assert "retain only: world_model, judge" in printed
+    assert "capabilities=unverified" in printed
+
+
+def test_offline_setup_preserves_exact_unverified_router_roles_without_revalidation(
+    tmp_path: Path,
+) -> None:
+    """Exact retained candidates persist without partial writes or capability invention.
+
+    Args:
+        tmp_path: Temporary WMO root containing complete build roles and legacy candidates.
+    """
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    chat = ModelCapabilities(
+        supports_completions=True,
+        supports_structured_output=True,
+        input_cost_per_million_tokens_usd=1.0,
+        output_cost_per_million_tokens_usd=4.0,
+        cached_input_cost_per_million_tokens_usd=0.0,
+        cache_write_cost_per_million_tokens_usd=0.0,
+    )
+    embedding = ModelCapabilities(
+        supports_embeddings=True,
+        input_cost_per_million_tokens_usd=0.02,
+    )
+    original = ModelCatalog(
+        connections={
+            "tinker": ConnectionConfig(provider="tinker", api_key_env="TINKER_API_KEY"),
+            "openai": ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY"),
+        },
+        models={
+            "legacy-a": ModelRecord(connection="tinker", model="tinker://sampling/a"),
+            "legacy-b": ModelRecord(connection="tinker", model="tinker://sampling/b"),
+            "chat": ModelRecord(connection="openai", model="chat-id", capabilities=chat),
+            "embed": ModelRecord(
+                connection="openai",
+                model="embed-id",
+                capabilities=embedding,
+            ),
+        },
+        roles=ModelRoles(
+            candidates=("legacy-a", "legacy-b"),
+            incumbent="legacy-a",
+            world_model="chat",
+            judge="chat",
+            embedder="embed",
+        ),
+    )
+    write_model_catalog(root / "models.toml", original)
+
+    saved = run_provider_setup(
+        root,
+        ProviderSetupOptions(),
+        non_interactive=False,
+        replace=False,
+        console=ScriptedConsole("1\n\n\n\n\n\n\n\n\ny\n"),
+        lister=_UnavailableLister(),
+    )
+
+    assert saved == original
+    assert load_model_catalog(root / "models.toml") == original
 
 
 def test_role_flags_preselect_the_roles_the_picker_offers(


### PR DESCRIPTION
## Summary

Configured-only provider setup keeps every model alias already bound to `world_model`, `judge`, `embedder`, router candidate, or incumbent visible when its capability or pricing metadata is missing or insufficient.

These rows are explicitly labeled retain-only. They may preserve only their exact existing role bindings; choosing the alias for a new or different role still requires verified metadata satisfying that role. No capability or price is inferred from the provider, model ID, or prior assignment.

The offline path performs no provider listing or credential resolution, preserves unassigned incomplete aliases without displaying them as compatible, and leaves existing model and connection records unchanged. The confirmation summary distinguishes verified roles from unverified retain-only bindings.

An incomplete router-candidate set bypasses strict candidate validation only when its ordered aliases and incumbent exactly equal the roles already preserved in the catalog. Any reordered or changed selection continues through the strict capability and pricing validator and fails closed.

## Contract

- Base: `7040711046f13054d76f208a9b8207aace20eb36`
- Head: `d19c13aff75c61d0016947d54bf450bc6eae4d3f`
- Scope: one semantic commit across the picker/setup implementation and paired tests
- Production file sizes: `model_picker.py` 551, `provider_picker.py` 621, `provider_setup.py` 587 lines

## Verification

- Picker, provider setup, discovery/listing/request, and first-build matrix: `142 passed`
- Release evidence: `4 passed, 1 skipped`
- Whole repository Ruff format, Ruff check, and Ty: green
- Wheel and sdist build: green
- Fresh Python 3.13 wheel install, `site-packages` import, and installed `wmo config providers --help`: green
- Independent semantic/range audit: exact-retention and reordered-candidate adversaries passed; exact six-file scope; clean worktree; no blocker
