### PR TITLE
Reuse canonical router simulation specs on resume

### DIFF
--- a/wmo/optimize/router/composition.py
+++ b/wmo/optimize/router/composition.py
@@ -278,7 +278,7 @@ def compose_router(
         task_input,
         setup,
         budget.maximum_simulation_cost_usd,
-        created_at,
+        plan.created_at,
         code_revision,
         fit_cells,
         phase="fit",
@@ -316,14 +316,14 @@ def compose_router(
         pricing_snapshot_id=setup.pricing_snapshot_id,
         guard=setup.guard,
         judgment_status=setup.judgment_status,
-        created_at=created_at,
+        created_at=plan.created_at,
         code_revision=code_revision,
     )
     fit, policy_lock = _fit_and_lock_once(
         project,
         plan_input,
         fit_config,
-        created_at,
+        plan.created_at,
         code_revision,
     )
     _phase(phase_hook, "policy_locked")
@@ -336,7 +336,7 @@ def compose_router(
         task_input,
         setup,
         remaining_cost_usd,
-        created_at,
+        plan.created_at,
         code_revision,
         held_cells,
         phase="heldout",
@@ -366,7 +366,7 @@ def compose_router(
                 cell_evidence=held_evidence,
             ),
             embedding_set_id=setup.embedding_set_id,
-            created_at=created_at,
+            created_at=plan.created_at,
             code_revision=code_revision,
         ),
     )

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
@@ -703,7 +703,7 @@ def test_public_composition_runs_and_resumes_complete_frozen_router(
             normalized,
             services=services,
             budget=budget,
-            created_at=_TIME,
+            created_at=_TIME + timedelta(hours=1),
             code_revision="test-revision",
             phase_hook=crash_after_lock,
         )
@@ -713,7 +713,7 @@ def test_public_composition_runs_and_resumes_complete_frozen_router(
         normalized,
         services=services,
         budget=budget,
-        created_at=_TIME,
+        created_at=_TIME + timedelta(hours=2),
         code_revision="test-revision",
         phase_hook=crash_after_lock,
     )
@@ -728,7 +728,7 @@ def test_public_composition_runs_and_resumes_complete_frozen_router(
         normalized,
         services=services,
         budget=budget,
-        created_at=_TIME,
+        created_at=_TIME + timedelta(hours=3),
         code_revision="test-revision",
     )
 

