### PR TITLE
Default judge setup confirmation to yes

### DIFF
--- a/wmo/cli/judge_config.py
+++ b/wmo/cli/judge_config.py
@@ -136,6 +136,7 @@ def judge_setup(
             plan = maybe_edit_setup_plan(plan, console=_console)
         confirmed = approve or _confirm(
             "Save this judge setup and finalize its rubric?",
+            default=True,
             non_interactive=non_interactive,
             required_flag="--approve",
         )
@@ -530,11 +531,18 @@ def _metric(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.3f}"
 
 
-def _confirm(question: str, *, non_interactive: bool, required_flag: str) -> bool:
+def _confirm(
+    question: str,
+    *,
+    default: bool = False,
+    non_interactive: bool,
+    required_flag: str,
+) -> bool:
     """Ask one non-spend confirmation or require its explicit flag.
 
     Args:
         question: Human-readable confirmation prompt.
+        default: Answer selected by a blank response.
         non_interactive: Whether terminal prompting is forbidden.
         required_flag: Explicit flag required without a prompt.
 
@@ -546,4 +554,4 @@ def _confirm(question: str, *, non_interactive: bool, required_flag: str) -> boo
     """
     if non_interactive or not can_prompt(_console):
         raise ValueError(f"noninteractive judge review requires {required_flag}")
-    return Confirm.ask(question, default=False)
+    return Confirm.ask(question, default=default)

--- a/wmo/cli/judge_config_test.py
+++ b/wmo/cli/judge_config_test.py
@@ -110,6 +110,62 @@ def _priced_catalog() -> ModelCatalog:
     )
 
 
+def test_interactive_judge_setup_accepts_enter_as_confirmation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A blank response accepts the displayed judge setup and persists it."""
+    store = _built_store(tmp_path)
+    _write_catalog(store.paths.root, _catalog())
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "a" * 40)
+    monkeypatch.setattr(judge_config_module, "can_prompt", lambda _console: True)
+    monkeypatch.setattr(
+        judge_config_module,
+        "maybe_edit_setup_plan",
+        lambda plan, *, console: plan,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["config", "judge", "setup", "support", "--root", str(store.paths.root)],
+        input="\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Save this judge setup and finalize its rubric? [y/n] (y):" in result.output
+    assert "Saved judge setup" in result.output
+    review = store.read_review()
+    assert isinstance(review, dict)
+    assert "manual_judge" in review
+
+
+def test_interactive_judge_setup_preserves_explicit_n_decline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit ``n`` still declines the displayed judge setup."""
+    store = _built_store(tmp_path)
+    _write_catalog(store.paths.root, _catalog())
+    monkeypatch.setenv("WMO_RELEASE_REVISION", "a" * 40)
+    monkeypatch.setattr(judge_config_module, "can_prompt", lambda _console: True)
+    monkeypatch.setattr(
+        judge_config_module,
+        "maybe_edit_setup_plan",
+        lambda plan, *, console: plan,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["config", "judge", "setup", "support", "--root", str(store.paths.root)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Save this judge setup and finalize its rubric? [y/n] (y):" in result.output
+    assert "Judge setup was not saved." in result.output
+    review = store.read_review()
+    assert isinstance(review, dict)
+    assert "manual_judge" not in review
+
+
 def test_calibrate_prints_catalog_pricing_breakdown_before_labels(tmp_path: Path) -> None:
     """Known catalog prices produce a spend preflight before consent or labels."""
     store = _built_store(tmp_path)


### PR DESCRIPTION
## Summary

- Make Enter accept the displayed interactive judge setup by default.
- Preserve explicit `n` cancellation and existing non-interactive/`--approve` behavior.
- Add focused CLI coverage for Enter acceptance and `n` decline.

## Validation

- `uv run --extra dev ruff check wmo/cli/judge_config.py wmo/cli/judge_config_test.py`
- `uv run --extra dev ruff format --check wmo/cli/judge_config.py wmo/cli/judge_config_test.py`
- `uv run --extra dev ty check`
- Non-live foundation, optimization, and simulation gate partitions pass locally.