### PR TITLE
Add cost-aware consent policy for paid commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ uv run pytest -q
 
 ## Writing
 
+- Do not modify `README.md` without explicit user approval for that file. A request to implement,
+  document, publish, or open a PR does not imply approval to change the README; ask first.
 - No em dashes in any NEW writing: code, comments, docstrings, docs, UI copy, commit messages, or
   PR descriptions. Use a comma, a colon, parentheses, a period, or a plain hyphen instead, or
   restructure the sentence. The rule applies to a diff's added lines and is checked in review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,16 +95,20 @@ uv run pytest -q
   in `fit/`, and evaluation preparation in `evaluation/`. The durable judgment ledger remains at
   `judgment_budget.py`.
 - The root CLI is locked to `build`, `optimize`, `run`, and `config`. The optimize group is locked
-  to `router` and `model`; the config group is locked to `telemetry` and `providers`. Widening any
-  of those three sets, whether with a command, an alias, or a flag, is a deliberate change to the
-  locked surface and needs the same scrutiny as a public API change.
+  to `router` and `model`; the config group is locked to `budget`, `judge`, `providers`, and
+  `telemetry`. Widening any of those three sets, whether with a command, an alias, or a flag, is a
+  deliberate change to the locked surface and needs the same scrutiny as a public API change.
+- Every paid CLI command uses `wmo.cli.consent.require_spend_consent` after a credential-free
+  conservative estimate and before credential or provider-client construction. The setting in
+  `.wmo/settings.toml` is a hard per-command ceiling. Estimates at or below half run automatically,
+  higher in-budget estimates need explicit confirmation, and `--yes` never overrides the ceiling.
 - `wmo optimize model PROJECT` runs only a project-bound immutable W12 to W13 SFT configuration.
   It never builds a dataset, creates teacher rollouts, changes routing roles, or launches a
   simulator. The config freezes the W12 manifest, native Tinker base-model snapshot, capability
   digest, and credential-reference digest without persisting any secret. A finite cap requires a
-  conservative estimate for every exact scheduled batch before consent; `--yes` confirms only
-  after those checks. Completed W13 artifacts are recursively verified before an opaque sampling
-  handle is atomically registered in `models.toml`.
+  conservative estimate for every exact scheduled batch before shared cost authorization;
+  `--yes` confirms only an in-budget estimate after those checks. Completed W13 artifacts are
+  recursively verified before an opaque sampling handle is atomically registered in `models.toml`.
 - Changes to this composition seam require focused persisted-dataset, resume, budget, immutable
   pointer, drift, and catalog-provenance coverage. The seam composes a persisted dataset into an
   SFT run and stops there; training-objective, promotion, and route-registration concerns belong to

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ result = router.complete(
 )
 ```
 
+## Command budgets
+
+Paid commands share one cost preflight and a user-owned per-command ceiling. The default is
+`$10.00`; change or inspect it without prompting:
+
+```bash
+wmo config budget
+wmo config budget 50
+```
+
+Every preflight names the command, conservative estimate, configured budget, and major bounded
+assumptions. Estimates at or below 50% of the budget run automatically. Higher in-budget estimates
+require a clear terminal confirmation or `--yes`. Estimates above the budget fail before
+credentials or provider clients, and `--yes` cannot override that ceiling.
+
 ## Telemetry
 
 Anonymous aggregate PostHog product telemetry is enabled by default. It never includes prompts,
@@ -89,7 +104,7 @@ wmo config telemetry disable
 wmo config telemetry enable
 ```
 
-The preference is stored locally in `.wmo/settings.toml`.
+The command budget and telemetry preference are stored locally in `.wmo/settings.toml`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -78,21 +78,6 @@ result = router.complete(
 )
 ```
 
-## Command budgets
-
-Paid commands share one cost preflight and a user-owned per-command ceiling. The default is
-`$10.00`; change or inspect it without prompting:
-
-```bash
-wmo config budget
-wmo config budget 50
-```
-
-Every preflight names the command, conservative estimate, configured budget, and major bounded
-assumptions. Estimates at or below 50% of the budget run automatically. Higher in-budget estimates
-require a clear terminal confirmation or `--yes`. Estimates above the budget fail before
-credentials or provider clients, and `--yes` cannot override that ceiling.
-
 ## Telemetry
 
 Anonymous aggregate PostHog product telemetry is enabled by default. It never includes prompts,
@@ -104,7 +89,7 @@ wmo config telemetry disable
 wmo config telemetry enable
 ```
 
-The command budget and telemetry preference are stored locally in `.wmo/settings.toml`.
+The preference is stored locally in `.wmo/settings.toml`.
 
 ## Development
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,18 +5,23 @@ The root surface is deliberately small:
 | Command | Purpose | Local result |
 |---|---|---|
 | `wmo build PROJECT TRACES --source SOURCE --root ROOT [--provider NAME ...]` | Normalize 100 through 1000 local traces from one [declared source](reference/ingest.md) and mine representative tasks. First-build setup uses a keyboard provider list, or exact `--provider` flags. | Manifest-bound `TraceDataset`, `TaskSet`, and `proposals_pending` review state. |
-| `wmo optimize router PROJECT --config FILE --root ROOT` | Fit, freeze, then report from explicit completed evidence. | Fit evaluation, bank, policy, held-out evaluation, and router report. |
+| `wmo optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
 | `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
+| `wmo config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.wmo/settings.toml`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 
-`build` makes zero model, provider, or judge paid calls. Successful build, router, simulation, and
-SFT operations preserve anonymous aggregate PostHog product telemetry, which may send unless
-disabled. `optimize router` does not make provider calls. `optimize model` requires an immutable
-positive cost ceiling, a finite conservative full-schedule estimate, explicit consent, and complete
-project evidence before Tinker can open. Unknown cost or incomplete provenance fails before
-dispatch. `run` makes no provider call at startup.
+`build`, judge calibration, `optimize router`, and `optimize model` use the same cost authorization
+policy. Each displays the command, conservative estimate, configured per-command budget, and major
+cost assumptions. An estimate at or below 50% of the budget runs automatically. A higher estimate
+up to the budget requires a clear terminal confirmation or `--yes`; an estimate above the budget
+fails before credentials or provider clients. Set the deterministic ceiling with
+`wmo config budget USD --root ROOT`. `--yes` confirms only an in-budget invocation and never raises
+the ceiling. Exact completed replays report a zero-dollar estimate and do not prompt.
+
+Successful build, router, simulation, and SFT operations preserve anonymous aggregate PostHog
+product telemetry, which may send unless disabled. `run` makes no provider call at startup.
 An HTTP completion or direct `RouterRuntime.complete` call is the explicit online model-call
 boundary. The router remains frozen for the process lifetime. `run --ghost` still permits provider
 calls but disables durable interaction, replay, RAG, and SFT state for that process.

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -9,7 +9,7 @@ from typer.main import get_group
 from wmo.cli.app import app
 
 EXPECTED_SUBCOMMANDS = {
-    "config": {"judge", "providers", "telemetry"},
+    "config": {"budget", "judge", "providers", "telemetry"},
     "optimize": {"model", "router"},
 }
 

--- a/wmo/cli/build_cmd.py
+++ b/wmo/cli/build_cmd.py
@@ -17,7 +17,13 @@ from wmo.cli.provider_setup import (
     provider_setup_json_examples,
     run_provider_setup,
 )
-from wmo.common.models import ModelCatalog, ModelCatalogError, load_model_catalog
+from wmo.common.models import (
+    ModelCapabilities,
+    ModelCatalog,
+    ModelCatalogError,
+    ModelSnapshot,
+    load_model_catalog,
+)
 from wmo.common.observability.telemetry import BuildTelemetryStats, capture_build_completed
 from wmo.common.project import (
     ArtifactStoreError,
@@ -31,7 +37,14 @@ from wmo.common.project import (
     artifact_input,
 )
 from wmo.common.release_revision import installed_release_revision
-from wmo.runtime.models import CapabilityRequirement, ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.models import (
+    CapabilityRequirement,
+    ModelCapabilityError,
+    ModelConnectionError,
+    ResolvedModel,
+    RuntimeModelCatalog,
+)
+from wmo.runtime.models.preflight import preflight_capabilities
 from wmo.runtime.models.providers.retry import RetryPolicy
 from wmo.simulation.build import ProjectBuild, TaskSetBuild, build_project, select_completed_build
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
@@ -43,7 +56,11 @@ from wmo.simulation.retrieval import (
     persist_trace_rag,
 )
 from wmo.simulation.retrieval.transitions import extract_real_transitions
-from wmo.simulation.world_model.artifact import persist_grounded_world_model
+from wmo.simulation.world_model.artifact import (
+    WORLD_MODEL_ARTIFACT_PATH,
+    GroundedWorldModelArtifact,
+    persist_grounded_world_model,
+)
 from wmo.simulation.world_model.runtime import load_grounded_world_model
 
 _console = Console()
@@ -86,11 +103,16 @@ def build(
         min=0.01,
         help="Strict embedding spend ceiling in USD.",
     ),
-    yes: bool = typer.Option(False, "--yes", help="Consent to the displayed embedding spend."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Confirm an in-budget estimate when the shared policy requires it.",
+    ),
     no_interactive: bool = typer.Option(
         False,
+        "--non-interactive",
         "--no-interactive",
-        help="Never prompt for missing model setup.",
+        help="Require complete model flags and never ask setup or cost questions.",
     ),
     provider: list[str] | None = _PROVIDER_OPTION,
 ) -> None:
@@ -110,15 +132,22 @@ def build(
         embedder: Optional configured alias override for this project.
         top_k: Positive serving retrieval result limit.
         maximum_build_cost_usd: Strict ceiling for provider embedding calls.
-        yes: Explicit noninteractive or advance spend consent.
-        no_interactive: Disable inline setup even when a terminal is available.
+        yes: Explicit confirmation for an in-budget estimate above the automatic threshold.
+        no_interactive: Disable inline setup and cost questions even at a terminal.
         provider: Repeatable provider names that skip the opening list during setup.
 
     Raises:
         typer.BadParameter: Input, setup, role, cost, project, or artifact validation fails.
     """
     started = time.monotonic()
-    with usage_error(ArtifactStoreError, ModelCatalogError, ProjectStoreError, ValueError):
+    with usage_error(
+        ArtifactStoreError,
+        ModelCapabilityError,
+        ModelCatalogError,
+        ModelConnectionError,
+        ProjectStoreError,
+        ValueError,
+    ):
         code_revision = installed_release_revision()
         ProjectStore(root, project)
         catalog = _load_or_setup_catalog(
@@ -133,11 +162,9 @@ def build(
             embedder=embedder,
         )
         runtime_catalog = RuntimeModelCatalog(catalog)
-        resolved_world = runtime_catalog.resolve(selected.world_model)
-        runtime_catalog.resolve(selected.judge)
-        resolved_embedder = runtime_catalog.preflight(
-            selected.embedder,
-            CapabilityRequirement(requires_embeddings=True),
+        world_snapshot, embedder_snapshot, embedder_capabilities = _validated_role_snapshots(
+            runtime_catalog,
+            selected,
         )
         path = _resolve_trace_file(trace_file)
         normalized = _load_canonical_traces(path, source)
@@ -165,31 +192,61 @@ def build(
         built = _reuse_completed_grounded_artifacts(
             store,
             completed,
-            resolved_world=resolved_world,
-            resolved_embedder=resolved_embedder,
+            world_alias=selected.world_model,
+            world_snapshot=world_snapshot,
+            embedder_snapshot=embedder_snapshot,
             top_k=top_k,
         )
         estimate = 0.0
         if built is None:
-            estimate = _embedding_cost_ceiling(completed, resolved_embedder)
+            estimate = _embedding_cost_ceiling(completed, embedder_capabilities)
             if estimate > maximum_build_cost_usd:
                 raise ValueError(
                     f"conservative embedding estimate ${estimate:.6f} exceeds "
                     f"--max-build-cost-usd ${maximum_build_cost_usd:.6f}"
                 )
-            if estimate > 0 and not require_spend_consent(
-                _console,
-                yes=yes,
-                spend=f"at most ${estimate:.6f} for provider embeddings",
-                command=f"wmo build {project} {trace_file}",
-            ):
-                return
+        assumptions = (
+            (
+                "verified immutable grounded indexes are reused",
+                "zero new provider calls",
+            )
+            if built is not None
+            else (
+                "serving and fit-only RAG embeddings",
+                "UTF-8 bytes conservatively counted as input tokens",
+                f"up to {RetryPolicy().maximum_attempts} embedding attempts",
+            )
+        )
+        if not require_spend_consent(
+            _console,
+            root=root,
+            yes=yes,
+            estimated_cost_usd=estimate,
+            command=f"wmo build {project} {trace_file}",
+            assumptions=assumptions,
+            non_interactive=no_interactive,
+        ):
+            return
+        resolved_world = runtime_catalog.resolve(selected.world_model)
+        runtime_catalog.resolve(selected.judge)
+        resolved_embedder = runtime_catalog.preflight(
+            selected.embedder,
+            CapabilityRequirement(requires_embeddings=True),
+        )
+        if built is None:
             built = _build_grounded_artifacts(
                 store,
                 completed,
                 resolved_world=resolved_world,
                 resolved_embedder=resolved_embedder,
                 top_k=top_k,
+            )
+        else:
+            _validate_reused_grounded_artifacts(
+                store,
+                built,
+                resolved_world=resolved_world,
+                resolved_embedder=resolved_embedder,
             )
         select_completed_build(store, built, completed.review)
     _capture_local_build_telemetry(
@@ -319,15 +376,49 @@ def _selected_roles(
     )
 
 
+def _validated_role_snapshots(
+    runtime_catalog: RuntimeModelCatalog,
+    selected: ProjectModelConfiguration,
+) -> tuple[ModelSnapshot, ModelSnapshot, ModelCapabilities]:
+    """Validate build roles from catalog metadata without reading credentials.
+
+    Args:
+        runtime_catalog: Resolver used only for static model snapshots.
+        selected: Frozen world-model, judge, and embedder aliases.
+
+    Returns:
+        World-model snapshot, embedder snapshot, and embedder capabilities.
+
+    Raises:
+        ModelCapabilityError: The embedder cannot prove embedding support.
+        ModelConnectionError: A selected alias or provider is unsupported.
+        ValueError: The embedder has no explicit input price.
+    """
+    world_snapshot, _world_capabilities = runtime_catalog.snapshot(selected.world_model)
+    runtime_catalog.snapshot(selected.judge)
+    embedder_snapshot, embedder_capabilities = runtime_catalog.snapshot(selected.embedder)
+    preflight_capabilities(
+        selected.embedder,
+        embedder_capabilities,
+        CapabilityRequirement(requires_embeddings=True),
+    )
+    if embedder_capabilities.input_cost_per_million_tokens_usd is None:
+        raise ValueError(
+            f"embedder alias {selected.embedder!r} has no input_cost_per_million_tokens_usd; "
+            "record explicit pricing before a provider-backed build"
+        )
+    return world_snapshot, embedder_snapshot, embedder_capabilities
+
+
 def _embedding_cost_ceiling(
     completed: ProjectBuild,
-    embedder: ResolvedModel,
+    capabilities: ModelCapabilities,
 ) -> float:
     """Bound retry-inclusive embedding spend from the exact rendered retrieval inputs.
 
     Args:
         completed: Persisted trace and task build whose transitions will be embedded.
-        embedder: Exact resolved embedding model and price metadata.
+        capabilities: Static embedder capabilities and price metadata.
 
     Returns:
         Conservative USD ceiling across serving and fit-only index construction.
@@ -335,10 +426,10 @@ def _embedding_cost_ceiling(
     Raises:
         ValueError: The selected embedder omits explicit input pricing.
     """
-    price = embedder.capabilities.input_cost_per_million_tokens_usd
+    price = capabilities.input_cost_per_million_tokens_usd
     if price is None:
         raise ValueError(
-            f"embedder alias {embedder.alias!r} has no input_cost_per_million_tokens_usd; "
+            "embedder has no input_cost_per_million_tokens_usd; "
             "record explicit pricing before a provider-backed build"
         )
     bindings = _lineage_bindings(completed)
@@ -463,24 +554,24 @@ def _reuse_completed_grounded_artifacts(
     store: ProjectStore,
     completed: ProjectBuild,
     *,
-    resolved_world: ResolvedModel,
-    resolved_embedder: ResolvedModel,
+    world_alias: str,
+    world_snapshot: ModelSnapshot,
+    embedder_snapshot: ModelSnapshot,
     top_k: int,
 ) -> ProjectBuildArtifacts | None:
-    """Reuse a completely matching verified build without another provider embedding call.
+    """Reuse a completely matching verified build without credentials or provider calls.
 
     Args:
         store: Project artifact store containing a possible completed build.
         completed: Current persisted trace and task build.
-        resolved_world: Exact world-model runtime binding.
-        resolved_embedder: Exact provider embedding binding.
+        world_alias: Configured world-model alias required by the artifact.
+        world_snapshot: Secret-free world-model identity required by the artifact.
+        embedder_snapshot: Secret-free embedder identity required by both indexes.
         top_k: Requested retrieval result count.
 
     Returns:
         Verified existing build pointers, or ``None`` when any identity differs.
 
-    Raises:
-        ValueError: The selected embedder lacks an explicit catalog input price.
     """
     existing = store.load_project().build
     if existing is None:
@@ -493,19 +584,49 @@ def _reuse_completed_grounded_artifacts(
         return None
     serving = load_rag_index(store.artifacts, existing.serving_rag.artifact_id)
     fit = load_rag_index(store.artifacts, existing.fit_rag.artifact_id)
-    expected_embedder = resolved_embedder.snapshot
     if (
-        serving.index.embedder != expected_embedder
-        or fit.index.embedder != expected_embedder
+        serving.index.embedder != embedder_snapshot
+        or fit.index.embedder != embedder_snapshot
         or serving.index.default_top_k != top_k
         or fit.index.default_top_k != top_k
         or serving.index.included_partitions != ("fit", "held_out")
         or fit.index.included_partitions != ("fit",)
     ):
         return None
+    world = GroundedWorldModelArtifact.model_validate_json(
+        store.artifacts.read_bytes(existing.world_model.artifact_id, WORLD_MODEL_ARTIFACT_PATH)
+    )
+    if (
+        world.serving_rag != existing.serving_rag
+        or world.model_alias != world_alias
+        or world.model != world_snapshot
+        or world.top_k != top_k
+    ):
+        return None
+    return existing
+
+
+def _validate_reused_grounded_artifacts(
+    store: ProjectStore,
+    existing: ProjectBuildArtifacts,
+    *,
+    resolved_world: ResolvedModel,
+    resolved_embedder: ResolvedModel,
+) -> None:
+    """Preserve runtime validation for a statically matched zero-call replay.
+
+    Args:
+        store: Project artifact store containing the completed build.
+        existing: Exact build pointers matched before cost authorization.
+        resolved_world: Post-authorization world-model runtime binding.
+        resolved_embedder: Post-authorization embedding runtime binding.
+
+    Raises:
+        ValueError: Runtime pricing or immutable artifact identity is invalid.
+    """
     assert resolved_embedder.embedding_client is not None
     embedding_price = resolved_embedder.capabilities.input_cost_per_million_tokens_usd
-    if embedding_price is None:  # pragma: no cover - setup and capability preflight require it
+    if embedding_price is None:  # pragma: no cover - static capability validation requires it
         raise ValueError("the selected embedder has no explicit input price")
     runtime = load_grounded_world_model(
         store.artifacts,
@@ -521,10 +642,8 @@ def _reuse_completed_grounded_artifacts(
     if (
         runtime.artifact.model_alias != resolved_world.alias
         or runtime.artifact.model != resolved_world.snapshot
-        or runtime.artifact.top_k != top_k
     ):
-        return None
-    return existing
+        raise ValueError("completed grounded world model differs from the selected runtime model")
 
 
 def _lineage_bindings(completed: ProjectBuild) -> tuple[RAGLineageBinding, ...]:

--- a/wmo/cli/build_cmd_test.py
+++ b/wmo/cli/build_cmd_test.py
@@ -14,9 +14,11 @@ from pydantic import JsonValue
 from typer.testing import CliRunner
 
 import wmo.cli.build_cmd as build_command
+import wmo.cli.consent as consent_module
 import wmo.simulation.build as simulation_build
 from wmo.cli.app import app
 from wmo.cli.provider_setup_test import _FakeLister as _SetupLister
+from wmo.common.config.settings import set_maximum_command_cost_usd
 from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
     ConnectionConfig,
@@ -259,12 +261,35 @@ class _RuntimeCatalog:
         self._embedding = _EmbeddingClient()
         self._completion = _CompletionClient()
 
+    def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+        """Return deterministic static identity without recording runtime construction.
+
+        Args:
+            alias: Configured fixture alias.
+
+        Returns:
+            Fixture model snapshot and capabilities.
+        """
+        resolved = self._resolved(alias)
+        return resolved.snapshot, resolved.capabilities
+
     def preflight(self, alias: str, _requirement: object | None = None) -> ResolvedModel:
         """Return exact static identities with alias-specific capabilities.
 
         Args:
             alias: Configured fixture model alias.
             _requirement: Unused requirement accepted by the runtime seam.
+
+        Returns:
+            Deterministic resolved fixture model.
+        """
+        return self._resolved(alias)
+
+    def _resolved(self, alias: str) -> ResolvedModel:
+        """Build one deterministic runtime binding for a fixture alias.
+
+        Args:
+            alias: Configured fixture alias.
 
         Returns:
             Deterministic resolved fixture model.
@@ -742,6 +767,169 @@ def test_build_package_upgrade_decline_preserves_selected_review(
     assert declined.exit_code == 0, declined.output
     assert store.load_project().build == first_build
     assert store.read_review() == first_review
+
+
+def test_configured_budget_rejects_build_before_provider_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An over-budget estimate performs zero credential or provider-client work.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and settings root.
+        monkeypatch: Cost and provider-resolution boundary replacements.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    set_maximum_command_cost_usd(0.5, root)
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 1.0)
+    provider_resolutions: list[str] = []
+
+    def forbidden_preflight(
+        self: _RuntimeCatalog,
+        alias: str,
+        requirement: object | None = None,
+    ) -> ResolvedModel:
+        """Fail if hard budget rejection reaches runtime model construction.
+
+        Args:
+            self: Runtime catalog instance.
+            alias: Unexpected model alias.
+            requirement: Unexpected capability requirement.
+
+        Raises:
+            AssertionError: Always, because provider resolution must not run.
+        """
+        del self, requirement
+        provider_resolutions.append(alias)
+        raise AssertionError("provider resolution must follow command budget authorization")
+
+    monkeypatch.setattr(_RuntimeCatalog, "preflight", forbidden_preflight)
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root), "--yes"],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "estimated cost: $1.00" in output
+    assert "configured budget: $0.50 per command" in output
+    assert "wmo config budget 1.00" in output
+    assert "--yes cannot override" in output
+    assert provider_resolutions == []
+    store = ProjectStore(root, "support")
+    assert store.load_project().build is None
+    assert store.read_review() is None
+
+
+def test_noninteractive_build_above_half_requires_yes_before_provider_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flag-declared noninteractive build receives deterministic remediation.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and settings root.
+        monkeypatch: Cost and provider-work boundary replacements.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    set_maximum_command_cost_usd(1.0, root)
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 0.75)
+    provider_calls: list[bool] = []
+
+    def forbidden_build(*_args: object, **_kwargs: object) -> None:
+        """Fail if missing confirmation reaches provider-backed artifact construction.
+
+        Raises:
+            AssertionError: Always, because ``--yes`` is absent.
+        """
+        provider_calls.append(True)
+        raise AssertionError("provider work requires shared cost authorization")
+
+    monkeypatch.setattr(build_command, "_build_grounded_artifacts", forbidden_build)
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root), "--no-interactive"],
+    )
+
+    assert result.exit_code == 2
+    assert "requires explicit confirmation" in unstyle(result.output)
+    assert "re-run with --yes" in unstyle(result.output)
+    assert provider_calls == []
+
+
+def test_noninteractive_build_yes_confirms_an_in_budget_estimate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flag-complete agent invocation runs after the shared preflight.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and settings root.
+        monkeypatch: Conservative estimate replacement.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    set_maximum_command_cost_usd(1.0, root)
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 0.75)
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "build",
+            "support",
+            str(source),
+            "--root",
+            str(root),
+            "--no-interactive",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "authorization: confirmed by --yes" in unstyle(result.output)
+    assert ProjectStore(root, "support").load_project().build is not None
+
+
+def test_interactive_build_uses_the_cost_specific_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real CLI prompt names the command, estimate, and configured budget.
+
+    Args:
+        tmp_path: Temporary trace, catalog, and settings root.
+        monkeypatch: Interactive-session and conservative-estimate replacements.
+    """
+    source = _otlp_export(tmp_path)
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    _catalog(root)
+    set_maximum_command_cost_usd(1.0, root)
+    monkeypatch.setattr(build_command, "_embedding_cost_ceiling", lambda *_args: 0.75)
+    monkeypatch.setattr(consent_module, "can_prompt", lambda _console: True)
+
+    result = _RUNNER.invoke(
+        app,
+        ["build", "support", str(source), "--root", str(root)],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "Authorize wmo build support" in output
+    assert "$0.75" in output
+    assert "$1.00 per-command budget" in output
+    assert "Proceed?" not in output
 
 
 @pytest.mark.parametrize("failure_mode", ["cost", "decline", "grounded"])

--- a/wmo/cli/cli_help_test.py
+++ b/wmo/cli/cli_help_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -55,8 +56,9 @@ def test_help_renders_only_user_facing_descriptions(argv: list[str]) -> None:
 )
 def test_every_paid_command_exposes_deterministic_agent_flags(argv: list[str]) -> None:
     """Paid CLI surfaces expose explicit confirmation and noninteractive mode."""
-    result = CliRunner().invoke(app, argv)
+    result = CliRunner().invoke(app, argv, color=True)
+    help_text = unstyle(result.output)
 
     assert result.exit_code == 0, result.output
-    assert "--yes" in result.output
-    assert "--non-interactive" in result.output
+    assert "--yes" in help_text
+    assert "--non-interactive" in help_text

--- a/wmo/cli/cli_help_test.py
+++ b/wmo/cli/cli_help_test.py
@@ -14,6 +14,7 @@ from wmo.cli.app import app
         ["--help"],
         ["build", "--help"],
         ["config", "telemetry", "--help"],
+        ["config", "budget", "--help"],
         ["config", "providers", "--help"],
         ["config", "judge", "setup", "--help"],
         ["config", "judge", "calibrate", "--help"],
@@ -25,6 +26,7 @@ from wmo.cli.app import app
         "root",
         "build",
         "telemetry",
+        "budget",
         "providers",
         "judge-setup",
         "judge-calibrate",
@@ -40,3 +42,21 @@ def test_help_renders_only_user_facing_descriptions(argv: list[str]) -> None:
     assert result.exit_code == 0, result.output
     for marker in ("Args:", "Returns:", "Inputs accepted by this callable"):
         assert marker not in result.output
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["build", "--help"],
+        ["config", "judge", "calibrate", "--help"],
+        ["optimize", "router", "--help"],
+        ["optimize", "model", "--help"],
+    ],
+)
+def test_every_paid_command_exposes_deterministic_agent_flags(argv: list[str]) -> None:
+    """Paid CLI surfaces expose explicit confirmation and noninteractive mode."""
+    result = CliRunner().invoke(app, argv)
+
+    assert result.exit_code == 0, result.output
+    assert "--yes" in result.output
+    assert "--non-interactive" in result.output

--- a/wmo/cli/config_cmd.py
+++ b/wmo/cli/config_cmd.py
@@ -13,6 +13,8 @@ from wmo.cli.provider_setup import ProviderSetupOptions, run_provider_setup
 from wmo.common.config import (
     ARTIFACT_DIR,
     load_settings,
+    resolve_command_budget_usd,
+    set_maximum_command_cost_usd,
     set_telemetry_enabled,
     settings_path,
 )
@@ -47,6 +49,32 @@ _PROVIDER_OPTION = typer.Option(
         "azure, bedrock."
     ),
 )
+
+
+@config_app.command("budget", help="View or set the maximum cost allowed for one command.")
+def config_budget(
+    maximum_cost_usd: float | None = typer.Argument(
+        None,
+        min=0,
+        metavar="USD",
+        help="Finite nonnegative per-command ceiling. Omit to show the current value.",
+    ),
+    root: Path = ROOT_OPTION,
+) -> None:
+    """View or persist the user-owned per-command cost ceiling.
+
+    Args:
+        maximum_cost_usd: Optional finite nonnegative ceiling in USD.
+        root: WMO artifact root containing ``settings.toml``.
+
+    Raises:
+        typer.BadParameter: Stored settings or the requested ceiling are invalid.
+    """
+    with usage_error(ValueError):
+        if maximum_cost_usd is not None:
+            set_maximum_command_cost_usd(maximum_cost_usd, root)
+        configured = resolve_command_budget_usd(root, None)
+    _console.print(f"maximum command cost: ${configured:.2f} ({settings_path(root)})")
 
 
 @config_app.command("telemetry", help="View or change project-local usage telemetry settings.")

--- a/wmo/cli/config_cmd_test.py
+++ b/wmo/cli/config_cmd_test.py
@@ -1,0 +1,45 @@
+"""CLI tests for project-local WMO settings commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click import unstyle
+from typer.testing import CliRunner
+
+from wmo.cli.app import app
+from wmo.common.config.settings import load_settings
+
+_RUNNER = CliRunner()
+
+
+def test_budget_status_reports_the_default_without_writing(tmp_path: Path) -> None:
+    """Reading the default is deterministic and does not create settings state."""
+    root = tmp_path / ".wmo"
+
+    result = _RUNNER.invoke(app, ["config", "budget", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "maximum command cost: $10.00" in unstyle(result.output)
+    assert not root.exists()
+
+
+def test_budget_command_persists_an_exact_noninteractive_limit(tmp_path: Path) -> None:
+    """Agents can set the shared ceiling with one flag-complete command."""
+    root = tmp_path / ".wmo"
+
+    result = _RUNNER.invoke(app, ["config", "budget", "12.5", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "maximum command cost: $12.50" in unstyle(result.output)
+    assert load_settings(root).commands.maximum_cost_usd == 12.5
+
+
+def test_budget_command_rejects_a_negative_limit_without_writing(tmp_path: Path) -> None:
+    """The CLI cannot persist a limit below zero."""
+    root = tmp_path / ".wmo"
+
+    result = _RUNNER.invoke(app, ["config", "budget", "-0.01", "--root", str(root)])
+
+    assert result.exit_code == 2
+    assert not root.exists()

--- a/wmo/cli/consent.py
+++ b/wmo/cli/consent.py
@@ -1,76 +1,42 @@
-"""The one spend boundary every `wmo` command that can cost money passes through.
-
-The rule: consent to spend is SAID, never inferred. It is said by `--yes`, or by answering the
-prompt at a terminal. The absence of an interactive session (CI, cron, a pipe, `| tee`, a
-redirected `< /dev/null` or heredoc stdin) is not consent, it is the absence of anyone to ask,
-so a spending run refuses there instead of starting. Nor is a blank line or an EOF an answer:
-the safe direction is refusal, so neither can authorize spend.
-
-"Interactive" means BOTH streams. Prompting reads stdin while the console reports on stdout, so a
-terminal stdout paired with a redirected stdin does not count: taking it for interactive lets the
-prompt read whatever the redirect supplies and a blank line pass as approval.
-
-This lives in one place because a per-command copy of the rule is a per-command chance to miss a
-site, and a missed site spends a scripted caller's real money. Every spend gate calls
-`require_spend_consent`, so there is one behaviour to read and one place a new spend surface has
-to reach for.
-"""
+"""Shared cost preflight and authorization for every paid WMO command."""
 
 from __future__ import annotations
 
+import math
+import shlex
 import sys
+from collections.abc import Sequence
+from decimal import ROUND_CEILING, Decimal, InvalidOperation
+from pathlib import Path
 from typing import NoReturn
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm
 
-# Exit code for "a spending run could not ask for consent". Distinct from the decline path
-# (0, the user said no and nothing happened) and from a run failure (1), so a CI job can tell
-# "you forgot --yes" apart from "the run broke".
-NO_CONSENT_EXIT_CODE = 2
+from wmo.common.config import ARTIFACT_DIR, resolve_command_budget_usd
 
-# The two ways there turns out to be nobody to ask. Both open the same refusal, so a caller
-# reads one shape of message and always learns the flag that authorizes the spend.
-_NO_ONE_TO_ASK = (
-    "non-interactive session: cannot ask for spend consent, and consent is never inferred "
-    "from the absence of someone to ask. A prompt needs a terminal on stdin as well as "
-    "stdout, so a redirected or piped input refuses here too."
-)
-_NO_ANSWER = (
-    "input ended before the spend question was answered: cannot ask for spend consent, and "
-    "consent is never inferred from an unanswered prompt."
-)
+NO_CONSENT_EXIT_CODE = 2
 
 
 def _stdin_is_terminal() -> bool:
-    """Whether the INPUT stream is a terminal.
-
-    Its own function so a test can force the input side the way rich's `force_terminal` forces
-    the output side: `click.testing.CliRunner` installs its own non-terminal `sys.stdin` for the
-    duration of an `invoke`, so a CLI test cannot fake this by replacing `sys.stdin` itself.
-    """
+    """Return whether the input stream is an open terminal."""
     stdin = sys.stdin
     try:
         return stdin is not None and stdin.isatty()
     except ValueError:
-        # A closed stdin. Nobody to ask, which is the same answer as a redirected one.
         return False
 
 
 def can_prompt(console: Console) -> bool:
-    """Whether there is an interactive human to ask, on BOTH ends of this session.
-
-    `console.is_terminal` answers only for the OUTPUT stream. A prompt reads the INPUT one, so
-    checking the console alone let `wmo ... < /dev/null`, a heredoc, or `printf y | wmo ...`
-    through with a terminal stdout and no human behind stdin. A prompt is only honest when both
-    streams belong to the same person, so both have to be a TTY.
+    """Return whether both input and output belong to an interactive terminal.
 
     Args:
-        console: The console the command prints to, owned by the calling CLI module.
+        console: Command-owned output console.
 
     Returns:
-        True only when stdout and stdin are both a terminal.
+        True only when both terminal streams can reach the same operator.
     """
     return console.is_terminal and _stdin_is_terminal()
 
@@ -78,66 +44,202 @@ def can_prompt(console: Console) -> bool:
 def require_spend_consent(
     console: Console,
     *,
+    root: str | Path = ARTIFACT_DIR,
     yes: bool,
-    spend: str,
+    estimated_cost_usd: float,
     command: str,
-    alternative: str | None = None,
-    question: str = "Proceed?",
+    assumptions: Sequence[str],
+    non_interactive: bool = False,
+    previously_confirmed: bool = False,
 ) -> bool:
-    """Get explicit consent before the first paid call, or refuse to start.
+    """Render one cost preflight and enforce the configured authorization policy.
+
+    Estimates at or below half of the configured budget run automatically. Higher estimates up
+    to the budget require ``--yes``, a prior immutable confirmation, or an explicit terminal
+    answer. An estimate above the budget always fails before credentials or provider clients.
 
     Args:
-        console: The console the command prints to. It is passed in rather than imported
-            because each CLI module owns its own `Console`, and tests drive this through a
-            non-terminal one. Whether there is anyone to ask is `can_prompt`'s decision, which
-            reads this console's stdout state AND stdin.
-        yes: The command's `--yes` flag. Consent, already said.
-        spend: What this run would spend, in whatever unit the command can honestly quote (a
-            projected dollar figure, or the rollout/episode counts when the work is unpriced).
-            Printed in the refusal, so a scripted caller learns the size of what it just
-            declined to authorize instead of only that something was skipped.
-        command: The command being run, e.g. `wmo optimize model`, named in the refusal
-            so the message says what to re-run.
-        alternative: An optional second way out, phrased as a flag plus what it does, e.g.
-            "--dry-run to see the plan without spending".
-        question: Named confirmation question shown after the caller's spend preflight.
+        console: Command-owned output console.
+        root: WMO root that owns ``settings.toml``.
+        yes: Explicit invocation confirmation for an in-budget estimate.
+        estimated_cost_usd: Conservative upper-bound estimate for this invocation.
+        command: Complete command identity shown to the operator.
+        assumptions: Major bounded inputs used to derive the estimate.
+        non_interactive: Whether this invocation forbids terminal questions.
+        previously_confirmed: Whether immutable command state records an earlier confirmation.
 
     Returns:
-        True when consent was given, False when the user declined at a terminal. Callers exit
-        on False rather than treating it as an error: nothing was run and nothing was spent.
+        True when execution is authorized, or False after an interactive decline.
 
     Raises:
-        typer.Exit: Code 2 when `--yes` was not passed and either there was no interactive
-            session to ask at, or the prompt reached EOF instead of an answer.
+        typer.BadParameter: Settings or cost arithmetic are invalid, or the estimate exceeds the
+            configured budget.
+        typer.Exit: No explicit confirmation is available in a noninteractive session.
     """
-    if yes:
-        return True
-    if not can_prompt(console):
-        _refuse(console, _NO_ONE_TO_ASK, spend=spend, command=command, alternative=alternative)
+    estimate = _cost_decimal(estimated_cost_usd, label="estimated command cost")
+    if not assumptions:
+        raise typer.BadParameter("cost preflight requires at least one major cost assumption")
     try:
-        # `default=False`: pressing Enter, and anything else that arrives as a blank line, is a
-        # refusal. Defaulting to True made the cheapest possible input authorize the spend.
-        return Confirm.ask(f"\n{question}", default=False)
+        configured = resolve_command_budget_usd(root, None)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from None
+    budget = _cost_decimal(configured, label="configured command budget")
+    _render_preflight(
+        console,
+        command=command,
+        estimate=estimate,
+        budget=budget,
+        assumptions=assumptions,
+    )
+    if estimate > budget:
+        raise typer.BadParameter(_over_budget_message(root, estimate, budget))
+    if estimate <= budget / Decimal(2):
+        console.print("authorization: automatic (estimate is at most 50% of budget)")
+        return True
+    if yes:
+        console.print("authorization: confirmed by --yes")
+        return True
+    if previously_confirmed:
+        console.print("authorization: reused immutable prior confirmation")
+        return True
+    if non_interactive or not can_prompt(console):
+        _refuse_noninteractive(console, command=command, estimate=estimate, budget=budget)
+    prompt = (
+        f"Authorize {command} to spend up to {_format_usd(estimate)} against the "
+        f"{_format_usd(budget)} per-command budget?"
+    )
+    try:
+        return Confirm.ask(prompt, default=False, console=console)
     except EOFError:
-        # Both streams claimed to be a terminal and then the input ended anyway (Ctrl-D, or a
-        # pty that closed under us). Nobody answered, so this is the "could not ask" refusal
-        # rather than a considered no, and it exits 2 instead of leaking a traceback.
-        _refuse(console, _NO_ANSWER, spend=spend, command=command, alternative=alternative)
+        _refuse_unanswered(console, command=command, estimate=estimate, budget=budget)
 
 
-def _refuse(
+def _cost_decimal(value: float, *, label: str) -> Decimal:
+    """Convert one finite nonnegative float into stable decimal policy arithmetic.
+
+    Args:
+        value: Numeric USD value.
+        label: Field name used in failures.
+
+    Returns:
+        Exact decimal representation of the supplied float string.
+
+    Raises:
+        typer.BadParameter: The value is negative or non-finite.
+    """
+    if not math.isfinite(value) or value < 0:
+        raise typer.BadParameter(f"{label} must be finite and nonnegative")
+    try:
+        return Decimal(str(value))
+    except InvalidOperation as exc:
+        raise typer.BadParameter(f"{label} must be finite and nonnegative") from exc
+
+
+def _render_preflight(
     console: Console,
-    lead: str,
     *,
-    spend: str,
     command: str,
-    alternative: str | None,
+    estimate: Decimal,
+    budget: Decimal,
+    assumptions: Sequence[str],
+) -> None:
+    """Print the concise cost contract before making an authorization decision.
+
+    Args:
+        console: Command-owned output console.
+        command: Complete command identity.
+        estimate: Conservative invocation estimate.
+        budget: Configured per-command ceiling.
+        assumptions: Major bounded cost inputs.
+    """
+    console.print("[bold]Cost preflight[/bold]")
+    console.print(f"command: {escape(command)}")
+    console.print(f"estimated cost: {_format_usd(estimate)} (conservative maximum)")
+    console.print(f"configured budget: {_format_usd(budget)} per command")
+    console.print("assumptions: " + escape("; ".join(assumptions)))
+
+
+def _format_usd(value: Decimal) -> str:
+    """Format USD compactly while preserving sub-cent boundary evidence.
+
+    Args:
+        value: Nonnegative finite decimal USD value.
+
+    Returns:
+        Dollar-prefixed value with at least two and at most six decimal places.
+    """
+    rounded = value.quantize(Decimal("0.000001"), rounding=ROUND_CEILING)
+    rendered = f"{rounded:.6f}".rstrip("0").rstrip(".")
+    whole, separator, fraction = rendered.partition(".")
+    if not separator:
+        fraction = "00"
+    elif len(fraction) < 2:
+        fraction = fraction.ljust(2, "0")
+    return f"${whole}.{fraction}"
+
+
+def _over_budget_message(root: str | Path, estimate: Decimal, budget: Decimal) -> str:
+    """Return actionable remediation for a hard ceiling rejection.
+
+    Args:
+        root: WMO settings root.
+        estimate: Rejected conservative estimate.
+        budget: Configured ceiling.
+
+    Returns:
+        Error text naming both safe ways to proceed.
+    """
+    sufficient = estimate.quantize(Decimal("0.000001"), rounding=ROUND_CEILING)
+    amount = _format_usd(sufficient).removeprefix("$")
+    command = f"wmo config budget {amount} --root {shlex.quote(str(root))}"
+    return (
+        f"conservative estimate {_format_usd(estimate)} exceeds the configured per-command "
+        f"budget {_format_usd(budget)}. Increase the limit to at least the estimate with "
+        f"`{command}`, or reduce this command's cost inputs. --yes cannot override the ceiling"
+    )
+
+
+def _refuse_noninteractive(
+    console: Console,
+    *,
+    command: str,
+    estimate: Decimal,
+    budget: Decimal,
 ) -> NoReturn:
-    """Print what would have been spent, what would have spent it, and the flag that allows it."""
-    tail = f", or with {alternative}" if alternative else ""
+    """Exit when an above-half estimate has no deterministic confirmation.
+
+    Args:
+        console: Command-owned output console.
+        command: Complete command identity.
+        estimate: Conservative invocation estimate.
+        budget: Configured per-command ceiling.
+    """
     console.print(
-        f"\n{lead}\n"
-        f"  [bold]{command}[/bold] would spend {spend} here.\n"
-        f"Re-run the same command with --yes to consent explicitly{tail}."
+        "authorization: this estimate requires explicit confirmation because it exceeds 50% "
+        "of the configured budget. This session cannot prompt; re-run with --yes after "
+        f"reviewing {escape(command)} ({_format_usd(estimate)} of {_format_usd(budget)})."
+    )
+    raise typer.Exit(NO_CONSENT_EXIT_CODE)
+
+
+def _refuse_unanswered(
+    console: Console,
+    *,
+    command: str,
+    estimate: Decimal,
+    budget: Decimal,
+) -> NoReturn:
+    """Exit when terminal input ends before confirmation.
+
+    Args:
+        console: Command-owned output console.
+        command: Complete command identity.
+        estimate: Conservative invocation estimate.
+        budget: Configured per-command ceiling.
+    """
+    console.print(
+        "authorization: input ended before confirmation. No spend was authorized. Re-run "
+        f"{escape(command)} with --yes after reviewing {_format_usd(estimate)} of the "
+        f"{_format_usd(budget)} budget."
     )
     raise typer.Exit(NO_CONSENT_EXIT_CODE)

--- a/wmo/cli/consent_test.py
+++ b/wmo/cli/consent_test.py
@@ -1,10 +1,11 @@
-"""The shared spend boundary: consent is said, never inferred from the absence of someone to ask."""
+"""Tests for the shared cost-aware paid-command authorization boundary."""
 
 from __future__ import annotations
 
 import io
 import re
 import sys
+from pathlib import Path
 
 import pytest
 import typer
@@ -12,237 +13,318 @@ from rich.console import Console
 
 from wmo.cli import consent as consent_module
 from wmo.cli.consent import NO_CONSENT_EXIT_CODE, can_prompt, require_spend_consent
+from wmo.common.config.settings import set_maximum_command_cost_usd
 
 
 class _TerminalStdin(io.StringIO):
-    """A stdin that claims to be a terminal, with `keystrokes` already queued for the prompt."""
+    """A stdin buffer that reports itself as an interactive terminal."""
 
     def isatty(self) -> bool:
+        """Report an interactive input stream."""
         return True
 
 
 class _Answer:
-    """A `rich.prompt.Confirm` stand-in recording what it was asked, and with what default."""
+    """Record one or more confirmation prompts and return a fixed answer."""
 
     def __init__(self, answer: bool) -> None:
+        """Configure the fixed confirmation answer.
+
+        Args:
+            answer: Boolean returned for every prompt.
+        """
         self._answer = answer
         self.asked: list[str] = []
         self.defaults: list[bool] = []
 
-    def ask(self, prompt: str, *, default: bool = True) -> bool:
+    def ask(
+        self,
+        prompt: str,
+        *,
+        default: bool = True,
+        console: Console | None = None,
+    ) -> bool:
+        """Record the prompt contract and return the configured answer.
+
+        Args:
+            prompt: User-facing confirmation question.
+            default: Answer selected by a blank line.
+            console: Console passed by the production boundary.
+
+        Returns:
+            The configured fixed answer.
+        """
+        del console
         self.asked.append(prompt)
         self.defaults.append(default)
         return self._answer
 
 
 def _console(*, terminal: bool) -> tuple[Console, io.StringIO]:
+    """Return a test console and its text buffer.
+
+    Args:
+        terminal: Whether the output side reports a TTY.
+
+    Returns:
+        Console and captured output buffer.
+    """
     buffer = io.StringIO()
     return Console(file=buffer, force_terminal=terminal, width=200), buffer
 
 
 def _flat(buffer: io.StringIO) -> str:
-    """The buffer as one line of plain text: a forced-terminal console also emits ANSI."""
+    """Return captured Rich output as one ANSI-free line."""
     return " ".join(_ANSI.sub("", buffer.getvalue()).split())
+
+
+def _authorize(
+    console: Console,
+    root: Path,
+    *,
+    estimate: float,
+    yes: bool = False,
+    non_interactive: bool = False,
+    previously_confirmed: bool = False,
+) -> bool:
+    """Invoke the shared boundary with one stable command fixture.
+
+    Args:
+        console: Capturing console.
+        root: WMO settings root.
+        estimate: Conservative command estimate.
+        yes: Explicit invocation confirmation.
+        non_interactive: Whether prompting is forbidden.
+        previously_confirmed: Whether immutable command state already records confirmation.
+
+    Returns:
+        Shared authorization decision.
+    """
+    return require_spend_consent(
+        console,
+        root=root,
+        yes=yes,
+        estimated_cost_usd=estimate,
+        command="wmo optimize model support",
+        assumptions=("full frozen schedule", "one retry per managed batch"),
+        non_interactive=non_interactive,
+        previously_confirmed=previously_confirmed,
+    )
 
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
 
-def test_yes_consents_without_asking_even_at_a_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_estimate_at_exactly_half_the_budget_runs_automatically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fifty percent belongs to the automatic side of the policy."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
     answer = _Answer(False)
     monkeypatch.setattr(consent_module, "Confirm", answer)
-    console, buffer = _console(terminal=True)
+    console, buffer = _console(terminal=False)
 
-    assert require_spend_consent(console, yes=True, spend="~$12.00", command="wmo optimize model")
+    assert _authorize(console, root, estimate=10.0)
     assert answer.asked == []
-    assert buffer.getvalue() == ""
+    rendered = _flat(buffer)
+    assert "Cost preflight" in rendered
+    assert "command: wmo optimize model support" in rendered
+    assert "estimated cost: $10.00" in rendered
+    assert "configured budget: $20.00 per command" in rendered
+    assert "full frozen schedule; one retry per managed batch" in rendered
+    assert "automatic" in rendered
 
 
-def test_a_terminal_is_asked_and_a_no_declines(
-    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
+def test_estimate_just_above_half_requires_a_clear_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interactive_stdin: None,
 ) -> None:
-    answer = _Answer(False)
+    """The first value above fifty percent opens the explicit prompt."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    answer = _Answer(True)
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, _buffer = _console(terminal=True)
 
-    assert not require_spend_consent(
-        console, yes=False, spend="~$12.00", command="wmo optimize model"
-    )
+    assert _authorize(console, root, estimate=10.000001)
+    assert len(answer.asked) == 1
+    prompt = answer.asked[0]
+    assert "wmo optimize model support" in prompt
+    assert "$10.000001" in prompt
+    assert "$20.00 per-command budget" in prompt
+    assert answer.defaults == [False]
+
+
+def test_estimate_at_exactly_the_budget_requires_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interactive_stdin: None,
+) -> None:
+    """One hundred percent is allowed only with explicit confirmation."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    answer = _Answer(True)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    assert _authorize(console, root, estimate=20.0)
     assert len(answer.asked) == 1
 
 
-def test_a_terminal_is_asked_and_a_yes_consents(
-    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
-) -> None:
-    answer = _Answer(True)
-    monkeypatch.setattr(consent_module, "Confirm", answer)
-    console, _buffer = _console(terminal=True)
-
-    assert require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
-    assert len(answer.asked) == 1
-
-
-def test_a_caller_can_name_the_spend_question(
-    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
-) -> None:
-    """A paid workflow can replace the generic prompt with its named operation."""
-    answer = _Answer(True)
-    monkeypatch.setattr(consent_module, "Confirm", answer)
-    console, _buffer = _console(terminal=True)
-
-    assert require_spend_consent(
-        console,
-        yes=False,
-        spend="at most $1.00",
-        command="wmo config judge calibrate",
-        question="Run this named judge calibration within the displayed ceiling?",
-    )
-
-    assert answer.asked == ["\nRun this named judge calibration within the displayed ceiling?"]
-
-
-def test_no_terminal_and_no_yes_refuses_naming_the_spend_and_the_flag(
+def test_estimate_above_budget_fails_even_with_yes(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A pipe, CI, or cron is not consent to spend: the run exits 2 instead of starting.
-
-    The refusal has to be actionable on its own, so it carries what would have been spent, the
-    command that would have spent it, and the flag that authorizes it.
-    """
+    """The invocation confirmation never overrides the configured ceiling."""
+    root = tmp_path / ".wmo root"
+    set_maximum_command_cost_usd(20.0, root)
     answer = _Answer(True)
     monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=True)
