### PR TITLE
Add CLI surfaces for judge labeling, custom endpoints, and RAG refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,9 @@ uv run pytest -q
   in `fit/`, and evaluation preparation in `evaluation/`. The durable judgment ledger remains at
   `judgment_budget.py`.
 - The root CLI is locked to `build`, `optimize`, `run`, and `config`. The optimize group is locked
-  to `router` and `model`; the config group is locked to `budget`, `judge`, `providers`, and
-  `telemetry`. Widening any of those three sets, whether with a command, an alias, or a flag, is a
-  deliberate change to the locked surface and needs the same scrutiny as a public API change.
+  to `router` and `model`; the config group is locked to `budget`, `judge`, `providers`, `rag`,
+  and `telemetry`. Widening any of those three sets, whether with a command, an alias, or a flag,
+  is a deliberate change to the locked surface and needs the same scrutiny as a public API change.
 - Every paid CLI command uses `wmo.cli.consent.require_spend_consent` after a credential-free
   conservative estimate and before credential or provider-client construction. The setting in
   `.wmo/settings.toml` is a hard per-command ceiling. Estimates at or below half run automatically,

--- a/docs/cookbook/router.md
+++ b/docs/cookbook/router.md
@@ -76,8 +76,16 @@ Chat requests are stateless. Responses continuations preserve routing affinity t
 `previous_response_id` field. Request-time embedding failure falls back to the frozen conservative
 baseline. Neither path updates the policy or evidence bank.
 
-By default, completed traffic enters the durable project journal and can later feed runtime RAG and
-SFT preparation. Use ghost mode when traffic must not be saved:
+By default, completed traffic enters the durable project journal. After the server stops, seal that
+journal into a new retrieval index beside the frozen build:
+
+```bash
+wmo config rag refresh support-agent --root .wmo --yes
+```
+
+The command writes a new combined dataset and RAG index. It does not mutate the completed-build
+serving RAG, fit RAG, or world model. Repeating it on the same journal prefix reprints the receipt
+and makes no new embedding calls. Use ghost mode when traffic must not be saved:
 
 ```bash
 wmo run support-agent --root .wmo --ghost

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,8 @@ The root surface is deliberately small:
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
 | `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
+| `wmo config judge setup\|calibrate PROJECT` | Confirm a judge contract, then label and approve calibration on real fit traces. | Approved judge setup and calibration artifacts. |
+| `wmo config rag refresh PROJECT` | Seal durable routed traffic into a new retrieval index beside the completed build. | Runtime snapshot, combined trace dataset, and a new RAG index. Frozen build artifacts stay unchanged. |
 | `wmo config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.wmo/settings.toml`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -9,7 +9,7 @@ from typer.main import get_group
 from wmo.cli.app import app
 
 EXPECTED_SUBCOMMANDS = {
-    "config": {"budget", "judge", "providers", "telemetry"},
+    "config": {"budget", "judge", "providers", "rag", "telemetry"},
     "optimize": {"model", "router"},
 }
 

--- a/wmo/cli/cli_help_test.py
+++ b/wmo/cli/cli_help_test.py
@@ -19,6 +19,7 @@ from wmo.cli.app import app
         ["config", "providers", "--help"],
         ["config", "judge", "setup", "--help"],
         ["config", "judge", "calibrate", "--help"],
+        ["config", "rag", "refresh", "--help"],
         ["optimize", "router", "--help"],
         ["optimize", "model", "--help"],
         ["run", "--help"],
@@ -31,6 +32,7 @@ from wmo.cli.app import app
         "providers",
         "judge-setup",
         "judge-calibrate",
+        "rag-refresh",
         "router",
         "model",
         "run",
@@ -50,6 +52,7 @@ def test_help_renders_only_user_facing_descriptions(argv: list[str]) -> None:
     [
         ["build", "--help"],
         ["config", "judge", "calibrate", "--help"],
+        ["config", "rag", "refresh", "--help"],
         ["optimize", "router", "--help"],
         ["optimize", "model", "--help"],
     ],

--- a/wmo/cli/config_cmd.py
+++ b/wmo/cli/config_cmd.py
@@ -29,6 +29,14 @@ add_deferred_typer(
     help="Set up and manually calibrate a project judge.",
     known_names=("setup", "calibrate"),
 )
+add_deferred_typer(
+    config_app,
+    name="rag",
+    module="wmo.cli.rag_config",
+    attr="rag_app",
+    help="Refresh retrieval from durable routed traffic.",
+    known_names=("refresh",),
+)
 _console = Console()
 _CONNECTION_JSON_OPTION = typer.Option(
     None,

--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -20,6 +20,7 @@ from wmo.cli.options import ROOT_OPTION, usage_error
 from wmo.common.config import resolve_command_budget_usd
 from wmo.common.judging import Rubric, RubricDimension, render_rubric_table, score_bounds
 from wmo.common.judging.provenance import read_artifact_json
+from wmo.common.judging.rubric import MAX_AXIS_SCORE
 from wmo.common.models import load_model_catalog
 from wmo.common.project import ProjectStore
 from wmo.common.release_revision import installed_release_revision
@@ -68,6 +69,13 @@ _LABEL_OPTION = typer.Option(
         "Repeat TRACE_ID:DIMENSION_ID=SCORE, or "
         "TRACE_ID:REFERENCE_TRACE_ID:DIMENSION_ID=winner_a|winner_b|tie for pairwise labels."
     ),
+)
+_LABEL_ALL_OPTION = typer.Option(
+    None,
+    "--label-all",
+    min=0,
+    max=MAX_AXIS_SCORE,
+    help="Apply one integer score to every unlabeled scalar axis inside that axis range.",
 )
 
 