--- a/wmo/simulation/engines/text/simulator.py
+++ b/wmo/simulation/engines/text/simulator.py
@@ -239,7 +239,7 @@ class WorldModelSimulator:
         """
         require_implemented_mode(spec, SimulationMode.WORLD_MODEL)
         cells, world_model, grounded_world_model = self._validate_spec_and_bindings(spec)
-        spec_input = self._persist_specification(spec)
+        spec, spec_input = self._persist_specification(spec)
         resolution, resolution_input, bindings = self._persist_resolution(
             spec,
             spec_input,
@@ -390,8 +390,18 @@ class WorldModelSimulator:
             cells.append(cell)
         return tuple(cells), world_model, grounded_world_model
 
-    def _persist_specification(self, spec: SimulationSpec) -> ArtifactInput:
-        """Atomically write or verify the immutable specification before rollout execution."""
+    def _persist_specification(self, spec: SimulationSpec) -> tuple[SimulationSpec, ArtifactInput]:
+        """Persist or adopt the canonical specification for timestamp-stable retries.
+
+        Args:
+            spec: Requested sparse simulation specification.
+
+        Returns:
+            Canonical specification and its manifest input.
+
+        Raises:
+            SimulationResumeError: Existing specification differs semantically.
+        """
         try:
             manifest = self._store.write_json(
                 artifact_id=spec.simulation_id,
@@ -399,7 +409,7 @@ class WorldModelSimulator:
                 envelope=spec,
                 files={_SPEC_FILE: spec},
             )
-            return artifact_input(manifest)
+            return spec, artifact_input(manifest)
         except ArtifactAlreadyExistsError as exc:
             stored = self._store.read(spec.simulation_id)
             if stored.manifest.artifact_type != "simulation-spec":
@@ -414,11 +424,11 @@ class WorldModelSimulator:
                 raise SimulationResumeError(
                     f"simulation specification {spec.simulation_id!r} cannot be read safely"
                 ) from exc
-            if persisted != spec:
+            if persisted.model_copy(update={"created_at": spec.created_at}) != spec:
                 raise SimulationResumeError(
                     f"simulation ID {spec.simulation_id!r} already names a different immutable spec"
                 ) from exc
-            return artifact_input(stored.manifest)
+            return persisted, artifact_input(stored.manifest)
 
     def _persist_resolution(
         self,

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -56,6 +56,7 @@ from wmo.simulation.engines.text.leases import TextCellLeaseStore
 from wmo.simulation.engines.text.simulator import (
     SimulationConfigurationError,
     SimulationContentionError,
+    SimulationResumeError,
     WorldModelSimulator,
 )
 from wmo.simulation.retrieval import (
@@ -658,7 +659,7 @@ def test_text_simulation_persists_separate_economics_and_resumes_without_duplica
     artifact_set = simulator.run(spec)
     rollout_id = artifact_set.artifact_ids[0]
     rollout = simulator._load_rollout(rollout_id)
-    resumed = simulator.run(spec)
+    resumed = simulator.run(spec.model_copy(update={"created_at": _TIME + timedelta(hours=1)}))
 
     assert rollout.candidate_economics.cost_usd == NumericMeasurement(
         value=0.2,
@@ -690,6 +691,34 @@ def test_text_simulation_persists_separate_economics_and_resumes_without_duplica
     assert retriever.estimate_calls == 1
     assert len(retriever.queries) == 1
     assert resumed.artifact_ids == artifact_set.artifact_ids
+    persisted_spec = SimulationSpec.model_validate_json(
+        store.read_bytes(spec.simulation_id, "simulation-spec.json")
+    )
+    assert persisted_spec.created_at == spec.created_at
+    assert persisted_spec == spec
+    assert persisted_spec != spec.model_copy(update={"created_at": _TIME + timedelta(hours=1)})
+
+    assert spec.world_model is not None
+    drifted_specs = (
+        spec.model_copy(update={"evaluation_plan_id": "different-plan"}),
+        spec.model_copy(update={"cell_ids": ("cell-b",)}),
+        spec.model_copy(
+            update={
+                "world_model": spec.world_model.model_copy(update={"prompt_version": "changed"})
+            }
+        ),
+        spec.model_copy(update={"maximum_steps": 3}),
+        spec.model_copy(update={"maximum_concurrency": 2}),
+        spec.model_copy(update={"maximum_cost_usd": 9.0}),
+        spec.model_copy(update={"code_revision": "changed-revision"}),
+    )
+    for drifted in drifted_specs:
+        with pytest.raises((SimulationConfigurationError, SimulationResumeError)):
+            simulator.run(drifted)
+    assert len(candidate_client.requests) == 1
+    assert len(world_client.requests) == 1
+    assert retriever.estimate_calls == 1
+    assert len(retriever.queries) == 1
 
 
 def test_persisted_rollout_redacts_generated_secrets_and_records_audit_count(
@@ -1318,9 +1347,9 @@ def test_stale_transition_blocks_paid_admission_until_unknown_spend_rollout_pers
     )
     spec = _spec(plan_input, task_set_input, ("cell-a", "cell-b"), maximum_cost_usd=1.0)
     selected, world_model, grounded_world_model = recovery._validate_spec_and_bindings(spec)
-    spec_input = recovery._persist_specification(spec)
+    canonical_spec, spec_input = recovery._persist_specification(spec)
     resolution, resolution_input, bindings = recovery._persist_resolution(
-        spec, spec_input, selected, world_model, grounded_world_model
+        canonical_spec, spec_input, selected, world_model, grounded_world_model
     )
     first_binding = bindings["cell-a"]
     holder = TextCellLeaseStore(store.project_directory, clock=lambda: _TIME)
@@ -1541,9 +1570,9 @@ def test_text_simulation_live_hung_claim_times_out_without_calls_or_result_artif
     )
     spec = _spec(plan_input, task_set_input, ("cell-a",), maximum_cost_usd=1.0)
     cells, world_model, grounded_world_model = simulator._validate_spec_and_bindings(spec)
-    spec_input = simulator._persist_specification(spec)
+    canonical_spec, spec_input = simulator._persist_specification(spec)
     resolution, resolution_input, bindings = simulator._persist_resolution(
-        spec, spec_input, cells, world_model, grounded_world_model
+        canonical_spec, spec_input, cells, world_model, grounded_world_model
     )
     binding = bindings[cell.cell_id]
     rollout_id = rollout_id_for_binding(binding)


### PR DESCRIPTION
## Summary

- derive fit and held-out simulation specifications from the persisted evaluation plan timestamp
- adopt an already persisted simulation specification when a retry differs only in invocation time
- keep semantic specification fields fail-closed and reuse canonical downstream rollout bindings
- cover changed-timestamp crash recovery and prove provider dispatches are not duplicated

## Root cause

Router simulation IDs intentionally exclude `created_at`, but the persisted simulation specification digest included the invocation timestamp. A retry could therefore find the existing completed artifact set and reject it before resume. Composition now binds phase specifications and downstream fit/report configuration to the accepted plan timestamp, while the text simulator adopts the persisted canonical specification before deriving resolution, binding, and rollout identities.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- focused simulation, composition, evaluation, and repository-layout tests: 26 passed
- full local suite: 1431 passed, 2 skipped; remaining failures were sandbox-sensitive terminal-rendering and release-evidence checks