### PR TITLE
Replace typed provider numbers with a keyboard list and --provider flags

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ results, and plans do not live here.
 |---|---|
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `cookbook/router.md` | Provider-free local artifact and loopback runtime walkthrough. |
-| `reference/providers.md` | Catalog providers, environment variables, Azure endpoint and deployment rules, and the Bedrock credential chain. |
+| `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, and the Bedrock credential chain. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -4,8 +4,15 @@ WMO resolves models from a secret-free `.wmo/models.toml` catalog. `RuntimeModel
 only construction service. Provider names do not imply capabilities or prices. Every completion or
 embedding alias must declare the protocol features and token prices it uses.
 
-Configure connections with `wmo config providers`. Setup stores configuration only. It makes no
-provider request and never prints a secret value.
+Configure connections with `wmo config providers` or the first `wmo build` on a clean checkout.
+An interactive terminal opens a provider list: Up and Down move focus, Enter selects or deselects
+the focused provider, and the Complete row submits the selection. Agents skip that list with
+repeatable `--provider` flags (`openai`, `anthropic`, `gemini`, `openrouter`,
+`openai-compatible`, `azure`, `bedrock`). Unsupported or duplicate values fail before any catalog
+write. Azure and Bedrock still require manual model IDs. Other selected providers use account
+model discovery when credentials are available.
+
+Setup writes only secret-free catalog fields and never prints a credential value.
 
 ## Supported providers
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,11 +4,11 @@ The root surface is deliberately small:
 
 | Command | Purpose | Local result |
 |---|---|---|