@@ -143,6 +151,7 @@ def judge_calibrate(
     root: Path = ROOT_OPTION,
     sample_size: int = typer.Option(10, "--sample-size", min=1),
     label: list[str] | None = _LABEL_OPTION,
+    label_all: int | None = _LABEL_ALL_OPTION,
     input_price: float | None = typer.Option(
         None,
         "--input-usd-per-million",
@@ -197,6 +206,7 @@ def judge_calibrate(
         root: Local project root containing ``models.toml``.
         sample_size: Maximum number of distinct fit lineages to calibrate.
         label: Repeatable explicit human score inputs.
+        label_all: Optional uniform integer score for remaining unlabeled scalar axes.
         input_price: Optional advanced input-price override.
         output_price: Optional advanced output-price override.
         maximum_input_tokens: Conservative input bound for every call attempt.
@@ -322,6 +332,7 @@ def judge_calibrate(
                 drafted,
                 persist,
                 non_interactive=non_interactive,
+                label_all=label_all,
             )
     else:
         labels = drafted
@@ -495,6 +506,7 @@ def _collect_labels(
     persist: Callable[[tuple[ManualJudgeLabel, ...]], None],
     *,
     non_interactive: bool,
+    label_all: int | None = None,
 ) -> tuple[ManualJudgeLabel, ...]:
     """Resume saved labels, parse explicit ones, and ask only for missing scores.
 
@@ -509,6 +521,7 @@ def _collect_labels(
         drafted: Labels already persisted for this exact frozen trace sample.
         persist: Durable writer for the labels collected so far.
         non_interactive: Whether all missing inputs must be reported without prompting.
+        label_all: Optional uniform integer score applied to remaining unlabeled scalar axes.
 
     Returns:
         Complete ordered human label set.
@@ -532,6 +545,18 @@ def _collect_labels(
             _label_value(item, pairwise=pairwise, axis=axis),
             pairwise=pairwise,
         )
+    if label_all is not None:
+        if pairwise:
+            raise ValueError("--label-all applies only to scalar calibration")
+        for preview in previews:
+            for dimension in rubric.dimensions:
+                if not dimension.contains_score(label_all):
+                    raise ValueError(
+                        f"--label-all {label_all} is outside {dimension.dimension_id} "
+                        f"range {dimension.min_score} through {dimension.max_score}"
+                    )
+                key = (preview.trace_id, preview.reference_trace_id, dimension.dimension_id)
+                parsed.setdefault(key, _label(key, label_all, pairwise=False))
     expected = tuple(
         (preview.trace_id, preview.reference_trace_id, dimension.dimension_id)
         for preview in previews
@@ -543,7 +568,7 @@ def _collect_labels(
             "unexpected labels: "
             + ", ".join(":".join(part or "-" for part in key) for key in unexpected)
         )
-    if explicit:
+    if explicit or label_all is not None:
         persist(tuple(parsed[key] for key in expected if key in parsed))
     missing = tuple(key for key in expected if key not in parsed)
     if missing and non_interactive:

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -18,7 +18,7 @@ from wmo.cli import judge_config as judge_config_module
 from wmo.cli.app import app
 from wmo.cli.judge_config import _label_value
 from wmo.common.core.artifacts import FailureCode, SourceIdentity, StructuredFailure
-from wmo.common.judging import Rubric, default_task_success_axis
+from wmo.common.judging import Rubric, RubricDimension, ScoreAnchor, default_task_success_axis
 from wmo.common.models import (
     ModelCapabilities,
     ModelCatalog,
@@ -110,6 +110,7 @@ def test_judge_commands_render_as_nested_config_commands() -> None:
     assert "rubric axes" in setup_output
     assert "--yes" in calibrate_output
     assert "--approve" in calibrate_output
+    assert "--label-all" in calibrate_output
     assert "Advanced" in calibrate_output
     assert "--input-usd-per-million" in calibrate_output
     assert "--output-usd-per-million" in calibrate_output
@@ -383,6 +384,165 @@ def test_pairwise_prompt_keeps_anchors_adjacent_and_uses_plain_a_b_labels(
     assert "Score prompt: Task success" in output
     assert "0: The agent did not complete the requested task." in output
     assert "1: The agent successfully completed the requested task." in output
+
+
+def _scalar_rubric() -> SimpleNamespace:
+    """Return a rubric stub with the default task-success axis and axis lookup."""
+    dimensions = default_judge_dimensions()
+    by_id = {item.dimension_id: item for item in dimensions}
+    return SimpleNamespace(dimensions=dimensions, axis=by_id.__getitem__)
+
+
+def test_label_all_fills_unlabeled_scalar_dimensions() -> None:
+    """A uniform in-range score labels every remaining scalar sample without prompting."""
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="scalar")),
+    )
+    previews = (
+        cast(JudgeTracePreview, SimpleNamespace(trace_id="trace-a", reference_trace_id=None)),
+        cast(JudgeTracePreview, SimpleNamespace(trace_id="trace-b", reference_trace_id=None)),
+    )
+    persisted: list[tuple[ManualJudgeLabel, ...]] = []
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Retain the uniform labels exactly as the command would save them."""
+        persisted.append(labels)
+
+    labels = judge_config_module._collect_labels(
+        setup,
+        cast(Rubric, _scalar_rubric()),
+        ("trace-a:task-success=0",),
+        previews,
+        (),
+        persist,
+        non_interactive=True,
+        label_all=1,
+    )
+
+    assert [item.trace_id for item in labels] == ["trace-a", "trace-b"]
+    assert [item.score for item in labels] == [0, 1]
+    assert persisted[-1] == labels
+
+
+def test_label_all_rejects_scores_outside_the_axis_range() -> None:
+    """A uniform score that the default 0-1 axis cannot hold fails before any draft."""
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="scalar")),
+    )
+    preview = cast(JudgeTracePreview, SimpleNamespace(trace_id="trace-a", reference_trace_id=None))
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Out-of-range --label-all must fail before any draft is written."""
+        raise AssertionError(f"out-of-range --label-all must not persist {labels!r}")
+
+    with pytest.raises(ValueError, match="outside task-success range 0 through 1"):
+        judge_config_module._collect_labels(
+            setup,
+            cast(Rubric, _scalar_rubric()),
+            (),
+            (preview,),
+            (),
+            persist,
+            non_interactive=True,
+            label_all=4,
+        )
+
+
+def test_label_all_rejects_pairwise_calibration() -> None:
+    """Pairwise setups require an explicit winner and cannot take a uniform score."""
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="pairwise")),
+    )
+    preview = cast(
+        JudgeTracePreview,
+        SimpleNamespace(trace_id="trace-a", reference_trace_id="trace-b"),
+    )
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Uniform pairwise labeling must fail before any draft is written."""
+        raise AssertionError(f"pairwise --label-all must not persist {labels!r}")
+
+    with pytest.raises(ValueError, match="--label-all applies only to scalar"):
+        judge_config_module._collect_labels(
+            setup,
+            cast(Rubric, _scalar_rubric()),
+            (),
+            (preview,),
+            (),
+            persist,
+            non_interactive=True,
+            label_all=1,
+        )
+
+
+def test_label_all_accepts_an_in_range_score_above_five() -> None:
+    """Typer must not reject a legal high-range axis score before axis validation."""
+    dimension = RubricDimension(
+        dimension_id="quality",
+        name="Quality",
+        description="Quality of the completed work.",
+        min_score=0,
+        max_score=10,
+        anchors=(
+            ScoreAnchor(score=0, description="Lowest quality."),
+            ScoreAnchor(score=10, description="Highest quality."),
+        ),
+    )
+    setup = cast(
+        ManualJudgeSetupArtifact,
+        SimpleNamespace(prompt_template=SimpleNamespace(response_shape="scalar")),
+    )
+    preview = cast(JudgeTracePreview, SimpleNamespace(trace_id="trace-a", reference_trace_id=None))
+    persisted: list[tuple[ManualJudgeLabel, ...]] = []
+
+    def persist(labels: tuple[ManualJudgeLabel, ...]) -> None:
+        """Retain the high-range uniform label."""
+        persisted.append(labels)
+
+    labels = judge_config_module._collect_labels(
+        setup,
+        cast(Rubric, SimpleNamespace(dimensions=(dimension,), axis=lambda key: dimension)),
+        (),
+        (preview,),
+        (),
+        persist,
+        non_interactive=True,
+        label_all=8,
+    )
+
+    assert [item.score for item in labels] == [8]
+    assert persisted[-1] == labels
+
+
+def test_label_all_cli_accepts_scores_through_the_rubric_maximum(tmp_path: Path) -> None:
+    """A score above five must pass Typer parsing and fail only on project or axis checks.
+
+    Args:
+        tmp_path: Isolated root with no project, so calibration fails after option parsing.
+    """
+    result = CliRunner().invoke(
+        app,
+        [
+            "config",
+            "judge",
+            "calibrate",
+            "missing",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--label-all",
+            "8",
+            "--non-interactive",
+            "--yes",
+        ],
+    )
+
+    output = unstyle(result.output)
+    assert "8 is not in the range" not in output
+    assert "0<=x<=5" not in output
+    assert result.exit_code != 0
 
 
 @pytest.mark.parametrize(

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -354,9 +354,10 @@ def _noninteractive_setup(
     errors: list[str] = []
     for position, payload in enumerate(options.connection_json, start=1):
         try:
-            connections.append(ProviderConnection.model_validate_json(payload))
-        except ValidationError as exc:
-            errors.append(f"--connection-json #{position}: {exc.errors()[0]['msg']}")
+            connections.append(_connection_from_json(payload))
+        except (ValueError, ValidationError) as exc:
+            message = exc.errors()[0]["msg"] if isinstance(exc, ValidationError) else str(exc)
+            errors.append(f"--connection-json #{position}: {message}")
     for position, payload in enumerate(options.model_json, start=1):
         try:
             models.append(ProviderModelSelection.model_validate_json(payload))
@@ -394,6 +395,40 @@ def _noninteractive_setup(
         judge=roles["--judge"],
         embedder=roles["--embedder"],
     )
+
+
+def _connection_from_json(payload: str) -> ProviderConnection:
+    """Parse one connection record, expanding ``base_url_env`` before validation.
+
+    Args:
+        payload: JSON object accepted by ``--connection-json``.
+
+    Returns:
+        A validated secret-free connection with any env-backed origin already expanded.
+
+    Raises:
+        ValueError: JSON is malformed or ``base_url_env`` cannot be resolved.
+        ValidationError: The expanded record is not a supported connection.
+    """
+    try:
+        raw = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError("connection JSON must be a complete object") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("connection JSON must be a complete object")
+    env_name = raw.pop("base_url_env", None)
+    if env_name is not None:
+        if raw.get("base_url") is not None:
+            raise ValueError("connection JSON cannot set both base_url and base_url_env")
+        if not isinstance(env_name, str) or not env_name.strip():
+            raise ValueError("base_url_env must be a nonempty environment-variable name")
+        origin = os.environ.get(env_name, "").strip()
+        if not origin:
+            raise ValueError(
+                f"{env_name} is empty; set that origin before configuring this connection"
+            )
+        raw["base_url"] = origin
+    return ProviderConnection.model_validate(raw)
 
 
 def _existing_connections(existing: ModelCatalog | None) -> tuple[ProviderConnection, ...]:

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -386,6 +386,128 @@ def test_setup_preserves_router_candidates_and_unrelated_entries(tmp_path: Path)
     assert catalog.models["candidate"].model == "vendor/candidate"
 
 
+def test_connection_json_expands_base_url_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compatible origins can be supplied as an environment name and stored as a URL.
+
+    Args:
+        tmp_path: Temporary WMO root receiving the catalog.
+        monkeypatch: Scoped origin environment for the compatible connection.
+    """
+    monkeypatch.setenv("WMO_ENDPOINT_BASE_URL", "https://wm.example.test/v1")
+    connection = json.dumps(
+        {
+            "name": "private",
+            "provider": "openai-compatible",
+            "api_key_env": "WMO_ENDPOINT_API_KEY",
+            "base_url_env": "WMO_ENDPOINT_BASE_URL",
+        }
+    )
+    model = json.dumps(
+        {
+            "alias": "private",
+            "connection": "private",
+            "model": "private-model",
+            "capabilities": {
+                "supports_completions": True,
+                "supports_embeddings": True,
+                "input_cost_per_million_tokens_usd": 0,
+                "output_cost_per_million_tokens_usd": 0,
+                "cached_input_cost_per_million_tokens_usd": 0,
+                "cache_write_cost_per_million_tokens_usd": 0,
+            },
+        }
+    )
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--non-interactive",
+            "--connection-json",
+            connection,
+            "--model-json",
+            model,
+            "--world-model",
+            "private",
+            "--judge",
+            "private",
+            "--embedder",
+            "private",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    catalog = load_model_catalog(tmp_path / ".wmo" / "models.toml")
+    assert catalog.connections["private"].base_url == "https://wm.example.test/v1"
+    text = (tmp_path / ".wmo" / "models.toml").read_text(encoding="utf-8")
+    assert "sk-" not in text
+    assert "base_url_env" not in text
+
+
+def test_connection_json_rejects_base_url_and_base_url_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An origin must come from exactly one of a literal URL or an environment name.
+
+    Args:
+        tmp_path: Temporary WMO root that must stay unwritten.
+        monkeypatch: Scoped origin environment that must not be consulted.
+    """
+    monkeypatch.setenv("WMO_ENDPOINT_BASE_URL", "https://wm.example.test/v1")
+    connection = json.dumps(
+        {
+            "name": "private",
+            "provider": "openai-compatible",
+            "api_key_env": "WMO_ENDPOINT_API_KEY",
+            "base_url": "https://other.example.test/v1",
+            "base_url_env": "WMO_ENDPOINT_BASE_URL",
+        }
+    )
+    model = json.dumps(
+        {
+            "alias": "private",
+            "connection": "private",
+            "model": "private-model",
+            "capabilities": {
+                "supports_embeddings": True,
+                "input_cost_per_million_tokens_usd": 0,
+            },
+        }
+    )
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--non-interactive",
+            "--connection-json",
+            connection,
+            "--model-json",
+            model,
+            "--world-model",
+            "private",
+            "--judge",
+            "private",
+            "--embedder",
+            "private",
+        ],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "cannot set both base_url" in output
+    assert "base_url_env" in output
+    assert not (tmp_path / ".wmo" / "models.toml").exists()
+
+
 def test_structured_input_rejects_openai_compatible_without_capabilities(tmp_path: Path) -> None:
     """Private compatible endpoints cannot acquire provider-wide capability guesses.
 

--- a/wmo/cli/rag_config.py
+++ b/wmo/cli/rag_config.py
@@ -1,0 +1,267 @@
+"""Refresh retrieval from durable routed traffic without mutating a completed build."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from wmo.cli.consent import require_spend_consent
+from wmo.cli.options import ROOT_OPTION, usage_error
+from wmo.common.config import resolve_command_budget_usd
+from wmo.common.core.locks import FileLockTimeout
+from wmo.common.models import EmbeddingCostReservation, ModelCatalogError, load_model_catalog
+from wmo.common.project import (
+    ArtifactStoreError,
+    ProjectBuildArtifacts,
+    ProjectStore,
+    ProjectStoreError,
+)
+from wmo.common.release_revision import installed_release_revision
+from wmo.runtime.models import CapabilityRequirement, ModelCapabilityError, RuntimeModelCatalog
+from wmo.runtime.models.preflight import preflight_capabilities
+from wmo.runtime.models.providers.retry import RetryPolicy
+from wmo.runtime.router import (
+    RuntimeInteractionJournal,
+    RuntimeJournalError,
+    RuntimeTraceSnapshotError,
+)
+from wmo.simulation.retrieval.build_inputs import load_completed_build_rag_lineage_bindings
+from wmo.simulation.retrieval.embedding import RAGEmbedderBinding
+from wmo.simulation.retrieval.refresh import (
+    PersistedRuntimeRAGRefresh,
+    RuntimeRAGRefreshError,
+    find_completed_runtime_rag_refresh,
+    refresh_runtime_trace_rag,
+)
+
+rag_app = typer.Typer(help="Refresh retrieval from durable routed traffic.", no_args_is_help=True)
+_console = Console()
+
+
+@rag_app.command(
+    "refresh",
+    help="Seal routed journal traffic into a new retrieval index beside the completed build.",
+)
+def rag_refresh(
+    project: str = typer.Argument(..., metavar="PROJECT", help="Configured local project ID."),
+    root: Path = ROOT_OPTION,
+    maximum_embedding_cost_usd: float | None = typer.Option(
+        None,
+        "--maximum-cost-usd",
+        min=0.000001,
+        help="Optional tighter refresh ceiling inside the shared per-command budget.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Confirm an in-budget estimate when the shared policy requires it.",
+    ),
+    non_interactive: bool = typer.Option(False, "--non-interactive"),
+) -> None:
+    """Seal the current journal and write a new combined retrieval index.
+
+    The completed build's serving RAG, fit RAG, and world model stay immutable. Replay of the
+    same journal prefix reprints the existing receipt and makes no new embedding calls.
+
+    Args:
+        project: Local project ID below ``<root>/projects``.
+        root: Local project root containing ``models.toml``.
+        maximum_embedding_cost_usd: Optional tighter embedding spend ceiling.
+        yes: Explicit confirmation for an in-budget estimate above the automatic threshold.
+        non_interactive: Refuse prompts and require complete flags.
+
+    Raises:
+        typer.BadParameter: Build, journal, catalog, budget, or refresh evidence is invalid.
+    """
+    with usage_error(
+        OSError,
+        ValueError,
+        FileLockTimeout,
+        ProjectStoreError,
+        ArtifactStoreError,
+        ModelCatalogError,
+        ModelCapabilityError,
+        RuntimeJournalError,
+        RuntimeTraceSnapshotError,
+        RuntimeRAGRefreshError,
+    ):
+        revision = installed_release_revision()
+        store = ProjectStore(root, project)
+        completed = store.load_project().build
+        if completed is None:
+            raise ValueError(
+                "runtime RAG refresh needs a completed build; "
+                "run `wmo build` for this project first"
+            )
+        journal = RuntimeInteractionJournal(store.paths)
+        if not journal.read_events():
+            raise ValueError(
+                "runtime RAG refresh needs durable routed traffic; run `wmo run` without --ghost "
+                "and complete at least one request before refreshing"
+            )
+        catalog = load_model_catalog(store.model_catalog_path)
+        embedder_alias = catalog.roles.embedder
+        if embedder_alias is None:
+            raise ValueError(
+                "runtime RAG refresh needs a configured embedder; "
+                "set one with `wmo config providers`"
+            )
+        runtime_catalog = RuntimeModelCatalog(catalog)
+        snapshot, capabilities = runtime_catalog.snapshot(embedder_alias)
+        preflight_capabilities(
+            embedder_alias,
+            capabilities,
+            CapabilityRequirement(requires_embeddings=True),
+        )
+        embedding_price = capabilities.input_cost_per_million_tokens_usd
+        if embedding_price is None:
+            raise ValueError("the selected embedder has no explicit input price")
+        maximum_attempts = RetryPolicy().maximum_attempts
+        maximum_input_tokens = capabilities.context_window_tokens or 8_192
+        reservation = EmbeddingCostReservation(
+            model=snapshot,
+            input_usd_per_million_tokens=embedding_price,
+            maximum_attempts=maximum_attempts,
+            maximum_input_tokens=maximum_input_tokens,
+        )
+        estimate = _reserved_ceiling_usd(reservation)
+        shared_ceiling = resolve_command_budget_usd(root, None)
+        ceiling = (
+            shared_ceiling
+            if maximum_embedding_cost_usd is None
+            else min(shared_ceiling, maximum_embedding_cost_usd)
+        )
+        if maximum_embedding_cost_usd is not None and estimate > maximum_embedding_cost_usd:
+            raise ValueError(
+                "runtime RAG refresh estimate exceeds --maximum-cost-usd; raise the ceiling "
+                "or reduce the reserved embedding bound"
+            )
+    if not require_spend_consent(
+        _console,
+        root=root,
+        yes=yes,
+        estimated_cost_usd=estimate,
+        command=f"wmo config rag refresh {project}",
+        assumptions=(
+            f"embedder {embedder_alias}: {snapshot.model_id}",
+            f"up to {maximum_input_tokens} input tokens per attempt",
+            f"up to {maximum_attempts} embedding attempts",
+            f"${embedding_price:.6f} input per million tokens",
+        ),
+        non_interactive=non_interactive,
+    ):
+        _console.print("Runtime RAG refresh was not started. No embedding calls ran.")
+        return
+    with usage_error(
+        OSError,
+        ValueError,
+        FileLockTimeout,
+        ProjectStoreError,
+        ArtifactStoreError,
+        ModelCatalogError,
+        ModelCapabilityError,
+        RuntimeJournalError,
+        RuntimeTraceSnapshotError,
+        RuntimeRAGRefreshError,
+    ):
+        imported_bindings = load_completed_build_rag_lineage_bindings(store.artifacts, completed)
+        created_at = datetime.now(UTC)
+        result = find_completed_runtime_rag_refresh(
+            journal,
+            store.artifacts,
+            (completed.trace_dataset,),
+            imported_bindings,
+            embedding_reservation=reservation,
+            maximum_embedding_cost_usd=ceiling,
+            created_at=created_at,
+            code_revision=revision,
+        )
+        if result is None:
+            resolved = runtime_catalog.preflight(
+                embedder_alias,
+                CapabilityRequirement(requires_embeddings=True),
+            )
+            if resolved.embedding_client is None:
+                raise ValueError(f"embedder {embedder_alias!r} did not resolve an embedding client")
+            binding = RAGEmbedderBinding(
+                client=resolved.embedding_client,
+                snapshot=resolved.snapshot,
+                maximum_attempts=maximum_attempts,
+                input_usd_per_million_tokens=embedding_price,
+            )
+            result = refresh_runtime_trace_rag(
+                journal,
+                store.artifacts,
+                (completed.trace_dataset,),
+                imported_bindings,
+                embedder=binding,
+                embedding_reservation=reservation,
+                maximum_embedding_cost_usd=ceiling,
+                created_at=created_at,
+                code_revision=revision,
+            )
+    _render_refresh_result(result, completed)
+
+
+def _render_refresh_result(
+    result: PersistedRuntimeRAGRefresh,
+    completed: ProjectBuildArtifacts,
+) -> None:
+    """Print the immutable refresh receipt and the unchanged completed-build pointers.
+
+    Args:
+        result: Verified refresh artifacts for the current journal prefix.
+        completed: Selected completed-build pointers whose serving and fit RAG stay frozen.
+    """
+    receipt = result.refresh
+    snapshot = result.snapshot_export.snapshot
+    _console.print(f"runtime RAG refresh {receipt.refresh_id}")
+    _console.print(
+        f"snapshot: {receipt.snapshot.artifact_id} "
+        f"(last_ordinal={snapshot.last_ordinal}, "
+        f"completed_targets={snapshot.completed_target_count})"
+    )
+    _console.print(f"runtime traces: {receipt.runtime_trace_dataset.artifact_id}")
+    _console.print(f"combined traces: {receipt.combined_trace_dataset.artifact_id}")
+    _console.print(f"retrieval index: {receipt.retrieval_index.artifact_id}")
+    _console.print(f"imported datasets: {len(receipt.imported_trace_datasets)}")
+    _console.print(
+        f"reserved embedding cost: ${_format_usd(receipt.reserved_embedding_cost_usd)} "
+        f"(ceiling ${_format_usd(receipt.maximum_embedding_cost_usd)})"
+    )
+    _console.print(
+        f"completed build serving RAG {completed.serving_rag.artifact_id} and "
+        f"fit RAG {completed.fit_rag.artifact_id} are unchanged"
+    )
+
+
+def _reserved_ceiling_usd(reservation: EmbeddingCostReservation) -> float:
+    """Return the conservative retry-inclusive reservation used for spend admission.
+
+    Args:
+        reservation: Exact embedder identity, price, token bound, and retry count.
+
+    Returns:
+        Finite nonnegative dollar bound for one full reserved embedding attempt budget.
+    """
+    tokens = reservation.maximum_input_tokens * reservation.maximum_attempts
+    return reservation.input_usd_per_million_tokens * tokens / 1_000_000
+
+
+def _format_usd(value: float) -> str:
+    """Format an admitted dollar bound without rounding a positive value to zero.
+
+    Args:
+        value: Finite nonnegative estimated cost or positive hard ceiling.
+
+    Returns:
+        Fixed-point decimal text preserving the float's round-trip value and at least four
+        fractional digits.
+    """
+    whole, separator, fraction = format(Decimal(str(value)), "f").partition(".")
+    significant_fraction = fraction.rstrip("0") if separator else ""
+    return f"{whole}.{significant_fraction.ljust(4, '0')}"

--- a/wmo/cli/rag_config_test.py
+++ b/wmo/cli/rag_config_test.py
@@ -1,0 +1,204 @@
+"""CLI surface tests for runtime retrieval refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click import unstyle
+from typer.testing import CliRunner
+
+from wmo.cli.app import app
+from wmo.common.core.artifacts import ArtifactInput
+from wmo.common.models import (
+    ConnectionConfig,
+    ModelCapabilities,
+    ModelCatalog,
+    ModelRecord,
+    ModelRoles,
+    write_model_catalog,
+)
+from wmo.common.project import ProjectBuildArtifacts, ProjectConfig, ProjectStore
+
+
+def _pointer(artifact_id: str) -> ArtifactInput:
+    """Return one secret-free artifact pointer for a fixture completed build.
+
+    Args:
+        artifact_id: Valid local artifact identity.
+
+    Returns:
+        Manifest pointer with a placeholder digest.
+    """
+    return ArtifactInput(artifact_id=artifact_id, sha256="0" * 64)
+
+
+def test_rag_refresh_renders_as_a_nested_config_command() -> None:
+    """Refresh is discoverable under config without expanding the root surface."""
+    result = CliRunner().invoke(app, ["config", "rag", "refresh", "--help"])
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "--yes" in output
+    assert "--non-interactive" in output
+    assert "--maximum-cost-usd" in output
+
+
+def test_rag_refresh_requires_a_completed_build(tmp_path: Path) -> None:
+    """A project without a selected build fails before journal or embedding work.
+
+    Args:
+        tmp_path: Isolated root containing only an initialized project.
+    """
+    root = tmp_path / ".wmo"
+    store = ProjectStore(root, "demo")
+    store.initialize(ProjectConfig(project_id="demo"))
+
+    result = CliRunner().invoke(
+        app,
+        ["config", "rag", "refresh", "demo", "--root", str(root), "--yes"],
+    )
+
+    assert result.exit_code == 2
+    assert "completed build" in unstyle(result.output)
+    assert "wmo build" in unstyle(result.output)
+
+
+def test_rag_refresh_requires_durable_routed_traffic(tmp_path: Path) -> None:
+    """An empty journal fails before catalog resolution or spend consent.
+
+    Args:
+        tmp_path: Isolated root containing a completed-build pointer and no journal.
+    """
+    root = tmp_path / ".wmo"
+    store = ProjectStore(root, "demo")
+    store.initialize(
+        ProjectConfig(
+            project_id="demo",
+            build=ProjectBuildArtifacts(
+                trace_dataset=_pointer("trace-dataset"),
+                task_set=_pointer("task-set"),
+                serving_rag=_pointer("serving-rag"),
+                fit_rag=_pointer("fit-rag"),
+                world_model=_pointer("world-model"),
+            ),
+        )
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["config", "rag", "refresh", "demo", "--root", str(root), "--yes"],
+    )
+
+    assert result.exit_code == 2
+    output = unstyle(result.output)
+    assert "durable routed traffic" in output
+    assert "without --ghost" in output
+
+
+def _write_priced_embedder_catalog(root: Path) -> None:
+    """Persist one secret-free catalog with an explicitly priced embedder.
+
+    Args:
+        root: Local WMO root receiving ``models.toml``.
+    """
+    write_model_catalog(
+        root / "models.toml",
+        ModelCatalog(
+            connections={
+                "fixture": ConnectionConfig(provider="openai", api_key_env="FIXTURE_API_KEY")
+            },
+            models={
+                "embed": ModelRecord(
+                    connection="fixture",
+                    model="embed-id",
+                    capabilities=ModelCapabilities(
+                        supports_embeddings=True,
+                        input_cost_per_million_tokens_usd=0.1,
+                        context_window_tokens=8_192,
+                    ),
+                )
+            },
+            roles=ModelRoles(embedder="embed"),
+        ),
+    )
+
+
+def test_rag_refresh_replay_does_not_construct_an_embedder_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Completed exact replay reprints the receipt without resolving a live client.
+
+    Args:
+        tmp_path: Isolated root with a completed-build pointer and priced embedder.
+        monkeypatch: Scoped replacements for journal, lookup, and client construction.
+    """
+    root = tmp_path / ".wmo"
+    store = ProjectStore(root, "demo")
+    store.initialize(
+        ProjectConfig(
+            project_id="demo",
+            build=ProjectBuildArtifacts(
+                trace_dataset=_pointer("trace-dataset"),
+                task_set=_pointer("task-set"),
+                serving_rag=_pointer("serving-rag"),
+                fit_rag=_pointer("fit-rag"),
+                world_model=_pointer("world-model"),
+            ),
+        )
+    )
+    _write_priced_embedder_catalog(root)
+    receipt = SimpleNamespace(
+        refresh_id="runtime-rag-refresh-replay",
+        snapshot=_pointer("runtime-snapshot"),
+        runtime_trace_dataset=_pointer("runtime-traces"),
+        combined_trace_dataset=_pointer("combined-traces"),
+        retrieval_index=_pointer("retrieval-index"),
+        imported_trace_datasets=(),
+        reserved_embedding_cost_usd=0.0025,
+        maximum_embedding_cost_usd=5.0,
+    )
+    fake = SimpleNamespace(
+        refresh=receipt,
+        snapshot_export=SimpleNamespace(
+            snapshot=SimpleNamespace(last_ordinal=3, completed_target_count=1)
+        ),
+    )
+
+    monkeypatch.setattr(
+        "wmo.cli.rag_config.RuntimeInteractionJournal.read_events",
+        lambda self: ("event",),
+    )
+    monkeypatch.setattr(
+        "wmo.cli.rag_config.load_completed_build_rag_lineage_bindings",
+        lambda *args, **kwargs: (),
+    )
+    monkeypatch.setattr(
+        "wmo.cli.rag_config.find_completed_runtime_rag_refresh",
+        lambda *args, **kwargs: fake,
+    )
+
+    def fail_preflight(_self: object, _alias: str, _requirement: object = None) -> None:
+        """Replay must not construct a credential-backed embedder client."""
+        raise AssertionError("replay must not construct an embedder client")
+
+    monkeypatch.setattr("wmo.cli.rag_config.RuntimeModelCatalog.preflight", fail_preflight)
+    monkeypatch.setattr(
+        "wmo.cli.rag_config.refresh_runtime_trace_rag",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("replay must not dispatch a new refresh")
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["config", "rag", "refresh", "demo", "--root", str(root), "--yes"],
+    )
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "runtime-rag-refresh-replay" in output
+    assert "serving-rag" in output
+    assert "fit-rag" in output

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -17,13 +17,13 @@ from wmo.common.core.artifacts import (
 )
 from wmo.common.models import ModelSnapshot
 
-_MAX_AXIS_SCORE = 10
+MAX_AXIS_SCORE = 10
 
 
 class ScoreAnchor(ContractModel):
     """Plain-language meaning for one integer score on a rubric axis."""
 
-    score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
+    score: int = Field(ge=0, le=MAX_AXIS_SCORE)
     description: str = Field(min_length=1)
 
 
@@ -33,8 +33,8 @@ class RubricDimension(ContractModel):
     dimension_id: ArtifactId
     name: str = Field(min_length=1, max_length=256)
     description: str = Field(min_length=1)
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(default=0, ge=0, le=MAX_AXIS_SCORE)
+    max_score: int = Field(default=5, ge=0, le=MAX_AXIS_SCORE)
     anchors: tuple[ScoreAnchor, ...]
 
     @model_validator(mode="after")
@@ -238,8 +238,8 @@ class DimensionScoreMap(ContractModel):
     """A monotonic mapping from raw judge scores to expected human scores."""
 
     dimension_id: ArtifactId
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(default=0, ge=0, le=MAX_AXIS_SCORE)
+    max_score: int = Field(default=5, ge=0, le=MAX_AXIS_SCORE)
     calibrated_scores: tuple[float, ...]
 
     @model_validator(mode="after")

--- a/wmo/simulation/retrieval/refresh.py
+++ b/wmo/simulation/retrieval/refresh.py
@@ -186,6 +186,186 @@ class PersistedRuntimeRAGRefresh:
     retrieval: PersistedRAGIndex
 
 
+@dataclass(frozen=True)
+class _PreparedRuntimeRAGRefresh:
+    """Sealed snapshot, union dataset, and replay identity before embedder dispatch."""
+
+    snapshot_export: PersistedRuntimeTraceExport
+    dataset: PersistedRuntimeRAGDataset
+    imports: tuple[ArtifactInput, ...]
+    bindings: tuple[RAGLineageBinding, ...]
+    transition_texts: tuple[str, ...]
+    refresh_id: str
+    maximum_embedding_cost_usd: float
+
+
+def _prepare_runtime_rag_refresh(
+    journal: RuntimeInteractionJournal,
+    store: ArtifactStore,
+    imported_trace_datasets: Sequence[ArtifactInput],
+    imported_lineage_bindings: Sequence[RAGLineageBinding],
+    *,
+    embedding_reservation: EmbeddingCostReservation,
+    maximum_embedding_cost_usd: float,
+    created_at: datetime,
+    code_revision: str,
+    last_ordinal: int | None = None,
+    default_top_k: int = 5,
+) -> _PreparedRuntimeRAGRefresh:
+    """Seal the current journal prefix and derive the exact refresh identity.
+
+    This step writes only the snapshot and union dataset. It does not construct an embedding
+    client or dispatch embeddings.
+
+    Args:
+        journal: Current project's validated append-only routed interaction journal.
+        store: Immutable artifact store for the same project.
+        imported_trace_datasets: Exact real trace-dataset pointers already imported by the project.
+        imported_lineage_bindings: Fit or held-out assignments covering imported traces exactly.
+        embedding_reservation: Explicit model, input ceiling, price, and retry-inclusive bound.
+        maximum_embedding_cost_usd: Finite total embedding-cost ceiling for this refresh.
+        created_at: Time new immutable artifacts are materialized.
+        code_revision: Exact WMO revision producing the artifacts.
+        last_ordinal: Optional inclusive journal prefix boundary.
+        default_top_k: Positive retrieval limit persisted in the new index.
+
+    Returns:
+        Sealed inputs and the deterministic refresh identity used for replay lookup.
+
+    Raises:
+        RuntimeRAGRefreshError: Source coverage or reservation inputs cannot be proven.
+        RuntimeTraceSnapshotError: The selected journal prefix cannot be sealed.
+    """
+    ceiling = _normalize_finite_nonnegative_cost(maximum_embedding_cost_usd)
+    imports = tuple(sorted(imported_trace_datasets, key=lambda item: item.artifact_id))
+    if len({item.artifact_id for item in imports}) != len(imports):
+        raise RuntimeRAGRefreshError("imported runtime RAG datasets must not repeat")
+    snapshot_export = seal_runtime_trace_snapshot(
+        journal,
+        store,
+        created_at=created_at,
+        code_revision=code_revision,
+        last_ordinal=last_ordinal,
+    )
+    runtime_dataset_input = artifact_input(snapshot_export.dataset_manifest)
+    snapshot_input = artifact_input(snapshot_export.snapshot_manifest)
+    if runtime_dataset_input in imports:
+        raise RuntimeRAGRefreshError(
+            "imported trace datasets must not repeat the current runtime snapshot dataset"
+        )
+    stitched = stitch_runtime_observations(snapshot_export)
+    dataset = persist_runtime_rag_dataset(
+        store,
+        (*imports, runtime_dataset_input),
+        runtime_dataset_input=runtime_dataset_input,
+        stitched_runtime_traces=stitched,
+        created_at=created_at,
+        code_revision=code_revision,
+    )
+    combined_input = artifact_input(dataset.manifest)
+    bindings = _combined_lineage_bindings(
+        store,
+        imports,
+        imported_lineage_bindings,
+        runtime_traces=stitched,
+    )
+    transitions = extract_fit_transitions(dataset.traces, bindings)
+    if not transitions:
+        raise RuntimeRAGRefreshError(
+            "runtime RAG refresh has no real observed fit transition after terminal exclusion"
+        )
+    refresh_id = _refresh_id(
+        project_id=journal.project_id,
+        snapshot=snapshot_input,
+        runtime_trace_dataset=runtime_dataset_input,
+        imported_trace_datasets=imports,
+        combined_trace_dataset=combined_input,
+        lineage_bindings=bindings,
+        embedding_reservation=embedding_reservation,
+        maximum_embedding_cost_usd=ceiling,
+        code_revision=code_revision,
+        default_top_k=default_top_k,
+    )
+    return _PreparedRuntimeRAGRefresh(
+        snapshot_export=snapshot_export,
+        dataset=dataset,
+        imports=imports,
+        bindings=bindings,
+        transition_texts=tuple(item.key_text for item in transitions),
+        refresh_id=refresh_id,
+        maximum_embedding_cost_usd=ceiling,
+    )
+
+
+def find_completed_runtime_rag_refresh(
+    journal: RuntimeInteractionJournal,
+    store: ArtifactStore,
+    imported_trace_datasets: Sequence[ArtifactInput],
+    imported_lineage_bindings: Sequence[RAGLineageBinding],
+    *,
+    embedding_reservation: EmbeddingCostReservation,
+    maximum_embedding_cost_usd: float,
+    created_at: datetime,
+    code_revision: str,
+    last_ordinal: int | None = None,
+    default_top_k: int = 5,
+) -> PersistedRuntimeRAGRefresh | None:
+    """Reopen a completed exact refresh without constructing an embedding client.
+
+    Args:
+        journal: Current project's validated append-only routed interaction journal.
+        store: Immutable artifact store for the same project.
+        imported_trace_datasets: Exact real trace-dataset pointers already imported by the project.
+        imported_lineage_bindings: Fit or held-out assignments covering imported traces exactly.
+        embedding_reservation: Explicit model, input ceiling, price, and retry-inclusive bound.
+        maximum_embedding_cost_usd: Finite total embedding-cost ceiling for this refresh.
+        created_at: Time new immutable artifacts are materialized.
+        code_revision: Exact WMO revision producing the artifacts.
+        last_ordinal: Optional inclusive journal prefix boundary.
+        default_top_k: Positive retrieval limit persisted in the requested index.
+
+    Returns:
+        The verified completed refresh, or ``None`` when this exact receipt has not been written.
+
+    Raises:
+        RuntimeRAGRefreshError: Source coverage, reservation, or a present receipt cannot be proven.
+        RuntimeTraceSnapshotError: The selected journal prefix cannot be sealed.
+    """
+    prepared = _prepare_runtime_rag_refresh(
+        journal,
+        store,
+        imported_trace_datasets,
+        imported_lineage_bindings,
+        embedding_reservation=embedding_reservation,
+        maximum_embedding_cost_usd=maximum_embedding_cost_usd,
+        created_at=created_at,
+        code_revision=code_revision,
+        last_ordinal=last_ordinal,
+        default_top_k=default_top_k,
+    )
+    destination = store.project_directory / "artifacts" / prepared.refresh_id
+    if not destination.exists():
+        return None
+    reserved_cost = _reservation_spend_usd(
+        prepared.transition_texts,
+        reservation=embedding_reservation,
+        maximum_cost_usd=prepared.maximum_embedding_cost_usd,
+    )
+    lock_target = store.project_directory / "runtime" / f"{prepared.refresh_id}.receipt"
+    with file_write_lock(lock_target, what="the runtime RAG refresh"):
+        if not destination.exists():
+            return None
+        return _load_exact_refresh(
+            store,
+            prepared.refresh_id,
+            snapshot_export=prepared.snapshot_export,
+            dataset=prepared.dataset,
+            expected_bindings=prepared.bindings,
+            expected_reservation=embedding_reservation,
+            expected_reserved_cost=reserved_cost,
+        )
+
+
 def refresh_runtime_trace_rag(
     journal: RuntimeInteractionJournal,
     store: ArtifactStore,
@@ -227,62 +407,27 @@ def refresh_runtime_trace_rag(
             cannot be proven before or after dispatch.
         RuntimeTraceSnapshotError: The selected journal prefix cannot be sealed.
     """
-    maximum_embedding_cost_usd = _normalize_finite_nonnegative_cost(maximum_embedding_cost_usd)
-    imports = tuple(sorted(imported_trace_datasets, key=lambda item: item.artifact_id))
-    if len({item.artifact_id for item in imports}) != len(imports):
-        raise RuntimeRAGRefreshError("imported runtime RAG datasets must not repeat")
-    snapshot_export = seal_runtime_trace_snapshot(
+    prepared = _prepare_runtime_rag_refresh(
         journal,
         store,
+        imported_trace_datasets,
+        imported_lineage_bindings,
+        embedding_reservation=embedding_reservation,
+        maximum_embedding_cost_usd=maximum_embedding_cost_usd,
         created_at=created_at,
         code_revision=code_revision,
         last_ordinal=last_ordinal,
-    )
-    runtime_dataset_input = artifact_input(snapshot_export.dataset_manifest)
-    snapshot_input = artifact_input(snapshot_export.snapshot_manifest)
-    if runtime_dataset_input in imports:
-        raise RuntimeRAGRefreshError(
-            "imported trace datasets must not repeat the current runtime snapshot dataset"
-        )
-    stitched = stitch_runtime_observations(snapshot_export)
-    dataset = persist_runtime_rag_dataset(
-        store,
-        (*imports, runtime_dataset_input),
-        runtime_dataset_input=runtime_dataset_input,
-        stitched_runtime_traces=stitched,
-        created_at=created_at,
-        code_revision=code_revision,
-    )
-    combined_input = artifact_input(dataset.manifest)
-    bindings = _combined_lineage_bindings(
-        store,
-        imports,
-        imported_lineage_bindings,
-        runtime_traces=stitched,
-    )
-    transitions = extract_fit_transitions(dataset.traces, bindings)
-    if not transitions:
-        raise RuntimeRAGRefreshError(
-            "runtime RAG refresh has no real observed fit transition after terminal exclusion"
-        )
-    reserved_cost = _reserved_embedding_cost(
-        tuple(item.key_text for item in transitions),
-        embedder=embedder,
-        reservation=embedding_reservation,
-        maximum_cost_usd=maximum_embedding_cost_usd,
-    )
-    refresh_id = _refresh_id(
-        project_id=journal.project_id,
-        snapshot=snapshot_input,
-        runtime_trace_dataset=runtime_dataset_input,
-        imported_trace_datasets=imports,
-        combined_trace_dataset=combined_input,
-        lineage_bindings=bindings,
-        embedding_reservation=embedding_reservation,
-        maximum_embedding_cost_usd=maximum_embedding_cost_usd,
-        code_revision=code_revision,
         default_top_k=default_top_k,
     )
+    reserved_cost = _reserved_embedding_cost(
+        prepared.transition_texts,
+        embedder=embedder,
+        reservation=embedding_reservation,
+        maximum_cost_usd=prepared.maximum_embedding_cost_usd,
+    )
+    snapshot_export = prepared.snapshot_export
+    dataset = prepared.dataset
+    refresh_id = prepared.refresh_id
     lock_target = store.project_directory / "runtime" / f"{refresh_id}.receipt"
     with file_write_lock(lock_target, what="the runtime RAG refresh"):
         destination = store.project_directory / "artifacts" / refresh_id
@@ -292,14 +437,14 @@ def refresh_runtime_trace_rag(
                 refresh_id,
                 snapshot_export=snapshot_export,
                 dataset=dataset,
-                expected_bindings=bindings,
+                expected_bindings=prepared.bindings,
                 expected_reservation=embedding_reservation,
                 expected_reserved_cost=reserved_cost,
             )
         retrieval = persist_trace_rag(
             store,
-            (combined_input,),
-            bindings,
+            (artifact_input(dataset.manifest),),
+            prepared.bindings,
             created_at=created_at,
             code_revision=code_revision,
             embedder=embedder,
@@ -308,14 +453,14 @@ def refresh_runtime_trace_rag(
         refresh = _refresh_envelope(
             refresh_id=refresh_id,
             project_id=journal.project_id,
-            snapshot=snapshot_input,
-            runtime_trace_dataset=runtime_dataset_input,
-            imported_trace_datasets=imports,
-            combined_trace_dataset=combined_input,
-            lineage_bindings=bindings,
+            snapshot=artifact_input(snapshot_export.snapshot_manifest),
+            runtime_trace_dataset=artifact_input(snapshot_export.dataset_manifest),
+            imported_trace_datasets=prepared.imports,
+            combined_trace_dataset=artifact_input(dataset.manifest),
+            lineage_bindings=prepared.bindings,
             retrieval_index=artifact_input(retrieval.manifest),
             embedding_reservation=embedding_reservation,
-            maximum_embedding_cost_usd=maximum_embedding_cost_usd,
+            maximum_embedding_cost_usd=prepared.maximum_embedding_cost_usd,
             reserved_embedding_cost_usd=reserved_cost,
             last_ordinal=snapshot_export.snapshot.last_ordinal,
             created_at=created_at,
@@ -335,7 +480,7 @@ def refresh_runtime_trace_rag(
                 refresh_id,
                 snapshot_export=snapshot_export,
                 dataset=dataset,
-                expected_bindings=bindings,
+                expected_bindings=prepared.bindings,
                 expected_reservation=embedding_reservation,
                 expected_reserved_cost=reserved_cost,
             )
@@ -533,6 +678,47 @@ def _combined_lineage_bindings(
     return tuple(by_trace[trace_id] for trace_id in sorted(by_trace))
 
 
+def _reservation_spend_usd(
+    texts: Sequence[str],
+    *,
+    reservation: EmbeddingCostReservation,
+    maximum_cost_usd: float,
+) -> float:
+    """Return the retry-inclusive reservation used for spend admission.
+
+    UTF-8 byte count is a conservative provider-independent input-token ceiling because every
+    nonempty token consumes at least one byte. The persisted reservation may be larger, but never
+    smaller, than this exact batch requirement.
+
+    Args:
+        texts: Exact canonical transition keys that will be embedded together.
+        reservation: Explicit model, price, retry, and input ceiling.
+        maximum_cost_usd: Finite total ceiling authorized for this refresh.
+
+    Returns:
+        Maximum retry-inclusive USD spend reserved for the dispatch.
+
+    Raises:
+        RuntimeRAGRefreshError: Input size or total-cost evidence is unknown or over the ceiling.
+    """
+    required_input_tokens = sum(len(text.encode("utf-8")) for text in texts)
+    if required_input_tokens > reservation.maximum_input_tokens:
+        raise RuntimeRAGRefreshError(
+            "embedding input exceeds the explicit provider-independent token reservation"
+        )
+    reserved = (
+        reservation.maximum_input_tokens
+        * reservation.maximum_attempts
+        * reservation.input_usd_per_million_tokens
+        / 1_000_000
+    )
+    if not math.isfinite(reserved) or reserved > maximum_cost_usd:
+        raise RuntimeRAGRefreshError(
+            "retry-inclusive embedding reservation exceeds the refresh cost ceiling"
+        )
+    return reserved
+
+
 def _reserved_embedding_cost(
     texts: Sequence[str],
     *,
@@ -541,10 +727,6 @@ def _reserved_embedding_cost(
     maximum_cost_usd: float,
 ) -> float:
     """Validate an exact retry-inclusive embedding reservation before dispatch.
-
-    UTF-8 byte count is a conservative provider-independent input-token ceiling because every
-    nonempty token consumes at least one byte. The persisted reservation may be larger, but never
-    smaller, than this exact batch requirement.
 
     Args:
         texts: Exact canonical transition keys that will be embedded together.
@@ -565,22 +747,11 @@ def _reserved_embedding_cost(
         raise RuntimeRAGRefreshError("embedding reservation retry bound differs from embedder")
     if reservation.input_usd_per_million_tokens != embedder.input_usd_per_million_tokens:
         raise RuntimeRAGRefreshError("embedding reservation price differs from configured embedder")
-    required_input_tokens = sum(len(text.encode("utf-8")) for text in texts)
-    if required_input_tokens > reservation.maximum_input_tokens:
-        raise RuntimeRAGRefreshError(
-            "embedding input exceeds the explicit provider-independent token reservation"
-        )
-    reserved = (
-        reservation.maximum_input_tokens
-        * reservation.maximum_attempts
-        * reservation.input_usd_per_million_tokens
-        / 1_000_000
+    return _reservation_spend_usd(
+        texts,
+        reservation=reservation,
+        maximum_cost_usd=maximum_cost_usd,
     )
-    if not math.isfinite(reserved) or reserved > maximum_cost_usd:
-        raise RuntimeRAGRefreshError(
-            "retry-inclusive embedding reservation exceeds the refresh cost ceiling"
-        )
-    return reserved
 
 
 def _refresh_id(

--- a/wmo/simulation/retrieval/refresh_test.py
+++ b/wmo/simulation/retrieval/refresh_test.py
@@ -63,6 +63,7 @@ from wmo.simulation.retrieval import (
     load_runtime_rag_refresh,
     refresh_runtime_trace_rag,
 )
+from wmo.simulation.retrieval.refresh import find_completed_runtime_rag_refresh
 
 _DIGEST = "a" * 64
 _TIME = datetime(2026, 8, 14, tzinfo=UTC)
@@ -402,6 +403,50 @@ def _refresh(
         created_at=created_at,
         code_revision="test-revision",
     )
+
+
+def test_find_completed_runtime_rag_refresh_reopens_without_an_embedder(
+    tmp_path: Path,
+) -> None:
+    """Exact replay lookup reopens the receipt without an embedding client.
+
+    Args:
+        tmp_path: Pytest-owned project directory.
+    """
+    journal, store, _first = _two_turn_journal(tmp_path)
+    client = CountingEmbedder()
+    binding = _binding(client)
+    missing = find_completed_runtime_rag_refresh(
+        journal,
+        store,
+        (),
+        (),
+        embedding_reservation=_reservation(binding),
+        maximum_embedding_cost_usd=1.0,
+        created_at=_TIME + timedelta(hours=1),
+        code_revision="test-revision",
+    )
+    assert missing is None
+    assert client.calls == 0
+
+    first = _refresh(journal, store, binding)
+    assert client.calls == 1
+
+    found = find_completed_runtime_rag_refresh(
+        journal,
+        store,
+        (),
+        (),
+        embedding_reservation=_reservation(binding),
+        maximum_embedding_cost_usd=1.0,
+        created_at=_TIME + timedelta(days=1),
+        code_revision="test-revision",
+    )
+
+    assert found is not None
+    assert found.refresh.refresh_id == first.refresh.refresh_id
+    assert found.retrieval.index.rag_id == first.retrieval.index.rag_id
+    assert client.calls == 1
 
 
 def test_zero_cost_int_and_float_share_identity_and_replay_without_dispatch(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The live happy path needed three product CLI commands. Those belong here, not in the skill PR.

- `wmo config judge calibrate --label-all SCORE` fills remaining unlabeled scalar axes. The score must lie inside each axis range. Typer accepts scores through the rubric maximum of 10, then each axis validates its own range. The default task-success axis is 0-1.
- `wmo config providers --connection-json` accepts `base_url_env` and stores the expanded origin. The catalog stays secret-free. `base_url` and `base_url_env` cannot be set together.
- `wmo config rag refresh PROJECT` seals durable `wmo run` traffic into a new retrieval index beside the completed build. It uses the shared cost-authorization policy. Exact replay reopens the receipt without constructing an embedder client.

The locked config group is now `budget`, `judge`, `providers`, `rag`, and `telemetry`. Frozen completed-build serving RAG, fit RAG, and world model stay unchanged.

The happy-path skill stays in a separate PR and should land after this surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7bfac4c-6dce-46e7-a07d-5959cd780390?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7bfac4c-6dce-46e7-a07d-5959cd780390&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

