### PR TITLE
Remove advanced provider picker paths

### DIFF
--- a/wmo/cli/provider_picker.py
+++ b/wmo/cli/provider_picker.py
@@ -4,7 +4,8 @@ Setup opens with one provider screen, resolves each selected provider's credenti
 canonical environment variable or a masked paste, then asks that provider which models the
 authenticated account may call. Discovered metadata is merged with WMO's maintained capability and
 price table, so a model whose metadata cannot satisfy any build role is hidden rather than turned
-into a questionnaire. Manual declaration stays available as an explicit advanced choice.
+into a questionnaire. Providers without a safe listing API keep manual declaration on the model
+screen.
 """
 
 from __future__ import annotations
@@ -60,8 +61,6 @@ CANONICAL_CREDENTIAL_ENV = {
 }
 _MANUAL_MODEL_PROVIDERS = frozenset({"azure", "bedrock"})
 _CONFIGURED_ONLY = "configured-models-only"
-_ADVANCED_CREDENTIALS = "advanced-credentials"
-_ADVANCED_MANUAL_MODEL = "advanced-manual-model"
 _RECOVERY_RETRY = "retry"
 _RECOVERY_SKIP = "skip"
 _RECOVERY_BACK = "back"
@@ -141,7 +140,6 @@ class SetupSession:
     """Answers already given, kept across back navigation and provider retries."""
 
     providers: tuple[str, ...] = ()
-    advanced_credentials: bool = False
     advanced_models: bool = False
     endpoints: tuple[PreparedEndpoint, ...] = ()
     available: tuple[AvailableModel, ...] = ()
@@ -196,20 +194,19 @@ def resolve_setup_providers(values: Sequence[str]) -> tuple[str, ...]:
 
 def explicit_provider_selection(
     providers: Sequence[str],
-) -> tuple[tuple[str, ...], bool, bool]:
+) -> tuple[tuple[str, ...], bool]:
     """Turn validated provider names into the same selection the picker returns.
 
     Args:
         providers: Already validated provider names in catalog order.
 
     Returns:
-        Providers plus advanced-credential and advanced-model flags. Azure and Bedrock
-        still require manual model declaration.
+        Providers plus the manual-model flag. Azure and Bedrock still require manual model
+        declaration.
     """
     selected = tuple(providers)
     return (
         selected,
-        False,
         any(provider in _MANUAL_MODEL_PROVIDERS for provider in selected),
     )
 
@@ -221,7 +218,7 @@ def select_providers(
     environment: MutableMapping[str, str],
     configured: bool = False,
     read_key: Callable[[], PickerKey] | None = None,
-) -> tuple[tuple[str, ...], bool, bool] | None:
+) -> tuple[tuple[str, ...], bool] | None:
     """Show the one provider screen that opens setup.
 
     Args:
