### PR TITLE
Add deadline-aware async provider core

### DIFF
--- a/wmo/runtime/models/providers/__init__.py
+++ b/wmo/runtime/models/providers/__init__.py
@@ -1,8 +1,14 @@
 """Native provider clients and shared non-streaming transport behavior."""
 
 from wmo.runtime.models.providers.anthropic import AnthropicClient
+from wmo.runtime.models.providers.async_transport import (
+    AsyncJsonHttpTransport,
+    HttpxAsyncJsonTransport,
+    ProviderDeadlineExceeded,
+    RequestDeadline,
+)
 from wmo.runtime.models.providers.azure import AzureClient
-from wmo.runtime.models.providers.bedrock import BedrockClient
+from wmo.runtime.models.providers.bedrock import BedrockClient, BoundedBedrockClient
 from wmo.runtime.models.providers.gemini import GeminiClient
 from wmo.runtime.models.providers.listing import (
     HttpProviderModelLister,
@@ -14,6 +20,14 @@ from wmo.runtime.models.providers.openai import OpenAIClient
 from wmo.runtime.models.providers.openai_compatible import (
     OpenAICompatibleClient,
     OpenRouterClient,
+)
+from wmo.runtime.models.providers.protocol import (
+    AsyncCompletedModelClient,
+    AsyncGatewayProvider,
+    BoundedSyncModelClientAdapter,
+    SyncModelClientAdapter,
+    preflight_gateway_request,
+    require_gateway_provider,
 )
 from wmo.runtime.models.providers.tinker_sampling import (
     TinkerOptionalDependencyError,
@@ -27,16 +41,25 @@ from wmo.runtime.models.providers.tinker_sampling import (
 
 __all__ = [
     "AnthropicClient",
+    "AsyncCompletedModelClient",
+    "AsyncGatewayProvider",
+    "AsyncJsonHttpTransport",
     "AzureClient",
     "BedrockClient",
+    "BoundedBedrockClient",
+    "BoundedSyncModelClientAdapter",
     "GeminiClient",
     "HttpProviderModelLister",
+    "HttpxAsyncJsonTransport",
     "OpenAIClient",
     "OpenAICompatibleClient",
     "OpenRouterClient",
     "ProviderEndpoint",
+    "ProviderDeadlineExceeded",
     "ProviderListingError",
     "ProviderModelLister",
+    "RequestDeadline",
+    "SyncModelClientAdapter",
     "TinkerOptionalDependencyError",
     "TinkerSample",
     "TinkerSampler",
@@ -44,4 +67,6 @@ __all__ = [
     "TinkerSamplingClient",
     "TinkerSdkSampler",
     "create_tinker_sampler",
+    "preflight_gateway_request",
+    "require_gateway_provider",
 ]

--- a/wmo/runtime/models/providers/anthropic.py
+++ b/wmo/runtime/models/providers/anthropic.py
@@ -20,6 +20,8 @@ from wmo.runtime.models.providers.base import (
     ProviderHttpClient,
 )
 from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
     ProviderResponseError,
     require_array,
     require_integer,
@@ -96,6 +98,11 @@ def anthropic_messages_response(
     Raises:
         ProviderResponseError: The completed response has malformed or unsupported content.
     """
+    if payload.get("stop_reason") == "refusal":
+        raise ProviderRefusalError(
+            provider="anthropic",
+            signal=ProviderRefusalSignal.PROVIDER_REFUSAL,
+        )
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
     for index, value in enumerate(require_array(payload.get("content"), "Anthropic content")):
@@ -106,6 +113,11 @@ def anthropic_messages_response(
             if not isinstance(text, str):
                 raise ProviderResponseError(f"Anthropic content[{index}].text must be text")
             text_parts.append(text)
+        elif block_type == "refusal":
+            raise ProviderRefusalError(
+                provider="anthropic",
+                signal=ProviderRefusalSignal.PROVIDER_REFUSAL,
+            )
         elif block_type == "tool_use":
             tool_calls.append(_anthropic_tool_call(block, index))
         else:

--- a/wmo/runtime/models/providers/async_transport.py
+++ b/wmo/runtime/models/providers/async_transport.py
@@ -1,0 +1,546 @@
+"""Async provider transport, absolute deadlines, and bounded same-endpoint retries."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+from uuid import uuid4
+
+import httpx
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.runtime.models.providers.transport import (
+    JsonHttpResponse,
+    JsonHttpTransport,
+    ProviderTransportError,
+    RecordedRequest,
+    RetryClassification,
+    RetryPolicy,
+    classify_retry,
+)
+
+
+class ProviderDeadlineExceeded(TimeoutError):
+    """One provider operation exhausted its immutable request-wide deadline."""
+
+
+@dataclass(frozen=True)
+class RequestDeadline:
+    """One absolute monotonic deadline shared by queueing, attempts, and backoff."""
+
+    expires_at_monotonic: float
+
+    def __post_init__(self) -> None:
+        """Reject a nonpositive absolute deadline that cannot bound execution."""
+        if self.expires_at_monotonic <= 0:
+            raise ValueError("expires_at_monotonic must be positive")
+
+    @classmethod
+    def after(
+        cls,
+        timeout_seconds: float,
+        *,
+        now_monotonic: float | None = None,
+    ) -> RequestDeadline:
+        """Create one absolute deadline from a positive remaining budget.
+
+        Args:
+            timeout_seconds: Total request-wide budget in seconds.
+            now_monotonic: Optional injected monotonic reading for deterministic tests.
+
+        Returns:
+            An immutable deadline at the end of the supplied budget.
+
+        Raises:
+            ValueError: The budget is not positive.
+        """
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        now = time.monotonic() if now_monotonic is None else now_monotonic
+        return cls(expires_at_monotonic=now + timeout_seconds)
+
+    def remaining_seconds(self, *, now_monotonic: float | None = None) -> float:
+        """Return nonnegative time remaining on the absolute deadline.
+
+        Args:
+            now_monotonic: Optional injected monotonic reading for deterministic tests.
+
+        Returns:
+            Remaining seconds, clamped to zero after expiry.
+        """
+        now = time.monotonic() if now_monotonic is None else now_monotonic
+        return max(0.0, self.expires_at_monotonic - now)
+
+    def attempt_timeout(
+        self,
+        maximum_seconds: float | None = None,
+        *,
+        now_monotonic: float | None = None,
+    ) -> float:
+        """Return the smaller of the attempt bound and remaining request time.
+
+        Args:
+            maximum_seconds: Optional provider-derived bound for this one attempt.
+            now_monotonic: Optional injected monotonic reading for deterministic tests.
+
+        Returns:
+            A positive timeout for the next attempt.
+
+        Raises:
+            ValueError: The optional attempt bound is not positive.
+            ProviderDeadlineExceeded: No request-wide time remains.
+        """
+        if maximum_seconds is not None and maximum_seconds <= 0:
+            raise ValueError("maximum_seconds must be positive")
+        remaining = self.remaining_seconds(now_monotonic=now_monotonic)
+        if remaining <= 0:
+            raise ProviderDeadlineExceeded("provider request deadline exceeded")
+        return remaining if maximum_seconds is None else min(remaining, maximum_seconds)
+
+
+@runtime_checkable
+class AsyncJsonHttpTransport(Protocol):
+    """Cancellable async JSON transport used by gateway-capable provider clients."""
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Read one bounded JSON object response."""
+        ...
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Send one bounded JSON request and decode an object response."""
+        ...
+
+
+class HttpxAsyncJsonTransport:
+    """Production async transport backed by ``httpx.AsyncClient``."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        """Use a caller-owned pooled client or short-lived clients per request.
+
+        Args:
+            client: Optional async client whose lifecycle remains with the caller.
+        """
+        self._client = client
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Read one provider endpoint with cancellable async I/O.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider headers, including resolved authentication.
+            timeout_seconds: Remaining bound for this attempt.
+
+        Returns:
+            The status and decoded JSON object.
+
+        Raises:
+            ProviderTransportError: The request or response body fails safely.
+        """
+        try:
+            if self._client is not None:
+                response = await self._client.get(
+                    url,
+                    headers=dict(headers),
+                    timeout=timeout_seconds,
+                )
+            else:
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(
+                        url,
+                        headers=dict(headers),
+                        timeout=timeout_seconds,
+                    )
+        except httpx.TimeoutException as exc:
+            raise ProviderTransportError("provider request timed out") from exc
+        except httpx.TransportError as exc:
+            raise ProviderTransportError("provider transport request failed") from exc
+        return _decoded_response(response)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Send one provider request with cancellable async I/O.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider headers, including resolved authentication.
+            payload: Complete JSON request body.
+            timeout_seconds: Remaining bound for this attempt.
+
+        Returns:
+            The status and decoded JSON object.
+
+        Raises:
+            ProviderTransportError: The request or response body fails safely.
+        """
+        try:
+            if self._client is not None:
+                response = await self._client.post(
+                    url,
+                    headers=dict(headers),
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+            else:
+                async with httpx.AsyncClient() as client:
+                    response = await client.post(
+                        url,
+                        headers=dict(headers),
+                        json=payload,
+                        timeout=timeout_seconds,
+                    )
+        except httpx.TimeoutException as exc:
+            raise ProviderTransportError("provider request timed out") from exc
+        except httpx.TransportError as exc:
+            raise ProviderTransportError("provider transport request failed") from exc
+        return _decoded_response(response)
+
+
+class SyncJsonTransportAdapter:
+    """Bound the wait around a legacy sync transport used by existing injected callers.
+
+    Gateway request handlers use ``HttpxAsyncJsonTransport`` directly. This adapter exists for
+    deterministic tests and external sync transport injections while those callers migrate.
+    """
+
+    def __init__(self, transport: JsonHttpTransport) -> None:
+        """Bind one legacy transport without executing it on the event loop.
+
+        Args:
+            transport: Existing sync JSON transport to run in the default worker pool.
+        """
+        self._transport = transport
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Run one sync GET off-loop and bound the caller's wait.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider request headers.
+            timeout_seconds: Maximum time the async caller waits.
+
+        Returns:
+            The legacy transport response.
+        """
+        operation = asyncio.to_thread(
+            self._transport.get,
+            url,
+            headers=headers,
+            timeout_seconds=timeout_seconds,
+        )
+        return await asyncio.wait_for(operation, timeout=timeout_seconds)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Run one sync POST off-loop and bound the caller's wait.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider request headers.
+            payload: Complete JSON request body.
+            timeout_seconds: Maximum time the async caller waits.
+
+        Returns:
+            The legacy transport response.
+        """
+        operation = asyncio.to_thread(
+            self._transport.post,
+            url,
+            headers=headers,
+            payload=payload,
+            timeout_seconds=timeout_seconds,
+        )
+        return await asyncio.wait_for(operation, timeout=timeout_seconds)
+
+
+class ScriptedAsyncJsonTransport:
+    """Deterministic async transport that records requests and replays scripted answers."""
+
+    def __init__(self, responses: Sequence[JsonHttpResponse | Exception] = ()) -> None:
+        """Store one answer for every expected async request.
+
+        Args:
+            responses: Ordered response objects or exceptions.
+        """
+        self._responses = list(responses)
+        self.requests: list[RecordedRequest] = []
+        self.timeouts: list[float] = []
+
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Record one GET and return the next scripted answer.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider request headers.
+            timeout_seconds: Remaining attempt timeout.
+
+        Returns:
+            The next scripted response.
+        """
+        self.requests.append(RecordedRequest(url, dict(headers), {}))
+        self.timeouts.append(timeout_seconds)
+        return self._answer()
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> JsonHttpResponse:
+        """Record one POST and return the next scripted answer.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider request headers.
+            payload: Complete JSON request body.
+            timeout_seconds: Remaining attempt timeout.
+
+        Returns:
+            The next scripted response.
+        """
+        self.requests.append(RecordedRequest(url, dict(headers), payload))
+        self.timeouts.append(timeout_seconds)
+        return self._answer()
+
+    def _answer(self) -> JsonHttpResponse:
+        """Consume the next answer, failing closed when the script is exhausted."""
+        if not self._responses:
+            raise AssertionError("test made an unexpected provider request")
+        answer = self._responses.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+async def run_with_retry_async[ResultT](
+    operation: Callable[[float], Awaitable[ResultT]],
+    *,
+    policy: RetryPolicy,
+    deadline: RequestDeadline,
+    attempt_timeout_seconds: float | None = None,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    classify: Callable[[Exception], RetryClassification] = classify_retry,
+) -> ResultT:
+    """Run one async attempt loop under a single absolute deadline.
+
+    Args:
+        operation: One same-endpoint attempt receiving its current timeout.
+        policy: Total attempt and backoff bounds for the whole operation.
+        deadline: Absolute request-wide deadline shared by every attempt.
+        attempt_timeout_seconds: Optional smaller provider-derived per-attempt bound.
+        sleep: Async delay function, injectable for deterministic tests.
+        classify: Retry classifier applied to each attempt error.
+
+    Returns:
+        The first successful result.
+
+    Raises:
+        ProviderDeadlineExceeded: Queueing, an attempt, or backoff exhausts the deadline.
+        Exception: The first non-retryable error or last retryable error.
+    """
+    delay = policy.initial_delay_seconds
+    for attempt in range(1, policy.maximum_attempts + 1):
+        timeout_seconds = deadline.attempt_timeout(attempt_timeout_seconds)
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                return await operation(timeout_seconds)
+        except TimeoutError as exc:
+            error: Exception
+            if deadline.remaining_seconds() <= 0:
+                error = ProviderDeadlineExceeded("provider request deadline exceeded")
+            else:
+                error = ProviderTransportError("provider request timed out")
+            error.__cause__ = exc
+        except Exception as exc:  # noqa: BLE001 - the injected classifier owns retry policy.
+            error = exc
+        classification = classify(error)
+        if not classification.retryable or attempt == policy.maximum_attempts:
+            raise error
+        remaining = deadline.remaining_seconds()
+        if remaining <= delay:
+            raise ProviderDeadlineExceeded("provider request deadline exceeded") from error
+        if delay > 0:
+            await sleep(delay)
+        delay = min(delay * 2, policy.maximum_delay_seconds)
+    raise RuntimeError("retry loop exhausted without running an attempt")
+
+
+async def get_json_async(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    deadline: RequestDeadline,
+    retry_policy: RetryPolicy,
+    attempt_timeout_seconds: float | None = None,
+) -> JsonObject:
+    """Read one JSON object through one deadline-aware async retry loop.
+
+    Args:
+        transport: Async transport used for every same-endpoint attempt.
+        url: Absolute provider endpoint URL.
+        headers: Provider request headers.
+        deadline: Absolute request-wide deadline.
+        retry_policy: Total same-endpoint attempt and delay bounds.
+        attempt_timeout_seconds: Optional smaller per-attempt bound.
+
+    Returns:
+        The first successful response body.
+    """
+
+    async def send(timeout_seconds: float) -> JsonObject:
+        """Send one GET attempt and validate its status."""
+        response = await transport.get(
+            url,
+            headers=headers,
+            timeout_seconds=timeout_seconds,
+        )
+        return _successful_body(response)
+
+    return await run_with_retry_async(
+        send,
+        policy=retry_policy,
+        deadline=deadline,
+        attempt_timeout_seconds=attempt_timeout_seconds,
+    )
+
+
+async def post_json_async(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    payload: JsonObject,
+    deadline: RequestDeadline,
+    retry_policy: RetryPolicy,
+    idempotency_key: str | None = None,
+    attempt_timeout_seconds: float | None = None,
+) -> JsonObject:
+    """Send one JSON request with stable identity across safe endpoint retries.
+
+    Args:
+        transport: Async transport used for every same-endpoint attempt.
+        url: Absolute provider endpoint URL.
+        headers: Provider request headers.
+        payload: Complete JSON request body.
+        deadline: Absolute request-wide deadline.
+        retry_policy: Total same-endpoint attempt and delay bounds.
+        idempotency_key: Optional stable caller or gateway attempt identity.
+        attempt_timeout_seconds: Optional smaller per-attempt bound.
+
+    Returns:
+        The first successful response body.
+    """
+    request_headers = {
+        name: value for name, value in headers.items() if name.lower() != "idempotency-key"
+    }
+    request_headers["Idempotency-Key"] = idempotency_key or f"wmo-{uuid4().hex}"
+
+    async def send(timeout_seconds: float) -> JsonObject:
+        """Send one POST attempt with the immutable request headers."""
+        response = await transport.post(
+            url,
+            headers=request_headers,
+            payload=payload,
+            timeout_seconds=timeout_seconds,
+        )
+        return _successful_body(response)
+
+    return await run_with_retry_async(
+        send,
+        policy=retry_policy,
+        deadline=deadline,
+        attempt_timeout_seconds=attempt_timeout_seconds,
+    )
+
+
+def as_async_transport(
+    transport: AsyncJsonHttpTransport | JsonHttpTransport | None,
+) -> AsyncJsonHttpTransport:
+    """Normalize caller-injected or default transports onto the async protocol.
+
+    Args:
+        transport: Async transport, legacy sync transport, or ``None`` for production HTTPX.
+
+    Returns:
+        A transport implementing cancellable async request methods.
+    """
+    if transport is None:
+        return HttpxAsyncJsonTransport()
+    if isinstance(transport, JsonHttpTransport):
+        return SyncJsonTransportAdapter(transport)
+    return transport
+
+
+def _decoded_response(response: httpx.Response) -> JsonHttpResponse:
+    """Decode one HTTPX response without retaining provider content in errors."""
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ProviderTransportError(
+            f"provider returned non-JSON HTTP {response.status_code}",
+            status_code=response.status_code,
+        ) from exc
+    if not isinstance(body, dict):
+        raise ProviderTransportError(
+            f"provider returned non-object JSON HTTP {response.status_code}",
+            status_code=response.status_code,
+        )
+    return JsonHttpResponse(status_code=response.status_code, body=body)
+
+
+def _successful_body(response: JsonHttpResponse) -> JsonObject:
+    """Return a successful body or raise a sanitized status-bearing error."""
+    if 200 <= response.status_code < 300:
+        return response.body
+    raise ProviderTransportError(
+        f"provider returned HTTP {response.status_code}",
+        status_code=response.status_code,
+    )

--- a/wmo/runtime/models/providers/async_transport_test.py
+++ b/wmo/runtime/models/providers/async_transport_test.py
@@ -1,0 +1,162 @@
+"""Tests for async provider transport, absolute deadlines, retries, and cancellation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from wmo.runtime.models.providers.async_transport import (
+    HttpxAsyncJsonTransport,
+    ProviderDeadlineExceeded,
+    RequestDeadline,
+    ScriptedAsyncJsonTransport,
+    post_json_async,
+    run_with_retry_async,
+)
+from wmo.runtime.models.providers.transport import (
+    JsonHttpResponse,
+    ProviderTransportError,
+    RetryPolicy,
+)
+
+_IMMEDIATE_RETRY = RetryPolicy(
+    maximum_attempts=2,
+    initial_delay_seconds=0,
+    maximum_delay_seconds=0,
+)
+
+
+def test_post_reuses_one_idempotency_identity_across_safe_retries() -> None:
+    """Same-endpoint retries must retain the caller-owned attempt identity."""
+    transport = ScriptedAsyncJsonTransport(
+        [
+            JsonHttpResponse(status_code=503, body={}),
+            JsonHttpResponse(status_code=200, body={"ok": True}),
+        ]
+    )
+
+    body = asyncio.run(
+        post_json_async(
+            transport,
+            "https://provider.test/v1/responses",
+            headers={"Authorization": "Bearer secret"},
+            payload={"model": "exact-model"},
+            deadline=RequestDeadline.after(2),
+            retry_policy=_IMMEDIATE_RETRY,
+            idempotency_key="attempt-stable",
+        )
+    )
+
+    assert body == {"ok": True}
+    assert [request.headers["Idempotency-Key"] for request in transport.requests] == [
+        "attempt-stable",
+        "attempt-stable",
+    ]
+
+
+def test_retry_loop_never_refreshes_the_absolute_deadline() -> None:
+    """A retry sees less remaining time instead of receiving a fresh full budget."""
+    observed_timeouts: list[float] = []
+
+    async def operation(timeout_seconds: float) -> str:
+        """Record attempt bounds, failing once before returning a result."""
+        observed_timeouts.append(timeout_seconds)
+        if len(observed_timeouts) == 1:
+            await asyncio.sleep(0.01)
+            raise ProviderTransportError("temporary")
+        return "ok"
+
+    result = asyncio.run(
+        run_with_retry_async(
+            operation,
+            policy=_IMMEDIATE_RETRY,
+            deadline=RequestDeadline.after(1),
+        )
+    )
+
+    assert result == "ok"
+    assert len(observed_timeouts) == 2
+    assert observed_timeouts[1] < observed_timeouts[0]
+
+
+def test_backoff_cannot_run_past_the_request_deadline() -> None:
+    """Retry backoff fails closed when it would consume the remaining budget."""
+
+    async def operation(timeout_seconds: float) -> str:
+        """Always fail with a retryable connection error."""
+        del timeout_seconds
+        raise ProviderTransportError("temporary")
+
+    with pytest.raises(ProviderDeadlineExceeded, match="deadline exceeded"):
+        asyncio.run(
+            run_with_retry_async(
+                operation,
+                policy=RetryPolicy(maximum_attempts=2, initial_delay_seconds=1),
+                deadline=RequestDeadline.after(0.05),
+            )
+        )
+
+
+def test_cancellation_propagates_into_the_active_httpx_request() -> None:
+    """Cancelling provider execution must cancel active async network work."""
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Block until cancellation and record that the handler received it."""
+        del request
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        raise AssertionError("blocking handler returned unexpectedly")
+
+    async def scenario() -> None:
+        """Start one HTTPX call, cancel it, and verify propagation."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            transport = HttpxAsyncJsonTransport(client)
+            task = asyncio.create_task(
+                transport.post(
+                    "https://provider.test/v1/responses",
+                    headers={},
+                    payload={},
+                    timeout_seconds=5,
+                )
+            )
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert cancelled.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_httpx_decode_failure_does_not_expose_body_or_headers() -> None:
+    """Malformed provider content must not appear in the surfaced transport error."""
+    canary = "secret-response-canary"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return one malformed body carrying a value that must stay private."""
+        del request
+        return httpx.Response(200, text=canary)
+
+    async def scenario() -> str:
+        """Execute the malformed request and return its sanitized error string."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            transport = HttpxAsyncJsonTransport(client)
+            with pytest.raises(ProviderTransportError) as error:
+                await transport.get(
+                    "https://provider.test/v1/models",
+                    headers={"Authorization": "Bearer header-canary"},
+                    timeout_seconds=1,
+                )
+            return str(error.value)
+
+    message = asyncio.run(scenario())
+    assert canary not in message
+    assert "header-canary" not in message

--- a/wmo/runtime/models/providers/azure.py
+++ b/wmo/runtime/models/providers/azure.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from urllib.parse import urlsplit
 
-from wmo.common.core.artifacts import JsonObject
 from wmo.common.models import ModelSnapshot
 from wmo.runtime.models.credentials import ModelCredentialError
+from wmo.runtime.models.providers.async_transport import AsyncJsonHttpTransport
 from wmo.runtime.models.providers.base import DEFAULT_RETRY_POLICY, DEFAULT_TIMEOUT_SECONDS
 from wmo.runtime.models.providers.openai_compatible import OpenAICompatibleClient
 from wmo.runtime.models.providers.transport import JsonHttpTransport, RetryPolicy
@@ -107,7 +107,7 @@ class AzureClient(OpenAICompatibleClient):
         endpoint: str,
         api_key: str,
         api_version: str,
-        transport: JsonHttpTransport | None = None,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
@@ -120,8 +120,7 @@ class AzureClient(OpenAICompatibleClient):
             api_version: ``v1`` or a dated Azure OpenAI API version.
             transport: Optional deterministic transport used by tests.
             retry_policy: Bounded same-endpoint retry policy.
-            timeout_seconds: Per-attempt timeout floor; completion attempts scale above it
-                with the requested maximum output tokens.
+            timeout_seconds: Timeout for every transport attempt.
 
         Raises:
             ValueError: The key, endpoint, API version, or timeout is missing or invalid.
@@ -147,27 +146,18 @@ class AzureClient(OpenAICompatibleClient):
             "Content-Type": "application/json",
         }
 
-    def _post(
-        self,
-        path: str,
-        payload: JsonObject,
-        *,
-        timeout_seconds: float | None = None,
-    ) -> JsonObject:
-        """Post below the Azure root, appending the dated API version when one is configured.
+    def _request_path(self, path: str) -> str:
+        """Append the dated API version to one logical Azure route.
 
         Args:
             path: Provider route below the configured base URL.
-            payload: JSON request body.
-            timeout_seconds: Optional per-attempt timeout override; the configured client
-                timeout applies when omitted.
 
         Returns:
-            The decoded JSON response body.
+            Wire path with the configured API version when required.
         """
         if self._api_version != _V1_API_VERSION:
             path = f"{path}?api-version={self._api_version}"
-        return super()._post(path, payload, timeout_seconds=timeout_seconds)
+        return path
 
 
 def _canonical_azure_endpoint(value: str) -> tuple[str, str, int | None, str]:

--- a/wmo/runtime/models/providers/azure.py
+++ b/wmo/runtime/models/providers/azure.py
@@ -120,7 +120,8 @@ class AzureClient(OpenAICompatibleClient):
             api_version: ``v1`` or a dated Azure OpenAI API version.
             transport: Optional deterministic transport used by tests.
             retry_policy: Bounded same-endpoint retry policy.
-            timeout_seconds: Timeout for every transport attempt.
+            timeout_seconds: Per-attempt timeout floor. Completion calls scale above it from the
+                requested maximum output tokens.
 
         Raises:
             ValueError: The key, endpoint, API version, or timeout is missing or invalid.

--- a/wmo/runtime/models/providers/base.py
+++ b/wmo/runtime/models/providers/base.py
@@ -3,20 +3,28 @@
 from __future__ import annotations
 
 import abc
+import asyncio
 import time
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
 from typing import ClassVar
+from uuid import uuid4
 
 from wmo.common.core.artifacts import JsonObject
 from wmo.common.models import ModelRequest, ModelResponse, ModelSnapshot
+from wmo.runtime.models.providers.async_transport import (
+    AsyncJsonHttpTransport,
+    RequestDeadline,
+    as_async_transport,
+    post_json_async,
+    run_with_retry_async,
+)
 from wmo.runtime.models.providers.errors import ProviderRetryableResponseError
 from wmo.runtime.models.providers.transport import (
-    HttpxJsonTransport,
     JsonHttpTransport,
+    ProviderTransportError,
     RetryClassification,
     RetryPolicy,
-    post_json,
-    run_with_retry,
+    classify_retry,
 )
 
 DEFAULT_TIMEOUT_SECONDS = 60.0
@@ -24,32 +32,24 @@ DEFAULT_RETRY_POLICY = RetryPolicy()
 DEFAULT_MAXIMUM_OUTPUT_TOKENS = 4096
 
 COMPLETION_SECONDS_PER_OUTPUT_TOKEN = 0.03
-"""Per-token completion time allowance, a conservative ~33 output tokens per second."""
+"""Per-token completion allowance, a conservative approximately 33 tokens per second."""
 
 MAXIMUM_COMPLETION_TIMEOUT_SECONDS = 600.0
-"""Hard ceiling on any derived completion attempt timeout, matching the Bedrock read bound."""
+"""Hard ceiling for a derived completion-attempt timeout."""
 
 
 def completion_timeout_seconds(
     configured_timeout_seconds: float,
     maximum_output_tokens: int | None,
 ) -> float:
-    """Derive one bounded per-attempt completion timeout from the requested output budget.
-
-    A fixed timeout cannot cover a long generation: at a conservative decode rate of about
-    33 output tokens per second, a 16000-token request needs roughly 480 seconds. The
-    derived value scales linearly with the requested maximum output tokens under
-    ``COMPLETION_SECONDS_PER_OUTPUT_TOKEN``, never drops below the client's configured
-    timeout, and caps the scaled value at ``MAXIMUM_COMPLETION_TIMEOUT_SECONDS`` so no
-    attempt waits unbounded.
+    """Derive one bounded completion timeout from the requested output budget.
 
     Args:
         configured_timeout_seconds: Positive per-attempt floor configured on the client.
-        maximum_output_tokens: Requested output token ceiling, or ``None`` when the request
-            leaves the provider default in place.
+        maximum_output_tokens: Requested output ceiling, or ``None`` for the provider default.
 
     Returns:
-        A finite timeout between the configured floor and the scaled bounded ceiling.
+        A finite timeout between the configured floor and scaled ceiling.
     """
     if maximum_output_tokens is None:
         return configured_timeout_seconds
@@ -68,7 +68,7 @@ class ProviderHttpClient(abc.ABC):
         model: ModelSnapshot,
         api_key: str,
         base_url: str,
-        transport: JsonHttpTransport | None = None,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
@@ -80,9 +80,8 @@ class ProviderHttpClient(abc.ABC):
             base_url: Endpoint root that exposes the provider's HTTP routes.
             transport: Optional deterministic transport used by tests.
             retry_policy: Bounded same-endpoint retry policy.
-            timeout_seconds: Per-attempt timeout floor. Completion attempts scale above it
-                with the requested maximum output tokens through
-                ``completion_timeout_seconds``; every other route uses it exactly.
+            timeout_seconds: Per-attempt timeout floor. Completion calls scale above it from the
+                requested maximum output tokens, while non-completion routes use it exactly.
         """
         if not api_key:
             raise ValueError(f"{type(self).__name__} requires a non-empty API key")
@@ -91,7 +90,7 @@ class ProviderHttpClient(abc.ABC):
         self._model = model
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
-        self._transport = transport or HttpxJsonTransport()
+        self._transport = as_async_transport(transport)
         self._retry_policy = retry_policy
         self._timeout_seconds = timeout_seconds
 
@@ -100,10 +99,7 @@ class ProviderHttpClient(abc.ABC):
 
         A completed response that decodes to no usable output, such as a reasoning model
         spending its whole output budget without visible text, is dispatched again under the
-        client's bounded retry policy before the last error surfaces to the caller. Each
-        attempt's timeout scales with the requested maximum output tokens through
-        ``completion_timeout_seconds`` so long generations are not cut off by the fixed
-        floor, while every wait stays finite.
+        client's bounded retry policy before the last error surfaces to the caller.
 
         Args:
             request: Visible messages, tool schemas, and sampling controls to send.
@@ -111,21 +107,72 @@ class ProviderHttpClient(abc.ABC):
         Returns:
             The typed non-streaming model response with observed request economics.
         """
-        payload = self._build_request(request)
-        timeout_seconds = completion_timeout_seconds(
-            self._timeout_seconds, request.maximum_output_tokens
+        completion_timeout = completion_timeout_seconds(
+            self._timeout_seconds,
+            request.maximum_output_tokens,
         )
+        return _run_sync(self.complete_async(request), timeout_seconds=completion_timeout)
 
-        def attempt() -> ModelResponse:
-            """Post and parse one complete request attempt."""
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Complete one request through one deadline-aware async attempt loop.
+
+        Transport failures and completed empty-output responses share one retry policy instead of
+        multiplying nested retry counts. The same idempotency identity is sent on every safe retry.
+
+        Args:
+            request: Visible messages, tool schemas, and sampling controls to send.
+            deadline: Optional request-wide deadline supplied by gateway execution.
+            idempotency_key: Optional stable caller or gateway attempt identity.
+
+        Returns:
+            The typed completed response with observed request economics.
+        """
+        completion_timeout = completion_timeout_seconds(
+            self._timeout_seconds,
+            request.maximum_output_tokens,
+        )
+        request_deadline = deadline or RequestDeadline.after(completion_timeout)
+        payload = self._build_request(request)
+        path = self._request_path(self._completion_path())
+        url = f"{self._base_url}/{path}"
+        request_headers = {
+            name: value
+            for name, value in self._headers().items()
+            if name.lower() != "idempotency-key"
+        }
+        request_headers["Idempotency-Key"] = idempotency_key or f"wmo-{uuid4().hex}"
+
+        async def attempt(timeout_seconds: float) -> ModelResponse:
+            """Send and parse one provider attempt under its remaining time bound."""
             started_at = time.monotonic()
-            response = self._post(self._completion_path(), payload, timeout_seconds=timeout_seconds)
-            return self._parse_response(response, latency_seconds=time.monotonic() - started_at)
+            response = await self._transport.post(
+                url,
+                headers=request_headers,
+                payload=payload,
+                timeout_seconds=timeout_seconds,
+            )
+            if not 200 <= response.status_code < 300:
+                raise ProviderTransportError(
+                    f"provider returned HTTP {response.status_code}",
+                    status_code=response.status_code,
+                )
+            return self._parse_response(
+                response.body,
+                latency_seconds=time.monotonic() - started_at,
+            )
 
-        return run_with_retry(
+        return await run_with_retry_async(
             attempt,
             policy=self._retry_policy,
-            classify=_classify_empty_output_retry,
+            deadline=request_deadline,
+            attempt_timeout_seconds=completion_timeout,
+            classify=_classify_complete_retry,
         )
 
     def _headers(self) -> dict[str, str]:
@@ -136,32 +183,54 @@ class ProviderHttpClient(abc.ABC):
             **self.default_headers,
         }
 
-    def _post(
+    def _post(self, path: str, payload: JsonObject) -> JsonObject:
+        """Post one JSON payload through the bounded sync compatibility path."""
+        return _run_sync(
+            self._post_async(path, payload),
+            timeout_seconds=self._timeout_seconds,
+        )
+
+    async def _post_async(
         self,
         path: str,
         payload: JsonObject,
         *,
-        timeout_seconds: float | None = None,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
     ) -> JsonObject:
-        """Post one JSON payload to a provider route below the configured base URL.
+        """Post one JSON payload through the shared async transport.
 
         Args:
             path: Provider route below the configured base URL.
-            payload: JSON request body.
-            timeout_seconds: Optional per-attempt timeout override; the configured client
-                timeout applies when omitted.
+            payload: Complete JSON request object.
+            deadline: Optional request-wide deadline.
+            idempotency_key: Optional stable identity for same-endpoint retries.
 
         Returns:
-            The decoded JSON response body.
+            The first successful decoded provider body.
         """
-        return post_json(
+        request_deadline = deadline or RequestDeadline.after(self._timeout_seconds)
+        return await post_json_async(
             self._transport,
-            f"{self._base_url}/{path}",
+            f"{self._base_url}/{self._request_path(path)}",
             headers=self._headers(),
             payload=payload,
-            timeout_seconds=(self._timeout_seconds if timeout_seconds is None else timeout_seconds),
+            deadline=request_deadline,
             retry_policy=self._retry_policy,
+            idempotency_key=idempotency_key,
+            attempt_timeout_seconds=self._timeout_seconds,
         )
+
+    def _request_path(self, path: str) -> str:
+        """Return the provider-specific wire path for one logical route.
+
+        Args:
+            path: Logical route below the configured base URL.
+
+        Returns:
+            Wire path including any provider-specific query parameters.
+        """
+        return path
 
     @abc.abstractmethod
     def _completion_path(self) -> str:
@@ -176,11 +245,8 @@ class ProviderHttpClient(abc.ABC):
         """Convert one decoded provider payload into the shared response contract."""
 
 
-def _classify_empty_output_retry(exception: Exception) -> RetryClassification:
-    """Retry only completed provider responses that decoded to no usable output.
-
-    Transport failures already retry inside each posted attempt, so this outer classifier
-    stays closed to everything except the explicit retryable empty-output signal.
+def _classify_complete_retry(exception: Exception) -> RetryClassification:
+    """Classify transport and empty-output failures in one shared attempt loop.
 
     Args:
         exception: Error raised by one post-and-parse attempt.
@@ -190,4 +256,47 @@ def _classify_empty_output_retry(exception: Exception) -> RetryClassification:
     """
     if isinstance(exception, ProviderRetryableResponseError):
         return RetryClassification(retryable=True, reason="empty_completed_output")
-    return RetryClassification(retryable=False, reason="non_retryable_response")
+    return classify_retry(exception)
+
+
+def _run_sync[ResultT](
+    operation: Coroutine[object, object, ResultT],
+    *,
+    timeout_seconds: float,
+) -> ResultT:
+    """Run one async provider operation for a non-event-loop compatibility caller.
+
+    Args:
+        operation: Async transport operation to execute.
+        timeout_seconds: Total caller-side bound including cancellation cleanup.
+
+    Returns:
+        The completed operation result.
+
+    Raises:
+        RuntimeError: Called from an event-loop thread, where the async method is required.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_wait_for(operation, timeout_seconds=timeout_seconds))
+    operation.close()
+    raise RuntimeError("sync provider compatibility cannot run on an event loop; use async APIs")
+
+
+async def _wait_for[ResultT](
+    operation: Coroutine[object, object, ResultT],
+    *,
+    timeout_seconds: float,
+) -> ResultT:
+    """Bound one compatibility coroutine by the configured total timeout.
+
+    Args:
+        operation: Provider coroutine to await.
+        timeout_seconds: Positive total wait bound.
+
+    Returns:
+        The provider result before timeout.
+    """
+    async with asyncio.timeout(timeout_seconds):
+        return await operation

--- a/wmo/runtime/models/providers/base.py
+++ b/wmo/runtime/models/providers/base.py
@@ -99,7 +99,9 @@ class ProviderHttpClient(abc.ABC):
 
         A completed response that decodes to no usable output, such as a reasoning model
         spending its whole output budget without visible text, is dispatched again under the
-        client's bounded retry policy before the last error surfaces to the caller.
+        client's bounded retry policy before the last error surfaces to the caller. The request's
+        output budget scales both the default request deadline and each transport-attempt ceiling,
+        while an injected request-wide deadline remains authoritative.
 
         Args:
             request: Visible messages, tool schemas, and sampling controls to send.

--- a/wmo/runtime/models/providers/base_test.py
+++ b/wmo/runtime/models/providers/base_test.py
@@ -204,4 +204,7 @@ def test_complete_passes_the_derived_timeout_to_the_transport() -> None:
     client.complete(ModelRequest(messages=(message,), maximum_output_tokens=16_000))
     client.complete(ModelRequest(messages=(message,)))
 
-    assert transport.timeouts == [pytest.approx(480.0), DEFAULT_TIMEOUT_SECONDS]
+    assert transport.timeouts == [
+        pytest.approx(480.0),
+        pytest.approx(DEFAULT_TIMEOUT_SECONDS),
+    ]

--- a/wmo/runtime/models/providers/bedrock.py
+++ b/wmo/runtime/models/providers/bedrock.py
@@ -25,6 +25,8 @@ from wmo.common.models import (
 )
 from wmo.runtime.models.providers.base import DEFAULT_RETRY_POLICY
 from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
     ProviderResponseError,
     require_array,
     require_integer,
@@ -32,6 +34,7 @@ from wmo.runtime.models.providers.errors import (
     require_string,
 )
 from wmo.runtime.models.providers.openai_compatible import normalize_embedding_vector
+from wmo.runtime.models.providers.protocol import BoundedSyncModelClientAdapter
 from wmo.runtime.models.providers.transport import (
     ProviderTransportError,
     RetryPolicy,
@@ -281,6 +284,32 @@ class BedrockClient:
                 raise _as_transport_error(exc) from exc
 
         return run_with_retry(send, policy=self._retry_policy)
+
+
+class BoundedBedrockClient(BoundedSyncModelClientAdapter):
+    """Gateway compatibility contract for blocking Bedrock SDK calls.
+
+    The wrapper bounds outstanding worker calls and caller wait time. Cancellation is best effort:
+    an active boto call may finish in its worker, but retains its admission permit until it stops.
+    Native Bedrock streaming remains outside this contract.
+    """
+
+    def __init__(
+        self,
+        client: BedrockClient,
+        *,
+        maximum_outstanding_calls: int = 4,
+    ) -> None:
+        """Bind one Bedrock client behind a finite blocking-worker bound.
+
+        Args:
+            client: Existing synchronous Bedrock client.
+            maximum_outstanding_calls: Running plus detached boto calls allowed at once.
+        """
+        super().__init__(
+            client,
+            maximum_outstanding_calls=maximum_outstanding_calls,
+        )
 
 
 def _boto_session_region() -> str | None:
@@ -576,6 +605,11 @@ def _finish_reason(value: object) -> ModelFinishReason:
         raise ProviderResponseError("Bedrock stopReason must be a non-empty string")
     if value in _LENGTH_STOP_REASONS:
         return ModelFinishReason.LENGTH
+    if value in {"content_filtered", "guardrail_intervened"}:
+        raise ProviderRefusalError(
+            provider="bedrock",
+            signal=ProviderRefusalSignal.GUARDRAIL,
+        )
     if value in _COMPLETED_STOP_REASONS:
         return ModelFinishReason.COMPLETED
     raise ProviderResponseError(f"Bedrock stopReason {value!r} is not supported")

--- a/wmo/runtime/models/providers/bedrock_test.py
+++ b/wmo/runtime/models/providers/bedrock_test.py
@@ -40,7 +40,11 @@ from wmo.runtime.models.providers.bedrock import (
     create_bedrock_runtime_client,
     resolve_bedrock_region,
 )
-from wmo.runtime.models.providers.errors import ProviderResponseError
+from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
+    ProviderResponseError,
+)
 from wmo.runtime.models.providers.transport import ProviderTransportError, ScriptedJsonTransport
 from wmo.runtime.models.registry import RuntimeModelCatalog
 
@@ -576,7 +580,7 @@ def test_converse_response_maps_length_and_rejects_unsupported_blocks() -> None:
             configured_model=_snapshot(),
             latency_seconds=0.1,
         )
-    with pytest.raises(ProviderResponseError, match="not supported"):
+    with pytest.raises(ProviderRefusalError) as refusal_error:
         converse_response(
             {
                 "output": {"message": {"content": [{"text": "blocked"}]}},
@@ -585,3 +589,5 @@ def test_converse_response_maps_length_and_rejects_unsupported_blocks() -> None:
             configured_model=_snapshot(),
             latency_seconds=0.1,
         )
+    assert refusal_error.value.signal is ProviderRefusalSignal.GUARDRAIL
+    assert "blocked" not in str(refusal_error.value)

--- a/wmo/runtime/models/providers/bedrock_test.py
+++ b/wmo/runtime/models/providers/bedrock_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -26,6 +27,7 @@ from wmo.common.models import (
     ToolChoice,
 )
 from wmo.common.tasks import ToolSchema
+from wmo.runtime.models.providers.async_transport import RequestDeadline
 from wmo.runtime.models.providers.bedrock import (
     AWS_DEFAULT_REGION_ENV,
     AWS_REGION_ENV,
@@ -35,6 +37,7 @@ from wmo.runtime.models.providers.bedrock import (
     BedrockClient,
     BedrockRegionError,
     BedrockRuntime,
+    BoundedBedrockClient,
     converse_request,
     converse_response,
     create_bedrock_runtime_client,
@@ -376,11 +379,23 @@ def test_catalog_rejects_bedrock_api_key_env_and_resolves_without_http() -> None
     response = resolved.client.complete(_request())
     vectors = embedder.embedding_client.embed(["hello"]) if embedder.embedding_client else ()
 
+    async def complete_through_bounded_lane() -> str | None:
+        """Exercise the catalog-exposed bounded async completion contract."""
+        assert isinstance(resolved.client, BoundedBedrockClient)
+        async_response = await resolved.client.complete_async(
+            _request(),
+            deadline=RequestDeadline.after(1),
+        )
+        return async_response.output.content
+
     assert snapshot.provider == "bedrock"
     assert snapshot.model_id == "us.anthropic.claude-sonnet-4-5"
-    assert isinstance(resolved.client, BedrockClient)
-    assert embedder.embedding_client is embedder.client
+    assert isinstance(resolved.client, BoundedBedrockClient)
+    assert isinstance(embedder.client, BoundedBedrockClient)
+    assert embedder.embedding_client is not embedder.client
+    assert isinstance(embedder.embedding_client, BedrockClient)
     assert response.output.content == "ok"
+    assert asyncio.run(complete_through_bounded_lane()) == "ok"
     assert vectors[0].values == (0.6, 0.8)
 
 

--- a/wmo/runtime/models/providers/errors.py
+++ b/wmo/runtime/models/providers/errors.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from enum import StrEnum
+
 from pydantic import JsonValue
 
 from wmo.common.core.artifacts import JsonObject
+from wmo.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
+from wmo.runtime.models.providers.transport import ProviderTransportError
 
 
 class ProviderResponseError(ValueError):
@@ -18,6 +24,154 @@ class ProviderRetryableResponseError(ProviderResponseError):
     neither visible text nor a tool call. The response is well formed on the wire, so the
     request is safe to dispatch again under the client's bounded retry policy.
     """
+
+
+class ProviderRefusalSignal(StrEnum):
+    """Content-free refusal signals normalized from provider-specific wire values."""
+
+    CONTENT_POLICY = "content_policy"
+    SAFETY = "safety"
+    COPYRIGHT = "copyright"
+    SENSITIVE_INFORMATION = "sensitive_information"
+    GUARDRAIL = "guardrail"
+    PROVIDER_REFUSAL = "provider_refusal"
+
+
+class ProviderRefusalError(ProviderResponseError):
+    """A provider refused the request without retaining or exposing refusal content."""
+
+    def __init__(self, *, provider: str, signal: ProviderRefusalSignal) -> None:
+        """Record only the provider family and normalized content-free signal.
+
+        Args:
+            provider: Stable provider family name.
+            signal: Sanitized refusal category derived from the wire response.
+        """
+        super().__init__(f"{provider} refused the request")
+        self.provider = provider
+        self.signal = signal
+
+
+class ProviderCapabilityError(ValueError):
+    """A request requires gateway behavior the deployment cannot preserve."""
+
+    def __init__(self, *, capability: str) -> None:
+        """Name the unsupported public capability without provider content.
+
+        Args:
+            capability: Stable capability field rejected before dispatch.
+        """
+        super().__init__(f"provider deployment does not support {capability}")
+        self.capability = capability
+
+
+def normalized_provider_failure(exception: BaseException) -> GatewayFailure:
+    """Convert an execution error into one stable sanitized gateway failure.
+
+    Args:
+        exception: Provider, transport, deadline, cancellation, or preflight failure.
+
+    Returns:
+        A content-free failure safe for public errors, ledgers, and logs.
+    """
+    if isinstance(exception, asyncio.CancelledError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.CANCELLED,
+            safe_message="provider request was cancelled",
+        )
+    if isinstance(exception, ProviderDeadlineExceeded):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.TIMEOUT,
+            safe_message="provider request deadline exceeded",
+            failover_eligible=True,
+        )
+    if isinstance(exception, ProviderRefusalError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.REFUSAL,
+            safe_message="provider refused the request",
+            safe_details={"signal": exception.signal.value},
+        )
+    if isinstance(exception, ProviderCapabilityError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
+            safe_message="provider deployment cannot preserve the requested capability",
+            safe_details={"capability": exception.capability},
+        )
+    if isinstance(exception, ProviderTransportError):
+        return _transport_failure(exception.status_code)
+    if isinstance(exception, ProviderResponseError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.MALFORMED_RESPONSE,
+            safe_message="provider returned a malformed response",
+            failover_eligible=True,
+        )
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.INTERNAL,
+        safe_message="provider execution failed",
+    )
+
+
+def _transport_failure(status_code: int | None) -> GatewayFailure:
+    """Classify one sanitized HTTP or connection failure by status only.
+
+    Args:
+        status_code: Provider HTTP status, or ``None`` for a connection failure.
+
+    Returns:
+        Stable retry and failover policy without response content.
+    """
+    details: JsonObject = {}
+    if status_code is not None:
+        details["status_code"] = status_code
+    if status_code in {401, 403}:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_AUTHENTICATION,
+            safe_message="provider authentication failed",
+            failover_eligible=True,
+            safe_details=details,
+        )
+    if status_code == 404:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_NOT_FOUND,
+            safe_message="provider deployment was not found",
+            failover_eligible=True,
+            safe_details=details,
+        )
+    if status_code == 429:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.THROTTLED,
+            safe_message="provider throttled the request",
+            failover_eligible=True,
+            safe_details=details,
+        )
+    if status_code == 408:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.TIMEOUT,
+            safe_message="provider request timed out",
+            retryable_same_deployment=True,
+            failover_eligible=True,
+            safe_details=details,
+        )
+    if status_code is not None and status_code >= 500:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+            safe_message="provider service failed",
+            retryable_same_deployment=True,
+            failover_eligible=True,
+            safe_details=details,
+        )
+    if status_code is not None:
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+            safe_message="provider rejected the request",
+            safe_details=details,
+        )
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.TRANSPORT,
+        safe_message="provider transport failed",
+        retryable_same_deployment=True,
+        failover_eligible=True,
+    )
 
 
 def require_array(value: JsonValue | None, label: str) -> list[JsonValue]:

