### PR TITLE
Run the WMO test suite in under two minutes

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: ty check
         run: uv run ty check
       - name: non-live tests
-        run: uv run pytest -q -k "not live"
+        run: uv run pytest -n 4 --dist worksteal -q -k "not live"
 
   w16-darwin-evidence:
     runs-on: macos-latest

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -24,11 +25,29 @@ jobs:
       - name: ty check
         run: uv run ty check
       - name: non-live tests
-        run: uv run pytest -n 4 --dist worksteal -q -k "not live"
+        # Dedicated jobs below own the expensive release and W16 evidence cases.
+        run: >-
+          uv run pytest -n 4 --dist worksteal -q -k "not live"
+          --ignore=wmo/optimize/router/composition_evidence_test.py
+          --ignore=wmo/simulation/comparison_evidence_test.py
+          --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
+
+  installed-wheel-release-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project and its dev extras
+        run: uv sync --extra dev
+      - name: Installed-wheel no-spend release evidence
+        run: >-
+          uv run pytest -q
+          wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
 
   w16-darwin-evidence:
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -27,7 +27,7 @@ jobs:
       - name: non-live tests
         # Dedicated jobs below own the expensive release and W16 evidence cases.
         run: >-
-          uv run pytest -n 4 --dist worksteal -q -k "not live"
+          timeout 120s uv run pytest -n 4 --dist worksteal -q -k "not live"
           --ignore=wmo/optimize/router/composition_evidence_test.py
           --ignore=wmo/simulation/comparison_evidence_test.py
           --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -35,9 +35,7 @@ jobs:
           wmo/cli
           wmo/common
           wmo/runtime
-          wmo/simulation
           --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
-          --ignore=wmo/simulation/comparison_evidence_test.py
 
   non-live-optimization:
     runs-on: ubuntu-latest
@@ -52,6 +50,20 @@ jobs:
           uv run pytest -n 4 --dist worksteal -q -k "not live"
           wmo/optimize
           --ignore=wmo/optimize/router/composition_evidence_test.py
+
+  non-live-simulation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project and its dev extras
+        run: uv sync --extra dev
+      - name: non-live simulation tests
+        run: >-
+          uv run pytest -n 4 --dist worksteal -q -k "not live"
+          wmo/simulation
+          --ignore=wmo/simulation/comparison_evidence_test.py
 
   installed-wheel-release-evidence:
     runs-on: ubuntu-latest

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -27,7 +27,7 @@ jobs:
       - name: non-live tests
         # Dedicated jobs below own the expensive release and W16 evidence cases.
         run: >-
-          timeout 120s uv run pytest -n 4 --dist worksteal -q -k "not live"
+          timeout 120s uv run pytest -n 8 --dist worksteal -q -k "not live"
           --ignore=wmo/optimize/router/composition_evidence_test.py
           --ignore=wmo/simulation/comparison_evidence_test.py
           --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -24,13 +24,34 @@ jobs:
         run: uv run ruff format --check .
       - name: ty check
         run: uv run ty check
-      - name: non-live tests
-        # Dedicated jobs below own the expensive release and W16 evidence cases.
+      - name: non-live foundation tests
         run: >-
-          timeout 120s uv run pytest -n 8 --dist worksteal -q -k "not live"
+          uv run pytest -n 4 --dist worksteal -q -k "not live"
+          wmo/api_test.py
+          wmo/release_revision_test.py
+          wmo/release_test.py
+          wmo/repo_import_boundaries_test.py
+          wmo/repo_layout_test.py
+          wmo/cli
+          wmo/common
+          wmo/runtime
+          --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
+
+  non-live-optimization:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project and its dev extras
+        run: uv sync --extra dev
+      - name: non-live optimize and simulation tests
+        run: >-
+          uv run pytest -n 4 --dist worksteal -q -k "not live"
+          wmo/optimize
+          wmo/simulation
           --ignore=wmo/optimize/router/composition_evidence_test.py
           --ignore=wmo/simulation/comparison_evidence_test.py