@@ -233,7 +230,8 @@ def select_providers(
         read_key: Optional keyboard source used by tests instead of the controlling terminal.
 
     Returns:
-        Selected providers with both advanced flags, or ``None`` when the user cancelled.
+        Selected providers plus whether manual model declaration is needed, or ``None`` when the
+        user cancelled.
     """
     options = [
         PickerOption(
@@ -243,18 +241,6 @@ def select_providers(
         )
         for provider, label in SETUP_PROVIDER_LABELS.items()
     ]
-    options.append(
-        PickerOption(
-            value=_ADVANCED_CREDENTIALS,
-            label="Advanced: choose credential environment-variable names",
-        )
-    )
-    options.append(
-        PickerOption(
-            value=_ADVANCED_MANUAL_MODEL,
-            label="Advanced: declare a model and its capabilities by hand",
-        )
-    )
     if configured:
         options.insert(
             0,
@@ -265,10 +251,6 @@ def select_providers(
             ),
         )
     preselected = list(session.providers)
-    if session.advanced_credentials:
-        preselected.append(_ADVANCED_CREDENTIALS)
-    if session.advanced_models:
-        preselected.append(_ADVANCED_MANUAL_MODEL)
     while True:
         result = _select_provider_rows(
             console,
@@ -286,12 +268,7 @@ def select_providers(
             console.print("[yellow]Select at least one provider.[/yellow]")
             preselected = list(result.values)
             continue
-        return (
-            providers,
-            _ADVANCED_CREDENTIALS in result.values,
-            _ADVANCED_MANUAL_MODEL in result.values
-            or any(provider in _MANUAL_MODEL_PROVIDERS for provider in providers),
-        )
+        return providers, any(provider in _MANUAL_MODEL_PROVIDERS for provider in providers)
 
 
 def _select_provider_rows(
@@ -305,7 +282,7 @@ def _select_provider_rows(
 
     Args:
         console: Terminal used for the screen.
-        options: Provider and advanced rows in presentation order.
+        options: Provider rows in presentation order.
         preselected: Values already chosen, kept when the screen is shown again.
         read_key: Optional keyboard source used by tests instead of the controlling terminal.
 
@@ -367,7 +344,6 @@ def prepare_providers(
             provider,
             existing_connections=existing_connections,
             taken_names=frozenset(taken_names),
-            advanced_credentials=session.advanced_credentials,
             console=console,
             environment=environment,
         )
@@ -413,7 +389,6 @@ def _resolve_endpoint(
     *,
     existing_connections: tuple[ProviderConnection, ...],
     taken_names: frozenset[str],
-    advanced_credentials: bool,
     console: Console,
     environment: MutableMapping[str, str],
 ) -> PreparedEndpoint | None:
@@ -423,7 +398,6 @@ def _resolve_endpoint(
         provider: Selected provider kind.
         existing_connections: Connections already configured in the catalog.
         taken_names: Connection names already used by the catalog or this session.
-        advanced_credentials: Whether the user asked to name credential variables.
         console: Terminal used for prompts.
         environment: Process environment consulted and updated for pasted credentials.
 
@@ -454,12 +428,6 @@ def _resolve_endpoint(
             or None
         )
     api_key_env = CANONICAL_CREDENTIAL_ENV.get(provider)
-    if advanced_credentials and api_key_env is not None:
-        api_key_env = ask_text(
-            f"{label} credential environment variable",
-            console=console,
-            default=api_key_env,
-        )
     connection = _reused_connection(
         existing_connections,
         provider=provider,

--- a/wmo/cli/provider_picker_test.py
+++ b/wmo/cli/provider_picker_test.py
@@ -67,7 +67,6 @@ def _prepare(
     environment: dict[str, str],
     existing_connections: tuple[ProviderConnection, ...] = (),
     existing_aliases: tuple[str, ...] = (),
-    advanced_credentials: bool = False,
 ) -> (
     tuple[tuple[provider_picker.PreparedEndpoint, ...], tuple[provider_picker.AvailableModel, ...]]
     | None
@@ -81,12 +80,11 @@ def _prepare(
         environment: Mutable process environment consulted for credentials.
         existing_connections: Connections already configured in the catalog.
         existing_aliases: Aliases already configured in the catalog.
-        advanced_credentials: Whether the advanced credential path is active.
 
     Returns:
         The prepared endpoints and configurable models, or ``None`` to reselect providers.
     """
-    session = SetupSession(providers=providers, advanced_credentials=advanced_credentials)
+    session = SetupSession(providers=providers)
     return prepare_providers(
         session,
         existing_connections=existing_connections,
@@ -115,28 +113,7 @@ def test_provider_screen_selects_several_providers_in_one_session() -> None:
         SetupSession(), console=console, environment={"OPENAI_API_KEY": "secret-key"}
     )
 
-    assert selection == (("openai", "anthropic", "openrouter"), False, False)
-
-
-def test_provider_screen_keeps_prior_answers_and_reports_advanced_choices() -> None:
-    """Reentering the screen preselects prior providers and both advanced paths."""
-    console = ScriptedConsole("8,9\n\n")
-    session = SetupSession(providers=("openai",))
-
-    selection = select_providers(session, console=console, environment={})
-
-    assert selection == (("openai",), True, True)
-    assert "OPENAI_API_KEY needs a value" in console.output
-
-
-def test_provider_screen_refuses_an_advanced_only_selection() -> None:
-    """Advanced rows configure providers, so at least one provider is still required."""
-    console = ScriptedConsole("8\n\n1\n\n")
-
-    selection = select_providers(SetupSession(), console=console, environment={})
-
-    assert selection == (("openai",), True, False)
-    assert "Select at least one provider." in console.output
+    assert selection == (("openai", "anthropic", "openrouter"), False)
 
 
 def test_cancelling_the_provider_screen_returns_no_selection() -> None:
@@ -151,7 +128,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
             PickerKey.ENTER,
             PickerKey.DOWN,
             PickerKey.ENTER,
-            *(PickerKey.DOWN for _ in range(8)),
+            *(PickerKey.DOWN for _ in range(6)),
             PickerKey.ENTER,
         )
     )