+
+    with pytest.raises(typer.BadParameter) as caught:
+        _authorize(console, root, estimate=20.000001, yes=True)
+
+    assert answer.asked == []
+    message = str(caught.value)
+    assert "exceeds the configured per-command budget" in message
+    assert "wmo config budget 20.000001 --root" in message
+    assert "wmo root" in message
+    assert "--yes cannot override" in message
+    assert "estimated cost: $20.000001" in _flat(buffer)
+
+
+def test_sub_microdollar_estimates_are_displayed_conservatively(tmp_path: Path) -> None:
+    """Visible estimates never round a positive conservative ceiling down to zero."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(1.0, root)
     console, buffer = _console(terminal=False)
 
-    with pytest.raises(typer.Exit) as caught:
-        require_spend_consent(
-            console,
-            yes=False,
-            spend="~$12.00 across 240 cell(s)",
-            command="wmo optimize model",
-        )
+    assert _authorize(console, root, estimate=0.0000001)
 
-    assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
-    assert answer.asked == []  # nothing was asked, because there was nobody to ask
-    flat = _flat(buffer)
-    assert "cannot ask for spend consent" in flat
-    assert "wmo optimize model would spend ~$12.00 across 240 cell(s) here" in flat
-    assert "Re-run the same command with --yes to consent explicitly." in flat
+    assert "estimated cost: $0.000001" in _flat(buffer)
 
 
-def test_the_refusal_names_a_second_way_out_when_the_command_has_one() -> None:
-    console, buffer = _console(terminal=False)
-
-    with pytest.raises(typer.Exit):
-        require_spend_consent(
-            console,
-            yes=False,
-            spend="~$1.65",
-            command="wmo optimize model",
-            alternative="--dry-run to see the plan without spending",
-        )
-
-    assert "or with --dry-run to see the plan without spending" in _flat(buffer)
-
-
-# -- the input stream is half of "interactive" --------------------------------------------------
-# Checking only the console asked the wrong stream: the console reports on stdout while the
-# prompt reads stdin, so `wmo optimize model < /dev/null` at a terminal passed the gate
-# and then had a redirect answer the money question for the absent human.
-
-
-def test_a_terminal_stdout_with_redirected_stdin_refuses(
+def test_noninteractive_above_half_requires_yes(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The hole: a TTY stdout is not a human if stdin comes from a file, a pipe, or a heredoc.
-
-    Under pytest `sys.stdin` is already a non-terminal stub, which is exactly the redirected
-    case, so only the console is forced here.
-    """
+    """Automation gets an exit-2 instruction instead of an implicit answer."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
     answer = _Answer(True)
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, buffer = _console(terminal=True)
 
     with pytest.raises(typer.Exit) as caught:
-        require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
+        _authorize(console, root, estimate=15.0, non_interactive=True)
 
     assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
-    assert answer.asked == []  # never offered, so a redirect could not answer it
-    flat = _flat(buffer)
-    assert "cannot ask for spend consent" in flat
-    # The reader IS at a terminal, so the refusal has to name the stream that is not one.
-    assert "needs a terminal on stdin as well as stdout" in flat
+    assert answer.asked == []
+    rendered = _flat(buffer)
+    assert "requires explicit confirmation" in rendered
+    assert "re-run with --yes" in rendered
+    assert "$15.00" in rendered
+    assert "$20.00" in rendered
 
 
-def test_can_prompt_needs_both_streams(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Either stream alone is not an interactive session."""
+def test_noninteractive_yes_confirms_an_in_budget_estimate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A complete agent invocation can authorize an above-half estimate."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=False)
+
+    assert _authorize(console, root, estimate=15.0, yes=True, non_interactive=True)
+    assert answer.asked == []
+    assert "confirmed by --yes" in _flat(buffer)
+
+
+def test_prior_immutable_confirmation_avoids_a_repeat_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A paid resume reuses its recorded confirmation while respecting the current ceiling."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=False)
+
+    assert _authorize(console, root, estimate=15.0, previously_confirmed=True)
+    assert answer.asked == []
+    assert "immutable prior confirmation" in _flat(buffer)
+
+
+def test_interactive_decline_returns_false_without_authorizing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    interactive_stdin: None,
+) -> None:
+    """A clearly worded prompt still permits an explicit refusal."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    assert not _authorize(console, root, estimate=15.0)
+    assert len(answer.asked) == 1
+
+
+def test_zero_budget_allows_only_a_zero_cost_replay(tmp_path: Path) -> None:
+    """A zero ceiling disables paid work while preserving deterministic replay."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(0.0, root)
+    console, _buffer = _console(terminal=False)
+
+    assert _authorize(console, root, estimate=0.0)
+    with pytest.raises(typer.BadParameter):
+        _authorize(console, root, estimate=0.000001, yes=True)
+
+
+def test_can_prompt_requires_both_terminal_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Terminal output alone cannot make redirected input interactive."""
     terminal, _ = _console(terminal=True)
     piped, _ = _console(terminal=False)
 
     monkeypatch.setattr(sys, "stdin", _TerminalStdin())
     assert can_prompt(terminal)
-    assert not can_prompt(piped)  # terminal stdin, redirected stdout
+    assert not can_prompt(piped)
 
     monkeypatch.setattr(sys, "stdin", io.StringIO("y\n"))
-    assert not can_prompt(terminal)  # terminal stdout, redirected stdin
+    assert not can_prompt(terminal)
     assert not can_prompt(piped)
 
 
-def test_a_closed_stdin_is_not_an_interactive_session(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`isatty()` raises on a closed stream; that is nobody to ask, not a crash."""
-    closed = io.StringIO()
-    closed.close()  # a later isatty() raises ValueError
-    monkeypatch.setattr(sys, "stdin", closed)
-    console, _buffer = _console(terminal=True)
-
-    assert not can_prompt(console)
-
-
-def test_a_blank_answer_refuses_instead_of_authorizing_the_spend(
+def test_eof_at_confirmation_is_an_actionable_refusal(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real `Confirm`, a real blank line: the cheapest possible input must not buy anything.
-
-    `default=True` made pressing Enter (and every blank line a redirect can supply) an approval.
-    The default is the answer given when nothing was said, so it has to be the refusal.
-    """
-    monkeypatch.setattr(sys, "stdin", _TerminalStdin("\n"))
-    console, _buffer = _console(terminal=True)
-
-    assert not require_spend_consent(
-        console, yes=False, spend="~$12.00", command="wmo optimize model"
-    )
-
-
-def test_eof_at_the_prompt_is_the_documented_refusal_not_a_traceback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An input that ends without answering exits 2 with the refusal, not an `EOFError`."""
-    monkeypatch.setattr(sys, "stdin", _TerminalStdin(""))  # readline() -> "" -> EOFError
+    """An unanswered interactive prompt exits cleanly without authorizing spend."""
+    root = tmp_path / ".wmo"
+    set_maximum_command_cost_usd(20.0, root)
+    monkeypatch.setattr(sys, "stdin", _TerminalStdin(""))
     console, buffer = _console(terminal=True)
 
     with pytest.raises(typer.Exit) as caught:
-        require_spend_consent(
-            console,
-            yes=False,
-            spend="~$12.00 across 240 cell(s)",
-            command="wmo optimize model",
-        )
+        _authorize(console, root, estimate=15.0)
 
     assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
-    flat = _flat(buffer)
-    assert "cannot ask for spend consent" in flat
-    assert "wmo optimize model would spend ~$12.00 across 240 cell(s) here" in flat
-    assert "Re-run the same command with --yes to consent explicitly." in flat
+    assert "input ended before confirmation" in _flat(buffer)
 
 
-def test_the_prompt_defaults_to_refusing(
-    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
-) -> None:
-    """Belt and braces on the default itself, in the units the stand-in tests are written in."""
-    answer = _Answer(False)
-    monkeypatch.setattr(consent_module, "Confirm", answer)
-    console, _buffer = _console(terminal=True)
+@pytest.mark.parametrize("estimate", [-0.01, float("inf"), float("nan")])
+def test_invalid_estimate_fails_closed(tmp_path: Path, estimate: float) -> None:
+    """Unsafe arithmetic cannot reach an automatic or confirmed decision."""
+    console, _buffer = _console(terminal=False)
 
-    require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize model")
-
-    assert answer.defaults == [False]
+    with pytest.raises(typer.BadParameter, match="finite and nonnegative"):
+        _authorize(console, tmp_path / ".wmo", estimate=estimate, yes=True)

--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
-from decimal import Decimal
 from pathlib import Path
 
 import typer
@@ -25,7 +25,6 @@ from wmo.common.project import ProjectStore
 from wmo.common.release_revision import installed_release_revision
 from wmo.optimize.router.judging.artifacts import read_audit, require_review_state
 from wmo.optimize.router.judging.contracts import (
-    JudgeCalibrationBudget,
     JudgePromptTemplate,
     JudgeTracePreview,
     ManualJudgeCalibrationResult,
@@ -137,7 +136,7 @@ def judge_setup(
 
 @judge_app.command(
     "calibrate",
-    help="Label real traces, run consented judge calls, and separately approve calibration.",
+    help="Label real traces, authorize bounded judge calls, and separately approve calibration.",
 )
 def judge_calibrate(
     project: str = typer.Argument(..., metavar="PROJECT", help="Configured local project ID."),
@@ -165,7 +164,11 @@ def judge_calibrate(
         min=0.000001,
         help="Calibration spend ceiling. Defaults to the shared command-budget setting, then $10.",
     ),
-    yes: bool = typer.Option(False, "--yes", help="Consent to the displayed judge spend."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Confirm an in-budget estimate when the shared policy requires it.",
+    ),
     approve: bool = typer.Option(
         False, "--approve", help="Approve the report after it is displayed."
     ),
@@ -187,7 +190,7 @@ def judge_calibrate(
         help="Page full transcripts in an interactive terminal instead of truncating them.",
     ),
 ) -> None:
-    """Collect frozen labels, run consented judge calls, and separately approve evidence.
+    """Collect frozen labels, authorize bounded judge calls, and separately approve evidence.
 
     Args:
         project: Local project ID below ``<root>/projects``.
@@ -198,7 +201,7 @@ def judge_calibrate(
         output_price: Optional advanced output-price override.
         maximum_input_tokens: Conservative input bound for every call attempt.
         maximum_cost_usd: Optional spend ceiling; otherwise the shared command-budget setting.
-        yes: Explicit spend consent only.
+        yes: Explicit confirmation for an in-budget estimate above the automatic threshold.
         approve: Separate approval of the displayed completed report.
         accept_insufficient_labels: Explicit risk acceptance below ten labeled rollouts.
         non_interactive: Refuse prompts and list missing explicit inputs.
@@ -206,7 +209,7 @@ def judge_calibrate(
         page: Page untruncated transcripts through the interactive terminal.
 
     Raises:
-        typer.BadParameter: Evidence, labels, budget, consent, or approval is invalid.
+        typer.BadParameter: Evidence, labels, budget, authorization, or approval is invalid.
     """
     with usage_error(OSError, ValueError, ManualJudgeError):
         revision = installed_release_revision()
@@ -228,14 +231,28 @@ def judge_calibrate(
             )
         else:
             catalog = load_model_catalog(store.model_catalog_path)
+            shared_ceiling = resolve_command_budget_usd(root, None)
+            calibration_ceiling = (
+                shared_ceiling
+                if maximum_cost_usd is None
+                else min(shared_ceiling, maximum_cost_usd)
+            )
             budget = estimate_manual_judge_budget(
                 plan,
                 catalog=catalog,
                 input_usd_per_million_tokens=input_price,
                 output_usd_per_million_tokens=output_price,
                 maximum_input_tokens_per_call=maximum_input_tokens,
-                maximum_cost_usd=resolve_command_budget_usd(root, maximum_cost_usd),
+                maximum_cost_usd=sys.float_info.max,
             )
+            if (
+                maximum_cost_usd is not None
+                and budget.estimated_cost_usd > maximum_cost_usd
+            ):
+                raise ValueError(
+                    "judge calibration estimate exceeds --maximum-cost-usd; raise the ceiling "
+                    "or reduce the labeled sample"
+                )
         if page and not completed and not can_prompt(_console):
             raise ValueError("--page requires an interactive terminal; omit it for wrapped output")
 
@@ -247,23 +264,50 @@ def judge_calibrate(
             """
             save_label_draft(store, plan.setup, sample_sha256, collected, now)
 
-    if not completed:
-        _render_spend_preflight(plan, budget)
-        spend = (
-            f"at most ${_format_usd(budget.estimated_cost_usd)} across "
-            f"{budget.call_count} judge calls "
-            f"with up to {budget.maximum_attempts_per_call} attempts each, inside the "
-            f"${_format_usd(budget.maximum_cost_usd)} ceiling"
+    estimate = 0.0 if completed else budget.estimated_cost_usd
+    assumptions = (
+        (
+            "verified immutable calibration replay",
+            "zero new judge calls",
         )
-        if not require_spend_consent(
-            _console,
-            yes=yes,
-            spend=spend,
-            command="wmo config judge calibrate",
-            question="Run this named judge calibration within the displayed ceiling?",
-        ):
-            _console.print("Judge calibration was not started. No labels or provider calls ran.")
-            return
+        if completed
+        else (
+            f"judge {plan.setup.judge_alias}: {model_display_name(plan.setup.judge_model)}",
+            (
+                f"{budget.call_count} judge calls with up to "
+                f"{budget.maximum_attempts_per_call} attempts each"
+            ),
+            (
+                f"{budget.maximum_input_tokens_per_call} input and "
+                f"{budget.maximum_output_tokens_per_call} output tokens per attempt"
+            ),
+            (
+                f"${budget.input_usd_per_million_tokens:.6f} input and "
+                f"${budget.output_usd_per_million_tokens:.6f} output per million tokens"
+            ),
+        )
+    )
+    if not require_spend_consent(
+        _console,
+        root=root,
+        yes=yes,
+        estimated_cost_usd=estimate,
+        command=f"wmo config judge calibrate {project}",
+        assumptions=assumptions,
+        non_interactive=non_interactive,
+    ):
+        _console.print("Judge calibration was not started. No labels or provider calls ran.")
+        return
+    if not completed:
+        with usage_error(OSError, ValueError, ManualJudgeError):
+            budget = estimate_manual_judge_budget(
+                plan,
+                catalog=catalog,
+                input_usd_per_million_tokens=input_price,
+                output_usd_per_million_tokens=output_price,
+                maximum_input_tokens_per_call=maximum_input_tokens,
+                maximum_cost_usd=max(calibration_ceiling, 0.000001),
+            )
         if drafted:
             _console.print(f"Resuming {len(drafted)} saved human labels for this trace sample.")
         _render_calibration_review(
@@ -382,48 +426,6 @@ def _render_setup(plan: ManualJudgeSetupPlan) -> None:
     for index, preview in enumerate(plan.previews, start=1):
         _console.print(f"{index}. {preview.task}", markup=False)
         _console.print(f"   Recorded outcome: {preview.outcome}", markup=False)
-
-
-def _render_spend_preflight(
-    plan: ManualJudgeCalibrationPlan,
-    budget: JudgeCalibrationBudget,
-) -> None:
-    """Display the exact judge identity and conservative spend admission.
-
-    Args:
-        plan: Frozen calibration plan naming the exact judge model.
-        budget: Conservative complete-call reservation already checked against its ceiling.
-    """
-    _console.print("\n[bold]Spend preflight: manual judge calibration[/bold]")
-    _console.print(f"Judge name: {plan.setup.judge_alias}", markup=False)
-    _console.print(f"Exact model: {model_display_name(plan.setup.judge_model)}", markup=False)
-    _console.print(f"Pricing: {budget.pricing_source.value}", markup=False)
-    _console.print(f"Judge calls authorized: {budget.call_count}", markup=False)
-    _console.print(
-        f"Tokens: up to {budget.maximum_input_tokens_per_call} input and "
-        f"{budget.maximum_output_tokens_per_call} output per attempt",
-        markup=False,
-    )
-    _console.print(
-        f"Maximum estimated cost: ${_format_usd(budget.estimated_cost_usd)}", markup=False
-    )
-    _console.print(f"Hard spend ceiling: ${_format_usd(budget.maximum_cost_usd)}", markup=False)
-    _console.print(f"Maximum attempts per call: {budget.maximum_attempts_per_call}", markup=False)
-
-
-def _format_usd(value: float) -> str:
-    """Format an admitted dollar bound without rounding a positive value to zero.
-
-    Args:
-        value: Finite nonnegative estimated cost or positive hard ceiling.
-
-    Returns:
-        Fixed-point decimal text preserving the float's round-trip value and at least four
-        fractional digits.
-    """
-    whole, separator, fraction = format(Decimal(str(value)), "f").partition(".")
-    significant_fraction = fraction.rstrip("0") if separator else ""
-    return f"{whole}.{significant_fraction.ljust(4, '0')}"
 
 
 def _render_calibration_review(

--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -245,10 +245,7 @@ def judge_calibrate(
                 maximum_input_tokens_per_call=maximum_input_tokens,
                 maximum_cost_usd=sys.float_info.max,
             )
-            if (
-                maximum_cost_usd is not None
-                and budget.estimated_cost_usd > maximum_cost_usd
-            ):
+            if maximum_cost_usd is not None and budget.estimated_cost_usd > maximum_cost_usd:
                 raise ValueError(
                     "judge calibration estimate exceeds --maximum-cost-usd; raise the ceiling "
                     "or reduce the labeled sample"

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -28,7 +28,6 @@ from wmo.common.models import (
 )
 from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
 from wmo.optimize.router.judging.contracts import (
-    JudgeCalibrationBudget,
     JudgeTracePreview,
     ManualJudgeLabel,
     ManualJudgeSetupArtifact,
@@ -284,38 +283,6 @@ def test_setup_output_is_plain_language_and_hides_execution_internals(
     assert "response schema" not in output.lower()
     assert "Score projection" not in output
     assert "0000000000000000" not in output
-
-
-def test_spend_preflight_preserves_a_small_positive_bound(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A small admitted estimate and ceiling never display as zero."""
-    buffer = io.StringIO()
-    monkeypatch.setattr(
-        judge_config_module,
-        "_console",
-        Console(file=buffer, width=80, color_system=None),
-    )
-    plan = cast(
-        ManualJudgeCalibrationPlan,
-        SimpleNamespace(setup=SimpleNamespace(judge_alias="judge", judge_model=_model())),
-    )
-    budget = JudgeCalibrationBudget(
-        input_usd_per_million_tokens=0,
-        output_usd_per_million_tokens=0,
-        maximum_input_tokens_per_call=1,
-        maximum_attempts_per_call=1,
-        call_count=1,
-        estimated_cost_usd=0.000049,
-        maximum_cost_usd=0.000049,
-    )
-
-    judge_config_module._render_spend_preflight(plan, budget)
-
-    output = buffer.getvalue()
-    assert "Maximum estimated cost: $0.000049" in output
-    assert "Hard spend ceiling: $0.000049" in output
-    assert "$0.0000\n" not in output
 
 
 def test_pairwise_calibration_renders_roles_and_truthful_truncation(

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -148,6 +148,10 @@ def test_calibrate_prints_catalog_pricing_breakdown_before_labels(tmp_path: Path
     store = _built_store(tmp_path)
     _setup(store)
     _write_catalog(store.paths.root, _priced_catalog())
+    (store.paths.root / "settings.toml").write_text(
+        "[commands]\nmaximum_cost_usd = 0.5\n",
+        encoding="utf-8",
+    )
 
     result = CliRunner().invoke(
         app,
@@ -164,15 +168,17 @@ def test_calibrate_prints_catalog_pricing_breakdown_before_labels(tmp_path: Path
         ],
     )
 
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert result.exit_code == 2
-    assert "Judge name: judge-main" in output
-    assert "Exact model: openai/judge-model" in output
-    assert "Pricing: configured" in output
-    assert "Judge calls authorized: 3" in output
-    assert "Tokens: up to 32768 input and 4096 output per attempt" in output
-    assert "Maximum estimated cost:" in output
-    assert "Hard spend ceiling: $10.0000" in output
+    assert "Cost preflight" in output
+    assert "command: wmo config judge calibrate support" in output
+    assert "estimated cost: $0.368641 (conservative maximum)" in output
+    assert "configured budget: $0.50 per command" in output
+    assert "judge judge-main: openai/judge-model" in output
+    assert "3 judge calls with up to 3 attempts each" in output
+    assert "32768 input and 4096 output tokens per attempt" in output
+    assert "$1.000000 input and $2.000000 output per million tokens" in output
+    assert "re-run with --yes" in output
     assert "missing labels" not in output
 
 
@@ -195,7 +201,7 @@ def test_calibrate_fails_closed_when_catalog_pricing_is_missing(tmp_path: Path) 
         ],
     )
 
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert result.exit_code == 2
     assert "no trustworthy input/output" in output
     assert "missing labels" not in output
@@ -227,9 +233,11 @@ def test_calibrate_uses_shared_command_budget_when_flag_is_omitted(tmp_path: Pat
         ],
     )
 
-    output = unstyle(result.output)
+    output = " ".join(unstyle(result.output).replace("│", " ").split())
     assert result.exit_code == 2
-    assert "exceeds --maximum-cost-usd" in output
+    assert "exceeds the configured per-command" in output
+    assert "wmo config budget 0.368641" in output
+    assert "--yes cannot override" in output
     assert "missing labels" not in output
 
 

--- a/wmo/cli/model_optimize.py
+++ b/wmo/cli/model_optimize.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -12,7 +11,7 @@ import typer
 from rich.console import Console
 from rich.prompt import Confirm, FloatPrompt, Prompt
 
-from wmo.cli.consent import require_spend_consent
+from wmo.cli.consent import can_prompt, require_spend_consent
 from wmo.cli.options import ROOT_OPTION, usage_error
 from wmo.common.core.artifacts import Sha256, sha256_json
 from wmo.common.core.locks import file_write_lock
@@ -73,7 +72,7 @@ def optimize_model(
     yes: bool = typer.Option(
         False,
         "--yes",
-        help="Confirm managed Tinker execution after all validation and risk gates pass.",
+        help="Confirm an in-budget estimate when the shared policy requires it.",
     ),
     tinker_connection: str | None = typer.Option(
         None,
@@ -107,19 +106,24 @@ def optimize_model(
         min=0,
         help="Explicit Tinker training price used for conservative local reservation.",
     ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Require complete flags and never ask setup or cost questions.",
+    ),
 ) -> None:
     """Build routed interactions into W12 and run bounded W13 SFT automatically.
 
     The command seals the current validated runtime journal prefix, reuses or creates its
     immutable W12 dataset and bounded config, then validates the complete local input graph before
-    consent. Failed and disconnected interactions never become training targets. A trained alias
-    is registered only after recursively verifying W13's completed result and opaque sampling
-    handle.
+    cost authorization. Failed and disconnected interactions never become training targets. A
+    trained alias is registered only after recursively verifying W13's completed result and
+    opaque sampling handle.
 
     Args:
         project: Local project ID below ``<root>/projects``.
         root: Local ``.wmo`` root containing the project and ``models.toml``.
-        yes: Explicit consent for managed execution only, never a validation or risk bypass.
+        yes: Explicit confirmation for an in-budget estimate, never a validation or risk bypass.
         tinker_connection: Native Tinker connection name used for first-run setup.
         tinker_api_key_env: Environment-variable name used by training and later sampling.
         base_model_alias: Local alias for the exact first-run Tinker base model.
@@ -127,6 +131,7 @@ def optimize_model(
         maximum_cost_usd: Optional first-run or consistency-checked managed-training cost cap.
         training_usd_per_million_tokens: Explicit model-specific training price. Zero is accepted
             only when supplied by the user or entered during interactive setup.
+        non_interactive: Require complete flags and refuse every prompt.
 
     Raises:
         typer.BadParameter: Local configuration, preflight, W13, or registration is unsafe.
@@ -146,6 +151,7 @@ def optimize_model(
             base_model=base_model,
             maximum_cost_usd=maximum_cost_usd,
             training_usd_per_million_tokens=training_usd_per_million_tokens,
+            non_interactive=non_interactive,
         )
         preparation = prepare_runtime_sft_model_optimization(
             store,
@@ -178,22 +184,35 @@ def optimize_model(
         backend: TrainerBackend = _LocalPreflightBackend()
         preflight = local_preflight
 
-    if preflight.completed_result is None and not preparation.accepted:
-        assert config.training.maximum_cost_usd is not None
+    if preflight.completed_result is None:
         assert preflight.conservative_schedule_cost_usd is not None
-        spend = (
-            "the managed Tinker SFT run bounded by immutable maximum_cost_usd "
-            f"${config.training.maximum_cost_usd:.2f} with a full-schedule conservative "
-            f"upper bound of ${preflight.conservative_schedule_cost_usd.value:.2f}"
+        assert config.training.maximum_datum_tokens is not None
+        assert config.training.training_usd_per_million_tokens is not None
+        estimate = preflight.conservative_schedule_cost_usd.value
+        assumptions = (
+            f"{len(preflight.planned_batch_counts)} frozen managed batches",
+            f"up to {config.training.maximum_datum_tokens} tokens per training datum",
+            (f"${config.training.training_usd_per_million_tokens:.6f} per million training tokens"),
         )
-        if not require_spend_consent(
-            _console,
-            yes=yes,
-            spend=spend,
-            command="wmo optimize model",
-        ):
-            _console.print("Managed Tinker SFT was not started.")
-            return
+    else:
+        estimate = 0.0
+        assumptions = (
+            "verified immutable completed SFT replay",
+            "zero new managed training calls",
+        )
+    if not require_spend_consent(
+        _console,
+        root=root,
+        yes=yes,
+        estimated_cost_usd=estimate,
+        command=f"wmo optimize model {project}",
+        assumptions=assumptions,
+        non_interactive=non_interactive,
+        previously_confirmed=preparation.accepted and preflight.completed_result is None,
+    ):
+        _console.print("Managed Tinker SFT was not started.")
+        return
+    if preflight.completed_result is None and not preparation.accepted:
         with usage_error(AutomaticSFTPreparationError):
             accept_runtime_sft_model_optimization(
                 store,
@@ -257,6 +276,7 @@ def _initial_settings(
     base_model: str | None,
     maximum_cost_usd: float | None,
     training_usd_per_million_tokens: float | None,
+    non_interactive: bool,
 ) -> InitialSFTModelOptimizationSettings | None:
     """Collect and persist only missing first-run Tinker catalog selections.
 
@@ -267,8 +287,9 @@ def _initial_settings(
         tinker_api_key_env: Optional environment-variable name for the Tinker credential.
         base_model_alias: Optional explicit local base-model alias from the CLI.
         base_model: Optional exact Tinker model ID for a new alias.
-        maximum_cost_usd: Optional finite immutable training cap shown before provider consent.
+        maximum_cost_usd: Optional finite immutable training cap shown before cost authorization.
         training_usd_per_million_tokens: Optional explicit model-specific training price.
+        non_interactive: Whether setup questions are forbidden.
 
     Returns:
         Confirmed first-run settings, or ``None`` when an immutable selection already exists.
@@ -291,7 +312,7 @@ def _initial_settings(
         return None
     catalog = load_model_catalog(store.model_catalog_path)
     catalog_sha256 = sha256_json(catalog)
-    interactive = sys.stdin.isatty()
+    interactive = not non_interactive and can_prompt(_console)
     connection_name = tinker_connection
     alias = base_model_alias
     if interactive:

--- a/wmo/cli/model_optimize_test.py
+++ b/wmo/cli/model_optimize_test.py
@@ -1279,7 +1279,7 @@ def test_command_budget_rejects_sft_before_credentials_even_with_yes(
         raise AssertionError("Tinker construction must follow command budget authorization")
 
     monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
-    monkeypatch.setattr(command, "_current_revision", lambda: "command-budget-test")
+    monkeypatch.setattr(command, "installed_release_revision", lambda: "command-budget-test")
 
     result = CliRunner().invoke(
         app,

--- a/wmo/cli/model_optimize_test.py
+++ b/wmo/cli/model_optimize_test.py
@@ -13,6 +13,7 @@ from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
+from wmo.common.config.settings import set_maximum_command_cost_usd
 from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
     AssistantAction,
@@ -398,14 +399,7 @@ def test_first_run_setup_cancellation_writes_no_catalog_or_training_state(
         now=_TIME,
     )
 
-    class _TTY:
-        """Minimal stdin contract used only to select interactive setup behavior."""
-
-        def isatty(self) -> bool:
-            """Report that setup may prompt interactively."""
-            return True
-
-    monkeypatch.setattr(command.sys, "stdin", _TTY())
+    monkeypatch.setattr(command, "can_prompt", lambda _console: True)
     monkeypatch.setattr(command.Prompt, "ask", lambda *args, **kwargs: next(answers))
     monkeypatch.setattr(command.Confirm, "ask", lambda *args, **kwargs: False)
 
@@ -432,6 +426,7 @@ def test_first_run_setup_cancellation_writes_no_catalog_or_training_state(
             base_model=None,
             maximum_cost_usd=25.0,
             training_usd_per_million_tokens=100.0,
+            non_interactive=False,
         )
 
     assert fixture.store.model_catalog_path.read_bytes() == catalog_bytes
@@ -901,7 +896,7 @@ def test_completion_during_consent_fails_before_run_acceptance_and_reconsents(
 def test_accepted_prefix_resumes_after_crash_and_defers_later_completion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Resume one accepted prefix without reconsent and train later appends next.
+    """Resume one accepted prefix without a repeat prompt and train later appends next.
 
     Args:
         tmp_path: Pytest-owned project directory.
@@ -980,18 +975,23 @@ def test_accepted_prefix_resumes_after_crash_and_defers_later_completion(
         now=_TIME,
     )
 
-    def reject_repeat_consent(*args: object, **kwargs: object) -> Never:
-        """Fail if recovery asks again for consent already bound to the accepted prefix.
+    def verify_prior_confirmation(*args: object, **kwargs: object) -> bool:
+        """Verify recovery presents its accepted prefix to the shared budget policy.
 
         Args:
-            args: Unexpected consent positional inputs.
-            kwargs: Unexpected consent keyword inputs.
+            args: Shared preflight positional inputs accepted without inspection.
+            kwargs: Shared preflight fields including immutable confirmation evidence.
+
+        Returns:
+            ``True`` after proving the prior confirmation is retained.
         """
-        del args, kwargs
-        raise AssertionError("accepted incomplete W13 run must resume without new consent")
+        del args
+        assert kwargs["previously_confirmed"] is True
+        consent_calls.append("accepted-resume")
+        return True
 
     resumed_backend = _FakeBackend(conservative_cost_per_batch=0.10)
-    monkeypatch.setattr(command, "require_spend_consent", reject_repeat_consent)
+    monkeypatch.setattr(command, "require_spend_consent", verify_prior_confirmation)
     monkeypatch.setattr(
         command,
         "_compose_tinker_backend",
@@ -1001,6 +1001,7 @@ def test_accepted_prefix_resumes_after_crash_and_defers_later_completion(
     resumed = runner.invoke(app, arguments)
 
     assert resumed.exit_code == 0, resumed.output
+    assert consent_calls == ["initial", "accepted-resume"]
     assert compose_calls == ["crash", "resume"]
     assert len(resumed_backend.trained_example_ids) == 1
     assert load_latest_sft_model_optimization(configured.store) == latest_before_append
@@ -1246,6 +1247,59 @@ def test_schedule_ceiling_refuses_before_tinker_backend_construction(
 
     assert result.exit_code == 2
     assert "exceedsmaximum_cost_usd" in _flat_cli_output(result.output)
+    assert backend_calls == []
+
+
+def test_command_budget_rejects_sft_before_credentials_even_with_yes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared ceiling rejects a priced schedule before Tinker construction.
+
+    Args:
+        tmp_path: Pytest-owned project and settings directory.
+        monkeypatch: Backend and revision replacements proving zero remote setup.
+    """
+    configured = _configured_project(tmp_path, _spec(maximum_cost_usd=1.0))
+    set_maximum_command_cost_usd(0.01, configured.store.paths.root)
+    command = importlib.import_module("wmo.cli.model_optimize")
+    backend_calls: list[bool] = []
+
+    def forbidden_backend(*args: object) -> Never:
+        """Fail if the rejected command reads credentials or constructs Tinker.
+
+        Args:
+            args: Unexpected project and connection inputs.
+
+        Raises:
+            AssertionError: Always, because the shared ceiling must reject first.
+        """
+        del args
+        backend_calls.append(True)
+        raise AssertionError("Tinker construction must follow command budget authorization")
+
+    monkeypatch.setattr(command, "_compose_tinker_backend", forbidden_backend)
+    monkeypatch.setattr(command, "_current_revision", lambda: "command-budget-test")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "optimize",
+            "model",
+            configured.store.paths.project_id,
+            "--root",
+            str(configured.store.paths.root),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "Cost preflight" in output
+    assert "configured budget: $0.01 per command" in output
+    flattened = _flat_cli_output(result.output)
+    assert "exceedstheconfiguredper-commandbudget" in flattened
+    assert "--yescannotoverride" in flattened
     assert backend_calls == []
 
 

--- a/wmo/cli/router_app.py
+++ b/wmo/cli/router_app.py
@@ -77,7 +77,7 @@ def router(
     yes: bool = typer.Option(
         False,
         "--yes",
-        help="Consent to the displayed shared provider-spend ceiling.",
+        help="Confirm an in-budget estimate when the shared policy requires it.",
     ),
     approve_fidelity: bool = typer.Option(
         False,
@@ -102,12 +102,13 @@ def router(
         maximum_retrieval_query_tokens: Input ceiling for each grounded retrieval query.
         simulation_maximum_output_tokens: Candidate and world-model output ceiling per turn.
         maximum_concurrency: Maximum simulation workers.
-        yes: Explicit shared provider-spend consent.
+        yes: Explicit confirmation for an in-budget estimate above the automatic threshold.
         approve_fidelity: Explicit approval for passing measured fidelity evidence.
         non_interactive: Refuse prompts and require complete repeatable inputs.
 
     Raises:
-        typer.BadParameter: Candidate, build, judge, budget, consent, or artifact input is invalid.
+        typer.BadParameter: Candidate, build, judge, budget, authorization, or artifact input is
+            invalid.
     """
     started = time.monotonic()
     now = datetime.now(UTC)
@@ -155,23 +156,41 @@ def router(
             raise ValueError("noninteractive router optimization requires --approve-fidelity")
 
     if replay is not None:
+        require_spend_consent(
+            _console,
+            root=root,
+            yes=yes,
+            estimated_cost_usd=0.0,
+            command=f"wmo optimize router {project}",
+            assumptions=(
+                "verified immutable optimization replay",
+                "zero new provider calls",
+            ),
+            non_interactive=effective_noninteractive,
+        )
         _console.print("replay: verified completed optimization")
         _console.print(f"policy: {replay.policy_id}")
         _console.print(f"report: {replay.report_id}")
         return
     _render_preflight(preflight, options)
-    spend = (
-        f"at most ${options.maximum_provider_cost_usd:.4f}, including "
-        f"${preflight.router_embedding_reservation.estimated_cost_usd:.4f} for router "
-        f"embeddings, ${preflight.judge_reservation_cost_usd:.4f} for all judge calls, and "
-        f"${preflight.remaining_simulation_cost_usd:.4f} for candidate, retrieval, and "
-        "world-model simulation"
-    )
     if not require_spend_consent(
         _console,
+        root=root,
         yes=yes,
-        spend=spend,
-        command="wmo optimize router",
+        estimated_cost_usd=options.maximum_provider_cost_usd,
+        command=f"wmo optimize router {project}",
+        assumptions=(
+            (
+                f"${preflight.router_embedding_reservation.estimated_cost_usd:.4f} router "
+                "embedding reservation"
+            ),
+            f"${preflight.judge_reservation_cost_usd:.4f} judge reservation",
+            (
+                f"${preflight.remaining_simulation_cost_usd:.4f} candidate, retrieval, and "
+                "world-model simulation allocation"
+            ),
+        ),
+        non_interactive=effective_noninteractive,
     ):
         _console.print("Router optimization was not started.")
         return

--- a/wmo/cli/tests/terminal_tasks_happy_path_test.py
+++ b/wmo/cli/tests/terminal_tasks_happy_path_test.py
@@ -23,6 +23,7 @@ from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
+from wmo.common.config.settings import set_maximum_command_cost_usd
 from wmo.common.models import (
     AssistantAction,
     ConnectionConfig,
@@ -115,6 +116,17 @@ class _RuntimeCatalog:
         """Wrap the real catalog so every snapshot stays exactly as configured."""
         self._real = RuntimeModelCatalog(catalog)
         self._embedding = _EmbeddingClient()
+
+    def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
+        """Return one credential-free static model identity.
+
+        Args:
+            alias: Configured local model alias.
+
+        Returns:
+            Exact model snapshot and capability declaration.
+        """
+        return self._real.snapshot(alias)
 
     def preflight(self, alias: str, requirement: object | None = None) -> ResolvedModel:
         """Return a deterministic resolved model for one configured alias."""
@@ -258,19 +270,25 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
     ]
 
     before_preflight = store.read_review()
-    without_consent = [
-        argument for argument in _calibrate_arguments(root, ()) if argument != "--yes"
-    ]
-    refused = runner.invoke(app, without_consent)
+    set_maximum_command_cost_usd(0.5, root)
+    over_budget = _calibrate_arguments(root, ())
+    over_budget[over_budget.index("--input-usd-per-million") + 1] = "1"
+    over_budget[over_budget.index("--output-usd-per-million") + 1] = "1"
+    _RuntimeCatalog.judge_clients = []
+    refused = runner.invoke(app, over_budget)
     assert refused.exit_code == 2
-    assert "Spend preflight: manual judge calibration" in refused.output
-    assert "Judge name: judge" in refused.output
-    assert "Exact model: openai/judge-id" in refused.output
-    assert "Judge calls authorized: 10" in refused.output
-    assert "Maximum estimated cost: $0.0000" in refused.output
-    assert "Hard spend ceiling: $10.0000" in refused.output
-    assert "missing labels" not in refused.output
+    refused_text = " ".join(unstyle(refused.output).replace("│", " ").split())
+    assert "Cost preflight" in refused_text
+    assert "command: wmo config judge calibrate terminal-tasks" in refused_text
+    assert "estimated cost: $1.10592" in refused_text
+    assert "configured budget: $0.50 per command" in refused_text
+    assert "judge judge: openai/judge-id" in refused_text
+    assert "10 judge calls with up to 3 attempts each" in refused_text
+    assert "--yes cannot override" in refused_text
+    assert "missing labels" not in refused_text
+    assert _RuntimeCatalog.judge_clients == []
     assert store.read_review() == before_preflight
+    set_maximum_command_cost_usd(25.0, root)
 
     _RuntimeCatalog.judge_fail_after = 0
     interrupted = runner.invoke(app, _calibrate_arguments(root, labels))
@@ -342,6 +360,9 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
         ],
     )
     assert replay.exit_code == 0, replay.output
+    assert "estimated cost: $0.00" in replay.output
+    assert "authorization: automatic" in replay.output
+    assert "Proceed?" not in replay.output
     assert "Approved judge calibration" in replay.output
     assert "Spend preflight" not in replay.output
     assert _RuntimeCatalog.judge_clients == []

--- a/wmo/cli/tests/terminal_tasks_happy_path_test.py
+++ b/wmo/cli/tests/terminal_tasks_happy_path_test.py
@@ -271,9 +271,13 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
 
     before_preflight = store.read_review()
     set_maximum_command_cost_usd(0.5, root)
-    over_budget = _calibrate_arguments(root, ())
-    over_budget[over_budget.index("--input-usd-per-million") + 1] = "1"
-    over_budget[over_budget.index("--output-usd-per-million") + 1] = "1"
+    over_budget = [
+        *_calibrate_arguments(root, ()),
+        "--input-usd-per-million",
+        "1",
+        "--output-usd-per-million",
+        "1",
+    ]
     _RuntimeCatalog.judge_clients = []
     refused = runner.invoke(app, over_budget)
     assert refused.exit_code == 2

--- a/wmo/common/config/__init__.py
+++ b/wmo/common/config/__init__.py
@@ -1,4 +1,4 @@
-"""Minimal environment loading, artifact path, and product-telemetry settings exports."""
+"""Minimal environment loading, artifact path, and local WMO settings exports."""
 
 from wmo.common.config.dotenv import load_env_file
 from wmo.common.config.paths import ARTIFACT_DIR
@@ -6,6 +6,7 @@ from wmo.common.config.settings import (
     DEFAULT_COMMAND_BUDGET_USD,
     load_settings,
     resolve_command_budget_usd,
+    set_maximum_command_cost_usd,
     set_telemetry_enabled,
     settings_path,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "load_env_file",
     "load_settings",
     "resolve_command_budget_usd",
+    "set_maximum_command_cost_usd",
     "set_telemetry_enabled",
     "settings_path",
 ]

--- a/wmo/common/config/settings.py
+++ b/wmo/common/config/settings.py
@@ -31,14 +31,24 @@ class TelemetrySettings(BaseModel):
 
 
 class CommandBudgetSettings(BaseModel):
-    """Shared spend ceiling used by paid CLI commands when they omit an explicit flag."""
+    """User-owned authorization ceiling shared by every paid CLI command."""
 
-    maximum_cost_usd: float | None = Field(default=None, gt=0)
+    maximum_cost_usd: float | None = Field(default=None, ge=0)
 
     @field_validator("maximum_cost_usd")
     @classmethod
     def _require_finite(cls, value: float | None) -> float | None:
-        """Reject a non-finite shared command-budget ceiling."""
+        """Reject a non-finite shared command-budget ceiling.
+
+        Args:
+            value: Parsed optional USD ceiling.
+
+        Returns:
+            The finite optional USD ceiling.
+
+        Raises:
+            ValueError: The configured ceiling is not finite.
+        """
         if value is not None and not math.isfinite(value):
             raise ValueError("command budget must be finite")
         return value
@@ -52,17 +62,15 @@ class ProjectSettings(BaseModel):
 
 
 def settings_path(root: str | Path = ARTIFACT_DIR) -> Path:
-    """Return the project-local telemetry settings path."""
+    """Return the local WMO settings path."""
     return Path(root) / SETTINGS_FILENAME
 
 
-_SETTINGS_REPAIR = (
-    "fix the file, or delete it and rerun `wmo config telemetry status` to use defaults"
-)
+_SETTINGS_REPAIR = "fix the file, or delete it and rerun the command to use default settings"
 """How to recover a settings file this loader refuses. Every raise below names it.
 
-Telemetry commands read the file before changing it, so a malformed file must be repaired or
-removed before the local default can be used.
+Settings commands read the file before changing it, so a malformed file must be repaired or
+removed before local defaults can be used.
 """
 
 
@@ -95,7 +103,7 @@ def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
 
 
 def save_settings(settings: ProjectSettings, root: str | Path = ARTIFACT_DIR) -> None:
-    """Atomically persist the project-local telemetry settings.
+    """Atomically persist the project-local WMO settings.
 
     Args:
         settings: Validated settings to persist.
@@ -104,6 +112,31 @@ def save_settings(settings: ProjectSettings, root: str | Path = ARTIFACT_DIR) ->
     path = settings_path(root)
     data = settings.model_dump(mode="json", exclude_none=True)
     write_text_atomic(path, tomli_w.dumps(data))
+
+
+def set_maximum_command_cost_usd(
+    maximum_cost_usd: float,
+    root: str | Path = ARTIFACT_DIR,
+) -> ProjectSettings:
+    """Persist the maximum conservative estimate allowed for one command.
+
+    Args:
+        maximum_cost_usd: Finite nonnegative per-command ceiling in USD.
+        root: Directory that owns the settings file.
+
+    Returns:
+        The updated settings.
+
+    Raises:
+        ValueError: The ceiling is negative or non-finite.
+    """
+    command_budget = CommandBudgetSettings(maximum_cost_usd=maximum_cost_usd)
+    path = settings_path(root)
+    with file_write_lock(path, what="command spending settings"):
+        settings = load_settings(root)
+        settings.commands = command_budget
+        save_settings(settings, root)
+    return settings
 
 
 def set_telemetry_enabled(enabled: bool, root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
@@ -151,7 +184,7 @@ def resolve_command_budget_usd(root: str | Path, explicit: float | None) -> floa
         explicit: Caller-supplied ceiling, or ``None`` to use the shared setting.
 
     Returns:
-        Finite positive spend ceiling in US dollars.
+        Finite nonnegative spend ceiling in US dollars.
     """
     if explicit is not None:
         return explicit

--- a/wmo/common/config/settings_test.py
+++ b/wmo/common/config/settings_test.py
@@ -12,6 +12,7 @@ from wmo.common.config.settings import (
     ensure_telemetry_anonymous_id,
     load_settings,
     resolve_command_budget_usd,
+    set_maximum_command_cost_usd,
     set_telemetry_enabled,
     settings_path,
 )
@@ -23,6 +24,36 @@ def test_missing_settings_defaults_to_telemetry_enabled(tmp_path: Path) -> None:
     assert settings.telemetry.anonymous_id is None
     assert settings.commands.maximum_cost_usd is None
     assert resolve_command_budget_usd(tmp_path / ".wmo", None) == DEFAULT_COMMAND_BUDGET_USD
+
+
+def test_set_maximum_command_cost_persists_with_telemetry(tmp_path: Path) -> None:
+    """The command ceiling shares the settings owner without replacing telemetry state."""
+    root = tmp_path / ".wmo"
+    set_telemetry_enabled(False, root)
+
+    updated = set_maximum_command_cost_usd(12.5, root)
+
+    assert updated.commands.maximum_cost_usd == 12.5
+    reloaded = load_settings(root)
+    assert reloaded.commands.maximum_cost_usd == 12.5
+    assert reloaded.telemetry.enabled is False
+    persisted = settings_path(root).read_text(encoding="utf-8")
+    assert "[commands]" in persisted
+    assert "maximum_cost_usd = 12.5" in persisted
+
+    set_telemetry_enabled(True, root)
+    assert load_settings(root).commands.maximum_cost_usd == 12.5
+
+
+@pytest.mark.parametrize("value", [-0.01, float("inf"), float("nan")])
+def test_set_maximum_command_cost_rejects_unsafe_values(tmp_path: Path, value: float) -> None:
+    """Negative and non-finite limits cannot become durable spend authorization."""
+    root = tmp_path / ".wmo"
+
+    with pytest.raises(ValueError):
+        set_maximum_command_cost_usd(value, root)
+
+    assert not settings_path(root).exists()
 
 
 def test_set_telemetry_enabled_writes_project_settings(tmp_path: Path) -> None:
@@ -85,7 +116,7 @@ def test_refused_settings_name_the_path_and_the_repair(
     message = str(excinfo.value)
     assert expected in message
     assert str(settings_path(root)) in message
-    assert "delete it and rerun `wmo config telemetry status`" in message
+    assert "delete it and rerun the command" in message
 
 
 def test_non_utf8_settings_name_the_path_and_the_repair(tmp_path: Path) -> None:
@@ -97,7 +128,7 @@ def test_non_utf8_settings_name_the_path_and_the_repair(tmp_path: Path) -> None:
     message = str(excinfo.value)
     assert "not valid TOML" in message
     assert str(settings_path(root)) in message
-    assert "delete it and rerun `wmo config telemetry status`" in message
+    assert "delete it and rerun the command" in message
 
 
 def test_telemetry_write_drops_unknown_model_role_settings(tmp_path: Path) -> None:

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -1308,6 +1308,9 @@ def _installed_release_driver() -> None:
         assert replayed_refresh.retrieval.index.rag_id == refresh.retrieval.index.rag_id
         assert state.snapshot() == provider_after_refresh
         provider_before_model_optimization = state.snapshot()
+        budget_result = run_cli("config", "budget", "1", "--root", str(root))
+        assert "maximum command cost: $1.00" in budget_result.stdout
+        training_price = 750_000 / (len(completed) * 4_096)
         model_optimization_output = run_tty(
             [
                 "optimize",
@@ -1326,11 +1329,11 @@ def _installed_release_driver() -> None:
                 "--maximum-cost-usd",
                 "1",
                 "--training-usd-per-million-tokens",
-                "0",
+                str(training_price),
             ],
             [
                 ("Use Tinker connection 'tinker-local'", "y"),
-                ("Proceed?", "n"),
+                ("Authorize wmo optimize model support-agent to spend up to", "n"),
             ],
             completion_marker="Managed Tinker SFT was not started.",
         )


### PR DESCRIPTION
## Summary

- add a user-owned per-command ceiling to the existing `[commands]` owner in `.wmo/settings.toml`, exposed through `wmo config budget [USD]`
- replace generic spend questions with one shared preflight showing the command, conservative estimate, configured budget, and major assumptions
- run automatically at or below 50%, require explicit confirmation above 50% through 100%, and reject above 100% before runtime credentials or provider clients; `--yes` cannot override the ceiling
- apply the policy to build, judge calibration, router optimization, and model optimization while preserving completed replay, accepted-resume, execution, and artifact contracts
- provide consistent `--yes` and `--non-interactive` automation surfaces

## Safety and compatibility

- rebased onto #459 through #465, including the canonical `$10` command-budget owner, catalog-priced judge calibration, and ordered-axis rubric UI
- judge changes are limited to the shared cost boundary and assertions; five-trace review, judge-first proposals, provenance, incremental labels, and approval state remain owned by the stacked judge PR
- provider setup preserves the keyboard picker and repeatable `--provider` automation added by #462
- completed replays render a zero-cost automatic preflight and perform zero new provider calls
- over-budget integration tests prove provider/runtime construction is not reached, including when `--yes` is present

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- focused consent/settings/paid-command/judge-pricing suite: 209 passed
- `uv run pytest -q -k "not live"`: 1,319 passed, 1 intentional skip, 13 live tests deselected
- fresh wheel and sdist built with `uv build --package world-model-optimizer --no-sources`
- exact archive membership and dependency contract: 1 passed
- isolated installed-wheel no-spend release evidence: 1 passed
- no live provider or paid calls