-          --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
 
   installed-wheel-release-evidence:
     runs-on: ubuntu-latest

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -35,7 +35,9 @@ jobs:
           wmo/cli
           wmo/common
           wmo/runtime
+          wmo/simulation
           --deselect=wmo/release_test.py::test_installed_wheel_no_spend_release_evidence
+          --ignore=wmo/simulation/comparison_evidence_test.py
 
   non-live-optimization:
     runs-on: ubuntu-latest
@@ -45,13 +47,11 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - name: Install the project and its dev extras
         run: uv sync --extra dev
-      - name: non-live optimize and simulation tests
+      - name: non-live optimize tests
         run: >-
           uv run pytest -n 4 --dist worksteal -q -k "not live"
           wmo/optimize
-          wmo/simulation
           --ignore=wmo/optimize/router/composition_evidence_test.py
-          --ignore=wmo/simulation/comparison_evidence_test.py
 
   installed-wheel-release-evidence:
     runs-on: ubuntu-latest

--- a/docs/research/w16-router-sandbox-evidence.md
+++ b/docs/research/w16-router-sandbox-evidence.md
@@ -22,8 +22,8 @@ The exact deterministic run retains these denominators:
 - 150 persisted judgments under one workflow ceiling of 200
 - one shared simulation ceiling of $2.00 and exactly $0.00 observed fake-client spend
 
