### PR TITLE
Improve judge setup and calibration UX

### DIFF
--- a/wmo/cli/consent.py
+++ b/wmo/cli/consent.py
@@ -82,6 +82,7 @@ def require_spend_consent(
     spend: str,
     command: str,
     alternative: str | None = None,
+    question: str = "Proceed?",
 ) -> bool:
     """Get explicit consent before the first paid call, or refuse to start.
 
@@ -99,6 +100,7 @@ def require_spend_consent(
             so the message says what to re-run.
         alternative: An optional second way out, phrased as a flag plus what it does, e.g.
             "--dry-run to see the plan without spending".
+        question: Named confirmation question shown after the caller's spend preflight.
 
     Returns:
         True when consent was given, False when the user declined at a terminal. Callers exit
@@ -115,7 +117,7 @@ def require_spend_consent(
     try:
         # `default=False`: pressing Enter, and anything else that arrives as a blank line, is a
         # refusal. Defaulting to True made the cheapest possible input authorize the spend.
-        return Confirm.ask("\nProceed?", default=False)
+        return Confirm.ask(f"\n{question}", default=False)
     except EOFError:
         # Both streams claimed to be a terminal and then the input ended anyway (Ctrl-D, or a
         # pty that closed under us). Nobody answered, so this is the "could not ask" refusal

--- a/wmo/cli/consent_test.py
+++ b/wmo/cli/consent_test.py
@@ -82,6 +82,25 @@ def test_a_terminal_is_asked_and_a_yes_consents(
     assert len(answer.asked) == 1
 
 
+def test_a_caller_can_name_the_spend_question(
+    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
+) -> None:
+    """A paid workflow can replace the generic prompt with its named operation."""
+    answer = _Answer(True)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    assert require_spend_consent(
+        console,
+        yes=False,
+        spend="at most $1.00",
+        command="wmo config judge calibrate",
+        question="Run this named judge calibration within the displayed ceiling?",
+    )
+
+    assert answer.asked == ["\nRun this named judge calibration within the displayed ceiling?"]
+
+
 def test_no_terminal_and_no_yes_refuses_naming_the_spend_and_the_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -5,19 +5,24 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 
 import typer
+from pydantic import JsonValue
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm, IntPrompt, Prompt
 
 from wmo.cli.consent import can_prompt, require_spend_consent
 from wmo.common.judging import Rubric, RubricDimension
 from wmo.common.judging.provenance import read_artifact_json
-from wmo.common.models import load_model_catalog
+from wmo.common.models import ModelSnapshot, load_model_catalog
 from wmo.common.project import ProjectStore
 from wmo.common.release_revision import installed_release_revision
+from wmo.common.traces import Trace, TraceSpan
 from wmo.optimize.router.judging.contracts import (
+    JudgeCalibrationBudget,
     JudgePromptTemplate,
     JudgeTracePreview,
     ManualJudgeCalibrationResult,
@@ -31,6 +36,7 @@ from wmo.optimize.router.judging.labels import (
 )
 from wmo.optimize.router.judging.service import (
     DEFAULT_JUDGE_TEMPLATE,
+    ManualJudgeCalibrationPlan,
     ManualJudgeError,
     ManualJudgeSetupPlan,
     calibrate_manual_judge,
@@ -150,6 +156,17 @@ def judge_calibrate(
         help="Accept valid grouped evidence from fewer than ten rollouts.",
     ),
     non_interactive: bool = typer.Option(False, "--non-interactive"),
+    transcript_character_limit: int = typer.Option(
+        1_200,
+        "--transcript-character-limit",
+        min=200,
+        help="Maximum characters shown for each transcript field before a truthful marker.",
+    ),
+    page: bool = typer.Option(
+        False,
+        "--page",
+        help="Page full transcripts in an interactive terminal instead of truncating them.",
+    ),
 ) -> None:
     """Collect frozen labels, run consented judge calls, and separately approve evidence.
 