--- a/wmo/runtime/models/providers/errors_test.py
+++ b/wmo/runtime/models/providers/errors_test.py
@@ -1,0 +1,99 @@
+"""Tests for provider refusal signals and sanitized gateway failure classification."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from wmo.runtime.gateway.contracts import GatewayFailureClass
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
+from wmo.runtime.models.providers.errors import (
+    ProviderCapabilityError,
+    ProviderRefusalError,
+    ProviderRefusalSignal,
+    ProviderResponseError,
+    normalized_provider_failure,
+)
+from wmo.runtime.models.providers.transport import ProviderTransportError
+
+
+@pytest.mark.parametrize(
+    ("exception", "failure_class", "retryable", "failover"),
+    [
+        (
+            ProviderTransportError("raw auth canary", status_code=401),
+            GatewayFailureClass.PROVIDER_AUTHENTICATION,
+            False,
+            True,
+        ),
+        (
+            ProviderTransportError("raw throttle canary", status_code=429),
+            GatewayFailureClass.THROTTLED,
+            False,
+            True,
+        ),
+        (
+            ProviderTransportError("raw server canary", status_code=503),
+            GatewayFailureClass.PROVIDER_INTERNAL,
+            True,
+            True,
+        ),
+        (
+            ProviderTransportError("raw body canary"),
+            GatewayFailureClass.TRANSPORT,
+            True,
+            True,
+        ),
+        (
+            ProviderDeadlineExceeded("raw deadline canary"),
+            GatewayFailureClass.TIMEOUT,
+            False,
+            True,
+        ),
+        (
+            ProviderResponseError("raw response canary"),
+            GatewayFailureClass.MALFORMED_RESPONSE,
+            False,
+            True,
+        ),
+    ],
+)
+def test_failures_are_typed_without_raw_provider_content(
+    exception: BaseException,
+    failure_class: GatewayFailureClass,
+    retryable: bool,
+    failover: bool,
+) -> None:
+    """Normalized failures retain policy but discard raw exception messages."""
+    failure = normalized_provider_failure(exception)
+
+    assert failure.failure_class is failure_class
+    assert failure.retryable_same_deployment is retryable
+    assert failure.failover_eligible is failover
+    assert "canary" not in failure.model_dump_json()
+
+
+def test_refusal_and_capability_failures_keep_only_safe_signals() -> None:
+    """Refusal and preflight failures expose categories without model-generated text."""
+    refusal = normalized_provider_failure(
+        ProviderRefusalError(
+            provider="fixture",
+            signal=ProviderRefusalSignal.SAFETY,
+        )
+    )
+    capability = normalized_provider_failure(ProviderCapabilityError(capability="strict_tools"))
+
+    assert refusal.failure_class is GatewayFailureClass.REFUSAL
+    assert refusal.safe_details == {"signal": "safety"}
+    assert capability.failure_class is GatewayFailureClass.UNSUPPORTED_CAPABILITY
+    assert capability.safe_details == {"capability": "strict_tools"}
+
+
+def test_cancellation_has_a_dedicated_nonretryable_failure() -> None:
+    """Client disconnect cancellation must not be retried or made failover eligible."""
+    failure = normalized_provider_failure(asyncio.CancelledError())
+
+    assert failure.failure_class is GatewayFailureClass.CANCELLED
+    assert failure.retryable_same_deployment is False
+    assert failure.failover_eligible is False

--- a/wmo/runtime/models/providers/gemini.py
+++ b/wmo/runtime/models/providers/gemini.py
@@ -24,6 +24,8 @@ from wmo.runtime.models.providers.base import (
     ProviderHttpClient,
 )
 from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
     ProviderResponseError,
     require_array,
     require_integer,
@@ -110,6 +112,9 @@ def gemini_generate_response(
     if not candidates:
         raise ProviderResponseError("Gemini response has no candidates")
     candidate = require_object(candidates[0], "Gemini candidates[0]")
+    refusal_signal = _gemini_refusal_signal(candidate.get("finishReason"))
+    if refusal_signal is not None:
+        raise ProviderRefusalError(provider="gemini", signal=refusal_signal)
     content = require_object(candidate.get("content"), "Gemini candidates[0].content")
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
@@ -288,3 +293,21 @@ def _gemini_usage(payload: JsonObject) -> Usage | None:
 def _path_model_id(model_id: str) -> str:
     """Remove the optional wire prefix before placing a model in a Gemini path."""
     return model_id.removeprefix("models/")
+
+
+def _gemini_refusal_signal(value: object) -> ProviderRefusalSignal | None:
+    """Map a Gemini finish reason to a content-free refusal category.
+
+    Args:
+        value: Provider-reported candidate finish reason.
+
+    Returns:
+        A normalized refusal signal, or ``None`` for ordinary terminal reasons.
+    """
+    if value in {"SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST"}:
+        return ProviderRefusalSignal.SAFETY
+    if value == "RECITATION":
+        return ProviderRefusalSignal.COPYRIGHT
+    if value == "SPII":
+        return ProviderRefusalSignal.SENSITIVE_INFORMATION
+    return None

--- a/wmo/runtime/models/providers/native_test.py
+++ b/wmo/runtime/models/providers/native_test.py
@@ -16,10 +16,15 @@ from wmo.common.models import (
 from wmo.runtime.models.providers.anthropic import (
     AnthropicClient,
     anthropic_messages_request,
+    anthropic_messages_response,
 )
-from wmo.runtime.models.providers.errors import ProviderRetryableResponseError
-from wmo.runtime.models.providers.gemini import GeminiClient
-from wmo.runtime.models.providers.openai import OpenAIClient
+from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
+    ProviderRetryableResponseError,
+)
+from wmo.runtime.models.providers.gemini import GeminiClient, gemini_generate_response
+from wmo.runtime.models.providers.openai import OpenAIClient, openai_responses_response
 from wmo.runtime.models.providers.openai_compatible import OpenRouterClient
 from wmo.runtime.models.providers.openai_compatible_test import _request, _snapshot
 from wmo.runtime.models.providers.tinker_sampling import (
@@ -475,6 +480,10 @@ def test_openai_reasoning_only_output_is_retried_and_a_later_answer_completes() 
 
     assert response.output.content == "ok"
     assert len(transport.requests) == 2
+    assert (
+        transport.requests[0].headers["Idempotency-Key"]
+        == transport.requests[1].headers["Idempotency-Key"]
+    )
 
 
 def test_openai_reasoning_only_output_surfaces_a_retryable_error_after_exhaustion() -> None:
@@ -492,3 +501,62 @@ def test_openai_reasoning_only_output_surfaces_a_retryable_error_after_exhaustio
         client.complete(_request())
 
     assert len(transport.requests) == 2
+
+
+def test_native_provider_refusals_are_typed_without_exposing_refusal_text() -> None:
+    """OpenAI, Anthropic, and Gemini preserve content-free refusal signals."""
+    openai_canary = "openai-refusal-canary"
+    with pytest.raises(ProviderRefusalError) as openai_error:
+        openai_responses_response(
+            {
+                "id": "resp_refusal",
+                "object": "response",
+                "created_at": 1.0,
+                "status": "completed",
+                "model": "gpt-fixture",
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_refusal",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "refusal", "refusal": openai_canary}],
+                    }
+                ],
+            },
+            configured_model=_snapshot("openai", "gpt-fixture"),
+            latency_seconds=0.1,
+        )
+    assert openai_error.value.signal is ProviderRefusalSignal.PROVIDER_REFUSAL
+    assert openai_canary not in str(openai_error.value)
+
+    with pytest.raises(ProviderRefusalError) as anthropic_error:
+        anthropic_messages_response(
+            {
+                "content": [{"type": "text", "text": "anthropic-refusal-canary"}],
+                "stop_reason": "refusal",
+            },
+            configured_model=_snapshot("anthropic", "claude-fixture"),
+            latency_seconds=0.1,
+        )
+    assert anthropic_error.value.signal is ProviderRefusalSignal.PROVIDER_REFUSAL
+    assert "anthropic-refusal-canary" not in str(anthropic_error.value)
+
+    with pytest.raises(ProviderRefusalError) as gemini_error:
+        gemini_generate_response(
+            {
+                "candidates": [
+                    {
+                        "finishReason": "SAFETY",
+                        "content": {"parts": [{"text": "gemini-refusal-canary"}]},
+                    }
+                ]
+            },
+            configured_model=_snapshot("gemini", "gemini-fixture"),
+            latency_seconds=0.1,
+        )
+    assert gemini_error.value.signal is ProviderRefusalSignal.SAFETY
+    assert "gemini-refusal-canary" not in str(gemini_error.value)

--- a/wmo/runtime/models/providers/openai.py
+++ b/wmo/runtime/models/providers/openai.py
@@ -25,8 +25,11 @@ from wmo.common.models import (
     ToolCall,
     Usage,
 )
+from wmo.runtime.models.providers.async_transport import AsyncJsonHttpTransport
 from wmo.runtime.models.providers.base import DEFAULT_RETRY_POLICY, DEFAULT_TIMEOUT_SECONDS
 from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
     ProviderResponseError,
     ProviderRetryableResponseError,
 )
@@ -142,7 +145,10 @@ def openai_responses_response(
                 if isinstance(part, ResponseOutputText):
                     text_parts.append(part.text)
                 elif isinstance(part, ResponseOutputRefusal):
-                    text_parts.append(part.refusal)
+                    raise ProviderRefusalError(
+                        provider="openai",
+                        signal=ProviderRefusalSignal.PROVIDER_REFUSAL,
+                    )
                 else:
                     raise ProviderResponseError(
                         f"OpenAI Responses output[{index}] has unsupported content type "
@@ -182,7 +188,7 @@ class OpenAIClient(OpenAIEmbeddingMixin):
         model: ModelSnapshot,
         api_key: str,
         base_url: str = OPENAI_BASE_URL,
-        transport: JsonHttpTransport | None = None,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
         supports_temperature: bool = True,

--- a/wmo/runtime/models/providers/openai_compatible.py
+++ b/wmo/runtime/models/providers/openai_compatible.py
@@ -22,6 +22,8 @@ from wmo.common.models import (
 )
 from wmo.runtime.models.providers.base import ProviderHttpClient
 from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
     ProviderResponseError,
     require_array,
     require_integer,
@@ -113,6 +115,13 @@ def openai_compatible_response(
         raise OpenAICompatibleResponseError("OpenAI-compatible response has no choices")
     choice = require_object(choices[0], "choices[0]")
     message = require_object(choice.get("message"), "choices[0].message")
+    if choice.get("finish_reason") in {"content_filter", "safety"} or isinstance(
+        message.get("refusal"), str
+    ):
+        raise ProviderRefusalError(
+            provider="openai-compatible",
+            signal=ProviderRefusalSignal.CONTENT_POLICY,
+        )
     content_value = message.get("content")
     content = content_value if isinstance(content_value, str) else None
     tool_call_values = _array_or_empty(message)

--- a/wmo/runtime/models/providers/openai_compatible_test.py
+++ b/wmo/runtime/models/providers/openai_compatible_test.py
@@ -21,10 +21,15 @@ from wmo.common.models import (
     ToolChoice,
 )
 from wmo.common.tasks import ToolSchema
+from wmo.runtime.models.providers.errors import (
+    ProviderRefusalError,
+    ProviderRefusalSignal,
+)
 from wmo.runtime.models.providers.openai_compatible import (
     OpenAICompatibleClient,
     OpenAICompatibleResponseError,
     openai_compatible_request,
+    openai_compatible_response,
 )
 from wmo.runtime.models.providers.transport import (
     JsonHttpResponse,
@@ -303,3 +308,25 @@ def test_openai_compatible_conversion_rejects_malformed_tool_arguments() -> None
 
     with pytest.raises(OpenAICompatibleResponseError, match="arguments is not JSON"):
         client.complete(_request())
+
+
+def test_openai_compatible_refusal_is_typed_without_exposing_content() -> None:
+    """Content-filter finish state must not be folded into visible assistant text."""
+    canary = "compatible-refusal-canary"
+
+    with pytest.raises(ProviderRefusalError) as error:
+        openai_compatible_response(
+            {
+                "choices": [
+                    {
+                        "finish_reason": "content_filter",
+                        "message": {"content": canary},
+                    }
+                ]
+            },
+            configured_model=_snapshot(),
+            latency_seconds=0.1,
+        )
+
+    assert error.value.signal is ProviderRefusalSignal.CONTENT_POLICY
+    assert canary not in str(error.value)

--- a/wmo/runtime/models/providers/protocol.py
+++ b/wmo/runtime/models/providers/protocol.py
@@ -1,0 +1,208 @@
+"""Gateway provider protocols and bounded compatibility adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from wmo.common.models import ModelClient, ModelRequest, ModelResponse
+from wmo.common.models.catalog import GatewayDeploymentCapabilities
+from wmo.runtime.gateway.contracts import GatewayRequest
+from wmo.runtime.gateway.interfaces import ProviderStream
+from wmo.runtime.models.providers.async_transport import RequestDeadline
+from wmo.runtime.models.providers.errors import ProviderCapabilityError
+
+
+class AsyncCompletedModelClient(Protocol):
+    """Async non-streaming completion seam used by existing provider translations."""
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Complete one request under an absolute deadline and stable attempt identity."""
+        ...
+
+
+class AsyncGatewayProvider(Protocol):
+    """Gateway-native provider that yields normalized events in provider order."""
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+    ) -> ProviderStream:
+        """Start one cancellable normalized provider stream."""
+        ...
+
+
+class SyncModelClientAdapter:
+    """Expose an async completed client through the existing sync ``ModelClient`` contract."""
+
+    def __init__(self, client: AsyncCompletedModelClient, *, timeout_seconds: float) -> None:
+        """Bind one async client and positive compatibility timeout.
+
+        Args:
+            client: Async provider client used for every completion.
+            timeout_seconds: Total request-wide compatibility budget.
+
+        Raises:
+            ValueError: The timeout is not positive.
+        """
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._client = client
+        self._timeout_seconds = timeout_seconds
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Run one async completion for a caller that is not on an event loop.
+
+        Args:
+            request: Existing provider-independent model request.
+
+        Returns:
+            The completed response from the async provider.
+
+        Raises:
+            RuntimeError: Called from an event-loop thread, where callers must await directly.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._complete(request))
+        raise RuntimeError(
+            "sync model compatibility cannot run on an event loop; await complete_async instead"
+        )
+
+    async def _complete(self, request: ModelRequest) -> ModelResponse:
+        """Apply the configured total deadline to one async provider completion."""
+        deadline = RequestDeadline.after(self._timeout_seconds)
+        async with asyncio.timeout(self._timeout_seconds):
+            return await self._client.complete_async(request, deadline=deadline)
+
+
+class BoundedSyncModelClientAdapter:
+    """Run blocking provider calls off-loop with a hard outstanding-work bound.
+
+    Cancellation and deadline expiry stop waiting immediately but cannot interrupt an SDK call
+    already executing in a worker thread. Its permit remains reserved until that call returns, so
+    repeated disconnects cannot create an unbounded set of blocking Bedrock operations.
+    """
+
+    def __init__(self, client: ModelClient, *, maximum_outstanding_calls: int = 4) -> None:
+        """Bind one sync client behind a finite worker admission bound.
+
+        Args:
+            client: Blocking provider client, currently intended for Bedrock.
+            maximum_outstanding_calls: Running plus detached calls allowed at once.
+
+        Raises:
+            ValueError: The outstanding-call bound is not positive.
+        """
+        if maximum_outstanding_calls < 1:
+            raise ValueError("maximum_outstanding_calls must be at least one")
+        self._client = client
+        self._permits = asyncio.Semaphore(maximum_outstanding_calls)
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Run one blocking completion while preserving queue and cancellation bounds.
+
+        Args:
+            request: Existing provider-independent model request.
+            deadline: Absolute request-wide deadline, required for gateway execution.
+            idempotency_key: Stable request identity, unsupported by blocking Bedrock today.
+
+        Returns:
+            The completed provider response.
+
+        Raises:
+            ValueError: No absolute deadline was supplied or idempotency forwarding was requested.
+            TimeoutError: Queueing or the caller's wait exhausts the deadline.
+        """
+        if deadline is None:
+            raise ValueError("bounded sync provider calls require an absolute deadline")
+        if idempotency_key is not None:
+            raise ValueError("blocking provider adapter cannot forward idempotency identity")
+        await self._acquire(deadline)
+        task = asyncio.create_task(asyncio.to_thread(self._client.complete, request))
+        task.add_done_callback(self._release_permit)
+        timeout_seconds = deadline.attempt_timeout()
+        async with asyncio.timeout(timeout_seconds):
+            return await asyncio.shield(task)
+
+    async def _acquire(self, deadline: RequestDeadline) -> None:
+        """Wait for one worker permit without exceeding the request deadline."""
+        timeout_seconds = deadline.attempt_timeout()
+        async with asyncio.timeout(timeout_seconds):
+            await self._permits.acquire()
+
+    def _release_permit(self, task: asyncio.Task[ModelResponse]) -> None:
+        """Release admission only after the underlying blocking call actually stops."""
+        del task
+        self._permits.release()
+
+
+def preflight_gateway_request(
+    request: GatewayRequest,
+    capabilities: GatewayDeploymentCapabilities,
+) -> None:
+    """Reject gateway semantics a deployment cannot preserve before provider dispatch.
+
+    Args:
+        request: Canonical request produced by the public protocol decoder.
+        capabilities: Versioned deployment and adapter capability declaration.
+
+    Raises:
+        ProviderCapabilityError: A present request feature is unsupported.
+    """
+    requirements = (
+        (request.stream, capabilities.supports_streaming, "streaming"),
+        (
+            any(message.role == "developer" for message in request.messages),
+            capabilities.supports_developer_messages,
+            "developer_messages",
+        ),
+        (bool(request.stop), capabilities.supports_stop_sequences, "stop_sequences"),
+        (
+            any(tool.strict for tool in request.tools),
+            capabilities.supports_strict_tools,
+            "strict_tools",
+        ),
+        (
+            request.parallel_tool_calls is True,
+            capabilities.supports_parallel_tool_calls,
+            "parallel_tool_calls",
+        ),
+        (
+            request.structured_text is not None,
+            capabilities.supports_structured_text,
+            "structured_text",
+        ),
+    )
+    for requested, supported, capability in requirements:
+        if requested and not supported:
+            raise ProviderCapabilityError(capability=capability)
+
+
+def require_gateway_provider(provider: str) -> None:
+    """Fail closed for provider families excluded from gateway execution.
+
+    Args:
+        provider: Stable provider family name from the catalog connection.
+
+    Raises:
+        ProviderCapabilityError: Tinker is selected for gateway execution.
+    """
+    if provider == "tinker":
+        raise ProviderCapabilityError(capability="tinker_gateway_execution")

