### PR TITLE
Add portable Project bundle and stage contracts

### DIFF
--- a/docs/reference/project-bundles.md
+++ b/docs/reference/project-bundles.md
@@ -1,0 +1,58 @@
+# Portable Project bundles
+
+WMO can export one Project's selected durable state as a deterministic bundle and restore it under
+a different local WMO root. The supported package-root API is limited to
+`export_project_bundle`, `restore_project_bundle`, and `ExportedProjectBundle`.
+
+## Selected immutable state
+
+The bundle contains `project.json` plus the exact transitive closure of every `ArtifactInput`
+selected by the Project configuration. Each artifact directory contains its verified
+`manifest.json` and the complete file set named by that manifest. Unselected artifacts that happen
+to exist below the same source root are not included.
+
+Artifact manifests remain authoritative for source identity, producer revision, dependency
+lineage, schema version, and payload digests. The bundle manifest does not copy those fields into a
+second provenance record. It binds the Project identity and schema, sorted selected pointers,
+completed durable stages, every member digest and expanded size, the bundle producer revision, and
+the explicit value `runtime_state = "excluded"`.
+
+An unchanged Project state and unchanged bundle producer revision produce identical bytes and the
+same SHA-256 digest. Callers should retain that digest next to the stored bundle and pass it as
+`expected_sha256` during restore.
+
+## Project-scoped model catalog
+
+A provider-free Project does not need model metadata. When a later selected stage needs model
+metadata, `ProjectConfig.model_catalog` points to one immutable `project-model-catalog` artifact
+whose aliases bind secret-free model and capability snapshots. Model roles and that pointer must be
+selected together.
+
+Export and restore use only this explicit Project pointer. They never read, infer, copy, or restore
+the root-global `models.toml` file. Catalog artifacts contain neither credentials nor Platform
+connection identifiers.
+
+## Restore boundary
+
+Restore first verifies the caller-supplied bundle digest, canonical regular-file archive metadata,
+portable relative paths, member and artifact digests, Project schema, selected closure, durable
+source identities, catalog bindings, and hard size limits. It rejects symlinks, traversal,
+duplicate or case-colliding names, compression, unsupported schemas, secret-bearing content, local
+absolute paths, extra artifacts, and incomplete content.
+
+Verified state is materialized beneath a private staging root and becomes visible only by renaming
+the completed Project directory into an absent `projects/<project_id>` destination. Failure removes
+the staging root and leaves no partially selected Project.
+
+## Stage events and runtime state
+
+Transport-neutral Project events use the stages `preparing_traces`, `building_world_model`,
+`optimizing_router`, and `completing_report`. Their event kinds are `started`, bounded `progress`,
+`completed`, and `failed`. Completion carries exact immutable output pointers; failure carries a
+typed redacted code and retryability, not provider text. WMO defines these domain records but does
+not provide an event bus, persistence service, or delivery guarantee.
+
+The bundle contains completed immutable build state only. A currently running operation belongs to
+the hosting system's job record. The mutable routed-interaction journal under the Project runtime
+directory is a separate serving concern: restore does not create it, and serving may attach or
+start runtime state only after the immutable Project has been verified and restored.

--- a/wmo/__init__.py
+++ b/wmo/__init__.py
@@ -11,10 +11,13 @@ if TYPE_CHECKING:
         build_fidelity_evaluation_plan as build_fidelity_evaluation_plan,
     )
     from wmo.common.evaluations import build_fidelity_report as build_fidelity_report
+    from wmo.common.project import ExportedProjectBundle as ExportedProjectBundle
     from wmo.common.project import ProjectProviderFreeStage as ProjectProviderFreeStage
     from wmo.common.project import (
         ProjectTracePreparationSettings as ProjectTracePreparationSettings,
     )