@@ -166,6 +183,8 @@ def judge_calibrate(
         approve: Separate approval of the displayed completed report.
         accept_insufficient_labels: Explicit risk acceptance below ten labeled rollouts.
         non_interactive: Refuse prompts and list missing explicit inputs.
+        transcript_character_limit: Maximum displayed characters per transcript field.
+        page: Page untruncated transcripts through the interactive terminal.
 
     Raises:
         typer.BadParameter: Evidence, labels, budget, consent, or approval is invalid.
@@ -176,7 +195,6 @@ def judge_calibrate(
         now = datetime.now(UTC)
         plan = prepare_manual_judge_calibration(store, sample_size=sample_size)
         rubric = _load_setup_rubric(store, plan.setup)
-        _render_calibration_previews(plan.previews)
         sample_sha256 = calibration_sample_digest(plan.setup, calibration_sample(plan))
         drafted = read_label_draft(store, plan.setup, sample_sha256)
         completed = manual_judge_calibration_is_complete(store)
@@ -185,8 +203,15 @@ def judge_calibrate(
                 "Judge calibration is already complete; replaying its immutable evidence "
                 "without collecting labels."
             )
-        elif drafted:
-            _console.print(f"Resuming {len(drafted)} saved human labels for this trace sample.")
+        budget = estimate_manual_judge_budget(
+            plan,
+            input_usd_per_million_tokens=input_price,
+            output_usd_per_million_tokens=output_price,
+            maximum_input_tokens_per_call=maximum_input_tokens,
+            maximum_cost_usd=maximum_cost_usd,
+        )
+        if page and not completed and not can_prompt(_console):
+            raise ValueError("--page requires an interactive terminal; omit it for wrapped output")
 
         def persist(collected: tuple[ManualJudgeLabel, ...]) -> None:
             """Save human labels to durable review state before any judge provider work.
@@ -196,10 +221,35 @@ def judge_calibrate(
             """
             save_label_draft(store, plan.setup, sample_sha256, collected, now)
 
-        labels = (
-            drafted
-            if completed
-            else _collect_labels(
+    except (OSError, ValueError, ManualJudgeError) as exc:
+        raise typer.BadParameter(str(exc)) from None
+    if not completed:
+        _render_spend_preflight(plan, budget)
+        spend = (
+            f"at most ${_format_usd(budget.estimated_cost_usd)} across "
+            f"{budget.call_count} judge calls "
+            f"with up to {budget.maximum_attempts_per_call} attempts each, inside the "
+            f"${_format_usd(budget.maximum_cost_usd)} ceiling"
+        )
+        if not require_spend_consent(
+            _console,
+            yes=yes,
+            spend=spend,
+            command="wmo config judge calibrate",
+            question="Run this named judge calibration within the displayed ceiling?",
+        ):
+            _console.print("Judge calibration was not started. No labels or provider calls ran.")
+            return
+        if drafted:
+            _console.print(f"Resuming {len(drafted)} saved human labels for this trace sample.")
+        _render_calibration_review(
+            plan,
+            rubric,
+            character_limit=None if page else transcript_character_limit,
+            page=page,
+        )
+        try:
+            labels = _collect_labels(
                 plan.setup,
                 rubric,
                 tuple(label or ()),
@@ -208,28 +258,10 @@ def judge_calibrate(
                 persist,
                 non_interactive=non_interactive,
             )
-        )
-        budget = estimate_manual_judge_budget(
-            plan,
-            input_usd_per_million_tokens=input_price,
-            output_usd_per_million_tokens=output_price,
-            maximum_input_tokens_per_call=maximum_input_tokens,
-            maximum_cost_usd=maximum_cost_usd,
-        )
-    except (OSError, ValueError, ManualJudgeError) as exc:
-        raise typer.BadParameter(str(exc)) from None
-    spend = (
-        f"at most ${budget.estimated_cost_usd:.4f} across {budget.call_count} judge calls "
-        f"with up to {budget.maximum_attempts_per_call} attempts each"
-    )
-    if not require_spend_consent(
-        _console,
-        yes=yes,
-        spend=spend,
-        command="wmo config judge calibrate",
-    ):
-        _console.print("Judge calibration was not started.")
-        return
+        except (OSError, ValueError, ManualJudgeError) as exc:
+            raise typer.BadParameter(str(exc)) from None
+    else:
+        labels = drafted
     try:
         runtime = RuntimeModelCatalog(load_model_catalog(store.model_catalog_path))
         result = calibrate_manual_judge(
@@ -245,10 +277,14 @@ def judge_calibrate(
             code_revision=revision,
         )
         _render_report(result)
-        should_approve = approve or _confirm(
-            "Approve this immutable judge calibration?",
-            non_interactive=non_interactive,
-            required_flag="--approve",
+        should_approve = (
+            result.approved_calibration is not None
+            or approve
+            or _confirm(
+                "Approve this immutable judge calibration?",
+                non_interactive=non_interactive,
+                required_flag="--approve",
+            )
         )
         if should_approve and result.approved_calibration is None:
             result = calibrate_manual_judge(
@@ -306,52 +342,342 @@ def _load_prompt_template(path: Path | None) -> JudgePromptTemplate:
 
 
 def _render_setup(plan: ManualJudgeSetupPlan) -> None:
-    """Display every setup identity and a concise real-trace preview.
+    """Display the judge, plain-language rubric, and representative tasks.
 
     Args:
         plan: Read-only setup plan awaiting confirmation.
     """
-    _console.print(f"Judge alias: {plan.judge_alias}")
-    _console.print(f"Judge model: {plan.judge_model.provider}/{plan.judge_model.model_id}")
-    _console.print(
-        f"Prompt: {plan.prompt_template.prompt.prompt_id} ({plan.prompt_template.prompt.sha256})"
+    _console.print("\n[bold]Judge setup[/bold]")
+    _console.print(f"Judge name: {plan.judge_alias}", markup=False)
+    _console.print(f"Exact model: {_model_name(plan.judge_model)}", markup=False)
+    mode = (
+        "A/B pairwise comparison"
+        if plan.prompt_template.response_shape == "pairwise"
+        else "Zero-to-five scoring"
     )
-    _console.print(f"Response shape: {plan.prompt_template.response_shape}")
-    _console.print(f"Variable mapping: {json.dumps(plan.prompt_template.variable_mapping)}")
-    _console.print(
-        "Structured response schema: "
-        + json.dumps(plan.prompt_template.response_schema, sort_keys=True)
-    )
-    _console.print(
-        "Score projection: "
-        + json.dumps(plan.prompt_template.score_projection.model_dump(mode="json"), sort_keys=True)
-    )
-    _console.print("Rubric:")
-    for dimension in plan.dimensions:
-        _console.print(f"  {dimension.dimension_id}: {dimension.name}")
-    _console.print("Real trace preview:")
-    for preview in plan.previews:
-        _console.print(
-            f"  {preview.trace_id} [{preview.outcome}] {preview.task} "
-            f"({len(preview.span_names)} spans)"
-        )
+    _console.print(f"Calibration mode: {mode}", markup=False)
+    _render_rubric(plan.dimensions)
+    _console.print("\n[bold]Representative tasks[/bold]")
+    for index, preview in enumerate(plan.previews, start=1):
+        _console.print(f"{index}. {preview.task}", markup=False)
+        _console.print(f"   Recorded outcome: {preview.outcome}", markup=False)
 
 
-def _render_calibration_previews(previews: tuple[JudgeTracePreview, ...]) -> None:
-    """Display the frozen real-trace sample before requesting human labels.
+def _render_spend_preflight(
+    plan: ManualJudgeCalibrationPlan,
+    budget: JudgeCalibrationBudget,
+) -> None:
+    """Display the exact judge identity and conservative spend admission.
 
     Args:
-        previews: Ordered real trace previews selected for calibration.
+        plan: Frozen calibration plan naming the exact judge model.
+        budget: Conservative complete-call reservation already checked against its ceiling.
     """
-    _console.print("Calibration traces:")
-    for preview in previews:
-        comparison = (
-            f" vs {preview.reference_trace_id}" if preview.reference_trace_id is not None else ""
+    _console.print("\n[bold]Spend preflight: manual judge calibration[/bold]")
+    _console.print(f"Judge name: {plan.setup.judge_alias}", markup=False)
+    _console.print(f"Exact model: {_model_name(plan.setup.judge_model)}", markup=False)
+    _console.print(f"Judge calls authorized: {budget.call_count}", markup=False)
+    _console.print(
+        f"Maximum estimated cost: ${_format_usd(budget.estimated_cost_usd)}", markup=False
+    )
+    _console.print(f"Hard spend ceiling: ${_format_usd(budget.maximum_cost_usd)}", markup=False)
+    _console.print(f"Maximum attempts per call: {budget.maximum_attempts_per_call}", markup=False)
+
+
+def _format_usd(value: float) -> str:
+    """Format an admitted dollar bound without rounding a positive value to zero.
+
+    Args:
+        value: Finite nonnegative estimated cost or positive hard ceiling.
+
+    Returns:
+        Fixed-point decimal text preserving the float's round-trip value and at least four
+        fractional digits.
+    """
+    whole, separator, fraction = format(Decimal(str(value)), "f").partition(".")
+    significant_fraction = fraction.rstrip("0") if separator else ""
+    return f"{whole}.{significant_fraction.ljust(4, '0')}"
+
+
+def _render_calibration_review(
+    plan: ManualJudgeCalibrationPlan,
+    rubric: Rubric,
+    *,
+    character_limit: int | None,
+    page: bool,
+) -> None:
+    """Render readable scalar or A/B transcripts after spend consent.
+
+    Args:
+        plan: Frozen traces and optional same-task references in display order.
+        rubric: Finalized plain-language zero-to-five rubric.
+        character_limit: Per-field limit, or ``None`` for full transcript text.
+        page: Whether to send the full review through Rich's terminal pager.
+    """
+
+    def render() -> None:
+        """Write the complete review into the active console or pager buffer."""
+        pairwise = plan.setup.prompt_template.response_shape == "pairwise"
+        heading = "PAIRWISE A/B CALIBRATION" if pairwise else "ZERO-TO-FIVE CALIBRATION"
+        _console.print(f"\n[bold]{heading}[/bold]")
+        _render_rubric(rubric.dimensions)
+        for index, (trace, reference) in enumerate(
+            zip(plan.traces, plan.reference_traces, strict=True), start=1
+        ):
+            if pairwise:
+                _console.print(f"\n[bold]Pair {index}, candidate A[/bold]")
+                _render_trace(trace, character_limit=character_limit)
+                if reference is None:
+                    raise ValueError("pairwise calibration preview is missing candidate B")
+                _console.print(f"\n[bold]Pair {index}, candidate B[/bold]")
+                _render_trace(reference, character_limit=character_limit)
+            else:
+                _console.print(f"\n[bold]Trace {index}[/bold]")
+                _render_trace(trace, character_limit=character_limit)
+
+    if page:
+        with _console.pager(styles=True):
+            render()
+    else:
+        render()
+
+
+def _render_rubric(dimensions: tuple[RubricDimension, ...]) -> None:
+    """Render complete plain-language rubric dimensions and zero-to-five anchors.
+
+    Args:
+        dimensions: Finalized rubric dimensions in scoring order.
+    """
+    _console.print("\n[bold]Rubric[/bold]")
+    for dimension in dimensions:
+        _console.print(dimension.name, style="bold", markup=False)
+        _console.print(dimension.description, markup=False)
+        for anchor in dimension.anchors:
+            _console.print(f"  {anchor.score}: {anchor.description}", markup=False)
+
+
+def _render_trace(trace: Trace, *, character_limit: int | None) -> None:
+    """Render one normalized trace as a role-separated readable transcript.
+
+    Args:
+        trace: Verified immutable normalized production trace.
+        character_limit: Maximum characters per field, or ``None`` for the full value.
+    """
+    _render_field("User / task", trace.task, character_limit=character_limit)
+    if trace.initial_context:
+        _render_field(
+            "Initial context",
+            _jsonish_text(trace.initial_context),
+            character_limit=character_limit,
         )
-        _console.print(
-            f"  {preview.trace_id}{comparison} [{preview.outcome}] {preview.task} "
-            f"spans={', '.join(preview.span_names)}"
+    for span in trace.spans:
+        _render_span(span, character_limit=character_limit)
+    outcome = trace.outcome
+    if outcome is None:
+        _render_field("Final outcome", "Not recorded", character_limit=character_limit)
+        return
+    outcome_text = outcome.status
+    if outcome.outcome_name is not None:
+        outcome_text += f" ({outcome.outcome_name})"
+    _render_field("Final outcome", outcome_text, character_limit=character_limit)
+    if outcome.failure is not None:
+        _render_field(
+            "Final failure",
+            f"{outcome.failure.code.value}: {outcome.failure.message} "
+            f"(retryable={str(outcome.failure.retryable).lower()})",
+            character_limit=character_limit,
         )
+
+
+def _render_span(span: TraceSpan, *, character_limit: int | None) -> None:
+    """Render recognized assistant, tool-call, tool-result, and failure evidence.
+
+    Args:
+        span: One normalized chronological trace span.
+        character_limit: Maximum characters per field, or ``None`` for the full value.
+    """
+    attributes = span.attributes
+    operation = attributes.get("gen_ai.operation.name")
+    tool_name = attributes.get("gen_ai.tool.name")
+    arguments = attributes.get("gen_ai.tool.call.arguments")
+    result = attributes.get("gen_ai.tool.message")
+    if result is None:
+        result = attributes.get("gen_ai.tool.output")
+    completion = _assistant_completion(attributes)
+    user_input = _user_input(attributes)
+    if user_input is not None:
+        _render_field("User message", user_input, character_limit=character_limit)
+    if span.model is not None:
+        _render_field("Assistant / model", _model_name(span.model), character_limit=character_limit)
+    if completion:
+        _render_field("Assistant output", completion, character_limit=character_limit)
+    if operation != "execute_tool" and isinstance(tool_name, str):
+        _render_field("Tool call", tool_name, character_limit=character_limit)
+        if arguments is not None:
+            _render_field(
+                "Tool arguments", _jsonish_text(arguments), character_limit=character_limit
+            )
+    if operation == "execute_tool":
+        _render_field(
+            "Tool result",
+            tool_name if isinstance(tool_name, str) else span.name,
+            character_limit=character_limit,
+        )
+        if result is not None:
+            _render_field("Tool output", _jsonish_text(result), character_limit=character_limit)
+    if span.failure is not None:
+        _render_field(
+            "Span failure",
+            f"{span.failure.code.value}: {span.failure.message}",
+            character_limit=character_limit,
+        )
+
+
+def _assistant_completion(attributes: dict[str, JsonValue]) -> str | None:
+    """Extract readable assistant content from supported normalized attributes.
+
+    Args:
+        attributes: Canonical normalized span attributes.
+
+    Returns:
+        Assistant content when captured, otherwise ``None``.
+    """
+    for key in ("gen_ai.completion", "gen_ai.response.text"):
+        value = attributes.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return _last_role_message(
+        _decoded_json_value(attributes.get("gen_ai.output.messages")),
+        frozenset({"assistant", "model"}),
+    )
+
+
+def _user_input(attributes: dict[str, JsonValue]) -> str | None:
+    """Extract the latest readable user message from one normalized span.
+
+    Args:
+        attributes: Canonical normalized span attributes.
+
+    Returns:
+        Latest user content when captured, otherwise the legacy prompt field.
+    """
+    text = _last_role_message(
+        _decoded_json_value(attributes.get("gen_ai.input.messages")),
+        frozenset({"user", "human"}),
+    )
+    if text is not None:
+        return text
+    prompt = attributes.get("gen_ai.prompt")
+    return prompt.strip() if isinstance(prompt, str) and prompt.strip() else None
+
+
+def _last_role_message(value: JsonValue, roles: frozenset[str]) -> str | None:
+    """Return the latest visible message for one set of transcript roles.
+
+    Args:
+        value: Decoded normalized message collection.
+        roles: Accepted lowercase role names.
+
+    Returns:
+        Latest nonempty message content, or ``None`` when absent.
+    """
+    if not isinstance(value, list):
+        return None
+    for item in reversed(value):
+        if not isinstance(item, dict) or item.get("role") not in roles:
+            continue
+        text = _message_text(item.get("content"))
+        if text is not None:
+            return text
+    return None
+
+
+def _decoded_json_value(value: JsonValue | None) -> JsonValue:
+    """Decode JSON-encoded semantic attributes without guessing malformed text.
+
+    Args:
+        value: Native or JSON-encoded normalized attribute value.
+
+    Returns:
+        Decoded JSON value, or the original value when it is not encoded JSON.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _message_text(value: JsonValue | None) -> str | None:
+    """Read plain text from one normalized message content value.
+
+    Args:
+        value: String or structured content parts.
+
+    Returns:
+        Joined text content, or ``None`` when no text was captured.
+    """
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if not isinstance(value, list):
+        return None
+    texts = tuple(
+        item["text"].strip()
+        for item in value
+        if isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"].strip()
+    )
+    return "\n".join(texts) if texts else None
+
+
+def _jsonish_text(value: JsonValue) -> str:
+    """Format native or JSON-encoded transcript evidence for a human.
+
+    Args:
+        value: Captured transcript value.
+
+    Returns:
+        Stable indented JSON when possible, otherwise its original text.
+    """
+    decoded = value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return json.dumps(decoded, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def _render_field(label: str, value: str, *, character_limit: int | None) -> None:
+    """Render one safely wrapped transcript field with truthful truncation.
+
+    Args:
+        label: Human role or evidence label.
+        value: Captured field text.
+        character_limit: Maximum characters, or ``None`` for the full value.
+    """
+    shown = value
+    if character_limit is not None and len(value) > character_limit:
+        omitted = len(value) - character_limit
+        shown = (
+            value[:character_limit]
+            + f"\n... [truncated {omitted} characters; use --page for the full transcript]"
+        )
+    _console.print(f"{label}:", style="bold", markup=False)
+    _console.print(shown, markup=False, overflow="fold")
+
+
+def _model_name(model: ModelSnapshot) -> str:
+    """Return the plain provider and model identity without internal hashes.
+
+    Args:
+        model: Model snapshot with provider, model, and optional revision fields.
+
+    Returns:
+        Human-readable exact provider and model identity.
+    """
+    suffix = f" (revision {model.revision})" if model.revision is not None else ""
+    return f"{model.provider}/{model.model_id}{suffix}"
 
 
 def _collect_labels(
@@ -413,21 +739,45 @@ def _collect_labels(
         raise ValueError(
             "missing labels: " + ", ".join(":".join(part or "-" for part in key) for key in missing)
         )
+    dimensions = {dimension.dimension_id: dimension for dimension in rubric.dimensions}
+    preview_positions = {
+        (preview.trace_id, preview.reference_trace_id): index
+        for index, preview in enumerate(previews, start=1)
+    }
     for key in missing:
         trace_id, reference_id, dimension_id = key
+        dimension = dimensions[dimension_id]
+        _render_score_prompt(dimension)
+        position = preview_positions[(trace_id, reference_id)]
         if pairwise:
-            value: int | str = Prompt.ask(
-                f"Winner for {trace_id} vs {reference_id} on {dimension_id}",
-                choices=["winner_a", "winner_b", "tie"],
+            choice = Prompt.ask(
+                "Pair "
+                f"{position}: choose candidate A, candidate B, or tie for "
+                f"{escape(dimension.name)}",
+                choices=["A", "B", "tie"],
             )
+            value: int | str = {"A": "winner_a", "B": "winner_b", "tie": "tie"}[choice]
         else:
-            score = IntPrompt.ask(f"Score {trace_id} on {dimension_id} (0-5)")
+            score = IntPrompt.ask(f"Trace {position}: score {escape(dimension.name)} from 0 to 5")
             if score not in range(6):
                 raise ValueError("judge labels must be integers from zero through five")
             value = score
         parsed[key] = _label(key, value, pairwise=pairwise)
         persist(tuple(parsed[item] for item in expected if item in parsed))
     return tuple(parsed[key] for key in expected)
+
+
+def _render_score_prompt(dimension: RubricDimension) -> None:
+    """Keep one score question adjacent to its complete plain-language anchors.
+
+    Args:
+        dimension: Rubric dimension the next prompt asks the operator to score.
+    """
+    _console.print()
+    _console.print(f"Score prompt: {dimension.name}", style="bold", markup=False)
+    _console.print(dimension.description, markup=False)
+    for anchor in dimension.anchors:
+        _console.print(f"  {anchor.score}: {anchor.description}", markup=False)
 
 
 def _label(

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -2,13 +2,60 @@
 
 from __future__ import annotations
 
+import io
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from click import unstyle
+from rich.console import Console
+from rich.text import Text
 from typer.testing import CliRunner
 
+from wmo.cli import judge_config as judge_config_module
 from wmo.cli.app import app
+from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
+from wmo.common.judging import Rubric
+from wmo.common.models import ModelSnapshot
+from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.optimize.router.judging.contracts import (
+    JudgeCalibrationBudget,
+    JudgeTracePreview,
+    ManualJudgeLabel,
+    ManualJudgeSetupArtifact,
+)
+from wmo.optimize.router.judging.service import (
+    ManualJudgeCalibrationPlan,
+    ManualJudgeSetupPlan,
+    default_judge_dimensions,
+)
+
+
+class _PairwiseAnswer:
+    """Return candidate B while retaining the exact human-facing prompt."""
+
+    prompt = ""
+
+    @classmethod
+    def ask(cls, prompt: str, *, choices: list[str]) -> str:
+        """Record one prompt and require plain A, B, and tie choices."""
+        cls.prompt = prompt
+        assert choices == ["A", "B", "tie"]
+        return "B"
+
+
+class _ScalarAnswer:
+    """Return score four while retaining the exact human-facing prompt."""
+
+    prompt = ""
+
+    @classmethod
+    def ask(cls, prompt: str) -> int:
+        """Record one prompt and return a valid scalar score."""
+        cls.prompt = prompt
+        return 4
 
 
 @pytest.mark.parametrize(
@@ -63,3 +110,309 @@ def test_judge_commands_render_as_nested_config_commands() -> None:
     assert "--approve" in setup_output
     assert "--yes" in calibrate_output
     assert "--approve" in calibrate_output
+
+
+def test_setup_output_is_plain_language_and_hides_execution_internals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default setup shows identity, full anchors, and tasks without prompt machinery."""
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        judge_config_module,
+        "_console",
+        Console(file=buffer, width=42, color_system=None),
+    )
+    plan = cast(
+        ManualJudgeSetupPlan,
+        SimpleNamespace(
+            judge_alias="review-judge",
+            judge_model=_model(),
+            prompt_template=SimpleNamespace(response_shape="scalar"),
+            dimensions=default_judge_dimensions(),
+            previews=(
+                SimpleNamespace(task="Summarize the customer issue.", outcome="success"),
+                SimpleNamespace(task="Find the failed command.", outcome="failure"),
+            ),
+        ),
+    )
+
+    judge_config_module._render_setup(plan)
+
+    output = buffer.getvalue()
+    assert "Judge name: review-judge" in output
+    assert "Exact model: openai/judge-model" in output
+    assert "Task success" in output
+    assert "0: The agent did not address the task." in output
+    assert "5: The agent fully and correctly" in output
+    assert "Summarize the customer issue." in output
+    assert "Find the failed command." in output
+    assert "Prompt:" not in output
+    assert "Variable mapping" not in output
+    assert "response schema" not in output.lower()
+    assert "Score projection" not in output
+    assert "0000000000000000" not in output
+
+
+def test_spend_preflight_preserves_a_small_positive_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A small admitted estimate and ceiling never display as zero."""
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        judge_config_module,
+        "_console",
+        Console(file=buffer, width=80, color_system=None),
+    )
+    plan = cast(
+        ManualJudgeCalibrationPlan,
+        SimpleNamespace(setup=SimpleNamespace(judge_alias="judge", judge_model=_model())),
+    )
+    budget = JudgeCalibrationBudget(
+        input_usd_per_million_tokens=0,
+        output_usd_per_million_tokens=0,
+        maximum_input_tokens_per_call=1,
+        maximum_attempts_per_call=1,
+        call_count=1,
+        estimated_cost_usd=0.000049,
+        maximum_cost_usd=0.000049,
+    )
+
+    judge_config_module._render_spend_preflight(plan, budget)
+
+    output = buffer.getvalue()
+    assert "Maximum estimated cost: $0.000049" in output
+    assert "Hard spend ceiling: $0.000049" in output
+    assert "$0.0000\n" not in output
+
+
+def test_pairwise_calibration_renders_roles_and_truthful_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A/B review separates task, assistant, tools, result, and terminal failure."""
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        judge_config_module,
+        "_console",
+        Console(file=buffer, width=36, color_system=None),
+    )
+    first = _trace("trace-a", completion="A" * 80, failed=True)
+    second = _trace("trace-b", completion="Candidate B finished.", failed=False)
+    plan = cast(
+        ManualJudgeCalibrationPlan,
+        SimpleNamespace(
+            setup=SimpleNamespace(prompt_template=SimpleNamespace(response_shape="pairwise")),
+            traces=(first,),
+            reference_traces=(second,),
+        ),
+    )
+
+    judge_config_module._render_calibration_review(
+        plan,
+        cast(Rubric, SimpleNamespace(dimensions=default_judge_dimensions())),
+        character_limit=40,
+        page=False,
+    )
+
+    output = buffer.getvalue()
+    assert "PAIRWISE A/B CALIBRATION" in output
+    assert "Pair 1, candidate A" in output
+    assert "Pair 1, candidate B" in output
+    assert "User / task:" in output
+    assert "User message:" in output
+    assert "Please resolve customer issue trace-a." in " ".join(output.split())
+    assert "Assistant / model:" in output
+    assert "Assistant output:" in output
+    assert "Tool call:" in output
+    assert "Tool arguments:" in output
+    assert "Tool result:" in output
+    assert "Tool output:" in output
+    assert "Final outcome:" in output
+    assert "Final failure:" in output
+    assert "truncated 40 characters" in output
+    assert "use --page for the full transcript" in " ".join(output.split())
+
+
+def test_pairwise_prompt_keeps_anchors_adjacent_and_uses_plain_a_b_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive pairwise scoring says A and B while persisting the typed winner."""
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        judge_config_module,
+        "_console",
+        Console(file=buffer, width=80, color_system=None),
+    )
+    monkeypatch.setattr(judge_config_module, "Prompt", _PairwiseAnswer)
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="pairwise")),
+    )
+    preview = cast(
+        JudgeTracePreview,
+        SimpleNamespace(trace_id="trace-a", reference_trace_id="trace-b"),
+    )
+    rubric = cast(Rubric, SimpleNamespace(dimensions=default_judge_dimensions()))
+    persisted: list[tuple[ManualJudgeLabel, ...]] = []
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Retain incremental labels exactly as the command would save them."""
+        persisted.append(labels)
+
+    labels = judge_config_module._collect_labels(
+        setup,
+        rubric,
+        (),
+        (preview,),
+        (),
+        persist,
+        non_interactive=False,
+    )
+
+    assert labels[0].winner == "winner_b"
+    assert persisted[-1] == labels
+    assert "choose candidate A, candidate B, or tie" in _PairwiseAnswer.prompt
+    output = buffer.getvalue()
+    assert "Score prompt: Task success" in output
+    assert "0: The agent did not address the task." in output
+    assert "5: The agent fully and correctly addressed the task." in output
+
+
+@pytest.mark.parametrize(
+    ("shape", "name"),
+    [
+        ("pairwise", "[/]"),
+        ("scalar", "[link=https://invalid.example]linked name[/link]"),
+    ],
+)
+def test_score_prompt_escapes_user_authored_rich_markup(
+    monkeypatch: pytest.MonkeyPatch,
+    shape: str,
+    name: str,
+) -> None:
+    """Malformed and link-like dimension names remain literal scoring text.
+
+    Args:
+        monkeypatch: Scoped prompt replacement.
+        shape: Prompt response shape under test.
+        name: Valid user-authored dimension name containing Rich markup syntax.
+    """
+    dimension = default_judge_dimensions()[0].model_copy(update={"name": name})
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape=shape)),
+    )
+    preview = cast(
+        JudgeTracePreview,
+        SimpleNamespace(
+            trace_id="trace-a",
+            reference_trace_id="trace-b" if shape == "pairwise" else None,
+        ),
+    )
+    rubric = cast(Rubric, SimpleNamespace(dimensions=(dimension,)))
+    persisted: list[tuple[ManualJudgeLabel, ...]] = []
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Retain the escaped-prompt test's incremental label."""
+        persisted.append(labels)
+
+    if shape == "pairwise":
+        monkeypatch.setattr(judge_config_module, "Prompt", _PairwiseAnswer)
+        answer_type = _PairwiseAnswer
+    else:
+        monkeypatch.setattr(judge_config_module, "IntPrompt", _ScalarAnswer)
+        answer_type = _ScalarAnswer
+
+    labels = judge_config_module._collect_labels(
+        setup,
+        rubric,
+        (),
+        (preview,),
+        (),
+        persist,
+        non_interactive=False,
+    )
+
+    assert persisted[-1] == labels
+    assert name in Text.from_markup(answer_type.prompt).plain
+
+
+def _model() -> ModelSnapshot:
+    """Return one exact secret-free judge identity."""
+    return ModelSnapshot(
+        provider="openai",
+        model_id="judge-model",
+        revision=None,
+        capabilities_sha256="0" * 64,
+        connection_sha256="1" * 64,
+    )
+
+
+def _trace(trace_id: str, *, completion: str, failed: bool) -> Trace:
+    """Return one transcript fixture with assistant and paired tool evidence.
+
+    Args:
+        trace_id: Stable fixture trace identity.
+        completion: Captured assistant response.
+        failed: Whether terminal evidence records a failure.
+
+    Returns:
+        Complete normalized trace for CLI rendering.
+    """
+    started = datetime(2026, 8, 16, tzinfo=UTC)
+    spans = (
+        TraceSpan(
+            span_id=f"{trace_id}-assistant",
+            name="agent.model_call",
+            started_at=started,
+            ended_at=started + timedelta(seconds=1),
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.input.messages": (
+                    f'[{{"role":"user","content":"Please resolve customer issue {trace_id}."}}]'
+                ),
+                "gen_ai.output.messages": [
+                    {"role": "assistant", "content": [{"type": "text", "text": completion}]}
+                ],
+            },
+            model=_model(),
+        ),
+        TraceSpan(
+            span_id=f"{trace_id}-tool-call",
+            name="agent.model_call",
+            started_at=started + timedelta(seconds=2),
+            ended_at=started + timedelta(seconds=3),
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.call.arguments": '{"query":"customer issue"}',
+            },
+            model=_model(),
+        ),
+        TraceSpan(
+            span_id=f"{trace_id}-tool-result",
+            name="agent.tool_call",
+            started_at=started + timedelta(seconds=4),
+            ended_at=started + timedelta(seconds=5),
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.output": "Found the relevant account record.",
+            },
+        ),
+    )
+    failure = StructuredFailure(code=FailureCode.INTERNAL, message="Customer request failed")
+    return Trace(
+        trace_id=trace_id,
+        task="Resolve the customer's support request.",
+        initial_context={"account_tier": "business"},
+        spans=spans,
+        outcome=(
+            TraceOutcome(status="failure", failure=failure)
+            if failed
+            else TraceOutcome(status="success", outcome_name="resolved")
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(kind="manual", source_id=trace_id, sha256="2" * 64),
+            semantic_convention_version="test-v1",
+        ),
+    )