-| `wmo build PROJECT TRACES --source SOURCE --root ROOT` | Normalize 100 through 1000 local traces from one [declared source](reference/ingest.md) and mine representative tasks. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
+| `wmo build PROJECT TRACES --source SOURCE --root ROOT [--provider NAME ...]` | Normalize 100 through 1000 local traces from one [declared source](reference/ingest.md) and mine representative tasks. First-build setup uses a keyboard provider list, or exact `--provider` flags. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
 | `wmo optimize router PROJECT --config FILE --root ROOT` | Fit, freeze, then report from explicit completed evidence. | Fit evaluation, bank, policy, held-out evaluation, and router report. |
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
-| `wmo config providers` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
+| `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
 `build` makes zero model, provider, or judge paid calls. Successful build, router, simulation, and

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -10,6 +10,7 @@ import typer
 from rich.console import Console
 
 from wmo.cli.consent import can_prompt, require_spend_consent
+from wmo.cli.provider_picker import resolve_setup_providers
 from wmo.cli.provider_setup import (
     ProviderSetupOptions,
     provider_setup_json_examples,
@@ -60,6 +61,15 @@ _TRACE_FILE_ARGUMENT = typer.Argument(
     ),
 )
 _ROOT_OPTION = typer.Option(Path(ARTIFACT_DIR), "--root", help="Local .wmo artifact root.")
+_PROVIDER_OPTION = typer.Option(
+    None,
+    "--provider",
+    help=(
+        "Repeatable provider to configure during first-build setup. "
+        "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
+        "azure, bedrock."
+    ),
+)
 
 
 def build(
@@ -87,6 +97,7 @@ def build(
         "--no-interactive",
         help="Never prompt for missing model setup.",
     ),
+    provider: list[str] | None = _PROVIDER_OPTION,
 ) -> None:
     """Build a reusable grounded world model and immutable fit evidence.
 
@@ -106,6 +117,7 @@ def build(
         maximum_build_cost_usd: Strict ceiling for provider embedding calls.
         yes: Explicit noninteractive or advance spend consent.
         no_interactive: Disable inline setup even when a terminal is available.
+        provider: Repeatable provider names that skip the opening list during setup.
 
     Raises:
         typer.BadParameter: Input, setup, role, cost, project, or artifact validation fails.
@@ -114,7 +126,11 @@ def build(
     try:
         code_revision = installed_release_revision()
         ProjectStore(root, project)
-        catalog = _load_or_setup_catalog(root, no_interactive=no_interactive)
+        catalog = _load_or_setup_catalog(
+            root,
+            no_interactive=no_interactive,
+            providers=tuple(provider or ()),
+        )
         selected = _selected_roles(
             catalog,
             world_model=world_model,
@@ -192,12 +208,18 @@ def build(
     _render_completed_build(completed, built=built, estimate=estimate)
 
 
-def _load_or_setup_catalog(root: Path, *, no_interactive: bool) -> ModelCatalog:
+def _load_or_setup_catalog(
+    root: Path,
+    *,
+    no_interactive: bool,
+    providers: tuple[str, ...] = (),
+) -> ModelCatalog:
     """Load complete build roles or run inline setup only for a real terminal.
 
     Args:
         root: Local WMO root containing the shared model catalog.
         no_interactive: Whether inline provider setup is forbidden.
+        providers: Repeatable ``--provider`` values that skip the opening list.
 
     Returns:
         A complete model catalog with all required build roles.
@@ -205,17 +227,19 @@ def _load_or_setup_catalog(root: Path, *, no_interactive: bool) -> ModelCatalog:
     Raises:
         ValueError: Required configuration is missing outside an interactive terminal.
     """
+    resolved_providers = resolve_setup_providers(providers)
     path = root / "models.toml"
     catalog = load_model_catalog(path) if path.exists() else None
     missing = _missing_build_configuration(catalog)
     if not missing:
         assert catalog is not None
         return catalog
+    options = ProviderSetupOptions(providers=resolved_providers)
     if not no_interactive and can_prompt(_console):
         _console.print(f"Model setup is required: {', '.join(missing)}.")
         return run_provider_setup(
             root,
-            ProviderSetupOptions(),
+            options,
             non_interactive=False,
             replace=False,
             console=_console,

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -342,6 +342,88 @@ def _fake_runtime_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("wmo.cli.build_cmd.capture_build_completed", lambda **_kwargs: None)
 
 
+def test_first_build_accepts_repeatable_provider_flags_and_replays_without_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exact --provider values skip the opening list and a replay does not reopen setup.
+
+    Args:
+        monkeypatch: Pytest patch fixture supplying a terminal, credential, and listing seam.
+        tmp_path: Temporary project and trace root.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    lister = _SetupLister()
+    monkeypatch.setattr("wmo.cli.build_cmd.can_prompt", lambda _console: True)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setattr("wmo.cli.provider_setup.HttpProviderModelLister", lambda: lister)
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "build",
+            "support",
+            str(source),
+            "--root",
+            str(root),
+            "--provider",
+            "openai",
+        ],
+        input="1,3\n\n1\n1\n1\ny\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert lister.requests == ["openai"]
+    printed = unstyle(result.output)
+    assert "Select the providers you want to use" not in printed
+    assert "openai-secret" not in printed
+    saved = load_model_catalog(root / "models.toml")
+    assert saved.connections["openai"].api_key_env == "OPENAI_API_KEY"
+    assert saved.roles.world_model == "gpt-5-6-luna"
+
+    replay = _RUNNER.invoke(app, ["build", "support", str(source), "--root", str(root)])
+
+    assert replay.exit_code == 0, replay.output
+    assert lister.requests == ["openai"]
+    assert "Select the providers you want to use" not in unstyle(replay.output)
+    assert "Model setup is required" not in unstyle(replay.output)
+
+
+def test_first_build_rejects_bad_provider_flags_before_any_write(tmp_path: Path) -> None:
+    """Unsupported or duplicate --provider values fail before project or catalog writes.
+
+    Args:
+        tmp_path: Temporary root without model configuration.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "build",
+            "support",
+            str(source),
+            "--root",
+            str(root),
+            "--no-interactive",
+            "--provider",
+            "openai",
+            "--provider",
+            "not-a-provider",
+            "--provider",
+            "openai",
+        ],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "unsupported --provider value 'not-a-provider'" in output
+    assert "duplicate --provider value 'openai'" in output
+    assert not root.exists()
+
+
 def test_first_build_configures_providers_and_models_through_the_picker(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -983,6 +1065,7 @@ def test_build_help_describes_the_completed_grounded_artifact() -> None:
     assert "Build a reusable grounded world model from local trace evidence." in unstyle(
         result.output
     )
+    assert "--provider" in unstyle(result.output)
 
 
 _TURNS = (

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -418,7 +418,7 @@ def test_first_build_rejects_bad_provider_flags_before_any_write(tmp_path: Path)
     )
 
     assert result.exit_code == 2
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "unsupported --provider value 'not-a-provider'" in output
     assert "duplicate --provider value 'openai'" in output
     assert not root.exists()

--- a/wmo/cli/config_cmd.py
+++ b/wmo/cli/config_cmd.py
@@ -38,6 +38,15 @@ _MODEL_JSON_OPTION = typer.Option(
     "--model-json",
     help="Repeatable JSON model alias with connection, model ID, and capabilities.",
 )
+_PROVIDER_OPTION = typer.Option(
+    None,
+    "--provider",
+    help=(
+        "Repeatable provider that skips the opening list during interactive setup. "
+        "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
+        "azure, bedrock."
+    ),
+)
 
 
 @config_app.command("telemetry", help="View or change project-local usage telemetry settings.")
@@ -73,6 +82,7 @@ def config_telemetry(
 @config_app.command("providers", help="Configure model providers and build-time model roles.")
 def config_providers(
     root: Path = _PROVIDER_ROOT_OPTION,
+    provider: list[str] | None = _PROVIDER_OPTION,
     connection_json: list[str] | None = _CONNECTION_JSON_OPTION,
     model_json: list[str] | None = _MODEL_JSON_OPTION,
     world_model: str | None = typer.Option(
@@ -96,9 +106,11 @@ def config_providers(
     """Configure provider connections before selecting exact build-time role models.
 
     Credential values are never requested or persisted. Only environment-variable names are
-    written. Router candidates remain untouched until ``wmo optimize router``.
+    written. Repeatable ``--provider`` flags skip the opening list. Router candidates remain
+    untouched until ``wmo optimize router``.
     """
     options = ProviderSetupOptions(
+        providers=tuple(provider or ()),
         connection_json=tuple(connection_json or ()),
         model_json=tuple(model_json or ()),
         world_model=world_model,

--- a/wmo/cli/picker.py
+++ b/wmo/cli/picker.py
@@ -8,13 +8,16 @@ line-based path remains available for scripted non-terminal sessions.
 
 from __future__ import annotations
 
+import os
 import select
 import sys
 import termios
 import tty
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
+from functools import partial
 
 from rich.console import Console
 from rich.markup import escape
@@ -294,30 +297,64 @@ def interpret_key_bytes(data: bytes) -> PickerKey:
     return PickerKey.IGNORE
 
 
+def _read_terminal_key_from_fd(fd: int) -> PickerKey:
+    """Read one key sequence without passing through a buffered text stream.
+
+    Args:
+        fd: Raw terminal file descriptor already configured for immediate input.
+
+    Returns:
+        The decoded picker action for the next key press.
+    """
+    first = os.read(fd, 1)
+    if first != b"\x1b":
+        return interpret_key_bytes(first)
+    readable, _, _ = select.select([fd], [], [], 0.05)
+    if not readable:
+        return PickerKey.CANCEL
+    rest = os.read(fd, 1)
+    if rest in {b"[", b"O"}:
+        extra_ready, _, _ = select.select([fd], [], [], 0.05)
+        if extra_ready:
+            rest += os.read(fd, 1)
+    return interpret_key_bytes(first + rest)
+
+
+@contextmanager
+def _terminal_key_reader(
+    read_key: Callable[[], PickerKey] | None,
+) -> Iterator[Callable[[], PickerKey]]:
+    """Yield a scripted reader or hold the controlling terminal in raw input mode.
+
+    Args:
+        read_key: Optional injected reader that requires no terminal configuration.
+
+    Yields:
+        A zero-argument reader for one decoded keyboard event.
+    """
+    if read_key is not None:
+        yield read_key
+        return
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        raw = termios.tcgetattr(fd)
+        raw[1] = old[1]
+        termios.tcsetattr(fd, termios.TCSANOW, raw)
+        yield partial(_read_terminal_key_from_fd, fd)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
 def read_terminal_key() -> PickerKey:
     """Read one key from the controlling terminal in raw mode.
 
     Returns:
         The decoded picker action for the next key press.
     """
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        first = sys.stdin.read(1)
-        if first != "\x1b":
-            return interpret_key_bytes(first.encode())
-        readable, _, _ = select.select([sys.stdin], [], [], 0.05)
-        if not readable:
-            return PickerKey.CANCEL
-        rest = sys.stdin.read(1)
-        if rest in {"[", "O"}:
-            extra_ready, _, _ = select.select([sys.stdin], [], [], 0.05)
-            if extra_ready:
-                rest += sys.stdin.read(1)
-        return interpret_key_bytes(("\x1b" + rest).encode())
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    with _terminal_key_reader(None) as reader:
+        return reader()
 
 
 def select_many_list(
@@ -354,38 +391,38 @@ def select_many_list(
     selected = [value for value in preselected if value in values]
     focus = 0
     complete_index = len(options)
-    reader = read_key if read_key is not None else read_terminal_key
-    console.print(f"[bold]{title}[/bold]")
-    while True:
-        _render_list(
-            console,
-            options,
-            selected=selected,
-            focus=focus,
-        )
-        key = reader()
-        if key is PickerKey.BACK:
-            return PickerResult(action=PickerAction.BACK)
-        if key is PickerKey.CANCEL:
-            return PickerResult(action=PickerAction.CANCEL)
-        if key is PickerKey.UP:
-            focus = (focus - 1) % (complete_index + 1)
-            continue
-        if key is PickerKey.DOWN:
-            focus = (focus + 1) % (complete_index + 1)
-            continue
-        if key is not PickerKey.ENTER:
-            continue
-        if focus == complete_index:
-            if len(selected) >= minimum:
-                return PickerResult(values=tuple(selected))
-            console.print(f"[yellow]Select at least {minimum}.[/yellow]")
-            continue
-        value = options[focus].value
-        if value in selected:
-            selected.remove(value)
-        else:
-            selected.append(value)
+    with _terminal_key_reader(read_key) as reader:
+        console.print(f"[bold]{title}[/bold]")
+        while True:
+            _render_list(
+                console,
+                options,
+                selected=selected,
+                focus=focus,
+            )
+            key = reader()
+            if key is PickerKey.BACK:
+                return PickerResult(action=PickerAction.BACK)
+            if key is PickerKey.CANCEL:
+                return PickerResult(action=PickerAction.CANCEL)
+            if key is PickerKey.UP:
+                focus = (focus - 1) % (complete_index + 1)
+                continue
+            if key is PickerKey.DOWN:
+                focus = (focus + 1) % (complete_index + 1)
+                continue
+            if key is not PickerKey.ENTER:
+                continue
+            if focus == complete_index:
+                if len(selected) >= minimum:
+                    return PickerResult(values=tuple(selected))
+                console.print(f"[yellow]Select at least {minimum}.[/yellow]")
+                continue
+            value = options[focus].value
+            if value in selected:
+                selected.remove(value)
+            else:
+                selected.append(value)
 
 
 def _render_list(

--- a/wmo/cli/picker.py
+++ b/wmo/cli/picker.py
@@ -1,13 +1,18 @@
-"""Line-based selection prompts shared by interactive CLI setup screens.
+"""Selection prompts shared by interactive CLI setup screens.
 
-Every prompt reads whole lines, so the same screens work in a terminal, in a pseudo-terminal test,
-and in a scripted session. A long list collapses to its first entries, typed text filters it, and
-each screen accepts back and cancel words so a flow can navigate without losing earlier answers.
+Provider setup uses a keyboard multi-select on a real terminal: Up and Down move focus, Enter
+selects or deselects the focused row, and a final Complete row submits. Other screens still read
+whole lines so a long list can filter, collapse, and accept back or cancel words. The same
+line-based path remains available for scripted non-terminal sessions.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import select
+import sys
+import termios
+import tty
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -20,6 +25,8 @@ _ALL_WORDS = frozenset({"a", "all"})
 _NONE_WORDS = frozenset({"none", "clear"})
 _MORE_WORDS = frozenset({"more", "m"})
 _COLLAPSED_LIMIT = 12
+_COMPLETE_LABEL = "Complete"
+_NARROW_WIDTH = 72
 
 
 class PickerAction(StrEnum):
@@ -27,6 +34,17 @@ class PickerAction(StrEnum):
 
     BACK = "back"
     CANCEL = "cancel"
+
+
+class PickerKey(StrEnum):
+    """One decoded key from a keyboard multi-select list."""
+
+    UP = "up"
+    DOWN = "down"
+    ENTER = "enter"
+    BACK = "back"
+    CANCEL = "cancel"
+    IGNORE = "ignore"
 
 
 @dataclass(frozen=True)
@@ -238,3 +256,171 @@ def _merged(selected: Sequence[str], additions: Sequence[str]) -> list[str]:
     merged = list(selected)
     merged.extend(value for value in additions if value not in merged)
     return merged
+
+
+def uses_keyboard_list(console: Console) -> bool:
+    """Return whether this console can drive the keyboard multi-select list.
+
+    Args:
+        console: Terminal used for the screen.
+
+    Returns:
+        True only when both stdout and stdin belong to an interactive terminal.
+    """
+    return console.is_terminal and _stdin_is_tty()
+
+
+def interpret_key_bytes(data: bytes) -> PickerKey:
+    """Map one raw terminal key sequence to a picker action.
+
+    Args:
+        data: Bytes read from the terminal for a single key press.
+
+    Returns:
+        The decoded action, or ``IGNORE`` for an unrecognized sequence.
+    """
+    if data in {b"\r", b"\n"}:
+        return PickerKey.ENTER
+    if data in {b"b", b"B"}:
+        return PickerKey.BACK
+    if data in {b"q", b"Q", b"\x03"}:
+        return PickerKey.CANCEL
+    if data in {b"\x1b", b"\x1b\x1b"}:
+        return PickerKey.CANCEL
+    if data in {b"\x1b[A", b"\x1bOA"}:
+        return PickerKey.UP
+    if data in {b"\x1b[B", b"\x1bOB"}:
+        return PickerKey.DOWN
+    return PickerKey.IGNORE
+
+
+def read_terminal_key() -> PickerKey:
+    """Read one key from the controlling terminal in raw mode.
+
+    Returns:
+        The decoded picker action for the next key press.
+    """
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        first = sys.stdin.read(1)
+        if first != "\x1b":
+            return interpret_key_bytes(first.encode())
+        readable, _, _ = select.select([sys.stdin], [], [], 0.05)
+        if not readable:
+            return PickerKey.CANCEL
+        rest = sys.stdin.read(1)
+        if rest in {"[", "O"}:
+            extra_ready, _, _ = select.select([sys.stdin], [], [], 0.05)
+            if extra_ready:
+                rest += sys.stdin.read(1)
+        return interpret_key_bytes(("\x1b" + rest).encode())
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def select_many_list(
+    console: Console,
+    *,
+    title: str,
+    options: Sequence[PickerOption],
+    preselected: Sequence[str] = (),
+    minimum: int = 1,
+    read_key: Callable[[], PickerKey] | None = None,
+) -> PickerResult:
+    """Choose several rows from a keyboard-driven list with a Complete action.
+
+    Up and Down move focus. Enter selects or deselects the focused option. Enter on the
+    Complete row submits the current selection and does nothing on any other row.
+
+    Args:
+        console: Terminal used for the list.
+        title: Screen heading describing what is being chosen.
+        options: Every selectable row, in presentation order.
+        preselected: Values already chosen, kept when the screen is shown again.
+        minimum: Smallest accepted number of selected values.
+        read_key: Optional key source used by tests instead of the controlling terminal.
+
+    Returns:
+        The chosen values, or the requested back or cancel navigation.
+
+    Raises:
+        ValueError: The screen has no rows to choose from.
+    """
+    if not options:
+        raise ValueError(f"{title} has no available choices")
+    values = {option.value for option in options}
+    selected = [value for value in preselected if value in values]
+    focus = 0
+    complete_index = len(options)
+    reader = read_key if read_key is not None else read_terminal_key
+    console.print(f"[bold]{title}[/bold]")
+    while True:
+        _render_list(
+            console,
+            options,
+            selected=selected,
+            focus=focus,
+        )
+        key = reader()
+        if key is PickerKey.BACK:
+            return PickerResult(action=PickerAction.BACK)
+        if key is PickerKey.CANCEL:
+            return PickerResult(action=PickerAction.CANCEL)
+        if key is PickerKey.UP:
+            focus = (focus - 1) % (complete_index + 1)
+            continue
+        if key is PickerKey.DOWN:
+            focus = (focus + 1) % (complete_index + 1)
+            continue
+        if key is not PickerKey.ENTER:
+            continue
+        if focus == complete_index:
+            if len(selected) >= minimum:
+                return PickerResult(values=tuple(selected))
+            console.print(f"[yellow]Select at least {minimum}.[/yellow]")
+            continue
+        value = options[focus].value
+        if value in selected:
+            selected.remove(value)
+        else:
+            selected.append(value)
+
+
+def _render_list(
+    console: Console,
+    options: Sequence[PickerOption],
+    *,
+    selected: Sequence[str],
+    focus: int,
+) -> None:
+    """Print the option rows, selection marks, focus marker, and Complete action."""
+    chosen = frozenset(selected)
+    width = console.width or 80
+    narrow = width < _NARROW_WIDTH
+    for index, option in enumerate(options):
+        pointer = ">" if index == focus else " "
+        mark = "[x]" if option.value in chosen else "[ ]"
+        console.print(f"  {pointer} {escape(mark)} {escape(option.label)}")
+        if option.detail:
+            console.print(f"      [dim]{escape(option.detail)}[/dim]")
+    pointer = ">" if focus == len(options) else " "
+    console.print(f"  {pointer} {_COMPLETE_LABEL}")
+    if narrow:
+        console.print("[dim]Up/Down moves focus. Enter selects or deselects.[/dim]")
+        console.print("[dim]Activate Complete to submit. b goes back, q cancels.[/dim]")
+        return
+    console.print(
+        "[dim]Up/Down moves focus, Enter selects or deselects, Complete submits, "
+        "b goes back, q cancels.[/dim]"
+    )
+
+
+def _stdin_is_tty() -> bool:
+    """Return whether the input stream is a terminal."""
+    stdin = sys.stdin
+    try:
+        return stdin is not None and stdin.isatty()
+    except ValueError:
+        return False

--- a/wmo/cli/picker_test.py
+++ b/wmo/cli/picker_test.py
@@ -1,16 +1,20 @@
-"""Line-based selection prompt tests."""
+"""Selection prompt tests for line-based screens and the keyboard multi-select list."""
 
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 
 import pytest
 from rich.console import Console
 
 from wmo.cli.picker import (
     PickerAction,
+    PickerKey,
     PickerOption,
+    interpret_key_bytes,
     select_many,
+    select_many_list,
     select_one,
 )
 
@@ -18,17 +22,18 @@ from wmo.cli.picker import (
 class ScriptedConsole(Console):
     """One console that answers every prompt from a script and records its output."""
 
-    def __init__(self, answers: str) -> None:
+    def __init__(self, answers: str, *, width: int = 100) -> None:
         """Build a console reading scripted lines into an in-memory transcript.
 
         Args:
             answers: Newline-separated answers the screens read in order.
+            width: Reported terminal width used for wrapping and narrow-list layout.
         """
         self._transcript = io.StringIO()
         super().__init__(
             file=self._transcript,
             force_terminal=False,
-            width=100,
+            width=width,
             no_color=True,
             highlight=False,
         )
@@ -216,3 +221,134 @@ def test_a_screen_without_rows_is_a_programming_error() -> None:
 
     with pytest.raises(ValueError, match="has no available choices"):
         select_many(console, title="Models", options=())
+
+
+def _keys(*actions: PickerKey) -> Callable[[], PickerKey]:
+    """Return a key source that yields the scripted keyboard events in order.
+
+    Args:
+        actions: Decoded keys the list should consume.
+
+    Returns:
+        Zero-argument reader used by ``select_many_list``.
+    """
+    iterator = iter(actions)
+    return lambda: next(iterator)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (b"\x1b[A", PickerKey.UP),
+        (b"\x1bOA", PickerKey.UP),
+        (b"\x1b[B", PickerKey.DOWN),
+        (b"\x1bOB", PickerKey.DOWN),
+        (b"\r", PickerKey.ENTER),
+        (b"\n", PickerKey.ENTER),
+        (b"b", PickerKey.BACK),
+        (b"B", PickerKey.BACK),
+        (b"q", PickerKey.CANCEL),
+        (b"\x03", PickerKey.CANCEL),
+        (b"\x1b", PickerKey.CANCEL),
+        (b"x", PickerKey.IGNORE),
+    ],
+)
+def test_interpret_key_bytes_maps_terminal_events(raw: bytes, expected: PickerKey) -> None:
+    """Each raw key sequence used by the list becomes one stable action.
+
+    Args:
+        raw: Bytes a terminal emits for one key press.
+        expected: Decoded picker action.
+    """
+    assert interpret_key_bytes(raw) is expected
+
+
+def test_keyboard_list_moves_focus_toggles_selection_and_submits_from_complete() -> None:
+    """Enter toggles the focused row; only Complete submits the current selection."""
+    console = _console("")
+
+    result = select_many_list(
+        console,
+        title="Providers",
+        options=_options(3),
+        read_key=_keys(
+            PickerKey.ENTER,
+            PickerKey.DOWN,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+            PickerKey.ENTER,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+        ),
+    )
+
+    assert result.action is None
+    assert result.values == ("model-1",)
+    assert "> [x] model-1" in console.output
+    assert "> [ ] model-3" in console.output
+    assert "> Complete" in console.output
+
+
+def test_keyboard_list_keeps_preselected_rows_and_back_cancel_keys() -> None:
+    """Reentering the list keeps current marks, and b or q still navigate away."""
+    console = _console("")
+
+    result = select_many_list(
+        console,
+        title="Providers",
+        options=_options(2),
+        preselected=("model-2",),
+        read_key=_keys(PickerKey.BACK),
+    )
+
+    assert result.action is PickerAction.BACK
+    assert "[x] model-2" in console.output
+
+    cancelled = select_many_list(
+        console,
+        title="Providers",
+        options=_options(2),
+        read_key=_keys(PickerKey.CANCEL),
+    )
+    assert cancelled.action is PickerAction.CANCEL
+
+
+def test_keyboard_list_refuses_complete_until_the_minimum_is_met() -> None:
+    """Complete does nothing useful until the required number of rows is selected."""
+    console = _console("")
+
+    result = select_many_list(
+        console,
+        title="Providers",
+        options=_options(2),
+        read_key=_keys(
+            PickerKey.DOWN,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+            PickerKey.UP,
+            PickerKey.UP,
+            PickerKey.ENTER,
+            PickerKey.DOWN,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+        ),
+    )
+
+    assert result.values == ("model-1",)
+    assert "Select at least 1." in console.output
+
+
+def test_keyboard_list_keeps_details_readable_on_a_narrow_terminal() -> None:
+    """Details sit on their own line so a narrow terminal does not collide with labels."""
+    console = ScriptedConsole("", width=40)
+
+    result = select_many_list(
+        console,
+        title="Providers",
+        options=_options(1),
+        read_key=_keys(PickerKey.ENTER, PickerKey.DOWN, PickerKey.ENTER),
+    )
+
+    assert result.values == ("model-1",)
+    assert "      detail 1" in console.output
+    assert "Activate Complete to submit." in console.output

--- a/wmo/cli/picker_test.py
+++ b/wmo/cli/picker_test.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import errno
 import io
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
 from collections.abc import Callable
 
 import pytest
@@ -236,6 +243,64 @@ def _keys(*actions: PickerKey) -> Callable[[], PickerKey]:
     return lambda: next(iterator)
 
 
+def _run_keyboard_picker_pty(*, ready_marker: str) -> str:
+    """Drive a real terminal picker with one immediate batched key sequence.
+
+    Args:
+        ready_marker: Output proving how far the child rendered before input is sent.
+
+    Returns:
+        Complete decoded terminal output from the child process.
+    """
+    script = """
+from rich.console import Console
+from wmo.cli.picker import PickerOption, select_many_list
+
+result = select_many_list(
+    Console(force_terminal=True),
+    title="Providers",
+    options=(PickerOption("a", "A"), PickerOption("b", "B")),
+)
+print("RESULT:" + ",".join(result.values), flush=True)
+"""
+    master, slave = pty.openpty()
+    process = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+    )
+    os.close(slave)
+    output = bytearray()
+    sent = False
+    deadline = time.monotonic() + 5
+    try:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.05)
+            if readable:
+                try:
+                    output.extend(os.read(master, 65_536))
+                except OSError as error:
+                    if error.errno != errno.EIO:
+                        raise
+                    break
+            if not sent and ready_marker.encode() in output:
+                os.write(master, b"\x1b[B\r\x1b[B\r")
+                sent = True
+            if process.poll() is not None:
+                break
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=2)
+    finally:
+        os.close(master)
+    transcript = output.decode(errors="replace")
+    assert sent, f"picker never rendered {ready_marker!r}:\n{transcript}"
+    assert process.returncode == 0, f"picker exited {process.returncode}:\n{transcript}"
+    return transcript
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -261,6 +326,19 @@ def test_interpret_key_bytes_maps_terminal_events(raw: bytes, expected: PickerKe
         expected: Decoded picker action.
     """
     assert interpret_key_bytes(raw) is expected
+
+
+@pytest.mark.parametrize("ready_marker", ["Providers", "q cancels."])
+def test_keyboard_list_accepts_batched_keys_from_a_real_terminal(ready_marker: str) -> None:
+    """Terminal readiness and unbuffered reads preserve an immediate arrow-key batch.
+
+    Args:
+        ready_marker: Early or fully rendered output that triggers the key batch.
+    """
+    transcript = _run_keyboard_picker_pty(ready_marker=ready_marker)
+
+    assert "RESULT:b" in transcript
+    assert "^[[B" not in transcript
 
 
 def test_keyboard_list_moves_focus_toggles_selection_and_submits_from_complete() -> None:

--- a/wmo/cli/provider_picker.py
+++ b/wmo/cli/provider_picker.py
@@ -9,14 +9,23 @@ into a questionnaire. Manual declaration stays available as an explicit advanced
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from getpass import getpass
 
 from rich.console import Console
 from rich.prompt import Confirm, IntPrompt, Prompt
 
-from wmo.cli.picker import PickerAction, PickerOption, select_many, select_one
+from wmo.cli.picker import (
+    PickerAction,
+    PickerKey,
+    PickerOption,
+    PickerResult,
+    select_many,
+    select_many_list,
+    select_one,
+    uses_keyboard_list,
+)
 from wmo.common.models import (
     ModelCapabilities,
     PricingSource,
@@ -142,12 +151,78 @@ class SetupSession:
     manual: list[AvailableModel] = field(default_factory=list)
 
 
+def resolve_setup_providers(values: Sequence[str]) -> tuple[str, ...]:
+    """Validate explicit provider names and return them in catalog order.
+
+    Args:
+        values: Provider names supplied on the command line, in flag order.
+
+    Returns:
+        Distinct supported providers in ``SETUP_PROVIDER_LABELS`` order.
+
+    Raises:
+        ValueError: A value is unsupported or repeated.
+    """
+    if not values:
+        return ()
+    supported = tuple(SETUP_PROVIDER_LABELS)
+    supported_lookup = {name: name for name in supported}
+    unknown: list[str] = []
+    duplicates: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        name = raw.strip().casefold()
+        canonical = supported_lookup.get(name)
+        if canonical is None:
+            unknown.append(raw.strip() or raw)
+            continue
+        if canonical in seen:
+            duplicates.append(canonical)
+            continue
+        seen.add(canonical)
+    errors: list[str] = []
+    if unknown:
+        listed = ", ".join(repr(item) for item in unknown)
+        noun = "values" if len(unknown) != 1 else "value"
+        errors.append(
+            f"unsupported --provider {noun} {listed}; choose from: {', '.join(supported)}"
+        )
+    if duplicates:
+        listed = ", ".join(repr(item) for item in dict.fromkeys(duplicates))
+        noun = "values" if len(duplicates) != 1 else "value"
+        errors.append(f"duplicate --provider {noun} {listed}")
+    if errors:
+        raise ValueError("; ".join(errors))
+    return tuple(name for name in supported if name in seen)
+
+
+def explicit_provider_selection(
+    providers: Sequence[str],
+) -> tuple[tuple[str, ...], bool, bool]:
+    """Turn validated provider names into the same selection the picker returns.
+
+    Args:
+        providers: Already validated provider names in catalog order.
+
+    Returns:
+        Providers plus advanced-credential and advanced-model flags. Azure and Bedrock
+        still require manual model declaration.
+    """
+    selected = tuple(providers)
+    return (
+        selected,
+        False,
+        any(provider in _MANUAL_MODEL_PROVIDERS for provider in selected),
+    )
+
+
 def select_providers(
     session: SetupSession,
     *,
     console: Console,
     environment: MutableMapping[str, str],
     configured: bool = False,
+    read_key: Callable[[], PickerKey] | None = None,
 ) -> tuple[tuple[str, ...], bool, bool] | None:
     """Show the one provider screen that opens setup.
 
@@ -157,6 +232,7 @@ def select_providers(
         environment: Process environment used to annotate credential availability.
         configured: Whether the catalog already holds usable models, which makes provider
             selection optional so roles can be edited offline.
+        read_key: Optional keyboard source used by tests instead of the controlling terminal.
 
     Returns:
         Selected providers with both advanced flags, or ``None`` when the user cancelled.
@@ -196,11 +272,11 @@ def select_providers(
     if session.advanced_models:
         preselected.append(_ADVANCED_MANUAL_MODEL)
     while True:
-        result = select_many(
+        result = _select_provider_rows(
             console,
-            title="Select the providers you want to use",
             options=options,
             preselected=preselected,
+            read_key=read_key,
         )
         if result.action is PickerAction.CANCEL:
             return None
@@ -218,6 +294,41 @@ def select_providers(
             _ADVANCED_MANUAL_MODEL in result.values
             or any(provider in _MANUAL_MODEL_PROVIDERS for provider in providers),
         )
+
+
+def _select_provider_rows(
+    console: Console,
+    *,
+    options: Sequence[PickerOption],
+    preselected: Sequence[str],
+    read_key: Callable[[], PickerKey] | None,
+) -> PickerResult:
+    """Show the provider list as a keyboard screen on a TTY, otherwise as typed rows.
+
+    Args:
+        console: Terminal used for the screen.
+        options: Provider and advanced rows in presentation order.
+        preselected: Values already chosen, kept when the screen is shown again.
+        read_key: Optional keyboard source used by tests instead of the controlling terminal.
+
+    Returns:
+        The chosen rows, or the requested back or cancel navigation.
+    """
+    title = "Select the providers you want to use"
+    if read_key is not None or uses_keyboard_list(console):
+        return select_many_list(
+            console,
+            title=title,
+            options=options,
+            preselected=preselected,
+            read_key=read_key,
+        )
+    return select_many(
+        console,
+        title=title,
+        options=options,
+        preselected=preselected,
+    )
 
 
 def credential_hint(provider: str, *, environment: MutableMapping[str, str]) -> str:

--- a/wmo/cli/provider_picker_test.py
+++ b/wmo/cli/provider_picker_test.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import pytest
 
 from wmo.cli import provider_picker
+from wmo.cli.picker import PickerKey
 from wmo.cli.picker_test import ScriptedConsole
 from wmo.cli.provider_picker import (
     SetupCancelled,
     SetupSession,
     credential_hint,
+    explicit_provider_selection,
     prepare_providers,
+    resolve_setup_providers,
     select_providers,
 )
 from wmo.common.models import DiscoveredModel, PricingSource, ProviderConnection, SetupRole
@@ -139,6 +142,72 @@ def test_provider_screen_refuses_an_advanced_only_selection() -> None:
 def test_cancelling_the_provider_screen_returns_no_selection() -> None:
     """Cancelling the first screen ends setup without preparing any provider."""
     assert select_providers(SetupSession(), console=ScriptedConsole("q\n"), environment={}) is None
+
+
+def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
+    """Up, Down, and Enter toggle providers; Complete is the only submit action."""
+    keys = iter(
+        (
+            PickerKey.ENTER,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+            *(PickerKey.DOWN for _ in range(8)),
+            PickerKey.ENTER,
+        )
+    )
+    console = ScriptedConsole("")
+
+    selection = select_providers(
+        SetupSession(),
+        console=console,
+        environment={"OPENAI_API_KEY": "secret-key"},
+        read_key=lambda: next(keys),
+    )
+
+    assert selection == (("openai", "anthropic"), False, False)
+    assert "> [x] OpenAI" in console.output
+    assert "Complete" in console.output
+    assert "Numbers or ranges" not in console.output
+
+
+def test_keyboard_provider_list_preserves_current_selection_and_cancel() -> None:
+    """Reentering the keyboard list keeps prior marks, and q still cancels."""
+    console = ScriptedConsole("")
+    session = SetupSession(providers=("openai",), advanced_credentials=True)
+
+    cancelled = select_providers(
+        session,
+        console=console,
+        environment={},
+        read_key=lambda: PickerKey.CANCEL,
+    )
+
+    assert cancelled is None
+    assert "[x] OpenAI" in console.output
+    assert "[x] Advanced: choose credential environment-variable names" in console.output
+
+
+def test_resolve_setup_providers_orders_and_rejects_bad_values() -> None:
+    """Explicit names are canonicalized, ordered, and fail closed on bad input."""
+    assert resolve_setup_providers(("bedrock", " OpenAI ", "anthropic")) == (
+        "openai",
+        "anthropic",
+        "bedrock",
+    )
+    with pytest.raises(ValueError, match="unsupported --provider value 'not-a-provider'"):
+        resolve_setup_providers(("openai", "not-a-provider"))
+    with pytest.raises(ValueError, match="duplicate --provider value 'openai'"):
+        resolve_setup_providers(("openai", "OPENAI"))
+
+
+def test_explicit_azure_and_bedrock_keep_manual_model_declaration() -> None:
+    """Named Azure and Bedrock selections still require hand-declared model IDs."""
+    assert explicit_provider_selection(("azure", "bedrock")) == (
+        ("azure", "bedrock"),
+        False,
+        True,
+    )
+    assert explicit_provider_selection(("openai",)) == (("openai",), False, False)
 
 
 def test_canonical_environment_credential_is_used_without_any_prompt() -> None:

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -1,8 +1,9 @@
 """Provider and model setup shared by configuration and first build.
 
 Interactive setup runs the provider and model picker in ``provider_picker``: providers, missing
-credentials, models, roles, and one confirmation. Automation supplies the same catalog update as
-repeatable JSON. Both paths end in one conflict-checked atomic ``models.toml`` write.
+credentials, models, roles, and one confirmation. Repeatable ``--provider`` flags skip the opening
+list and feed the same session. Automation supplies the same catalog update as repeatable JSON.
+Both paths end in one conflict-checked atomic ``models.toml`` write.
 """
 
 from __future__ import annotations
@@ -33,7 +34,9 @@ from wmo.cli.provider_picker import (
     SetupCancelled,
     SetupRoleInputs,
     SetupSession,
+    explicit_provider_selection,
     prepare_providers,
+    resolve_setup_providers,
     select_providers,
 )
 from wmo.common.models import (
@@ -57,6 +60,7 @@ from wmo.runtime.models.providers import HttpProviderModelLister, ProviderModelL
 class ProviderSetupOptions:
     """Structured automation values or optional role choices for setup."""
 
+    providers: tuple[str, ...] = ()
     connection_json: tuple[str, ...] = ()
     model_json: tuple[str, ...] = ()
     world_model: str | None = None
@@ -93,6 +97,10 @@ def run_provider_setup(
     path = root / "models.toml"
     starting_digest = catalog_state_sha256(path)
     existing = load_model_catalog(path) if path.exists() else None
+    try:
+        explicit_providers = resolve_setup_providers(options.providers)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from None
     if non_interactive:
         try:
             setup = _noninteractive_setup(options, existing=existing)
@@ -111,6 +119,7 @@ def run_provider_setup(
         existing_models=_existing_models(existing),
         retainable_roles=_retained_setup_roles(existing),
         role_inputs=_role_inputs(options, existing=existing),
+        explicit_providers=explicit_providers,
         console=console,
         lister=lister if lister is not None else HttpProviderModelLister(),
         environment=os.environ,
@@ -128,6 +137,7 @@ def _interactive_setup(
     existing_models: tuple[ProviderModelSelection, ...],
     retainable_roles: Mapping[str, frozenset[SetupRole]],
     role_inputs: SetupRoleInputs,
+    explicit_providers: tuple[str, ...],
     console: Console,
     lister: ProviderModelLister,
     environment: MutableMapping[str, str],
@@ -141,6 +151,7 @@ def _interactive_setup(
         existing_models: Model aliases already configured in the catalog.
         retainable_roles: Exact prior roles each incomplete alias may retain.
         role_inputs: Role values supplied by flags or already persisted.
+        explicit_providers: Validated ``--provider`` values that skip the opening list once.
         console: Terminal used for every screen.
         lister: Provider listing seam, injected by tests so no live request is made.
         environment: Process environment consulted and updated for pasted credentials.
@@ -156,17 +167,27 @@ def _interactive_setup(
         retainable_roles=retainable_roles,
     )
     session = SetupSession(selected=tuple(model.alias for model in configured))
+    skip_opening_list = bool(explicit_providers)
+    if explicit_providers:
+        (
+            session.providers,
+            session.advanced_credentials,
+            session.advanced_models,
+        ) = explicit_provider_selection(explicit_providers)
     try:
         while True:
-            selection = select_providers(
-                session,
-                console=console,
-                environment=environment,
-                configured=bool(configured),
-            )
-            if selection is None:
-                return None
-            session.providers, session.advanced_credentials, session.advanced_models = selection
+            if skip_opening_list:
+                skip_opening_list = False
+            else:
+                selection = select_providers(
+                    session,
+                    console=console,
+                    environment=environment,
+                    configured=bool(configured),
+                )
+                if selection is None:
+                    return None
+                session.providers, session.advanced_credentials, session.advanced_models = selection
             discovered: tuple[AvailableModel, ...] = ()
             session.endpoints = ()
             if session.providers:

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -189,6 +189,125 @@ def test_noninteractive_setup_accepts_azure_and_bedrock_connections(tmp_path: Pa
     assert "sk-" not in text
 
 
+def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_path: Path) -> None:
+    """Repeatable --provider values are checked before any catalog write or prompt.
+
+    Args:
+        tmp_path: Temporary WMO root without provider configuration.
+    """
+    root = tmp_path / ".wmo"
+    result = _RUNNER.invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--provider",
+            "bedrock",
+            "--provider",
+            "openai",
+            "--provider",
+            "not-a-provider",
+            "--provider",
+            "openai",
+        ],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "unsupported --provider value 'not-a-provider'" in output
+    assert "duplicate --provider value 'openai'" in output
+    assert (
+        "choose from: openai, anthropic, gemini, openrouter, openai-compatible, azure, bedrock"
+        in output
+    )
+    assert "Select the providers you want to use" not in output
+    assert not (root / "models.toml").exists()
+
+
+def test_noninteractive_valid_providers_still_require_structured_collections(
+    tmp_path: Path,
+) -> None:
+    """Accepted --provider flags do not invent connections or start a prompt.
+
+    Args:
+        tmp_path: Temporary WMO root without provider configuration.
+    """
+    result = _RUNNER.invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--non-interactive",
+            "--provider",
+            "anthropic",
+            "--provider",
+            "openai",
+        ],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "at least one --connection-json" in output
+    assert "Select the providers you want to use" not in output
+    assert not (tmp_path / ".wmo" / "models.toml").exists()
+
+
+def test_explicit_providers_skip_the_opening_list_and_still_discover_models(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Named providers enter the existing setup session without the opening list.
+
+    Args:
+        tmp_path: Temporary WMO root receiving the saved catalog.
+        monkeypatch: Patch fixture supplying the canonical credential.
+    """
+    root = tmp_path / ".wmo"
+    options = ProviderSetupOptions(providers=("openai",))
+
+    console, catalog = _setup(
+        root,
+        "1,3\n\n1\n1\n1\ny\n",
+        monkeypatch=monkeypatch,
+        options=options,
+    )
+
+    assert catalog is not None
+    assert "Select the providers you want to use" not in unstyle(console.output)
+    saved = load_model_catalog(root / "models.toml")
+    assert set(saved.connections) == {"openai"}
+    assert saved.roles.embedder == "text-embedding-3-small"
+
+
+def test_cancelling_after_explicit_providers_writes_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel after --provider still leaves the catalog untouched.
+
+    Args:
+        tmp_path: Temporary WMO root used to prove no catalog write occurs.
+        monkeypatch: Patch fixture supplying the canonical credential.
+    """
+    root = tmp_path / ".wmo"
+
+    console, catalog = _setup(
+        root,
+        "q\n",
+        monkeypatch=monkeypatch,
+        options=ProviderSetupOptions(providers=("openai",)),
+    )
+
+    assert catalog is None
+    assert "Setup cancelled. Nothing was written." in console.output
+    assert not (root / "models.toml").exists()
+
+
 def test_noninteractive_setup_reports_every_missing_collection_and_role(tmp_path: Path) -> None:
     """One failure lists the complete remediation instead of serial missing prompts.
 

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -216,7 +216,7 @@ def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_pa
     )
 
     assert result.exit_code == 2
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "unsupported --provider value 'not-a-provider'" in output
     assert "duplicate --provider value 'openai'" in output
     assert (
@@ -251,7 +251,7 @@ def test_noninteractive_valid_providers_still_require_structured_collections(
     )
 
     assert result.exit_code == 2
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "at least one --connection-json" in output
     assert "Select the providers you want to use" not in output
     assert not (tmp_path / ".wmo" / "models.toml").exists()

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -244,6 +244,24 @@ def _run_checked(
     return result
 
 
+def _tty_answer_bytes(answer: str) -> bytes:
+    """Encode one scripted terminal answer.
+
+    Keyboard sequences that start with an escape, or a lone carriage return, are written
+    exactly so a raw-mode picker can read them. Line-oriented prompts still receive a
+    trailing newline.
+
+    Args:
+        answer: Scripted key sequence or line-oriented prompt answer.
+
+    Returns:
+        Bytes written to the child pseudo-terminal.
+    """
+    if answer.startswith("\x1b") or answer == "\r":
+        return answer.encode()
+    return (answer + "\n").encode()
+
+
 def _run_tty_child(
     command: list[str],
     *,
@@ -308,7 +326,7 @@ def _run_tty_child(
                 prompt, answer = pending[0]
                 search_from = prompt_position + len(prompt)
                 try:
-                    os.write(master, (answer + "\n").encode())
+                    os.write(master, _tty_answer_bytes(answer))
                 except OSError as error:
                     if error.errno != errno.EIO:
                         raise
@@ -854,9 +872,13 @@ def _installed_release_driver() -> None:
             completion_marker=completion_marker,
         )
 
+    down = "\x1b[B"
+    enter = "\r"
     setup_answers = [
-        ("Select the providers you want to use", "5,8,9"),
-        ("cancels.", ""),
+        (
+            "Select the providers you want to use",
+            (down * 4) + enter + (down * 3) + enter + down + enter + down + enter,
+        ),
         ("base URL", provider_url),
         ("credential environment variable", "P17_PROVIDER_KEY"),
         ("Continue without this provider", "2"),


### PR DESCRIPTION
## Summary

- Replace typed provider row numbers with a keyboard multi-select on real terminals: Up/Down moves focus, Enter toggles, and Complete submits.
- Add repeatable `--provider` flags to `wmo build` and `wmo config providers`, with strict duplicate/unsupported validation and preserved catalog order.
- Keep scripted non-terminal sessions on the line-based picker and preserve manual Azure/Bedrock model declaration.
- Hold terminal input in immediate mode before rendering the list and read escape sequences from the unbuffered file descriptor, so early or batched arrow input is never echoed, dropped, or mistaken for Escape.

## Dependency and contract

- Base: `6eb2e16264bb50cd1a0f388ccd256defe4c329e3` (current main, including #460 and #461).
- Head: `1fcce177eadf33454d4d20ecc184e19ad73d3008`.
- The three unique commits range-diff exactly from the audited #460-based range. The synthetic Git merge tree of current main and the prior audited head is byte-identical to this head (`bfc4ec53b68e04e2bcd6f16c6093c521763c6bf5`).
- #460 remains intact: incomplete persisted aliases retain only their exact assigned roles; no capabilities or prices are invented, and incompatible reassignment still fails closed.
- Effective UX scope is 13 files. The terminal correction changes only `wmo/cli/picker.py` and its paired test.

## Verification

- Focused picker/provider/setup/discovery/build/release matrix: 147 passed, 1 skipped.
- Real PTY adversaries pass when the same batched arrow/Enter input is sent at the first title and after the full ready instruction.
- Installed-wheel no-spend release evidence: passed.
- Whole repository Ruff format/check and Ty: passed.
- Production file sizes: picker 463, provider picker 732, provider setup 613 lines.
- Independent reconstruction and terminal-contract audit: passed.

[Slack thread](https://experientiallabs.slack.com/archives/D0BFY60R0H5/p1786923199490789?thread_ts=1786923199.490789&cid=D0BFY60R0H5)