--- a/wmo/runtime/models/providers/protocol.py
+++ b/wmo/runtime/models/providers/protocol.py
@@ -109,6 +109,17 @@ class BoundedSyncModelClientAdapter:
         self._client = client
         self._permits = asyncio.Semaphore(maximum_outstanding_calls)
 
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Preserve the existing synchronous completion contract for optimizer callers.
+
+        Args:
+            request: Existing provider-independent model request.
+
+        Returns:
+            The completed response from the wrapped blocking provider.
+        """
+        return self._client.complete(request)
+
     async def complete_async(
         self,
         request: ModelRequest,

--- a/wmo/runtime/models/providers/protocol_test.py
+++ b/wmo/runtime/models/providers/protocol_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from wmo.common.models import (
     AssistantAction,
+    BillingSource,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -43,6 +44,7 @@ def _response() -> ModelResponse:
         configured_model=ModelSnapshot(
             provider="fixture",
             model_id="fixture-model",
+            billing_source=BillingSource.CUSTOMER_MANAGED,
             revision="fixture-revision",
             capabilities_sha256="a" * 64,
             connection_sha256="b" * 64,

--- a/wmo/runtime/models/providers/protocol_test.py
+++ b/wmo/runtime/models/providers/protocol_test.py
@@ -1,0 +1,156 @@
+"""Tests for provider protocols, sync bridges, preflight, and gateway exclusions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from wmo.common.models import (
+    AssistantAction,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+)
+from wmo.common.models.catalog import GatewayDeploymentCapabilities
+from wmo.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
+from wmo.runtime.models.providers.async_transport import RequestDeadline
+from wmo.runtime.models.providers.errors import ProviderCapabilityError
+from wmo.runtime.models.providers.protocol import (
+    BoundedSyncModelClientAdapter,
+    SyncModelClientAdapter,
+    preflight_gateway_request,
+    require_gateway_provider,
+)
+
+
+def _request() -> ModelRequest:
+    """Build one existing sync-model request fixture."""
+    return ModelRequest(messages=(ModelMessage(role="user", content="hi"),))
+
+
+def _response() -> ModelResponse:
+    """Build one completed model response fixture."""
+    return ModelResponse.completed(
+        output=AssistantAction(content="ok"),
+        configured_model=ModelSnapshot(
+            provider="fixture",
+            model_id="fixture-model",
+            revision="fixture-revision",
+            capabilities_sha256="a" * 64,
+            connection_sha256="b" * 64,
+        ),
+        served_model_id=None,
+        usage=None,
+        latency_seconds=0.01,
+    )
+
+
+class _AsyncClient:
+    """Minimal async completed client for sync compatibility tests."""
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Return one fixture response after validating adapter inputs."""
+        assert request == _request()
+        assert deadline is not None
+        assert idempotency_key is None
+        return _response()
+
+
+class _BlockingClient:
+    """Sync client that blocks until a test-controlled release event."""
+
+    def __init__(self) -> None:
+        """Create blocked-call coordination state."""
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.calls = 0
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Block one worker completion until the test releases it."""
+        assert request == _request()
+        self.calls += 1
+        self.started.set()
+        self.release.wait(timeout=2)
+        return _response()
+
+
+def test_sync_adapter_preserves_existing_model_client_callers() -> None:
+    """Optimizer callers can retain ``complete`` while providers execute asynchronously."""
+    adapter = SyncModelClientAdapter(_AsyncClient(), timeout_seconds=1)
+
+    assert adapter.complete(_request()).output.content == "ok"
+
+
+def test_sync_adapter_refuses_to_block_an_event_loop() -> None:
+    """Gateway handlers must await providers instead of using the sync bridge."""
+
+    async def scenario() -> None:
+        """Call the sync method from an event loop and require a focused failure."""
+        adapter = SyncModelClientAdapter(_AsyncClient(), timeout_seconds=1)
+        with pytest.raises(RuntimeError, match="await complete_async"):
+            adapter.complete(_request())
+
+    asyncio.run(scenario())
+
+
+def test_bounded_worker_holds_admission_after_client_cancellation() -> None:
+    """A detached blocking call retains its permit until the SDK work actually stops."""
+    client = _BlockingClient()
+
+    async def scenario() -> None:
+        """Cancel one call, then prove a second call cannot enter the full worker bound."""
+        adapter = BoundedSyncModelClientAdapter(client, maximum_outstanding_calls=1)
+        first = asyncio.create_task(
+            adapter.complete_async(_request(), deadline=RequestDeadline.after(1))
+        )
+        await asyncio.to_thread(client.started.wait, 1)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        with pytest.raises(TimeoutError):
+            await adapter.complete_async(_request(), deadline=RequestDeadline.after(0.02))
+        assert client.calls == 1
+        client.release.set()
+        await asyncio.sleep(0.02)
+
+    asyncio.run(scenario())
+
+
+def test_preflight_rejects_unsupported_semantics_before_dispatch() -> None:
+    """A deployment that cannot preserve strict tools fails before provider construction."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        tools=(
+            GatewayToolDefinition(
+                name="lookup",
+                parameters={"type": "object"},
+                strict=True,
+            ),
+        ),
+    )
+
+    with pytest.raises(ProviderCapabilityError, match="strict_tools"):
+        preflight_gateway_request(request, GatewayDeploymentCapabilities())
+
+
+def test_tinker_is_explicitly_excluded_from_gateway_execution() -> None:
+    """Tinker remains optimizer-only until it has a cancellable stream contract."""
+    with pytest.raises(ProviderCapabilityError, match="tinker_gateway_execution"):
+        require_gateway_provider("tinker")
+
+    require_gateway_provider("openai")

--- a/wmo/runtime/models/registry.py
+++ b/wmo/runtime/models/registry.py
@@ -19,6 +19,10 @@ from wmo.common.models import (
 from wmo.runtime.models.credentials import read_connection_api_key
 from wmo.runtime.models.preflight import CapabilityRequirement, preflight_capabilities
 from wmo.runtime.models.providers.anthropic import ANTHROPIC_BASE_URL, AnthropicClient
+from wmo.runtime.models.providers.async_transport import (
+    AsyncJsonHttpTransport,
+    HttpxAsyncJsonTransport,
+)
 from wmo.runtime.models.providers.azure import AzureClient, bind_azure_api_key
 from wmo.runtime.models.providers.bedrock import BedrockClient, BedrockRuntimeFactory
 from wmo.runtime.models.providers.gemini import GEMINI_BASE_URL, GeminiClient
@@ -34,7 +38,9 @@ from wmo.runtime.models.providers.tinker_sampling import (
     TinkerSamplingClient,
     create_tinker_sampler,
 )
-from wmo.runtime.models.providers.transport import HttpxJsonTransport, JsonHttpTransport
+from wmo.runtime.models.providers.transport import JsonHttpTransport
+
+ProviderTransport = AsyncJsonHttpTransport | JsonHttpTransport
 
 CatalogRoleName = Literal["world_model", "judge", "candidate"]
 """Completion role whose catalog-configured reasoning effort shapes resolved requests."""
@@ -75,7 +81,7 @@ class _HttpClientFactory(Protocol):
         model: ModelSnapshot,
         api_key: str,
         base_url: str,
-        transport: JsonHttpTransport,
+        transport: ProviderTransport,
     ) -> ModelClient:
         """Return a focused completion client for one resolved connection.
 