--- a/wmo/cli/tests/terminal_tasks_happy_path_test.py
+++ b/wmo/cli/tests/terminal_tasks_happy_path_test.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -253,27 +254,103 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
         for argument in ("--label", f"{trace.trace_id}:task-success=4")
     ]
 
+    before_preflight = store.read_review()
+    without_consent = [
+        argument for argument in _calibrate_arguments(root, ()) if argument != "--yes"
+    ]
+    refused = runner.invoke(app, without_consent)
+    assert refused.exit_code == 2
+    assert "Spend preflight: manual judge calibration" in refused.output
+    assert "Judge name: judge" in refused.output
+    assert "Exact model: openai/judge-id" in refused.output
+    assert "Judge calls authorized: 10" in refused.output
+    assert "Maximum estimated cost: $0.0000" in refused.output
+    assert "Hard spend ceiling: $10.0000" in refused.output
+    assert "missing labels" not in refused.output
+    assert store.read_review() == before_preflight
+
     _RuntimeCatalog.judge_fail_after = 0
     interrupted = runner.invoke(app, _calibrate_arguments(root, labels))
     assert interrupted.exit_code != 0
+    assert "ZERO-TO-FIVE CALIBRATION" in interrupted.output
+    assert "User / task:" in interrupted.output
+    assert "Tool call:" in interrupted.output
+    assert "Tool arguments:" in interrupted.output
+    assert "Tool result:" in interrupted.output
+    assert "Tool output:" in interrupted.output
+    assert "Final outcome:" in interrupted.output
+    assert "0: The agent did not address the task." in interrupted.output
+    assert "5: The agent fully and correctly addressed the task." in interrupted.output
     drafted = _drafted_labels(store)
     assert len(drafted) == _SAMPLE_SIZE
     assert {item["score"] for item in drafted} == {4}
 
     _RuntimeCatalog.judge_fail_after = None
     _RuntimeCatalog.judge_clients = []