@@ -164,7 +141,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
         read_key=lambda: next(keys),
     )
 
-    assert selection == (("openai", "anthropic"), False, False)
+    assert selection == (("openai", "anthropic"), False)
     assert "> [x] OpenAI" in console.output
     assert "Complete" in console.output
     assert "Numbers or ranges" not in console.output
@@ -173,7 +150,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
 def test_keyboard_provider_list_preserves_current_selection_and_cancel() -> None:
     """Reentering the keyboard list keeps prior marks, and q still cancels."""
     console = ScriptedConsole("")
-    session = SetupSession(providers=("openai",), advanced_credentials=True)
+    session = SetupSession(providers=("openai",))
 
     cancelled = select_providers(
         session,
@@ -184,7 +161,6 @@ def test_keyboard_provider_list_preserves_current_selection_and_cancel() -> None
 
     assert cancelled is None
     assert "[x] OpenAI" in console.output
-    assert "[x] Advanced: choose credential environment-variable names" in console.output
 
 
 def test_resolve_setup_providers_orders_and_rejects_bad_values() -> None:
@@ -204,10 +180,9 @@ def test_explicit_azure_and_bedrock_keep_manual_model_declaration() -> None:
     """Named Azure and Bedrock selections still require hand-declared model IDs."""
     assert explicit_provider_selection(("azure", "bedrock")) == (
         ("azure", "bedrock"),
-        False,
         True,
     )
-    assert explicit_provider_selection(("openai",)) == (("openai",), False, False)
+    assert explicit_provider_selection(("openai",)) == (("openai",), False)
 
 
 def test_canonical_environment_credential_is_used_without_any_prompt() -> None:
@@ -486,25 +461,6 @@ def test_an_identical_configured_connection_is_reused_instead_of_duplicated() ->
     assert models[0].connection == "primary"
 
 
-def test_advanced_path_can_name_the_credential_environment_variable() -> None:
-    """The advanced path still allows an explicit credential variable name."""
-    console = ScriptedConsole("TEAM_OPENAI_API_KEY\n")
-    lister = _FakeLister({"openai": [(_LUNA,)]})
-
-    prepared = _prepare(
-        console,
-        providers=("openai",),
-        lister=lister,
-        environment={"TEAM_OPENAI_API_KEY": "team-secret"},
-        advanced_credentials=True,
-    )
-
-    assert prepared is not None
-    endpoints, _ = prepared
-    assert endpoints[0].connection.api_key_env == "TEAM_OPENAI_API_KEY"
-    assert lister.requests[0].api_key == "team-secret"
-
-
 def test_openai_compatible_endpoint_asks_only_for_its_base_url() -> None:
     """A compatible endpoint needs an explicit base URL and nothing else by hand."""
     console = ScriptedConsole("https://models.example.test/v1\n")
@@ -596,7 +552,7 @@ def test_azure_and_bedrock_force_explicit_manual_model_declaration() -> None:
 
     selection = select_providers(SetupSession(), console=console, environment={})
 
-    assert selection == (("azure", "bedrock"), False, True)
+    assert selection == (("azure", "bedrock"), True)
     assert "deployment IDs are declared manually" in console.output
     assert "AWS credential chain" in console.output
 

--- a/wmo/cli/provider_setup.py
+++ b/wmo/cli/provider_setup.py
@@ -166,11 +166,7 @@ def _interactive_setup(
     session = SetupSession(selected=tuple(model.alias for model in configured))
     skip_opening_list = bool(explicit_providers)
     if explicit_providers:
-        (
-            session.providers,
-            session.advanced_credentials,
-            session.advanced_models,
-        ) = explicit_provider_selection(explicit_providers)
+        session.providers, session.advanced_models = explicit_provider_selection(explicit_providers)
     try:
         while True:
             if skip_opening_list:
@@ -184,7 +180,7 @@ def _interactive_setup(
                 )
                 if selection is None:
                     return None
-                session.providers, session.advanced_credentials, session.advanced_models = selection
+                session.providers, session.advanced_models = selection
             discovered: tuple[AvailableModel, ...] = ()
             session.endpoints = ()
             if session.providers:

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -710,9 +710,7 @@ def _installed_release_driver() -> None:
             trace_ids.append(trace_id)
             model = "core-model" if index % 2 == 0 else "candidate-b-model"
             capabilities_sha256 = (
-                core_capabilities_sha256
-                if model == "core-model"
-                else candidate_capabilities_sha256
+                core_capabilities_sha256 if model == "core-model" else candidate_capabilities_sha256
             )
             base = 1_760_000_000_000_000_000 + index * 10_000_000_000
             common = [
@@ -919,9 +917,8 @@ def _installed_release_driver() -> None:
         ),
         ("Azure OpenAI base URL", azure_endpoint),
         ("Azure OpenAI API version", ""),
-        ("Select the models to configure", "1"),
-        ("cancels.", ""),
-        ("Connection for the declared model", "1"),
+        ("Select the models to configure", space + down + enter),
+        ("Connection for the declared model", enter),
         ("Provider model ID", "core-model"),
         ("Supports chat completions?", "y"),
         ("Supports embeddings?", "y"),

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -408,7 +408,12 @@ def _installed_release_driver() -> None:
     from openai.types.responses import FunctionToolParam
 
     import wmo
-    from wmo.common.models import EmbeddingCostReservation, load_model_catalog
+    from wmo.common.models import (
+        ConnectionConfig,
+        EmbeddingCostReservation,
+        ModelCapabilities,
+        load_model_catalog,
+    )
     from wmo.common.project import ProjectStore, artifact_input
     from wmo.optimize.model.sft import (
         RuntimeInteractionExampleSource,
@@ -510,7 +515,7 @@ def _installed_release_driver() -> None:
                 self.send_error(400)
                 return
             ordinal = state.append(self.path, payload)
-            if self.path == "/v1/embeddings":
+            if self.path.endswith("/embeddings"):
                 values = payload.get("input", [])
                 texts = [values] if isinstance(values, str) else list(values)
                 data = []
@@ -617,6 +622,37 @@ def _installed_release_driver() -> None:
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
     provider_url = f"http://127.0.0.1:{server.server_port}/v1"
+    azure_endpoint = provider_url.removesuffix("/v1")
+    provider_embeddings_path = "/openai/v1/embeddings"
+    provider_chat_path = "/openai/v1/chat/completions"
+    azure_connection_sha256 = ConnectionConfig(
+        provider="azure",
+        base_url=azure_endpoint,
+        api_key_env="AZURE_OPENAI_API_KEY",
+        api_version="v1",
+    ).identity_sha256()
+    core_capabilities_sha256 = ModelCapabilities(
+        supports_completions=True,
+        supports_embeddings=True,
+        supports_tools=True,
+        supports_structured_output=True,
+        context_window_tokens=128000,
+        maximum_output_tokens=16000,
+        input_cost_per_million_tokens_usd=0,
+        output_cost_per_million_tokens_usd=0,
+        cached_input_cost_per_million_tokens_usd=0,
+        cache_write_cost_per_million_tokens_usd=0,
+    ).identity_sha256()
+    candidate_capabilities_sha256 = ModelCapabilities(
+        supports_completions=True,
+        supports_tools=True,
+        context_window_tokens=128000,
+        maximum_output_tokens=16000,
+        input_cost_per_million_tokens_usd=0,
+        output_cost_per_million_tokens_usd=0,
+        cached_input_cost_per_million_tokens_usd=0,
+        cache_write_cost_per_million_tokens_usd=0,
+    ).identity_sha256()
 
     root = execution_root / ".wmo"
     traces = execution_root / "support.otel.jsonl"
@@ -627,7 +663,7 @@ def _installed_release_driver() -> None:
         {
             "WMO_RELEASE_REVISION": _RELEASE_REVISION,
             "WMO_INSTALLED_RELEASE_EVIDENCE": "0",
-            "P17_PROVIDER_KEY": "deterministic-loopback-placeholder",
+            "AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder",
             "NO_PROXY": "127.0.0.1,localhost",
             "no_proxy": "127.0.0.1,localhost",
             "HTTP_PROXY": "http://127.0.0.1:9",
@@ -673,11 +709,18 @@ def _installed_release_driver() -> None:
             trace_id = f"{index + 1:032x}"
             trace_ids.append(trace_id)
             model = "core-model" if index % 2 == 0 else "candidate-b-model"
+            capabilities_sha256 = (
+                core_capabilities_sha256
+                if model == "core-model"
+                else candidate_capabilities_sha256
+            )
             base = 1_760_000_000_000_000_000 + index * 10_000_000_000
             common = [
                 attribute("gen_ai.operation.name", "chat"),
-                attribute("gen_ai.provider.name", "openai-compatible"),
+                attribute("gen_ai.provider.name", "azure"),
                 attribute("gen_ai.request.model", model),
+                attribute("wmo.model.capabilities_sha256", capabilities_sha256),
+                attribute("wmo.model.connection_sha256", azure_connection_sha256),
                 attribute("wmo.customer.id", f"customer-{index}"),
                 attribute("wmo.conversation.id", f"conversation-{index}"),
             ]
@@ -872,13 +915,13 @@ def _installed_release_driver() -> None:
     setup_answers = [
         (
             "Select the providers you want to use",
-            (down * 4) + enter + (down * 3) + enter + down + enter + down + enter,
+            (down * 5) + enter + (down * 2) + enter,
         ),
-        ("base URL", provider_url),
-        ("credential environment variable", "P17_PROVIDER_KEY"),
-        ("Continue without this provider", down + enter),
-        ("Select the models to configure", space + down + enter),
-        ("Connection for the declared model", enter),
+        ("Azure OpenAI base URL", azure_endpoint),
+        ("Azure OpenAI API version", ""),
+        ("Select the models to configure", "1"),
+        ("cancels.", ""),
+        ("Connection for the declared model", "1"),
         ("Provider model ID", "core-model"),
         ("Supports chat completions?", "y"),
         ("Supports embeddings?", "y"),
@@ -916,14 +959,14 @@ def _installed_release_driver() -> None:
         assert support_project.models.candidates == ()
         catalog_text = (root / "models.toml").read_text(encoding="utf-8")
         assert "deterministic-loopback-placeholder" not in catalog_text
-        assert "P17_PROVIDER_KEY" in catalog_text
+        assert "AZURE_OPENAI_API_KEY" in catalog_text
         build_counts = state.counts()
-        assert build_counts["/v1/embeddings"] > 0
-        assert build_counts["/v1/chat/completions"] == 0
+        assert build_counts[provider_embeddings_path] > 0
+        assert build_counts[provider_chat_path] == 0
         world_model = wmo.load_world_model(
             "support-agent",
             root=root,
-            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+            environment={"AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder"},
         )
         session = world_model.new_session(task="Help a customer reset their password")
         observation = world_model.step(
@@ -937,8 +980,8 @@ def _installed_release_driver() -> None:
         assert observation.terminal is True
         world_requests = state.snapshot()[sum(build_counts.values()) :]
         assert [item["path"] for item in world_requests] == [
-            "/v1/embeddings",
-            "/v1/chat/completions",
+            provider_embeddings_path,
+            provider_chat_path,
         ]
         world_prompt = json.dumps(world_requests[-1]["payload"], sort_keys=True)
         assert "What account email?" in world_prompt
@@ -1031,7 +1074,7 @@ def _installed_release_driver() -> None:
             optimize_arguments,
             [
                 ("Candidate alias", "candidate-b"),
-                ("Provider connection", "openai-compatible"),
+                ("Provider connection", "azure"),
                 ("Provider model ID", "candidate-b-model"),
                 ("Supports tools?", "y"),
                 ("Context window tokens", "128000"),
@@ -1146,11 +1189,12 @@ def _installed_release_driver() -> None:
             )
             assert second_response.previous_response_id == first_response.id
             second_response_counts = state.counts()
-            assert first_response_counts["/v1/embeddings"] == (
-                response_calls_before["/v1/embeddings"] + 1
+            assert first_response_counts[provider_embeddings_path] == (
+                response_calls_before[provider_embeddings_path] + 1
             )
             assert (
-                second_response_counts["/v1/embeddings"] == first_response_counts["/v1/embeddings"]
+                second_response_counts[provider_embeddings_path]
+                == first_response_counts[provider_embeddings_path]
             )
             keyed_chat = client.chat.completions.create(
                 model="support-agent",
@@ -1171,7 +1215,7 @@ def _installed_release_driver() -> None:
         with wmo.load_router(
             "support-agent",
             root=root,
-            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+            environment={"AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder"},
         ) as loaded_router:
             replayed_chat = loaded_router.chat.completions.create(
                 model="support-agent",
@@ -1231,7 +1275,7 @@ def _installed_release_driver() -> None:
         catalog = load_model_catalog(root / "models.toml")
         resolved_embedder = RuntimeModelCatalog(
             catalog,
-            environment={"P17_PROVIDER_KEY": "deterministic-loopback-placeholder"},
+            environment={"AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder"},
         ).preflight(
             current_project.models.embedder,
             CapabilityRequirement(requires_embeddings=True),
@@ -1267,7 +1311,7 @@ def _installed_release_driver() -> None:
         provider_after_refresh = state.snapshot()
         assert len(provider_after_refresh) > len(provider_before_refresh)
         assert all(
-            request["path"] == "/v1/embeddings"
+            request["path"] == provider_embeddings_path
             for request in provider_after_refresh[len(provider_before_refresh) :]
         )
         assert refresh.snapshot_export.snapshot.completed_target_count == len(completed)

--- a/wmo/simulation/ingest/model_identity.py
+++ b/wmo/simulation/ingest/model_identity.py
@@ -235,12 +235,17 @@ def require_model_identity_evidence_matches_traces(
                 error_type=ValueError,
             ),
         )
+        inferred_connection_digest = (
+            None
+            if CONNECTION_DIGEST_ATTRIBUTE in span.attributes
+            else ConnectionConfig(provider=item.model.provider).identity_sha256()
+        )
         _require_component_provenance(
             span.attributes,
             CONNECTION_DIGEST_ATTRIBUTE,
             item.connection,
             item.model.connection_sha256,
-            ConnectionConfig(provider=item.model.provider).identity_sha256(),
+            inferred_connection_digest,
         )
 
 
@@ -249,7 +254,7 @@ def _require_component_provenance(
     key: str,
     provenance: IdentityComponentProvenance,
     recorded_digest: Sha256,
-    inferred_digest: Sha256,
+    inferred_digest: Sha256 | None,
 ) -> None:
     """Verify one declared or inferred digest against canonical span attributes.
 
@@ -258,7 +263,8 @@ def _require_component_provenance(
         key: WMO digest extension key.
         provenance: Persisted declared, inferred, or unspecified classification.
         recorded_digest: Digest retained in the span's model snapshot.
-        inferred_digest: Deterministic normalizer fallback digest.
+        inferred_digest: Deterministic normalizer fallback digest, or ``None`` when the
+            component was declared directly on the span.
 
     Raises:
         ValueError: Declared or inferred provenance disagrees with the canonical span.
@@ -267,5 +273,7 @@ def _require_component_provenance(
     if provenance == "declared":
         if attribute != recorded_digest:
             raise ValueError(f"declared {key} is absent or differs from its model snapshot")
-    elif provenance == "inferred" and (attribute is not None or recorded_digest != inferred_digest):
+    elif provenance == "inferred" and (
+        attribute is not None or inferred_digest is None or recorded_digest != inferred_digest
+    ):
         raise ValueError(f"inferred {key} differs from the canonical telemetry fallback")


### PR DESCRIPTION
## Summary

- Remove the two advanced rows from provider selection: custom credential environment-variable names and generic manual model declaration.
- Keep canonical credential resolution and the remaining Azure/Bedrock manual-model flow.
- Update the installed-release evidence to exercise the supported Azure path and declared endpoint identity.

## Validation

- `wmo/cli/provider_picker_test.py` and `wmo/cli/model_picker_test.py`: 44 passed
- Identity/OTLP/vendor-trace and provider/model picker suites: 73 passed
- Installed-wheel no-spend release evidence: 1 passed
- Clean-checkout evidence tests: 2 passed
- Ruff, Ty, and `git diff --check` passed

No new test cases were added; existing tests and release evidence were adjusted only for the removed prompts.