@@ -111,7 +117,7 @@ class RuntimeModelCatalog:
         catalog: ModelCatalog,
         *,
         environment: Mapping[str, str] | None = None,
-        transport_factory: Callable[[], JsonHttpTransport] = HttpxJsonTransport,
+        transport_factory: Callable[[], ProviderTransport] = HttpxAsyncJsonTransport,
         tinker_sampler_factory: TinkerSamplerFactory | None = None,
         bedrock_runtime_factory: BedrockRuntimeFactory | None = None,
     ) -> None:

--- a/wmo/runtime/models/registry.py
+++ b/wmo/runtime/models/registry.py
@@ -24,7 +24,11 @@ from wmo.runtime.models.providers.async_transport import (
     HttpxAsyncJsonTransport,
 )
 from wmo.runtime.models.providers.azure import AzureClient, bind_azure_api_key
-from wmo.runtime.models.providers.bedrock import BedrockClient, BedrockRuntimeFactory
+from wmo.runtime.models.providers.bedrock import (
+    BedrockClient,
+    BedrockRuntimeFactory,
+    BoundedBedrockClient,
+)
 from wmo.runtime.models.providers.gemini import GEMINI_BASE_URL, GeminiClient
 from wmo.runtime.models.providers.openai import OPENAI_BASE_URL, OpenAIClient
 from wmo.runtime.models.providers.openai_compatible import (
@@ -215,18 +219,19 @@ class RuntimeModelCatalog:
                 )
         provider = connection.provider
         if provider == "bedrock":