-    resumed = runner.invoke(app, _calibrate_arguments(root, ()))
-    assert resumed.exit_code == 0, resumed.output
+    resumed = runner.invoke(
+        app,
+        [argument for argument in _calibrate_arguments(root, ()) if argument != "--approve"],
+    )
+    assert resumed.exit_code == 2
     assert "Resuming 10 saved human labels" in resumed.output
-    assert "Approved judge calibration" in resumed.output
+    resumed_text = unstyle(resumed.output)
+    assert "--approve" in resumed_text
     assert sum(client.calls for client in _RuntimeCatalog.judge_clients) == _SAMPLE_SIZE
+    assert _review_completion(store) == (True, False)
 
     _RuntimeCatalog.judge_fail_after = 0
-    replay = runner.invoke(app, _calibrate_arguments(root, ()))
+    _RuntimeCatalog.judge_clients = []
+    unapproved_replay = runner.invoke(
+        app,
+        [
+            argument
+            for argument in _calibrate_arguments(root, ())
+            if argument not in {"--yes", "--approve"}
+        ],
+    )
+    assert unapproved_replay.exit_code == 2
+    assert "already complete" in unapproved_replay.output
+    replay_text = unstyle(unapproved_replay.output)
+    assert "--approve" in replay_text
+    assert "Spend preflight" not in unapproved_replay.output
+    assert "Resuming" not in unapproved_replay.output
+    assert _RuntimeCatalog.judge_clients == []
+    assert _review_completion(store) == (True, False)
+
+    approved = runner.invoke(
+        app,
+        [argument for argument in _calibrate_arguments(root, ()) if argument != "--yes"],
+    )
+    assert approved.exit_code == 0, approved.output
+    assert "Approved judge calibration" in approved.output
+    assert "Spend preflight" not in approved.output
+    assert _RuntimeCatalog.judge_clients == []
+    assert _review_completion(store) == (True, True)
+
+    replay = runner.invoke(
+        app,
+        [
+            *[
+                argument
+                for argument in _calibrate_arguments(root, ())
+                if argument not in {"--yes", "--approve"}
+            ],
+            "--page",
+        ],
+    )
     assert replay.exit_code == 0, replay.output
     assert "Approved judge calibration" in replay.output
