### PR TITLE
Audit OpenAI known-model metadata

### DIFF
--- a/wmo/cli/model_picker_test.py
+++ b/wmo/cli/model_picker_test.py
@@ -208,8 +208,8 @@ def test_the_setup_written_from_confirmed_answers_carries_verified_metadata() ->
     assert chat.capabilities.supports_tools
     assert chat.capabilities.supports_structured_output
     assert chat.capabilities.context_window_tokens == 1_050_000
-    assert chat.capabilities.input_cost_per_million_tokens_usd == 1.0
-    assert chat.capabilities.cache_write_cost_per_million_tokens_usd == 1.25
+    assert chat.capabilities.input_cost_per_million_tokens_usd == 0.2
+    assert chat.capabilities.cache_write_cost_per_million_tokens_usd == 0.25
     assert (setup.world_model, setup.judge, setup.embedder) == ("luna", "luna", "embedder")
 
 

--- a/wmo/cli/provider_setup_test.py
+++ b/wmo/cli/provider_setup_test.py
@@ -500,7 +500,7 @@ def test_interactive_setup_saves_providers_models_and_roles_it_derived(
     assert luna is not None
     assert luna.supports_tools
     assert luna.context_window_tokens == 1_050_000
-    assert luna.input_cost_per_million_tokens_usd == 1.0
+    assert luna.input_cost_per_million_tokens_usd == 0.2
     assert "internal-preview-model" not in {model.model for model in saved.models.values()}
     persisted = (root / "models.toml").read_text(encoding="utf-8")
     assert "OPENAI_API_KEY" in persisted

--- a/wmo/common/models/discovery.py
+++ b/wmo/common/models/discovery.py
@@ -160,6 +160,11 @@ def resolve_discovered_model(discovered: DiscoveredModel) -> ResolvedDiscoveredM
             discovered.supports_completions,
             known.supports_completions if known else None,
         ),
+        supports_temperature=(
+            known.supports_temperature
+            if known is not None and known.supports_temperature is not None
+            else True
+        ),
         context_window_tokens=discovered.context_window_tokens
         or (known.context_window_tokens if known else None),
         maximum_output_tokens=discovered.maximum_output_tokens

--- a/wmo/common/models/discovery_test.py
+++ b/wmo/common/models/discovery_test.py
@@ -113,6 +113,22 @@ def test_router_candidate_role_requires_prices_and_both_token_limits() -> None:
     )
 
 