-            client = BedrockClient(
+            bedrock_client = BedrockClient(
                 model=snapshot,
                 region=connection.region,
                 environment=self._environment,
                 runtime_factory=self._bedrock_runtime_factory,
             )
+            client = BoundedBedrockClient(bedrock_client)
             return ResolvedModel(
                 alias,
                 snapshot,
                 capabilities,
                 client,
-                client if capabilities.supports_embeddings else None,
+                bedrock_client if capabilities.supports_embeddings else None,
             )
         api_key = read_connection_api_key(connection, environment=self._environment)
         if provider == "openai":


### PR DESCRIPTION
## What changed

- add an async-native provider transport backed by `httpx.AsyncClient`
- collapse transport and empty-output retries into one absolute-deadline attempt loop
- preserve one idempotency identity across safe same-endpoint retries
- keep existing synchronous `ModelClient` callers through a bounded compatibility adapter
- add typed, content-free provider failures and refusal signals for OpenAI, Anthropic, OpenAI-compatible, Gemini, and Bedrock
- add capability preflight, bounded blocking-worker admission for Bedrock, and explicit Tinker gateway exclusion
- make the runtime catalog construct the async transport by default while retaining deterministic sync transport injection

## Why

The provider stack was synchronous and applied separate full-budget retry loops at the HTTP and decoded-output layers. That prevented reliable cancellation and could multiply attempts without one request-wide bound. This change establishes the async execution and failure contracts needed by provider streaming while preserving current optimizer behavior.

## Scope boundaries

This PR does not implement public OpenAI SSE, cross-provider waterfalls, gateway CLI or lifecycle, SQLite state, or launch-provider streaming certification. Bedrock remains a bounded blocking compatibility lane, and Tinker remains optimizer-only.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- 125 focused provider, gateway-contract, journal, model, and registry tests

Full repository pytest and installed-wheel certification continue in the review pass.