+    assert "Spend preflight" not in replay.output
+    assert _RuntimeCatalog.judge_clients == []
 
-    resampled = runner.invoke(app, _calibrate_arguments(root, (), sample_size=_SAMPLE_SIZE - 2))
+    resampled = runner.invoke(
+        app,
+        [
+            argument
+            for argument in _calibrate_arguments(root, (), sample_size=_SAMPLE_SIZE - 2)
+            if argument not in {"--yes", "--approve"}
+        ],
+    )
     assert resampled.exit_code == 0, resampled.output
     assert "already complete" in resampled.output
     assert "Approved judge calibration" in resampled.output
@@ -317,3 +394,21 @@ def _drafted_labels(store: ProjectStore) -> tuple[dict[str, object], ...]:
         assert isinstance(entry, dict)
         labels.append(entry)
     return tuple(labels)
+
+
+def _review_completion(store: ProjectStore) -> tuple[bool, bool]:
+    """Return whether judge audit and explicit approval pointers are present.
+
+    Args:
+        store: Project whose mutable review pointers are inspected.
+
+    Returns:
+        Audit-present and approved-calibration-present flags.
+    """
+    review = store.read_review()
+    assert isinstance(review, dict)
+    manual_judge = review["manual_judge"]
+    assert isinstance(manual_judge, dict)
+    return manual_judge.get("audit") is not None, manual_judge.get(
+        "approved_calibration"
+    ) is not None