+    from wmo.common.project import export_project_bundle as export_project_bundle
+    from wmo.common.project import restore_project_bundle as restore_project_bundle
     from wmo.optimize.router.activation import load_project_router as load_project_router
     from wmo.optimize.router.activation import load_router as load_router
     from wmo.optimize.router.composition import (
@@ -76,6 +79,9 @@ if TYPE_CHECKING:
     from wmo.simulation.world_model.application import load_world_model as load_world_model
 
 _EXPORT_MODULES = {
+    "ExportedProjectBundle": "wmo.common.project",
+    "export_project_bundle": "wmo.common.project",
+    "restore_project_bundle": "wmo.common.project",
     "ProjectProviderFreeStage": "wmo.common.project",
     "ProjectTracePreparationSettings": "wmo.common.project",
     "BuildReviewReadiness": "wmo.simulation.build",

--- a/wmo/api_test.py
+++ b/wmo/api_test.py
@@ -14,7 +14,13 @@ from wmo.common.evaluations import (
     build_fidelity_evaluation_plan,
     build_fidelity_report,
 )
-from wmo.common.project import ProjectProviderFreeStage, ProjectTracePreparationSettings
+from wmo.common.project import (
+    ExportedProjectBundle,
+    ProjectProviderFreeStage,
+    ProjectTracePreparationSettings,
+    export_project_bundle,
+    restore_project_bundle,
+)
 from wmo.optimize.router.activation import load_project_router, load_router
 from wmo.optimize.router.automatic import service as automatic_router
 from wmo.optimize.router.composition import compose_router
@@ -50,6 +56,21 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.load_project_provider_free_stage is load_project_provider_free_stage
     assert wmo.ProjectProviderFreeStage is ProjectProviderFreeStage
     assert wmo.ProjectTracePreparationSettings is ProjectTracePreparationSettings
+    assert wmo.export_project_bundle is export_project_bundle
+    assert wmo.restore_project_bundle is restore_project_bundle
+    assert wmo.ExportedProjectBundle is ExportedProjectBundle
+    assert {
+        "export_project_bundle",
+        "restore_project_bundle",
+        "ExportedProjectBundle",
+    }.issubset(wmo.__all__)
+    assert not {
+        "ProjectBundleManifest",
+        "ProjectBundleMember",
+        "ProjectBundleError",
+        "ProjectStageEvent",
+        "ProjectModelCatalog",
+    }.intersection(wmo.__all__)
     assert wmo.optimize_router is optimize_router
     assert wmo.fit_router is fit_router
     assert wmo.report_router is report_router

--- a/wmo/common/project/__init__.py
+++ b/wmo/common/project/__init__.py
@@ -1,5 +1,14 @@
 """Canonical project configuration and immutable local artifact storage."""
 
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from wmo.common.project.events import (
+    ProjectStage,
+    ProjectStageEvent,
+    ProjectStageEventKind,
+    ProjectStageFailure,
+)
 from wmo.common.project.manifests import ArtifactFile, ArtifactManifest, artifact_input
 from wmo.common.project.paths import ProjectPathError, ProjectPaths
 from wmo.common.project.project import (
@@ -26,6 +35,35 @@ from wmo.common.project.store import (
     coordinate_completed_build_selection,
 )
 
+if TYPE_CHECKING:
+    from wmo.common.project.bundle import ExportedProjectBundle as ExportedProjectBundle
+    from wmo.common.project.bundle import ProjectBundleError as ProjectBundleError
+    from wmo.common.project.bundle import ProjectBundleManifest as ProjectBundleManifest
+    from wmo.common.project.bundle import ProjectBundleMember as ProjectBundleMember
+    from wmo.common.project.bundle import export_project_bundle as export_project_bundle
+    from wmo.common.project.bundle import restore_project_bundle as restore_project_bundle
+    from wmo.common.project.catalog import ProjectCatalogModel as ProjectCatalogModel
+    from wmo.common.project.catalog import ProjectModelCatalog as ProjectModelCatalog
+    from wmo.common.project.catalog import ProjectModelCatalogError as ProjectModelCatalogError
+    from wmo.common.project.catalog import load_project_model_catalog as load_project_model_catalog
+    from wmo.common.project.catalog import (
+        persist_project_model_catalog as persist_project_model_catalog,
+    )
+
+_LAZY_EXPORT_MODULES = {
+    "ExportedProjectBundle": "wmo.common.project.bundle",
+    "ProjectBundleError": "wmo.common.project.bundle",
+    "ProjectBundleManifest": "wmo.common.project.bundle",
+    "ProjectBundleMember": "wmo.common.project.bundle",
+    "ProjectCatalogModel": "wmo.common.project.catalog",
+    "ProjectModelCatalog": "wmo.common.project.catalog",
+    "ProjectModelCatalogError": "wmo.common.project.catalog",
+    "export_project_bundle": "wmo.common.project.bundle",
+    "load_project_model_catalog": "wmo.common.project.catalog",
+    "persist_project_model_catalog": "wmo.common.project.catalog",
+    "restore_project_bundle": "wmo.common.project.bundle",
+}
+
 __all__ = [
     "AgentConfiguration",
     "ArtifactAlreadyExistsError",
@@ -34,11 +72,18 @@ __all__ = [
     "ArtifactManifest",
     "ArtifactStore",
     "ArtifactStoreError",
+    "ExportedProjectBundle",
+    "ProjectBundleError",
+    "ProjectBundleManifest",
+    "ProjectBundleMember",
+    "ProjectCatalogModel",
     "ProjectConfig",
     "ProjectConfigError",
     "ProjectBuildArtifacts",
     "ProjectBudgetConfiguration",
     "ProjectModelConfiguration",
+    "ProjectModelCatalog",
+    "ProjectModelCatalogError",
     "ProjectProviderFreeStage",
     "ProjectRetrievalConfiguration",
     "ProjectTracePreparationSettings",
@@ -46,9 +91,42 @@ __all__ = [
     "ProjectPaths",
     "ProjectStore",
     "ProjectStoreError",
+    "ProjectStage",
+    "ProjectStageEvent",
+    "ProjectStageEventKind",
+    "ProjectStageFailure",
     "StoredArtifact",
     "artifact_input",
     "coordinate_completed_build_selection",
+    "export_project_bundle",
     "load_project_config",
+    "load_project_model_catalog",
+    "persist_project_model_catalog",
+    "restore_project_bundle",
     "write_project_config",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve one catalog or bundle helper without creating common-package import cycles.
+
+    Args:
+        name: Package attribute requested by Python.
+
+    Returns:
+        The supported object loaded from its owning Project module.
+
+    Raises:
+        AttributeError: The name is not a supported lazy Project export.
+    """
+    module_name = _LAZY_EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return module globals plus supported lazy Project exports."""
+    return sorted(set(globals()) | set(_LAZY_EXPORT_MODULES))

--- a/wmo/common/project/bundle.py
+++ b/wmo/common/project/bundle.py
@@ -10,6 +10,7 @@ import hashlib
 import os
 import shutil
 import stat
+import tempfile
 import unicodedata
 import zipfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -63,6 +64,7 @@ _BUNDLE_MANIFEST_PATH = "bundle.json"
 _PROJECT_CONFIG_PATH = "project.json"
 _MAX_BUNDLE_MEMBERS = 20_000
 _MAX_EXPANDED_BYTES = 1_073_741_824
+_MAX_ARCHIVE_BYTES = 2 * _MAX_EXPANDED_BYTES
 _READ_CHUNK_BYTES = 1024 * 1024
 _SUPPORTED_PROJECT_SCHEMA_VERSIONS = frozenset({1, 2, 3})
 _JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
@@ -296,11 +298,14 @@ def restore_project_bundle(
     except ValidationError as exc:
         raise ProjectBundleError("expected bundle digest is not a lowercase SHA-256 value") from exc
     source = Path(bundle_path)
-    with _open_regular_file(source) as handle:
-        actual = _sha256_file(handle)
-        if actual != expected:
-            raise ProjectBundleError("Project bundle content digest does not match expected_sha256")
-        loaded = _load_and_verify_bundle(handle)
+    with _open_regular_file(source) as source_handle:
+        with tempfile.TemporaryFile(mode="w+b") as snapshot:
+            actual = _copy_bundle_snapshot(source_handle, snapshot)
+            if actual != expected:
+                raise ProjectBundleError(
+                    "Project bundle content digest does not match expected_sha256"
+                )
+            loaded = _load_and_verify_bundle(snapshot)
     destination_root = Path(root)
     _require_safe_restore_root(destination_root)
     paths = ProjectPaths(destination_root, loaded.project.project_id)
@@ -866,4 +871,22 @@ def _sha256_file(handle: BinaryIO) -> str:
     while chunk := handle.read(_READ_CHUNK_BYTES):
         digest.update(chunk)
     handle.seek(0)
+    return digest.hexdigest()
+
+
+def _copy_bundle_snapshot(source: BinaryIO, snapshot: BinaryIO) -> str:
+    """Hash one bounded source read into the private snapshot used for restore."""
+    source.seek(0)
+    digest = hashlib.sha256(usedforsecurity=False)
+    size_bytes = 0
+    while chunk := source.read(_READ_CHUNK_BYTES):
+        size_bytes += len(chunk)
+        if size_bytes > _MAX_ARCHIVE_BYTES:
+            raise ProjectBundleError(
+                f"Project bundle archive exceeds the {_MAX_ARCHIVE_BYTES} byte limit"
+            )
+        digest.update(chunk)
+        snapshot.write(chunk)
+    snapshot.flush()
+    snapshot.seek(0)
     return digest.hexdigest()

--- a/wmo/common/project/bundle.py
+++ b/wmo/common/project/bundle.py
@@ -296,10 +296,11 @@ def restore_project_bundle(
     except ValidationError as exc:
         raise ProjectBundleError("expected bundle digest is not a lowercase SHA-256 value") from exc
     source = Path(bundle_path)
-    actual = _sha256_path(source)
-    if actual != expected:
-        raise ProjectBundleError("Project bundle content digest does not match expected_sha256")
-    loaded = _load_and_verify_bundle(source)
+    with _open_regular_file(source) as handle:
+        actual = _sha256_file(handle)
+        if actual != expected:
+            raise ProjectBundleError("Project bundle content digest does not match expected_sha256")
+        loaded = _load_and_verify_bundle(handle)
     destination_root = Path(root)
     _require_safe_restore_root(destination_root)
     paths = ProjectPaths(destination_root, loaded.project.project_id)
@@ -393,12 +394,11 @@ def _canonical_zip_info(path: str) -> zipfile.ZipInfo:
     return info
 
 
-def _load_and_verify_bundle(path: Path) -> _LoadedBundle:
-    """Read, bound, and recursively verify every archive member before restore writes."""
+def _load_and_verify_bundle(handle: BinaryIO) -> _LoadedBundle:
+    """Verify every archive member through the descriptor authenticated by the caller."""
     try:
-        with _open_regular_file(path) as handle:
-            with zipfile.ZipFile(handle, mode="r") as archive:
-                payloads = _read_archive_payloads(archive)
+        with zipfile.ZipFile(handle, mode="r") as archive:
+            payloads = _read_archive_payloads(archive)
     except ProjectBundleError:
         raise
     except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
@@ -855,8 +855,15 @@ def _open_regular_file(path: Path) -> Iterator[BinaryIO]:
 
 def _sha256_path(path: Path) -> str:
     """Hash one regular non-symlink file through a stable descriptor."""
-    digest = hashlib.sha256(usedforsecurity=False)
     with _open_regular_file(Path(path)) as handle:
-        while chunk := handle.read(_READ_CHUNK_BYTES):
-            digest.update(chunk)
+        return _sha256_file(handle)
+
+
+def _sha256_file(handle: BinaryIO) -> str:
+    """Hash and rewind one open file so its authenticated bytes can be consumed next."""
+    handle.seek(0)
+    digest = hashlib.sha256(usedforsecurity=False)
+    while chunk := handle.read(_READ_CHUNK_BYTES):
+        digest.update(chunk)
+    handle.seek(0)
     return digest.hexdigest()

--- a/wmo/common/project/bundle.py
+++ b/wmo/common/project/bundle.py
@@ -1,0 +1,862 @@
+"""Deterministic export and atomic restore for one selected WMO Project state.
+
+The immutable bundle intentionally excludes ``ProjectPaths.runtime_directory``. Serving restores
+the verified build state first, then attaches its separately owned mutable runtime journal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import unicodedata
+import zipfile
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import BinaryIO, Literal
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from pydantic import (
+    BaseModel,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    JsonObject,
+    JsonValue,
+    SecretBoundaryError,
+    Sha256,
+    assert_secret_free,
+    canonical_json_bytes,
+    sha256_bytes,
+    validate_artifact_file_path,
+)
+from wmo.common.core.files import fsync_directory_best_effort
+from wmo.common.core.locks import file_write_lock
+from wmo.common.project.catalog import (
+    ProjectModelCatalog,
+    ProjectModelCatalogError,
+    load_project_model_catalog,
+)
+from wmo.common.project.events import ProjectStage
+from wmo.common.project.manifests import ArtifactManifest, artifact_input
+from wmo.common.project.paths import ProjectPaths, validate_local_id
+from wmo.common.project.project import (
+    ProjectConfig,
+    require_durable_source_id,
+)
+from wmo.common.project.store import ProjectStore
+
+_BUNDLE_MANIFEST_PATH = "bundle.json"
+_PROJECT_CONFIG_PATH = "project.json"
+_MAX_BUNDLE_MEMBERS = 20_000
+_MAX_EXPANDED_BYTES = 1_073_741_824
+_READ_CHUNK_BYTES = 1024 * 1024
+_SUPPORTED_PROJECT_SCHEMA_VERSIONS = frozenset({1, 2, 3})
+_JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
+_SHA256_ADAPTER = TypeAdapter(Sha256)
+_STAGE_ORDER = {
+    ProjectStage.PREPARING_TRACES: 0,
+    ProjectStage.BUILDING_WORLD_MODEL: 1,
+    ProjectStage.OPTIMIZING_ROUTER: 2,
+    ProjectStage.COMPLETING_REPORT: 3,
+}
+
+
+class ProjectBundleError(RuntimeError):
+    """A Project could not be exported or restored without weakening bundle guarantees."""
+
+
+class ProjectBundleMember(ContractModel):
+    """Digest and expanded size of one canonical regular file inside a bundle."""
+
+    path: str = Field(min_length=1, max_length=4_096)
+    sha256: Sha256
+    size_bytes: int = Field(ge=0, le=_MAX_EXPANDED_BYTES)
+
+    @field_validator("path")
+    @classmethod
+    def _require_safe_member_path(cls, value: str) -> str:
+        """Return one normalized portable relative member path."""
+        return validate_artifact_file_path(value).as_posix()
+
+
+class ProjectBundleManifest(ContractModel):
+    """Versioned binding for one Project config and its selected artifact closure."""
+
+    schema_version: Literal[1] = 1
+    project_id: ArtifactId
+    project_schema_version: int = Field(ge=1)
+    producer_revision: str = Field(min_length=1, max_length=256)
+    selected_artifacts: tuple[ArtifactInput, ...]
+    completed_stages: tuple[ProjectStage, ...]
+    members: tuple[ProjectBundleMember, ...] = Field(
+        min_length=1,
+        max_length=_MAX_BUNDLE_MEMBERS,
+    )
+    expanded_file_count: int = Field(ge=1, le=_MAX_BUNDLE_MEMBERS)
+    expanded_size_bytes: int = Field(ge=0, le=_MAX_EXPANDED_BYTES)
+    runtime_state: Literal["excluded"] = "excluded"
+
+    @field_validator("producer_revision")
+    @classmethod
+    def _require_canonical_revision(cls, value: str) -> str:
+        """Reject blank or padded producer identities."""
+        if value != value.strip():
+            raise ValueError("bundle producer_revision must not have surrounding whitespace")
+        return value
+
+    @field_validator("selected_artifacts")
+    @classmethod
+    def _require_sorted_unique_artifacts(
+        cls, value: tuple[ArtifactInput, ...]
+    ) -> tuple[ArtifactInput, ...]:
+        """Require one canonical pointer per selected artifact ID."""
+        artifact_ids = tuple(item.artifact_id for item in value)
+        if not artifact_ids:
+            raise ValueError("project bundle needs at least one selected artifact")
+        if len(set(artifact_ids)) != len(artifact_ids):
+            raise ValueError("project bundle selected artifacts must not repeat")
+        if artifact_ids != tuple(sorted(artifact_ids)):
+            raise ValueError("project bundle selected artifacts must be sorted")
+        return value
+
+    @field_validator("completed_stages")
+    @classmethod
+    def _require_ordered_unique_stages(
+        cls, value: tuple[ProjectStage, ...]
+    ) -> tuple[ProjectStage, ...]:
+        """Require completed durable stages in the canonical workflow order."""
+        if not value:
+            raise ValueError("project bundle needs at least one completed durable stage")
+        if len(set(value)) != len(value):
+            raise ValueError("completed project stages must not repeat")
+        if value != tuple(sorted(value, key=_STAGE_ORDER.__getitem__)):
+            raise ValueError("completed project stages must follow workflow order")
+        return value
+
+    @field_validator("members")
+    @classmethod
+    def _require_sorted_unique_members(
+        cls, value: tuple[ProjectBundleMember, ...]
+    ) -> tuple[ProjectBundleMember, ...]:
+        """Require canonical member order without exact or case-folding collisions."""
+        paths = tuple(item.path for item in value)
+        if paths != tuple(sorted(paths)):
+            raise ValueError("project bundle members must be sorted by path")
+        _require_unique_portable_names(paths)
+        return value
+
+    @model_validator(mode="after")
+    def _require_exact_expansion_totals(self) -> ProjectBundleManifest:
+        """Bind the declared expansion bounds to the complete member list."""
+        if self.expanded_file_count != len(self.members):
+            raise ValueError("bundle expanded_file_count differs from its member list")
+        if self.expanded_size_bytes != sum(item.size_bytes for item in self.members):
+            raise ValueError("bundle expanded_size_bytes differs from its member list")
+        if _PROJECT_CONFIG_PATH not in {item.path for item in self.members}:
+            raise ValueError("project bundle manifest does not bind project.json")
+        return self
+
+
+@dataclass(frozen=True)
+class ExportedProjectBundle:
+    """Published bundle path, content identity, size, and parsed manifest."""
+
+    path: Path
+    sha256: str
+    size_bytes: int
+    manifest: ProjectBundleManifest
+
+
+@dataclass(frozen=True)
+class _LoadedBundle:
+    """Fully verified archive content used only before atomic restore visibility."""
+
+    manifest: ProjectBundleManifest
+    project: ProjectConfig
+    artifacts: Mapping[str, ArtifactManifest]
+    payloads: Mapping[str, bytes]
+
+
+def export_project_bundle(
+    store: ProjectStore,
+    destination: Path,
+    *,
+    producer_revision: str,
+) -> ExportedProjectBundle:
+    """Export one selected Project state as a deterministic verified bundle.
+
+    Args:
+        store: Project-local store whose selected immutable state is exported.
+        destination: Final bundle file, published through an atomic replacement.
+        producer_revision: Exact WMO revision or installed distribution identity.
+
+    Returns:
+        Final path, content digest, size, and parsed versioned manifest.
+
+    Raises:
+        ProjectBundleError: The selected graph is unsafe, incomplete, oversized, or cannot be
+            published atomically.
+    """
+    try:
+        project = store.load_project()
+        _validate_project_config(project)
+
+        def resolve(artifact_id: str) -> ArtifactManifest:
+            """Read one fully verified selected artifact manifest."""
+            return store.artifacts.read(artifact_id).manifest
+
+        selected_artifacts, manifests = _collect_selected_artifacts(project, resolve)
+        _validate_catalog_from_store(store, project, manifests)
+        completed_stages = _completed_stages(project)
+        payloads = _export_payloads(store, project, manifests)
+        members = _bundle_members(payloads)
+        manifest = ProjectBundleManifest(
+            project_id=project.project_id,
+            project_schema_version=project.schema_version,
+            producer_revision=producer_revision,
+            selected_artifacts=selected_artifacts,
+            completed_stages=completed_stages,
+            members=members,
+            expanded_file_count=len(members),
+            expanded_size_bytes=sum(item.size_bytes for item in members),
+        )
+        assert_secret_free(manifest)
+        if manifest.expanded_size_bytes + len(canonical_json_bytes(manifest)) > _MAX_EXPANDED_BYTES:
+            raise ProjectBundleError(
+                f"Project bundle exceeds the {_MAX_EXPANDED_BYTES} total expanded-byte limit"
+            )
+    except ProjectBundleError:
+        raise
+    except (OSError, RuntimeError, SecretBoundaryError, ValidationError, ValueError) as exc:
+        raise ProjectBundleError(f"cannot export selected Project state: {exc}") from exc
+    final_path = Path(destination)
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    if final_path.exists() and final_path.is_dir():
+        raise ProjectBundleError(f"bundle destination is a directory: {final_path}")
+    staging = final_path.parent / f".{final_path.name}.{uuid4().hex}.partial"
+    try:
+        with file_write_lock(final_path, what="project bundle export"):
+            _write_bundle_archive(staging, payloads, manifest)
+            digest = _sha256_path(staging)
+            size_bytes = staging.stat().st_size
+            os.replace(staging, final_path)
+            fsync_directory_best_effort(final_path.parent)
+    except ProjectBundleError:
+        staging.unlink(missing_ok=True)
+        raise
+    except (OSError, RuntimeError, ValueError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        staging.unlink(missing_ok=True)
+        raise ProjectBundleError(f"cannot atomically export Project bundle: {exc}") from exc
+    except BaseException:
+        staging.unlink(missing_ok=True)
+        raise
+    return ExportedProjectBundle(
+        path=final_path,
+        sha256=digest,
+        size_bytes=size_bytes,
+        manifest=manifest,
+    )
+
+
+def restore_project_bundle(
+    bundle_path: Path,
+    *,
+    root: Path,
+    expected_sha256: str,
+) -> ProjectStore:
+    """Verify and atomically restore one Project into an absent scoped destination.
+
+    Args:
+        bundle_path: Downloaded canonical bundle file.
+        root: Local WMO root that will own ``projects/<project_id>``.
+        expected_sha256: Content address supplied by the bundle storage owner.
+
+    Returns:
+        Project store addressing the newly visible restored state.
+
+    Raises:
+        ProjectBundleError: The content address, archive, graph, or destination is unsafe.
+    """
+    try:
+        expected = _SHA256_ADAPTER.validate_python(expected_sha256)
+    except ValidationError as exc:
+        raise ProjectBundleError("expected bundle digest is not a lowercase SHA-256 value") from exc
+    source = Path(bundle_path)
+    actual = _sha256_path(source)
+    if actual != expected:
+        raise ProjectBundleError("Project bundle content digest does not match expected_sha256")
+    loaded = _load_and_verify_bundle(source)
+    destination_root = Path(root)
+    _require_safe_restore_root(destination_root)
+    paths = ProjectPaths(destination_root, loaded.project.project_id)
+    destination = paths.project_directory
+    if destination.exists() or destination.is_symlink():
+        raise ProjectBundleError(
+            f"restore destination must be absent and scoped to one Project: {destination}"
+        )
+    paths.projects_directory.mkdir(parents=True, exist_ok=True)
+    staging_root = destination_root / f".restore-{uuid4().hex}.partial"
+    staged = ProjectStore(staging_root, loaded.project.project_id)
+    try:
+        _materialize_loaded_bundle(staged, loaded)
+        _verify_restored_project(staged, loaded)
+        os.rename(staged.paths.project_directory, destination)
+        fsync_directory_best_effort(paths.projects_directory)
+    except ProjectBundleError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ProjectBundleError(f"cannot atomically restore Project bundle: {exc}") from exc
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+    return ProjectStore(destination_root, loaded.project.project_id)
+
+
+def _export_payloads(
+    store: ProjectStore,
+    project: ProjectConfig,
+    manifests: Mapping[str, ArtifactManifest],
+) -> dict[str, bytes]:
+    """Read the canonical Project config and selected artifact closure into bundle members."""
+    payloads = {_PROJECT_CONFIG_PATH: canonical_json_bytes(project)}
+    for artifact_id in sorted(manifests):
+        manifest = manifests[artifact_id]
+        prefix = f"artifacts/{artifact_id}"
+        payloads[f"{prefix}/manifest.json"] = canonical_json_bytes(manifest)
+        for entry in manifest.files:
+            payloads[f"{prefix}/{entry.path}"] = store.artifacts.read_bytes(
+                artifact_id,
+                entry.path,
+            )
+    return payloads
+
+
+def _bundle_members(payloads: Mapping[str, bytes]) -> tuple[ProjectBundleMember, ...]:
+    """Build bounded digest records for every member except the manifest itself."""
+    if len(payloads) > _MAX_BUNDLE_MEMBERS:
+        raise ProjectBundleError(
+            f"Project bundle exceeds the {_MAX_BUNDLE_MEMBERS} expanded-file limit"
+        )
+    members = tuple(
+        ProjectBundleMember(
+            path=path,
+            sha256=sha256_bytes(payload),
+            size_bytes=len(payload),
+        )
+        for path, payload in sorted(payloads.items())
+    )
+    expanded = sum(item.size_bytes for item in members)
+    if expanded > _MAX_EXPANDED_BYTES:
+        raise ProjectBundleError(
+            f"Project bundle exceeds the {_MAX_EXPANDED_BYTES} expanded-byte limit"
+        )
+    return members
+
+
+def _write_bundle_archive(
+    path: Path,
+    payloads: Mapping[str, bytes],
+    manifest: ProjectBundleManifest,
+) -> None:
+    """Write one canonical uncompressed ZIP archive to a new private path."""
+    with path.open("xb") as handle:
+        with zipfile.ZipFile(handle, mode="w", allowZip64=True) as archive:
+            for member_path in sorted(payloads):
+                archive.writestr(_canonical_zip_info(member_path), payloads[member_path])
+            archive.writestr(
+                _canonical_zip_info(_BUNDLE_MANIFEST_PATH),
+                canonical_json_bytes(manifest),
+            )
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _canonical_zip_info(path: str) -> zipfile.ZipInfo:
+    """Return deterministic regular-file metadata for one canonical archive member."""
+    info = zipfile.ZipInfo(path, date_time=(1980, 1, 1, 0, 0, 0))
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = (stat.S_IFREG | 0o600) << 16
+    return info
+
+
+def _load_and_verify_bundle(path: Path) -> _LoadedBundle:
+    """Read, bound, and recursively verify every archive member before restore writes."""
+    try:
+        with _open_regular_file(path) as handle:
+            with zipfile.ZipFile(handle, mode="r") as archive:
+                payloads = _read_archive_payloads(archive)
+    except ProjectBundleError:
+        raise
+    except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        raise ProjectBundleError(
+            f"Project bundle is not a complete readable archive: {exc}"
+        ) from exc
+    manifest_payload = payloads.get(_BUNDLE_MANIFEST_PATH)
+    if manifest_payload is None:
+        raise ProjectBundleError("Project bundle has no bundle.json manifest")
+    try:
+        manifest = ProjectBundleManifest.model_validate_json(manifest_payload)
+        assert_secret_free(manifest)
+    except (SecretBoundaryError, ValidationError, ValueError) as exc:
+        raise ProjectBundleError("Project bundle manifest is invalid or unsupported") from exc
+    expected_names = {_BUNDLE_MANIFEST_PATH, *(item.path for item in manifest.members)}
+    if set(payloads) != expected_names:
+        raise ProjectBundleError("Project bundle member set differs from its manifest")
+    for member in manifest.members:
+        payload = payloads[member.path]
+        if len(payload) != member.size_bytes or sha256_bytes(payload) != member.sha256:
+            raise ProjectBundleError(f"Project bundle member digest changed: {member.path}")
+    project_payload = payloads.get(_PROJECT_CONFIG_PATH)
+    if project_payload is None:
+        raise ProjectBundleError("Project bundle has no project.json")
+    try:
+        project = ProjectConfig.model_validate_json(project_payload)
+        assert_secret_free(project)
+        _validate_project_config(project)
+    except (SecretBoundaryError, ValidationError, ValueError) as exc:
+        raise ProjectBundleError(f"bundled Project configuration is invalid: {exc}") from exc
+    if (
+        project.project_id != manifest.project_id
+        or project.schema_version != manifest.project_schema_version
+    ):
+        raise ProjectBundleError("bundled Project identity or schema differs from bundle.json")
+    artifact_manifests = _parse_artifact_members(payloads)
+
+    def resolve(artifact_id: str) -> ArtifactManifest:
+        """Resolve one manifest already bounded by the archive member set."""
+        try:
+            return artifact_manifests[artifact_id]
+        except KeyError as exc:
+            raise ProjectBundleError(f"selected artifact is missing: {artifact_id}") from exc
+
+    selected, closure = _collect_selected_artifacts(project, resolve)
+    if selected != manifest.selected_artifacts:
+        raise ProjectBundleError("selected artifact closure differs from bundle.json")
+    if set(artifact_manifests) != set(closure):
+        raise ProjectBundleError("bundle contains an unselected artifact directory")
+    if _completed_stages(project) != manifest.completed_stages:
+        raise ProjectBundleError("completed durable stage selection differs from bundle.json")
+    _validate_catalog_from_payloads(project, closure, payloads)
+    return _LoadedBundle(
+        manifest=manifest,
+        project=project,
+        artifacts=closure,
+        payloads=payloads,
+    )
+
+
+def _read_archive_payloads(archive: zipfile.ZipFile) -> dict[str, bytes]:
+    """Reject noncanonical ZIP metadata and read every member within hard expansion bounds."""
+    infos = archive.infolist()
+    if not infos or len(infos) > _MAX_BUNDLE_MEMBERS + 1:
+        raise ProjectBundleError("Project bundle archive has an invalid member count")
+    names = []
+    declared_size = 0
+    for info in infos:
+        if info.orig_filename != info.filename:
+            raise ProjectBundleError("Project bundle member names cannot contain NUL bytes")
+        try:
+            name = validate_artifact_file_path(info.filename).as_posix()
+        except ValueError as exc:
+            raise ProjectBundleError(
+                f"Project bundle member path is not relative POSIX: {exc}"
+            ) from exc
+        if info.is_dir():
+            raise ProjectBundleError("Project bundle members must be regular files")
+        unix_mode = info.external_attr >> 16
+        if info.create_system != 3 or stat.S_IFMT(unix_mode) != stat.S_IFREG:
+            raise ProjectBundleError("Project bundle members must be canonical Unix regular files")
+        if info.compress_type != zipfile.ZIP_STORED:
+            raise ProjectBundleError("Project bundle members must be uncompressed")
+        if info.flag_bits & 0x1:
+            raise ProjectBundleError("Project bundle members must not be encrypted")
+        declared_size += info.file_size
+        if declared_size > _MAX_EXPANDED_BYTES:
+            raise ProjectBundleError("Project bundle exceeds its hard expanded-byte limit")
+        names.append(name)
+    _require_unique_portable_names(names)
+    payloads: dict[str, bytes] = {}
+    actual_size = 0
+    for info, name in zip(infos, names, strict=True):
+        payload = _read_bounded_member(archive, info)
+        actual_size += len(payload)
+        if actual_size > _MAX_EXPANDED_BYTES:
+            raise ProjectBundleError("Project bundle expansion exceeds its hard byte limit")
+        payloads[name] = payload
+    return payloads
+
+
+def _read_bounded_member(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    """Read one stored member without trusting its declared size as an allocation bound."""
+    chunks: list[bytes] = []
+    total = 0
+    with archive.open(info, mode="r") as member:
+        while chunk := member.read(_READ_CHUNK_BYTES):
+            total += len(chunk)
+            if total > info.file_size or total > _MAX_EXPANDED_BYTES:
+                raise ProjectBundleError(
+                    f"Project bundle member expands beyond bounds: {info.filename}"
+                )
+            chunks.append(chunk)
+    if total != info.file_size:
+        raise ProjectBundleError(f"Project bundle member is truncated: {info.filename}")
+    return b"".join(chunks)
+
+
+def _parse_artifact_members(
+    payloads: Mapping[str, bytes],
+) -> dict[str, ArtifactManifest]:
+    """Parse every artifact manifest and bind its complete declared member set."""
+    artifact_files: dict[str, set[str]] = {}
+    for path in payloads:
+        if not path.startswith("artifacts/"):
+            continue
+        parts = PurePosixPath(path).parts
+        if len(parts) < 3:
+            raise ProjectBundleError(f"artifact bundle member has an incomplete path: {path}")
+        try:
+            artifact_id = validate_local_id(parts[1], label="artifact ID")
+        except ValueError as exc:
+            raise ProjectBundleError(f"artifact bundle member has an invalid ID: {path}") from exc
+        artifact_files.setdefault(artifact_id, set()).add("/".join(parts[2:]))
+    manifests: dict[str, ArtifactManifest] = {}
+    for artifact_id, relative_files in artifact_files.items():
+        manifest_path = f"artifacts/{artifact_id}/manifest.json"
+        payload = payloads.get(manifest_path)
+        if payload is None:
+            raise ProjectBundleError(f"bundled artifact has no manifest.json: {artifact_id}")
+        try:
+            manifest = ArtifactManifest.model_validate_json(payload)
+            assert_secret_free(manifest)
+        except (SecretBoundaryError, ValidationError, ValueError) as exc:
+            raise ProjectBundleError(
+                f"bundled artifact manifest is invalid: {artifact_id}"
+            ) from exc
+        if manifest.artifact_id != artifact_id:
+            raise ProjectBundleError(
+                f"bundled artifact directory differs from its manifest: {artifact_id}"
+            )
+        expected = {"manifest.json", *(item.path for item in manifest.files)}
+        if relative_files != expected:
+            raise ProjectBundleError(
+                f"bundled artifact file set differs from manifest: {artifact_id}"
+            )
+        for entry in manifest.files:
+            data = payloads[f"artifacts/{artifact_id}/{entry.path}"]
+            if len(data) != entry.size_bytes or sha256_bytes(data) != entry.sha256:
+                raise ProjectBundleError(
+                    f"bundled artifact data digest changed: {artifact_id}/{entry.path}"
+                )
+        manifests[artifact_id] = manifest
+    return manifests
+
+
+def _collect_selected_artifacts(
+    project: ProjectConfig,
+    resolve: Callable[[str], ArtifactManifest],
+) -> tuple[tuple[ArtifactInput, ...], dict[str, ArtifactManifest]]:
+    """Resolve the exact transitive closure of every selected Project artifact pointer."""
+    direct = _project_artifact_inputs(project)
+    if not direct:
+        raise ProjectBundleError("Project has no completed durable artifact selection to export")
+    expected: dict[str, ArtifactInput] = {}
+    manifests: dict[str, ArtifactManifest] = {}
+    visited: set[str] = set()
+    visiting: set[str] = set()
+    stack: list[tuple[ArtifactInput, bool]] = [(pointer, False) for pointer in reversed(direct)]
+    while stack:
+        pointer, exiting = stack.pop()
+        previous = expected.get(pointer.artifact_id)
+        if previous is not None and previous != pointer:
+            raise ProjectBundleError(
+                f"artifact {pointer.artifact_id} has conflicting selected manifest digests"
+            )
+        expected[pointer.artifact_id] = pointer
+        if exiting:
+            visiting.remove(pointer.artifact_id)
+            visited.add(pointer.artifact_id)
+            continue
+        if pointer.artifact_id in visited:
+            continue
+        if pointer.artifact_id in visiting:
+            raise ProjectBundleError("selected artifact graph contains a provenance cycle")
+        manifest = resolve(pointer.artifact_id)
+        if artifact_input(manifest) != pointer:
+            raise ProjectBundleError(
+                f"selected artifact manifest digest changed: {pointer.artifact_id}"
+            )
+        _validate_manifest_source(manifest)
+        manifests[pointer.artifact_id] = manifest
+        visiting.add(pointer.artifact_id)
+        stack.append((pointer, True))
+        stack.extend((dependency, False) for dependency in reversed(manifest.inputs))
+    selected = tuple(expected[artifact_id] for artifact_id in sorted(expected))
+    return selected, manifests
+
+
+def _project_artifact_inputs(project: ProjectConfig) -> tuple[ArtifactInput, ...]:
+    """Return every explicitly selected ArtifactInput nested in Project configuration."""
+    pointers: list[ArtifactInput] = []
+
+    def collect(value: object) -> None:
+        """Walk typed Project fields without interpreting arbitrary serialized dictionaries."""
+        if isinstance(value, ArtifactInput):
+            pointers.append(value)
+            return
+        if isinstance(value, BaseModel):
+            for field_name in type(value).model_fields:
+                collect(getattr(value, field_name))
+            return
+        if isinstance(value, (tuple, list)):
+            for item in value:
+                collect(item)
+
+    collect(project)
+    by_id: dict[str, ArtifactInput] = {}
+    for pointer in pointers:
+        previous = by_id.get(pointer.artifact_id)
+        if previous is not None and previous != pointer:
+            raise ProjectBundleError(
+                f"Project selects conflicting digests for artifact {pointer.artifact_id}"
+            )
+        by_id[pointer.artifact_id] = pointer
+    return tuple(by_id[artifact_id] for artifact_id in sorted(by_id))
+
+
+def _completed_stages(project: ProjectConfig) -> tuple[ProjectStage, ...]:
+    """Derive completed WMO stage vocabulary only from durable selected pointers."""
+    stages = []
+    if project.provider_free_stage is not None or project.build is not None:
+        stages.append(ProjectStage.PREPARING_TRACES)
+    if project.build is not None:
+        stages.append(ProjectStage.BUILDING_WORLD_MODEL)
+    return tuple(stages)
+
+
+def _validate_project_config(project: ProjectConfig) -> None:
+    """Enforce portable config state without reading ambient root-global files."""
+    assert_secret_free(project)
+    if project.schema_version not in _SUPPORTED_PROJECT_SCHEMA_VERSIONS:
+        raise ProjectBundleError(
+            f"Project schema version is unsupported by this bundle reader: {project.schema_version}"
+        )
+    _reject_absolute_path_values(project.model_dump(mode="json"), path="project")
+    if (project.models is None) != (project.model_catalog is None):
+        raise ProjectBundleError(
+            "Project model roles and project-scoped catalog pointer must be selected together"
+        )
+
+
+def _validate_manifest_source(manifest: ArtifactManifest) -> None:
+    """Reject worker-local source provenance while retaining durable URI labels."""
+    if manifest.source is None:
+        return
+    try:
+        require_durable_source_id(manifest.source.source_id)
+    except ValueError as exc:
+        raise ProjectBundleError(
+            f"artifact {manifest.artifact_id} has worker-local source provenance: {exc}"
+        ) from exc
+
+
+def _validate_catalog_from_store(
+    store: ProjectStore,
+    project: ProjectConfig,
+    manifests: Mapping[str, ArtifactManifest],
+) -> None:
+    """Verify an optional catalog artifact from its explicit Project pointer only."""
+    pointer = project.model_catalog
+    if pointer is None:
+        return
+    if pointer.artifact_id not in manifests:
+        raise ProjectBundleError("Project catalog pointer is absent from selected closure")
+    try:
+        catalog = load_project_model_catalog(store.artifacts, pointer)
+    except ProjectModelCatalogError as exc:
+        raise ProjectBundleError(str(exc)) from exc
+    _validate_catalog_roles(project, catalog)
+
+
+def _validate_catalog_from_payloads(
+    project: ProjectConfig,
+    manifests: Mapping[str, ArtifactManifest],
+    payloads: Mapping[str, bytes],
+) -> None:
+    """Verify an optional catalog artifact from already bounded archive payloads."""
+    pointer = project.model_catalog
+    if pointer is None:
+        return
+    manifest = manifests.get(pointer.artifact_id)
+    if manifest is None or artifact_input(manifest) != pointer:
+        raise ProjectBundleError("bundled Project catalog pointer is stale or missing")
+    if manifest.artifact_type != "project-model-catalog":
+        raise ProjectBundleError("bundled Project catalog has the wrong artifact type")
+    if tuple(item.path for item in manifest.files) != ("catalog.json",):
+        raise ProjectBundleError("bundled Project catalog must contain only catalog.json")
+    try:
+        catalog = ProjectModelCatalog.model_validate_json(
+            payloads[f"artifacts/{pointer.artifact_id}/catalog.json"]
+        )
+    except (KeyError, ValidationError, ValueError) as exc:
+        raise ProjectBundleError("bundled Project catalog payload is invalid") from exc
+    _validate_catalog_roles(project, catalog)
+
+
+def _validate_catalog_roles(project: ProjectConfig, catalog: ProjectModelCatalog) -> None:
+    """Bind Project role aliases to one complete project-scoped catalog snapshot."""
+    if catalog.project_id != project.project_id:
+        raise ProjectBundleError("Project catalog belongs to a different Project")
+    models = project.models
+    if models is None:
+        raise ProjectBundleError("Project catalog cannot be selected without model roles")
+    available = {item.alias for item in catalog.models}
+    required = {
+        models.world_model,
+        models.judge,
+        models.embedder,
+        *models.candidates,
+    }
+    missing = sorted(required - available)
+    if missing:
+        raise ProjectBundleError(f"Project catalog is missing selected model aliases: {missing}")
+
+
+def _materialize_loaded_bundle(store: ProjectStore, loaded: _LoadedBundle) -> None:
+    """Write every verified immutable artifact and the config into a private staging root."""
+    for artifact_id in sorted(loaded.artifacts):
+        manifest = loaded.artifacts[artifact_id]
+        files = {
+            entry.path: loaded.payloads[f"artifacts/{artifact_id}/{entry.path}"]
+            for entry in manifest.files
+        }
+        written = store.artifacts.write(
+            artifact_id=artifact_id,
+            artifact_type=manifest.artifact_type,
+            envelope=ArtifactEnvelope(
+                schema_version=manifest.schema_version,
+                created_at=manifest.created_at,
+                inputs=manifest.inputs,
+                code_revision=manifest.code_revision,
+                source=manifest.source,
+            ),
+            files=files,
+        )
+        if written != manifest:
+            raise ProjectBundleError(f"restored artifact manifest changed: {artifact_id}")
+    store.initialize(loaded.project)
+
+
+def _verify_restored_project(store: ProjectStore, loaded: _LoadedBundle) -> None:
+    """Reopen staged state and verify stage, closure, catalog, and runtime exclusion contracts."""
+    project = store.load_project()
+    if project != loaded.project:
+        raise ProjectBundleError("restored Project configuration changed")
+    if project.provider_free_stage is not None:
+        store.bind_provider_free_stage(project.provider_free_stage)
+    if project.build is not None:
+        store.bind_completed_build(project.build)
+
+    def resolve(artifact_id: str) -> ArtifactManifest:
+        """Resolve one fully verified staged artifact manifest."""
+        return store.artifacts.read(artifact_id).manifest
+
+    selected, manifests = _collect_selected_artifacts(project, resolve)
+    if selected != loaded.manifest.selected_artifacts or set(manifests) != set(loaded.artifacts):
+        raise ProjectBundleError("restored selected artifact closure changed")
+    _validate_catalog_from_store(store, project, manifests)
+    if store.paths.runtime_directory.exists():
+        raise ProjectBundleError("immutable bundle restore must not create mutable runtime state")
+
+
+def _require_safe_restore_root(root: Path) -> None:
+    """Reject a symlinked or non-directory restore root before creating staged state."""
+    if root.is_symlink():
+        raise ProjectBundleError(f"restore root must not be a symlink: {root}")
+    if root.exists() and not root.is_dir():
+        raise ProjectBundleError(f"restore root must be a directory: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    projects = root / "projects"
+    if projects.is_symlink():
+        raise ProjectBundleError(f"restore projects directory must not be a symlink: {projects}")
+    if projects.exists() and not projects.is_dir():
+        raise ProjectBundleError(f"restore projects path must be a directory: {projects}")
+
+
+def _reject_absolute_path_values(value: JsonValue, *, path: str) -> None:
+    """Reject local absolute filesystem strings from portable Project metadata."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _reject_absolute_path_values(item, path=f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_absolute_path_values(item, path=f"{path}[{index}]")
+        return
+    if not isinstance(value, str):
+        return
+    parsed = urlsplit(value)
+    windows = PureWindowsPath(value)
+    if (
+        PurePosixPath(value).is_absolute()
+        or windows.is_absolute()
+        or bool(windows.drive)
+        or parsed.scheme.casefold() == "file"
+    ):
+        raise ProjectBundleError(f"portable Project metadata contains an absolute path at {path}")
+
+
+def _require_unique_portable_names(names: Sequence[str]) -> None:
+    """Reject duplicate, case-colliding, and Unicode-normalization-colliding member names."""
+    exact: set[str] = set()
+    portable: set[str] = set()
+    for name in names:
+        if name in exact:
+            raise ProjectBundleError(f"Project bundle contains duplicate member {name}")
+        exact.add(name)
+        normalized = unicodedata.normalize("NFC", name).casefold()
+        if normalized in portable:
+            raise ProjectBundleError(
+                f"Project bundle contains a case- or Unicode-colliding member {name}"
+            )
+        portable.add(normalized)
+
+
+@contextmanager
+def _open_regular_file(path: Path) -> Iterator[BinaryIO]:
+    """Open one regular file descriptor without following a final symlink."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ProjectBundleError("secure bundle reads require O_NOFOLLOW")
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        raise ProjectBundleError(f"Project bundle is missing or unsafe: {path}") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ProjectBundleError(f"Project bundle is not a regular file: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            yield handle
+    finally:
+        os.close(descriptor)
+
+
+def _sha256_path(path: Path) -> str:
+    """Hash one regular non-symlink file through a stable descriptor."""
+    digest = hashlib.sha256(usedforsecurity=False)
+    with _open_regular_file(Path(path)) as handle:
+        while chunk := handle.read(_READ_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/wmo/common/project/bundle_test.py
+++ b/wmo/common/project/bundle_test.py
@@ -493,26 +493,65 @@ def test_restore_uses_the_same_descriptor_for_digest_and_archive_loading(
         tmp_path / "replacement.wmo-project",
         producer_revision=_REVISION,
     )
-    hash_file = bundle_module._sha256_file
+    copy_snapshot = bundle_module._copy_bundle_snapshot
     swapped = False
 
-    def hash_then_replace_path(handle: BinaryIO) -> str:
+    def copy_then_replace_path(source: BinaryIO, snapshot: BinaryIO) -> str:
         """Replace the pathname only after its already-open content has been authenticated."""
         nonlocal swapped
-        digest = hash_file(handle)
+        digest = copy_snapshot(source, snapshot)
         if not swapped:
             os.replace(replacement.path, authenticated.path)
             swapped = True
         return digest
 
-    monkeypatch.setattr(bundle_module, "_sha256_file", hash_then_replace_path)
+    monkeypatch.setattr(bundle_module, "_copy_bundle_snapshot", copy_then_replace_path)
     restored = restore_project_bundle(
         authenticated.path,
         root=tmp_path / "restored-root",
         expected_sha256=authenticated.sha256,
     )
 
+    assert swapped
     assert restored.paths.project_id == "portable-project"
+    assert restored.load_project().project_id == "portable-project"
+    assert not (tmp_path / "restored-root" / "projects" / "replacement-project").exists()
+
+
+def test_restore_loads_the_private_snapshot_when_the_source_inode_is_rewritten(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In-place source mutation after copying cannot change the authenticated Project."""
+    authenticated = export_project_bundle(
+        _project_store(tmp_path / "authenticated"),
+        tmp_path / "authenticated.wmo-project",
+        producer_revision=_REVISION,
+    )
+    replacement = export_project_bundle(
+        _project_store(tmp_path / "replacement", project_id="replacement-project"),
+        tmp_path / "replacement.wmo-project",
+        producer_revision=_REVISION,
+    )
+    replacement_bytes = replacement.path.read_bytes()
+    copy_snapshot = bundle_module._copy_bundle_snapshot
+    rewritten = False
+
+    def copy_then_rewrite_inode(source: BinaryIO, snapshot: BinaryIO) -> str:
+        """Rewrite the open source inode only after its bytes are in the private snapshot."""
+        nonlocal rewritten
+        digest = copy_snapshot(source, snapshot)
+        authenticated.path.write_bytes(replacement_bytes)
+        rewritten = True
+        return digest
+
+    monkeypatch.setattr(bundle_module, "_copy_bundle_snapshot", copy_then_rewrite_inode)
+    restored = restore_project_bundle(
+        authenticated.path,
+        root=tmp_path / "restored-root",
+        expected_sha256=authenticated.sha256,
+    )
+
+    assert rewritten
     assert restored.load_project().project_id == "portable-project"
     assert not (tmp_path / "restored-root" / "projects" / "replacement-project").exists()
 

--- a/wmo/common/project/bundle_test.py
+++ b/wmo/common/project/bundle_test.py
@@ -9,6 +9,7 @@ import zipfile
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import BinaryIO
 
 import pytest
 
@@ -65,9 +66,14 @@ def _catalog_model(alias: str) -> ProjectCatalogModel:
     )
 
 
-def _project_store(tmp_path: Path, *, with_catalog: bool = False) -> ProjectStore:
+def _project_store(
+    tmp_path: Path,
+    *,
+    with_catalog: bool = False,
+    project_id: str = "portable-project",
+) -> ProjectStore:
     """Create a selected provider-free graph plus one unrelated sibling artifact."""
-    store = ProjectStore(tmp_path / "source-root", "portable-project")
+    store = ProjectStore(tmp_path / "source-root", project_id)
     trace = store.artifacts.write_json(
         artifact_id="trace-selected",
         artifact_type="trace-dataset",
@@ -109,7 +115,7 @@ def _project_store(tmp_path: Path, *, with_catalog: bool = False) -> ProjectStor
     models = None
     if with_catalog:
         catalog = ProjectModelCatalog(
-            project_id="portable-project",
+            project_id=project_id,
             models=(
                 _catalog_model("baseline"),
                 _catalog_model("candidate-a"),
@@ -137,7 +143,7 @@ def _project_store(tmp_path: Path, *, with_catalog: bool = False) -> ProjectStor
     )
     store.initialize(
         ProjectConfig(
-            project_id="portable-project",
+            project_id=project_id,
             trace_preparation=ProjectTracePreparationSettings(source_kind="otlp"),
             provider_free_stage=stage,
             models=models,
@@ -471,6 +477,44 @@ def test_restore_requires_exact_digest_absent_destination_and_hard_bounds(
             expected_sha256=exported.sha256,
         )
     assert not (bounded_root / "projects" / "portable-project").exists()
+
+
+def test_restore_uses_the_same_descriptor_for_digest_and_archive_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replacing the pathname after hashing cannot substitute another valid Project bundle."""
+    authenticated = export_project_bundle(
+        _project_store(tmp_path / "authenticated"),
+        tmp_path / "authenticated.wmo-project",
+        producer_revision=_REVISION,
+    )
+    replacement = export_project_bundle(
+        _project_store(tmp_path / "replacement", project_id="replacement-project"),
+        tmp_path / "replacement.wmo-project",
+        producer_revision=_REVISION,
+    )
+    hash_file = bundle_module._sha256_file
+    swapped = False
+
+    def hash_then_replace_path(handle: BinaryIO) -> str:
+        """Replace the pathname only after its already-open content has been authenticated."""
+        nonlocal swapped
+        digest = hash_file(handle)
+        if not swapped:
+            os.replace(replacement.path, authenticated.path)
+            swapped = True
+        return digest
+
+    monkeypatch.setattr(bundle_module, "_sha256_file", hash_then_replace_path)
+    restored = restore_project_bundle(
+        authenticated.path,
+        root=tmp_path / "restored-root",
+        expected_sha256=authenticated.sha256,
+    )
+
+    assert restored.paths.project_id == "portable-project"
+    assert restored.load_project().project_id == "portable-project"
+    assert not (tmp_path / "restored-root" / "projects" / "replacement-project").exists()
 
 
 def test_bundle_manifest_does_not_duplicate_artifact_provenance() -> None:

--- a/wmo/common/project/bundle_test.py
+++ b/wmo/common/project/bundle_test.py
@@ -1,0 +1,688 @@
+"""Tests for deterministic, verified, secret-free Project bundles."""
+
+from __future__ import annotations
+
+import os
+import stat
+import warnings
+import zipfile
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import wmo.common.project.bundle as bundle_module
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    SourceIdentity,
+    canonical_json_bytes,
+    sha256_bytes,
+)
+from wmo.common.models import ModelCapabilities, ModelSnapshot
+from wmo.common.project import (
+    ProjectConfig,
+    ProjectModelConfiguration,
+    ProjectProviderFreeStage,
+    ProjectStore,
+    ProjectTracePreparationSettings,
+    artifact_input,
+    export_project_bundle,
+    restore_project_bundle,
+)
+from wmo.common.project.bundle import ProjectBundleError
+from wmo.common.project.catalog import (
+    ProjectCatalogModel,
+    ProjectModelCatalog,
+    persist_project_model_catalog,
+)
+from wmo.common.project.events import ProjectStage
+from wmo.common.project.manifests import ArtifactManifest, file_digest
+from wmo.common.project.project import write_project_config
+
+_CREATED_AT = datetime(2026, 8, 17, tzinfo=UTC)
+_REVISION = "producer-revision"
+
+
+def _catalog_model(alias: str) -> ProjectCatalogModel:
+    """Build one portable model snapshot for a catalog fixture."""
+    capabilities = ModelCapabilities(
+        supports_completions=True,
+        context_window_tokens=8_192,
+        maximum_output_tokens=1_024,
+        input_cost_per_million_tokens_usd=1.0,
+        output_cost_per_million_tokens_usd=2.0,
+    )
+    return ProjectCatalogModel(
+        alias=alias,
+        model=ModelSnapshot(
+            provider="openai",
+            model_id=f"model-{alias}",
+            capabilities_sha256=capabilities.identity_sha256(),
+            connection_sha256="c" * 64,
+        ),
+        capabilities=capabilities,
+    )
+
+
+def _project_store(tmp_path: Path, *, with_catalog: bool = False) -> ProjectStore:
+    """Create a selected provider-free graph plus one unrelated sibling artifact."""
+    store = ProjectStore(tmp_path / "source-root", "portable-project")
+    trace = store.artifacts.write_json(
+        artifact_id="trace-selected",
+        artifact_type="trace-dataset",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=_CREATED_AT,
+            code_revision=_REVISION,
+            source=SourceIdentity(
+                kind="file",
+                source_id="platform-source:upload-1",
+                sha256="a" * 64,
+            ),
+        ),
+        files={"nested/trace.json": {"trace_id": "trace-1"}},
+    )
+    trace_input = artifact_input(trace)
+    task = store.artifacts.write_json(
+        artifact_id="tasks-selected",
+        artifact_type="task-set",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=_CREATED_AT,
+            code_revision=_REVISION,
+            inputs=(trace_input,),
+        ),
+        files={"tasks.json": {"task_ids": ["task-1"]}},
+    )
+    store.artifacts.write_json(
+        artifact_id="tasks-unselected",
+        artifact_type="task-set",
+        envelope=ArtifactEnvelope(
+            schema_version=1,
+            created_at=_CREATED_AT,
+            code_revision=_REVISION,
+        ),
+        files={"tasks.json": {"task_ids": ["unselected"]}},
+    )
+    catalog_pointer = None
+    models = None
+    if with_catalog:
+        catalog = ProjectModelCatalog(
+            project_id="portable-project",
+            models=(
+                _catalog_model("baseline"),
+                _catalog_model("candidate-a"),
+                _catalog_model("candidate-b"),
+                _catalog_model("embedder"),
+                _catalog_model("judge"),
+                _catalog_model("world-model"),
+            ),
+        )
+        catalog_pointer = persist_project_model_catalog(
+            store.artifacts,
+            catalog,
+            created_at=_CREATED_AT,
+            code_revision=_REVISION,
+        )
+        models = ProjectModelConfiguration(
+            world_model="world-model",
+            judge="judge",
+            embedder="embedder",
+            candidates=("baseline", "candidate-a", "candidate-b"),
+        )
+    stage = ProjectProviderFreeStage(
+        trace_dataset=trace_input,
+        task_set=artifact_input(task),
+    )
+    store.initialize(
+        ProjectConfig(
+            project_id="portable-project",
+            trace_preparation=ProjectTracePreparationSettings(source_kind="otlp"),
+            provider_free_stage=stage,
+            models=models,
+            model_catalog=catalog_pointer,
+            retrieval=None,
+            budgets=None,
+        )
+    )
+    store.paths.runtime_directory.mkdir()
+    store.paths.runtime_journal.write_text('{"mutable":true}\n', encoding="utf-8")
+    return store
+
+
+def _canonical_info(name: str, *, mode: int = stat.S_IFREG | 0o600) -> zipfile.ZipInfo:
+    """Return one deterministic Unix ZIP member descriptor for adversarial fixtures."""
+    info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_STORED
+    info.external_attr = mode << 16
+    return info
+
+
+def _rewrite_bundle(
+    source: Path,
+    destination: Path,
+    transform: Callable[[list[tuple[zipfile.ZipInfo, bytes]]], None],
+) -> Path:
+    """Copy a bundle after applying one deliberate archive-level corruption."""
+    with zipfile.ZipFile(source, "r") as archive:
+        entries = [(info, archive.read(info)) for info in archive.infolist()]
+    transform(entries)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Duplicate name:", category=UserWarning)
+        with zipfile.ZipFile(destination, "w") as archive:
+            for info, payload in entries:
+                archive.writestr(info, payload)
+    return destination
+
+
+def test_provider_free_bundle_is_deterministic_minimal_and_portable(tmp_path: Path) -> None:
+    """Only the selected closure round-trips under a different root with stable identities."""
+    store = _project_store(tmp_path)
+    first = export_project_bundle(
+        store,
+        tmp_path / "first.wmo-project",
+        producer_revision=_REVISION,
+    )
+    second = export_project_bundle(
+        store,
+        tmp_path / "second.wmo-project",
+        producer_revision=_REVISION,
+    )
+
+    assert first.sha256 == second.sha256
+    assert first.path.read_bytes() == second.path.read_bytes()
+    assert tuple(item.artifact_id for item in first.manifest.selected_artifacts) == (
+        "tasks-selected",
+        "trace-selected",
+    )
+    assert first.manifest.completed_stages == (ProjectStage.PREPARING_TRACES,)
+    assert first.manifest.runtime_state == "excluded"
+    with zipfile.ZipFile(first.path, "r") as archive:
+        names = archive.namelist()
+    assert "artifacts/tasks-unselected/manifest.json" not in names
+    assert "runtime/interactions.jsonl" not in names
+    assert all("\\" not in name and not name.startswith("/") for name in names)
+
+    restored = restore_project_bundle(
+        first.path,
+        root=tmp_path / "different-absolute-root",
+        expected_sha256=first.sha256,
+    )
+
+    assert restored.load_project() == store.load_project()
+    assert restored.artifacts.list_ids() == ("tasks-selected", "trace-selected")
+    assert not restored.paths.runtime_directory.exists()
+    for artifact_id in restored.artifacts.list_ids():
+        assert artifact_input(restored.artifacts.read(artifact_id).manifest) == artifact_input(
+            store.artifacts.read(artifact_id).manifest
+        )
+
+
+def test_catalog_binding_round_trips_without_ambient_models_toml(tmp_path: Path) -> None:
+    """An explicit project catalog is in closure while root-global catalog bytes are irrelevant."""
+    store = _project_store(tmp_path, with_catalog=True)
+    store.model_catalog_path.write_text("ambient = 'first'\n", encoding="utf-8")
+    first = export_project_bundle(
+        store,
+        tmp_path / "catalog-first.wmo-project",
+        producer_revision=_REVISION,
+    )
+    store.model_catalog_path.write_text("ambient = 'changed'\n", encoding="utf-8")
+    second = export_project_bundle(
+        store,
+        tmp_path / "catalog-second.wmo-project",
+        producer_revision=_REVISION,
+    )
+
+    assert first.sha256 == second.sha256
+    catalog_pointer = store.load_project().model_catalog
+    assert catalog_pointer is not None
+    assert catalog_pointer in first.manifest.selected_artifacts
+    restored = restore_project_bundle(
+        first.path,
+        root=tmp_path / "restored-catalog-root",
+        expected_sha256=first.sha256,
+    )
+    assert restored.load_project().model_catalog == catalog_pointer
+    assert not restored.model_catalog_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "transform", "message"),
+    [
+        (
+            "missing",
+            lambda entries: entries.pop(0),
+            "member set",
+        ),
+        (
+            "extra",
+            lambda entries: entries.append((_canonical_info("extra.txt"), b"extra")),
+            "member set",
+        ),
+        (
+            "duplicate",
+            lambda entries: entries.append(entries[0]),
+            "duplicate",
+        ),
+        (
+            "case-collision",
+            lambda entries: entries.append((_canonical_info("PROJECT.JSON"), b"{}")),
+            "colliding member",
+        ),
+        (
+            "unicode-collision",
+            lambda entries: entries.extend(
+                (
+                    (_canonical_info("caf\N{LATIN SMALL LETTER E WITH ACUTE}.txt"), b"first"),
+                    (_canonical_info("cafe\N{COMBINING ACUTE ACCENT}.txt"), b"second"),
+                )
+            ),
+            "colliding member",
+        ),
+        (
+            "traversal",
+            lambda entries: entries.append((_canonical_info("../escape"), b"escape")),
+            "relative POSIX",
+        ),
+        (
+            "absolute",
+            lambda entries: entries.append((_canonical_info("/escape"), b"escape")),
+            "relative POSIX",
+        ),
+        (
+            "backslash",
+            lambda entries: entries.append((_canonical_info(r"artifacts\\escape"), b"escape")),
+            "relative POSIX",
+        ),
+        (
+            "symlink",
+            lambda entries: entries.append(
+                ((_canonical_info("unsafe-link", mode=stat.S_IFLNK | 0o777)), b"project.json")
+            ),
+            "regular files",
+        ),
+        (
+            "fifo",
+            lambda entries: entries.append(
+                ((_canonical_info("unsafe-fifo", mode=stat.S_IFIFO | 0o600)), b"pipe")
+            ),
+            "regular files",
+        ),
+    ],
+)
+def test_restore_rejects_unsafe_archive_members(
+    tmp_path: Path,
+    name: str,
+    transform: Callable[[list[tuple[zipfile.ZipInfo, bytes]]], None],
+    message: str,
+) -> None:
+    """Archive membership attacks fail before the destination Project becomes visible."""
+    exported = export_project_bundle(
+        _project_store(tmp_path),
+        tmp_path / "valid.wmo-project",
+        producer_revision=_REVISION,
+    )
+    corrupted = _rewrite_bundle(exported.path, tmp_path / f"{name}.zip", transform)
+    digest = bundle_module._sha256_path(corrupted)
+    root = tmp_path / f"restore-{name}"
+
+    with pytest.raises(ProjectBundleError, match=message):
+        restore_project_bundle(corrupted, root=root, expected_sha256=digest)
+
+    assert not (root / "projects" / "portable-project").exists()
+
+
+def test_restore_rejects_corruption_schema_drift_and_compression(tmp_path: Path) -> None:
+    """Payload drift, unsupported schemas, and compressed expansion inputs fail closed."""
+    exported = export_project_bundle(
+        _project_store(tmp_path),
+        tmp_path / "valid.wmo-project",
+        producer_revision=_REVISION,
+    )
+
+    def corrupt_payload(entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+        """Change a selected payload without updating its bundle digest record."""
+        index = next(
+            index
+            for index, (info, _payload) in enumerate(entries)
+            if info.filename.endswith("tasks.json")
+        )
+        info, _payload = entries[index]
+        entries[index] = (info, b'{"task_ids":["changed"]}')
+
+    corrupt = _rewrite_bundle(
+        exported.path,
+        tmp_path / "corrupt.zip",
+        corrupt_payload,
+    )
+    with pytest.raises(ProjectBundleError, match="digest"):
+        restore_project_bundle(
+            corrupt,
+            root=tmp_path / "corrupt-root",
+            expected_sha256=bundle_module._sha256_path(corrupt),
+        )
+
+    def change_schema(entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+        """Replace the bundle schema with an unsupported future value."""
+        index = next(
+            index
+            for index, (info, _payload) in enumerate(entries)
+            if info.filename == "bundle.json"
+        )
+        info, payload = entries[index]
+        raw = bundle_module._JSON_OBJECT_ADAPTER.validate_json(payload)
+        assert isinstance(raw, dict)
+        raw["schema_version"] = 999
+        entries[index] = (info, canonical_json_bytes(raw))
+
+    schema = _rewrite_bundle(exported.path, tmp_path / "schema.zip", change_schema)
+    with pytest.raises(ProjectBundleError, match="manifest"):
+        restore_project_bundle(
+            schema,
+            root=tmp_path / "schema-root",
+            expected_sha256=bundle_module._sha256_path(schema),
+        )
+
+    def compress_member(entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+        """Mark one member as compressed so expansion is never attempted."""
+        info, payload = entries[0]
+        replacement = _canonical_info(info.filename)
+        replacement.compress_type = zipfile.ZIP_DEFLATED
+        entries[0] = (replacement, payload)
+
+    compressed = _rewrite_bundle(exported.path, tmp_path / "compressed.zip", compress_member)
+    with pytest.raises(ProjectBundleError, match="uncompressed"):
+        restore_project_bundle(
+            compressed,
+            root=tmp_path / "compressed-root",
+            expected_sha256=bundle_module._sha256_path(compressed),
+        )
+
+
+def test_bundle_rejects_unsupported_project_schema_and_truncation(tmp_path: Path) -> None:
+    """Future Project schemas and incomplete archives fail before destination visibility."""
+    unsupported = _project_store(tmp_path / "unsupported")
+    write_project_config(
+        unsupported.paths.project_toml,
+        unsupported.load_project().model_copy(update={"schema_version": 999}),
+    )
+    with pytest.raises(ProjectBundleError, match="schema version is unsupported"):
+        export_project_bundle(
+            unsupported,
+            tmp_path / "unsupported.wmo-project",
+            producer_revision=_REVISION,
+        )
+
+    exported = export_project_bundle(
+        _project_store(tmp_path / "truncated"),
+        tmp_path / "valid-for-truncation.wmo-project",
+        producer_revision=_REVISION,
+    )
+    truncated = tmp_path / "truncated.wmo-project"
+    truncated.write_bytes(exported.path.read_bytes()[:32])
+    root = tmp_path / "truncated-root"
+    with pytest.raises(ProjectBundleError, match="readable archive"):
+        restore_project_bundle(
+            truncated,
+            root=root,
+            expected_sha256=bundle_module._sha256_path(truncated),
+        )
+    assert not (root / "projects" / "portable-project").exists()
+
+
+def test_restore_requires_exact_digest_absent_destination_and_hard_bounds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Restore verifies content identity, destination absence, and expansion before writing."""
+    exported = export_project_bundle(
+        _project_store(tmp_path),
+        tmp_path / "valid.wmo-project",
+        producer_revision=_REVISION,
+    )
+    with pytest.raises(ProjectBundleError, match="content digest"):
+        restore_project_bundle(
+            exported.path,
+            root=tmp_path / "wrong-digest-root",
+            expected_sha256="0" * 64,
+        )
+
+    existing_root = tmp_path / "existing-root"
+    existing = existing_root / "projects" / "portable-project"
+    existing.mkdir(parents=True)
+    sentinel = existing / "sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+    with pytest.raises(ProjectBundleError, match="destination must be absent"):
+        restore_project_bundle(
+            exported.path,
+            root=existing_root,
+            expected_sha256=exported.sha256,
+        )
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+    monkeypatch.setattr(bundle_module, "_MAX_EXPANDED_BYTES", 1)
+    bounded_root = tmp_path / "bounded-root"
+    with pytest.raises(ProjectBundleError, match="expanded-byte limit"):
+        restore_project_bundle(
+            exported.path,
+            root=bounded_root,
+            expected_sha256=exported.sha256,
+        )
+    assert not (bounded_root / "projects" / "portable-project").exists()
+
+
+def test_bundle_manifest_does_not_duplicate_artifact_provenance() -> None:
+    """Stage selection stays small while artifact manifests own source and lineage fields."""
+    assert {
+        "source",
+        "source_id",
+        "created_at",
+        "inputs",
+        "artifact_producer_revision",
+    }.isdisjoint(bundle_module.ProjectBundleManifest.model_fields)
+
+
+def test_export_rejects_secret_bearing_and_absolute_source_provenance(tmp_path: Path) -> None:
+    """A self-consistent forged graph still fails the bundle's secret and path boundaries."""
+    secret_store = _project_store(tmp_path / "secret")
+    _rewrite_trace_graph(
+        secret_store,
+        payload={"authorization": "Bearer abcdefghijklmnopqrstuvwxyz"},
+    )
+    with pytest.raises(ProjectBundleError, match="secret boundary"):
+        export_project_bundle(
+            secret_store,
+            tmp_path / "secret.wmo-project",
+            producer_revision=_REVISION,
+        )
+
+    path_store = _project_store(tmp_path / "path")
+    _rewrite_trace_graph(path_store, source_id="/tmp/worker-upload.json")
+    with pytest.raises(ProjectBundleError, match="worker-local"):
+        export_project_bundle(
+            path_store,
+            tmp_path / "path.wmo-project",
+            producer_revision=_REVISION,
+        )
+
+
+def test_restore_rejects_a_digest_consistent_secret_bearing_artifact(tmp_path: Path) -> None:
+    """Recomputed archive and provenance digests cannot bypass artifact secret validation."""
+    exported = export_project_bundle(
+        _project_store(tmp_path),
+        tmp_path / "valid.wmo-project",
+        producer_revision=_REVISION,
+    )
+
+    def inject_secret(entries: list[tuple[zipfile.ZipInfo, bytes]]) -> None:
+        """Rebind every affected digest around one malicious selected trace payload."""
+        by_name = {info.filename: index for index, (info, _payload) in enumerate(entries)}
+        changed: dict[str, bytes] = {}
+        trace_data_path = "artifacts/trace-selected/nested/trace.json"
+        changed[trace_data_path] = canonical_json_bytes(
+            {"authorization": "Bearer abcdefghijklmnopqrstuvwxyz"}
+        )
+        trace_manifest_path = "artifacts/trace-selected/manifest.json"
+        trace_manifest = ArtifactManifest.model_validate_json(
+            entries[by_name[trace_manifest_path]][1]
+        ).model_copy(
+            update={"files": (file_digest("nested/trace.json", changed[trace_data_path]),)}
+        )
+        changed[trace_manifest_path] = canonical_json_bytes(trace_manifest)
+        trace_pointer = artifact_input(trace_manifest)
+
+        task_manifest_path = "artifacts/tasks-selected/manifest.json"
+        task_manifest = ArtifactManifest.model_validate_json(
+            entries[by_name[task_manifest_path]][1]
+        ).model_copy(update={"inputs": (trace_pointer,)})
+        changed[task_manifest_path] = canonical_json_bytes(task_manifest)
+        task_pointer = artifact_input(task_manifest)
+
+        project = ProjectConfig.model_validate_json(entries[by_name["project.json"]][1])
+        project = project.model_copy(
+            update={
+                "provider_free_stage": ProjectProviderFreeStage(
+                    trace_dataset=trace_pointer,
+                    task_set=task_pointer,
+                )
+            }
+        )
+        changed["project.json"] = canonical_json_bytes(project)
+
+        bundle_manifest = bundle_module.ProjectBundleManifest.model_validate_json(
+            entries[by_name["bundle.json"]][1]
+        )
+        members = tuple(
+            member.model_copy(
+                update={
+                    "sha256": sha256_bytes(
+                        changed.get(member.path, entries[by_name[member.path]][1])
+                    ),
+                    "size_bytes": len(changed.get(member.path, entries[by_name[member.path]][1])),
+                }
+            )
+            for member in bundle_manifest.members
+        )
+        bundle_manifest = bundle_manifest.model_copy(
+            update={
+                "selected_artifacts": tuple(
+                    sorted((task_pointer, trace_pointer), key=lambda item: item.artifact_id)
+                ),
+                "members": members,
+                "expanded_size_bytes": sum(member.size_bytes for member in members),
+            }
+        )
+        changed["bundle.json"] = canonical_json_bytes(bundle_manifest)
+        for member_path, payload in changed.items():
+            index = by_name[member_path]
+            info, _old_payload = entries[index]
+            entries[index] = (info, payload)
+
+    poisoned = _rewrite_bundle(
+        exported.path,
+        tmp_path / "secret-bearing.wmo-project",
+        inject_secret,
+    )
+    root = tmp_path / "secret-restore-root"
+    with pytest.raises(ProjectBundleError, match="secret boundary"):
+        restore_project_bundle(
+            poisoned,
+            root=root,
+            expected_sha256=bundle_module._sha256_path(poisoned),
+        )
+    assert not (root / "projects" / "portable-project").exists()
+
+
+def _rewrite_trace_graph(
+    store: ProjectStore,
+    *,
+    payload: dict[str, str] | None = None,
+    source_id: str = "platform-source:upload-1",
+) -> None:
+    """Forge a digest-consistent selected graph for boundary-failure tests."""
+    trace_directory = store.paths.artifact_directory("trace-selected")
+    trace_manifest = ArtifactManifest.model_validate_json(
+        (trace_directory / "manifest.json").read_bytes()
+    )
+    trace_payload = canonical_json_bytes(payload or {"trace_id": "trace-1"})
+    (trace_directory / "nested/trace.json").write_bytes(trace_payload)
+    source = trace_manifest.source
+    assert source is not None
+    trace_manifest = trace_manifest.model_copy(
+        update={
+            "source": source.model_copy(update={"source_id": source_id}),
+            "files": (file_digest("nested/trace.json", trace_payload),),
+        }
+    )
+    (trace_directory / "manifest.json").write_bytes(canonical_json_bytes(trace_manifest))
+    trace_pointer = artifact_input(trace_manifest)
+
+    task_directory = store.paths.artifact_directory("tasks-selected")
+    task_manifest = ArtifactManifest.model_validate_json(
+        (task_directory / "manifest.json").read_bytes()
+    ).model_copy(update={"inputs": (trace_pointer,)})
+    (task_directory / "manifest.json").write_bytes(canonical_json_bytes(task_manifest))
+    project = store.load_project()
+    write_project_config(
+        store.paths.project_toml,
+        project.model_copy(
+            update={
+                "provider_free_stage": ProjectProviderFreeStage(
+                    trace_dataset=trace_pointer,
+                    task_set=artifact_input(task_manifest),
+                )
+            }
+        ),
+    )
+
+
+def test_restore_failure_never_exposes_a_partial_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure at the final atomic rename leaves no selected destination Project."""
+    exported = export_project_bundle(
+        _project_store(tmp_path),
+        tmp_path / "valid.wmo-project",
+        producer_revision=_REVISION,
+    )
+    root = tmp_path / "restore-root"
+
+    def fail_rename(source: os.PathLike[str], destination: os.PathLike[str]) -> None:
+        """Simulate a crash immediately before destination visibility."""
+        raise OSError(f"cannot rename {source!s} to {destination!s}")
+
+    monkeypatch.setattr(bundle_module.os, "rename", fail_rename)
+    with pytest.raises(ProjectBundleError, match="atomically restore"):
+        restore_project_bundle(
+            exported.path,
+            root=root,
+            expected_sha256=exported.sha256,
+        )
+
+    assert not (root / "projects" / "portable-project").exists()
+    assert not tuple(root.glob(".restore-*.partial"))
+
+
+def test_export_failure_never_replaces_the_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed final export promotion removes its temporary file and leaves no target."""
+    store = _project_store(tmp_path)
+    destination = tmp_path / "failed-export.wmo-project"
+
+    def fail_replace(source: os.PathLike[str], target: os.PathLike[str]) -> None:
+        """Simulate a crash immediately before bundle publication."""
+        raise OSError(f"cannot replace {source!s} with {target!s}")
+
+    monkeypatch.setattr(bundle_module.os, "replace", fail_replace)
+    with pytest.raises(ProjectBundleError, match="atomically export"):
+        export_project_bundle(
+            store,
+            destination,
+            producer_revision=_REVISION,
+        )
+
+    assert not destination.exists()
+    assert not tuple(tmp_path.glob(".failed-export.wmo-project.*.partial"))

--- a/wmo/common/project/catalog.py
+++ b/wmo/common/project/catalog.py
@@ -1,0 +1,141 @@
+"""Credential-free model snapshots bound to one portable WMO Project."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Annotated, Literal
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactEnvelope,
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    canonical_json_bytes,
+    stable_id,
+)
+from wmo.common.models import ModelCapabilities, ModelSnapshot
+from wmo.common.project.manifests import artifact_input
+
+if TYPE_CHECKING:
+    from wmo.common.project.store import ArtifactStore
+
+_CATALOG_ARTIFACT_TYPE = "project-model-catalog"
+_CATALOG_FILE = "catalog.json"
+
+
+class ProjectModelCatalogError(ValueError):
+    """A project-scoped model catalog artifact was absent, stale, or malformed."""
+
+
+class ProjectCatalogModel(ContractModel):
+    """One stable alias with its exact secret-free model and capability snapshots."""
+
+    alias: ArtifactId
+    model: ModelSnapshot
+    capabilities: ModelCapabilities
+
+    @model_validator(mode="after")
+    def _require_matching_capability_digest(self) -> ProjectCatalogModel:
+        """Require the model identity to bind the accompanying capability declaration."""
+        if self.model.capabilities_sha256 != self.capabilities.identity_sha256():
+            raise ValueError("project catalog model capability digest does not match its snapshot")
+        return self
+
+
+class ProjectModelCatalog(ContractModel):
+    """The exact credential-free model metadata selected by one Project."""
+
+    schema_version: Literal[1] = 1
+    project_id: ArtifactId
+    models: Annotated[tuple[ProjectCatalogModel, ...], Field(min_length=1)]
+
+    @field_validator("models")
+    @classmethod
+    def _require_sorted_unique_models(
+        cls, value: tuple[ProjectCatalogModel, ...]
+    ) -> tuple[ProjectCatalogModel, ...]:
+        """Require canonical alias order and reject repeated model aliases."""
+        aliases = tuple(item.alias for item in value)
+        if len(set(aliases)) != len(aliases):
+            raise ValueError("project catalog model aliases must not repeat")
+        if aliases != tuple(sorted(aliases)):
+            raise ValueError("project catalog models must be sorted by alias")
+        return value
+
+
+def persist_project_model_catalog(
+    store: ArtifactStore,
+    catalog: ProjectModelCatalog,
+    *,
+    created_at: datetime,
+    code_revision: str,
+) -> ArtifactInput:
+    """Persist one immutable project catalog and return its exact manifest pointer.
+
+    Args:
+        store: Project-local immutable artifact store.
+        catalog: Secret-free aliases and exact model metadata to bind.
+        created_at: Stable attempt timestamp for exact replay.
+        code_revision: Exact WMO revision producing the catalog artifact.
+
+    Returns:
+        Exact artifact-manifest input for ``ProjectConfig.model_catalog``.
+
+    Raises:
+        ProjectModelCatalogError: The catalog collides with different persisted content.
+    """
+    catalog_id = stable_id(
+        _CATALOG_ARTIFACT_TYPE,
+        {
+            "catalog": catalog.model_dump(mode="json"),
+            "code_revision": code_revision,
+        },
+    )
+    try:
+        manifest = store.write_or_verify_exact(
+            artifact_id=catalog_id,
+            artifact_type=_CATALOG_ARTIFACT_TYPE,
+            envelope=ArtifactEnvelope(
+                schema_version=catalog.schema_version,
+                created_at=created_at,
+                code_revision=code_revision,
+            ),
+            files={_CATALOG_FILE: canonical_json_bytes(catalog)},
+        )
+    except (ValueError, RuntimeError) as exc:
+        raise ProjectModelCatalogError(f"cannot persist project model catalog: {exc}") from exc
+    return artifact_input(manifest)
+
+
+def load_project_model_catalog(
+    store: ArtifactStore,
+    pointer: ArtifactInput,
+) -> ProjectModelCatalog:
+    """Load and verify one exact project-scoped catalog artifact.
+
+    Args:
+        store: Project-local immutable artifact store.
+        pointer: Exact manifest identity selected by the Project.
+
+    Returns:
+        Parsed credential-free model metadata.
+
+    Raises:
+        ProjectModelCatalogError: The pointer, artifact type, file set, or payload is invalid.
+    """
+    try:
+        stored = store.read(pointer.artifact_id)
+        if stored.manifest.artifact_type != _CATALOG_ARTIFACT_TYPE:
+            raise ValueError("project catalog pointer names the wrong artifact type")
+        if artifact_input(stored.manifest) != pointer:
+            raise ValueError("project catalog manifest digest changed")
+        if tuple(item.path for item in stored.manifest.files) != (_CATALOG_FILE,):
+            raise ValueError("project catalog artifact must contain only catalog.json")
+        catalog = ProjectModelCatalog.model_validate_json(
+            store.read_bytes(pointer.artifact_id, _CATALOG_FILE)
+        )
+    except (RuntimeError, ValidationError, ValueError) as exc:
+        raise ProjectModelCatalogError(f"cannot load project model catalog: {exc}") from exc
+    return catalog

--- a/wmo/common/project/catalog_test.py
+++ b/wmo/common/project/catalog_test.py
@@ -1,0 +1,103 @@
+"""Tests for the credential-free Project model-catalog artifact seam."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.models import ModelCapabilities, ModelSnapshot
+from wmo.common.project import ProjectStore
+from wmo.common.project.catalog import (
+    ProjectCatalogModel,
+    ProjectModelCatalog,
+    load_project_model_catalog,
+    persist_project_model_catalog,
+)
+
+_CREATED_AT = datetime(2026, 8, 17, tzinfo=UTC)
+
+
+def _model(alias: str) -> ProjectCatalogModel:
+    """Build one internally consistent secret-free catalog entry."""
+    capabilities = ModelCapabilities(
+        supports_completions=True,
+        context_window_tokens=16_384,
+        maximum_output_tokens=2_048,
+        input_cost_per_million_tokens_usd=1.0,
+        output_cost_per_million_tokens_usd=2.0,
+    )
+    return ProjectCatalogModel(
+        alias=alias,
+        model=ModelSnapshot(
+            provider="openai",
+            model_id=f"model-{alias}",
+            capabilities_sha256=capabilities.identity_sha256(),
+            connection_sha256="b" * 64,
+        ),
+        capabilities=capabilities,
+    )
+
+
+def test_project_catalog_persists_and_replays_as_one_exact_artifact(tmp_path: Path) -> None:
+    """The project-scoped snapshot has a stable ID and never reads ambient models.toml."""
+    store = ProjectStore(tmp_path / ".wmo", "project-1")
+    catalog = ProjectModelCatalog(
+        project_id="project-1",
+        models=(_model("baseline"), _model("candidate")),
+    )
+    ambient = store.model_catalog_path
+    ambient.parent.mkdir(parents=True)
+    ambient.write_text("api_key_env = 'DO_NOT_READ'\n", encoding="utf-8")
+
+    first = persist_project_model_catalog(
+        store.artifacts,
+        catalog,
+        created_at=_CREATED_AT,
+        code_revision="producer-revision",
+    )
+    ambient.write_text("changed = true\n", encoding="utf-8")
+    replay = persist_project_model_catalog(
+        store.artifacts,
+        catalog,
+        created_at=_CREATED_AT,
+        code_revision="producer-revision",
+    )
+
+    assert replay == first
+    assert load_project_model_catalog(store.artifacts, first) == catalog
+    assert store.artifacts.list_ids() == (first.artifact_id,)
+
+
+def test_project_catalog_requires_sorted_unique_models_and_matching_capability_digest() -> None:
+    """Alias order and immutable capability identities fail closed before persistence."""
+    baseline = _model("baseline")
+    candidate = _model("candidate")
+    with pytest.raises(ValidationError, match="sorted by alias"):
+        ProjectModelCatalog(
+            project_id="project-1",
+            models=(candidate, baseline),
+        )
+    with pytest.raises(ValidationError, match="must not repeat"):
+        ProjectModelCatalog(
+            project_id="project-1",
+            models=(baseline, baseline),
+        )
+    with pytest.raises(ValidationError, match="capability digest"):
+        ProjectCatalogModel(
+            alias="baseline",
+            model=baseline.model.model_copy(update={"capabilities_sha256": "c" * 64}),
+            capabilities=baseline.capabilities,
+        )
+
+
+def test_project_catalog_has_no_credential_or_connection_reference_fields() -> None:
+    """The portable catalog carries model identity, capabilities, and no secret handle seam."""
+    assert set(ProjectCatalogModel.model_fields) == {"alias", "model", "capabilities"}
+    assert set(ProjectModelCatalog.model_fields) == {
+        "schema_version",
+        "project_id",
+        "models",
+    }

--- a/wmo/common/project/events.py
+++ b/wmo/common/project/events.py
@@ -1,0 +1,94 @@
+"""Typed, transport-neutral domain events for durable WMO Project stages."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import AwareDatetime, Field, field_validator, model_validator
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    ArtifactInput,
+    ContractModel,
+    FailureCode,
+)
+
+
+class ProjectStage(StrEnum):
+    """WMO-owned durable stages exposed to hosted Project orchestration."""
+
+    PREPARING_TRACES = "preparing_traces"
+    BUILDING_WORLD_MODEL = "building_world_model"
+    OPTIMIZING_ROUTER = "optimizing_router"
+    COMPLETING_REPORT = "completing_report"
+
+
+class ProjectStageEventKind(StrEnum):
+    """Supported state transitions and bounded progress observations for one stage."""
+
+    STARTED = "started"
+    PROGRESS = "progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ProjectStageFailure(ContractModel):
+    """Customer-safe failure identity without provider text or free-form detail payloads."""
+
+    code: FailureCode
+    retryable: bool = False
+    detail_code: ArtifactId | None = None
+
+
+class ProjectStageEvent(ContractModel):
+    """One ordered WMO domain event independent of persistence and delivery transport."""
+
+    schema_version: Literal[1] = 1
+    event_id: ArtifactId
+    project_id: ArtifactId
+    attempt_id: ArtifactId
+    sequence: int = Field(ge=0)
+    occurred_at: AwareDatetime
+    stage: ProjectStage
+    kind: ProjectStageEventKind
+    completed_units: int | None = Field(default=None, ge=0)
+    total_units: int | None = Field(default=None, gt=0)
+    outputs: tuple[ArtifactInput, ...] = ()
+    failure: ProjectStageFailure | None = None
+
+    @field_validator("outputs")
+    @classmethod
+    def _require_sorted_unique_outputs(
+        cls, value: tuple[ArtifactInput, ...]
+    ) -> tuple[ArtifactInput, ...]:
+        """Require canonical output ordering without conflicting or repeated IDs."""
+        artifact_ids = tuple(item.artifact_id for item in value)
+        if len(set(artifact_ids)) != len(artifact_ids):
+            raise ValueError("stage event outputs must not repeat an artifact_id")
+        if artifact_ids != tuple(sorted(artifact_ids)):
+            raise ValueError("stage event outputs must be sorted by artifact_id")
+        return value
+
+    @model_validator(mode="after")
+    def _require_kind_specific_payload(self) -> ProjectStageEvent:
+        """Keep progress, completion, and failure payloads disjoint and fully typed."""
+        has_progress = self.completed_units is not None or self.total_units is not None
+        if self.kind == ProjectStageEventKind.PROGRESS:
+            if self.completed_units is None or self.total_units is None:
+                raise ValueError("progress events require completed_units and total_units")
+            if self.completed_units > self.total_units:
+                raise ValueError("completed_units cannot exceed total_units")
+        elif has_progress:
+            raise ValueError("only progress events may carry completed_units or total_units")
+        if self.kind == ProjectStageEventKind.COMPLETED:
+            if not self.outputs:
+                raise ValueError("completed events require at least one immutable output")
+        elif self.outputs:
+            raise ValueError("only completed events may carry immutable outputs")
+        if self.kind == ProjectStageEventKind.FAILED:
+            if self.failure is None:
+                raise ValueError("failed events require a structured failure")
+        elif self.failure is not None:
+            raise ValueError("only failed events may carry a structured failure")
+        return self

--- a/wmo/common/project/events_test.py
+++ b/wmo/common/project/events_test.py
@@ -1,0 +1,102 @@
+"""Tests for typed WMO Project stage events."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from wmo.common.core.artifacts import ArtifactInput, FailureCode
+from wmo.common.project.events import (
+    ProjectStage,
+    ProjectStageEvent,
+    ProjectStageEventKind,
+    ProjectStageFailure,
+)
+
+_DIGEST = "a" * 64
+_OCCURRED_AT = datetime(2026, 8, 17, tzinfo=UTC)
+
+
+def _event(**updates: object) -> ProjectStageEvent:
+    """Build one valid stage-started event with selected field replacements."""
+    values: dict[str, object] = {
+        "event_id": "event-1",
+        "project_id": "project-1",
+        "attempt_id": "attempt-1",
+        "sequence": 1,
+        "occurred_at": _OCCURRED_AT,
+        "stage": ProjectStage.PREPARING_TRACES,
+        "kind": ProjectStageEventKind.STARTED,
+    }
+    values.update(updates)
+    return ProjectStageEvent.model_validate(values)
+
+
+def test_stage_event_vocabulary_and_serialization_are_stable() -> None:
+    """Events expose only WMO-owned stages and deterministic structured state."""
+    assert tuple(ProjectStage) == (
+        ProjectStage.PREPARING_TRACES,
+        ProjectStage.BUILDING_WORLD_MODEL,
+        ProjectStage.OPTIMIZING_ROUTER,
+        ProjectStage.COMPLETING_REPORT,
+    )
+    started = _event()
+    restored = ProjectStageEvent.model_validate_json(started.model_dump_json())
+
+    assert restored == started
+    assert "message" not in ProjectStageFailure.model_fields
+    assert "details" not in ProjectStageFailure.model_fields
+
+
+def test_stage_progress_requires_a_real_bounded_denominator() -> None:
+    """Progress exists only when WMO knows a finite completed and total count."""
+    progress = _event(
+        kind=ProjectStageEventKind.PROGRESS,
+        completed_units=3,
+        total_units=10,
+    )
+    assert progress.completed_units == 3
+    assert progress.total_units == 10
+    with pytest.raises(ValidationError, match="require completed_units and total_units"):
+        _event(kind=ProjectStageEventKind.PROGRESS)
+    with pytest.raises(ValidationError, match="cannot exceed"):
+        _event(
+            kind=ProjectStageEventKind.PROGRESS,
+            completed_units=11,
+            total_units=10,
+        )
+    with pytest.raises(ValidationError, match="only progress events"):
+        _event(completed_units=1, total_units=2)
+
+
+def test_completed_and_failed_events_have_disjoint_typed_payloads() -> None:
+    """Completion carries verified pointers while failure carries no free-form provider text."""
+    output = ArtifactInput(artifact_id="task-set", sha256=_DIGEST)
+    completed = _event(
+        kind=ProjectStageEventKind.COMPLETED,
+        outputs=(output,),
+    )
+    failed = _event(
+        kind=ProjectStageEventKind.FAILED,
+        failure=ProjectStageFailure(
+            code=FailureCode.VALIDATION,
+            retryable=False,
+            detail_code="missing-project-catalog",
+        ),
+    )
+
+    assert completed.outputs == (output,)
+    assert failed.failure is not None
+    with pytest.raises(ValidationError, match="completed events require"):
+        _event(kind=ProjectStageEventKind.COMPLETED)
+    with pytest.raises(ValidationError, match="failed events require"):
+        _event(kind=ProjectStageEventKind.FAILED)
+    with pytest.raises(ValidationError, match="only failed events"):
+        _event(
+            failure=ProjectStageFailure(
+                code=FailureCode.INTERNAL,
+                retryable=False,
+            )
+        )

--- a/wmo/common/project/project.py
+++ b/wmo/common/project/project.py
@@ -170,12 +170,13 @@ class ProjectBuildArtifacts(ContractModel):
 class ProjectConfig(ContractModel):
     """Project-local configuration that names no provider credentials or secret references."""
 
-    schema_version: int = Field(default=2, ge=1)
+    schema_version: int = Field(default=3, ge=1)
     project_id: ArtifactId
     trace_source: str | None = Field(default=None, max_length=64)
     trace_preparation: ProjectTracePreparationSettings | None = None
     provider_free_stage: ProjectProviderFreeStage | None = None
     models: ProjectModelConfiguration | None = None
+    model_catalog: ArtifactInput | None = None
     retrieval: ProjectRetrievalConfiguration | None = Field(
         default_factory=ProjectRetrievalConfiguration
     )

--- a/wmo/common/project/project_test.py
+++ b/wmo/common/project/project_test.py
@@ -92,6 +92,21 @@ def test_provider_free_contract_keeps_settings_and_stage_ownership_minimal() -> 
         ProjectConfig(project_id="missing-settings", provider_free_stage=stage)
 
 
+def test_project_config_has_one_optional_project_scoped_catalog_pointer() -> None:
+    """Provider-free Projects need no catalog while configured Projects bind one artifact."""
+    pointer = ArtifactInput(artifact_id="project-model-catalog", sha256=_DIGEST)
+
+    provider_free = ProjectConfig(
+        project_id="provider-free",
+        trace_preparation=ProjectTracePreparationSettings(source_kind="otlp"),
+    )
+    configured = ProjectConfig(project_id="configured", model_catalog=pointer)
+
+    assert provider_free.model_catalog is None
+    assert configured.model_catalog == pointer
+    assert "model_catalog" in ProjectConfig.model_fields
+
+
 def test_project_config_round_trip_preserves_safe_local_metadata(tmp_path: Path) -> None:
     """Project TOML contains customer wiring metadata but no provider credential references."""
     path = tmp_path / "project.toml"


### PR DESCRIPTION
## Summary

- add WMO-owned schema-v1 deterministic Project bundle export and verified atomic restore
- export only the exact transitive closure of `ArtifactInput` pointers selected by `ProjectConfig`, with artifact manifests remaining authoritative for provenance
- add an optional immutable, credential-free Project model-catalog artifact and pointer without reading ambient `models.toml`
- add typed WMO stage events for started, real bounded progress, completed, and redacted failure state
- document that mutable routed-interaction runtime state is outside the immutable bundle

## Stack evidence

- stacked on PR #488
- required base branch: `agent/convergence-pr01-provider-free-bootstrap`
- exact base SHA: `facf91512cbb3dee4f0fc9162dd192972cbbb893`
- exact head SHA: `d7a56ae0680ca3d3b8d6a4799dd1796ad876c22f`
- GitHub workflows have unfiltered `pull_request` triggers, so this feature-branch base receives fresh exact-base/head CI

## Contracts

- top-level `wmo` adds exactly `export_project_bundle`, `restore_project_bundle`, and `ExportedProjectBundle`
- bundle schema 1 binds Project schema, producer revision, sorted selected closure, completed durable stages, member digests and sizes, and explicit runtime exclusion
- Project schema 3 adds only the optional `model_catalog: ArtifactInput` seam
- Project catalogs bind sorted aliases to exact secret-free `ModelSnapshot` and `ModelCapabilities` values; provider-free Projects need no catalog
- WMO stage vocabulary is `preparing_traces`, `building_world_model`, `optimizing_router`, and `completing_report`
- event kinds are `started`, `progress`, `completed`, and `failed`; progress requires a real denominator and failures expose no provider text

## Security and portability

- restore requires the expected bundle SHA-256 and an absent scoped destination
- export and restore verify the complete manifest and payload digest chain
- archive members are bounded to 20,000 selected payload files and 1 GiB total expanded content
- traversal, absolute and backslash paths, duplicate/case/Unicode-colliding members, symlinks and nonregular files, compression, unsupported schemas, truncation, extra or missing artifacts, secrets, and worker-local source paths fail before destination visibility
- export uses a private temporary file plus atomic replacement; restore verifies and materializes under a private root before one atomic Project-directory rename
- unselected sibling artifacts, root-global `models.toml`, and mutable runtime journals are excluded

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- focused PR2 behavior and API suite: 46 passed
- terminal and cache-sensitive regression suite: 72 passed
- full repository suite on the clean exact head: 1507 passed, 2 skipped, 2 existing fork deprecation warnings

## Scope exclusions

No service layer, CLI expansion, provider client workflow, Platform IDs, human-approval gate, event bus, broker, SSE transport, runtime cache, or PR3 provider-backed behavior is added here.