+def test_catalog_request_shaping_capability_reaches_openai_runtime_metadata() -> None:
+    """OpenAI reasoning models resolve with temperature disabled for request shaping."""
+    resolved = resolve_discovered_model(DiscoveredModel(provider="openai", model="gpt-5.4-mini"))
+
+    assert not resolved.capabilities.supports_temperature
+
+
+def test_openai_pro_models_without_structured_output_are_not_offered_as_judges() -> None:
+    """Unsupported structured-output roles stay hidden while world-model use remains available."""
+    for model in ("gpt-5.4-pro", "gpt-5.2-pro"):
+        resolved = resolve_discovered_model(DiscoveredModel(provider="openai", model=model))
+
+        assert not serves_role(resolved.capabilities, SetupRole.JUDGE)
+        assert served_roles(resolved.capabilities) == (SetupRole.WORLD_MODEL,)
+
+
 def test_embedder_role_requires_priced_embedding_support() -> None:
     """Only a priced embedding model is offered for the embedder role."""
     priced = resolve_discovered_model(

--- a/wmo/common/models/known_models.py
+++ b/wmo/common/models/known_models.py
@@ -27,6 +27,7 @@ class KnownModel:
     supports_embeddings: bool = False
     supports_tools: bool = False
     supports_structured_output: bool = False
+    supports_temperature: bool | None = None
     context_window_tokens: int | None = None
     maximum_output_tokens: int | None = None
     input_cost_per_million_tokens_usd: float | None = None
@@ -43,8 +44,10 @@ def _chat(
     cache_write_usd: float | None = None,
     context_window_tokens: int | None = None,
     maximum_output_tokens: int | None = None,
+    supports_temperature: bool | None = True,
+    supports_structured_output: bool = True,
 ) -> KnownModel:
-    """Describe one documented chat model that supports tools and structured output.
+    """Describe one documented chat model with its verified protocol capabilities.
 
     Args:
         input_usd: Documented input price per million tokens.
@@ -53,6 +56,8 @@ def _chat(
         cache_write_usd: Documented cache-write price, when the provider publishes one.
         context_window_tokens: Documented context window, when the provider publishes one.
         maximum_output_tokens: Documented output ceiling, when the provider publishes one.
+        supports_temperature: Whether the model accepts an explicit temperature parameter.
+        supports_structured_output: Whether the model supports structured outputs.
 
     Returns:
         The verified metadata record for the model.
@@ -60,7 +65,8 @@ def _chat(
     return KnownModel(
         supports_completions=True,
         supports_tools=True,
-        supports_structured_output=True,
+        supports_structured_output=supports_structured_output,
+        supports_temperature=supports_temperature,
         context_window_tokens=context_window_tokens,
         maximum_output_tokens=maximum_output_tokens,
         input_cost_per_million_tokens_usd=input_usd,
@@ -96,44 +102,141 @@ _OPENAI_MODELS: dict[str, KnownModel] = {
         output_usd=30.0,
         context_window_tokens=1_050_000,
         maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
     "gpt-5.6-terra": _chat(
+        input_usd=2.0,
+        cached_input_usd=0.2,
+        cache_write_usd=2.5,
+        output_usd=12.0,
+        context_window_tokens=1_050_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.6-luna": _chat(
+        input_usd=0.2,
+        cached_input_usd=0.02,
+        cache_write_usd=0.25,
+        output_usd=1.2,
+        context_window_tokens=1_050_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.5": _chat(
+        input_usd=5.0,
+        cached_input_usd=0.5,
+        cache_write_usd=0.0,
+        output_usd=30.0,
+        context_window_tokens=1_050_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.5-pro": _chat(
+        input_usd=30.0,
+        cache_write_usd=0.0,
+        output_usd=180.0,
+        context_window_tokens=1_050_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.4": _chat(
         input_usd=2.5,
         cached_input_usd=0.25,
-        cache_write_usd=3.125,
+        cache_write_usd=0.0,
         output_usd=15.0,
         context_window_tokens=1_050_000,
         maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
-    "gpt-5.6-luna": _chat(
-        input_usd=1.0,
-        cached_input_usd=0.1,
-        cache_write_usd=1.25,
-        output_usd=6.0,
-        context_window_tokens=1_050_000,
-        maximum_output_tokens=128_000,
-    ),
-    "gpt-5.5": _chat(input_usd=5.0, cached_input_usd=0.5, cache_write_usd=0.0, output_usd=30.0),
-    "gpt-5.5-pro": _chat(input_usd=30.0, cache_write_usd=0.0, output_usd=180.0),
-    "gpt-5.4": _chat(input_usd=2.5, cached_input_usd=0.25, cache_write_usd=0.0, output_usd=15.0),
     "gpt-5.4-mini": _chat(
-        input_usd=0.75, cached_input_usd=0.075, cache_write_usd=0.0, output_usd=4.5
+        input_usd=0.75,
+        cached_input_usd=0.075,
+        cache_write_usd=0.0,
+        output_usd=4.5,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
     "gpt-5.4-nano": _chat(
-        input_usd=0.2, cached_input_usd=0.02, cache_write_usd=0.0, output_usd=1.25
+        input_usd=0.2,
+        cached_input_usd=0.02,
+        cache_write_usd=0.0,
+        output_usd=1.25,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
-    "gpt-5.4-pro": _chat(input_usd=30.0, cache_write_usd=0.0, output_usd=180.0),
-    "gpt-5.2": _chat(input_usd=1.75, cached_input_usd=0.175, cache_write_usd=0.0, output_usd=14.0),
-    "gpt-5.2-pro": _chat(input_usd=21.0, cache_write_usd=0.0, output_usd=168.0),
-    "gpt-5.1": _chat(input_usd=1.25, cached_input_usd=0.125, cache_write_usd=0.0, output_usd=10.0),
-    "gpt-5": _chat(input_usd=1.25, cached_input_usd=0.125, cache_write_usd=0.0, output_usd=10.0),
+    "gpt-5.4-pro": _chat(
+        input_usd=30.0,
+        cache_write_usd=0.0,
+        output_usd=180.0,
+        supports_structured_output=False,
+        context_window_tokens=1_050_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.2": _chat(
+        input_usd=1.75,
+        cached_input_usd=0.175,
+        cache_write_usd=0.0,
+        output_usd=14.0,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.2-pro": _chat(
+        input_usd=21.0,
+        cache_write_usd=0.0,
+        output_usd=168.0,
+        supports_structured_output=False,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5.1": _chat(
+        input_usd=1.25,
+        cached_input_usd=0.125,
+        cache_write_usd=0.0,
+        output_usd=10.0,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
+    "gpt-5": _chat(
+        input_usd=1.25,
+        cached_input_usd=0.125,
+        cache_write_usd=0.0,
+        output_usd=10.0,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
+    ),
     "gpt-5-mini": _chat(
-        input_usd=0.25, cached_input_usd=0.025, cache_write_usd=0.0, output_usd=2.0
+        input_usd=0.25,
+        cached_input_usd=0.025,
+        cache_write_usd=0.0,
+        output_usd=2.0,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
     "gpt-5-nano": _chat(
-        input_usd=0.05, cached_input_usd=0.005, cache_write_usd=0.0, output_usd=0.4
+        input_usd=0.05,
+        cached_input_usd=0.005,
+        cache_write_usd=0.0,
+        output_usd=0.4,
+        context_window_tokens=400_000,
+        maximum_output_tokens=128_000,
+        supports_temperature=False,
     ),
-    "gpt-5-pro": _chat(input_usd=15.0, cache_write_usd=0.0, output_usd=120.0),
+    "gpt-5-pro": _chat(
+        input_usd=15.0,
+        cache_write_usd=0.0,
+        output_usd=120.0,
+        context_window_tokens=400_000,
+        maximum_output_tokens=272_000,
+        supports_temperature=False,
+    ),
     "text-embedding-3-small": _embedding(input_usd=0.02, context_window_tokens=8_192),
     "text-embedding-3-large": _embedding(input_usd=0.13, context_window_tokens=8_192),
     "text-embedding-ada-002": _embedding(input_usd=0.1, context_window_tokens=8_192),

--- a/wmo/common/models/known_models_test.py
+++ b/wmo/common/models/known_models_test.py
@@ -43,21 +43,105 @@ def test_documented_chat_model_carries_verified_capabilities_and_prices() -> Non
     assert not known.supports_embeddings
     assert known.context_window_tokens == 1_050_000
     assert known.maximum_output_tokens == 128_000
-    assert known.input_cost_per_million_tokens_usd == 2.5
-    assert known.output_cost_per_million_tokens_usd == 15.0
-    assert known.cached_input_cost_per_million_tokens_usd == 0.25
-    assert known.cache_write_cost_per_million_tokens_usd == 3.125
+    assert known.input_cost_per_million_tokens_usd == 2.0
+    assert known.output_cost_per_million_tokens_usd == 12.0
+    assert known.cached_input_cost_per_million_tokens_usd == 0.2
+    assert known.cache_write_cost_per_million_tokens_usd == 2.5
+    assert known.supports_temperature is False
 
 
-def test_documented_embedding_model_serves_embeddings_only() -> None:
-    """An embedding entry prices input tokens and never claims completion support."""
-    known = known_model_metadata("openai", "text-embedding-3-small")
+@pytest.mark.parametrize(
+    (
+        "model",
+        "context_window_tokens",
+        "maximum_output_tokens",
+        "input_usd",
+        "output_usd",
+        "cached_input_usd",
+        "cache_write_usd",
+        "supports_structured_output",
+    ),
+    [
+        ("gpt-5.6-sol", 1_050_000, 128_000, 5.0, 30.0, 0.5, 6.25, True),
+        ("gpt-5.6-terra", 1_050_000, 128_000, 2.0, 12.0, 0.2, 2.5, True),
+        ("gpt-5.6-luna", 1_050_000, 128_000, 0.2, 1.2, 0.02, 0.25, True),
+        ("gpt-5.5", 1_050_000, 128_000, 5.0, 30.0, 0.5, 0.0, True),
+        ("gpt-5.5-pro", 1_050_000, 128_000, 30.0, 180.0, None, 0.0, True),
+        ("gpt-5.4", 1_050_000, 128_000, 2.5, 15.0, 0.25, 0.0, True),
+        ("gpt-5.4-mini", 400_000, 128_000, 0.75, 4.5, 0.075, 0.0, True),
+        ("gpt-5.4-nano", 400_000, 128_000, 0.2, 1.25, 0.02, 0.0, True),
+        ("gpt-5.4-pro", 1_050_000, 128_000, 30.0, 180.0, None, 0.0, False),
+        ("gpt-5.2", 400_000, 128_000, 1.75, 14.0, 0.175, 0.0, True),
+        ("gpt-5.2-pro", 400_000, 128_000, 21.0, 168.0, None, 0.0, False),
+        ("gpt-5.1", 400_000, 128_000, 1.25, 10.0, 0.125, 0.0, True),
+        ("gpt-5", 400_000, 128_000, 1.25, 10.0, 0.125, 0.0, True),
+        ("gpt-5-mini", 400_000, 128_000, 0.25, 2.0, 0.025, 0.0, True),
+        ("gpt-5-nano", 400_000, 128_000, 0.05, 0.4, 0.005, 0.0, True),
+        ("gpt-5-pro", 400_000, 272_000, 15.0, 120.0, None, 0.0, True),
+    ],
+)
+def test_every_openai_chat_entry_has_complete_verified_metadata(
+    model: str,
+    context_window_tokens: int,
+    maximum_output_tokens: int,
+    input_usd: float,
+    output_usd: float,
+    cached_input_usd: float | None,
+    cache_write_usd: float,
+    supports_structured_output: bool,
+) -> None:
+    """Every advertised OpenAI chat role has verified limits, prices, and request shaping.
+
+    Args:
+        model: Canonical OpenAI model identifier.
+        context_window_tokens: Documented input context ceiling.
+        maximum_output_tokens: Documented output ceiling.
+        input_usd: Documented input price per million tokens.
+        output_usd: Documented output price per million tokens.
+        cached_input_usd: Documented cache-hit price, or ``None`` when no discount exists.
+        cache_write_usd: Documented cache-write price.
+        supports_structured_output: Whether the model supports structured outputs.
+    """
+    known = known_model_metadata("openai", model)
+
+    assert known is not None
+    assert known.supports_completions
+    assert known.supports_tools
+    assert known.supports_temperature is False
+    assert known.context_window_tokens == context_window_tokens
+    assert known.maximum_output_tokens == maximum_output_tokens
+    assert known.input_cost_per_million_tokens_usd == input_usd
+    assert known.output_cost_per_million_tokens_usd == output_usd
+    assert known.cached_input_cost_per_million_tokens_usd == cached_input_usd
+    assert known.cache_write_cost_per_million_tokens_usd == cache_write_usd
+    assert known.supports_structured_output is supports_structured_output
+
+
+@pytest.mark.parametrize(
+    ("model", "input_usd"),
+    [
+        ("text-embedding-3-small", 0.02),
+        ("text-embedding-3-large", 0.13),
+        ("text-embedding-ada-002", 0.1),
+    ],
+)
+def test_documented_embedding_models_serve_embeddings_only(model: str, input_usd: float) -> None:
+    """Every maintained OpenAI embedding entry has its verified input price and limit.
+
+    Args:
+        model: Canonical OpenAI embedding model identifier.
+        input_usd: Documented input price per million tokens.
+    """
+    known = known_model_metadata("openai", model)
 
     assert known is not None
     assert known.supports_embeddings
     assert not known.supports_completions
-    assert known.input_cost_per_million_tokens_usd == 0.02
+    assert known.context_window_tokens == 8_192
+    assert known.input_cost_per_million_tokens_usd == input_usd
     assert known.output_cost_per_million_tokens_usd is None
+    assert known.cached_input_cost_per_million_tokens_usd is None
+    assert known.cache_write_cost_per_million_tokens_usd is None
 
 
 def test_documented_anthropic_model_prices_both_cache_operations() -> None:


### PR DESCRIPTION
## Summary

- complete verified limits, pricing, cache behavior, and request-shaping metadata for every maintained OpenAI GPT chat entry
- keep unsupported structured-output roles out of model discovery for GPT-5.4 Pro and GPT-5.2 Pro
- add exhaustive catalog/discovery regression coverage and update affected setup expectations

## Root cause

The OpenAI catalog had incomplete metadata beyond the mini/nano rows, while discovery treated those rows as broadly configurable.

## Validation

- `UV_CACHE_DIR=/private/tmp/wmo-uv-cache uv run pytest -q wmo/common/models/known_models_test.py wmo/common/models/discovery_test.py wmo/cli/model_picker_test.py wmo/cli/provider_setup_test.py wmo/runtime/models/providers/native_test.py wmo/runtime/models/registry_test.py wmo/optimize/router/judging/pricing_test.py` — 107 passed
- targeted Ruff check — passed
- targeted Ruff format check — passed