### PR TITLE
Add incremental judge proposal review

### DIFF
--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -4,18 +4,17 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
 from rich.console import Console
-from rich.markup import escape
-from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.prompt import Confirm
 
 from wmo.cli.consent import can_prompt, require_spend_consent
+from wmo.cli.judge_review import build_manual_judge_reviewer
 from wmo.cli.judge_rubric import maybe_edit_setup_plan
-from wmo.cli.judge_transcript import model_display_name, render_trace
+from wmo.cli.judge_transcript import model_display_name
 from wmo.cli.options import ROOT_OPTION, usage_error
 from wmo.common.config import resolve_command_budget_usd
 from wmo.common.judging import Rubric, RubricDimension, render_rubric_table, score_bounds
@@ -26,19 +25,21 @@ from wmo.common.release_revision import installed_release_revision
 from wmo.optimize.router.judging.artifacts import read_audit, require_review_state
 from wmo.optimize.router.judging.contracts import (
     JudgePromptTemplate,
-    JudgeTracePreview,
+    ManualJudgeAxisDecision,
     ManualJudgeCalibrationResult,
-    ManualJudgeLabel,
     ManualJudgeSetupArtifact,
 )
 from wmo.optimize.router.judging.labels import (
     calibration_sample_digest,
     read_label_draft,
-    save_label_draft,
+)
+from wmo.optimize.router.judging.review import (
+    ManualJudgeReviewer,
+    ManualJudgeTraceProposal,
+    completed_trace_review_count,
 )
 from wmo.optimize.router.judging.service import (
     DEFAULT_JUDGE_TEMPLATE,
-    ManualJudgeCalibrationPlan,
     ManualJudgeError,
     ManualJudgeSetupPlan,
     calibrate_manual_judge,
@@ -66,7 +67,18 @@ _LABEL_OPTION = typer.Option(
     "--label",
     help=(
         "Repeat TRACE_ID:DIMENSION_ID=SCORE, or "
-        "TRACE_ID:REFERENCE_TRACE_ID:DIMENSION_ID=winner_a|winner_b|tie for pairwise labels."
+        "TRACE_ID:REFERENCE_TRACE_ID:DIMENSION_ID=winner_a|winner_b|tie. "
+        "Use a JSON array target when trace IDs contain ambiguous delimiters. "
+        "A value matching the judge proposal accepts it; another value is a correction."
+    ),
+)
+_JUDGMENT_OPTION = typer.Option(
+    None,
+    "--judgment",
+    help=(
+        "Repeat TRACE_ID:DIMENSION_ID=TEXT, or include REFERENCE_TRACE_ID for pairwise. "
+        "Use a JSON array target when trace IDs contain ambiguous delimiters. "
+        "Required with a noninteractive corrected score."
     ),
 )
 
@@ -136,13 +148,19 @@ def judge_setup(
 
 @judge_app.command(
     "calibrate",
-    help="Label real traces, authorize bounded judge calls, and separately approve calibration.",
+    help="Judge and review real traces incrementally, then separately approve calibration.",
 )
 def judge_calibrate(
     project: str = typer.Argument(..., metavar="PROJECT", help="Configured local project ID."),
     root: Path = ROOT_OPTION,
-    sample_size: int = typer.Option(10, "--sample-size", min=1),
+    sample_size: int = typer.Option(
+        5,
+        "--sample-size",
+        min=1,
+        help="Distinct trace lineages to review; defaults to the normal sufficient count of five.",
+    ),
     label: list[str] | None = _LABEL_OPTION,
+    judgment: list[str] | None = _JUDGMENT_OPTION,
     input_price: float | None = typer.Option(
         None,
         "--input-usd-per-million",
@@ -175,41 +193,44 @@ def judge_calibrate(
     accept_insufficient_labels: bool = typer.Option(
         False,
         "--accept-insufficient-labels",
-        help="Accept valid grouped evidence from fewer than ten rollouts.",
+        help="Accept valid grouped evidence from fewer than five distinct trace lineages.",
     ),
     non_interactive: bool = typer.Option(False, "--non-interactive"),
     transcript_character_limit: int = typer.Option(
         1_200,
         "--transcript-character-limit",
         min=200,
-        help="Maximum characters shown for each transcript field before a truthful marker.",
+        help="Maximum characters per transcript field before an exact truncation marker.",
     ),
     page: bool = typer.Option(
         False,
         "--page",
-        help="Page full transcripts in an interactive terminal instead of truncating them.",
+        help=(
+            "Page the current full transcript; proposals and decisions remain one trace at a time."
+        ),
     ),
 ) -> None:
-    """Collect frozen labels, authorize bounded judge calls, and separately approve evidence.
+    """Run judge-first review, persist each trace, and separately approve evidence.
 
     Args:
         project: Local project ID below ``<root>/projects``.
         root: Local project root containing ``models.toml``.
-        sample_size: Maximum number of distinct fit lineages to calibrate.
-        label: Repeatable explicit human score inputs.
+        sample_size: Number of distinct fit lineages, with five as the sufficient default.
+        label: Optional explicit accepted or corrected score expressions.
+        judgment: Optional explicit human-authored corrected judgment expressions.
         input_price: Optional advanced input-price override.
         output_price: Optional advanced output-price override.
         maximum_input_tokens: Conservative input bound for every call attempt.
         maximum_cost_usd: Optional spend ceiling; otherwise the shared command-budget setting.
         yes: Explicit confirmation for an in-budget estimate above the automatic threshold.
         approve: Separate approval of the displayed completed report.
-        accept_insufficient_labels: Explicit risk acceptance below ten labeled rollouts.
-        non_interactive: Refuse prompts and list missing explicit inputs.
+        accept_insufficient_labels: Explicit risk acceptance below five completed reviews.
+        non_interactive: Refuse prompts and require complete explicit decisions.
         transcript_character_limit: Maximum displayed characters per transcript field.
-        page: Page untruncated transcripts through the interactive terminal.
+        page: Page the untruncated current trace through an interactive terminal.
 
     Raises:
-        typer.BadParameter: Evidence, labels, budget, authorization, or approval is invalid.
+        typer.BadParameter: Evidence, review inputs, budget, consent, or approval is invalid.
     """
     with usage_error(OSError, ValueError, ManualJudgeError):
         revision = installed_release_revision()
@@ -221,14 +242,11 @@ def judge_calibrate(
         sample_sha256 = calibration_sample_digest(plan.setup, calibration_sample(plan))
         drafted = read_label_draft(store, plan.setup, sample_sha256)
         completed = manual_judge_calibration_is_complete(store)
+        reviewed = completed_trace_review_count(store, plan.setup, sample_sha256)
         if completed:
             state = require_review_state(store)
             assert state.audit is not None
             budget = read_audit(store, state.audit).budget
-            _console.print(
-                "Judge calibration is already complete; replaying its immutable evidence "
-                "without collecting labels."
-            )
         else:
             catalog = load_model_catalog(store.model_catalog_path)
             shared_ceiling = resolve_command_budget_usd(root, None)
@@ -244,34 +262,27 @@ def judge_calibrate(
                 output_usd_per_million_tokens=output_price,
                 maximum_input_tokens_per_call=maximum_input_tokens,
                 maximum_cost_usd=sys.float_info.max,
+                completed_review_count=reviewed,
             )
             if maximum_cost_usd is not None and budget.estimated_cost_usd > maximum_cost_usd:
                 raise ValueError(
                     "judge calibration estimate exceeds --maximum-cost-usd; raise the ceiling "
                     "or reduce the labeled sample"
                 )
-        if page and not completed and not can_prompt(_console):
+        if page and not completed and budget.call_count and not can_prompt(_console):
             raise ValueError("--page requires an interactive terminal; omit it for wrapped output")
-
-        def persist(collected: tuple[ManualJudgeLabel, ...]) -> None:
-            """Save human labels to durable review state before any judge provider work.
-
-            Args:
-                collected: Every human label known for the frozen trace sample so far.
-            """
-            save_label_draft(store, plan.setup, sample_sha256, collected, now)
-
-    estimate = 0.0 if completed else budget.estimated_cost_usd
-    assumptions = (
-        (
-            "verified immutable calibration replay",
-            "zero new judge calls",
+    if completed:
+        _console.print(
+            "Judge calibration is already complete; replaying immutable evidence with zero "
+            "provider calls and no review prompts."
         )
-        if completed
-        else (
+    elif budget.call_count:
+        assumptions = (
+            f"review progress: {reviewed}/{len(plan.traces)} distinct trace lineages complete",
             f"judge {plan.setup.judge_alias}: {model_display_name(plan.setup.judge_model)}",
+            f"pricing source: {budget.pricing_source.value}",
             (
-                f"{budget.call_count} judge calls with up to "
+                f"at most {budget.call_count} remaining judge calls with up to "
                 f"{budget.maximum_attempts_per_call} attempts each"
             ),
             (
@@ -283,19 +294,18 @@ def judge_calibrate(
                 f"${budget.output_usd_per_million_tokens:.6f} output per million tokens"
             ),
         )
-    )
-    if not require_spend_consent(
-        _console,
-        root=root,
-        yes=yes,
-        estimated_cost_usd=estimate,
-        command=f"wmo config judge calibrate {project}",
-        assumptions=assumptions,
-        non_interactive=non_interactive,
-    ):
-        _console.print("Judge calibration was not started. No labels or provider calls ran.")
-        return
-    if not completed:
+        if not require_spend_consent(
+            _console,
+            root=root,
+            yes=yes,
+            estimated_cost_usd=budget.estimated_cost_usd,
+            command=f"wmo config judge calibrate {project}",
+            assumptions=assumptions,
+            non_interactive=non_interactive,
+            previously_confirmed=False,
+        ):
+            _console.print("Judge calibration was not started. No provider calls or reviews ran.")
+            return
         with usage_error(OSError, ValueError, ManualJudgeError):
             budget = estimate_manual_judge_budget(
                 plan,
@@ -304,40 +314,48 @@ def judge_calibrate(
                 output_usd_per_million_tokens=output_price,
                 maximum_input_tokens_per_call=maximum_input_tokens,
                 maximum_cost_usd=max(calibration_ceiling, 0.000001),
+                completed_review_count=reviewed,
             )
         if drafted:
-            _console.print(f"Resuming {len(drafted)} saved human labels for this trace sample.")
-        _render_calibration_review(
-            plan,
-            rubric,
-            character_limit=None if page else transcript_character_limit,
-            page=page,
-        )
-        with usage_error(OSError, ValueError, ManualJudgeError):
-            labels = _collect_labels(
-                plan.setup,
-                rubric,
-                tuple(label or ()),
-                plan.previews,
-                drafted,
-                persist,
-                non_interactive=non_interactive,
+            _console.print(
+                f"Found {len(drafted)} saved human score inputs. They will be applied only "
+                "after the configured judge proposals are shown."
             )
     else:
-        labels = drafted
+        _console.print(
+            f"Review progress: {reviewed}/{len(plan.traces)} distinct trace lineages complete. "
+            "Finalizing from immutable reviews with zero provider calls."
+        )
     with usage_error(OSError, ValueError, ManualJudgeError):
+        reviewer: ManualJudgeReviewer = (
+            build_manual_judge_reviewer(
+                plan.setup,
+                rubric,
+                plan.previews,
+                drafted_labels=drafted,
+                supplied_labels=tuple(label or ()),
+                supplied_judgments=tuple(judgment or ()),
+                non_interactive=non_interactive,
+                character_limit=transcript_character_limit,
+                page=page,
+                console=_console,
+            )
+            if not completed and budget.call_count
+            else _unexpected_review
+        )
         runtime = RuntimeModelCatalog(load_model_catalog(store.model_catalog_path))
         result = calibrate_manual_judge(
             store,
             runtime,
             plan,
-            labels,
+            (),
             budget,
             spend_consented=True,
             approve=False,
             accept_insufficient_labels=accept_insufficient_labels,
             created_at=now,
             code_revision=revision,
+            reviewer=reviewer,
         )
         _render_report(result)
         should_approve = (
@@ -354,18 +372,33 @@ def judge_calibrate(
                 store,
                 runtime,
                 plan,
-                labels,
+                (),
                 budget,
                 spend_consented=True,
                 approve=True,
                 accept_insufficient_labels=accept_insufficient_labels,
                 created_at=now,
                 code_revision=revision,
+                reviewer=reviewer,
             )
     if result.approved_calibration is None:
         _console.print("Calibration evidence saved but not approved.")
     else:
         _console.print(f"Approved judge calibration {result.approved_calibration.artifact_id}.")
+
+
+def _unexpected_review(
+    _proposal: ManualJudgeTraceProposal,
+) -> tuple[ManualJudgeAxisDecision, ...]:
+    """Fail closed if completed review state requests another decision.
+
+    Args:
+        _proposal: Unexpected proposal supplied by the review workflow.
+
+    Raises:
+        ManualJudgeError: Always, because completed state cannot request review.
+    """
+    raise ManualJudgeError("completed calibration unexpectedly requested another human review")
 
 
 def _load_rubric_dimensions(path: Path | None) -> tuple[RubricDimension, ...] | None:
@@ -392,10 +425,10 @@ def _load_prompt_template(path: Path | None) -> JudgePromptTemplate:
     """Load an optional exact versioned prompt contract from JSON.
 
     Args:
-        path: Optional local JSON file.
+        path: Optional local prompt contract file.
 
     Returns:
-        Validated prompt contract, or the current built-in scalar contract.
+        Validated file content or the built-in scalar contract.
     """
     if path is None:
         return DEFAULT_JUDGE_TEMPLATE
@@ -406,7 +439,7 @@ def _render_setup(plan: ManualJudgeSetupPlan) -> None:
     """Display the judge, human-readable rubric table, and representative tasks.
 
     Args:
-        plan: Read-only setup plan awaiting confirmation.
+        plan: Read-only judge setup awaiting explicit confirmation.
     """
     _console.print("\n[bold]Judge setup[/bold]")
     _console.print(f"Judge name: {plan.judge_alias}", markup=False)
@@ -425,278 +458,15 @@ def _render_setup(plan: ManualJudgeSetupPlan) -> None:
         _console.print(f"   Recorded outcome: {preview.outcome}", markup=False)
 
 
-def _render_calibration_review(
-    plan: ManualJudgeCalibrationPlan,
-    rubric: Rubric,
-    *,
-    character_limit: int | None,
-    page: bool,
-) -> None:
-    """Render readable scalar or A/B transcripts after spend consent.
-
-    Args:
-        plan: Frozen traces and optional same-task references in display order.
-        rubric: Finalized plain-language scoring rubric.
-        character_limit: Per-field limit, or ``None`` for full transcript text.
-        page: Whether to send the full review through Rich's terminal pager.
-    """
-
-    def render() -> None:
-        """Write the complete review into the active console or pager buffer."""
-        pairwise = plan.setup.prompt_template.response_shape == "pairwise"
-        if pairwise:
-            heading = "PAIRWISE A/B CALIBRATION"
-        else:
-            lowest, highest = score_bounds(rubric.dimensions)
-            heading = f"INTEGER {lowest}-{highest} CALIBRATION"
-        _console.print(f"\n[bold]{heading}[/bold]")
-        _render_rubric(rubric.dimensions)
-        for index, (trace, reference) in enumerate(
-            zip(plan.traces, plan.reference_traces, strict=True), start=1
-        ):
-            if pairwise:
-                _console.print(f"\n[bold]Pair {index}, candidate A[/bold]")
-                render_trace(_console, trace, character_limit=character_limit)
-                if reference is None:
-                    raise ValueError("pairwise calibration preview is missing candidate B")
-                _console.print(f"\n[bold]Pair {index}, candidate B[/bold]")
-                render_trace(_console, reference, character_limit=character_limit)
-            else:
-                _console.print(f"\n[bold]Trace {index}[/bold]")
-                render_trace(_console, trace, character_limit=character_limit)
-
-    if page:
-        with _console.pager(styles=True):
-            render()
-    else:
-        render()
-
-
-def _render_rubric(dimensions: tuple[RubricDimension, ...]) -> None:
-    """Render complete plain-language rubric axes and score meanings.
-
-    Args:
-        dimensions: Finalized rubric dimensions in scoring order.
-    """
-    _console.print("\n[bold]Rubric[/bold]")
-    for dimension in dimensions:
-        _console.print(dimension.name, style="bold", markup=False)
-        _console.print(dimension.description, markup=False)
-        for anchor in dimension.anchors:
-            _console.print(f"  {anchor.score}: {anchor.description}", markup=False)
-
-
-def _collect_labels(
-    setup: ManualJudgeSetupArtifact,
-    rubric: Rubric,
-    supplied: tuple[str, ...],
-    previews: tuple[JudgeTracePreview, ...],
-    drafted: tuple[ManualJudgeLabel, ...],
-    persist: Callable[[tuple[ManualJudgeLabel, ...]], None],
-    *,
-    non_interactive: bool,
-) -> tuple[ManualJudgeLabel, ...]:
-    """Resume saved labels, parse explicit ones, and ask only for missing scores.
-
-    Every label is handed to ``persist`` as soon as it exists, so an interrupted or failed
-    calibration never discards completed human ratings.
-
-    Args:
-        setup: Finalized setup used for stable prompt context.
-        rubric: Verified finalized scoring rubric.
-        supplied: Repeatable CLI label expressions.
-        previews: Frozen ordered calibration trace previews.
-        drafted: Labels already persisted for this exact frozen trace sample.
-        persist: Durable writer for the labels collected so far.
-        non_interactive: Whether all missing inputs must be reported without prompting.
-
-    Returns:
-        Complete ordered human label set.
-
-    Raises:
-        ValueError: A label is malformed, duplicated, missing, or outside the axis range.
-    """
-    pairwise = setup.prompt_template.response_shape == "pairwise"
-    parsed: dict[tuple[str, str | None, str], ManualJudgeLabel] = {
-        (item.trace_id, item.reference_trace_id, item.dimension_id): item for item in drafted
-    }
-    explicit: set[tuple[str, str | None, str]] = set()
-    for item in supplied:
-        key = _label_key(item, pairwise=pairwise)
-        if key in explicit:
-            raise ValueError("duplicate label for " + ":".join(part or "-" for part in key))
-        explicit.add(key)
-        axis = None if pairwise else rubric.axis(key[2])
-        parsed[key] = _label(
-            key,
-            _label_value(item, pairwise=pairwise, axis=axis),
-            pairwise=pairwise,
-        )
-    expected = tuple(
-        (preview.trace_id, preview.reference_trace_id, dimension.dimension_id)
-        for preview in previews
-        for dimension in rubric.dimensions
-    )
-    unexpected = sorted(set(parsed).difference(expected))
-    if unexpected:
-        raise ValueError(
-            "unexpected labels: "
-            + ", ".join(":".join(part or "-" for part in key) for key in unexpected)
-        )
-    if explicit:
-        persist(tuple(parsed[key] for key in expected if key in parsed))
-    missing = tuple(key for key in expected if key not in parsed)
-    if missing and non_interactive:
-        raise ValueError(
-            "missing labels: " + ", ".join(":".join(part or "-" for part in key) for key in missing)
-        )
-    dimensions = {dimension.dimension_id: dimension for dimension in rubric.dimensions}
-    preview_positions = {
-        (preview.trace_id, preview.reference_trace_id): index
-        for index, preview in enumerate(previews, start=1)
-    }
-    for key in missing:
-        trace_id, reference_id, dimension_id = key
-        dimension = dimensions[dimension_id]
-        _render_score_prompt(dimension)
-        position = preview_positions[(trace_id, reference_id)]
-        if pairwise:
-            choice = Prompt.ask(
-                "Pair "
-                f"{position}: choose candidate A, candidate B, or tie for "
-                f"{escape(dimension.name)}",
-                choices=["A", "B", "tie"],
-            )
-            value: int | str = {"A": "winner_a", "B": "winner_b", "tie": "tie"}[choice]
-        else:
-            score = IntPrompt.ask(
-                f"Trace {position}: score {escape(dimension.name)} from "
-                f"{dimension.min_score} to {dimension.max_score}"
-            )
-            if not dimension.contains_score(score):
-                raise ValueError(
-                    f"judge labels for {dimension_id} must be integers from "
-                    f"{dimension.min_score} through {dimension.max_score}"
-                )
-            value = score
-        parsed[key] = _label(key, value, pairwise=pairwise)
-        persist(tuple(parsed[item] for item in expected if item in parsed))
-    return tuple(parsed[key] for key in expected)
-
-
-def _render_score_prompt(dimension: RubricDimension) -> None:
-    """Keep one score question adjacent to its complete plain-language anchors.
-
-    Args:
-        dimension: Rubric dimension the next prompt asks the operator to score.
-    """
-    _console.print()
-    _console.print(f"Score prompt: {dimension.name}", style="bold", markup=False)
-    _console.print(dimension.description, markup=False)
-    for anchor in dimension.anchors:
-        _console.print(f"  {anchor.score}: {anchor.description}", markup=False)
-
-
-def _label(
-    key: tuple[str, str | None, str],
-    value: int | str,
-    *,
-    pairwise: bool,
-) -> ManualJudgeLabel:
-    """Build one validated human label from its key and typed value.
-
-    Args:
-        key: Trace, optional reference trace, and dimension identifiers.
-        value: Integer axis score, or a typed pairwise winner.
-        pairwise: Whether the finalized setup requires a comparison label.
-
-    Returns:
-        Validated human label for the calibration sample.
-    """
-    trace_id, reference_id, dimension_id = key
-    return ManualJudgeLabel.model_validate(
-        {
-            "trace_id": trace_id,
-            "reference_trace_id": reference_id,
-            "dimension_id": dimension_id,
-            **({"winner": value} if pairwise else {"score": value}),
-        }
-    )
-
-
-def _label_key(value: str, *, pairwise: bool) -> tuple[str, str | None, str]:
-    """Parse the trace and dimension key from one CLI label expression.
-
-    Args:
-        value: Scalar or pairwise CLI label expression.
-        pairwise: Whether the finalized setup requires a comparison trace.
-
-    Returns:
-        Trace, optional reference trace, and dimension identifiers.
-
-    Raises:
-        ValueError: The expression does not have the required separators.
-    """
-    target, separator, _score = value.rpartition("=")
-    parts = target.split(":")
-    expected_parts = 3 if pairwise else 2
-    if not separator or len(parts) != expected_parts or any(not part for part in parts):
-        expected = (
-            "TRACE_ID:REFERENCE_TRACE_ID:DIMENSION_ID=winner_a|winner_b|tie"
-            if pairwise
-            else "TRACE_ID:DIMENSION_ID=SCORE"
-        )
-        raise ValueError(f"labels must use {expected}")
-    if pairwise:
-        return parts[0], parts[1], parts[2]
-    return parts[0], None, parts[1]
-
-
-def _label_value(
-    value: str,
-    *,
-    pairwise: bool,
-    axis: RubricDimension | None = None,
-) -> int | str:
-    """Parse and validate one CLI label value.
-
-    Args:
-        value: Scalar or pairwise CLI label expression.
-        pairwise: Whether the finalized setup requires a typed winner.
-        axis: Axis that bounds a scalar score.
-
-    Returns:
-        Integer score or typed pairwise winner.
-
-    Raises:
-        ValueError: The score is not an integer inside the axis range.
-    """
-    raw = value.rpartition("=")[2]
-    if pairwise:
-        if raw not in {"winner_a", "winner_b", "tie"}:
-            raise ValueError("pairwise judge labels must use winner_a, winner_b, or tie")
-        return raw
-    try:
-        score = int(raw)
-    except ValueError as exc:
-        raise ValueError("judge labels must use an integer score") from exc
-    if axis is not None and not axis.contains_score(score):
-        raise ValueError(
-            f"judge labels for {axis.dimension_id} must be integers from "
-            f"{axis.min_score} through {axis.max_score}"
-        )
-    return score
-
-
 def _load_setup_rubric(store: ProjectStore, setup: ManualJudgeSetupArtifact) -> Rubric:
     """Load and verify the finalized rubric named by setup.
 
     Args:
         store: Project-local immutable artifact store.
-        setup: Finalized manual judge setup.
+        setup: Finalized setup naming the exact rubric manifest.
 
     Returns:
-        Verified human-approved rubric.
+        Verified finalized rubric.
 
     Raises:
         ValueError: The rubric manifest differs from setup.
@@ -717,7 +487,7 @@ def _render_report(result: ManualJudgeCalibrationResult) -> None:
     """Display agreement, disagreement, and schema-appropriate positional bias.
 
     Args:
-        result: Completed immutable audit and calibration report.
+        result: Completed immutable calibration result.
     """
     report = result.report
     _console.print(
@@ -752,21 +522,21 @@ def _metric(value: float | None) -> str:
     """Format one optional calibration metric for concise CLI output.
 
     Args:
-        value: Optional finite report metric.
+        value: Optional finite calibration metric.
 
     Returns:
-        Three-decimal value or ``n/a`` when grouped evidence is unavailable.
+        Three-decimal text or ``n/a`` when evidence is unavailable.
     """
     return "n/a" if value is None else f"{value:.3f}"
 
 
 def _confirm(question: str, *, non_interactive: bool, required_flag: str) -> bool:
-    """Ask one non-spend confirmation or require its explicit noninteractive flag.
+    """Ask one non-spend confirmation or require its explicit flag.
 
     Args:
-        question: Human-readable decision prompt.
-        non_interactive: Whether prompting is forbidden.
-        required_flag: Flag that provides the explicit decision in scripts.
+        question: Human-readable confirmation prompt.
+        non_interactive: Whether terminal prompting is forbidden.
+        required_flag: Explicit flag required without a prompt.
 
     Returns:
         The operator's explicit answer.

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -11,14 +10,10 @@ from typing import cast
 import pytest
 from click import unstyle
 from rich.console import Console
-from rich.text import Text
 from typer.testing import CliRunner
 
 from wmo.cli import judge_config as judge_config_module
 from wmo.cli.app import app
-from wmo.cli.judge_config import _label_value
-from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
-from wmo.common.judging import Rubric, default_task_success_axis
 from wmo.common.models import (
     ModelCapabilities,
     ModelCatalog,
@@ -26,43 +21,11 @@ from wmo.common.models import (
     ModelSnapshot,
     write_model_catalog,
 )
-from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
-from wmo.optimize.router.judging.contracts import (
-    JudgeTracePreview,
-    ManualJudgeLabel,
-    ManualJudgeSetupArtifact,
-)
 from wmo.optimize.router.judging.service import (
-    ManualJudgeCalibrationPlan,
     ManualJudgeSetupPlan,
     default_judge_dimensions,
 )
 from wmo.optimize.router.judging.service_test import _built_store, _catalog, _setup
-
-
-class _PairwiseAnswer:
-    """Return candidate B while retaining the exact human-facing prompt."""
-
-    prompt = ""
-
-    @classmethod
-    def ask(cls, prompt: str, *, choices: list[str]) -> str:
-        """Record one prompt and require plain A, B, and tie choices."""
-        cls.prompt = prompt
-        assert choices == ["A", "B", "tie"]
-        return "B"
-
-
-class _ScalarAnswer:
-    """Return the default-axis success score while retaining the prompt."""
-
-    prompt = ""
-
-    @classmethod
-    def ask(cls, prompt: str) -> int:
-        """Record one prompt and return a valid scalar score."""
-        cls.prompt = prompt
-        return 1
 
 
 @pytest.mark.parametrize(
@@ -95,7 +58,7 @@ def test_malformed_release_revision_fails_before_judge_state(
 
 
 def test_judge_commands_render_as_nested_config_commands() -> None:
-    """Both manual judge stages are discoverable without expanding the root surface."""
+    """Setup and judge-first review controls remain discoverable under config."""
     runner = CliRunner()
 
     setup = runner.invoke(app, ["config", "judge", "setup", "--help"])
@@ -115,6 +78,10 @@ def test_judge_commands_render_as_nested_config_commands() -> None:
     assert "--output-usd-per-million" in calibrate_output
     assert "--maximum-cost-usd" in calibrate_output
     assert "command-budget" in calibrate_output
+    assert "--judgment" in calibrate_output
+    assert "--sample-size" in calibrate_output
+    assert "[default: 5]" in calibrate_output
+    assert "five." in calibrate_output
 
 
 def _write_catalog(root: Path, catalog: ModelCatalog) -> None:
@@ -175,7 +142,8 @@ def test_calibrate_prints_catalog_pricing_breakdown_before_labels(tmp_path: Path
     assert "estimated cost: $0.368641 (conservative maximum)" in output
     assert "configured budget: $0.50 per command" in output
     assert "judge judge-main: openai/judge-model" in output
-    assert "3 judge calls with up to 3 attempts each" in output
+    assert "pricing source: configured" in output
+    assert "at most 3 remaining judge calls with up to 3 attempts each" in output
     assert "32768 input and 4096 output tokens per attempt" in output
     assert "$1.000000 input and $2.000000 output per million tokens" in output
     assert "re-run with --yes" in output
@@ -241,15 +209,6 @@ def test_calibrate_uses_shared_command_budget_when_flag_is_omitted(tmp_path: Pat
     assert "missing labels" not in output
 
 
-def test_scalar_label_values_follow_the_axis_range() -> None:
-    """CLI label parsing accepts 0-1 default scores and rejects out-of-range values."""
-    axis = default_task_success_axis()
-
-    assert _label_value("trace-1:task-success=1", pairwise=False, axis=axis) == 1
-    with pytest.raises(ValueError, match="from 0 through 1"):
-        _label_value("trace-1:task-success=4", pairwise=False, axis=axis)
-
-
 def test_setup_output_is_plain_language_and_hides_execution_internals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -293,157 +252,6 @@ def test_setup_output_is_plain_language_and_hides_execution_internals(
     assert "0000000000000000" not in output
 
 
-def test_pairwise_calibration_renders_roles_and_truthful_truncation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A/B review separates task, assistant, tools, result, and terminal failure."""
-    buffer = io.StringIO()
-    monkeypatch.setattr(
-        judge_config_module,
-        "_console",
-        Console(file=buffer, width=36, color_system=None),
-    )
-    first = _trace("trace-a", completion="A" * 80, failed=True)
-    second = _trace("trace-b", completion="Candidate B finished.", failed=False)
-    plan = cast(
-        ManualJudgeCalibrationPlan,
-        SimpleNamespace(
-            setup=SimpleNamespace(prompt_template=SimpleNamespace(response_shape="pairwise")),
-            traces=(first,),
-            reference_traces=(second,),
-        ),
-    )
-
-    judge_config_module._render_calibration_review(
-        plan,
-        cast(Rubric, SimpleNamespace(dimensions=default_judge_dimensions())),
-        character_limit=40,
-        page=False,
-    )
-
-    output = buffer.getvalue()
-    assert "PAIRWISE A/B CALIBRATION" in output
-    assert "Pair 1, candidate A" in output
-    assert "Pair 1, candidate B" in output
-    assert "User / task:" in output
-    assert "User message:" in output
-    assert "Please resolve customer issue trace-a." in " ".join(output.split())
-    assert "Assistant / model:" in output
-    assert "Assistant output:" in output
-    assert "Tool call:" in output
-    assert "Tool arguments:" in output
-    assert "Tool result:" in output
-    assert "Tool output:" in output
-    assert "Final outcome:" in output
-    assert "Final failure:" in output
-    assert "truncated 40 characters" in output
-    assert "use --page for the full transcript" in " ".join(output.split())
-
-
-def test_pairwise_prompt_keeps_anchors_adjacent_and_uses_plain_a_b_labels(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Interactive pairwise scoring says A and B while persisting the typed winner."""
-    buffer = io.StringIO()
-    monkeypatch.setattr(
-        judge_config_module,
-        "_console",
-        Console(file=buffer, width=80, color_system=None),
-    )
-    monkeypatch.setattr(judge_config_module, "Prompt", _PairwiseAnswer)
-    setup = cast(
-        ManualJudgeSetupArtifact,
-        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="pairwise")),
-    )
-    preview = cast(
-        JudgeTracePreview,
-        SimpleNamespace(trace_id="trace-a", reference_trace_id="trace-b"),
-    )
-    rubric = cast(Rubric, SimpleNamespace(dimensions=default_judge_dimensions()))
-    persisted: list[tuple[ManualJudgeLabel, ...]] = []
-
-    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
-        """Retain incremental labels exactly as the command would save them."""
-        persisted.append(labels)
-
-    labels = judge_config_module._collect_labels(
-        setup,
-        rubric,
-        (),
-        (preview,),
-        (),
-        persist,
-        non_interactive=False,
-    )
-
-    assert labels[0].winner == "winner_b"
-    assert persisted[-1] == labels
-    assert "choose candidate A, candidate B, or tie" in _PairwiseAnswer.prompt
-    output = buffer.getvalue()
-    assert "Score prompt: Task success" in output
-    assert "0: The agent did not complete the requested task." in output
-    assert "1: The agent successfully completed the requested task." in output
-
-
-@pytest.mark.parametrize(
-    ("shape", "name"),
-    [
-        ("pairwise", "[/]"),
-        ("scalar", "[link=https://invalid.example]linked name[/link]"),
-    ],
-)
-def test_score_prompt_escapes_user_authored_rich_markup(
-    monkeypatch: pytest.MonkeyPatch,
-    shape: str,
-    name: str,
-) -> None:
-    """Malformed and link-like dimension names remain literal scoring text.
-
-    Args:
-        monkeypatch: Scoped prompt replacement.
-        shape: Prompt response shape under test.
-        name: Valid user-authored dimension name containing Rich markup syntax.
-    """
-    dimension = default_judge_dimensions()[0].model_copy(update={"name": name})
-    setup = cast(
-        ManualJudgeSetupArtifact,
-        SimpleNamespace(prompt_template=SimpleNamespace(response_shape=shape)),
-    )
-    preview = cast(
-        JudgeTracePreview,
-        SimpleNamespace(
-            trace_id="trace-a",
-            reference_trace_id="trace-b" if shape == "pairwise" else None,
-        ),
-    )
-    rubric = cast(Rubric, SimpleNamespace(dimensions=(dimension,)))
-    persisted: list[tuple[ManualJudgeLabel, ...]] = []
-
-    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
-        """Retain the escaped-prompt test's incremental label."""
-        persisted.append(labels)
-
-    if shape == "pairwise":
-        monkeypatch.setattr(judge_config_module, "Prompt", _PairwiseAnswer)
-        answer_type = _PairwiseAnswer
-    else:
-        monkeypatch.setattr(judge_config_module, "IntPrompt", _ScalarAnswer)
-        answer_type = _ScalarAnswer
-
-    labels = judge_config_module._collect_labels(
-        setup,
-        rubric,
-        (),
-        (preview,),
-        (),
-        persist,
-        non_interactive=False,
-    )
-
-    assert persisted[-1] == labels
-    assert name in Text.from_markup(answer_type.prompt).plain
-
-
 def _model() -> ModelSnapshot:
     """Return one exact secret-free judge identity."""
     return ModelSnapshot(
@@ -452,75 +260,4 @@ def _model() -> ModelSnapshot:
         revision=None,
         capabilities_sha256="0" * 64,
         connection_sha256="1" * 64,
-    )
-
-
-def _trace(trace_id: str, *, completion: str, failed: bool) -> Trace:
-    """Return one transcript fixture with assistant and paired tool evidence.
-
-    Args:
-        trace_id: Stable fixture trace identity.
-        completion: Captured assistant response.
-        failed: Whether terminal evidence records a failure.
-
-    Returns:
-        Complete normalized trace for CLI rendering.
-    """
-    started = datetime(2026, 8, 16, tzinfo=UTC)
-    spans = (
-        TraceSpan(
-            span_id=f"{trace_id}-assistant",
-            name="agent.model_call",
-            started_at=started,
-            ended_at=started + timedelta(seconds=1),
-            attributes={
-                "gen_ai.operation.name": "chat",
-                "gen_ai.input.messages": (
-                    f'[{{"role":"user","content":"Please resolve customer issue {trace_id}."}}]'
-                ),
-                "gen_ai.output.messages": [
-                    {"role": "assistant", "content": [{"type": "text", "text": completion}]}
-                ],
-            },
-            model=_model(),
-        ),
-        TraceSpan(
-            span_id=f"{trace_id}-tool-call",
-            name="agent.model_call",
-            started_at=started + timedelta(seconds=2),
-            ended_at=started + timedelta(seconds=3),
-            attributes={
-                "gen_ai.operation.name": "chat",
-                "gen_ai.tool.name": "search",
-                "gen_ai.tool.call.arguments": '{"query":"customer issue"}',
-            },
-            model=_model(),
-        ),
-        TraceSpan(
-            span_id=f"{trace_id}-tool-result",
-            name="agent.tool_call",
-            started_at=started + timedelta(seconds=4),
-            ended_at=started + timedelta(seconds=5),
-            attributes={
-                "gen_ai.operation.name": "execute_tool",
-                "gen_ai.tool.name": "search",
-                "gen_ai.tool.output": "Found the relevant account record.",
-            },
-        ),
-    )
-    failure = StructuredFailure(code=FailureCode.INTERNAL, message="Customer request failed")
-    return Trace(
-        trace_id=trace_id,
-        task="Resolve the customer's support request.",
-        initial_context={"account_tier": "business"},
-        spans=spans,
-        outcome=(
-            TraceOutcome(status="failure", failure=failure)
-            if failed
-            else TraceOutcome(status="success", outcome_name="resolved")
-        ),
-        source=TraceSource(
-            identity=SourceIdentity(kind="manual", source_id=trace_id, sha256="2" * 64),
-            semantic_convention_version="test-v1",
-        ),
     )

--- a/wmo/cli/judge_review.py
+++ b/wmo/cli/judge_review.py
@@ -1,0 +1,641 @@
+"""One-trace-at-a-time terminal review for configured judge proposals."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+from rich.console import Console
+from rich.markup import escape
+from rich.prompt import Confirm, IntPrompt, Prompt
+
+from wmo.cli.judge_transcript import render_field, render_trace, span_evidence_text
+from wmo.common.judging import Rubric, RubricDimension
+from wmo.common.traces import TraceSpan
+from wmo.optimize.router.judging.contracts import (
+    HumanJudgeCorrection,
+    JudgeTracePreview,
+    ManualJudgeAxisDecision,
+    ManualJudgeLabel,
+    ManualJudgeSetupArtifact,
+)
+from wmo.optimize.router.judging.review import (
+    ManualJudgeReviewer,
+    ManualJudgeTraceProposal,
+    manual_label_score,
+)
+
+_ReviewKey = tuple[str, str | None, str]
+
+
+@dataclass(frozen=True)
+class _ExplicitReviewInputs:
+    """Validated score and judgment corrections keyed by frozen trace and axis."""
+
+    labels: dict[_ReviewKey, ManualJudgeLabel]
+    judgments: dict[_ReviewKey, str]
+
+
+def build_manual_judge_reviewer(
+    setup: ManualJudgeSetupArtifact,
+    rubric: Rubric,
+    previews: Sequence[JudgeTracePreview],
+    *,
+    drafted_labels: Sequence[ManualJudgeLabel],
+    supplied_labels: Sequence[str],
+    supplied_judgments: Sequence[str],
+    non_interactive: bool,
+    character_limit: int,
+    page: bool,
+    console: Console,
+) -> ManualJudgeReviewer:
+    """Build a reviewer that displays each proposal before taking a human decision.
+
+    Args:
+        setup: Finalized judge setup and score projection.
+        rubric: Exact finalized rubric revision.
+        previews: Frozen sample identities in review order.
+        drafted_labels: Human labels already saved for this frozen sample.
+        supplied_labels: Explicit CLI score or pairwise winner expressions.
+        supplied_judgments: Explicit CLI corrected-judgment expressions.
+        non_interactive: Whether every decision must be provided by flags.
+        character_limit: Maximum characters shown for each transcript field.
+        page: Whether each full transcript is displayed through a terminal pager.
+        console: Rich console used for all review output and prompts.
+
+    Returns:
+        Callback invoked only after the configured judge response is immutable.
+
+    Raises:
+        ValueError: Explicit inputs are malformed, conflicting, or incomplete.
+    """
+    expected = tuple(
+        (preview.trace_id, preview.reference_trace_id, dimension.dimension_id)
+        for preview in previews
+        for dimension in rubric.dimensions
+    )
+    explicit = _parse_explicit_inputs(
+        setup,
+        rubric,
+        expected,
+        drafted_labels=drafted_labels,
+        supplied_labels=supplied_labels,
+        supplied_judgments=supplied_judgments,
+    )
+    missing = tuple(key for key in expected if key not in explicit.labels)
+    if non_interactive and missing:
+        raise ValueError("missing labels: " + ", ".join(_display_key(key) for key in missing))
+
+    def review(proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Render one trace and return explicit decisions for all proposed axes.
+
+        Args:
+            proposal: Persisted configured-judge proposal for the current trace.
+
+        Returns:
+            One explicit human decision per proposed rubric axis.
+        """
+        render_trace_proposal(
+            proposal,
+            character_limit=character_limit,
+            page=page,
+            console=console,
+        )
+        reference_id = (
+            proposal.reference_trace.trace_id if proposal.reference_trace is not None else None
+        )
+        decisions: list[ManualJudgeAxisDecision] = []
+        for proposed in proposal.judgment.dimensions:
+            axis = rubric.axis(proposed.dimension_id)
+            key = (proposal.trace.trace_id, reference_id, proposed.dimension_id)
+            label = explicit.labels.get(key)
+            corrected_judgment = explicit.judgments.get(key)
+            if label is not None:
+                score = manual_label_score(setup, label)
+                decisions.append(
+                    _explicit_decision(
+                        key,
+                        axis=axis,
+                        proposed_score=proposed.raw_score,
+                        proposed_judgment=proposed.feedback,
+                        score=score,
+                        corrected_judgment=corrected_judgment,
+                        non_interactive=non_interactive,
+                        console=console,
+                    )
+                )
+                continue
+            accepted = Confirm.ask(
+                f"Accept the proposed score and judgment for {escape(proposed.dimension_id)}?",
+                default=True,
+                console=console,
+            )
+            if accepted:
+                decisions.append(
+                    ManualJudgeAxisDecision(
+                        dimension_id=proposed.dimension_id,
+                        accepted=True,
+                    )
+                )
+                continue
+            score = _prompt_score(axis, console)
+            judgment = _prompt_judgment(proposed.dimension_id, console)
+            decisions.append(
+                ManualJudgeAxisDecision(
+                    dimension_id=proposed.dimension_id,
+                    accepted=False,
+                    correction=HumanJudgeCorrection(
+                        corrected_score=score,
+                        corrected_judgment=judgment,
+                    ),
+                )
+            )
+        return tuple(decisions)
+
+    return review
+
+
+def render_trace_proposal(
+    proposal: ManualJudgeTraceProposal,
+    *,
+    character_limit: int,
+    page: bool,
+    console: Console,
+) -> None:
+    """Display one conversation and every configured-judge axis proposal.
+
+    Args:
+        proposal: Immutable configured-judge result and its source trace.
+        character_limit: Maximum characters per field outside full paging.
+        page: Whether to page the complete transcript.
+        console: Rich console used for review output.
+    """
+    limit = None if page else character_limit
+
+    def render_conversation() -> None:
+        """Write only the current trace conversation to the active output buffer."""
+        console.print(
+            f"\n[bold]Trace {proposal.position} of {proposal.total}[/bold]",
+        )
+        if proposal.reference_trace is None:
+            render_trace(console, proposal.trace, character_limit=limit)
+            return
+        console.print("\n[bold]Candidate A[/bold]")
+        render_trace(console, proposal.trace, character_limit=limit)
+        console.print("\n[bold]Candidate B[/bold]")
+        render_trace(console, proposal.reference_trace, character_limit=limit)
+
+    if page:
+        with console.pager(styles=True):
+            render_conversation()
+    else:
+        render_conversation()
+    _render_axis_proposals(proposal, character_limit=limit, console=console)
+
+
+def _render_axis_proposals(
+    proposal: ManualJudgeTraceProposal,
+    *,
+    character_limit: int | None,
+    console: Console,
+) -> None:
+    """Show complete rubric context and judge evidence before any human prompt.
+
+    Args:
+        proposal: Current trace and immutable configured-judge result.
+        character_limit: Per-field limit, or ``None`` for complete evidence.
+        console: Rich console receiving review output.
+    """
+    dimensions = {item.dimension_id: item for item in proposal.rubric.dimensions}
+    reference_citations = {
+        dimension_id: reference for dimension_id, _target, reference in proposal.pairwise_citations
+    }
+    console.print(
+        f"\nConfigured judge proposals (rubric revision {proposal.rubric.rubric_id})",
+        style="bold",
+        markup=False,
+    )
+    for index, proposed in enumerate(proposal.judgment.dimensions, start=1):
+        dimension = dimensions[proposed.dimension_id]
+        console.print(
+            f"\nAxis {index} of {len(dimensions)}: {dimension.name}",
+            style="bold",
+            markup=False,
+        )
+        console.print(f"Axis ID: {dimension.dimension_id}", markup=False)
+        console.print(f"Description: {dimension.description}", markup=False)
+        console.print(
+            f"Numeric range: {dimension.min_score} to {dimension.max_score}",
+            markup=False,
+        )
+        console.print("Score anchors:", style="bold")
+        for anchor in dimension.anchors:
+            console.print(f"  {anchor.score}: {anchor.description}", markup=False)
+        console.print(f"Proposed score: {proposed.raw_score}", markup=False)
+        render_field(
+            console,
+            "Proposed judgment",
+            proposed.feedback,
+            character_limit=character_limit,
+        )
+        console.print("Cited trace evidence:", style="bold")
+        for span_id in proposed.evidence_span_ids:
+            source, span = _find_evidence_span(proposal, span_id, reference=False)
+            console.print(f"  {span_id} ({source}; {span.name})", markup=False)
+            render_field(
+                console,
+                "  Evidence content",
+                span_evidence_text(span),
+                character_limit=character_limit,
+            )
+        cited_reference = reference_citations.get(proposed.dimension_id, ())
+        if cited_reference:
+            console.print("Cited reference trace evidence:", style="bold")
+            for span_id in cited_reference:
+                source, span = _find_evidence_span(proposal, span_id, reference=True)
+                console.print(f"  {span_id} ({source}; {span.name})", markup=False)
+                render_field(
+                    console,
+                    "  Evidence content",
+                    span_evidence_text(span),
+                    character_limit=character_limit,
+                )
+
+
+def _parse_explicit_inputs(
+    setup: ManualJudgeSetupArtifact,
+    rubric: Rubric,
+    expected: Sequence[_ReviewKey],
+    *,
+    drafted_labels: Sequence[ManualJudgeLabel],
+    supplied_labels: Sequence[str],
+    supplied_judgments: Sequence[str],
+) -> _ExplicitReviewInputs:
+    """Validate persisted and flag-provided decisions against the frozen sample.
+
+    Args:
+        setup: Finalized judge response and score-projection contract.
+        rubric: Exact ordered axes and inclusive score ranges.
+        expected: Frozen trace, reference, and axis keys.
+        drafted_labels: Previously persisted human score inputs.
+        supplied_labels: Score expressions supplied to this invocation.
+        supplied_judgments: Corrected judgment expressions supplied to this invocation.
+
+    Returns:
+        Validated score and judgment inputs keyed by frozen review identity.
+
+    Raises:
+        ValueError: Inputs are malformed, duplicated, conflicting, or unexpected.
+    """
+    pairwise = setup.prompt_template.response_shape == "pairwise"
+    labels = {_label_key_from_model(item): item for item in drafted_labels}
+    for key, label in labels.items():
+        if label.score is not None and not rubric.axis(key[2]).contains_score(label.score):
+            axis = rubric.axis(key[2])
+            raise ValueError(
+                f"saved label for {key[2]} must be an integer from "
+                f"{axis.min_score} through {axis.max_score}"
+            )
+    drafted_keys = set(labels)
+    supplied_keys: set[_ReviewKey] = set()
+    for value in supplied_labels:
+        key, body = _expression_parts(
+            value,
+            expected=expected,
+            pairwise=pairwise,
+            kind="labels",
+        )
+        if key in supplied_keys:
+            raise ValueError("duplicate label for " + _display_key(key))
+        supplied_keys.add(key)
+        axis = None if pairwise else rubric.axis(key[2])
+        parsed = _label(
+            key,
+            _label_value(body, pairwise=pairwise, axis=axis),
+            pairwise=pairwise,
+        )
+        existing = labels.get(key)
+        if existing is not None and existing != parsed:
+            raise ValueError(
+                "supplied label conflicts with the saved label for " + _display_key(key)
+            )
+        if key in labels and key not in drafted_keys:
+            raise ValueError("duplicate label for " + _display_key(key))
+        labels[key] = parsed
+    judgments: dict[_ReviewKey, str] = {}
+    for value in supplied_judgments:
+        key, body = _expression_parts(
+            value,
+            expected=expected,
+            pairwise=pairwise,
+            kind="judgments",
+        )
+        text = body.strip()
+        if not text:
+            raise ValueError("corrected judgments must contain nonempty text")
+        if key in judgments:
+            raise ValueError("duplicate corrected judgment for " + _display_key(key))
+        judgments[key] = text
+    expected_set = set(expected)
+    unexpected = sorted(set(labels).union(judgments).difference(expected_set))
+    if unexpected:
+        raise ValueError("unexpected review inputs: " + ", ".join(map(_display_key, unexpected)))
+    without_score = sorted(set(judgments).difference(labels))
+    if without_score:
+        raise ValueError(
+            "corrected judgments also require --label for "
+            + ", ".join(map(_display_key, without_score))
+        )
+    return _ExplicitReviewInputs(labels=labels, judgments=judgments)
+
+
+def _explicit_decision(
+    key: _ReviewKey,
+    *,
+    axis: RubricDimension,
+    proposed_score: int,
+    proposed_judgment: str,
+    score: int,
+    corrected_judgment: str | None,
+    non_interactive: bool,
+    console: Console,
+) -> ManualJudgeAxisDecision:
+    """Convert one explicit score into acceptance or an authored correction.
+
+    Args:
+        key: Frozen trace, reference, and axis identity.
+        axis: Finalized axis that bounds the accepted score.
+        proposed_score: Configured judge's immutable score.
+        proposed_judgment: Configured judge's immutable judgment text.
+        score: Explicit human-authorized score.
+        corrected_judgment: Optional explicit human correction text.
+        non_interactive: Whether missing correction text must fail without prompting.
+        console: Rich console used for any required correction prompt.
+
+    Returns:
+        Explicit acceptance or complete human correction.
+
+    Raises:
+        ValueError: The score is outside the axis or a correction lacks authored judgment text.
+    """
+    dimension_id = key[2]
+    if not axis.contains_score(score):
+        raise ValueError(
+            f"judge labels for {dimension_id} must be integers from "
+            f"{axis.min_score} through {axis.max_score}"
+        )
+    if score == proposed_score and (
+        corrected_judgment is None or corrected_judgment == proposed_judgment
+    ):
+        return ManualJudgeAxisDecision(dimension_id=dimension_id, accepted=True)
+    judgment = corrected_judgment
+    if judgment is None:
+        if non_interactive:
+            raise ValueError(
+                f"a corrected score requires --judgment {_display_key(key)}=CORRECTED_JUDGMENT"
+            )
+        console.print(
+            f"Saved human score {score} differs from the configured judge proposal "
+            f"{proposed_score} for {dimension_id}.",
+            markup=False,
+        )
+        judgment = _prompt_judgment(dimension_id, console)
+    return ManualJudgeAxisDecision(
+        dimension_id=dimension_id,
+        accepted=False,
+        correction=HumanJudgeCorrection(
+            corrected_score=score,
+            corrected_judgment=judgment,
+        ),
+    )
+
+
+def _prompt_score(axis: RubricDimension, console: Console) -> int:
+    """Prompt until the reviewer supplies an integer in the rubric range.
+
+    Args:
+        axis: Rubric axis receiving a corrected score.
+        console: Interactive Rich console.
+
+    Returns:
+        Human-authored integer inside the axis range.
+    """
+    while True:
+        score = IntPrompt.ask(
+            f"Corrected score for {escape(axis.dimension_id)} "
+            f"({axis.min_score} through {axis.max_score})",
+            console=console,
+        )
+        if axis.contains_score(score):
+            return score
+        console.print(
+            f"Corrected scores must be integers from {axis.min_score} through {axis.max_score}."
+        )
+
+
+def _prompt_judgment(dimension_id: str, console: Console) -> str:
+    """Prompt until the reviewer supplies a nonempty authored judgment.
+
+    Args:
+        dimension_id: Rubric axis receiving corrected judgment text.
+        console: Interactive Rich console.
+
+    Returns:
+        Nonempty stripped human-authored judgment text.
+    """
+    while True:
+        judgment = Prompt.ask(
+            f"Corrected judgment for {escape(dimension_id)}",
+            console=console,
+        ).strip()
+        if judgment:
+            return judgment
+        console.print("Corrected judgments must contain nonempty text.")
+
+
+def _find_evidence_span(
+    proposal: ManualJudgeTraceProposal,
+    span_id: str,
+    *,
+    reference: bool,
+) -> tuple[str, TraceSpan]:
+    """Resolve one cited span to its displayed candidate without guessing.
+
+    Args:
+        proposal: Current trace proposal containing displayed candidates.
+        span_id: Exact judge-cited normalized span identity.
+        reference: Whether the citation belongs to the pairwise reference trace.
+
+    Returns:
+        Human-readable candidate label and exact cited span.
+
+    Raises:
+        ValueError: The cited span is absent from its displayed trace.
+    """
+    trace = proposal.reference_trace if reference else proposal.trace
+    source = (
+        "candidate B"
+        if reference
+        else ("candidate A" if proposal.reference_trace is not None else "trace")
+    )
+    if trace is not None:
+        for span in trace.spans:
+            if span.span_id == span_id:
+                return source, span
+    raise ValueError(f"judge cited {source} evidence that is not displayed: {span_id}")
+
+
+def _label(
+    key: _ReviewKey,
+    value: int | str,
+    *,
+    pairwise: bool,
+) -> ManualJudgeLabel:
+    """Build one validated explicit label from its key and typed value.
+
+    Args:
+        key: Frozen trace, optional reference, and rubric axis identity.
+        value: Scalar score or typed pairwise preference.
+        pairwise: Whether the finalized response shape is pairwise.
+
+    Returns:
+        Validated explicit human label.
+    """
+    trace_id, reference_id, dimension_id = key
+    return ManualJudgeLabel.model_validate(
+        {
+            "trace_id": trace_id,
+            "reference_trace_id": reference_id,
+            "dimension_id": dimension_id,
+            **({"winner": value} if pairwise else {"score": value}),
+        }
+    )
+
+
+def _expression_parts(
+    value: str,
+    *,
+    expected: Sequence[_ReviewKey],
+    pairwise: bool,
+    kind: str,
+) -> tuple[_ReviewKey, str]:
+    """Parse one score or judgment expression without splitting valid trace IDs.
+
+    Args:
+        value: CLI expression containing a target and value.
+        expected: Frozen trace, optional reference, and dimension identities.
+        pairwise: Whether the target must include a reference trace.
+        kind: Human-readable expression class for validation errors.
+
+    Returns:
+        Exact frozen review key and the unmodified expression body.
+
+    Raises:
+        ValueError: The target is malformed or ambiguous.
+    """
+    expected_parts = 3 if pairwise else 2
+    stripped = value.lstrip()
+    if stripped.startswith("["):
+        try:
+            target, end = json.JSONDecoder().raw_decode(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{kind} contain a malformed JSON target") from exc
+        remainder = stripped[end:]
+        if (
+            not isinstance(target, list)
+            or len(target) != expected_parts
+            or any(not isinstance(part, str) or not part for part in target)
+            or not remainder.startswith("=")
+        ):
+            raise ValueError(f"{kind} JSON targets must contain {expected_parts} nonempty strings")
+        parts = cast(list[str], target)
+        key: _ReviewKey = (parts[0], parts[1], parts[2]) if pairwise else (parts[0], None, parts[1])
+        return key, remainder[1:]
+    matches = tuple(
+        (key, value[len(prefix) :])
+        for key in expected
+        if value.startswith(prefix := _display_key(key) + "=")
+    )
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        json_target = (
+            '["TRACE_ID", "REFERENCE_TRACE_ID", "DIMENSION_ID"]=VALUE'
+            if pairwise
+            else '["TRACE_ID", "DIMENSION_ID"]=VALUE'
+        )
+        raise ValueError(
+            f"{kind} target is ambiguous; use a JSON array target such as {json_target}"
+        )
+    syntax = (
+        "TRACE_ID:REFERENCE_TRACE_ID:DIMENSION_ID=VALUE"
+        if pairwise
+        else "TRACE_ID:DIMENSION_ID=VALUE"
+    )
+    raise ValueError(
+        f"{kind} must target a frozen review key using {syntax}; "
+        "use a JSON array target when identifiers contain ambiguous delimiters"
+    )
+
+
+def _label_value(
+    raw: str,
+    *,
+    pairwise: bool,
+    axis: RubricDimension | None,
+) -> int | str:
+    """Parse one axis-range score or typed pairwise winner.
+
+    Args:
+        raw: Unmodified label body after the target separator.
+        pairwise: Whether the value must be a typed pairwise preference.
+        axis: Axis that bounds scalar scores, or ``None`` for pairwise input.
+
+    Returns:
+        Integer score or typed pairwise winner.
+
+    Raises:
+        ValueError: The value is malformed or outside the supported contract.
+    """
+    if pairwise:
+        if raw not in {"winner_a", "winner_b", "tie"}:
+            raise ValueError("pairwise judge labels must use winner_a, winner_b, or tie")
+        return raw
+    try:
+        score = int(raw)
+    except ValueError as exc:
+        raise ValueError("judge labels must use an integer score") from exc
+    if axis is None or not axis.contains_score(score):
+        if axis is None:
+            raise ValueError("scalar judge labels require a finalized rubric axis")
+        raise ValueError(
+            f"judge labels for {axis.dimension_id} must be integers from "
+            f"{axis.min_score} through {axis.max_score}"
+        )
+    return score
+
+
+def _label_key_from_model(label: ManualJudgeLabel) -> _ReviewKey:
+    """Return the stable review key carried by one persisted human label.
+
+    Args:
+        label: Persisted explicit human label.
+
+    Returns:
+        Trace, optional reference trace, and rubric axis identity.
+    """
+    return label.trace_id, label.reference_trace_id, label.dimension_id
+
+
+def _display_key(key: _ReviewKey) -> str:
+    """Render one stable review key in the matching CLI expression form.
+
+    Args:
+        key: Trace, optional reference trace, and rubric axis identity.
+
+    Returns:
+        Colon-separated CLI target text.
+    """
+    return ":".join(part for part in key if part is not None)

--- a/wmo/cli/judge_review_test.py
+++ b/wmo/cli/judge_review_test.py
@@ -1,0 +1,676 @@
+"""Tests for one-trace configured-judge proposal review."""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from rich.console import Console
+from rich.text import Text
+
+from wmo.cli import judge_review as review_module
+from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
+from wmo.common.judging import Rubric, RubricDimension
+from wmo.common.judging.judgment import Judgment
+from wmo.common.models import ModelSnapshot
+from wmo.common.traces import Trace, TraceOutcome, TraceSource, TraceSpan
+from wmo.optimize.router.judging.contracts import (
+    JudgeTracePreview,
+    ManualJudgeSetupArtifact,
+)
+from wmo.optimize.router.judging.review import ManualJudgeTraceProposal
+from wmo.optimize.router.judging.service import default_judge_dimensions
+
+
+class _ConfirmAnswers:
+    """Return queued accept-or-correct choices and retain pre-prompt output."""
+
+    answers: list[bool] = []
+    output_before_prompt: list[str] = []
+    prompts: list[str] = []
+
+    @classmethod
+    def ask(
+        cls,
+        prompt: str,
+        *,
+        default: bool,
+        console: Console,
+    ) -> bool:
+        """Return the next queued answer after recording visible proposal context.
+
+        Args:
+            prompt: Rich-compatible accept-or-correct question.
+            default: Expected default acceptance choice.
+            console: Review console whose prior output must contain every proposal.
+
+        Returns:
+            Next queued explicit human choice.
+        """
+        assert default is True
+        file = console.file
+        assert isinstance(file, io.StringIO)
+        cls.output_before_prompt.append(file.getvalue())
+        cls.prompts.append(prompt)
+        return cls.answers.pop(0)
+
+
+class _CorrectedScore:
+    """Supply one corrected rubric score."""
+
+    @classmethod
+    def ask(cls, _prompt: str, *, console: Console) -> int:
+        """Return score zero through the expected review console.
+
+        Args:
+            _prompt: Corrected-score prompt, unused by this deterministic fixture.
+            console: Review console supplied to the Rich prompt.
+
+        Returns:
+            Corrected score zero.
+        """
+        assert isinstance(console, Console)
+        return 0
+
+
+class _CorrectedJudgment:
+    """Supply one human-authored corrected judgment."""
+
+    @classmethod
+    def ask(cls, _prompt: str, *, console: Console) -> str:
+        """Return explicit correction text through the expected review console.
+
+        Args:
+            _prompt: Corrected-judgment prompt, unused by this fixture.
+            console: Review console supplied to the Rich prompt.
+
+        Returns:
+            Deterministic human-authored correction text.
+        """
+        assert isinstance(console, Console)
+        return "The tool result did not establish that the customer request was resolved."
+
+
+class _PagingConsole(Console):
+    """Record one pager expansion while retaining rendered content in memory."""
+
+    pager_count: int
+
+    def __init__(self, buffer: io.StringIO) -> None:
+        """Initialize a deterministic non-terminal console around ``buffer``.
+
+        Args:
+            buffer: In-memory destination retaining pager output.
+        """
+        super().__init__(file=buffer, width=88, color_system=None)
+        self.pager_count = 0
+
+    @contextmanager
+    def pager(self, styles: bool = False, links: bool = False) -> Iterator[None]:
+        """Record pager use without starting an external terminal process.
+
+        Args:
+            styles: Whether Rich styles are retained in pager output.
+            links: Whether terminal hyperlinks are retained.
+
+        Yields:
+            Control to the current-trace renderer.
+        """
+        assert styles is True
+        assert links is False
+        self.pager_count += 1
+        yield
+
+
+class _RubricView:
+    """Expose the ordered-axis methods used by the review adapter."""
+
+    def __init__(self, dimensions: tuple[RubricDimension, ...]) -> None:
+        """Retain deterministic axes under one fixture revision.
+
+        Args:
+            dimensions: Ordered rubric axes used by the proposal.
+        """
+        self.rubric_id = "rubric-revision-1"
+        self.dimensions = dimensions
+
+    def axis(self, dimension_id: str) -> RubricDimension:
+        """Return the fixture axis with ``dimension_id``.
+
+        Args:
+            dimension_id: Stable axis identity.
+
+        Returns:
+            Matching fixture axis.
+
+        Raises:
+            ValueError: The fixture has no matching axis.
+        """
+        for dimension in self.dimensions:
+            if dimension.dimension_id == dimension_id:
+                return dimension
+        raise ValueError(f"fixture rubric has no axis {dimension_id}")
+
+
+def test_one_trace_view_separates_conversation_and_truthfully_truncates() -> None:
+    """The current A/B trace alone shows role, tool, final, rubric, and cited evidence fields."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=48, color_system=None)
+    first = _trace("trace-a", completion="A" * 80, failed=True)
+    second = _trace("trace-b", completion="Candidate B finished.", failed=False)
+    proposal = _proposal(first, reference=second, total=5, multi_axis=True)
+
+    review_module.render_trace_proposal(
+        proposal,
+        character_limit=40,
+        page=False,
+        console=console,
+    )
+
+    output = buffer.getvalue()
+    flattened = " ".join(output.split())
+    assert "Trace 1 of 5" in output
+    assert "Trace 2 of 5" not in output
+    assert "Candidate A" in output
+    assert "Candidate B" in output
+    assert "Original user request:" in output
+    assert "User message:" in output
+    assert "Assistant message:" in output
+    assert "Final response:" in output
+    assert "Tool call:" in output
+    assert "Tool arguments:" in output
+    assert "Tool result:" in output
+    assert "Final outcome:" in output
+    assert "Final failure:" in output
+    assert "Axis 1 of 2: Task success" in output
+    assert "Description: The agent successfully completed the task requested" in flattened
+    assert "Numeric range: 0 to 1" in output
+    assert "0: The agent did not complete the requested task." in flattened
+    assert "1: The agent successfully completed the requested task." in flattened
+    assert "Proposed score: 1" in output
+    assert "Proposed judgment:" in output
+    assert "Cited trace evidence:" in output
+    assert "trace-a-assistant" in output
+    assert "Cited reference trace evidence:" in output
+    assert "trace-b-assistant" in output
+    assert "Evidence content:" in output
+    assert "truncated 40 characters" in output
+    assert "use --page for the full transcript" in flattened
+
+
+def test_acceptance_prompts_only_after_every_axis_proposal_is_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All axis descriptions, anchors, scores, judgments, and citations precede human input.
+
+    Args:
+        monkeypatch: Scoped confirmation prompt replacement.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, color_system=None)
+    proposal = _proposal(_trace("trace-a", completion="Done.", failed=False), multi_axis=True)
+    _ConfirmAnswers.answers = [True, True]
+    _ConfirmAnswers.output_before_prompt = []
+    _ConfirmAnswers.prompts = []
+    monkeypatch.setattr(review_module, "Confirm", _ConfirmAnswers)
+    reviewer = review_module.build_manual_judge_reviewer(
+        _setup(),
+        proposal.rubric,
+        _previews(proposal),
+        drafted_labels=(),
+        supplied_labels=(),
+        supplied_judgments=(),
+        non_interactive=False,
+        character_limit=1_200,
+        page=False,
+        console=console,
+    )
+
+    decisions = reviewer(proposal)
+
+    assert tuple(item.accepted for item in decisions) == (True, True)
+    assert all(item.correction is None for item in decisions)
+    assert len(_ConfirmAnswers.output_before_prompt) == 2
+    assert "Axis 2 of 2: Policy compliance" in _ConfirmAnswers.output_before_prompt[0]
+    assert "Proposed judgment: The response followed the policy." in " ".join(
+        _ConfirmAnswers.output_before_prompt[0].split()
+    )
+
+
+def test_axis_markup_is_rendered_and_prompted_as_literal_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User-authored rubric markup cannot alter proposal output or prompt structure.
+
+    Args:
+        monkeypatch: Scoped confirmation prompt replacement.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, color_system=None)
+    base = _proposal(_trace("trace-a", completion="Done.", failed=False))
+    axis_id = "task-success"
+    axis_name = "[link=https://invalid.example]literal axis[/link] [/]"
+    dimension = base.rubric.dimensions[0].model_copy(
+        update={"dimension_id": axis_id, "name": axis_name}
+    )
+    proposed = base.judgment.dimensions[0]
+    proposal = ManualJudgeTraceProposal(
+        position=base.position,
+        total=base.total,
+        trace=base.trace,
+        reference_trace=base.reference_trace,
+        rubric=cast(Rubric, _RubricView((dimension,))),
+        judgment=cast(
+            Judgment,
+            SimpleNamespace(
+                dimensions=(
+                    SimpleNamespace(
+                        dimension_id=axis_id,
+                        raw_score=proposed.raw_score,
+                        min_score=proposed.min_score,
+                        max_score=proposed.max_score,
+                        feedback=proposed.feedback,
+                        evidence_span_ids=proposed.evidence_span_ids,
+                    ),
+                )
+            ),
+        ),
+    )
+    _ConfirmAnswers.answers = [True]
+    _ConfirmAnswers.output_before_prompt = []
+    _ConfirmAnswers.prompts = []
+    monkeypatch.setattr(review_module, "Confirm", _ConfirmAnswers)
+    reviewer = review_module.build_manual_judge_reviewer(
+        _setup(),
+        proposal.rubric,
+        _previews(proposal),
+        drafted_labels=(),
+        supplied_labels=(),
+        supplied_judgments=(),
+        non_interactive=False,
+        character_limit=1_200,
+        page=False,
+        console=console,
+    )
+
+    decisions = reviewer(proposal)
+
+    assert decisions[0].accepted is True
+    assert axis_name in buffer.getvalue()
+    assert axis_id in buffer.getvalue()
+    assert axis_id in Text.from_markup(_ConfirmAnswers.prompts[0]).plain
+
+
+def test_interactive_correction_captures_score_and_human_judgment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rejecting a proposal records both correction fields without changing judge authorship.
+
+    Args:
+        monkeypatch: Scoped score, judgment, and confirmation prompt replacements.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, color_system=None)
+    proposal = _proposal(_trace("trace-a", completion="Done.", failed=False))
+    _ConfirmAnswers.answers = [False]
+    _ConfirmAnswers.output_before_prompt = []
+    _ConfirmAnswers.prompts = []
+    monkeypatch.setattr(review_module, "Confirm", _ConfirmAnswers)
+    monkeypatch.setattr(review_module, "IntPrompt", _CorrectedScore)
+    monkeypatch.setattr(review_module, "Prompt", _CorrectedJudgment)
+    reviewer = review_module.build_manual_judge_reviewer(
+        _setup(),
+        proposal.rubric,
+        _previews(proposal),
+        drafted_labels=(),
+        supplied_labels=(),
+        supplied_judgments=(),
+        non_interactive=False,
+        character_limit=1_200,
+        page=False,
+        console=console,
+    )
+
+    decision = reviewer(proposal)[0]
+
+    assert decision.accepted is False
+    assert decision.correction is not None
+    assert decision.correction.corrected_score == 0
+    assert decision.correction.corrected_judgment == (
+        "The tool result did not establish that the customer request was resolved."
+    )
+
+
+def test_noninteractive_multi_axis_inputs_accept_and_correct_independently() -> None:
+    """Explicit decisions can accept one proposal and correct another with authored text."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, color_system=None)
+    proposal = _proposal(_trace("trace-a", completion="Done.", failed=False), multi_axis=True)
+    reviewer = review_module.build_manual_judge_reviewer(
+        _setup(),
+        proposal.rubric,
+        _previews(proposal),
+        drafted_labels=(),
+        supplied_labels=("trace-a:task-success=1", "trace-a:policy-compliance=0"),
+        supplied_judgments=(
+            "trace-a:policy-compliance=The response violated the documented escalation rule.",
+        ),
+        non_interactive=True,
+        character_limit=1_200,
+        page=False,
+        console=console,
+    )
+
+    accepted, corrected = reviewer(proposal)
+
+    assert accepted.dimension_id == "task-success"
+    assert accepted.accepted is True
+    assert accepted.correction is None
+    assert corrected.dimension_id == "policy-compliance"
+    assert corrected.accepted is False
+    assert corrected.correction is not None
+    assert corrected.correction.corrected_score == 0
+    assert corrected.correction.corrected_judgment == (
+        "The response violated the documented escalation rule."
+    )
+
+
+def test_noninteractive_scalar_score_respects_the_saved_axis_range() -> None:
+    """Explicit scalar corrections cannot leave the finalized inclusive range."""
+    proposal = _proposal(_trace("trace-a", completion="Done.", failed=False))
+
+    with pytest.raises(ValueError, match="from 0 through 1"):
+        review_module.build_manual_judge_reviewer(
+            _setup(),
+            proposal.rubric,
+            _previews(proposal),
+            drafted_labels=(),
+            supplied_labels=("trace-a:task-success=2",),
+            supplied_judgments=("trace-a:task-success=Outside the saved range.",),
+            non_interactive=True,
+            character_limit=1_200,
+            page=False,
+            console=Console(file=io.StringIO(), color_system=None),
+        )
+
+
+def test_explicit_pairwise_json_target_preserves_trace_id_delimiters() -> None:
+    """JSON targets address pairwise trace IDs containing colons and equals signs."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, color_system=None)
+    trace = _trace("trace:a=1", completion="Candidate A finished.", failed=False)
+    reference = _trace("trace:b=2", completion="Candidate B finished.", failed=False)
+    proposal = _proposal(trace, reference=reference)
+    target = json.dumps([trace.trace_id, reference.trace_id, "task-success"])
+    reviewer = review_module.build_manual_judge_reviewer(
+        _setup(response_shape="pairwise"),
+        proposal.rubric,
+        _previews(proposal),
+        drafted_labels=(),
+        supplied_labels=(target + "=winner_a",),
+        supplied_judgments=(),
+        non_interactive=True,
+        character_limit=1_200,
+        page=False,
+        console=console,
+    )
+
+    decisions = reviewer(proposal)
+
+    assert decisions[0].accepted is True
+    assert decisions[0].correction is None
+
+
+def test_page_expands_only_the_current_full_transcript() -> None:
+    """Paging is explicit, current-trace scoped, and removes every truncation marker."""
+    buffer = io.StringIO()
+    console = _PagingConsole(buffer)
+    completion = "full response " * 80
+    proposal = _proposal(_trace("trace-a", completion=completion, failed=False), total=5)
+
+    review_module.render_trace_proposal(
+        proposal,
+        character_limit=40,
+        page=True,
+        console=console,
+    )
+
+    output = buffer.getvalue()
+    assert console.pager_count == 1
+    assert "Trace 1 of 5" in output
+    assert "Trace 2 of 5" not in output
+    assert " ".join(completion.split()) in " ".join(output.split())
+    assert "truncated" not in output
+
+
+def _setup(*, response_shape: str = "scalar") -> ManualJudgeSetupArtifact:
+    """Return the scalar or pairwise setup surface needed by the reviewer.
+
+    Args:
+        response_shape: Finalized configured-judge response shape.
+
+    Returns:
+        Minimal setup surface used by the CLI review adapter.
+    """
+    return cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(
+            prompt_template=SimpleNamespace(
+                response_shape=response_shape,
+                score_projection=SimpleNamespace(
+                    pairwise_scores={"winner_a": 1, "winner_b": 0, "tie": 1}
+                ),
+            )
+        ),
+    )
+
+
+def _previews(proposal: ManualJudgeTraceProposal) -> tuple[JudgeTracePreview, ...]:
+    """Return the frozen preview identity matching ``proposal``.
+
+    Args:
+        proposal: Current configured-judge trace proposal.
+
+    Returns:
+        Single matching preview identity.
+    """
+    return (
+        cast(
+            JudgeTracePreview,
+            SimpleNamespace(
+                trace_id=proposal.trace.trace_id,
+                reference_trace_id=(
+                    proposal.reference_trace.trace_id
+                    if proposal.reference_trace is not None
+                    else None
+                ),
+            ),
+        ),
+    )
+
+
+def _proposal(
+    trace: Trace,
+    *,
+    reference: Trace | None = None,
+    total: int = 1,
+    multi_axis: bool = False,
+) -> ManualJudgeTraceProposal:
+    """Return one configured-judge proposal over exact trace span citations.
+
+    Args:
+        trace: Target conversation trace.
+        reference: Optional same-task candidate B trace.
+        total: Total trace count shown in progress.
+        multi_axis: Whether to add a second policy rubric axis.
+
+    Returns:
+        Deterministic proposal fixture with concrete trace citations.
+    """
+    task_success = default_judge_dimensions()[0]
+    policy = task_success.model_copy(
+        update={
+            "dimension_id": "policy-compliance",
+            "name": "Policy compliance",
+            "description": "Whether the response followed the documented escalation policy.",
+        }
+    )
+    dimensions: tuple[RubricDimension, ...] = (
+        (task_success, policy) if multi_axis else (task_success,)
+    )
+    judgments = [
+        SimpleNamespace(
+            dimension_id="task-success",
+            raw_score=1,
+            min_score=task_success.min_score,
+            max_score=task_success.max_score,
+            feedback="The response completed the requested account lookup.",
+            evidence_span_ids=(f"{trace.trace_id}-assistant",),
+        )
+    ]
+    if multi_axis:
+        judgments.append(
+            SimpleNamespace(
+                dimension_id="policy-compliance",
+                raw_score=1,
+                min_score=policy.min_score,
+                max_score=policy.max_score,
+                feedback="The response followed the policy.",
+                evidence_span_ids=(f"{trace.trace_id}-tool-result",),
+            )
+        )
+    rubric = cast(Rubric, _RubricView(dimensions))
+    judgment = cast(Judgment, SimpleNamespace(dimensions=tuple(judgments)))
+    pairwise_citations = (
+        tuple(
+            (
+                item.dimension_id,
+                item.evidence_span_ids,
+                (f"{reference.trace_id}-assistant",)
+                if item.dimension_id == "task-success"
+                else (f"{reference.trace_id}-tool-result",),
+            )
+            for item in judgments
+        )
+        if reference is not None
+        else ()
+    )
+    return ManualJudgeTraceProposal(
+        position=1,
+        total=total,
+        trace=trace,
+        reference_trace=reference,
+        rubric=rubric,
+        judgment=judgment,
+        pairwise_citations=pairwise_citations,
+    )
+
+
+def _model() -> ModelSnapshot:
+    """Return one exact secret-free assistant identity."""
+    return ModelSnapshot(
+        provider="openai",
+        model_id="assistant-model",
+        revision=None,
+        capabilities_sha256="0" * 64,
+        connection_sha256="1" * 64,
+    )
+
+
+def _trace(trace_id: str, *, completion: str, failed: bool) -> Trace:
+    """Return a conversation with user, assistant, tool, result, and final response events.
+
+    Args:
+        trace_id: Stable trace and span identity prefix.
+        completion: First captured assistant message.
+        failed: Whether the terminal outcome records a failure.
+
+    Returns:
+        Complete normalized conversation fixture.
+    """
+    started = datetime(2026, 8, 16, tzinfo=UTC)
+    spans = (
+        TraceSpan(
+            span_id=f"{trace_id}-assistant",
+            name="agent.model_call",
+            started_at=started,
+            ended_at=started + timedelta(seconds=1),
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.input.messages": (
+                    f"[{json_message('user', f'Please resolve customer issue {trace_id}.')}]"
+                ),
+                "gen_ai.output.messages": [
+                    {"role": "assistant", "content": [{"type": "text", "text": completion}]}
+                ],
+            },
+            model=_model(),
+        ),
+        TraceSpan(
+            span_id=f"{trace_id}-tool-call",
+            name="agent.model_call",
+            started_at=started + timedelta(seconds=2),
+            ended_at=started + timedelta(seconds=3),
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.call.arguments": '{"query":"customer issue"}',
+            },
+            model=_model(),
+        ),
+        TraceSpan(
+            span_id=f"{trace_id}-tool-result",
+            name="agent.tool_call",
+            started_at=started + timedelta(seconds=4),
+            ended_at=started + timedelta(seconds=5),
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.output": "Found the relevant account record.",
+            },
+        ),
+        TraceSpan(
+            span_id=f"{trace_id}-final",
+            name="agent.model_call",
+            started_at=started + timedelta(seconds=6),
+            ended_at=started + timedelta(seconds=7),
+            attributes={"gen_ai.response.text": "The customer request is resolved."},
+            model=_model(),
+        ),
+    )
+    failure = StructuredFailure(code=FailureCode.INTERNAL, message="Customer request failed")
+    return Trace(
+        trace_id=trace_id,
+        task="Resolve the customer's support request.",
+        initial_context={"account_tier": "business"},
+        spans=spans,
+        outcome=(
+            TraceOutcome(status="failure", failure=failure)
+            if failed
+            else TraceOutcome(status="success", outcome_name="resolved")
+        ),
+        source=TraceSource(
+            identity=SourceIdentity(kind="manual", source_id=trace_id, sha256="2" * 64),
+            semantic_convention_version="test-v1",
+        ),
+    )
+
+
+def json_message(role: str, content: str) -> str:
+    """Return one compact JSON object without importing a fixture serializer.
+
+    Args:
+        role: Normalized conversation role.
+        content: Message content requiring JSON string escaping.
+
+    Returns:
+        Compact JSON object text.
+    """
+    escaped = content.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{{"role":"{role}","content":"{escaped}"}}'

--- a/wmo/cli/judge_transcript.py
+++ b/wmo/cli/judge_transcript.py
@@ -32,26 +32,35 @@ def render_trace(console: Console, trace: Trace, *, character_limit: int | None)
         trace: Verified immutable normalized production trace.
         character_limit: Maximum characters per field, or ``None`` for the full value.
     """
-    _render_field(console, "User / task", trace.task, character_limit=character_limit)
+    render_field(console, "Original user request", trace.task, character_limit=character_limit)
     if trace.initial_context:
-        _render_field(
+        render_field(
             console,
             "Initial context",
-            _jsonish_text(trace.initial_context),
+            jsonish_text(trace.initial_context),
             character_limit=character_limit,
         )
-    for span in trace.spans:
-        _render_span(console, span, character_limit=character_limit)
+    completion_positions = tuple(
+        index for index, span in enumerate(trace.spans) if assistant_completion(span.attributes)
+    )
+    final_completion = completion_positions[-1] if completion_positions else None
+    for index, span in enumerate(trace.spans):
+        _render_span(
+            console,
+            span,
+            final_response=index == final_completion,
+            character_limit=character_limit,
+        )
     outcome = trace.outcome
     if outcome is None:
-        _render_field(console, "Final outcome", "Not recorded", character_limit=character_limit)
+        render_field(console, "Final outcome", "Not recorded", character_limit=character_limit)
         return
     outcome_text = outcome.status
     if outcome.outcome_name is not None:
         outcome_text += f" ({outcome.outcome_name})"
-    _render_field(console, "Final outcome", outcome_text, character_limit=character_limit)
+    render_field(console, "Final outcome", outcome_text, character_limit=character_limit)
     if outcome.failure is not None:
-        _render_field(
+        render_field(
             console,
             "Final failure",
             f"{outcome.failure.code.value}: {outcome.failure.message} "
@@ -60,12 +69,19 @@ def render_trace(console: Console, trace: Trace, *, character_limit: int | None)
         )
 
 
-def _render_span(console: Console, span: TraceSpan, *, character_limit: int | None) -> None:
+def _render_span(
+    console: Console,
+    span: TraceSpan,
+    *,
+    final_response: bool,
+    character_limit: int | None,
+) -> None:
     """Render recognized assistant, tool-call, tool-result, and failure evidence.
 
     Args:
         console: Destination for the rendered fields.
         span: One normalized chronological trace span.
+        final_response: Whether this span holds the last captured assistant response.
         character_limit: Maximum characters per field, or ``None`` for the full value.
     """
     attributes = span.attributes
@@ -75,44 +91,42 @@ def _render_span(console: Console, span: TraceSpan, *, character_limit: int | No
     result = attributes.get("gen_ai.tool.message")
     if result is None:
         result = attributes.get("gen_ai.tool.output")
-    completion = _assistant_completion(attributes)
-    user_input = _user_input(attributes)
-    if user_input is not None:
-        _render_field(console, "User message", user_input, character_limit=character_limit)
+    completion = assistant_completion(attributes)
+    user_message = user_input(attributes)
+    console.print(f"\nEvidence span {span.span_id} ({span.name})", style="dim", markup=False)
+    if user_message is not None:
+        render_field(console, "User message", user_message, character_limit=character_limit)
     if span.model is not None:
-        _render_field(
+        render_field(
             console,
-            "Assistant / model",
+            "Assistant model",
             model_display_name(span.model),
             character_limit=character_limit,
         )
     if completion:
-        _render_field(console, "Assistant output", completion, character_limit=character_limit)
+        render_field(
+            console,
+            "Final response" if final_response else "Assistant message",
+            completion,
+            character_limit=character_limit,
+        )
     if operation != "execute_tool" and isinstance(tool_name, str):
-        _render_field(console, "Tool call", tool_name, character_limit=character_limit)
+        render_field(console, "Tool call", tool_name, character_limit=character_limit)
         if arguments is not None:
-            _render_field(
+            render_field(
                 console,
                 "Tool arguments",
-                _jsonish_text(arguments),
+                jsonish_text(arguments),
                 character_limit=character_limit,
             )
     if operation == "execute_tool":
-        _render_field(
-            console,
-            "Tool result",
-            tool_name if isinstance(tool_name, str) else span.name,
-            character_limit=character_limit,
-        )
+        result_name = tool_name if isinstance(tool_name, str) else span.name
+        result_text = result_name
         if result is not None:
-            _render_field(
-                console,
-                "Tool output",
-                _jsonish_text(result),
-                character_limit=character_limit,
-            )
+            result_text += "\n" + jsonish_text(result)
+        render_field(console, "Tool result", result_text, character_limit=character_limit)
     if span.failure is not None:
-        _render_field(
+        render_field(
             console,
             "Span failure",
             f"{span.failure.code.value}: {span.failure.message}",
@@ -120,7 +134,7 @@ def _render_span(console: Console, span: TraceSpan, *, character_limit: int | No
         )
 
 
-def _assistant_completion(attributes: dict[str, JsonValue]) -> str | None:
+def assistant_completion(attributes: dict[str, JsonValue]) -> str | None:
     """Extract readable assistant content from supported normalized attributes.
 
     Args:
@@ -139,7 +153,7 @@ def _assistant_completion(attributes: dict[str, JsonValue]) -> str | None:
     )
 
 
-def _user_input(attributes: dict[str, JsonValue]) -> str | None:
+def user_input(attributes: dict[str, JsonValue]) -> str | None:
     """Extract the latest readable user message from one normalized span.
 
     Args:
@@ -217,7 +231,7 @@ def _message_text(value: JsonValue | None) -> str | None:
     return "\n".join(texts) if texts else None
 
 
-def _jsonish_text(value: JsonValue) -> str:
+def jsonish_text(value: JsonValue) -> str:
     """Format native or JSON-encoded transcript evidence for a human.
 
     Args:
@@ -235,7 +249,40 @@ def _jsonish_text(value: JsonValue) -> str:
     return json.dumps(decoded, indent=2, sort_keys=True, ensure_ascii=False)
 
 
-def _render_field(console: Console, label: str, value: str, *, character_limit: int | None) -> None:
+def span_evidence_text(span: TraceSpan) -> str:
+    """Return role- and tool-labeled visible content from one cited span.
+
+    Args:
+        span: Judge-cited normalized trace span.
+
+    Returns:
+        Captured evidence text without inferred facts.
+    """
+    attributes = span.attributes
+    pieces: list[str] = []
+    user_message = user_input(attributes)
+    completion = assistant_completion(attributes)
+    if user_message is not None:
+        pieces.append("User message: " + user_message)
+    if completion is not None:
+        pieces.append("Assistant message: " + completion)
+    tool_name = attributes.get("gen_ai.tool.name")
+    if isinstance(tool_name, str):
+        pieces.append("Tool: " + tool_name)
+    arguments = attributes.get("gen_ai.tool.call.arguments")
+    if arguments is not None:
+        pieces.append("Tool arguments: " + jsonish_text(arguments))
+    result = attributes.get("gen_ai.tool.message")
+    if result is None:
+        result = attributes.get("gen_ai.tool.output")
+    if result is not None:
+        pieces.append("Tool result: " + jsonish_text(result))
+    if span.failure is not None:
+        pieces.append(f"Failure: {span.failure.code.value}: {span.failure.message}")
+    return "\n".join(pieces) if pieces else f"Captured span {span.name}"
+
+
+def render_field(console: Console, label: str, value: str, *, character_limit: int | None) -> None:
     """Render one safely wrapped transcript field with truthful truncation.
 
     Args:

--- a/wmo/cli/tests/terminal_tasks_happy_path_test.py
+++ b/wmo/cli/tests/terminal_tasks_happy_path_test.py
@@ -1,10 +1,10 @@
 """End-to-end regression over the pinned public terminal-tasks trace export.
 
 The published quickstart hands `wmo build` one unmodified Hugging Face OTLP export whose
-environment-capture spans carry no provider or model identity, then sets up a judge, labels real
+environment-capture spans carry no provider or model identity, then sets up a judge, reviews real
 traces, calibrates, and approves. This module walks that whole path with deterministic local
-model clients and proves the source stays provider free, that completed human labels survive a
-provider failure, and that replay and approval never ask for a label again.
+model clients and proves the source stays provider free, that completed trace reviews survive a
+provider failure, and that replay and approval make no provider calls or review prompts.
 """
 
 from __future__ import annotations
@@ -41,6 +41,7 @@ from wmo.common.models import (
 from wmo.common.project import ProjectStore
 from wmo.common.rollouts import RolloutArtifact
 from wmo.common.traces import load_trace_dataset
+from wmo.optimize.router.judging.contracts import ManualJudgeTraceReviewArtifact
 from wmo.optimize.router.judging.service import prepare_manual_judge_calibration
 from wmo.runtime.models import ResolvedModel
 from wmo.runtime.models.registry import RuntimeModelCatalog
@@ -52,7 +53,7 @@ TRACES_URL = (
 TRACES_SHA256 = "21c62cba7e3372cbf03df051dc2408699fbf8ea3561ba661b599e4949f0e5d42"
 _JUDGE_MODEL_ID = "judge-id"
 _PROJECT = "terminal-tasks"
-_SAMPLE_SIZE = 10
+_SAMPLE_SIZE = 5
 
 
 class _EmbeddingClient:
@@ -200,23 +201,35 @@ def _write_catalog(root: Path) -> None:
 
 
 def _calibrate_arguments(
-    root: Path, labels: Sequence[str], sample_size: int = _SAMPLE_SIZE
+    root: Path,
+    labels: Sequence[str],
+    sample_size: int | None = None,
 ) -> list[str]:
-    """Return one non-interactive calibrate invocation that uses catalog prices."""
-    return [
+    """Return one noninteractive calibrate invocation using catalog prices.
+
+    Args:
+        root: Local test project root.
+        labels: Repeatable explicit label arguments.
+        sample_size: Optional override; ``None`` exercises the installed default of five.
+
+    Returns:
+        Complete nested CLI argument list.
+    """
+    arguments = [
         "config",
         "judge",
         "calibrate",
         _PROJECT,
         "--root",
         str(root),
-        "--sample-size",
-        str(sample_size),
         "--yes",
         "--approve",
         "--non-interactive",
         *labels,
     ]
+    if sample_size is not None:
+        arguments[6:6] = ["--sample-size", str(sample_size)]
+    return arguments
 
 
 def _rollout_payloads(store: ProjectStore) -> tuple[tuple[RolloutArtifact, str], ...]:
@@ -260,7 +273,7 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
     assert setup.exit_code == 0, setup.output
 
     store = ProjectStore(root, _PROJECT)
-    plan = prepare_manual_judge_calibration(store, sample_size=_SAMPLE_SIZE)
+    plan = prepare_manual_judge_calibration(store)
     assert len(plan.traces) == _SAMPLE_SIZE
     assert all(span.model is None for trace in plan.traces for span in trace.spans)
     labels = [
@@ -284,43 +297,50 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
     refused_text = " ".join(unstyle(refused.output).replace("│", " ").split())
     assert "Cost preflight" in refused_text
     assert "command: wmo config judge calibrate terminal-tasks" in refused_text
-    assert "estimated cost: $1.10592" in refused_text
+    assert "estimated cost: $0.55296" in refused_text
     assert "configured budget: $0.50 per command" in refused_text
     assert "judge judge: openai/judge-id" in refused_text
-    assert "10 judge calls with up to 3 attempts each" in refused_text
+    assert "5 remaining judge calls with up to 3 attempts each" in refused_text
     assert "--yes cannot override" in refused_text
     assert "missing labels" not in refused_text
     assert _RuntimeCatalog.judge_clients == []
     assert store.read_review() == before_preflight
     set_maximum_command_cost_usd(25.0, root)
 
-    _RuntimeCatalog.judge_fail_after = 0
+    _RuntimeCatalog.judge_fail_after = 1
     interrupted = runner.invoke(app, _calibrate_arguments(root, labels))
     assert interrupted.exit_code != 0
-    assert "INTEGER 0-1 CALIBRATION" in interrupted.output
-    assert "User / task:" in interrupted.output
+    assert "Trace 1 of 5" in interrupted.output
+    assert "Original user request:" in interrupted.output
     assert "Tool call:" in interrupted.output
     assert "Tool arguments:" in interrupted.output
     assert "Tool result:" in interrupted.output
-    assert "Tool output:" in interrupted.output
     assert "Final outcome:" in interrupted.output
+    assert "Configured judge proposals" in interrupted.output
+    assert "Proposed score: 1" in interrupted.output
+    assert "Proposed judgment:" in interrupted.output
+    assert "Cited trace evidence:" in interrupted.output
     assert "0: The agent did not complete the requested task." in interrupted.output
     assert "1: The agent successfully completed the requested task." in interrupted.output
-    drafted = _drafted_labels(store)
-    assert len(drafted) == _SAMPLE_SIZE
-    assert {item["score"] for item in drafted} == {1}
+    assert len(_trace_reviews(store)) == 1
 
     _RuntimeCatalog.judge_fail_after = None
     _RuntimeCatalog.judge_clients = []
     resumed = runner.invoke(
         app,
-        [argument for argument in _calibrate_arguments(root, ()) if argument != "--approve"],
+        [argument for argument in _calibrate_arguments(root, labels) if argument != "--approve"],
     )
     assert resumed.exit_code == 2
-    assert "Resuming 10 saved human labels" in resumed.output
-    resumed_text = unstyle(resumed.output)
+    resumed_text = " ".join(unstyle(resumed.output).replace("│", " ").split())
+    assert "review progress: 1/5 distinct trace lineages complete" in resumed_text
+    assert "Trace 1 of 5" not in resumed.output
+    assert "Trace 2 of 5" in resumed.output
     assert "--approve" in resumed_text
-    assert sum(client.calls for client in _RuntimeCatalog.judge_clients) == _SAMPLE_SIZE
+    assert sum(client.calls for client in _RuntimeCatalog.judge_clients) == _SAMPLE_SIZE - 1
+    drafted = _drafted_labels(store)
+    assert len(drafted) == _SAMPLE_SIZE
+    assert {item["score"] for item in drafted} == {1}
+    assert len(_trace_reviews(store)) == _SAMPLE_SIZE
     assert _review_completion(store) == (True, False)
 
     _RuntimeCatalog.judge_fail_after = 0
@@ -337,7 +357,7 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
     assert "already complete" in unapproved_replay.output
     replay_text = unstyle(unapproved_replay.output)
     assert "--approve" in replay_text
-    assert "Spend preflight" not in unapproved_replay.output
+    assert "Cost preflight" not in unapproved_replay.output
     assert "Resuming" not in unapproved_replay.output
     assert _RuntimeCatalog.judge_clients == []
     assert _review_completion(store) == (True, False)
@@ -348,7 +368,7 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
     )
     assert approved.exit_code == 0, approved.output
     assert "Approved judge calibration" in approved.output
-    assert "Spend preflight" not in approved.output
+    assert "Cost preflight" not in approved.output
     assert _RuntimeCatalog.judge_clients == []
     assert _review_completion(store) == (True, True)
 
@@ -364,11 +384,10 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
         ],
     )
     assert replay.exit_code == 0, replay.output
-    assert "estimated cost: $0.00" in replay.output
-    assert "authorization: automatic" in replay.output
+    assert "Cost preflight" not in replay.output
+    assert "authorization:" not in replay.output
     assert "Proceed?" not in replay.output
     assert "Approved judge calibration" in replay.output
-    assert "Spend preflight" not in replay.output
     assert _RuntimeCatalog.judge_clients == []
 
     resampled = runner.invoke(
@@ -395,6 +414,19 @@ def test_public_terminal_tasks_path_stays_provider_free_and_keeps_labels(
         assert provenance.checked_span_count == len(rollout.spans)
         assert all(span.model is None for span in rollout.spans)
         assert _JUDGE_MODEL_ID not in text
+
+    reviews = _trace_reviews(store)
+    assert len(reviews) == _SAMPLE_SIZE
+    for review in reviews:
+        assert review.provenance.historical_source == "provider_free_production_trace"
+        assert review.provenance.proposal_author == "configured_judge"
+        assert review.provenance.decision_author == "human"
+        assert review.original_judge_response
+        assert review.judge_model.model_id == _JUDGE_MODEL_ID
+        assert review.rubric_revision == plan.setup.rubric
+        assert review.axes[0].human_correction is None
+        assert review.axes[0].final_accepted_label.score_source == "configured_judge"
+        assert review.axes[0].final_accepted_label.judgment_source == "configured_judge"
 
     dataset = load_trace_dataset(store.artifacts, plan.setup.trace_dataset.artifact_id)
     assert len(dataset.traces) >= 100
@@ -440,3 +472,31 @@ def _review_completion(store: ProjectStore) -> tuple[bool, bool]:
     return manual_judge.get("audit") is not None, manual_judge.get(
         "approved_calibration"
     ) is not None
+
+
+def _trace_reviews(store: ProjectStore) -> tuple[ManualJudgeTraceReviewArtifact, ...]:
+    """Return completed immutable trace review artifacts from mutable pointer state.
+
+    Args:
+        store: Project whose completed trace review pointers are inspected.
+
+    Returns:
+        Parsed trace review artifacts in incremental completion order.
+    """
+    review = store.read_review()
+    assert isinstance(review, dict)
+    manual_judge = review["manual_judge"]
+    assert isinstance(manual_judge, dict)
+    pointers = manual_judge["trace_reviews"]
+    assert isinstance(pointers, list)
+    artifacts: list[ManualJudgeTraceReviewArtifact] = []
+    for pointer in pointers:
+        assert isinstance(pointer, dict)
+        artifact_id = pointer["artifact_id"]
+        assert isinstance(artifact_id, str)
+        artifacts.append(
+            ManualJudgeTraceReviewArtifact.model_validate_json(
+                store.artifacts.read_bytes(artifact_id, "review.json")
+            )
+        )
+    return tuple(artifacts)

--- a/wmo/common/judging/calibration.py
+++ b/wmo/common/judging/calibration.py
@@ -276,7 +276,7 @@ class JudgeCalibrationService:
             store: Project store containing the exact completed reviewed report artifact.
             report: Report whose persisted evidence is being approved.
             approved_at: Time the customer accepted the visible OOF evidence.
-            accept_insufficient_labels: Explicit risk acceptance below ten rollouts when
+            accept_insufficient_labels: Explicit risk acceptance below five rollouts when
                 per-dimension OOF evidence is valid.
 
         Returns:
@@ -733,7 +733,7 @@ def _report_status(
         tuple(dimension.dimension_id for dimension in rubric.dimensions), metrics, predictions
     ):
         return "insufficient"
-    if len({item.human_score.rollout_id for item in data}) < 10:
+    if len({item.human_score.rollout_id for item in data}) < 5:
         return "insufficient"
     return "ready_for_approval"
 

--- a/wmo/common/judging/calibration_assembly.py
+++ b/wmo/common/judging/calibration_assembly.py
@@ -58,6 +58,7 @@ def calibration_from_report(
         out_of_fold_report_sha256=report_input.sha256,
         score_maps=report.score_maps,
         label_count=report.eligible_label_count,
+        recommended_label_count=report.recommended_label_count,
         status=status,
         approved_at=approved_at,
         risk_acceptance=risk_acceptance,

--- a/wmo/common/judging/calibration_contracts.py
+++ b/wmo/common/judging/calibration_contracts.py
@@ -43,19 +43,21 @@ class JudgeScoreObservation(ContractModel):
 
 
 class InsufficientCalibrationRiskAcceptance(ArtifactEnvelope):
-    """Explicit human acceptance of the risk from fewer than ten eligible rollouts."""
+    """Explicit human acceptance of the risk from fewer than five eligible rollouts."""
 
     acceptance_id: ArtifactId
     report: ArtifactInput
     eligible_label_count: int = Field(ge=1)
     eligible_rollout_count: int = Field(ge=1, lt=10)
-    recommended_label_count: Literal[10] = 10
+    recommended_label_count: Literal[5, 10] = 5
     accepted_at: AwareDatetime
     risk_accepted: Literal[True] = True
 
     @model_validator(mode="after")
     def _require_report_bound_acceptance(self) -> InsufficientCalibrationRiskAcceptance:
         """Require this durable decision to hash exactly its accepted report."""
+        if self.eligible_rollout_count >= self.recommended_label_count:
+            raise ValueError("risk acceptance requires fewer than the recommended rollout count")
         if self.created_at != self.accepted_at:
             raise ValueError("risk acceptance created_at must equal accepted_at")
         if self.inputs != (self.report,):
@@ -84,7 +86,7 @@ class CalibrationReport(ArtifactEnvelope):
     excluded_held_out_rollout_count: int = Field(ge=0)
     excluded_held_out_lineage_ids: tuple[ArtifactId, ...]
     excluded_held_out_lineage_count: int = Field(ge=0)
-    recommended_label_count: Literal[10] = 10
+    recommended_label_count: Literal[5, 10] = 5
     status: Literal["provisional", "insufficient", "ready_for_approval"]
     score_maps: tuple[DimensionScoreMap, ...]
     dimension_metrics: tuple[DimensionCalibrationMetrics, ...]

--- a/wmo/common/judging/risk_acceptance.py
+++ b/wmo/common/judging/risk_acceptance.py
@@ -65,8 +65,8 @@ def require_calibration_risk_acceptance(
     if report.status == "insufficient" and calibration.status == "human_calibrated":
         if report.eligible_rollout_count >= report.recommended_label_count:
             raise RiskAcceptanceError(
-                "insufficient human calibration risk acceptance is limited to fewer than ten "
-                "eligible rollouts"
+                "insufficient human calibration risk acceptance is limited to fewer than "
+                f"{report.recommended_label_count} eligible rollouts"
             )
         if calibration.risk_acceptance is None:
             raise RiskAcceptanceError(
@@ -167,7 +167,10 @@ def _acceptance_from_report(
     if report.status != "insufficient":
         raise RiskAcceptanceError("risk acceptance requires an insufficient calibration report")
     if report.eligible_rollout_count >= report.recommended_label_count:
-        raise RiskAcceptanceError("risk acceptance requires fewer than ten eligible rollouts")
+        raise RiskAcceptanceError(
+            "risk acceptance requires fewer than "
+            f"{report.recommended_label_count} eligible rollouts"
+        )
     if report_input.artifact_id != report.report_id:
         raise RiskAcceptanceError("risk acceptance report manifest has the wrong artifact identity")
     acceptance_id = stable_id(
@@ -190,6 +193,7 @@ def _acceptance_from_report(
         report=report_input,
         eligible_label_count=report.eligible_label_count,
         eligible_rollout_count=report.eligible_rollout_count,
+        recommended_label_count=report.recommended_label_count,
         accepted_at=accepted_at,
     )
 

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -320,7 +320,7 @@ class JudgeCalibration(ArtifactEnvelope):
     out_of_fold_report_sha256: Sha256
     score_maps: tuple[DimensionScoreMap, ...]
     label_count: int = Field(default=0, ge=0)
-    recommended_label_count: Literal[10] = 10
+    recommended_label_count: Literal[5, 10] = 5
     status: Literal["provisional", "insufficient", "human_calibrated"] = "provisional"
     approved_at: AwareDatetime | None = None
     risk_acceptance: ArtifactInput | None = None

--- a/wmo/optimize/router/automatic/service_test.py
+++ b/wmo/optimize/router/automatic/service_test.py
@@ -958,6 +958,7 @@ def test_automatic_router_rejects_substituted_manual_judge_audit_before_calls(
         report_input=audit.report,
         budget=substituted_budget,
         judgments=audit.judgments,
+        trace_reviews=audit.trace_reviews,
         positional_bias=(
             (audit.positional_bias_comparisons, audit.positional_bias_flips)
             if audit.positional_bias_comparisons is not None

--- a/wmo/optimize/router/judging/artifacts.py
+++ b/wmo/optimize/router/judging/artifacts.py
@@ -44,6 +44,7 @@ from wmo.optimize.router.judging.contracts import (
     ManualJudgeError,
     ManualJudgeReviewState,
     ManualJudgeSetupArtifact,
+    ManualJudgeTraceReviewArtifact,
 )
 from wmo.simulation.build import BuildReviewReadiness, coordinate_selected_build_review
 
@@ -739,6 +740,7 @@ def write_audit(
     report_input: ArtifactInput,
     budget: JudgeCalibrationBudget,
     judgments: tuple[JudgeRunEvidence, ...],
+    trace_reviews: tuple[ArtifactInput, ...],
     positional_bias: tuple[int, int] | None,
     created_at: datetime,
     code_revision: str,
@@ -754,6 +756,7 @@ def write_audit(
         report_input: Completed disagreement report pointer.
         budget: Consent-bound conservative spend reservation.
         judgments: Persisted rollout and structured judgment pairs.
+        trace_reviews: Immutable human decisions aligned with ``judgments``.
         positional_bias: Pairwise comparison and order-flip counts, otherwise ``None``.
         created_at: Artifact completion time.
         code_revision: Exact producer revision.
@@ -777,6 +780,7 @@ def write_audit(
                 ),
                 *(item.judgment for item in judgments),
                 *(probe for item in judgments for probe in item.probes),
+                *trace_reviews,
             ),
             key=lambda item: item.artifact_id,
         )
@@ -787,11 +791,12 @@ def write_audit(
             "inputs": [item.model_dump(mode="json") for item in inputs],
             "budget": budget.model_dump(mode="json"),
             "judgments": [item.model_dump(mode="json") for item in judgments],
+            "trace_reviews": [item.model_dump(mode="json") for item in trace_reviews],
             "positional_bias": positional_bias,
         },
     )
     audit = ManualJudgeCalibrationAudit(
-        schema_version=1,
+        schema_version=2,
         created_at=created_at,
         inputs=inputs,
         code_revision=code_revision,
@@ -803,6 +808,7 @@ def write_audit(
         report=report_input,
         budget=budget,
         judgments=judgments,
+        trace_reviews=trace_reviews,
         positional_bias_comparisons=(positional_bias[0] if positional_bias is not None else None),
         positional_bias_flips=(positional_bias[1] if positional_bias is not None else None),
     )
@@ -861,6 +867,26 @@ def read_audit(store: ProjectStore, expected: ArtifactInput) -> ManualJudgeCalib
         )
     except JudgingProvenanceError as exc:
         raise ManualJudgeError("completed judge calibration audit is unavailable") from exc
+    for review_input, evidence in zip(audit.trace_reviews, audit.judgments, strict=True):
+        try:
+            review, _ = read_artifact_json(
+                store,
+                artifact_id=review_input.artifact_id,
+                expected_artifact_type="manual-judge-trace-review",
+                relative_path="review.json",
+                model_type=ManualJudgeTraceReviewArtifact,
+                expected_input=review_input,
+            )
+        except JudgingProvenanceError as exc:
+            raise ManualJudgeError("completed judge trace review is unavailable") from exc
+        if (
+            review.setup != audit.setup
+            or review.trace_evidence != evidence.rollout
+            or review.reference_trace_evidence != evidence.reference_rollout
+            or review.normalized_judgment != evidence.judgment
+            or review.original_judge_response != evidence.probes
+        ):
+            raise ManualJudgeError("completed judge trace review differs from its audit evidence")
     return audit
 
 
@@ -906,7 +932,7 @@ def replay_or_approve(
         store: Project-local immutable artifact and review store.
         state: Review state naming a completed audit.
         approve: Separate explicit report approval decision.
-        accept_insufficient_labels: Explicit acceptance below ten eligible rollouts.
+        accept_insufficient_labels: Explicit acceptance below five eligible rollouts.
         approved_at: Time of the separate approval decision.
         provider_calls_made: Calls performed immediately before this replay step.
 

--- a/wmo/optimize/router/judging/contracts.py
+++ b/wmo/optimize/router/judging/contracts.py
@@ -46,7 +46,7 @@ class ManualJudgeLabel(ContractModel):
         Raises:
             ValueError: Scalar and pairwise fields are mixed or incomplete.
         """
-        scalar = self.score is not None and self.winner is None and self.reference_trace_id is None
+        scalar = self.score is not None and self.winner is None
         pairwise = (
             self.score is None and self.winner is not None and self.reference_trace_id is not None
         )
@@ -211,7 +211,7 @@ class JudgeCalibrationBudget(ContractModel):
     maximum_input_tokens_per_call: int = Field(gt=0)
     maximum_output_tokens_per_call: Literal[4096] = 4096
     maximum_attempts_per_call: int = Field(gt=0)
-    call_count: int = Field(gt=0)
+    call_count: int = Field(ge=0)
     estimated_cost_usd: float = Field(ge=0)
     maximum_cost_usd: float = Field(gt=0)
 
@@ -223,7 +223,17 @@ class JudgeCalibrationBudget(ContractModel):
     )
     @classmethod
     def _require_finite(cls, value: float) -> float:
-        """Reject non-finite price and budget values."""
+        """Reject non-finite price and budget values.
+
+        Args:
+            value: Parsed pricing or budget value.
+
+        Returns:
+            The finite value unchanged.
+
+        Raises:
+            ValueError: The value is NaN or infinite.
+        """
         if not math.isfinite(value):
             raise ValueError("judge calibration economics must be finite")
         return value
@@ -253,6 +263,357 @@ class JudgeRunEvidence(ContractModel):
     reference_rollout: ArtifactInput | None = None
     judgment: ArtifactInput
     probes: tuple[ArtifactInput, ...] = ()
+
+
+class JudgeAxisProposal(ContractModel):
+    """One configured-judge proposal retained before a human decision."""
+
+    dimension_id: ArtifactId
+    proposed_score: int = Field(ge=0, le=10)
+    proposed_judgment: str = Field(min_length=1)
+    cited_trace_evidence: tuple[str, ...]
+    cited_reference_trace_evidence: tuple[str, ...] = ()
+
+    @field_validator("cited_trace_evidence")
+    @classmethod
+    def _require_unique_evidence(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Require at least one unique cited trace span for the proposal.
+
+        Args:
+            value: Configured-judge cited span identities.
+
+        Returns:
+            The ordered citations unchanged.
+
+        Raises:
+            ValueError: Citations are absent, empty, or repeated.
+        """
+        if not value:
+            raise ValueError("judge proposals require cited trace evidence")
+        if any(not item for item in value) or len(set(value)) != len(value):
+            raise ValueError("judge proposal evidence IDs must be nonempty and unique")
+        return value
+
+    @field_validator("cited_reference_trace_evidence")
+    @classmethod
+    def _require_unique_reference_evidence(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Validate optional citations from the pairwise reference trace.
+
+        Args:
+            value: Configured-judge cited reference span identities.
+
+        Returns:
+            The ordered optional citations unchanged.
+
+        Raises:
+            ValueError: A citation is empty or repeated.
+        """
+        if any(not item for item in value) or len(set(value)) != len(value):
+            raise ValueError("judge reference evidence IDs must be nonempty and unique")
+        return value
+
+
+class HumanJudgeCorrection(ContractModel):
+    """A human-authored replacement for one judge score and judgment."""
+
+    corrected_score: int = Field(ge=0, le=10)
+    corrected_judgment: str | None = Field(default=None, min_length=1)
+
+
+class FinalAcceptedJudgeLabel(ContractModel):
+    """The label authorized by a human after reviewing a judge proposal."""
+
+    score: int = Field(ge=0, le=10)
+    judgment: str = Field(min_length=1)
+    cited_trace_evidence: tuple[str, ...]
+    cited_reference_trace_evidence: tuple[str, ...] = ()
+    score_source: Literal["configured_judge", "human_correction"]
+    judgment_source: Literal["configured_judge", "human_correction"]
+
+    @field_validator("cited_trace_evidence")
+    @classmethod
+    def _require_unique_evidence(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Require the accepted label to retain concrete trace evidence.
+
+        Args:
+            value: Trace span identities retained with the accepted label.
+
+        Returns:
+            The ordered citations unchanged.
+
+        Raises:
+            ValueError: Citations are absent, empty, or repeated.
+        """
+        if not value:
+            raise ValueError("accepted judge labels require cited trace evidence")
+        if any(not item for item in value) or len(set(value)) != len(value):
+            raise ValueError("accepted label evidence IDs must be nonempty and unique")
+        return value
+
+    @field_validator("cited_reference_trace_evidence")
+    @classmethod
+    def _require_unique_reference_evidence(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Validate optional accepted citations from the pairwise reference trace.
+
+        Args:
+            value: Accepted reference span identities.
+
+        Returns:
+            The ordered optional citations unchanged.
+
+        Raises:
+            ValueError: A citation is empty or repeated.
+        """
+        if any(not item for item in value) or len(set(value)) != len(value):
+            raise ValueError("accepted reference evidence IDs must be nonempty and unique")
+        return value
+
+
+class ManualJudgeAxisDecision(ContractModel):
+    """One explicit accept or correction decision returned by a human reviewer."""
+
+    dimension_id: ArtifactId
+    accepted: bool
+    correction: HumanJudgeCorrection | None = None
+
+    @model_validator(mode="after")
+    def _require_exact_decision_shape(self) -> ManualJudgeAxisDecision:
+        """Require acceptance without a correction or rejection with one correction.
+
+        Returns:
+            The validated human decision.
+
+        Raises:
+            ValueError: Acceptance and correction fields contradict each other.
+        """
+        if self.accepted == (self.correction is not None):
+            raise ValueError("axis decisions must either accept or supply one human correction")
+        return self
+
+
+class ManualJudgeAxisReview(ContractModel):
+    """Separate judge, human, and accepted fields for one rubric axis."""
+
+    dimension_id: ArtifactId
+    judge_proposal: JudgeAxisProposal
+    human_correction: HumanJudgeCorrection | None = None
+    final_accepted_label: FinalAcceptedJudgeLabel
+
+    @model_validator(mode="after")
+    def _require_authorship_preserving_result(self) -> ManualJudgeAxisReview:
+        """Bind the final label to either explicit acceptance or a human correction.
+
+        Returns:
+            The validated axis review.
+
+        Raises:
+            ValueError: The final fields misstate their proposal or correction source.
+        """
+        if self.judge_proposal.dimension_id != self.dimension_id:
+            raise ValueError("judge proposal dimension differs from its reviewed axis")
+        final = self.final_accepted_label
+        proposal = self.judge_proposal
+        if self.human_correction is None:
+            expected = FinalAcceptedJudgeLabel(
+                score=proposal.proposed_score,
+                judgment=proposal.proposed_judgment,
+                cited_trace_evidence=proposal.cited_trace_evidence,
+                cited_reference_trace_evidence=proposal.cited_reference_trace_evidence,
+                score_source="configured_judge",
+                judgment_source="configured_judge",
+            )
+        else:
+            corrected_judgment = self.human_correction.corrected_judgment
+            expected = FinalAcceptedJudgeLabel(
+                score=self.human_correction.corrected_score,
+                judgment=corrected_judgment or proposal.proposed_judgment,
+                cited_trace_evidence=proposal.cited_trace_evidence,
+                cited_reference_trace_evidence=proposal.cited_reference_trace_evidence,
+                score_source="human_correction",
+                judgment_source=(
+                    "human_correction" if corrected_judgment is not None else "configured_judge"
+                ),
+            )
+        if final != expected:
+            raise ValueError("final accepted label does not match its human review decision")
+        return self
+
+
+class ManualJudgeReviewPricing(ContractModel):
+    """Per-trace pricing and observed economics retained with a review."""
+
+    input_usd_per_million_tokens: float = Field(ge=0)
+    output_usd_per_million_tokens: float = Field(ge=0)
+    pricing_source: PricingSource = PricingSource.UNKNOWN
+    maximum_input_tokens_per_call: int = Field(gt=0)
+    maximum_output_tokens_per_call: Literal[4096] = 4096
+    maximum_attempts_per_call: int = Field(gt=0)
+    authorized_call_count: Literal[1, 2]
+    maximum_reserved_cost_usd: float = Field(ge=0)
+    observed_economics: OperationEconomics
+
+    @field_validator(
+        "input_usd_per_million_tokens",
+        "output_usd_per_million_tokens",
+        "maximum_reserved_cost_usd",
+    )
+    @classmethod
+    def _require_finite_pricing(cls, value: float) -> float:
+        """Reject non-finite review prices and reservations.
+
+        Args:
+            value: Parsed price or reserved cost.
+
+        Returns:
+            The finite value unchanged.
+
+        Raises:
+            ValueError: The value is NaN or infinite.
+        """
+        if not math.isfinite(value):
+            raise ValueError("judge review pricing must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def _require_exact_reservation(self) -> ManualJudgeReviewPricing:
+        """Require the trace reservation to match its price and retry bounds.
+
+        Returns:
+            The validated review pricing contract.
+
+        Raises:
+            ValueError: The reserved cost differs from the bounded inputs.
+        """
+        per_attempt = (
+            self.maximum_input_tokens_per_call * self.input_usd_per_million_tokens
+            + self.maximum_output_tokens_per_call * self.output_usd_per_million_tokens
+        ) / 1_000_000
+        expected = per_attempt * self.maximum_attempts_per_call * self.authorized_call_count
+        if not math.isclose(
+            self.maximum_reserved_cost_usd,
+            expected,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("judge review reservation differs from its bounded pricing inputs")
+        return self
+
+
+class ManualJudgeReviewProvenance(ContractModel):
+    """Explicit authorship and source provenance for one completed trace review."""
+
+    proposal_author: Literal["configured_judge"] = "configured_judge"
+    decision_author: Literal["human"] = "human"
+    final_label_authority: Literal["human_acceptance"] = "human_acceptance"
+    historical_source: Literal["recorded_model", "provider_free_production_trace"]
+
+
+class ManualJudgeTraceReviewArtifact(ArtifactEnvelope):
+    """One immutable judge-first trace review completed by a human."""
+
+    review_id: ArtifactId
+    setup: ArtifactInput
+    sample_sha256: Sha256
+    trace_id: str = Field(min_length=1, max_length=512)
+    reference_trace_id: str | None = Field(default=None, min_length=1, max_length=512)
+    lineage_id: ArtifactId
+    trace_evidence: ArtifactInput
+    reference_trace_evidence: ArtifactInput | None = None
+    rubric_revision: ArtifactInput
+    provisional_calibration: ArtifactInput
+    original_judge_response: tuple[ArtifactInput, ...]
+    normalized_judgment: ArtifactInput
+    judge_model: ModelSnapshot
+    pricing: ManualJudgeReviewPricing
+    axes: tuple[ManualJudgeAxisReview, ...]
+    provenance: ManualJudgeReviewProvenance
+    reviewed_at: datetime
+
+    @field_validator("original_judge_response")
+    @classmethod
+    def _require_raw_responses(cls, value: tuple[ArtifactInput, ...]) -> tuple[ArtifactInput, ...]:
+        """Require one scalar response or two counterbalanced pairwise responses.
+
+        Args:
+            value: Original immutable provider-response pointers.
+
+        Returns:
+            The ordered response pointers unchanged.
+
+        Raises:
+            ValueError: The response count is unsupported or a pointer repeats.
+        """
+        if len(value) not in {1, 2}:
+            raise ValueError("trace reviews require one or two original judge responses")
+        if len({item.artifact_id for item in value}) != len(value):
+            raise ValueError("trace review judge responses must be unique")
+        return value
+
+    @field_validator("axes")
+    @classmethod
+    def _require_unique_axes(
+        cls, value: tuple[ManualJudgeAxisReview, ...]
+    ) -> tuple[ManualJudgeAxisReview, ...]:
+        """Require one completed review for every retained rubric axis.
+
+        Args:
+            value: Completed per-axis reviews.
+
+        Returns:
+            The ordered axis reviews unchanged.
+
+        Raises:
+            ValueError: No axis is present or an axis repeats.
+        """
+        if not value:
+            raise ValueError("trace reviews require at least one reviewed rubric axis")
+        dimensions = tuple(item.dimension_id for item in value)
+        if len(set(dimensions)) != len(dimensions):
+            raise ValueError("trace reviews must not repeat a rubric axis")
+        return value
+
+    @model_validator(mode="after")
+    def _require_complete_review_provenance(self) -> ManualJudgeTraceReviewArtifact:
+        """Bind the review to every immutable source and its exact decision time.
+
+        Returns:
+            The validated immutable trace review.
+
+        Raises:
+            ValueError: Timing, comparison evidence, or the input graph is inconsistent.
+        """
+        if self.created_at != self.reviewed_at:
+            raise ValueError("trace review created_at must equal reviewed_at")
+        if (self.reference_trace_id is None) != (self.reference_trace_evidence is None):
+            raise ValueError("reference trace identity and evidence must be present together")
+        reference_citations = tuple(
+            axis.judge_proposal.cited_reference_trace_evidence for axis in self.axes
+        )
+        if self.reference_trace_evidence is None and any(reference_citations):
+            raise ValueError("scalar trace reviews cannot cite reference trace evidence")
+        if self.reference_trace_evidence is not None and any(
+            not citations for citations in reference_citations
+        ):
+            raise ValueError("pairwise trace reviews must cite reference trace evidence")
+        expected = tuple(
+            sorted(
+                (
+                    self.setup,
+                    self.trace_evidence,
+                    *((self.reference_trace_evidence,) if self.reference_trace_evidence else ()),
+                    self.rubric_revision,
+                    self.provisional_calibration,
+                    *self.original_judge_response,
+                    self.normalized_judgment,
+                ),
+                key=lambda item: item.artifact_id,
+            )
+        )
+        if len({item.artifact_id for item in expected}) != len(expected):
+            raise ValueError("trace review inputs must have unique artifact IDs")
+        if self.inputs != expected:
+            raise ValueError("trace review must hash its complete canonical input graph")
+        return self
 
 
 class JudgeProtocolProbeArtifact(ArtifactEnvelope):
@@ -431,6 +792,7 @@ class ManualJudgeCalibrationAudit(ArtifactEnvelope):
     report: ArtifactInput
     budget: JudgeCalibrationBudget
     judgments: tuple[JudgeRunEvidence, ...]
+    trace_reviews: tuple[ArtifactInput, ...] = ()
     positional_bias_comparisons: int | None = Field(default=None, ge=1)
     positional_bias_flips: int | None = Field(default=None, ge=0)
 
@@ -460,6 +822,7 @@ class ManualJudgeCalibrationAudit(ArtifactEnvelope):
                     ),
                     *(item.judgment for item in self.judgments),
                     *(probe for item in self.judgments for probe in item.probes),
+                    *self.trace_reviews,
                 ),
                 key=lambda item: item.artifact_id,
             )
@@ -468,6 +831,12 @@ class ManualJudgeCalibrationAudit(ArtifactEnvelope):
             raise ValueError("manual judge audit must hash its complete canonical input graph")
         if not self.judgments:
             raise ValueError("manual judge audit requires at least one judge probe")
+        if self.schema_version >= 2 and len(self.trace_reviews) != len(self.judgments):
+            raise ValueError("manual judge audit requires one human review per judgment")
+        if self.schema_version == 1 and self.trace_reviews:
+            raise ValueError("version-one manual judge audits cannot name trace reviews")
+        if len({item.artifact_id for item in self.trace_reviews}) != len(self.trace_reviews):
+            raise ValueError("manual judge audit trace reviews must be unique")
         if (self.positional_bias_comparisons is None) != (self.positional_bias_flips is None):
             raise ValueError("positional-bias counts must be both present or both absent")
         if (
@@ -499,7 +868,17 @@ class ManualJudgeLabelDraft(ContractModel):
     def _require_unique_label_keys(
         cls, value: tuple[ManualJudgeLabel, ...]
     ) -> tuple[ManualJudgeLabel, ...]:
-        """Reject two drafted scores for one trace, reference, and dimension key."""
+        """Reject two drafted scores for one trace, reference, and dimension key.
+
+        Args:
+            value: Drafted explicit score inputs.
+
+        Returns:
+            The ordered unique labels unchanged.
+
+        Raises:
+            ValueError: More than one label claims the same review key.
+        """
         keys = tuple(
             (label.trace_id, label.reference_trace_id, label.dimension_id) for label in value
         )
@@ -513,6 +892,7 @@ class ManualJudgeReviewState(ContractModel):
 
     setup: ArtifactInput
     label_drafts: tuple[ManualJudgeLabelDraft, ...] = ()
+    trace_reviews: tuple[ArtifactInput, ...] = ()
     audit: ArtifactInput | None = None
     approved_calibration: ArtifactInput | None = None
 
@@ -535,6 +915,26 @@ class ManualJudgeReviewState(ContractModel):
         keys = tuple((draft.setup_id, draft.sample_sha256) for draft in value)
         if len(set(keys)) != len(keys):
             raise ValueError("review state must not hold two drafts for one calibration sample")
+        return value
+
+    @field_validator("trace_reviews")
+    @classmethod
+    def _require_unique_trace_review_pointers(
+        cls, value: tuple[ArtifactInput, ...]
+    ) -> tuple[ArtifactInput, ...]:
+        """Reject duplicate immutable review pointers in resumable state.
+
+        Args:
+            value: Completed trace review pointers.
+
+        Returns:
+            The ordered unique pointers unchanged.
+
+        Raises:
+            ValueError: A trace review pointer repeats.
+        """
+        if len({item.artifact_id for item in value}) != len(value):
+            raise ValueError("review state must not repeat a trace review pointer")
         return value
 
 

--- a/wmo/optimize/router/judging/protocol.py
+++ b/wmo/optimize/router/judging/protocol.py
@@ -33,6 +33,8 @@ from wmo.optimize.router.judging.contracts import (
     ManualJudgeError,
 )
 
+PairwiseCitationEvidence = tuple[tuple[ArtifactId, tuple[str, ...], tuple[str, ...]], ...]
+
 
 class _EvidenceDimension(ContractModel):
     """Shared identity, evidence citations, and feedback for one structured dimension."""
@@ -176,6 +178,7 @@ class TemplateJudgeClient:
         self._code_revision = code_revision
         self._probes: list[ArtifactInput] = []
         self._provider_calls_made = 0
+        self._pairwise_citation_evidence: PairwiseCitationEvidence = ()
 
     @property
     def probes(self) -> tuple[ArtifactInput, ...]:
@@ -186,6 +189,11 @@ class TemplateJudgeClient:
     def provider_calls_made(self) -> int:
         """Return provider dispatches made instead of replayed by this adapter."""
         return self._provider_calls_made
+
+    @property
+    def pairwise_citation_evidence(self) -> PairwiseCitationEvidence:
+        """Return target and reference citations retained from both pairwise orders."""
+        return self._pairwise_citation_evidence
 
     def complete(self, request: ModelRequest) -> ModelResponse:
         """Execute the finalized schema and normalize its explicit projection.
@@ -400,6 +408,7 @@ class TemplateJudgeClient:
             )
         mapping = self._template.score_projection.pairwise_scores
         normalized: list[JsonObject] = []
+        citations: list[tuple[ArtifactId, tuple[str, ...], tuple[str, ...]]] = []
         for dimension in self._rubric.dimensions:
             left = first_by_id[dimension.dimension_id]
             right = second_by_id[dimension.dimension_id]
@@ -407,16 +416,22 @@ class TemplateJudgeClient:
             _validate_pairwise_spans(right, self._reference, self._rollout)
             right_target = _reverse_winner(right.winner)
             score = (mapping[left.winner] + mapping[right_target] + 1) // 2
+            target_evidence = tuple(
+                dict.fromkeys((*left.evidence_span_ids_a, *right.evidence_span_ids_b))
+            )
+            reference_evidence = tuple(
+                dict.fromkeys((*left.evidence_span_ids_b, *right.evidence_span_ids_a))
+            )
+            citations.append((dimension.dimension_id, target_evidence, reference_evidence))
             normalized.append(
                 {
                     "dimension_id": dimension.dimension_id,
                     "raw_score": score,
-                    "evidence_span_ids": list(
-                        dict.fromkeys((*left.evidence_span_ids_a, *right.evidence_span_ids_b))
-                    ),
+                    "evidence_span_ids": list(target_evidence),
                     "feedback": f"forward: {left.feedback} reverse: {right.feedback}",
                 }
             )
+        self._pairwise_citation_evidence = tuple(citations)
         return ModelResponse(
             output=AssistantAction(content=json.dumps({"dimensions": normalized})),
             model=forward.model,
@@ -452,6 +467,54 @@ def positional_bias_count(
         item.winner != _reverse_winner(second_by_id[item.dimension_id].winner) for item in first
     )
     return len(first), disagreements
+
+
+def pairwise_citation_evidence_from_probes(
+    store: ProjectStore,
+    probes: tuple[ArtifactInput, ...],
+    rollout: RolloutArtifact,
+    reference: RolloutArtifact,
+) -> PairwiseCitationEvidence:
+    """Recover target and reference citations from immutable counterbalanced probes.
+
+    Args:
+        store: Project-local immutable artifact store.
+        probes: Exact forward and reverse probe pointers.
+        rollout: Target rollout shown as candidate A in the forward probe.
+        reference: Reference rollout shown as candidate B in the forward probe.
+
+    Returns:
+        Rubric dimension IDs with separate target and reference citation tuples.
+
+    Raises:
+        ManualJudgeError: Probe order, dimensions, or citations are malformed.
+    """
+    loaded = tuple(_read_probe(store, item) for item in probes)
+    if len(loaded) != 2 or loaded[0].order != "forward" or loaded[1].order != "reverse":
+        raise ManualJudgeError("pairwise citations require forward and reverse probes")
+    first = _PairwiseResponse.model_validate(loaded[0].response).dimensions
+    second = _PairwiseResponse.model_validate(loaded[1].response).dimensions
+    first_by_id = {item.dimension_id: item for item in first}
+    second_by_id = {item.dimension_id: item for item in second}
+    if (
+        len(first_by_id) != len(first)
+        or len(second_by_id) != len(second)
+        or set(first_by_id) != set(second_by_id)
+    ):
+        raise ManualJudgeError("pairwise probes evaluated different rubric dimensions")
+    evidence: list[tuple[ArtifactId, tuple[str, ...], tuple[str, ...]]] = []
+    for dimension_id, left in first_by_id.items():
+        right = second_by_id[dimension_id]
+        _validate_pairwise_spans(left, rollout, reference)
+        _validate_pairwise_spans(right, reference, rollout)
+        evidence.append(
+            (
+                dimension_id,
+                tuple(dict.fromkeys((*left.evidence_span_ids_a, *right.evidence_span_ids_b))),
+                tuple(dict.fromkeys((*left.evidence_span_ids_b, *right.evidence_span_ids_a))),
+            )
+        )
+    return tuple(evidence)
 
 
 def _read_probe_if_present(store: ProjectStore, probe_id: str) -> JudgeProtocolProbeArtifact | None:

--- a/wmo/optimize/router/judging/review.py
+++ b/wmo/optimize/router/judging/review.py
@@ -1,0 +1,960 @@
+"""Incremental judge-first review persistence for manual calibration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from wmo.common.core.artifacts import ArtifactInput, Sha256, stable_id
+from wmo.common.judging import LMJudge, Rubric
+from wmo.common.judging.judgment import Judgment
+from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
+from wmo.common.models import ModelSnapshot, OperationEconomics
+from wmo.common.project import ArtifactAlreadyExistsError, ProjectStore, artifact_input
+from wmo.common.rollouts import RolloutArtifact
+from wmo.common.tasks import TaskCase
+from wmo.common.traces import Trace
+from wmo.optimize.router.judging.artifacts import (
+    require_review_state,
+    update_review_state,
+)
+from wmo.optimize.router.judging.contracts import (
+    FinalAcceptedJudgeLabel,
+    HumanJudgeCorrection,
+    JudgeAxisProposal,
+    JudgeCalibrationBudget,
+    JudgeRunEvidence,
+    ManualJudgeAxisDecision,
+    ManualJudgeAxisReview,
+    ManualJudgeError,
+    ManualJudgeLabel,
+    ManualJudgeReviewPricing,
+    ManualJudgeReviewProvenance,
+    ManualJudgeReviewState,
+    ManualJudgeSetupArtifact,
+    ManualJudgeTraceReviewArtifact,
+)
+from wmo.optimize.router.judging.protocol import (
+    PairwiseCitationEvidence,
+    TemplateJudgeClient,
+    pairwise_citation_evidence_from_probes,
+)
+from wmo.optimize.router.judging.selection import read_rollout
+from wmo.runtime.models.registry import ResolvedModel
+
+
+@dataclass(frozen=True)
+class ManualJudgeTraceProposal:
+    """One persisted judge proposal awaiting a human decision.
+
+    Args:
+        position: One-based trace position in the frozen calibration sample.
+        total: Total distinct trace lineages in the sample.
+        trace: Original normalized production trace shown to the reviewer.
+        reference_trace: Optional same-task comparison trace.
+        rubric: Exact finalized rubric revision used by the judge.
+        judgment: Immutable normalized configured-judge output.
+        pairwise_citations: Separate target and reference citations from both judge orders.
+    """
+
+    position: int
+    total: int
+    trace: Trace
+    reference_trace: Trace | None
+    rubric: Rubric
+    judgment: Judgment
+    pairwise_citations: PairwiseCitationEvidence = ()
+
+
+ManualJudgeReviewer = Callable[[ManualJudgeTraceProposal], Sequence[ManualJudgeAxisDecision]]
+
+
+@dataclass(frozen=True)
+class ManualJudgeReviewCollection:
+    """Completed trace reviews and provider work performed during this invocation.
+
+    Args:
+        reviews: Immutable completed reviews in frozen sample order.
+        provider_calls_made: Provider dispatches made instead of replayed this invocation.
+    """
+
+    reviews: tuple[ManualJudgeTraceReviewArtifact, ...]
+    provider_calls_made: int
+
+
+def completed_trace_review_count(
+    store: ProjectStore,
+    setup: ManualJudgeSetupArtifact,
+    sample_sha256: Sha256,
+) -> int:
+    """Count completed immutable reviews for one frozen calibration sample.
+
+    Args:
+        store: Project-local review and artifact store.
+        setup: Finalized manual judge setup.
+        sample_sha256: Exact frozen trace-sample digest.
+
+    Returns:
+        Number of verified completed trace reviews for the sample.
+    """
+    return len(read_trace_reviews(store, setup, sample_sha256))
+
+
+def read_trace_reviews(
+    store: ProjectStore,
+    setup: ManualJudgeSetupArtifact,
+    sample_sha256: Sha256,
+) -> tuple[ManualJudgeTraceReviewArtifact, ...]:
+    """Load verified completed reviews for one setup and sample.
+
+    Args:
+        store: Project-local review and artifact store.
+        setup: Finalized manual judge setup.
+        sample_sha256: Exact frozen trace-sample digest.
+
+    Returns:
+        Matching immutable trace reviews in stored pointer order.
+
+    Raises:
+        ManualJudgeError: A pointer is corrupt or two reviews claim one trace.
+    """
+    state = require_review_state(store)
+    setup_input = artifact_input(store.artifacts.read(setup.setup_id).manifest)
+    matching: list[ManualJudgeTraceReviewArtifact] = []
+    keys: set[tuple[str, str | None]] = set()
+    for expected in state.trace_reviews:
+        review = _read_trace_review(store, expected)
+        if review.setup != state.setup:
+            raise ManualJudgeError("trace review setup differs from current review state")
+        if review.setup != setup_input:
+            raise ManualJudgeError("trace review setup differs from finalized judge setup")
+        if review.sample_sha256 != sample_sha256:
+            continue
+        key = (review.trace_id, review.reference_trace_id)
+        if key in keys:
+            raise ManualJudgeError("multiple completed reviews claim one calibration trace")
+        keys.add(key)
+        matching.append(review)
+    return tuple(matching)
+
+
+def collect_trace_reviews(
+    store: ProjectStore,
+    resolved: ResolvedModel,
+    *,
+    setup: ManualJudgeSetupArtifact,
+    setup_input: ArtifactInput,
+    tasks: Sequence[TaskCase],
+    traces: Sequence[Trace],
+    reference_traces: Sequence[Trace | None],
+    rollout_inputs: Sequence[ArtifactInput],
+    reference_inputs: Sequence[ArtifactInput | None],
+    provisional_input: ArtifactInput,
+    rubric: Rubric,
+    budget: JudgeCalibrationBudget,
+    sample_sha256: Sha256,
+    reviewer: ManualJudgeReviewer,
+    created_at: datetime,
+    code_revision: str,
+) -> ManualJudgeReviewCollection:
+    """Judge and persist each incomplete trace before requesting its human decision.
+
+    Args:
+        store: Project-local immutable artifact and review store.
+        resolved: Exact configured judge client and model identity.
+        setup: Finalized manual judge setup.
+        setup_input: Exact setup manifest pointer.
+        tasks: Distinct-lineage tasks in frozen sample order.
+        traces: Production traces aligned with ``tasks``.
+        reference_traces: Optional pairwise traces aligned with ``traces``.
+        rollout_inputs: Persisted target rollout pointers.
+        reference_inputs: Optional persisted reference rollout pointers.
+        provisional_input: Calibration binding used only for raw judge scoring.
+        rubric: Exact finalized rubric revision.
+        budget: Consent-bound complete-run reservation.
+        sample_sha256: Frozen sample digest for resumability.
+        reviewer: Human decision supplier called only after judge evidence exists.
+        created_at: Artifact completion and review time.
+        code_revision: Exact producer revision for immutable outputs.
+
+    Returns:
+        Completed reviews in sample order and provider calls made in this invocation.
+
+    Raises:
+        ManualJudgeError: Saved progress, judge output, or human decisions violate the contract.
+    """
+    lengths = {
+        len(tasks),
+        len(traces),
+        len(reference_traces),
+        len(rollout_inputs),
+        len(reference_inputs),
+    }
+    if len(lengths) != 1 or not traces:
+        raise ManualJudgeError("manual judge review inputs must be nonempty and aligned")
+    completed = {
+        (item.trace_id, item.reference_trace_id): item
+        for item in read_trace_reviews(store, setup, sample_sha256)
+    }
+    ordered: list[ManualJudgeTraceReviewArtifact] = []
+    provider_calls = 0
+    total = len(traces)
+    for index, values in enumerate(
+        zip(
+            tasks,
+            traces,
+            reference_traces,
+            rollout_inputs,
+            reference_inputs,
+            strict=True,
+        ),
+        start=1,
+    ):
+        task, trace, reference_trace, rollout_input, reference_input = values
+        reference_id = reference_trace.trace_id if reference_trace is not None else None
+        saved = completed.get((trace.trace_id, reference_id))
+        if saved is not None:
+            _require_review_matches_plan(
+                saved,
+                setup=setup,
+                task=task,
+                rollout_input=rollout_input,
+                reference_input=reference_input,
+                provisional_input=provisional_input,
+                rubric=rubric,
+                judge_model=resolved.snapshot,
+            )
+            ordered.append(saved)
+            continue
+        rollout = read_rollout(store, rollout_input)
+        reference = read_rollout(store, reference_input) if reference_input is not None else None
+        adapter = TemplateJudgeClient(
+            resolved.client,
+            setup.prompt_template,
+            rollout,
+            rubric,
+            reference,
+            store=store,
+            setup_input=setup_input,
+            rollout_input=rollout_input,
+            reference_input=reference_input,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+        judge = LMJudge(
+            adapter,
+            setup.prompt_template.prompt,
+            code_revision=code_revision,
+            clock=lambda: created_at,
+        )
+        judgment = judge.judge_and_write(
+            store,
+            rollout_artifact_id=rollout_input.artifact_id,
+            rubric_artifact_id=setup.rubric.artifact_id,
+            calibration_artifact_id=provisional_input.artifact_id,
+        )
+        provider_calls += adapter.provider_calls_made
+        judgment_input = artifact_input(store.artifacts.read(judgment.judgment_id).manifest)
+        proposal = ManualJudgeTraceProposal(
+            position=index,
+            total=total,
+            trace=trace,
+            reference_trace=reference_trace,
+            rubric=rubric,
+            judgment=judgment,
+            pairwise_citations=adapter.pairwise_citation_evidence,
+        )
+        decisions = _validated_decisions(reviewer(proposal), judgment, rubric)
+        review = _build_trace_review(
+            setup=setup,
+            setup_input=setup_input,
+            sample_sha256=sample_sha256,
+            task=task,
+            trace=trace,
+            reference_trace=reference_trace,
+            rollout=rollout,
+            rollout_input=rollout_input,
+            reference_input=reference_input,
+            provisional_input=provisional_input,
+            rubric=rubric,
+            judgment=judgment,
+            judgment_input=judgment_input,
+            probes=adapter.probes,
+            pairwise_citations=adapter.pairwise_citation_evidence,
+            decisions=decisions,
+            budget=budget,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+        saved_input = _write_trace_review(store, review)
+        _publish_trace_review(store, setup_input, saved_input, review)
+        ordered.append(review)
+    return ManualJudgeReviewCollection(
+        reviews=tuple(ordered),
+        provider_calls_made=provider_calls,
+    )
+
+
+def _validated_decisions(
+    supplied: Sequence[ManualJudgeAxisDecision],
+    judgment: Judgment,
+    rubric: Rubric,
+) -> tuple[ManualJudgeAxisDecision, ...]:
+    """Validate one explicit decision for every judge-proposed dimension.
+
+    Args:
+        supplied: Human accept-or-correct decisions.
+        judgment: Immutable normalized configured-judge proposal.
+        rubric: Exact axes and inclusive ranges used for the proposal.
+
+    Returns:
+        Decisions ordered to match the configured judge dimensions.
+
+    Raises:
+        ManualJudgeError: A dimension is missing, unexpected, or repeated.
+    """
+    decisions = tuple(supplied)
+    by_dimension = {item.dimension_id: item for item in decisions}
+    expected = tuple(item.dimension_id for item in judgment.dimensions)
+    rubric_dimensions = tuple(item.dimension_id for item in rubric.dimensions)
+    if expected != rubric_dimensions:
+        raise ManualJudgeError("configured judge proposal axes differ from the finalized rubric")
+    if len(by_dimension) != len(decisions):
+        raise ManualJudgeError("human review must not repeat a rubric axis")
+    missing = sorted(set(expected).difference(by_dimension))
+    unexpected = sorted(set(by_dimension).difference(expected))
+    if missing or unexpected:
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected " + ", ".join(unexpected))
+        raise ManualJudgeError(
+            "human review axes do not match judge proposal: " + "; ".join(details)
+        )
+    for dimension in judgment.dimensions:
+        axis = rubric.axis(dimension.dimension_id)
+        if (dimension.min_score, dimension.max_score) != (axis.min_score, axis.max_score):
+            raise ManualJudgeError("configured judge proposal range differs from the rubric")
+        correction = by_dimension[dimension.dimension_id].correction
+        if correction is not None and not axis.contains_score(correction.corrected_score):
+            raise ManualJudgeError(
+                f"human correction for {axis.dimension_id} must be an integer from "
+                f"{axis.min_score} through {axis.max_score}"
+            )
+    return tuple(by_dimension[item] for item in expected)
+
+
+def _build_trace_review(
+    *,
+    setup: ManualJudgeSetupArtifact,
+    setup_input: ArtifactInput,
+    sample_sha256: Sha256,
+    task: TaskCase,
+    trace: Trace,
+    reference_trace: Trace | None,
+    rollout: RolloutArtifact,
+    rollout_input: ArtifactInput,
+    reference_input: ArtifactInput | None,
+    provisional_input: ArtifactInput,
+    rubric: Rubric,
+    judgment: Judgment,
+    judgment_input: ArtifactInput,
+    probes: tuple[ArtifactInput, ...],
+    pairwise_citations: PairwiseCitationEvidence,
+    decisions: Sequence[ManualJudgeAxisDecision],
+    budget: JudgeCalibrationBudget,
+    created_at: datetime,
+    code_revision: str,
+) -> ManualJudgeTraceReviewArtifact:
+    """Build one immutable authorship-preserving trace review.
+
+    Args:
+        setup: Finalized configured-judge setup.
+        setup_input: Exact persisted setup pointer.
+        sample_sha256: Frozen calibration sample digest.
+        task: Canonical task and lineage for the reviewed trace.
+        trace: Reviewed production trace.
+        reference_trace: Optional same-task comparison trace.
+        rollout: Persisted target rollout content.
+        rollout_input: Exact target rollout pointer.
+        reference_input: Optional comparison rollout pointer.
+        provisional_input: Provisional calibration used for raw judging.
+        rubric: Exact finalized rubric revision.
+        judgment: Normalized immutable configured-judge response.
+        judgment_input: Exact normalized judgment pointer.
+        probes: Original immutable provider-response pointers.
+        pairwise_citations: Separate target and reference citations from both pairwise orders.
+        decisions: Human decisions aligned with the judgment axes.
+        budget: Consent-bound pricing and retry reservation.
+        created_at: Human review completion time.
+        code_revision: Exact producer revision.
+
+    Returns:
+        Complete immutable review with distinct judge, human, and final fields.
+    """
+    decision_by_id = {item.dimension_id: item for item in decisions}
+    citation_by_id = {
+        dimension_id: (target, reference) for dimension_id, target, reference in pairwise_citations
+    }
+    expected_dimensions = {item.dimension_id for item in judgment.dimensions}
+    if reference_trace is None:
+        if citation_by_id:
+            raise ManualJudgeError("scalar review cannot retain pairwise citations")
+    elif set(citation_by_id) != expected_dimensions:
+        raise ManualJudgeError("pairwise review citations do not match judge dimensions")
+    axes: list[ManualJudgeAxisReview] = []
+    for dimension in judgment.dimensions:
+        target_evidence, reference_evidence = citation_by_id.get(
+            dimension.dimension_id,
+            (dimension.evidence_span_ids, ()),
+        )
+        if target_evidence != dimension.evidence_span_ids:
+            raise ManualJudgeError("pairwise target citations differ from normalized judgment")
+        proposal = JudgeAxisProposal(
+            dimension_id=dimension.dimension_id,
+            proposed_score=dimension.raw_score,
+            proposed_judgment=dimension.feedback,
+            cited_trace_evidence=dimension.evidence_span_ids,
+            cited_reference_trace_evidence=reference_evidence,
+        )
+        correction = decision_by_id[dimension.dimension_id].correction
+        final = FinalAcceptedJudgeLabel(
+            score=proposal.proposed_score if correction is None else correction.corrected_score,
+            judgment=(
+                proposal.proposed_judgment
+                if correction is None or correction.corrected_judgment is None
+                else correction.corrected_judgment
+            ),
+            cited_trace_evidence=proposal.cited_trace_evidence,
+            cited_reference_trace_evidence=proposal.cited_reference_trace_evidence,
+            score_source="configured_judge" if correction is None else "human_correction",
+            judgment_source=(
+                "human_correction"
+                if correction is not None and correction.corrected_judgment is not None
+                else "configured_judge"
+            ),
+        )
+        axes.append(
+            ManualJudgeAxisReview(
+                dimension_id=dimension.dimension_id,
+                judge_proposal=proposal,
+                human_correction=correction,
+                final_accepted_label=final,
+            )
+        )
+    calls_per_trace = 2 if setup.prompt_template.response_shape == "pairwise" else 1
+    per_attempt = (
+        budget.maximum_input_tokens_per_call * budget.input_usd_per_million_tokens
+        + budget.maximum_output_tokens_per_call * budget.output_usd_per_million_tokens
+    ) / 1_000_000
+    pricing = ManualJudgeReviewPricing(
+        input_usd_per_million_tokens=budget.input_usd_per_million_tokens,
+        output_usd_per_million_tokens=budget.output_usd_per_million_tokens,
+        pricing_source=budget.pricing_source,
+        maximum_input_tokens_per_call=budget.maximum_input_tokens_per_call,
+        maximum_attempts_per_call=budget.maximum_attempts_per_call,
+        authorized_call_count=calls_per_trace,
+        maximum_reserved_cost_usd=(
+            per_attempt * budget.maximum_attempts_per_call * calls_per_trace
+        ),
+        observed_economics=judgment.judge_economics or OperationEconomics(),
+    )
+    inputs = tuple(
+        sorted(
+            (
+                setup_input,
+                rollout_input,
+                *((reference_input,) if reference_input is not None else ()),
+                setup.rubric,
+                provisional_input,
+                *probes,
+                judgment_input,
+            ),
+            key=lambda item: item.artifact_id,
+        )
+    )
+    provenance = ManualJudgeReviewProvenance(
+        historical_source=(
+            "provider_free_production_trace"
+            if rollout.provider_free_source is not None
+            else "recorded_model"
+        )
+    )
+    review_id = stable_id(
+        "manual-judge-trace-review",
+        {
+            "setup": setup_input.model_dump(mode="json"),
+            "sample_sha256": sample_sha256,
+            "trace_id": trace.trace_id,
+            "reference_trace_id": (
+                reference_trace.trace_id if reference_trace is not None else None
+            ),
+            "lineage_id": task.lineage_group_id,
+            "inputs": [item.model_dump(mode="json") for item in inputs],
+            "axes": [item.model_dump(mode="json") for item in axes],
+            "judge_model": judgment.judge_model.model_dump(mode="json"),
+            "pricing": pricing.model_dump(mode="json"),
+            "provenance": provenance.model_dump(mode="json"),
+            "code_revision": code_revision,
+        },
+    )
+    return ManualJudgeTraceReviewArtifact(
+        schema_version=1,
+        created_at=created_at,
+        inputs=inputs,
+        code_revision=code_revision,
+        review_id=review_id,
+        setup=setup_input,
+        sample_sha256=sample_sha256,
+        trace_id=trace.trace_id,
+        reference_trace_id=(reference_trace.trace_id if reference_trace is not None else None),
+        lineage_id=task.lineage_group_id,
+        trace_evidence=rollout_input,
+        reference_trace_evidence=reference_input,
+        rubric_revision=setup.rubric,
+        provisional_calibration=provisional_input,
+        original_judge_response=probes,
+        normalized_judgment=judgment_input,
+        judge_model=judgment.judge_model,
+        pricing=pricing,
+        axes=tuple(axes),
+        provenance=provenance,
+        reviewed_at=created_at,
+    )
+
+
+def _write_trace_review(
+    store: ProjectStore, review: ManualJudgeTraceReviewArtifact
+) -> ArtifactInput:
+    """Persist or verify one immutable completed trace review.
+
+    Args:
+        store: Project-local immutable artifact store.
+        review: Completed trace review to persist.
+
+    Returns:
+        Exact manifest pointer for the persisted review.
+
+    Raises:
+        ManualJudgeError: An existing artifact conflicts with the review.
+    """
+    try:
+        manifest = store.artifacts.write_json(
+            artifact_id=review.review_id,
+            artifact_type="manual-judge-trace-review",
+            envelope=review,
+            files={"review.json": review},
+        )
+    except ArtifactAlreadyExistsError:
+        saved, saved_input = _read_trace_review_with_input(store, review.review_id)
+        if saved != review.model_copy(
+            update={"created_at": saved.created_at, "reviewed_at": saved.reviewed_at}
+        ):
+            raise ManualJudgeError(
+                "existing trace review conflicts with this human decision"
+            ) from None
+        return saved_input
+    return artifact_input(manifest)
+
+
+def _publish_trace_review(
+    store: ProjectStore,
+    setup_input: ArtifactInput,
+    review_input: ArtifactInput,
+    review: ManualJudgeTraceReviewArtifact,
+) -> None:
+    """Append one immutable review pointer without replacing concurrent progress.
+
+    Args:
+        store: Project-local artifact and mutable review store.
+        setup_input: Exact finalized setup pointer.
+        review_input: Newly completed immutable review pointer.
+        review: Completed review used to detect conflicting decisions.
+
+    Raises:
+        ManualJudgeError: The same sample trace already has a different review.
+    """
+
+    def mutate(current: ManualJudgeReviewState) -> ManualJudgeReviewState:
+        """Retain all reviews and reject another decision for the same sample trace.
+
+        Args:
+            current: Latest review state read while holding the project lock.
+
+        Returns:
+            State containing the new pointer, or unchanged idempotent state.
+
+        Raises:
+            ManualJudgeError: Another review claims the same frozen sample trace.
+        """
+        for expected in current.trace_reviews:
+            saved = _read_trace_review(store, expected)
+            same_key = (
+                saved.sample_sha256 == review.sample_sha256
+                and saved.trace_id == review.trace_id
+                and saved.reference_trace_id == review.reference_trace_id
+            )
+            if same_key and expected != review_input:
+                raise ManualJudgeError("calibration trace already has a different human review")
+            if expected == review_input:
+                return current
+        return current.model_copy(update={"trace_reviews": (*current.trace_reviews, review_input)})
+
+    update_review_state(store, setup_input, mutate)
+
+
+def _read_trace_review(
+    store: ProjectStore, expected: ArtifactInput
+) -> ManualJudgeTraceReviewArtifact:
+    """Read one review and require its exact persisted manifest pointer.
+
+    Args:
+        store: Project-local immutable artifact store.
+        expected: Manifest pointer retained by review state or an audit.
+
+    Returns:
+        Verified immutable trace review.
+
+    Raises:
+        ManualJudgeError: The review is missing, malformed, or changed.
+    """
+    review, _review_input = _read_trace_review_with_input(
+        store,
+        expected.artifact_id,
+        expected=expected,
+    )
+    return review
+
+
+def _read_trace_review_with_input(
+    store: ProjectStore,
+    review_id: str,
+    *,
+    expected: ArtifactInput | None = None,
+) -> tuple[ManualJudgeTraceReviewArtifact, ArtifactInput]:
+    """Read one immutable trace review through the shared provenance verifier.
+
+    Args:
+        store: Project-local immutable artifact store.
+        review_id: Trace review artifact identity.
+        expected: Optional exact manifest pointer required by the caller.
+
+    Returns:
+        Verified trace review and its canonical manifest pointer.
+
+    Raises:
+        ManualJudgeError: The review cannot be verified or has the wrong identity.
+    """
+    try:
+        review, review_input = read_artifact_json(
+            store,
+            artifact_id=review_id,
+            expected_artifact_type="manual-judge-trace-review",
+            relative_path="review.json",
+            model_type=ManualJudgeTraceReviewArtifact,
+            expected_input=expected,
+        )
+    except JudgingProvenanceError as exc:
+        raise ManualJudgeError("completed manual judge trace review is unavailable") from exc
+    if review.review_id != review_id:
+        raise ManualJudgeError("manual judge trace review has the wrong artifact identity")
+    return review, review_input
+
+
+def _require_review_matches_plan(
+    review: ManualJudgeTraceReviewArtifact,
+    *,
+    setup: ManualJudgeSetupArtifact,
+    task: TaskCase,
+    rollout_input: ArtifactInput,
+    reference_input: ArtifactInput | None,
+    provisional_input: ArtifactInput,
+    rubric: Rubric,
+    judge_model: ModelSnapshot,
+) -> None:
+    """Reject persisted progress that differs from the current frozen plan.
+
+    Args:
+        review: Persisted completed review being resumed.
+        setup: Current finalized judge setup.
+        task: Expected canonical task and lineage.
+        rollout_input: Expected target rollout pointer.
+        reference_input: Expected optional comparison rollout pointer.
+        provisional_input: Expected provisional calibration pointer.
+        rubric: Current finalized rubric revision.
+        judge_model: Exact configured judge identity.
+
+    Raises:
+        ManualJudgeError: Any immutable plan binding differs.
+    """
+    expected_dimensions = tuple(item.dimension_id for item in rubric.dimensions)
+    reviewed_dimensions = tuple(item.dimension_id for item in review.axes)
+    if (
+        review.rubric_revision != setup.rubric
+        or review.trace_evidence != rollout_input
+        or review.reference_trace_evidence != reference_input
+        or review.provisional_calibration != provisional_input
+        or review.lineage_id != task.lineage_group_id
+        or review.judge_model != judge_model
+        or reviewed_dimensions != expected_dimensions
+    ):
+        raise ManualJudgeError("completed trace review differs from the frozen calibration plan")
+    for axis_review in review.axes:
+        axis = rubric.axis(axis_review.dimension_id)
+        scores = [
+            axis_review.judge_proposal.proposed_score,
+            axis_review.final_accepted_label.score,
+        ]
+        if axis_review.human_correction is not None:
+            scores.append(axis_review.human_correction.corrected_score)
+        if any(not axis.contains_score(score) for score in scores):
+            raise ManualJudgeError("completed trace review score differs from its rubric range")
+
+
+def review_evidence(
+    reviews: Sequence[ManualJudgeTraceReviewArtifact],
+) -> tuple[JudgeRunEvidence, ...]:
+    """Project completed trace reviews into the existing audit evidence contract.
+
+    Args:
+        reviews: Completed immutable reviews in frozen trace order.
+
+    Returns:
+        Existing rollout, judgment, and probe evidence projections.
+    """
+    return tuple(
+        JudgeRunEvidence(
+            rollout=review.trace_evidence,
+            reference_rollout=review.reference_trace_evidence,
+            judgment=review.normalized_judgment,
+            probes=review.original_judge_response,
+        )
+        for review in reviews
+    )
+
+
+def read_review_judgment(store: ProjectStore, review: ManualJudgeTraceReviewArtifact) -> Judgment:
+    """Load the normalized immutable judge response named by one completed review.
+
+    Args:
+        store: Project-local immutable artifact store.
+        review: Completed review naming the normalized judgment.
+
+    Returns:
+        Verified normalized configured-judge response.
+
+    Raises:
+        ManualJudgeError: The judgment is unavailable or differs from the proposal fields.
+    """
+    try:
+        judgment, _judgment_input = read_artifact_json(
+            store,
+            artifact_id=review.normalized_judgment.artifact_id,
+            expected_artifact_type="judgment",
+            relative_path="judgment.json",
+            model_type=Judgment,
+            expected_input=review.normalized_judgment,
+        )
+    except JudgingProvenanceError as exc:
+        raise ManualJudgeError("trace review normalized judgment is unavailable") from exc
+    citation_by_id: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
+    if review.reference_trace_evidence is not None:
+        rollout = read_rollout(store, review.trace_evidence)
+        reference = read_rollout(store, review.reference_trace_evidence)
+        citation_by_id = {
+            dimension_id: (target, reference_spans)
+            for dimension_id, target, reference_spans in pairwise_citation_evidence_from_probes(
+                store,
+                review.original_judge_response,
+                rollout,
+                reference,
+            )
+        }
+        if set(citation_by_id) != {item.dimension_id for item in judgment.dimensions}:
+            raise ManualJudgeError("pairwise probe citations differ from normalized judgment")
+    proposals: list[JudgeAxisProposal] = []
+    for item in judgment.dimensions:
+        target_evidence, reference_evidence = citation_by_id.get(
+            item.dimension_id,
+            (item.evidence_span_ids, ()),
+        )
+        if target_evidence != item.evidence_span_ids:
+            raise ManualJudgeError("pairwise target citations differ from normalized judgment")
+        proposals.append(
+            JudgeAxisProposal(
+                dimension_id=item.dimension_id,
+                proposed_score=item.raw_score,
+                proposed_judgment=item.feedback,
+                cited_trace_evidence=item.evidence_span_ids,
+                cited_reference_trace_evidence=reference_evidence,
+            )
+        )
+    if (
+        judgment.judge_model != review.judge_model
+        or judgment.calibration_id != review.provisional_calibration.artifact_id
+        or tuple(item.judge_proposal for item in review.axes) != tuple(proposals)
+    ):
+        raise ManualJudgeError("trace review does not match its immutable judge response")
+    return judgment
+
+
+def reviewer_from_labels(
+    setup: ManualJudgeSetupArtifact,
+    labels: Sequence[ManualJudgeLabel],
+) -> ManualJudgeReviewer:
+    """Adapt explicit scores into truthful judge-first review decisions.
+
+    A score equal to the proposal is an acceptance. A differing score is retained as a human
+    correction with no invented human judgment text, so the final judgment remains attributed to
+    the configured judge.
+
+    Args:
+        setup: Finalized prompt and score projection contract.
+        labels: Complete validated explicit human labels.
+
+    Returns:
+        Reviewer that consumes the labels only after each judge proposal exists.
+    """
+    by_key = {(item.trace_id, item.reference_trace_id, item.dimension_id): item for item in labels}
+
+    def review(proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Return one acceptance or score-only correction per proposed axis.
+
+        Args:
+            proposal: Immutable configured-judge proposal for one trace.
+
+        Returns:
+            Explicit decisions ordered to match the proposal axes.
+        """
+        reference_id = (
+            proposal.reference_trace.trace_id if proposal.reference_trace is not None else None
+        )
+        decisions: list[ManualJudgeAxisDecision] = []
+        for dimension in proposal.judgment.dimensions:
+            key = (proposal.trace.trace_id, reference_id, dimension.dimension_id)
+            label = by_key[key]
+            score = manual_label_score(setup, label)
+            decisions.append(
+                ManualJudgeAxisDecision(
+                    dimension_id=dimension.dimension_id,
+                    accepted=score == dimension.raw_score,
+                    correction=(
+                        None
+                        if score == dimension.raw_score
+                        else HumanJudgeCorrection(corrected_score=score)
+                    ),
+                )
+            )
+        return tuple(decisions)
+
+    return review
+
+
+def manual_label_score(setup: ManualJudgeSetupArtifact, label: ManualJudgeLabel) -> int:
+    """Project one scalar or pairwise human label onto the finalized axis range.
+
+    Args:
+        setup: Finalized prompt and score projection contract.
+        label: Validated human label.
+
+    Returns:
+        Integer score used by grouped calibration.
+
+    Raises:
+        ManualJudgeError: A human label lacks both a direct score and a winner.
+    """
+    if label.score is not None:
+        return label.score
+    if label.winner is None:
+        raise ManualJudgeError("human labels require an axis-range score or pairwise winner")
+    return setup.prompt_template.score_projection.pairwise_scores[label.winner]
+
+
+def labels_from_reviews(
+    reviews: Sequence[ManualJudgeTraceReviewArtifact],
+) -> tuple[ManualJudgeLabel, ...]:
+    """Project human-authorized review results into the existing label-set boundary.
+
+    Args:
+        reviews: Completed immutable reviews in frozen trace order.
+
+    Returns:
+        Final accepted axis-range scores for grouped calibration.
+    """
+    return tuple(
+        ManualJudgeLabel(
+            trace_id=review.trace_id,
+            reference_trace_id=review.reference_trace_id,
+            dimension_id=axis.dimension_id,
+            score=axis.final_accepted_label.score,
+        )
+        for review in reviews
+        for axis in review.axes
+    )
+
+
+def ordered_completed_reviews(
+    reviews: Sequence[ManualJudgeTraceReviewArtifact],
+    *,
+    setup: ManualJudgeSetupArtifact,
+    setup_input: ArtifactInput,
+    tasks: Sequence[TaskCase],
+    traces: Sequence[Trace],
+    reference_traces: Sequence[Trace | None],
+    rollout_inputs: Sequence[ArtifactInput],
+    reference_inputs: Sequence[ArtifactInput | None],
+    provisional_input: ArtifactInput,
+    rubric: Rubric,
+) -> tuple[ManualJudgeTraceReviewArtifact, ...]:
+    """Order and verify a completed sample without resolving a provider.
+
+    Args:
+        reviews: Verified trace reviews loaded from resumable state.
+        setup: Finalized judge setup.
+        setup_input: Exact finalized setup pointer.
+        tasks: Frozen distinct-lineage tasks.
+        traces: Frozen target traces.
+        reference_traces: Optional pairwise traces.
+        rollout_inputs: Persisted target rollout pointers.
+        reference_inputs: Optional pairwise rollout pointers.
+        provisional_input: Exact scoring calibration pointer.
+        rubric: Exact finalized rubric revision.
+
+    Returns:
+        Reviews in frozen trace order.
+
+    Raises:
+        ManualJudgeError: A frozen trace is missing, unexpected, or bound differently.
+    """
+    by_key = {(item.trace_id, item.reference_trace_id): item for item in reviews}
+    ordered: list[ManualJudgeTraceReviewArtifact] = []
+    for task, trace, reference, rollout_input, reference_input in zip(
+        tasks,
+        traces,
+        reference_traces,
+        rollout_inputs,
+        reference_inputs,
+        strict=True,
+    ):
+        reference_id = reference.trace_id if reference is not None else None
+        review = by_key.get((trace.trace_id, reference_id))
+        if review is None:
+            raise ManualJudgeError("completed review state is missing a frozen calibration trace")
+        if review.setup != setup_input:
+            raise ManualJudgeError("completed trace review differs from finalized setup")
+        _require_review_matches_plan(
+            review,
+            setup=setup,
+            task=task,
+            rollout_input=rollout_input,
+            reference_input=reference_input,
+            provisional_input=provisional_input,
+            rubric=rubric,
+            judge_model=setup.judge_model,
+        )
+        ordered.append(review)
+    if len(ordered) != len(reviews):
+        raise ManualJudgeError("completed review state contains traces outside the frozen sample")
+    return tuple(ordered)

--- a/wmo/optimize/router/judging/review_test.py
+++ b/wmo/optimize/router/judging/review_test.py
@@ -1,0 +1,477 @@
+"""Behavioral tests for incremental judge-first calibration review artifacts."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from wmo.common.judging.judgment import Judgment
+from wmo.common.judging.rubric import JudgeCalibration
+from wmo.common.models import ModelCapabilities, ModelSnapshot
+from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.optimize.router.judging.contracts import (
+    HumanJudgeCorrection,
+    JudgeCalibrationBudget,
+    JudgeProtocolProbeArtifact,
+    ManualJudgeAxisDecision,
+    ManualJudgeError,
+    ManualJudgeSetupArtifact,
+)
+from wmo.optimize.router.judging.labels import calibration_sample_digest
+from wmo.optimize.router.judging.review import (
+    ManualJudgeTraceProposal,
+    completed_trace_review_count,
+    read_trace_reviews,
+)
+from wmo.optimize.router.judging.service import (
+    ManualJudgeCalibrationPlan,
+    calibrate_manual_judge,
+    calibration_sample,
+    commit_manual_judge_setup,
+    estimate_manual_judge_budget,
+    prepare_manual_judge_calibration,
+    prepare_manual_judge_setup,
+)
+from wmo.optimize.router.judging.service_test import (
+    _TIME,
+    _built_store,
+    _catalog,
+    _persist_grounded_build,
+    _RuntimeCatalog,
+    _StructuredJudgeClient,
+    _trace,
+)
+from wmo.runtime.models.registry import ResolvedModel, RuntimeModelCatalog
+from wmo.simulation.build import build_project
+from wmo.simulation.ingest.otlp import TraceNormalizationResult
+from wmo.simulation.mining.service import MiningSpec
+
+
+def test_trace_review_separates_judge_human_final_and_provenance_fields(
+    tmp_path: Path,
+) -> None:
+    """One correction retains raw judge output and every distinct authorship field.
+
+    Args:
+        tmp_path: Pytest-owned project storage.
+    """
+    store = _built_store(tmp_path)
+    setup = _commit_setup(store)
+    plan = prepare_manual_judge_calibration(store, sample_size=1)
+    client, runtime = _runtime(plan.setup.judge_model)
+    budget = _budget(plan)
+
+    def correct(proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Correct both score and judgment after observing immutable judge evidence.
+
+        Args:
+            proposal: Persisted configured-judge result awaiting a decision.
+
+        Returns:
+            One complete human correction.
+        """
+        assert proposal.judgment.judgment_id in store.artifacts.list_ids()
+        return (
+            ManualJudgeAxisDecision(
+                dimension_id="task-success",
+                accepted=False,
+                correction=HumanJudgeCorrection(
+                    corrected_score=0,
+                    corrected_judgment="The trace made progress but did not prove completion.",
+                ),
+            ),
+        )
+
+    result = calibrate_manual_judge(
+        store,
+        cast(RuntimeModelCatalog, runtime),
+        plan,
+        (),
+        budget,
+        spend_consented=True,
+        approve=False,
+        accept_insufficient_labels=True,
+        created_at=_TIME,
+        code_revision="test-revision",
+        reviewer=correct,
+    )
+
+    sample_sha256 = calibration_sample_digest(setup, calibration_sample(plan))
+    reviews = read_trace_reviews(store, setup, sample_sha256)
+    assert len(reviews) == 1
+    review = reviews[0]
+    assert result.audit.trace_reviews[0].artifact_id == review.review_id
+    assert review.trace_id == plan.traces[0].trace_id
+    assert review.lineage_id == plan.tasks[0].lineage_group_id
+    assert review.rubric_revision == setup.rubric
+    assert review.trace_evidence.artifact_id.startswith("production-rollout-")
+    assert review.reference_trace_evidence is None
+    assert review.judge_model == plan.setup.judge_model
+    assert review.pricing.input_usd_per_million_tokens == 1.0
+    assert review.pricing.output_usd_per_million_tokens == 2.0
+    assert review.pricing.pricing_source.value == "configured"
+    assert review.pricing.authorized_call_count == 1
+    assert review.pricing.maximum_reserved_cost_usd == pytest.approx(budget.estimated_cost_usd)
+    assert review.provenance.proposal_author == "configured_judge"
+    assert review.provenance.decision_author == "human"
+    assert review.provenance.final_label_authority == "human_acceptance"
+    assert review.provenance.historical_source == "recorded_model"
+    axis = review.axes[0]
+    assert axis.judge_proposal.proposed_score == 1
+    assert axis.judge_proposal.proposed_judgment == "Structured evidence supports the verdict."
+    assert axis.judge_proposal.cited_trace_evidence == (plan.traces[0].spans[0].span_id,)
+    assert axis.human_correction is not None
+    assert axis.human_correction.corrected_score == 0
+    assert axis.human_correction.corrected_judgment == (
+        "The trace made progress but did not prove completion."
+    )
+    assert axis.final_accepted_label.score == 0
+    assert axis.final_accepted_label.judgment == axis.human_correction.corrected_judgment
+    assert axis.final_accepted_label.score_source == "human_correction"
+    assert axis.final_accepted_label.judgment_source == "human_correction"
+    assert len(review.original_judge_response) == 1
+    probe = JudgeProtocolProbeArtifact.model_validate_json(
+        store.artifacts.read_bytes(review.original_judge_response[0].artifact_id, "probe.json")
+    )
+    judgment = Judgment.model_validate_json(
+        store.artifacts.read_bytes(review.normalized_judgment.artifact_id, "judgment.json")
+    )
+    assert probe.response == {
+        "dimensions": [
+            {
+                "dimension_id": "task-success",
+                "raw_score": 1,
+                "evidence_span_ids": [plan.traces[0].spans[0].span_id],
+                "feedback": "Structured evidence supports the verdict.",
+            }
+        ]
+    }
+    assert probe.model == review.judge_model
+    assert judgment.dimensions[0].feedback == axis.judge_proposal.proposed_judgment
+    assert len(client.requests) == 1
+
+
+def test_interruption_resumes_next_incomplete_review_and_replays_saved_probe(
+    tmp_path: Path,
+) -> None:
+    """Completed reviews and a pre-decision probe survive interruption without duplicate calls.
+
+    Args:
+        tmp_path: Pytest-owned project storage.
+    """
+    store = _built_store(tmp_path)
+    setup = _commit_setup(store)
+    plan = prepare_manual_judge_calibration(store, sample_size=3)
+    first_client, first_runtime = _runtime(plan.setup.judge_model)
+    budget = _budget(plan)
+    seen: list[int] = []
+
+    def interrupt(proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Accept the first trace and interrupt after the second judge response is saved.
+
+        Args:
+            proposal: Current immutable judge proposal.
+
+        Returns:
+            Acceptance for the first trace only.
+
+        Raises:
+            RuntimeError: The second proposal simulates a human interruption.
+        """
+        seen.append(proposal.position)
+        if proposal.position == 2:
+            raise RuntimeError("simulated human interruption")
+        return (_accept(),)
+
+    with pytest.raises(RuntimeError, match="simulated human interruption"):
+        calibrate_manual_judge(
+            store,
+            cast(RuntimeModelCatalog, first_runtime),
+            plan,
+            (),
+            budget,
+            spend_consented=True,
+            approve=False,
+            accept_insufficient_labels=True,
+            created_at=_TIME,
+            code_revision="test-revision",
+            reviewer=interrupt,
+        )
+    assert seen == [1, 2]
+    assert len(first_client.requests) == 2
+    sample_sha256 = calibration_sample_digest(setup, calibration_sample(plan))
+    assert completed_trace_review_count(store, setup, sample_sha256) == 1
+
+    retry_client, retry_runtime = _runtime(plan.setup.judge_model)
+    resumed: list[int] = []
+
+    def accept_remaining(
+        proposal: ManualJudgeTraceProposal,
+    ) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Accept only incomplete trace proposals in frozen sample order.
+
+        Args:
+            proposal: Current resumed immutable judge proposal.
+
+        Returns:
+            One explicit acceptance.
+        """
+        resumed.append(proposal.position)
+        return (_accept(),)
+
+    remaining_budget = _budget(plan, completed_review_count=1)
+    result = calibrate_manual_judge(
+        store,
+        cast(RuntimeModelCatalog, retry_runtime),
+        plan,
+        (),
+        remaining_budget,
+        spend_consented=True,
+        approve=False,
+        accept_insufficient_labels=True,
+        created_at=_TIME + timedelta(minutes=10),
+        code_revision="test-revision",
+        reviewer=accept_remaining,
+    )
+    assert resumed == [2, 3]
+    assert len(retry_client.requests) == 1
+    assert result.provider_calls_made == 1
+    assert completed_trace_review_count(store, setup, sample_sha256) == 3
+
+    preflight_calls = retry_runtime.preflight_calls
+    provider_calls = len(retry_client.requests)
+    replay = calibrate_manual_judge(
+        store,
+        cast(RuntimeModelCatalog, retry_runtime),
+        plan,
+        (),
+        remaining_budget,
+        spend_consented=False,
+        approve=False,
+        accept_insufficient_labels=True,
+        created_at=_TIME + timedelta(minutes=20),
+        code_revision="test-revision",
+        reviewer=accept_remaining,
+    )
+    assert replay.audit == result.audit
+    assert replay.provider_calls_made == 0
+    assert retry_runtime.preflight_calls == preflight_calls
+    assert len(retry_client.requests) == provider_calls
+    assert resumed == [2, 3]
+
+
+def test_five_default_lineages_are_normally_sufficient_without_risk_acceptance(
+    tmp_path: Path,
+) -> None:
+    """Five completed distinct-lineage reviews produce an approvable normal calibration.
+
+    Args:
+        tmp_path: Pytest-owned project storage.
+    """
+    store = _five_lineage_store(tmp_path)
+    _commit_setup(store)
+    plan = prepare_manual_judge_calibration(store)
+    assert len(plan.traces) == len({task.lineage_group_id for task in plan.tasks}) == 5
+    client, runtime = _runtime(plan.setup.judge_model)
+    budget = _budget(plan)
+    reviewed_positions: list[int] = []
+
+    def accept(proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Accept each configured-judge proposal independently in sample order.
+
+        Args:
+            proposal: Current immutable configured-judge proposal.
+
+        Returns:
+            One explicit acceptance.
+        """
+        reviewed_positions.append(proposal.position)
+        return (_accept(),)
+
+    result = calibrate_manual_judge(
+        store,
+        cast(RuntimeModelCatalog, runtime),
+        plan,
+        (),
+        budget,
+        spend_consented=True,
+        approve=True,
+        accept_insufficient_labels=False,
+        created_at=_TIME,
+        code_revision="test-revision",
+        reviewer=accept,
+    )
+
+    assert reviewed_positions == [1, 2, 3, 4, 5]
+    assert len(client.requests) == 5
+    assert result.report.eligible_rollout_count == 5
+    assert result.report.eligible_lineage_count == 5
+    assert result.report.recommended_label_count == 5
+    assert result.report.status == "ready_for_approval"
+    assert result.approved_calibration is not None
+    approved = JudgeCalibration.model_validate_json(
+        store.artifacts.read_bytes(
+            result.approved_calibration.artifact_id,
+            "calibration.json",
+        )
+    )
+    assert approved.status == "human_calibrated"
+    assert approved.recommended_label_count == 5
+    assert approved.risk_acceptance is None
+
+
+def test_completed_replay_verifies_each_trace_review_without_provider_calls(
+    tmp_path: Path,
+) -> None:
+    """A corrupt review blocks audit replay before the configured judge is resolved.
+
+    Args:
+        tmp_path: Pytest-owned project storage.
+    """
+    store = _built_store(tmp_path)
+    _commit_setup(store)
+    plan = prepare_manual_judge_calibration(store, sample_size=1)
+    client, runtime = _runtime(plan.setup.judge_model)
+    budget = _budget(plan)
+
+    def accept(_proposal: ManualJudgeTraceProposal) -> tuple[ManualJudgeAxisDecision, ...]:
+        """Accept the immutable proposal without altering judge-authored fields.
+
+        Args:
+            _proposal: Current proposal, unused by this single-axis fixture.
+
+        Returns:
+            One explicit acceptance.
+        """
+        return (_accept(),)
+
+    result = calibrate_manual_judge(
+        store,
+        cast(RuntimeModelCatalog, runtime),
+        plan,
+        (),
+        budget,
+        spend_consented=True,
+        approve=False,
+        accept_insufficient_labels=True,
+        created_at=_TIME,
+        code_revision="test-revision",
+        reviewer=accept,
+    )
+    review_input = result.audit.trace_reviews[0]
+    review_path = store.artifacts.read(review_input.artifact_id).directory / "review.json"
+    review_path.write_text("{}", encoding="utf-8")
+    preflight_calls = runtime.preflight_calls
+    provider_calls = len(client.requests)
+
+    with pytest.raises(ManualJudgeError, match="trace review is unavailable"):
+        calibrate_manual_judge(
+            store,
+            cast(RuntimeModelCatalog, runtime),
+            plan,
+            (),
+            budget,
+            spend_consented=False,
+            approve=False,
+            accept_insufficient_labels=True,
+            created_at=_TIME + timedelta(minutes=1),
+            code_revision="test-revision",
+            reviewer=accept,
+        )
+
+    assert runtime.preflight_calls == preflight_calls
+    assert len(client.requests) == provider_calls
+
+
+def _accept() -> ManualJudgeAxisDecision:
+    """Return one explicit acceptance for the fixture rubric axis."""
+    return ManualJudgeAxisDecision(dimension_id="task-success", accepted=True)
+
+
+def _commit_setup(store: ProjectStore) -> ManualJudgeSetupArtifact:
+    """Persist the default finalized judge setup for one completed build.
+
+    Args:
+        store: Selected completed build receiving the finalized setup.
+
+    Returns:
+        Immutable finalized manual judge setup.
+    """
+    setup_plan = prepare_manual_judge_setup(
+        store,
+        _catalog(),
+        created_at=_TIME,
+        code_revision="test-revision",
+    )
+    return commit_manual_judge_setup(store, setup_plan, confirmed=True)
+
+
+def _runtime(model: ModelSnapshot) -> tuple[_StructuredJudgeClient, _RuntimeCatalog]:
+    """Return a deterministic scalar judge client and injected runtime catalog.
+
+    Args:
+        model: Exact configured judge snapshot.
+
+    Returns:
+        Fake provider client and its runtime resolver.
+    """
+    client = _StructuredJudgeClient(model, "scalar")
+    runtime = _RuntimeCatalog(
+        ResolvedModel(
+            alias="judge-main",
+            snapshot=model,
+            capabilities=ModelCapabilities(),
+            client=client,
+            embedding_client=None,
+        )
+    )
+    return client, runtime
+
+
+def _budget(
+    plan: ManualJudgeCalibrationPlan,
+    *,
+    completed_review_count: int = 0,
+) -> JudgeCalibrationBudget:
+    """Return the exact conservative fixture reservation for remaining reviews.
+
+    Args:
+        plan: Frozen calibration sample.
+        completed_review_count: Reviews that require no more provider reservation.
+
+    Returns:
+        Conservative budget for incomplete reviews.
+    """
+    return estimate_manual_judge_budget(
+        plan,
+        input_usd_per_million_tokens=1.0,
+        output_usd_per_million_tokens=2.0,
+        maximum_input_tokens_per_call=4_096,
+        maximum_cost_usd=1.0,
+        completed_review_count=completed_review_count,
+    )
+
+
+def _five_lineage_store(tmp_path: Path) -> ProjectStore:
+    """Create a selected build with five fit lineages and one held-out lineage.
+
+    Args:
+        tmp_path: Pytest-owned project root.
+
+    Returns:
+        Initialized project store with a selected completed build.
+    """
+    store = ProjectStore(tmp_path / ".wmo", "support")
+    store.initialize(ProjectConfig(project_id="support"))
+    built = build_project(
+        TraceNormalizationResult(traces=tuple(_trace(index) for index in range(100)), issues=()),
+        store,
+        created_at=_TIME,
+        code_revision="test-revision",
+        mining_spec=MiningSpec(fit_task_budget=5, held_out_task_budget=1),
+    )
+    _persist_grounded_build(store, built, select=True)
+    return store

--- a/wmo/optimize/router/judging/service.py
+++ b/wmo/optimize/router/judging/service.py
@@ -12,7 +12,6 @@ from wmo.common.judging import (
     HumanScoreReview,
     JudgeCalibrationService,
     JudgeScoreObservation,
-    LMJudge,
     RouterLineageAssignment,
     RouterLineageSplit,
     Rubric,
@@ -21,11 +20,7 @@ from wmo.common.judging import (
     write_router_lineage_split,
 )
 from wmo.common.judging.provenance import JudgingProvenanceError, read_artifact_json
-from wmo.common.models import (
-    ModelCatalog,
-    ModelSnapshot,
-    PricingSource,
-)
+from wmo.common.models import ModelCatalog, ModelSnapshot, PricingSource
 from wmo.common.project import ArtifactAlreadyExistsError, ProjectStore, artifact_input
 from wmo.common.tasks import TaskCase, load_task_set
 from wmo.common.traces import Trace, load_trace_dataset
@@ -49,7 +44,6 @@ from wmo.optimize.router.judging.artifacts import (
 from wmo.optimize.router.judging.contracts import (
     JudgeCalibrationBudget,
     JudgePromptTemplate,
-    JudgeRunEvidence,
     JudgeTracePreview,
     ManualJudgeCalibrationResult,
     ManualJudgeError,
@@ -59,10 +53,21 @@ from wmo.optimize.router.judging.contracts import (
 )
 from wmo.optimize.router.judging.labels import calibration_sample_digest, save_label_draft
 from wmo.optimize.router.judging.pricing import resolve_manual_judge_prices
-from wmo.optimize.router.judging.protocol import TemplateJudgeClient, positional_bias_count
+from wmo.optimize.router.judging.protocol import positional_bias_count
+from wmo.optimize.router.judging.review import (
+    ManualJudgeReviewCollection,
+    ManualJudgeReviewer,
+    collect_trace_reviews,
+    labels_from_reviews,
+    manual_label_score,
+    ordered_completed_reviews,
+    read_review_judgment,
+    read_trace_reviews,
+    review_evidence,
+    reviewer_from_labels,
+)
 from wmo.optimize.router.judging.selection import (
     pairwise_references,
-    read_rollout,
     representative_pairs,
     representative_pairwise_pairs,
     trace_preview,
@@ -294,7 +299,7 @@ def commit_manual_judge_setup(
 def prepare_manual_judge_calibration(
     store: ProjectStore,
     *,
-    sample_size: int = 10,
+    sample_size: int = 5,
 ) -> ManualJudgeCalibrationPlan:
     """Select representative real fit-lineage traces for labeling without writes.
 
@@ -357,9 +362,6 @@ def calibration_sample(
 def manual_judge_calibration_is_complete(store: ProjectStore) -> bool:
     """Report whether a completed audit already fixes this project's calibration.
 
-    A completed audit makes calibration replay its own immutable evidence, so callers must
-    not collect new human labels that the replay would ignore.
-
     Args:
         store: Project-local review store.
 
@@ -381,6 +383,7 @@ def estimate_manual_judge_budget(
     maximum_input_tokens_per_call: int,
     maximum_cost_usd: float,
     retry_policy: RetryPolicy | None = None,
+    completed_review_count: int = 0,
 ) -> JudgeCalibrationBudget:
     """Reserve worst-case judging spend before credentials or provider calls.
 
@@ -392,6 +395,7 @@ def estimate_manual_judge_budget(
         maximum_input_tokens_per_call: Conservative request-token ceiling.
         maximum_cost_usd: Operator's total calibration spend ceiling.
         retry_policy: Runtime retry bound used by provider clients.
+        completed_review_count: Immutable trace reviews that require no further provider calls.
 
     Returns:
         Finite conservative admission budget for one call per labeled rollout.
@@ -417,8 +421,10 @@ def estimate_manual_judge_budget(
             output_usd_per_million_tokens=output_usd_per_million_tokens,
         )
     resolved_retry = retry_policy or RetryPolicy()
+    if completed_review_count < 0 or completed_review_count > len(plan.traces):
+        raise ValueError("completed judge review count is outside the frozen trace sample")
     calls_per_trace = 2 if plan.setup.prompt_template.response_shape == "pairwise" else 1
-    call_count = len(plan.traces) * calls_per_trace
+    call_count = (len(plan.traces) - completed_review_count) * calls_per_trace
     per_attempt = (maximum_input_tokens_per_call * input_price + 4_096 * output_price) / 1_000_000
     return JudgeCalibrationBudget(
         input_usd_per_million_tokens=input_price,
@@ -445,20 +451,22 @@ def calibrate_manual_judge(
     accept_insufficient_labels: bool,
     created_at: datetime,
     code_revision: str,
+    reviewer: ManualJudgeReviewer | None = None,
 ) -> ManualJudgeCalibrationResult:
-    """Freeze labels, run scalar judge calls, report evidence, and optionally approve.
+    """Run judge-first trace reviews, report evidence, and optionally approve.
 
     Args:
         store: Project-local artifact and review store.
         runtime_catalog: Injected resolver for the configured judge alias.
         plan: Frozen representative real-trace calibration plan.
-        labels: Complete human scores for every selected trace and rubric dimension.
+        labels: Complete explicit human scores used when ``reviewer`` is not supplied.
         budget: Explicit conservative spend reservation shown before consent.
         spend_consented: Whether the operator accepted the displayed reservation.
         approve: Separate explicit approval of the completed calibration report.
-        accept_insufficient_labels: Explicit risk acceptance below ten labels.
+        accept_insufficient_labels: Explicit risk acceptance below five completed reviews.
         created_at: Time for newly completed artifacts and decisions.
         code_revision: Exact producer revision for new artifacts.
+        reviewer: Human decision supplier invoked after each immutable judge proposal.
 
     Returns:
         Calibration audit, report, optional approved calibration pointer, and call count.
@@ -478,24 +486,23 @@ def calibrate_manual_judge(
             accept_insufficient_labels=accept_insufficient_labels,
             approved_at=created_at,
         )
-    _validate_labels(store, plan, setup, labels)
-    save_label_draft(
-        store,
-        setup,
-        calibration_sample_digest(setup, calibration_sample(plan)),
-        labels,
-        created_at,
-    )
-    expected_calls = len(plan.traces) * (
-        2 if setup.prompt_template.response_shape == "pairwise" else 1
-    )
-    if budget.call_count != expected_calls:
-        raise ManualJudgeError("judge budget call count differs from the frozen trace sample")
-    if not spend_consented:
+    sample_sha256 = calibration_sample_digest(setup, calibration_sample(plan))
+    completed_reviews = read_trace_reviews(store, setup, sample_sha256)
+    supplied_labels = tuple(labels)
+    explicit_label_input = reviewer is None
+    if explicit_label_input:
+        _validate_labels(store, plan, setup, supplied_labels)
+        save_label_draft(store, setup, sample_sha256, supplied_labels, created_at)
+        reviewer = reviewer_from_labels(setup, supplied_labels)
+    elif supplied_labels:
+        raise ManualJudgeError("supply either a review callback or legacy labels, not both")
+    calls_per_trace = 2 if setup.prompt_template.response_shape == "pairwise" else 1
+    expected_calls = (len(plan.traces) - len(completed_reviews)) * (calls_per_trace)
+    total_calls = len(plan.traces) * calls_per_trace
+    if budget.call_count not in {expected_calls, total_calls}:
+        raise ManualJudgeError("judge budget call count differs from incomplete trace reviews")
+    if expected_calls and not spend_consented:
         raise ManualJudgeError("judge calibration requires explicit spend consent before writes")
-    resolved = runtime_catalog.preflight(setup.judge_alias)
-    if resolved.snapshot != setup.judge_model:
-        raise ManualJudgeError("configured judge identity changed after setup")
     rollout_inputs = tuple(
         write_production_rollout(
             store,
@@ -543,73 +550,87 @@ def calibrate_manual_judge(
             created_at=created_at,
             code_revision=code_revision,
         )
+    provisional_input = artifact_input(store.artifacts.read(provisional.calibration_id).manifest)
+    rubric, rubric_input = read_artifact_json(
+        store,
+        artifact_id=setup.rubric.artifact_id,
+        expected_artifact_type="rubric",
+        relative_path="rubric.json",
+        model_type=Rubric,
+    )
+    if rubric_input != setup.rubric:
+        raise ManualJudgeError("manual judge rubric manifest differs from setup")
+    if len(completed_reviews) < len(plan.traces):
+        resolved = runtime_catalog.preflight(setup.judge_alias)
+        if resolved.snapshot != setup.judge_model:
+            raise ManualJudgeError("configured judge identity changed after setup")
+        collection = collect_trace_reviews(
+            store,
+            resolved,
+            setup=setup,
+            setup_input=state.setup,
+            tasks=plan.tasks,
+            traces=plan.traces,
+            reference_traces=plan.reference_traces,
+            rollout_inputs=rollout_inputs,
+            reference_inputs=reference_inputs,
+            provisional_input=provisional_input,
+            rubric=rubric,
+            budget=budget,
+            sample_sha256=sample_sha256,
+            reviewer=reviewer,
+            created_at=created_at,
+            code_revision=code_revision,
+        )
+    else:
+        collection = ManualJudgeReviewCollection(
+            reviews=ordered_completed_reviews(
+                completed_reviews,
+                setup=setup,
+                setup_input=state.setup,
+                tasks=plan.tasks,
+                traces=plan.traces,
+                reference_traces=plan.reference_traces,
+                rollout_inputs=rollout_inputs,
+                reference_inputs=reference_inputs,
+                provisional_input=provisional_input,
+                rubric=rubric,
+            ),
+            provider_calls_made=0,
+        )
+    accepted_labels = labels_from_reviews(collection.reviews)
+    _validate_labels(store, plan, setup, accepted_labels)
+    if not explicit_label_input:
+        save_label_draft(
+            store,
+            setup,
+            sample_sha256,
+            accepted_labels,
+            created_at,
+        )
     human_labels = _write_labels(
         label_review,
         setup,
         plan,
         rollout_inputs,
-        labels,
+        accepted_labels,
         created_at,
         code_revision,
     )
-    evidence: list[JudgeRunEvidence] = []
+    evidence = review_evidence(collection.reviews)
     observations: list[JudgeScoreObservation] = []
-    provider_calls = 0
     positional_comparisons = 0
     positional_flips = 0
-    for rollout_input, reference_input in zip(rollout_inputs, reference_inputs, strict=True):
-        rollout = read_rollout(store, rollout_input)
-        reference = read_rollout(store, reference_input) if reference_input is not None else None
-        rubric, _rubric_input = read_artifact_json(
-            store,
-            artifact_id=setup.rubric.artifact_id,
-            expected_artifact_type="rubric",
-            relative_path="rubric.json",
-            model_type=Rubric,
-        )
-        adapter = TemplateJudgeClient(
-            resolved.client,
-            setup.prompt_template,
-            rollout,
-            rubric,
-            reference,
-            store=store,
-            setup_input=state.setup,
-            rollout_input=rollout_input,
-            reference_input=reference_input,
-            created_at=created_at,
-            code_revision=code_revision,
-        )
-        judge = LMJudge(
-            adapter,
-            setup.prompt_template.prompt,
-            code_revision=code_revision,
-            clock=lambda: created_at,
-        )
-        judgment = judge.judge_and_write(
-            store,
-            rollout_artifact_id=rollout_input.artifact_id,
-            rubric_artifact_id=setup.rubric.artifact_id,
-            calibration_artifact_id=provisional.calibration_id,
-        )
-        provider_calls += adapter.provider_calls_made
+    for review in collection.reviews:
+        judgment = read_review_judgment(store, review)
         if setup.prompt_template.response_shape == "pairwise":
-            comparisons, flips = positional_bias_count(store, adapter.probes)
+            comparisons, flips = positional_bias_count(store, review.original_judge_response)
             positional_comparisons += comparisons
             positional_flips += flips
-        judgment_input = artifact_input(store.artifacts.read(judgment.judgment_id).manifest)
-        evidence.append(
-            JudgeRunEvidence(
-                rollout=rollout_input,
-                reference_rollout=reference_input,
-                judgment=judgment_input,
-                probes=adapter.probes,
-            )
-        )
         observations.extend(
             JudgeScoreObservation(
-                judgment=judgment_input,
-                source_rollout=rollout_input,
+                judgment=review.normalized_judgment,
+                source_rollout=review.trace_evidence,
                 dimension_id=dimension.dimension_id,
                 raw_score=dimension.raw_score,
                 evidence_span_ids=dimension.evidence_span_ids,
@@ -635,7 +656,11 @@ def calibrate_manual_judge(
         provisional_input=artifact_input(store.artifacts.read(provisional.calibration_id).manifest),
         report_input=artifact_input(store.artifacts.read(report.report_id).manifest),
         budget=budget,
-        judgments=tuple(evidence),
+        judgments=evidence,
+        trace_reviews=tuple(
+            artifact_input(store.artifacts.read(review.review_id).manifest)
+            for review in collection.reviews
+        ),
         positional_bias=(
             (positional_comparisons, positional_flips)
             if setup.prompt_template.response_shape == "pairwise"
@@ -645,7 +670,7 @@ def calibrate_manual_judge(
         code_revision=code_revision,
     )
     audit_input = artifact_input(store.artifacts.read(audit.audit_id).manifest)
-    next_state = state.model_copy(update={"audit": audit_input})
+    next_state = require_review_state(store).model_copy(update={"audit": audit_input})
     write_review_state(store, next_state)
     return replay_or_approve(
         store,
@@ -653,7 +678,7 @@ def calibrate_manual_judge(
         approve=approve,
         accept_insufficient_labels=accept_insufficient_labels,
         approved_at=created_at,
-        provider_calls_made=provider_calls,
+        provider_calls_made=collection.provider_calls_made,
     )
 
 
@@ -773,10 +798,12 @@ def _validate_labels(
         for dimension in rubric.dimensions
     }
     supplied = [(label.trace_id, label.reference_trace_id, label.dimension_id) for label in labels]
-    if any((label.winner is not None) != pairwise for label in labels):
-        raise ManualJudgeError(
-            "pairwise setups require typed winner labels; other setups require axis-range scores"
-        )
+    if pairwise and any(label.reference_trace_id is None for label in labels):
+        raise ManualJudgeError("pairwise labels must retain their reference trace")
+    if not pairwise and any(
+        label.reference_trace_id is not None or label.winner is not None for label in labels
+    ):
+        raise ManualJudgeError("non-pairwise setups require direct axis-range scores")
     axes = {item.dimension_id: item for item in rubric.dimensions}
     for label in labels:
         if label.score is None:
@@ -897,7 +924,7 @@ def _write_labels(
         Immutable labeled human score set.
     """
     score_by_key = {
-        (item.trace_id, item.reference_trace_id, item.dimension_id): _label_score(setup, item)
+        (item.trace_id, item.reference_trace_id, item.dimension_id): manual_label_score(setup, item)
         for item in labels
     }
     for trace, reference, task, rollout in zip(
@@ -936,25 +963,3 @@ def _write_labels(
         code_revision=code_revision,
         created_at=created_at,
     )
-
-
-def _label_score(setup: ManualJudgeSetupArtifact, label: ManualJudgeLabel) -> int:
-    """Project one human label under the exact saved response contract.
-
-    Args:
-        setup: Finalized setup containing the versioned projection.
-        label: Validated scalar score or typed pairwise preference.
-
-    Returns:
-        Integer human score on the finalized axis range.
-
-    Raises:
-        ManualJudgeError: Label shape differs from the finalized setup.
-    """
-    if setup.prompt_template.response_shape == "pairwise":
-        if label.winner is None:
-            raise ManualJudgeError("pairwise human labels require winner_a, winner_b, or tie")
-        return setup.prompt_template.score_projection.pairwise_scores[label.winner]
-    if label.score is None:
-        raise ManualJudgeError("non-pairwise human labels require an integer axis score")
-    return label.score

--- a/wmo/optimize/router/judging/service_test.py
+++ b/wmo/optimize/router/judging/service_test.py
@@ -61,6 +61,7 @@ from wmo.optimize.router.judging.contracts import (
     judge_feedback_schema,
 )
 from wmo.optimize.router.judging.labels import calibration_sample_digest, read_label_draft
+from wmo.optimize.router.judging.review import read_trace_reviews
 from wmo.optimize.router.judging.service import (
     ManualJudgeError,
     calibrate_manual_judge,
@@ -1286,6 +1287,14 @@ def test_pairwise_calibration_uses_same_task_and_counterbalances_order(tmp_path:
     assert len(result.audit.judgments[0].probes) == 2
     assert result.audit.positional_bias_comparisons == 1
     assert result.audit.positional_bias_flips == 1
+    sample_sha256 = calibration_sample_digest(plan.setup, calibration_sample(plan))
+    review = read_trace_reviews(store, plan.setup, sample_sha256)[0]
+    proposal = review.axes[0].judge_proposal
+    accepted = review.axes[0].final_accepted_label
+    assert proposal.cited_trace_evidence == (plan.traces[0].spans[0].span_id,)
+    assert proposal.cited_reference_trace_evidence == (reference.spans[0].span_id,)
+    assert accepted.cited_trace_evidence == proposal.cited_trace_evidence
+    assert accepted.cited_reference_trace_evidence == proposal.cited_reference_trace_evidence
     first = client.requests[0].messages[1].content or ""
     second = client.requests[1].messages[1].content or ""
     target_rollout = plan.previews[0].rollout_id

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -60,6 +60,8 @@ REQUIRED_WHEEL_MODULES = frozenset(
         "wmo/optimize/router/evaluation/setup.py",
         "wmo/optimize/router/fit/workflow.py",
         "wmo/optimize/router/judging/service.py",
+        "wmo/optimize/router/judging/review.py",
+        "wmo/cli/judge_review.py",
         "wmo/optimize/router/judgment_budget.py",
     }
 )
@@ -73,6 +75,8 @@ REQUIRED_SDIST_MEMBERS = frozenset(
         "wmo/optimize/router/evaluation/setup.py",
         "wmo/optimize/router/fit/workflow.py",
         "wmo/optimize/router/judging/service.py",
+        "wmo/optimize/router/judging/review.py",
+        "wmo/cli/judge_review.py",
         "wmo/optimize/router/judgment_budget.py",
     }
 )
@@ -413,6 +417,7 @@ def _installed_release_driver() -> None:
         prepare_runtime_sft_model_optimization,
     )
     from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
+    from wmo.optimize.router.judging.contracts import ManualJudgeTraceReviewArtifact
     from wmo.optimize.router.judging.service import prepare_manual_judge_calibration
     from wmo.runtime.models import CapabilityRequirement, RuntimeModelCatalog
     from wmo.runtime.router import (
@@ -961,7 +966,8 @@ def _installed_release_driver() -> None:
         )
         assert "Saved judge setup" in setup_result.stdout
         assert sum(state.counts().values()) == setup_call_count
-        calibration_plan = prepare_manual_judge_calibration(support_store, sample_size=10)
+        calibration_plan = prepare_manual_judge_calibration(support_store)
+        assert len(calibration_plan.previews) == 5
         assert len(calibration_plan.previews) >= 2
         calibration_arguments = [
             "config",
@@ -970,8 +976,6 @@ def _installed_release_driver() -> None:
             "support-agent",
             "--root",
             str(root),
-            "--sample-size",
-            "10",
         ]
         for preview in calibration_plan.previews:
             calibration_arguments.extend(["--label", f"{preview.trace_id}:task-success=1"])
@@ -981,18 +985,39 @@ def _installed_release_driver() -> None:
                 "0.000001",
                 "--yes",
                 "--approve",
-                "--accept-insufficient-labels",
                 "--non-interactive",
             ]
         )
         calibration_result = run_cli(*calibration_arguments)
         assert "Approved judge calibration" in calibration_result.stdout
+        assert "Trace 1 of 5" in calibration_result.stdout
+        assert "Original user request:" in calibration_result.stdout
+        assert "Configured judge proposals" in calibration_result.stdout
+        assert "Description: The agent successfully completed" in calibration_result.stdout
+        assert "Numeric range: 0 to 1" in calibration_result.stdout
+        assert "Proposed score: 1" in calibration_result.stdout
+        assert "Proposed judgment:" in calibration_result.stdout
+        assert "Cited trace evidence:" in calibration_result.stdout
         assert sum(state.counts().values()) - setup_call_count == len(calibration_plan.previews)
         review = support_store.read_review()
         assert isinstance(review, dict)
         manual_judge = review.get("manual_judge")
         assert isinstance(manual_judge, dict)
         assert manual_judge.get("approved_calibration") is not None
+        trace_review_pointers = manual_judge.get("trace_reviews")
+        assert isinstance(trace_review_pointers, list)
+        assert len(trace_review_pointers) == 5
+        for pointer in trace_review_pointers:
+            assert isinstance(pointer, dict)
+            review_id = pointer.get("artifact_id")
+            assert isinstance(review_id, str)
+            trace_review = ManualJudgeTraceReviewArtifact.model_validate_json(
+                support_store.artifacts.read_bytes(review_id, "review.json")
+            )
+            assert trace_review.provenance.proposal_author == "configured_judge"
+            assert trace_review.provenance.decision_author == "human"
+            assert trace_review.axes[0].human_correction is None
+            assert trace_review.axes[0].final_accepted_label.score_source == "configured_judge"
         optimize_arguments = [
             "optimize",
             "router",


### PR DESCRIPTION
## Summary

- Extend the canonical `wmo/cli/judge_transcript.py` renderer with one-trace-at-a-time conversation review that separates the original user request, assistant messages, tool calls and arguments, tool results, and final response. Truncation is exact and each current trace can be paged without restoring the former transcript wall.
- Run and persist the configured judge proposal before each human decision under the shared `require_spend_consent` boundary. Show every ordered rubric axis with its label, full description, inclusive numeric range, anchors, proposed score, concise judgment, and cited trace evidence.
- Support per-axis acceptance or score-and-judgment correction while preserving the immutable judge response, human correction, final accepted label, rubric revision, target and reference evidence, judge identity, catalog pricing, and provenance as separate fields. Judge-authored content is never recorded as human-authored.
- Default calibration to five distinct trace lineages, retain `--sample-size`, save completed reviews incrementally, resume at the next incomplete review, and replay completed calibration with zero provider or review calls.
- Preserve pairwise reference identity and citations. Persisted judge targets use delimiter-safe structured JSON, including trace identifiers that contain `:` or `=`.

## Ownership and stack

- This draft is one feature commit on `main` at `3c348e117c15d255f04fd84fb433c230cb52acf0`, the squash merge of #467.
- Transcript formatting remains owned by `wmo/cli/judge_transcript.py`; this change extends that renderer instead of adding another formatting path.
- Spend approval remains owned by the shared `require_spend_consent` API from #467; there is no judge-specific cost formatter or consent path.
- #468 remains draft and must not be merged as part of this work.

## Exact-head validation

Validated at `8614795c07c0fd347173e780607b5f6f7d78305d`:

- `uv run ruff format --check .`: 444 files already formatted
- `uv run ruff check .`: passed
- `uv run ty check`: passed
- Focused CLI, transcript, review, judging, calibration, and router suites: 126 passed
- Full non-live suite: 1,326 passed, 1 skipped, 13 deselected
- Fresh wheel and sdist built with `uv build --package world-model-optimizer --no-sources`
- Built-archive contract: 1 passed
- Installed-wheel no-spend release evidence: 1 passed
- No live or paid provider calls were made