-The test crashes once after the fit lock and once after durable report and telemetry creation. Resume
-and exact replay add no model, world-model, judge, approval, or telemetry delivery. Two HTTP turns
+Exact replay adds no model, world-model, judge, approval, or telemetry delivery; crash-and-resume at
+both durable phase boundaries is pinned by wmo/optimize/router/composition_test.py. Two HTTP turns
 with one episode ID retain one hashed episode identity and one sticky routed alias without exposing
 the raw episode ID.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ sft = ["tinker>=0.23,<0.24", "tinker-cookbook>=0.4.3,<0.5"]
 postgres = ["psycopg[binary]>=3.1"]
 dev = [
     "pytest>=8.0",
+    "pytest-xdist>=3.8",
     "ruff>=0.5",
     "ty>=0.0.1a1",
     "world-model-optimizer[sft]",

--- a/uv.lock
+++ b/uv.lock
@@ -465,6 +465,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1999,6 +2008,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2651,6 +2673,7 @@ dependencies = [
 dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tinker" },
     { name = "tinker-cookbook" },
@@ -2678,6 +2701,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8" },
     { name = "rich", specifier = ">=14.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "tinker", marker = "extra == 'sft'", specifier = ">=0.23,<0.24" },

--- a/wmo/optimize/router/composition.py
+++ b/wmo/optimize/router/composition.py
@@ -80,6 +80,7 @@ from wmo.optimize.router.fit.workflow import (
 from wmo.optimize.router.judgment_budget import (
     JudgmentBudgetError,
     find_verified_judgment,
+    find_verified_judgments,
     persist_dispatch_reservation,
     read_dispatch_reservation,
 )
@@ -798,8 +799,8 @@ def _complete_cell_evidence(
         (item.task_id, item.candidate_alias, item.repeat): item.rollout_artifact_id
         for item in setup.observed_cells
     }
-    evidence = []
-    consumed = 0
+    bound_cells = []
+    protocols_by_rollout: dict[str, EvaluationProtocol] = {}
     for cell in cells:
         rollout_id = (
             cell.observed_rollout_id
@@ -818,14 +819,25 @@ def _complete_cell_evidence(
         protocol = (
             setup.production_protocol if cell.execution == "observed" else setup.simulation_protocol
         )
+        existing_protocol = protocols_by_rollout.setdefault(rollout_id, protocol)
+        if existing_protocol != protocol:
+            raise RouterCompositionError("one rollout is bound to conflicting evaluation protocols")
+        bound_cells.append((cell, rollout_id, protocol))
+    try:
+        judgments_by_rollout = find_verified_judgments(
+            project,
+            protocols_by_rollout=protocols_by_rollout,
+            rubric_id=review.rubric_id,
+            calibration_id=review.calibration_id,
+        )
+    except JudgmentBudgetError as exc:
+        raise RouterCompositionError(str(exc)) from exc
+
+    evidence = []
+    consumed = 0
+    for cell, rollout_id, protocol in bound_cells:
         try:
-            judgment = find_verified_judgment(
-                project,
-                rollout_id,
-                review.rubric_id,
-                review.calibration_id,
-                protocol,
-            )
+            judgment = judgments_by_rollout.get(rollout_id)
             receipt = read_dispatch_reservation(
                 project,
                 plan_input,
@@ -835,6 +847,16 @@ def _complete_cell_evidence(
                 review.calibration_id,
                 protocol,
             )
+            if judgment is None and receipt is not None:
+                judgment = find_verified_judgment(
+                    project,
+                    rollout_id,
+                    review.rubric_id,
+                    review.calibration_id,
+                    protocol,
+                )
+                if judgment is not None:
+                    judgments_by_rollout[rollout_id] = judgment
         except JudgmentBudgetError as exc:
             raise RouterCompositionError(str(exc)) from exc
         if judgment is not None or receipt is not None:
@@ -868,6 +890,7 @@ def _complete_cell_evidence(
                 calibration_artifact_id=review.calibration_id,
             )
             _persist_judgment(project, judgment)
+            judgments_by_rollout[rollout_id] = judgment
         rollout, _input = read_rollout(project.artifacts, rollout_id)
         evidence.append(
             EvaluationCellEvidence(

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -388,7 +388,10 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prove phase locks, replay, budgets, and HTTP stickiness end to end.
+    """Prove replay safety, budgets, and HTTP stickiness end to end.
+
+    Crash-and-resume at the durable phase boundaries is owned by
+    composition_test.py::test_public_composition_runs_and_resumes_complete_frozen_router.
 
     Args:
         tmp_path: Isolated project root for composed router evidence.
@@ -397,6 +400,16 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
     revision = exact_checkout_revision()
     project = ProjectStore(tmp_path, "w16-project")
     project.initialize(ProjectConfig(project_id="w16-project"))
+    list_ids_calls = 0
+    list_ids = project.artifacts.list_ids
+
+    def count_list_ids() -> tuple[str, ...]:
+        """Count artifact-directory scans across the complete evidence workflow."""
+        nonlocal list_ids_calls
+        list_ids_calls += 1
+        return list_ids()
+
+    monkeypatch.setattr(project.artifacts, "list_ids", count_list_ids)
     normalized = TraceNormalizationResult(
         traces=tuple(_trace(index) for index in range(100)),
         issues=(),
@@ -431,40 +444,6 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
         return True
 
     monkeypatch.setattr("wmo.optimize.router.composition.capture_completion_once", capture)
-    crash_after_policy = True
-    crash_after_report = True
-
-    def checkpoint(phase: str) -> None:
-        """Inject one crash after each durable composition boundary."""
-        nonlocal crash_after_policy, crash_after_report
-        if phase == "policy_locked" and crash_after_policy:
-            crash_after_policy = False
-            raise RuntimeError("w16 crash after fit lock")
-        if phase == "report_complete" and crash_after_report:
-            crash_after_report = False
-            raise RuntimeError("w16 crash after durable report and telemetry")
-
-    with pytest.raises(RuntimeError, match="after fit lock"):
-        wmo.compose_router(
-            project,
-            normalized,
-            services=services,
-            budget=budget,
-            created_at=_TIME,
-            code_revision=revision,
-            phase_hook=checkpoint,
-        )
-    dispatches_after_crash = _dispatch_counts(simulator, judge, approval)
-    with pytest.raises(RuntimeError, match="after durable report"):
-        wmo.compose_router(
-            project,
-            normalized,
-            services=services,
-            budget=budget,
-            created_at=_TIME,
-            code_revision=revision,
-            phase_hook=checkpoint,
-        )
     result = wmo.compose_router(
         project,
         normalized,
@@ -472,7 +451,6 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
         budget=budget,
         created_at=_TIME,
         code_revision=revision,
-        phase_hook=checkpoint,
     )
     dispatches_after_completion = _dispatch_counts(simulator, judge, approval)
     replay = wmo.compose_router(
@@ -514,7 +492,6 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
     assert report.run_spend.judge.missing_row_count == 0
     assert replay.optimization == result.optimization
     assert _dispatch_counts(simulator, judge, approval) == dispatches_after_completion
-    assert dispatches_after_completion[0] > dispatches_after_crash[0]
     planned_phase_cells = len(result.simulation_spec.cell_ids) + len(
         result.held_out_simulation_spec.cell_ids
     )
@@ -533,7 +510,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
     assert len(reservations) == judge.calls == len(result.plan.cells) == 150
     assert judge.calls <= budget.maximum_judgments
     assert len(telemetry_delivered) == 1
-    assert len(telemetry_attempts) == 3
+    assert len(telemetry_attempts) == 2
 
     app = create_project_router_app("w16-router", result.runtime)
     http = TestClient(app)
@@ -576,6 +553,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
         },
     )
     assert provenance["code_revision"] == revision
+    assert list_ids_calls < 1_000
 
 
 class _EvidenceReviewSupplier:

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -417,7 +417,7 @@ class _Judge:
             raise RuntimeError("simulated judgment dispatch interruption")
         rollout_value = read_rollout(store.artifacts, rollout_artifact_id)[0]
         locked = any(
-            store.artifacts.read(artifact_id).manifest.artifact_type == "router-policy-lock"
+            artifact_id.startswith("router-policy-lock-")
             for artifact_id in store.artifacts.list_ids()
         )
         self.log.append((rollout_value.cell_id or "observed", locked))
@@ -546,7 +546,7 @@ class _LoggingSimulator:
     def run(self, spec: SimulationSpec) -> SimulationArtifactSet:
         """Record policy-lock state and delegate one simulation phase."""
         locked = any(
-            self.project.artifacts.read(artifact_id).manifest.artifact_type == "router-policy-lock"
+            artifact_id.startswith("router-policy-lock-")
             for artifact_id in self.project.artifacts.list_ids()
         )
         self.log.append((spec.cell_ids, locked))

--- a/wmo/optimize/router/judgment_budget.py
+++ b/wmo/optimize/router/judgment_budget.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from wmo.common.core.artifacts import (
     ArtifactEnvelope,
     ArtifactInput,
@@ -58,23 +60,60 @@ def find_verified_judgment(
     Raises:
         JudgmentBudgetError: Matching evidence is duplicated or differs from frozen pins.
     """
-    matches = []
+    return find_verified_judgments(
+        project,
+        protocols_by_rollout={rollout_id: protocol},
+        rubric_id=rubric_id,
+        calibration_id=calibration_id,
+    ).get(rollout_id)
+
+
+def find_verified_judgments(
+    project: ProjectStore,
+    *,
+    protocols_by_rollout: Mapping[str, EvaluationProtocol],
+    rubric_id: str,
+    calibration_id: str,
+) -> dict[str, Judgment]:
+    """Index fully verified judgments for a set of exact plan-bound rollouts.
+
+    Args:
+        project: Project whose immutable evidence is being resumed.
+        protocols_by_rollout: Frozen protocol for each relevant rollout identity.
+        rubric_id: Approved rubric identity for the workflow.
+        calibration_id: Approved calibration identity for the workflow.
+
+    Returns:
+        Unique exact judgments keyed by relevant rollout identity.
+
+    Raises:
+        JudgmentBudgetError: Matching evidence is duplicated or differs from frozen pins.
+    """
+    matches: dict[str, Judgment] = {}
     for artifact_id in project.artifacts.list_ids():
         stored = project.artifacts.read(artifact_id)
         if stored.manifest.artifact_type != "judgment":
             continue
         judgment, _input = read_judgment(project.artifacts, artifact_id)
+        protocol = protocols_by_rollout.get(judgment.rollout_id)
         if (
-            judgment.rollout_id != rollout_id
+            protocol is None
             or judgment.rubric_id != rubric_id
             or judgment.calibration_id != calibration_id
         ):
             continue
-        _require_judgment(project, judgment, rollout_id, rubric_id, calibration_id, protocol)
-        matches.append(judgment)
-    if len(matches) > 1:
-        raise JudgmentBudgetError("multiple judgments bind the same rollout and review")
-    return matches[0] if matches else None
+        _require_judgment(
+            project,
+            judgment,
+            judgment.rollout_id,
+            rubric_id,
+            calibration_id,
+            protocol,
+        )
+        if judgment.rollout_id in matches:
+            raise JudgmentBudgetError("multiple judgments bind the same rollout and review")
+        matches[judgment.rollout_id] = judgment
+    return matches
 
 
 def read_dispatch_reservation(

--- a/wmo/runtime/environments/local_test.py
+++ b/wmo/runtime/environments/local_test.py
@@ -53,7 +53,7 @@ def test_local_process_environment_times_out_and_cleans_up(tmp_path: Path) -> No
     runtime = _runtime(
         tmp_path,
         limits=LocalProcessLimits(
-            request_timeout_seconds=0.05,
+            request_timeout_seconds=0.5,
             session_timeout_seconds=1.0,
             cleanup_timeout_seconds=1.0,
         ),

--- a/wmo/simulation/engines/text/simulator.py
+++ b/wmo/simulation/engines/text/simulator.py
@@ -938,7 +938,8 @@ class WorldModelSimulator:
 
     def _load_optional_rollout(self, rollout_id: ArtifactId) -> RolloutArtifact | None:
         """Load an existing rollout while distinguishing absence from immutable corruption."""
-        if rollout_id not in self._store.list_ids():
+        destination = self._store.project_directory / "artifacts" / rollout_id
+        if not destination.exists():
             return None
         return self._load_rollout(rollout_id)
 


### PR DESCRIPTION
## Summary

- Index verified judgments once per composition phase instead of rescanning the full artifact graph for every evaluation cell.
- Check the exact expected rollout artifact path during budget reconciliation instead of listing every artifact for every expected rollout.
- Remove duplicate W16 crash/replay passes while retaining focused phase-boundary coverage, all 100-trace, 50/20-task, and 150-cell evidence denominators, and a deterministic artifact-scan regression guard.
- Run the non-live collection with four pytest-xdist workers in explicit foundation, optimize, simulation, installed-wheel, and W16 shards. Every test job has a hard two-minute timeout.
- Give the Darwin local-process timeout test enough budget to start its Python fixture before exercising the intended blocked-response timeout.

## Performance

Baseline on `main` ([run 31976972672](https://github.com/experientiallabs/world-model-optimizer/actions/runs/31976972672)):

- Non-live test step: 11m18s.
- Darwin evidence step: 4m28s.

Final rebased GitHub result at `1c3d44ba` ([run 31981999491](https://github.com/experientiallabs/world-model-optimizer/actions/runs/31981999491)):

| Job | Whole job | Pytest step | Result |
| --- | ---: | ---: | --- |
| non-live-simulation | 59s | 28.91s | 323 passed |
| installed-wheel-release-evidence | 1m00s | 28.76s | 1 passed |
| w16-darwin-evidence | 1m13s | 42.99s | 2 passed |
| gate | 1m26s | 56.48s | 749 passed, 11 skipped |
| non-live-optimization | 1m31s | 61.16s | 148 passed |

The slowest complete CI job is 1m31s, including checkout and dependency installation. No evidence scale was reduced.

## Validation

- Rebasing onto latest `main` (`6eb2e162`) increased the non-live collection to 1,234 selected nodes. The five shard selectors partition all 1,234: foundation (760), optimize (148), simulation (323), installed-wheel (1), and W16 (2).
- Rebased local shard validation: 1,233 passed, 1 skipped.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Final GitHub gate, package build, and CodeQL checks pass.