### PR DESCRIPTION
## What changed

- make `wmo config judge setup` show the configured judge identity, the plain-language 0-5 rubric anchors, representative tasks, and a clear save decision while keeping prompt hashes, variable maps, schemas, and score-projection internals out of normal output
- make `wmo config judge calibrate` render normalized traces as readable user, assistant/model, tool call, tool result, and terminal-outcome sections, with narrow-terminal wrapping, truthful bounded truncation, optional interactive paging, and explicit A/B/tie pairwise labels
- move judge spend consent ahead of manual labeling and provider work, naming the exact judge model, call count, maximum estimated cost, hard ceiling, and attempt limit
- keep completed replay prompt-free, preserve incremental label drafts and provider-free historical provenance, and leave the existing immutable spend and calibration gates authoritative
- preserve the separate approval boundary: completed-but-unapproved evidence remains unapproved until `--approve` or an interactive confirmation, while replay performs no repeated provider or label work

## Why

The current judge commands expose implementation contracts during setup, flatten calibration traces into terse previews, and ask a generic spend question only after operators have already entered labels. The revised flow gives operators the review evidence and cost boundary they need without weakening artifact identity, provenance, replay, or spend enforcement.

## Safety and compatibility

- no provider, environment, paid, or external model call was used
- no final `wmo build` wizard is introduced
- the approved patch was replayed byte-for-byte onto `7040711046f13054d76f208a9b8207aace20eb36`; stable patch ID `0ad5d90ec58d5415db4e42160c482e5d2f032121`, binary diff SHA `1271f4793444c277ddcd4462d12d1d999c7bd7d62399280faa0eefc09b11796f`
- zero path overlap with #456/#457 and with retain-only follow-up `9c5eac2f`; merge-tree is clean at `d1f7ff28c0de59f2eaea6c99be4c8b2c9c36943e`
- independent exact-head audit passed

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- exact current-head focused judge, consent, provider-free provenance, draft/replay, spend, layout/import, and release coverage: 83 passed, 1 skipped
- exact-head Ubuntu non-live CI: 1,218 passed, 12 skipped, 13 deselected
- exact W16 router and local-process evidence: 2 passed
- fresh wheel and sdist release guard: 5 passed
- fresh isolated core and `sft` installs imported from site-packages; both installed judge command help surfaces passed

This PR is intentionally draft until fresh exact-head CI, CodeQL, and Greptile review are green with zero unresolved actionable threads.
