### PR TITLE
Add gateway SQLite authority and ledger

### DIFF
--- a/wmo/runtime/gateway/auth.py
+++ b/wmo/runtime/gateway/auth.py
@@ -1,0 +1,241 @@
+"""Virtual-key issuance and versioned local fingerprint protection."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import stat
+import tempfile
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import AwareDatetime
+
+from wmo.common.core.artifacts import ContractModel, Sha256
+from wmo.runtime.gateway.contracts import IdentityId, OrganizationId, VirtualKeyId
+
+
+class GatewayAuthError(ValueError):
+    """A virtual key or fingerprint-pepper operation is invalid."""
+
+
+class IssuedVirtualKey(ContractModel):
+    """One newly issued virtual key whose raw value is revealed exactly once."""
+
+    key_id: VirtualKeyId
+    organization_id: OrganizationId
+    identity_id: IdentityId
+    prefix: str
+    raw_key: str
+    expires_at: AwareDatetime | None
+    created_at: AwareDatetime
+
+
+class PepperKey(ContractModel):
+    """One decoded HMAC key selected by its stored fingerprint version."""
+
+    version: int
+    value: bytes
+
+
+class FingerprintPepperFile:
+    """Atomically created, user-only file containing versioned HMAC keys."""
+
+    def __init__(self, path: Path) -> None:
+        """Initialize the pepper file owner.
+
+        Args:
+            path: User-only file path outside the gateway database.
+        """
+        self._path = path
+        self._lock = threading.RLock()
+
+    @property
+    def path(self) -> Path:
+        """Return the configured pepper file path."""
+        return self._path
+
+    def current(self) -> PepperKey:
+        """Load or atomically create the current fingerprint key.
+
+        Returns:
+            The current version and decoded 256-bit key.
+        """
+        with self._lock:
+            if not self._path.exists():
+                self._create_initial()
+            current_version, keys = self._read()
+            return PepperKey(version=current_version, value=keys[current_version])
+
+    def key(self, version: int) -> PepperKey:
+        """Load one retained fingerprint key version.
+
+        Args:
+            version: Stored fingerprint version.
+
+        Returns:
+            The matching decoded HMAC key.
+
+        Raises:
+            GatewayAuthError: The version is not retained.
+        """
+        with self._lock:
+            _, keys = self._read()
+            try:
+                value = keys[version]
+            except KeyError as exc:
+                raise GatewayAuthError("virtual-key fingerprint version is unavailable") from exc
+            return PepperKey(version=version, value=value)
+
+    def rotate(self) -> int:
+        """Append and select a fresh key while retaining older versions.
+
+        Returns:
+            The new current version.
+        """
+        with self._lock:
+            current_version, keys = self._read()
+            next_version = current_version + 1
+            keys[next_version] = secrets.token_bytes(32)
+            self._replace(next_version, keys)
+            return next_version
+
+    def _create_initial(self) -> None:
+        """Create version one without following links or replacing existing state."""
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        payload = self._encode(1, {1: secrets.token_bytes(32)})
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(self._path, flags, 0o600)
+        except FileExistsError:
+            return
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except BaseException:
+            self._path.unlink(missing_ok=True)
+            raise
+
+    def _read(self) -> tuple[int, dict[int, bytes]]:
+        """Validate permissions and decode all retained key versions."""
+        try:
+            metadata = self._path.lstat()
+        except FileNotFoundError as exc:
+            raise GatewayAuthError("virtual-key fingerprint pepper is missing") from exc
+        if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+            raise GatewayAuthError(
+                "virtual-key fingerprint pepper must be a regular mode-0600 file"
+            )
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+            current_version = int(payload["current_version"])
+            encoded_keys = payload["keys"]
+            if not isinstance(encoded_keys, dict):
+                raise TypeError("keys is not an object")
+            keys = {
+                int(version): base64.b64decode(encoded, validate=True)
+                for version, encoded in encoded_keys.items()
+                if isinstance(version, str) and isinstance(encoded, str)
+            }
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise GatewayAuthError("virtual-key fingerprint pepper is invalid") from exc
+        if current_version not in keys or any(len(value) != 32 for value in keys.values()):
+            raise GatewayAuthError("virtual-key fingerprint pepper is invalid")
+        return current_version, keys
+
+    def _replace(self, current_version: int, keys: dict[int, bytes]) -> None:
+        """Atomically replace the pepper file with a validated version set."""
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{self._path.name}.", dir=self._path.parent
+        )
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(self._encode(current_version, keys))
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self._path)
+            os.chmod(self._path, 0o600)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    @staticmethod
+    def _encode(current_version: int, keys: dict[int, bytes]) -> bytes:
+        """Encode a deterministic pepper document without logging key bytes."""
+        payload = {
+            "current_version": current_version,
+            "keys": {
+                str(version): base64.b64encode(keys[version]).decode("ascii")
+                for version in sorted(keys)
+            },
+        }
+        return (json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def issue_key_material() -> tuple[str, str]:
+    """Create a display-safe prefix and a raw key with at least 256 random bits.
+
+    Returns:
+        The non-secret prefix and one-time raw key.
+    """
+    prefix = secrets.token_hex(6)
+    secret = secrets.token_urlsafe(32)
+    return prefix, f"wmo_vk_{prefix}_{secret}"
+
+
+def key_prefix(raw_key: str) -> str:
+    """Extract the lookup prefix without exposing the secret component.
+
+    Args:
+        raw_key: Caller-supplied virtual key.
+
+    Returns:
+        The non-secret prefix.
+
+    Raises:
+        GatewayAuthError: The key has no valid gateway shape.
+    """
+    parts = raw_key.split("_", 3)
+    if len(parts) != 4 or parts[:2] != ["wmo", "vk"] or len(parts[2]) != 12 or not parts[3]:
+        raise GatewayAuthError("virtual key is invalid")
+    return parts[2]
+
+
+def fingerprint_virtual_key(raw_key: str, pepper: PepperKey) -> Sha256:
+    """Return the version-selected HMAC-SHA256 fingerprint for one raw key.
+
+    Args:
+        raw_key: Caller-supplied or newly issued key.
+        pepper: Retained HMAC key version.
+
+    Returns:
+        Lowercase hexadecimal HMAC digest.
+    """
+    return hmac.new(pepper.value, raw_key.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def utc_text(value: datetime) -> str:
+    """Serialize a timezone-aware timestamp for lexical SQLite comparison.
+
+    Args:
+        value: Timezone-aware timestamp.
+
+    Returns:
+        UTC ISO-8601 text with microsecond precision.
+
+    Raises:
+        ValueError: The value is timezone-naive.
+    """
+    if value.tzinfo is None:
+        raise ValueError("gateway timestamps must be timezone-aware")
+    return value.astimezone(UTC).isoformat(timespec="microseconds")

--- a/wmo/runtime/gateway/auth_test.py
+++ b/wmo/runtime/gateway/auth_test.py
@@ -1,0 +1,58 @@
+"""Tests for virtual-key material and versioned fingerprint protection."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from wmo.runtime.gateway.auth import (
+    FingerprintPepperFile,
+    GatewayAuthError,
+    fingerprint_virtual_key,
+    issue_key_material,
+    key_prefix,
+)
+
+
+def test_pepper_is_mode_0600_and_rotation_retains_old_fingerprint_keys(tmp_path: Path) -> None:
+    """Pepper rotation changes future HMACs without invalidating retained versions."""
+    path = tmp_path / "state" / "gateway-key-pepper.json"
+    pepper_file = FingerprintPepperFile(path)
+    first = pepper_file.current()
+    _, raw_key = issue_key_material()
+    first_fingerprint = fingerprint_virtual_key(raw_key, first)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert pepper_file.rotate() == 2
+    assert pepper_file.current().version == 2
+    assert fingerprint_virtual_key(raw_key, pepper_file.key(1)) == first_fingerprint
+    assert fingerprint_virtual_key(raw_key, pepper_file.current()) != first_fingerprint
+
+
+def test_pepper_rejects_group_readable_and_symlink_state(tmp_path: Path) -> None:
+    """Permission drift and link substitution fail closed."""
+    path = tmp_path / "pepper.json"
+    pepper_file = FingerprintPepperFile(path)
+    pepper_file.current()
+    path.chmod(0o640)
+
+    with pytest.raises(GatewayAuthError, match="mode-0600"):
+        pepper_file.current()
+
+    target = tmp_path / "target.json"
+    path.rename(target)
+    path.symlink_to(target)
+    with pytest.raises(GatewayAuthError, match="regular"):
+        pepper_file.current()
+
+
+def test_virtual_key_has_256_random_bits_and_parseable_prefix() -> None:
+    """Issued raw keys carry a non-secret lookup prefix and a 32-byte random secret."""
+    prefix, raw_key = issue_key_material()
+
+    assert key_prefix(raw_key) == prefix
+    assert len(raw_key.removeprefix(f"wmo_vk_{prefix}_")) >= 43
+    with pytest.raises(GatewayAuthError, match="invalid"):
+        key_prefix("not-a-gateway-key")

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -1,0 +1,565 @@
+"""Content-free SQLite request, attempt, recovery, and usage accounting."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from wmo.common.core.artifacts import ContractModel
+from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.runtime.gateway.auth import utc_text
+from wmo.runtime.gateway.contracts import (
+    AttemptId,
+    AuthorizationSnapshot,
+    ExecutionSnapshot,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayUsage,
+)
+from wmo.runtime.gateway.interfaces import GatewayClock
+from wmo.runtime.gateway.sqlite.migrations import connect_database, initialize_database
+from wmo.runtime.gateway.sqlite.store import SystemGatewayClock
+
+
+class GatewayLedgerError(ValueError):
+    """A request or attempt transition violates the content-free ledger contract."""
+
+
+class IdempotencyConflictError(GatewayLedgerError):
+    """A caller operation key was reused with different canonical request content."""
+
+
+class IdempotencyReplayUnavailableError(GatewayLedgerError):
+    """A completed or accepted keyed request exists but its content cannot be replayed."""
+
+
+class UsageTerminalCount(ContractModel):
+    """Count of attempts ending in one normalized terminal state."""
+
+    state: str
+    attempts: int
+
+
+class IdentityUsage(ContractModel):
+    """Content-free usage totals for one identity."""
+
+    organization_id: str
+    identity_id: str
+    requests: int
+    attempts: int
+    input_tokens: int
+    cached_input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    known_estimated_cost_micro_usd: int
+    unknown_cost_attempts: int
+    total_latency_ms: int
+    average_latency_ms: float | None
+    terminal_counts: tuple[UsageTerminalCount, ...]
+
+
+class SQLiteAttemptLedger:
+    """Durable content-free attempt ledger sharing the gateway control database."""
+
+    def __init__(
+        self,
+        database_path: Path,
+        *,
+        clock: GatewayClock | None = None,
+        busy_timeout_ms: int = 5_000,
+    ) -> None:
+        """Initialize a ledger on an existing or new gateway database.
+
+        Args:
+            database_path: Shared gateway SQLite path.
+            clock: Injectable wall and monotonic clock.
+            busy_timeout_ms: Maximum SQLite lock wait.
+        """
+        self.database_path = database_path
+        self._clock = SystemGatewayClock() if clock is None else clock
+        self._busy_timeout_ms = busy_timeout_ms
+        initialize_database(database_path, busy_timeout_ms=busy_timeout_ms)
+
+    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
+        """Persist accepted authority before route selection or dispatch.
+
+        Args:
+            authorization: Frozen authority and request identity.
+
+        Raises:
+            IdempotencyConflictError: The caller operation exists for another request.
+            IdempotencyReplayUnavailableError: The matching operation already exists.
+        """
+        now = self._clock.now()
+        remaining = max(0.0, authorization.deadline_monotonic - self._clock.monotonic())
+        deadline_at = now + timedelta(seconds=remaining)
+        with self._transaction() as connection:
+            if authorization.caller_operation_sha256 is not None:
+                prior = connection.execute(
+                    """
+                    SELECT canonical_request_sha256, terminal_state
+                    FROM gateway_requests
+                    WHERE organization_id = ? AND identity_id = ?
+                      AND alias_revision_id = ? AND api_surface = ?
+                      AND caller_operation_sha256 = ?
+                    ORDER BY accepted_at DESC LIMIT 1
+                    """,
+                    (
+                        authorization.organization_id,
+                        authorization.identity_id,
+                        authorization.alias_revision_id,
+                        authorization.surface.value,
+                        authorization.caller_operation_sha256,
+                    ),
+                ).fetchone()
+                if prior is not None:
+                    if str(prior["canonical_request_sha256"]) != (
+                        authorization.canonical_request_sha256
+                    ):
+                        raise IdempotencyConflictError(
+                            "caller operation key was reused with different request content"
+                        )
+                    if str(prior["terminal_state"]) not in {
+                        "expired_before_dispatch",
+                        "unknown_after_crash",
+                    }:
+                        raise IdempotencyReplayUnavailableError(
+                            "matching keyed request exists but durable content replay "
+                            "is unavailable"
+                        )
+            alias_row = connection.execute(
+                """
+                SELECT alias_id FROM alias_revisions
+                WHERE organization_id = ? AND revision_id = ?
+                """,
+                (authorization.organization_id, authorization.alias_revision_id),
+            ).fetchone()
+            if alias_row is None:
+                raise GatewayLedgerError("authorized alias revision is not present in the ledger")
+            connection.execute(
+                """
+                INSERT INTO gateway_requests (
+                    request_id, organization_id, identity_id, key_id, alias_id,
+                    alias_revision_id, api_surface, canonical_request_sha256,
+                    caller_operation_sha256, accepted_at, deadline_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    authorization.request_id,
+                    authorization.organization_id,
+                    authorization.identity_id,
+                    authorization.virtual_key_id,
+                    str(alias_row["alias_id"]),
+                    authorization.alias_revision_id,
+                    authorization.surface.value,
+                    authorization.canonical_request_sha256,
+                    authorization.caller_operation_sha256,
+                    utc_text(now),
+                    utc_text(deadline_at),
+                ),
+            )
+
+    def start_attempt(
+        self,
+        *,
+        snapshot: ExecutionSnapshot,
+        deployment: ExactModelDeployment,
+        route_depth: int,
+    ) -> AttemptId:
+        """Durably mark a provider dispatch before starting network work.
+
+        Args:
+            snapshot: Route-bound immutable request plan.
+            deployment: Exact deployment about to receive the request.
+            route_depth: Zero-based operational route position.
+
+        Returns:
+            Stable new attempt ID.
+        """
+        if deployment.deployment_id not in snapshot.deployment_ids:
+            raise GatewayLedgerError("attempt deployment is absent from the execution snapshot")
+        if deployment.exact_model_id != snapshot.exact_model_id:
+            raise GatewayLedgerError("attempt deployment changes the selected exact model")
+        attempt_id = f"attempt-{uuid.uuid4().hex}"
+        prices = deployment.gateway.prices
+        with self._transaction() as connection:
+            request = connection.execute(
+                """
+                SELECT organization_id, terminal_state FROM gateway_requests
+                WHERE request_id = ?
+                """,
+                (snapshot.authorization.request_id,),
+            ).fetchone()
+            if request is None:
+                raise GatewayLedgerError("attempt request was not durably accepted")
+            if str(request["organization_id"]) != snapshot.authorization.organization_id:
+                raise GatewayLedgerError("attempt authority differs from accepted request")
+            connection.execute(
+                """
+                INSERT INTO gateway_attempts (
+                    attempt_id, request_id, organization_id, route_depth, deployment_id,
+                    provider, exact_model_id, pool_id, catalog_sha256,
+                    pricing_source, pricing_effective_at,
+                    input_rate, cached_input_rate, output_rate, reasoning_rate,
+                    state, started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?)
+                """,
+                (
+                    attempt_id,
+                    snapshot.authorization.request_id,
+                    snapshot.authorization.organization_id,
+                    route_depth,
+                    deployment.deployment_id,
+                    deployment.provider,
+                    snapshot.exact_model_id,
+                    snapshot.pool_id,
+                    snapshot.authorization.catalog_sha256,
+                    deployment.gateway.pricing_source,
+                    (
+                        None
+                        if deployment.gateway.pricing_effective_at is None
+                        else utc_text(deployment.gateway.pricing_effective_at)
+                    ),
+                    prices.input_micro_usd_per_million_tokens,
+                    prices.cached_input_micro_usd_per_million_tokens,
+                    prices.output_micro_usd_per_million_tokens,
+                    prices.reasoning_micro_usd_per_million_tokens,
+                    utc_text(self._clock.now()),
+                ),
+            )
+        return attempt_id
+
+    def record_route_context(
+        self,
+        *,
+        attempt_id: AttemptId,
+        route_reason: str | None,
+        fallback_reason: str | None,
+    ) -> None:
+        """Attach display-safe learned-route context without request content.
+
+        Args:
+            attempt_id: Stable dispatched attempt ID.
+            route_reason: Optional learned-selection reason code.
+            fallback_reason: Optional embedding or router fallback reason code.
+        """
+        for value in (route_reason, fallback_reason):
+            if value is not None and (len(value) > 512 or any(ord(char) < 32 for char in value)):
+                raise GatewayLedgerError("route context must be a short display-safe code")
+        with self._transaction() as connection:
+            result = connection.execute(
+                """
+                UPDATE gateway_attempts SET route_reason = ?, fallback_reason = ?
+                WHERE attempt_id = ? AND state = 'dispatched'
+                """,
+                (route_reason, fallback_reason, attempt_id),
+            )
+            if result.rowcount != 1:
+                raise GatewayLedgerError("route context requires a dispatched attempt")
+
+    def finish_attempt(
+        self,
+        *,
+        attempt_id: AttemptId,
+        terminal_event: GatewayEvent | None,
+        failure: GatewayFailure | None,
+    ) -> None:
+        """Idempotently settle one attempt with normalized content-free fields.
+
+        Args:
+            attempt_id: Stable attempt ID.
+            terminal_event: Provider terminal event, possibly carrying usage.
+            failure: Sanitized failure when no successful terminal event exists.
+        """
+        state, normalized_failure, usage = _terminal_values(terminal_event, failure)
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT request_id, state, input_rate, cached_input_rate,
+                       output_rate, reasoning_rate
+                FROM gateway_attempts WHERE attempt_id = ?
+                """,
+                (attempt_id,),
+            ).fetchone()
+            if row is None:
+                raise GatewayLedgerError("attempt does not exist")
+            current_state = str(row["state"])
+            if current_state != "dispatched":
+                if current_state == state:
+                    return
+                raise GatewayLedgerError("attempt is already settled with another terminal state")
+            cost = _estimated_cost(
+                usage,
+                input_rate=_optional_int(row["input_rate"]),
+                cached_input_rate=_optional_int(row["cached_input_rate"]),
+                output_rate=_optional_int(row["output_rate"]),
+                reasoning_rate=_optional_int(row["reasoning_rate"]),
+            )
+            connection.execute(
+                """
+                UPDATE gateway_attempts
+                SET state = ?, terminal_at = ?, failure_class = ?,
+                    input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
+                    reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?
+                WHERE attempt_id = ? AND state = 'dispatched'
+                """,
+                (
+                    state,
+                    utc_text(self._clock.now()),
+                    normalized_failure,
+                    None if usage is None else usage.input_tokens,
+                    None if usage is None else usage.cached_input_tokens,
+                    None if usage is None else usage.output_tokens,
+                    None if usage is None else usage.reasoning_tokens,
+                    "unknown" if usage is None else "observed",
+                    cost,
+                    attempt_id,
+                ),
+            )
+            if state in {"completed", "cancelled", "incomplete"}:
+                connection.execute(
+                    """
+                    UPDATE gateway_requests SET terminal_state = ?, terminal_at = ?
+                    WHERE request_id = ? AND terminal_state IS NULL
+                    """,
+                    (state, utc_text(self._clock.now()), str(row["request_id"])),
+                )
+
+    def reconcile_crashed_requests(self, *, cleanup_grace: timedelta) -> tuple[int, int]:
+        """Settle expired pre-dispatch and dispatched work after a crash.
+
+        Args:
+            cleanup_grace: Additional bound allowed for upstream cleanup after deadline.
+
+        Returns:
+            Counts of expired pre-dispatch requests and unknown dispatched attempts.
+        """
+        if cleanup_grace < timedelta(0):
+            raise ValueError("cleanup grace cannot be negative")
+        now = self._clock.now()
+        expired_requests = 0
+        unknown_attempts = 0
+        with self._transaction() as connection:
+            request_rows = connection.execute(
+                """
+                SELECT r.request_id, r.deadline_at,
+                       EXISTS(
+                           SELECT 1 FROM gateway_attempts AS a WHERE a.request_id = r.request_id
+                       ) AS has_attempt
+                FROM gateway_requests AS r WHERE r.terminal_state IS NULL
+                """
+            ).fetchall()
+            for request in request_rows:
+                deadline = datetime.fromisoformat(str(request["deadline_at"]))
+                if int(request["has_attempt"]) == 0 and deadline <= now:
+                    connection.execute(
+                        """
+                        UPDATE gateway_requests
+                        SET terminal_state = 'expired_before_dispatch', terminal_at = ?
+                        WHERE request_id = ? AND terminal_state IS NULL
+                        """,
+                        (utc_text(now), str(request["request_id"])),
+                    )
+                    expired_requests += 1
+            attempt_rows = connection.execute(
+                """
+                SELECT a.attempt_id, a.request_id, r.deadline_at
+                FROM gateway_attempts AS a
+                JOIN gateway_requests AS r ON r.request_id = a.request_id
+                WHERE a.state = 'dispatched'
+                """
+            ).fetchall()
+            for attempt in attempt_rows:
+                deadline = datetime.fromisoformat(str(attempt["deadline_at"]))
+                if deadline + cleanup_grace > now:
+                    continue
+                connection.execute(
+                    """
+                    UPDATE gateway_attempts
+                    SET state = 'unknown_after_crash', terminal_at = ?,
+                        usage_source = 'unknown'
+                    WHERE attempt_id = ? AND state = 'dispatched'
+                    """,
+                    (utc_text(now), str(attempt["attempt_id"])),
+                )
+                connection.execute(
+                    """
+                    UPDATE gateway_requests
+                    SET terminal_state = 'unknown_after_crash', terminal_at = ?
+                    WHERE request_id = ? AND terminal_state IS NULL
+                    """,
+                    (utc_text(now), str(attempt["request_id"])),
+                )
+                unknown_attempts += 1
+        return expired_requests, unknown_attempts
+
+    def usage(
+        self, *, organization_id: str, identity_id: str | None = None
+    ) -> tuple[IdentityUsage, ...]:
+        """Aggregate request, usage, cost, and terminal states by identity.
+
+        Args:
+            organization_id: Tenant boundary.
+            identity_id: Optional identity filter.
+
+        Returns:
+            Stable identity usage rows without prompts or outputs.
+        """
+        parameters: tuple[str, ...]
+        predicate = "i.organization_id = ?"
+        if identity_id is None:
+            parameters = (organization_id,)
+        else:
+            predicate += " AND i.identity_id = ?"
+            parameters = (organization_id, identity_id)
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT i.identity_id,
+                       COUNT(DISTINCT r.request_id) AS requests,
+                       COUNT(a.attempt_id) AS attempts,
+                       COALESCE(SUM(a.input_tokens), 0) AS input_tokens,
+                       COALESCE(SUM(a.cached_input_tokens), 0) AS cached_input_tokens,
+                       COALESCE(SUM(a.output_tokens), 0) AS output_tokens,
+                       COALESCE(SUM(a.reasoning_tokens), 0) AS reasoning_tokens,
+                       COALESCE(SUM(a.estimated_cost_micro_usd), 0) AS known_cost,
+                       COALESCE(SUM(CASE
+                           WHEN a.attempt_id IS NOT NULL
+                            AND a.estimated_cost_micro_usd IS NULL THEN 1 ELSE 0 END), 0
+                       ) AS unknown_cost_attempts,
+                       COALESCE(SUM(CASE WHEN a.terminal_at IS NOT NULL THEN
+                           ROUND((julianday(a.terminal_at) - julianday(a.started_at)) * 86400000)
+                           ELSE 0 END), 0) AS total_latency_ms,
+                       AVG(CASE WHEN a.terminal_at IS NOT NULL THEN
+                           (julianday(a.terminal_at) - julianday(a.started_at)) * 86400000
+                           ELSE NULL END) AS average_latency_ms
+                FROM identities AS i
+                LEFT JOIN gateway_requests AS r
+                  ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
+                LEFT JOIN gateway_attempts AS a ON a.request_id = r.request_id
+                WHERE {predicate}
+                GROUP BY i.identity_id ORDER BY i.identity_id
+                """,
+                parameters,
+            ).fetchall()
+            terminal_rows = connection.execute(
+                f"""
+                SELECT i.identity_id, a.state, COUNT(*) AS attempts
+                FROM identities AS i
+                JOIN gateway_requests AS r
+                  ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
+                JOIN gateway_attempts AS a ON a.request_id = r.request_id
+                WHERE {predicate} AND a.state != 'dispatched'
+                GROUP BY i.identity_id, a.state ORDER BY i.identity_id, a.state
+                """,
+                parameters,
+            ).fetchall()
+        terminal_by_identity: dict[str, list[UsageTerminalCount]] = {}
+        for row in terminal_rows:
+            terminal_by_identity.setdefault(str(row["identity_id"]), []).append(
+                UsageTerminalCount(state=str(row["state"]), attempts=int(row["attempts"]))
+            )
+        return tuple(
+            IdentityUsage(
+                organization_id=organization_id,
+                identity_id=str(row["identity_id"]),
+                requests=int(row["requests"]),
+                attempts=int(row["attempts"]),
+                input_tokens=int(row["input_tokens"]),
+                cached_input_tokens=int(row["cached_input_tokens"]),
+                output_tokens=int(row["output_tokens"]),
+                reasoning_tokens=int(row["reasoning_tokens"]),
+                known_estimated_cost_micro_usd=int(row["known_cost"]),
+                unknown_cost_attempts=int(row["unknown_cost_attempts"]),
+                total_latency_ms=int(row["total_latency_ms"]),
+                average_latency_ms=(
+                    None if row["average_latency_ms"] is None else float(row["average_latency_ms"])
+                ),
+                terminal_counts=tuple(terminal_by_identity.get(str(row["identity_id"]), [])),
+            )
+            for row in rows
+        )
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open and close one configured read connection."""
+        connection = connect_database(self.database_path, busy_timeout_ms=self._busy_timeout_ms)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        """Run one explicit immediate transaction with rollback on failure."""
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                yield connection
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+            else:
+                connection.execute("COMMIT")
+
+
+def _terminal_values(
+    terminal_event: GatewayEvent | None,
+    failure: GatewayFailure | None,
+) -> tuple[str, str | None, GatewayUsage | None]:
+    """Normalize one finish call to state, safe failure class, and usage."""
+    event_failure = None if terminal_event is None else terminal_event.failure
+    normalized = failure or event_failure
+    if terminal_event is None and normalized is None:
+        raise GatewayLedgerError("attempt finish needs a terminal event or failure")
+    if terminal_event is not None and terminal_event.kind not in {
+        GatewayEventKind.COMPLETED,
+        GatewayEventKind.INCOMPLETE,
+        GatewayEventKind.FAILED,
+    }:
+        raise GatewayLedgerError("attempt finish event must be terminal")
+    if normalized is not None:
+        state = (
+            "cancelled" if normalized.failure_class == GatewayFailureClass.CANCELLED else "failed"
+        )
+        return (
+            state,
+            normalized.failure_class.value,
+            (None if terminal_event is None else terminal_event.usage),
+        )
+    assert terminal_event is not None
+    return terminal_event.kind.value, None, terminal_event.usage
+
+
+def _estimated_cost(
+    usage: GatewayUsage | None,
+    *,
+    input_rate: int | None,
+    cached_input_rate: int | None,
+    output_rate: int | None,
+    reasoning_rate: int | None,
+) -> int | None:
+    """Compute attributed integer micro-USD or preserve unknown pricing."""
+    if usage is None:
+        return None
+    dimensions = (
+        (usage.input_tokens, input_rate),
+        (usage.cached_input_tokens or 0, cached_input_rate),
+        (usage.output_tokens, output_rate),
+        (usage.reasoning_tokens or 0, reasoning_rate),
+    )
+    if any(tokens > 0 and rate is None for tokens, rate in dimensions):
+        return None
+    numerator = sum(tokens * (rate or 0) for tokens, rate in dimensions)
+    return (numerator + 500_000) // 1_000_000
+
+
+def _optional_int(value: int | None) -> int | None:
+    """Convert one nullable SQLite integer value to its precise type."""
+    return None if value is None else int(value)

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -204,11 +204,11 @@ class SQLiteAttemptLedger:
                 """
                 INSERT INTO gateway_attempts (
                     attempt_id, request_id, organization_id, route_depth, deployment_id,
-                    provider, exact_model_id, pool_id, catalog_sha256,
+                    provider, exact_model_id, pool_id, catalog_sha256, billing_source,
                     pricing_source, pricing_effective_at,
                     input_rate, cached_input_rate, output_rate, reasoning_rate,
                     state, started_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?)
                 """,
                 (
                     attempt_id,
@@ -220,6 +220,7 @@ class SQLiteAttemptLedger:
                     snapshot.exact_model_id,
                     snapshot.pool_id,
                     snapshot.authorization.catalog_sha256,
+                    deployment.billing_source.value,
                     deployment.gateway.pricing_source,
                     (
                         None

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -322,7 +322,7 @@ class SQLiteAttemptLedger:
                     attempt_id,
                 ),
             )
-            if state in {"completed", "cancelled", "incomplete"}:
+            if state in {"completed", "failed", "cancelled", "incomplete"}:
                 connection.execute(
                     """
                     UPDATE gateway_requests SET terminal_state = ?, terminal_at = ?

--- a/wmo/runtime/gateway/ledger_test.py
+++ b/wmo/runtime/gateway/ledger_test.py
@@ -1,0 +1,416 @@
+"""Tests for content-free attempt accounting, recovery, and usage."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmo.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
+from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayUsage,
+)
+from wmo.runtime.gateway.ledger import (
+    IdempotencyConflictError,
+    IdempotencyReplayUnavailableError,
+    SQLiteAttemptLedger,
+)
+from wmo.runtime.gateway.sqlite.store import SQLiteGatewayStore
+
+_CATALOG_DIGEST = "a" * 64
+
+
+class FakeLedgerClock:
+    """Controllable wall and monotonic clock for ledger tests."""
+
+    def __init__(self) -> None:
+        """Initialize fixed wall and monotonic times."""
+        self.wall = datetime(2026, 8, 18, 20, 0, tzinfo=UTC)
+        self.monotonic_value = 1_000.0
+
+    def now(self) -> datetime:
+        """Return the controlled wall time."""
+        return self.wall
+
+    def monotonic(self) -> float:
+        """Return the controlled monotonic time."""
+        return self.monotonic_value
+
+    def advance(self, seconds: float) -> None:
+        """Advance wall and monotonic time equally.
+
+        Args:
+            seconds: Elapsed seconds.
+        """
+        self.wall += timedelta(seconds=seconds)
+        self.monotonic_value += seconds
+
+
+def _deployment(*, priced: bool = True) -> ExactModelDeployment:
+    """Create one exact singleton deployment with optional known rates."""
+    prices = (
+        GatewayTokenPrices(
+            input_micro_usd_per_million_tokens=2_000_000,
+            cached_input_micro_usd_per_million_tokens=1_000_000,
+            output_micro_usd_per_million_tokens=4_000_000,
+            reasoning_micro_usd_per_million_tokens=5_000_000,
+        )
+        if priced
+        else GatewayTokenPrices()
+    )
+    return ExactModelDeployment(
+        deployment_id="deployment-one",
+        source_alias="source-one",
+        exact_model_id="exact-one",
+        connection="connection-one",
+        provider="openai",
+        provider_model="provider-model-canary",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(
+            prices=prices,
+            pricing_source="operator-authored",
+            pricing_effective_at=datetime(2026, 8, 18, tzinfo=UTC),
+        ),
+    )
+
+
+def _request(content: str, *, idempotency_key: str | None = None) -> GatewayRequest:
+    """Create one request whose content must not enter SQLite."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content=content),),
+        idempotency_key=idempotency_key,
+    )
+
+
+def _authority_fixture(
+    tmp_path: Path,
+    clock: FakeLedgerClock,
+) -> tuple[SQLiteGatewayStore, SQLiteAttemptLedger, str]:
+    """Create explicit authority and one granted key for ledger tests."""
+    path = tmp_path / "gateway.db"
+    store = SQLiteGatewayStore(path, clock=clock)
+    ledger = SQLiteAttemptLedger(path, clock=clock)
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.create_identity(
+        organization_id="org-one", identity_id="identity-one", display_name="Identity"
+    )
+    store.register_catalog_snapshot(
+        organization_id="org-one",
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_CATALOG_DIGEST,
+    )
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_name="coding",
+        revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_CATALOG_DIGEST,
+    )
+    store.grant_alias(organization_id="org-one", identity_id="identity-one", alias_id="alias-one")
+    issued = store.issue_virtual_key(
+        organization_id="org-one", identity_id="identity-one", key_id="key-one"
+    )
+    return store, ledger, issued.raw_key
+
+
+def _execution(authorization: AuthorizationSnapshot) -> ExecutionSnapshot:
+    """Bind a typed authorization snapshot to the singleton route."""
+    return ExecutionSnapshot(
+        authorization=authorization,
+        exact_model_id="exact-one",
+        pool_id="pool-one",
+        deployment_ids=("deployment-one",),
+    )
+
+
+def test_attempt_usage_and_integer_cost_are_content_free(tmp_path: Path) -> None:
+    """Attempt settlement preserves normalized usage and attributed integer cost only."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    request = _request("prompt-content-canary")
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=request,
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=_deployment(), route_depth=0
+    )
+    ledger.record_route_context(
+        attempt_id=attempt_id,
+        route_reason="direct_alias",
+        fallback_reason=None,
+    )
+    clock.advance(0.125)
+
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=3,
+            usage=GatewayUsage(
+                input_tokens=1_000,
+                cached_input_tokens=100,
+                output_tokens=500,
+                reasoning_tokens=50,
+            ),
+        ),
+        failure=None,
+    )
+
+    usage = ledger.usage(organization_id="org-one")
+    assert len(usage) == 1
+    assert usage[0].requests == 1
+    assert usage[0].attempts == 1
+    assert usage[0].known_estimated_cost_micro_usd == 4_350
+    assert usage[0].unknown_cost_attempts == 0
+    assert 124 <= usage[0].total_latency_ms <= 126
+    assert usage[0].average_latency_ms is not None
+    assert usage[0].terminal_counts[0].state == "completed"
+
+    durable = (tmp_path / "gateway.db").read_bytes()
+    wal = tmp_path / "gateway.db-wal"
+    if wal.exists():
+        durable += wal.read_bytes()
+    assert b"prompt-content-canary" not in durable
+    assert raw_key.encode() not in durable
+    assert b"provider-model-canary" not in durable
+
+
+def test_unknown_prices_remain_unknown_instead_of_zero(tmp_path: Path) -> None:
+    """Observed token usage with absent rates increments unknown-cost accounting."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("unknown-price"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=_deployment(priced=False), route_depth=0
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=1, output_tokens=1),
+        ),
+        failure=None,
+    )
+
+    usage = ledger.usage(organization_id="org-one")[0]
+    assert usage.known_estimated_cost_micro_usd == 0
+    assert usage.unknown_cost_attempts == 1
+
+
+def test_cancelled_post_commit_attempt_keeps_observed_billable_usage(tmp_path: Path) -> None:
+    """Cancellation does not erase observed provider usage or attributed cost."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("cancelled-stream"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=_deployment(), route_depth=0
+    )
+    cancelled = GatewayFailure(
+        failure_class=GatewayFailureClass.CANCELLED,
+        safe_message="client disconnected",
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.FAILED,
+            sequence_number=2,
+            failure=cancelled,
+            usage=GatewayUsage(input_tokens=100, output_tokens=20),
+        ),
+        failure=cancelled,
+    )
+
+    usage = ledger.usage(organization_id="org-one")[0]
+    assert usage.known_estimated_cost_micro_usd == 280
+    assert usage.terminal_counts[0].attempts == 1
+    assert usage.terminal_counts[0].state == "cancelled"
+
+
+def test_idempotency_is_opt_in_and_restart_replay_fails_closed(tmp_path: Path) -> None:
+    """A stored keyed request is never redispatched when response content is unavailable."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    first = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("same", idempotency_key="caller-operation"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=first)
+
+    restarted = SQLiteAttemptLedger(tmp_path / "gateway.db", clock=clock)
+    matching = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("same", idempotency_key="caller-operation"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    with pytest.raises(IdempotencyReplayUnavailableError, match="replay is unavailable"):
+        restarted.accept_request(authorization=matching)
+
+    conflicting = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("different", idempotency_key="caller-operation"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    with pytest.raises(IdempotencyConflictError, match="different request"):
+        restarted.accept_request(authorization=conflicting)
+
+
+def test_crash_reconciliation_waits_for_deadline_and_cleanup_bound(tmp_path: Path) -> None:
+    """Expired accepted work is free while dispatched work becomes unknown after crash."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    accepted = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("accepted-only"),
+        deadline_monotonic=clock.monotonic() + 10,
+    )
+    ledger.accept_request(authorization=accepted)
+    dispatched = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("dispatched", idempotency_key="crash-operation"),
+        deadline_monotonic=clock.monotonic() + 10,
+    )
+    ledger.accept_request(authorization=dispatched)
+    ledger.start_attempt(snapshot=_execution(dispatched), deployment=_deployment(), route_depth=0)
+
+    clock.advance(12)
+    assert ledger.reconcile_crashed_requests(cleanup_grace=timedelta(seconds=5)) == (1, 0)
+    clock.advance(4)
+    assert ledger.reconcile_crashed_requests(cleanup_grace=timedelta(seconds=5)) == (0, 1)
+
+    superseding = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("dispatched", idempotency_key="crash-operation"),
+        deadline_monotonic=clock.monotonic() + 10,
+    )
+    ledger.accept_request(authorization=superseding)
+    ledger.start_attempt(snapshot=_execution(superseding), deployment=_deployment(), route_depth=0)
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM gateway_attempts WHERE state = 'unknown_after_crash'"
+            ).fetchone()[0]
+            == 1
+        )
+        assert connection.execute("SELECT COUNT(*) FROM gateway_attempts").fetchone()[0] == 2
+    finally:
+        connection.close()
+
+
+def test_concurrent_multi_identity_wal_preserves_receipts_grants_and_attempts(
+    tmp_path: Path,
+) -> None:
+    """Concurrent writers retain each authority mutation and terminal attempt exactly once."""
+    path = tmp_path / "gateway.db"
+    store = SQLiteGatewayStore(path, busy_timeout_ms=10_000)
+    ledger = SQLiteAttemptLedger(path, busy_timeout_ms=10_000)
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.register_catalog_snapshot(
+        organization_id="org-one",
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_CATALOG_DIGEST,
+    )
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_name="coding",
+        revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_CATALOG_DIGEST,
+    )
+
+    def run_identity(index: int) -> None:
+        """Create one identity and account one completed request."""
+        identity_id = f"identity-{index}"
+        key_id = f"key-{index}"
+        store.create_identity(
+            organization_id="org-one",
+            identity_id=identity_id,
+            display_name=f"Identity {index}",
+            operation_id=f"operation-identity-{index}",
+        )
+        store.grant_alias(organization_id="org-one", identity_id=identity_id, alias_id="alias-one")
+        issued = store.issue_virtual_key(
+            organization_id="org-one",
+            identity_id=identity_id,
+            key_id=key_id,
+            operation_id=f"operation-key-{index}",
+        )
+        authorization = store.authorize_request(
+            raw_key=issued.raw_key,
+            alias="coding",
+            request=_request(f"concurrent-content-{index}"),
+            deadline_monotonic=time.monotonic() + 60,
+        )
+        ledger.accept_request(authorization=authorization)
+        attempt_id = ledger.start_attempt(
+            snapshot=_execution(authorization), deployment=_deployment(), route_depth=0
+        )
+        ledger.finish_attempt(
+            attempt_id=attempt_id,
+            terminal_event=GatewayEvent(
+                kind=GatewayEventKind.COMPLETED,
+                sequence_number=1,
+                usage=GatewayUsage(input_tokens=1, output_tokens=1),
+            ),
+            failure=None,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        tuple(executor.map(run_identity, range(8)))
+
+    usage = ledger.usage(organization_id="org-one")
+    assert len(usage) == 8
+    assert sum(item.requests for item in usage) == 8
+    assert sum(item.attempts for item in usage) == 8
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM operation_receipts").fetchone()[0] == 16
+        assert connection.execute("SELECT COUNT(*) FROM identity_alias_grants").fetchone()[0] == 8
+    finally:
+        connection.close()

--- a/wmo/runtime/gateway/ledger_test.py
+++ b/wmo/runtime/gateway/ledger_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from wmo.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
+from wmo.common.models.catalog import BillingSource, GatewayDeploymentMetadata, GatewayTokenPrices
 from wmo.common.models.gateway_catalog import ExactModelDeployment
 from wmo.runtime.gateway.contracts import (
     AuthorizationSnapshot,
@@ -61,7 +61,11 @@ class FakeLedgerClock:
         self.monotonic_value += seconds
 
 
-def _deployment(*, priced: bool = True) -> ExactModelDeployment:
+def _deployment(
+    *,
+    priced: bool = True,
+    billing_source: BillingSource = BillingSource.CUSTOMER_MANAGED,
+) -> ExactModelDeployment:
     """Create one exact singleton deployment with optional known rates."""
     prices = (
         GatewayTokenPrices(
@@ -80,6 +84,7 @@ def _deployment(*, priced: bool = True) -> ExactModelDeployment:
         connection="connection-one",
         provider="openai",
         provider_model="provider-model-canary",
+        billing_source=billing_source,
         connection_sha256="b" * 64,
         capabilities_sha256="c" * 64,
         gateway=GatewayDeploymentMetadata(
@@ -196,6 +201,47 @@ def test_attempt_usage_and_integer_cost_are_content_free(tmp_path: Path) -> None
     assert b"prompt-content-canary" not in durable
     assert raw_key.encode() not in durable
     assert b"provider-model-canary" not in durable
+
+
+def test_attempt_retains_dispatch_billing_source_after_catalog_change(tmp_path: Path) -> None:
+    """Attempt attribution remains frozen when later catalog ownership changes."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("billing-freeze"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    dispatched = _deployment(billing_source=BillingSource.HOST_MANAGED)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=dispatched, route_depth=0
+    )
+
+    authored_after_dispatch = dispatched.model_copy(
+        update={"billing_source": BillingSource.CUSTOMER_MANAGED}
+    )
+    assert authored_after_dispatch.billing_source == BillingSource.CUSTOMER_MANAGED
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=1, output_tokens=1),
+        ),
+        failure=None,
+    )
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        row = connection.execute(
+            "SELECT billing_source, state FROM gateway_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row == (BillingSource.HOST_MANAGED.value, "completed")
 
 
 def test_unknown_prices_remain_unknown_instead_of_zero(tmp_path: Path) -> None:

--- a/wmo/runtime/gateway/ledger_test.py
+++ b/wmo/runtime/gateway/ledger_test.py
@@ -262,6 +262,42 @@ def test_cancelled_post_commit_attempt_keeps_observed_billable_usage(tmp_path: P
     assert usage.terminal_counts[0].state == "cancelled"
 
 
+def test_failed_attempt_terminalizes_its_parent_request(tmp_path: Path) -> None:
+    """An ordinary terminal provider failure closes both attempt and request state."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("failed-request"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=_deployment(), route_depth=0
+    )
+    failure = GatewayFailure(
+        failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+        safe_message="provider request failed",
+    )
+
+    ledger.finish_attempt(attempt_id=attempt_id, terminal_event=None, failure=failure)
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        request_state = connection.execute(
+            "SELECT terminal_state FROM gateway_requests WHERE request_id = ?",
+            (authorization.request_id,),
+        ).fetchone()[0]
+        attempt_state = connection.execute(
+            "SELECT state FROM gateway_attempts WHERE attempt_id = ?", (attempt_id,)
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert request_state == "failed"
+    assert attempt_state == "failed"
+
+
 def test_idempotency_is_opt_in_and_restart_replay_fails_closed(tmp_path: Path) -> None:
     """A stored keyed request is never redispatched when response content is unavailable."""
     clock = FakeLedgerClock()

--- a/wmo/runtime/gateway/secrets.py
+++ b/wmo/runtime/gateway/secrets.py
@@ -1,0 +1,45 @@
+"""Environment-only provider secret resolution for the local gateway."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+
+_ENV_REFERENCE = re.compile(r"env://([A-Z_][A-Z0-9_]*)\Z")
+
+
+class SecretResolutionError(ValueError):
+    """A provider secret reference is unsupported, absent, or empty."""
+
+
+class EnvironmentSecretResolver:
+    """Resolve only explicit environment references without retaining values."""
+
+    def __init__(self, environment: Mapping[str, str] | None = None) -> None:
+        """Initialize the resolver.
+
+        Args:
+            environment: Optional injected environment for deterministic tests.
+        """
+        self._environment = os.environ if environment is None else environment
+
+    def resolve(self, reference: str) -> str:
+        """Resolve one ``env://VARIABLE`` reference.
+
+        Args:
+            reference: Opaque provider credential reference.
+
+        Returns:
+            The current non-empty environment value.
+
+        Raises:
+            SecretResolutionError: The reference is unsupported or not populated.
+        """
+        match = _ENV_REFERENCE.fullmatch(reference)
+        if match is None:
+            raise SecretResolutionError("provider secret reference must use env://VARIABLE_NAME")
+        value = self._environment.get(match.group(1))
+        if not value:
+            raise SecretResolutionError("provider secret environment variable is not populated")
+        return value

--- a/wmo/runtime/gateway/secrets_test.py
+++ b/wmo/runtime/gateway/secrets_test.py
@@ -1,0 +1,18 @@
+"""Tests for environment-only provider secret resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.runtime.gateway.secrets import EnvironmentSecretResolver, SecretResolutionError
+
+
+def test_environment_secret_resolver_accepts_only_populated_env_references() -> None:
+    """The resolver returns a current value without supporting inline secret forms."""
+    resolver = EnvironmentSecretResolver({"PROVIDER_API_KEY": "canary-secret"})
+
+    assert resolver.resolve("env://PROVIDER_API_KEY") == "canary-secret"
+    with pytest.raises(SecretResolutionError, match="env://"):
+        resolver.resolve("literal://canary-secret")
+    with pytest.raises(SecretResolutionError, match="not populated"):
+        resolver.resolve("env://MISSING_API_KEY")

--- a/wmo/runtime/gateway/sqlite/__init__.py
+++ b/wmo/runtime/gateway/sqlite/__init__.py
@@ -1,0 +1,5 @@
+"""SQLite authority and content-free accounting implementation."""
+
+from wmo.runtime.gateway.sqlite.store import SQLiteGatewayStore
+
+__all__ = ["SQLiteGatewayStore"]

--- a/wmo/runtime/gateway/sqlite/migrations.py
+++ b/wmo/runtime/gateway/sqlite/migrations.py
@@ -8,7 +8,7 @@ import stat
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 class GatewaySchemaError(RuntimeError):
@@ -250,7 +250,15 @@ _MIGRATION_2 = (
     """,
 )
 
-_MIGRATIONS = {1: _MIGRATION_1, 2: _MIGRATION_2}
+_MIGRATION_3 = (
+    """
+    ALTER TABLE gateway_attempts
+    ADD COLUMN billing_source TEXT NOT NULL DEFAULT 'customer_managed'
+    CHECK (billing_source IN ('customer_managed', 'host_managed'))
+    """,
+)
+
+_MIGRATIONS = {1: _MIGRATION_1, 2: _MIGRATION_2, 3: _MIGRATION_3}
 
 
 def connect_database(

--- a/wmo/runtime/gateway/sqlite/migrations.py
+++ b/wmo/runtime/gateway/sqlite/migrations.py
@@ -8,7 +8,7 @@ import stat
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 class GatewaySchemaError(RuntimeError):
@@ -258,7 +258,73 @@ _MIGRATION_3 = (
     """,
 )
 
-_MIGRATIONS = {1: _MIGRATION_1, 2: _MIGRATION_2, 3: _MIGRATION_3}
+_MIGRATION_4 = (
+    """
+    CREATE TABLE provider_connections (
+        connection_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        active_revision_id TEXT,
+        active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (organization_id, connection_id),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id),
+        FOREIGN KEY (organization_id, connection_id, active_revision_id)
+            REFERENCES provider_connection_revisions (
+                organization_id, connection_id, revision_id
+            )
+            DEFERRABLE INITIALLY DEFERRED
+    ) STRICT
+    """,
+    """
+    CREATE TABLE provider_connection_revisions (
+        revision_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        connection_id TEXT NOT NULL,
+        revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+        provider TEXT NOT NULL,
+        base_url TEXT,
+        api_key_env TEXT,
+        api_version TEXT,
+        region TEXT,
+        connection_sha256 TEXT NOT NULL CHECK (length(connection_sha256) = 64),
+        created_at TEXT NOT NULL,
+        UNIQUE (organization_id, connection_id, revision_number),
+        UNIQUE (organization_id, connection_id, revision_id),
+        FOREIGN KEY (organization_id, connection_id)
+            REFERENCES provider_connections (organization_id, connection_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE alias_revision_provider_connections (
+        organization_id TEXT NOT NULL,
+        alias_id TEXT NOT NULL,
+        alias_revision_id TEXT NOT NULL,
+        connection_id TEXT NOT NULL,
+        connection_revision_id TEXT NOT NULL,
+        connection_sha256 TEXT NOT NULL CHECK (length(connection_sha256) = 64),
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (
+            organization_id, alias_id, alias_revision_id, connection_id
+        ),
+        FOREIGN KEY (organization_id, alias_id, alias_revision_id)
+            REFERENCES alias_revisions (organization_id, alias_id, revision_id)
+            ON DELETE CASCADE,
+        FOREIGN KEY (
+            organization_id, connection_id, connection_revision_id
+        ) REFERENCES provider_connection_revisions (
+            organization_id, connection_id, revision_id
+        )
+    ) STRICT
+    """,
+)
+
+_MIGRATIONS = {
+    1: _MIGRATION_1,
+    2: _MIGRATION_2,
+    3: _MIGRATION_3,
+    4: _MIGRATION_4,
+}
 
 
 def connect_database(
@@ -419,7 +485,10 @@ def _require_schema_objects(connection: sqlite3.Connection) -> None:
         "identity_alias_grants",
         "operation_receipts",
         "organizations",
+        "provider_connection_revisions",
+        "provider_connections",
         "project_activation_bindings",
+        "alias_revision_provider_connections",
         "virtual_keys",
     }
     rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()

--- a/wmo/runtime/gateway/sqlite/migrations.py
+++ b/wmo/runtime/gateway/sqlite/migrations.py
@@ -1,0 +1,381 @@
+"""Forward-only SQLite schema initialization and guarded migration."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCHEMA_VERSION = 2
+
+
+class GatewaySchemaError(RuntimeError):
+    """The gateway database schema cannot be opened safely."""
+
+
+_MIGRATION_1 = (
+    """
+    CREATE TABLE organizations (
+        organization_id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL UNIQUE,
+        display_name TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    ) STRICT
+    """,
+    """
+    CREATE TABLE identities (
+        identity_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        description TEXT,
+        active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (organization_id, identity_id),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE virtual_keys (
+        key_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        identity_id TEXT NOT NULL,
+        prefix TEXT NOT NULL,
+        fingerprint_version INTEGER NOT NULL CHECK (fingerprint_version > 0),
+        fingerprint_sha256 TEXT NOT NULL CHECK (length(fingerprint_sha256) = 64),
+        expires_at TEXT,
+        revoked_at TEXT,
+        last_used_at TEXT,
+        created_at TEXT NOT NULL,
+        UNIQUE (fingerprint_version, fingerprint_sha256),
+        UNIQUE (organization_id, prefix),
+        UNIQUE (organization_id, key_id),
+        FOREIGN KEY (organization_id, identity_id)
+            REFERENCES identities (organization_id, identity_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE catalog_snapshot_refs (
+        snapshot_ref TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        catalog_sha256 TEXT NOT NULL CHECK (length(catalog_sha256) = 64),
+        created_at TEXT NOT NULL,
+        UNIQUE (organization_id, catalog_sha256),
+        UNIQUE (organization_id, snapshot_ref),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE gateway_aliases (
+        alias_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        alias_name TEXT NOT NULL,
+        active_revision_id TEXT,
+        active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (organization_id, alias_name),
+        UNIQUE (organization_id, alias_id),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id),
+        FOREIGN KEY (organization_id, alias_id, active_revision_id)
+            REFERENCES alias_revisions (organization_id, alias_id, revision_id)
+            DEFERRABLE INITIALLY DEFERRED
+    ) STRICT
+    """,
+    """
+    CREATE TABLE alias_revisions (
+        revision_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        alias_id TEXT NOT NULL,
+        revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+        target_kind TEXT NOT NULL CHECK (target_kind IN ('direct', 'project')),
+        pool_id TEXT,
+        project_ref TEXT,
+        activation_ref TEXT,
+        catalog_sha256 TEXT NOT NULL CHECK (length(catalog_sha256) = 64),
+        snapshot_ref TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (organization_id, alias_id, revision_number),
+        UNIQUE (organization_id, alias_id, revision_id),
+        CHECK (
+            (target_kind = 'direct' AND pool_id IS NOT NULL
+                AND project_ref IS NULL AND activation_ref IS NULL)
+            OR
+            (target_kind = 'project' AND pool_id IS NULL
+                AND project_ref IS NOT NULL AND activation_ref IS NOT NULL)
+        ),
+        FOREIGN KEY (organization_id, alias_id)
+            REFERENCES gateway_aliases (organization_id, alias_id),
+        FOREIGN KEY (organization_id, snapshot_ref)
+            REFERENCES catalog_snapshot_refs (organization_id, snapshot_ref)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE project_activation_bindings (
+        organization_id TEXT NOT NULL,
+        project_ref TEXT NOT NULL,
+        activation_ref TEXT NOT NULL,
+        alias_id TEXT NOT NULL,
+        revision_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (organization_id, project_ref, activation_ref),
+        UNIQUE (organization_id, alias_id),
+        UNIQUE (organization_id, revision_id),
+        FOREIGN KEY (organization_id, alias_id, revision_id)
+            REFERENCES alias_revisions (organization_id, alias_id, revision_id)
+            ON DELETE CASCADE
+    ) STRICT
+    """,
+    """
+    CREATE TABLE identity_alias_grants (
+        organization_id TEXT NOT NULL,
+        identity_id TEXT NOT NULL,
+        alias_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (organization_id, identity_id, alias_id),
+        FOREIGN KEY (organization_id, identity_id)
+            REFERENCES identities (organization_id, identity_id),
+        FOREIGN KEY (organization_id, alias_id)
+            REFERENCES gateway_aliases (organization_id, alias_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE operation_receipts (
+        organization_id TEXT NOT NULL,
+        operation_id TEXT NOT NULL,
+        operation_kind TEXT NOT NULL,
+        request_sha256 TEXT NOT NULL CHECK (length(request_sha256) = 64),
+        resource_kind TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (organization_id, operation_id),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id)
+    ) STRICT
+    """,
+)
+
+_MIGRATION_2 = (
+    """
+    CREATE TABLE gateway_requests (
+        request_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        identity_id TEXT NOT NULL,
+        key_id TEXT NOT NULL,
+        alias_id TEXT NOT NULL,
+        alias_revision_id TEXT NOT NULL,
+        api_surface TEXT NOT NULL CHECK (api_surface IN ('chat_completions', 'responses')),
+        canonical_request_sha256 TEXT NOT NULL CHECK (length(canonical_request_sha256) = 64),
+        caller_operation_sha256 TEXT,
+        accepted_at TEXT NOT NULL,
+        deadline_at TEXT NOT NULL,
+        terminal_state TEXT CHECK (
+            terminal_state IS NULL OR terminal_state IN (
+                'completed', 'failed', 'cancelled', 'incomplete',
+                'expired_before_dispatch', 'unknown_after_crash'
+            )
+        ),
+        terminal_at TEXT,
+        content_retained INTEGER NOT NULL DEFAULT 0 CHECK (content_retained = 0),
+        UNIQUE (organization_id, request_id),
+        FOREIGN KEY (organization_id, identity_id)
+            REFERENCES identities (organization_id, identity_id),
+        FOREIGN KEY (organization_id, key_id)
+            REFERENCES virtual_keys (organization_id, key_id),
+        FOREIGN KEY (organization_id, alias_id, alias_revision_id)
+            REFERENCES alias_revisions (organization_id, alias_id, revision_id)
+    ) STRICT
+    """,
+    """
+    CREATE INDEX gateway_requests_caller_operation
+    ON gateway_requests (
+        organization_id, identity_id, alias_revision_id, api_surface, caller_operation_sha256
+    ) WHERE caller_operation_sha256 IS NOT NULL
+    """,
+    """
+    CREATE TABLE gateway_attempts (
+        attempt_id TEXT PRIMARY KEY,
+        request_id TEXT NOT NULL,
+        organization_id TEXT NOT NULL,
+        route_depth INTEGER NOT NULL CHECK (route_depth >= 0),
+        deployment_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        exact_model_id TEXT NOT NULL,
+        pool_id TEXT NOT NULL,
+        catalog_sha256 TEXT NOT NULL CHECK (length(catalog_sha256) = 64),
+        pricing_source TEXT,
+        pricing_effective_at TEXT,
+        route_reason TEXT,
+        fallback_reason TEXT,
+        input_rate INTEGER CHECK (input_rate IS NULL OR input_rate >= 0),
+        cached_input_rate INTEGER CHECK (cached_input_rate IS NULL OR cached_input_rate >= 0),
+        output_rate INTEGER CHECK (output_rate IS NULL OR output_rate >= 0),
+        reasoning_rate INTEGER CHECK (reasoning_rate IS NULL OR reasoning_rate >= 0),
+        state TEXT NOT NULL CHECK (state IN (
+            'dispatched', 'completed', 'failed', 'cancelled',
+            'incomplete', 'unknown_after_crash'
+        )),
+        started_at TEXT NOT NULL,
+        terminal_at TEXT,
+        failure_class TEXT,
+        input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
+        cached_input_tokens INTEGER CHECK (
+            cached_input_tokens IS NULL OR cached_input_tokens >= 0
+        ),
+        output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
+        reasoning_tokens INTEGER CHECK (reasoning_tokens IS NULL OR reasoning_tokens >= 0),
+        usage_source TEXT CHECK (
+            usage_source IS NULL OR usage_source IN ('observed', 'estimated', 'unknown')
+        ),
+        estimated_cost_micro_usd INTEGER CHECK (
+            estimated_cost_micro_usd IS NULL OR estimated_cost_micro_usd >= 0
+        ),
+        content_retained INTEGER NOT NULL DEFAULT 0 CHECK (content_retained = 0),
+        UNIQUE (organization_id, attempt_id),
+        UNIQUE (request_id, route_depth),
+        FOREIGN KEY (organization_id, request_id)
+            REFERENCES gateway_requests (organization_id, request_id)
+    ) STRICT
+    """,
+    """
+    CREATE INDEX gateway_attempts_usage
+    ON gateway_attempts (organization_id, terminal_at, state)
+    """,
+    """
+    CREATE INDEX gateway_requests_identity
+    ON gateway_requests (organization_id, identity_id, accepted_at)
+    """,
+)
+
+_MIGRATIONS = {1: _MIGRATION_1, 2: _MIGRATION_2}
+
+
+def connect_database(
+    path: Path, *, busy_timeout_ms: int = 5_000, enable_wal: bool = True
+) -> sqlite3.Connection:
+    """Open one configured SQLite connection with mandatory safety pragmas.
+
+    Args:
+        path: Gateway database path.
+        busy_timeout_ms: Bounded lock wait in milliseconds.
+        enable_wal: Whether to assert the supported journal mode after version checks.
+
+    Returns:
+        Configured connection with row-name access.
+    """
+    connection = sqlite3.connect(path, timeout=busy_timeout_ms / 1_000, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+    if enable_wal:
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = FULL")
+    return connection
+
+
+def initialize_database(path: Path, *, busy_timeout_ms: int = 5_000) -> Path | None:
+    """Create or forward-migrate one database without deleting incompatible state.
+
+    Args:
+        path: Gateway database path.
+        busy_timeout_ms: Bounded lock wait in milliseconds.
+
+    Returns:
+        Backup path when an existing older schema was migrated, otherwise ``None``.
+
+    Raises:
+        GatewaySchemaError: State is corrupt, newer, or cannot migrate atomically.
+    """
+    _create_private_database_file(path)
+    try:
+        connection = connect_database(path, busy_timeout_ms=busy_timeout_ms, enable_wal=False)
+    except sqlite3.DatabaseError as exc:
+        raise GatewaySchemaError("gateway database is corrupt or unreadable") from exc
+    backup: Path | None = None
+    try:
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if integrity is None or integrity[0] != "ok":
+            raise GatewaySchemaError("gateway database failed integrity check")
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version > SCHEMA_VERSION:
+            raise GatewaySchemaError(
+                f"gateway database schema {version} is newer than supported {SCHEMA_VERSION}"
+            )
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = FULL")
+        if 0 < version < SCHEMA_VERSION:
+            backup = _backup_database(connection, path, version)
+        connection.execute("BEGIN EXCLUSIVE")
+        try:
+            for next_version in range(version + 1, SCHEMA_VERSION + 1):
+                for statement in _MIGRATIONS[next_version]:
+                    connection.execute(statement)
+                connection.execute(f"PRAGMA user_version = {next_version}")
+            connection.execute("COMMIT")
+        except (sqlite3.DatabaseError, OSError) as exc:
+            connection.execute("ROLLBACK")
+            raise GatewaySchemaError("gateway database migration failed") from exc
+        _require_schema_objects(connection)
+    except sqlite3.DatabaseError as exc:
+        raise GatewaySchemaError("gateway database is corrupt or unreadable") from exc
+    finally:
+        connection.close()
+    os.chmod(path, 0o600)
+    return backup
+
+
+def _create_private_database_file(path: Path) -> None:
+    """Create a missing database as a user-only regular file."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if not path.exists():
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            os.close(descriptor)
+    metadata = path.lstat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GatewaySchemaError("gateway database path must be a regular file")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise GatewaySchemaError("gateway database must not be group or world accessible")
+
+
+def _backup_database(connection: sqlite3.Connection, path: Path, version: int) -> Path:
+    """Create a consistent mode-0600 SQLite backup before forward migration."""
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    backup = path.with_name(f"{path.name}.backup-v{version}-{stamp}")
+    descriptor = os.open(backup, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    destination = sqlite3.connect(backup)
+    try:
+        connection.backup(destination)
+    finally:
+        destination.close()
+    os.chmod(backup, 0o600)
+    return backup
+
+
+def _require_schema_objects(connection: sqlite3.Connection) -> None:
+    """Refuse a version marker that does not have every required table."""
+    expected = {
+        "alias_revisions",
+        "catalog_snapshot_refs",
+        "gateway_aliases",
+        "gateway_attempts",
+        "gateway_requests",
+        "identities",
+        "identity_alias_grants",
+        "operation_receipts",
+        "organizations",
+        "project_activation_bindings",
+        "virtual_keys",
+    }
+    rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    actual = {str(row[0]) for row in rows}
+    if not expected.issubset(actual):
+        raise GatewaySchemaError("gateway database schema marker does not match required tables")

--- a/wmo/runtime/gateway/sqlite/migrations.py
+++ b/wmo/runtime/gateway/sqlite/migrations.py
@@ -296,35 +296,61 @@ def initialize_database(path: Path, *, busy_timeout_ms: int = 5_000) -> Path | N
         raise GatewaySchemaError("gateway database is corrupt or unreadable") from exc
     backup: Path | None = None
     try:
-        integrity = connection.execute("PRAGMA integrity_check").fetchone()
-        if integrity is None or integrity[0] != "ok":
-            raise GatewaySchemaError("gateway database failed integrity check")
-        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-        if version > SCHEMA_VERSION:
-            raise GatewaySchemaError(
-                f"gateway database schema {version} is newer than supported {SCHEMA_VERSION}"
-            )
-        connection.execute("PRAGMA journal_mode = WAL")
-        connection.execute("PRAGMA synchronous = FULL")
-        if 0 < version < SCHEMA_VERSION:
-            backup = _backup_database(connection, path, version)
         connection.execute("BEGIN EXCLUSIVE")
         try:
+            _supported_schema_version(connection)
+            connection.execute("COMMIT")
+        except GatewaySchemaError:
+            connection.execute("ROLLBACK")
+            raise
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = FULL")
+        connection.execute("BEGIN EXCLUSIVE")
+        try:
+            version = _supported_schema_version(connection)
+            if 0 < version < SCHEMA_VERSION:
+                backup = _backup_database(path, version)
             for next_version in range(version + 1, SCHEMA_VERSION + 1):
                 for statement in _MIGRATIONS[next_version]:
                     connection.execute(statement)
                 connection.execute(f"PRAGMA user_version = {next_version}")
+            _require_schema_objects(connection)
             connection.execute("COMMIT")
+        except GatewaySchemaError:
+            connection.execute("ROLLBACK")
+            raise
         except (sqlite3.DatabaseError, OSError) as exc:
             connection.execute("ROLLBACK")
             raise GatewaySchemaError("gateway database migration failed") from exc
-        _require_schema_objects(connection)
     except sqlite3.DatabaseError as exc:
         raise GatewaySchemaError("gateway database is corrupt or unreadable") from exc
     finally:
         connection.close()
     os.chmod(path, 0o600)
     return backup
+
+
+def _supported_schema_version(connection: sqlite3.Connection) -> int:
+    """Read and validate schema state while the caller holds an exclusive transaction.
+
+    Args:
+        connection: Database connection inside an exclusive transaction.
+
+    Returns:
+        Supported current schema version.
+
+    Raises:
+        GatewaySchemaError: Integrity fails or the schema is newer than this code.
+    """
+    integrity = connection.execute("PRAGMA integrity_check").fetchone()
+    if integrity is None or integrity[0] != "ok":
+        raise GatewaySchemaError("gateway database failed integrity check")
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if version > SCHEMA_VERSION:
+        raise GatewaySchemaError(
+            f"gateway database schema {version} is newer than supported {SCHEMA_VERSION}"
+        )
+    return version
 
 
 def _create_private_database_file(path: Path) -> None:
@@ -345,17 +371,30 @@ def _create_private_database_file(path: Path) -> None:
         raise GatewaySchemaError("gateway database must not be group or world accessible")
 
 
-def _backup_database(connection: sqlite3.Connection, path: Path, version: int) -> Path:
-    """Create a consistent mode-0600 SQLite backup before forward migration."""
+def _backup_database(path: Path, version: int) -> Path:
+    """Create a consistent mode-0600 SQLite backup before forward migration.
+
+    The caller retains the exclusive migration transaction while this separate read
+    connection copies the last committed WAL snapshot.
+
+    Args:
+        path: Database protected by the caller's exclusive transaction.
+        version: Last committed schema version represented by the backup.
+
+    Returns:
+        Private path containing the consistent pre-migration snapshot.
+    """
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
     backup = path.with_name(f"{path.name}.backup-v{version}-{stamp}")
     descriptor = os.open(backup, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
     os.close(descriptor)
+    source = sqlite3.connect(path)
     destination = sqlite3.connect(backup)
     try:
-        connection.backup(destination)
+        source.backup(destination)
     finally:
         destination.close()
+        source.close()
     os.chmod(backup, 0o600)
     return backup
 

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -13,6 +13,7 @@ import pytest
 
 from wmo.runtime.gateway.sqlite.migrations import (
     _MIGRATION_1,
+    _MIGRATION_2,
     SCHEMA_VERSION,
     GatewaySchemaError,
     connect_database,
@@ -66,6 +67,150 @@ def test_forward_migration_creates_consistent_private_backup(tmp_path: Path) -> 
             is None
         )
     finally:
+        backup_connection.close()
+
+
+def test_attempt_billing_migration_is_explicit_and_preserves_v2_backup(tmp_path: Path) -> None:
+    """Legacy attempts migrate to customer-managed while the v2 backup stays unchanged."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in (*_MIGRATION_1, *_MIGRATION_2):
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO organizations VALUES (?, ?, ?, 1, ?, ?)",
+            ("org-one", "one", "One", "2026-08-18T00:00:00Z", "2026-08-18T00:00:00Z"),
+        )
+        connection.execute(
+            "INSERT INTO identities VALUES (?, ?, ?, NULL, 1, ?, ?)",
+            (
+                "identity-one",
+                "org-one",
+                "Identity",
+                "2026-08-18T00:00:00Z",
+                "2026-08-18T00:00:00Z",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO virtual_keys (
+                key_id, organization_id, identity_id, prefix, fingerprint_version,
+                fingerprint_sha256, created_at
+            ) VALUES (?, ?, ?, ?, 1, ?, ?)
+            """,
+            (
+                "key-one",
+                "org-one",
+                "identity-one",
+                "wmo_test",
+                "a" * 64,
+                "2026-08-18T00:00:00Z",
+            ),
+        )
+        connection.execute(
+            "INSERT INTO catalog_snapshot_refs VALUES (?, ?, ?, ?)",
+            ("snapshot-one", "org-one", "b" * 64, "2026-08-18T00:00:00Z"),
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_aliases (
+                alias_id, organization_id, alias_name, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "alias-one",
+                "org-one",
+                "coding",
+                "2026-08-18T00:00:00Z",
+                "2026-08-18T00:00:00Z",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO alias_revisions (
+                revision_id, organization_id, alias_id, revision_number, target_kind,
+                pool_id, catalog_sha256, snapshot_ref, created_at
+            ) VALUES (?, ?, ?, 1, 'direct', ?, ?, ?, ?)
+            """,
+            (
+                "revision-one",
+                "org-one",
+                "alias-one",
+                "pool-one",
+                "b" * 64,
+                "snapshot-one",
+                "2026-08-18T00:00:00Z",
+            ),
+        )
+        connection.execute(
+            "UPDATE gateway_aliases SET active_revision_id = ? WHERE alias_id = ?",
+            ("revision-one", "alias-one"),
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_requests (
+                request_id, organization_id, identity_id, key_id, alias_id,
+                alias_revision_id, api_surface, canonical_request_sha256,
+                accepted_at, deadline_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'responses', ?, ?, ?)
+            """,
+            (
+                "request-one",
+                "org-one",
+                "identity-one",
+                "key-one",
+                "alias-one",
+                "revision-one",
+                "c" * 64,
+                "2026-08-18T00:00:00Z",
+                "2026-08-18T00:01:00Z",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_attempts (
+                attempt_id, request_id, organization_id, route_depth, deployment_id,
+                provider, exact_model_id, pool_id, catalog_sha256, state, started_at
+            ) VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, 'completed', ?)
+            """,
+            (
+                "attempt-one",
+                "request-one",
+                "org-one",
+                "deployment-one",
+                "openai",
+                "exact-one",
+                "pool-one",
+                "b" * 64,
+                "2026-08-18T00:00:01Z",
+            ),
+        )
+        connection.execute("PRAGMA user_version = 2")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None
+    backup_connection = sqlite3.connect(backup)
+    current = connect_database(path)
+    try:
+        backup_columns = {
+            str(row[1]) for row in backup_connection.execute("PRAGMA table_info(gateway_attempts)")
+        }
+        assert "billing_source" not in backup_columns
+        assert backup_connection.execute("PRAGMA user_version").fetchone()[0] == 2
+        row = current.execute(
+            "SELECT billing_source FROM gateway_attempts WHERE attempt_id = 'attempt-one'"
+        ).fetchone()
+        assert row is not None
+        assert row["billing_source"] == "customer_managed"
+    finally:
+        current.close()
         backup_connection.close()
 
 

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import sqlite3
 import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -65,6 +67,41 @@ def test_forward_migration_creates_consistent_private_backup(tmp_path: Path) -> 
         )
     finally:
         backup_connection.close()
+
+
+def test_concurrent_initializers_choose_migration_plan_under_exclusive_lock(
+    tmp_path: Path,
+) -> None:
+    """Concurrent initializers re-read schema version after exclusive serialization."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in _MIGRATION_1:
+            connection.execute(statement)
+        connection.execute("PRAGMA user_version = 1")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+    barrier = threading.Barrier(2)
+
+    def initialize() -> Path | None:
+        """Start one initializer at the same concurrency boundary."""
+        barrier.wait(timeout=5)
+        return initialize_database(path, busy_timeout_ms=10_000)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = (executor.submit(initialize), executor.submit(initialize))
+        results = tuple(future.result(timeout=15) for future in futures)
+
+    assert sum(result is not None for result in results) == 1
+    connection = connect_database(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    finally:
+        connection.close()
 
 
 def test_newer_and_marker_only_schemas_refuse_without_deleting_state(tmp_path: Path) -> None:

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -1,0 +1,101 @@
+"""Tests for guarded SQLite initialization and forward migration."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from wmo.runtime.gateway.sqlite.migrations import (
+    _MIGRATION_1,
+    SCHEMA_VERSION,
+    GatewaySchemaError,
+    connect_database,
+    initialize_database,
+)
+
+
+def test_initial_database_is_private_wal_with_foreign_keys(tmp_path: Path) -> None:
+    """Fresh state enables WAL, foreign keys, bounded busy waits, and mode 0600."""
+    path = tmp_path / "gateway.db"
+
+    assert initialize_database(path) is None
+    connection = connect_database(path, busy_timeout_ms=321)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert connection.execute("PRAGMA busy_timeout").fetchone()[0] == 321
+    finally:
+        connection.close()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_forward_migration_creates_consistent_private_backup(tmp_path: Path) -> None:
+    """Existing old schemas are backed up before the next forward-only migration."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in _MIGRATION_1:
+            connection.execute(statement)
+        connection.execute("PRAGMA user_version = 1")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None
+    assert backup.exists()
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    backup_connection = sqlite3.connect(backup)
+    try:
+        assert backup_connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert (
+            backup_connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'gateway_requests'"
+            ).fetchone()
+            is None
+        )
+    finally:
+        backup_connection.close()
+
+
+def test_newer_and_marker_only_schemas_refuse_without_deleting_state(tmp_path: Path) -> None:
+    """Unknown future versions and missing schema objects fail closed."""
+    newer = tmp_path / "newer.db"
+    descriptor = os.open(newer, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = sqlite3.connect(newer)
+    connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+    connection.close()
+
+    with pytest.raises(GatewaySchemaError, match="newer"):
+        initialize_database(newer)
+    assert newer.exists()
+    connection = sqlite3.connect(newer)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        connection.close()
+
+    marker_only = tmp_path / "marker-only.db"
+    descriptor = os.open(marker_only, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = sqlite3.connect(marker_only)
+    connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    connection.close()
+    with pytest.raises(GatewaySchemaError, match="marker"):
+        initialize_database(marker_only)
+
+    corrupt = tmp_path / "corrupt.db"
+    corrupt.write_bytes(b"not a sqlite database")
+    corrupt.chmod(0o600)
+    with pytest.raises(GatewaySchemaError, match="corrupt"):
+        initialize_database(corrupt)

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -214,6 +214,60 @@ def test_attempt_billing_migration_is_explicit_and_preserves_v2_backup(tmp_path:
         backup_connection.close()
 
 
+def test_provider_authority_migration_preserves_v3_backup(tmp_path: Path) -> None:
+    """Schema v4 adds serving connection revisions without rewriting prior authority."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in (*_MIGRATION_1, *_MIGRATION_2):
+            connection.execute(statement)
+        connection.execute(
+            """
+            ALTER TABLE gateway_attempts
+            ADD COLUMN billing_source TEXT NOT NULL DEFAULT 'customer_managed'
+            CHECK (billing_source IN ('customer_managed', 'host_managed'))
+            """
+        )
+        connection.execute("PRAGMA user_version = 3")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None
+    backup_connection = sqlite3.connect(backup)
+    current = connect_database(path)
+    try:
+        assert backup_connection.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert (
+            backup_connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'provider_connections'"
+            ).fetchone()
+            is None
+        )
+        tables = {
+            str(row[0])
+            for row in current.execute(
+                """
+                SELECT name FROM sqlite_master
+                WHERE type = 'table' AND name LIKE '%provider_connection%'
+                """
+            )
+        }
+        assert tables == {
+            "alias_revision_provider_connections",
+            "provider_connection_revisions",
+            "provider_connections",
+        }
+    finally:
+        current.close()
+        backup_connection.close()
+
+
 def test_concurrent_initializers_choose_migration_plan_under_exclusive_lock(
     tmp_path: Path,
 ) -> None:

--- a/wmo/runtime/gateway/sqlite/provider_authority.py
+++ b/wmo/runtime/gateway/sqlite/provider_authority.py
@@ -1,0 +1,327 @@
+"""Versioned SQLite authority for secret-free serving provider connections."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from wmo.common.core.artifacts import ContractModel, Sha256
+from wmo.common.models import ConnectionConfig
+
+
+class ProviderAuthorityError(ValueError):
+    """Provider connection state conflicts with immutable serving authority."""
+
+
+class ProviderConnectionBinding(ContractModel):
+    """One alias-revision binding to an exact provider connection revision."""
+
+    connection_id: str
+    connection_revision_id: str
+    connection_sha256: Sha256
+
+
+class ProviderConnectionAuthority(ContractModel):
+    """One active or revision-pinned secret-free provider connection."""
+
+    connection_id: str
+    revision_id: str
+    revision_number: int
+    connection_sha256: Sha256
+    config: ConnectionConfig
+    active: bool = True
+
+
+def upsert_provider_connection(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    connection_id: str,
+    revision_id: str,
+    config: ConnectionConfig,
+    replace: bool,
+    now: str,
+) -> tuple[bool, ProviderConnectionAuthority]:
+    """Create or explicitly revise one provider connection.
+
+    Args:
+        connection: Open SQLite transaction.
+        organization_id: Owning tenant.
+        connection_id: Stable operator-facing connection name.
+        revision_id: Immutable revision identity for a changed configuration.
+        config: Validated secret-free connection metadata.
+        replace: Whether an existing different configuration may be revised.
+        now: Canonical transaction timestamp.
+
+    Returns:
+        Change flag and the exact active authority.
+
+    Raises:
+        ProviderAuthorityError: Identity, replacement, or revision invariants conflict.
+    """
+    current = _active_row(
+        connection,
+        organization_id=organization_id,
+        connection_id=connection_id,
+    )
+    digest = config.identity_sha256()
+    if current is not None:
+        authority = _authority(current)
+        if authority.config == config and authority.connection_sha256 == digest:
+            return False, authority
+        if not replace:
+            raise ProviderAuthorityError(
+                "provider connection already exists with different metadata; pass --replace"
+            )
+        revision_number = authority.revision_number + 1
+    else:
+        existing_id = connection.execute(
+            """
+            SELECT organization_id FROM provider_connections
+            WHERE connection_id = ?
+            """,
+            (connection_id,),
+        ).fetchone()
+        if existing_id is not None and str(existing_id["organization_id"]) != organization_id:
+            raise ProviderAuthorityError("provider connection ID belongs to another organization")
+        connection.execute(
+            """
+            INSERT INTO provider_connections (
+                connection_id, organization_id, active, created_at, updated_at
+            ) VALUES (?, ?, 1, ?, ?)
+            """,
+            (connection_id, organization_id, now, now),
+        )
+        revision_number = 1
+    revision_owner = connection.execute(
+        """
+        SELECT organization_id, connection_id
+        FROM provider_connection_revisions WHERE revision_id = ?
+        """,
+        (revision_id,),
+    ).fetchone()
+    if revision_owner is not None:
+        raise ProviderAuthorityError("provider connection revision ID is already in use")
+    connection.execute(
+        """
+        INSERT INTO provider_connection_revisions (
+            revision_id, organization_id, connection_id, revision_number,
+            provider, base_url, api_key_env, api_version, region,
+            connection_sha256, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            revision_id,
+            organization_id,
+            connection_id,
+            revision_number,
+            config.provider,
+            config.base_url,
+            config.api_key_env,
+            config.api_version,
+            config.region,
+            digest,
+            now,
+        ),
+    )
+    connection.execute(
+        """
+        UPDATE provider_connections
+        SET active_revision_id = ?, active = 1, updated_at = ?
+        WHERE organization_id = ? AND connection_id = ?
+        """,
+        (revision_id, now, organization_id, connection_id),
+    )
+    return (
+        True,
+        ProviderConnectionAuthority(
+            connection_id=connection_id,
+            revision_id=revision_id,
+            revision_number=revision_number,
+            connection_sha256=digest,
+            config=config,
+        ),
+    )
+
+
+def active_provider_connections(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+) -> tuple[ProviderConnectionAuthority, ...]:
+    """Return active provider authorities in stable connection-name order."""
+    rows = connection.execute(
+        f"""
+        {_SELECT_AUTHORITY}
+        WHERE c.organization_id = ? AND c.active = 1
+        ORDER BY c.connection_id
+        """,
+        (organization_id,),
+    ).fetchall()
+    return tuple(_authority(row) for row in rows)
+
+
+def bound_provider_connections(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_revision_id: str,
+) -> tuple[ProviderConnectionAuthority, ...]:
+    """Return exact connection revisions frozen into one alias revision."""
+    rows = connection.execute(
+        """
+        SELECT c.connection_id, r.revision_id, r.revision_number,
+               r.provider, r.base_url, r.api_key_env, r.api_version, r.region,
+               r.connection_sha256, c.active
+        FROM alias_revision_provider_connections AS b
+        JOIN provider_connections AS c
+          ON c.organization_id = b.organization_id
+         AND c.connection_id = b.connection_id
+        JOIN provider_connection_revisions AS r
+          ON r.organization_id = b.organization_id
+         AND r.connection_id = b.connection_id
+         AND r.revision_id = b.connection_revision_id
+        WHERE b.organization_id = ? AND b.alias_id = ?
+          AND b.alias_revision_id = ?
+        ORDER BY c.connection_id
+        """,
+        (organization_id, alias_id, alias_revision_id),
+    ).fetchall()
+    return tuple(_authority(row) for row in rows)
+
+
+def bind_alias_provider_connections(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_revision_id: str,
+    bindings: tuple[ProviderConnectionBinding, ...],
+    now: str,
+) -> None:
+    """Bind one alias revision to current exact provider revisions atomically."""
+    names = tuple(item.connection_id for item in bindings)
+    if len(set(names)) != len(names):
+        raise ProviderAuthorityError("alias provider connection bindings must not repeat")
+    for binding in bindings:
+        row = connection.execute(
+            """
+            SELECT c.active_revision_id, c.active, r.connection_sha256
+            FROM provider_connections AS c
+            JOIN provider_connection_revisions AS r
+              ON r.organization_id = c.organization_id
+             AND r.connection_id = c.connection_id
+             AND r.revision_id = c.active_revision_id
+            WHERE c.organization_id = ? AND c.connection_id = ?
+            """,
+            (organization_id, binding.connection_id),
+        ).fetchone()
+        if (
+            row is None
+            or not bool(row["active"])
+            or str(row["active_revision_id"]) != binding.connection_revision_id
+            or str(row["connection_sha256"]) != binding.connection_sha256
+        ):
+            raise ProviderAuthorityError(
+                "alias provider connection binding differs from active SQLite authority"
+            )
+        connection.execute(
+            """
+            INSERT INTO alias_revision_provider_connections (
+                organization_id, alias_id, alias_revision_id, connection_id,
+                connection_revision_id, connection_sha256, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                organization_id,
+                alias_id,
+                alias_revision_id,
+                binding.connection_id,
+                binding.connection_revision_id,
+                binding.connection_sha256,
+                now,
+            ),
+        )
+
+
+def disable_provider_connection(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    connection_id: str,
+    now: str,
+) -> bool:
+    """Disable an unreferenced provider connection without deleting its revisions."""
+    referenced = connection.execute(
+        """
+        SELECT 1
+        FROM alias_revision_provider_connections AS b
+        JOIN gateway_aliases AS a
+          ON a.organization_id = b.organization_id
+         AND a.alias_id = b.alias_id
+         AND a.active_revision_id = b.alias_revision_id
+        WHERE b.organization_id = ? AND b.connection_id = ? AND a.active = 1
+        LIMIT 1
+        """,
+        (organization_id, connection_id),
+    ).fetchone()
+    if referenced is not None:
+        raise ProviderAuthorityError("provider connection is bound to an active alias revision")
+    result = connection.execute(
+        """
+        UPDATE provider_connections SET active = 0, updated_at = ?
+        WHERE organization_id = ? AND connection_id = ? AND active = 1
+        """,
+        (now, organization_id, connection_id),
+    )
+    return result.rowcount == 1
+
+
+def _active_row(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    connection_id: str,
+) -> sqlite3.Row | None:
+    """Read one current provider authority inside the caller transaction."""
+    return connection.execute(
+        f"""
+        {_SELECT_AUTHORITY}
+        WHERE c.organization_id = ? AND c.connection_id = ? AND c.active = 1
+        """,
+        (organization_id, connection_id),
+    ).fetchone()
+
+
+def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
+    """Validate one SQLite authority row as a typed provider record."""
+    config = ConnectionConfig(
+        provider=str(row["provider"]),
+        base_url=None if row["base_url"] is None else str(row["base_url"]),
+        api_key_env=None if row["api_key_env"] is None else str(row["api_key_env"]),
+        api_version=None if row["api_version"] is None else str(row["api_version"]),
+        region=None if row["region"] is None else str(row["region"]),
+    )
+    digest = str(row["connection_sha256"])
+    if config.identity_sha256() != digest:
+        raise ProviderAuthorityError("provider connection revision digest is invalid")
+    return ProviderConnectionAuthority(
+        connection_id=str(row["connection_id"]),
+        revision_id=str(row["revision_id"]),
+        revision_number=int(row["revision_number"]),
+        connection_sha256=digest,
+        config=config,
+        active=bool(row["active"]),
+    )
+
+
+_SELECT_AUTHORITY = """
+SELECT c.connection_id, r.revision_id, r.revision_number,
+       r.provider, r.base_url, r.api_key_env, r.api_version, r.region,
+       r.connection_sha256, c.active
+FROM provider_connections AS c
+JOIN provider_connection_revisions AS r
+  ON r.organization_id = c.organization_id
+ AND r.connection_id = c.connection_id
+ AND r.revision_id = c.active_revision_id
+"""

--- a/wmo/runtime/gateway/sqlite/provider_store.py
+++ b/wmo/runtime/gateway/sqlite/provider_store.py
@@ -1,0 +1,104 @@
+"""SQLite store facade for versioned serving provider connections."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+from typing import Protocol, cast
+
+from wmo.common.models import ConnectionConfig
+from wmo.runtime.gateway.auth import utc_text
+from wmo.runtime.gateway.interfaces import GatewayClock
+from wmo.runtime.gateway.sqlite.provider_authority import (
+    ProviderConnectionAuthority,
+    active_provider_connections,
+    bound_provider_connections,
+    disable_provider_connection,
+    upsert_provider_connection,
+)
+
+
+class _ProviderStore(Protocol):
+    """Structural view of store facilities used by the provider facade."""
+
+    _clock: GatewayClock
+
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        """Open one configured SQLite connection."""
+        ...
+
+    def _transaction(self) -> AbstractContextManager[sqlite3.Connection]:
+        """Open one immediate SQLite transaction."""
+        ...
+
+
+class ProviderConnectionStoreMixin:
+    """Expose provider connection authority through the gateway store facade."""
+
+    def upsert_provider_connection(
+        self,
+        *,
+        organization_id: str,
+        connection_id: str,
+        revision_id: str,
+        config: ConnectionConfig,
+        replace: bool = False,
+    ) -> tuple[bool, ProviderConnectionAuthority]:
+        """Create or explicitly revise one secret-free serving connection."""
+        store = cast(_ProviderStore, self)
+        with store._transaction() as connection:
+            return upsert_provider_connection(
+                connection,
+                organization_id=organization_id,
+                connection_id=connection_id,
+                revision_id=revision_id,
+                config=config,
+                replace=replace,
+                now=utc_text(store._clock.now()),
+            )
+
+    def provider_connections(
+        self,
+        *,
+        organization_id: str,
+    ) -> tuple[ProviderConnectionAuthority, ...]:
+        """Return active provider connections from SQLite authority."""
+        store = cast(_ProviderStore, self)
+        with store._connect() as connection:
+            return active_provider_connections(
+                connection,
+                organization_id=organization_id,
+            )
+
+    def alias_provider_connections(
+        self,
+        *,
+        organization_id: str,
+        alias_id: str,
+        alias_revision_id: str,
+    ) -> tuple[ProviderConnectionAuthority, ...]:
+        """Return exact provider revisions frozen into one alias revision."""
+        store = cast(_ProviderStore, self)
+        with store._connect() as connection:
+            return bound_provider_connections(
+                connection,
+                organization_id=organization_id,
+                alias_id=alias_id,
+                alias_revision_id=alias_revision_id,
+            )
+
+    def disable_provider_connection(
+        self,
+        *,
+        organization_id: str,
+        connection_id: str,
+    ) -> bool:
+        """Disable an unreferenced serving provider connection."""
+        store = cast(_ProviderStore, self)
+        with store._transaction() as connection:
+            return disable_provider_connection(
+                connection,
+                organization_id=organization_id,
+                connection_id=connection_id,
+                now=utc_text(store._clock.now()),
+            )

--- a/wmo/runtime/gateway/sqlite/store.py
+++ b/wmo/runtime/gateway/sqlite/store.py
@@ -13,7 +13,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from wmo.common.core.artifacts import Sha256, sha256_json
-from wmo.common.models import ConnectionConfig
 from wmo.runtime.gateway.auth import (
     FingerprintPepperFile,
     GatewayAuthError,
@@ -33,14 +32,10 @@ from wmo.runtime.gateway.contracts import (
 from wmo.runtime.gateway.interfaces import GatewayClock
 from wmo.runtime.gateway.sqlite.migrations import connect_database, initialize_database
 from wmo.runtime.gateway.sqlite.provider_authority import (
-    ProviderConnectionAuthority,
     ProviderConnectionBinding,
-    active_provider_connections,
     bind_alias_provider_connections,
-    bound_provider_connections,
-    disable_provider_connection,
-    upsert_provider_connection,
 )
+from wmo.runtime.gateway.sqlite.provider_store import ProviderConnectionStoreMixin
 
 
 class GatewayStoreError(ValueError):
@@ -75,7 +70,7 @@ class SystemGatewayClock:
         return time.monotonic()
 
 
-class SQLiteGatewayStore:
+class SQLiteGatewayStore(ProviderConnectionStoreMixin):
     """SQLite implementation of gateway authority and management operations."""
 
     def __init__(
@@ -131,70 +126,6 @@ class SQLiteGatewayStore:
                 ) VALUES (?, ?, ?, ?, ?)
                 """,
                 (organization_id, slug, display_name, now, now),
-            )
-
-    def upsert_provider_connection(
-        self,
-        *,
-        organization_id: str,
-        connection_id: str,
-        revision_id: str,
-        config: ConnectionConfig,
-        replace: bool = False,
-    ) -> tuple[bool, ProviderConnectionAuthority]:
-        """Create or explicitly revise one secret-free serving connection."""
-        with self._transaction() as connection:
-            return upsert_provider_connection(
-                connection,
-                organization_id=organization_id,
-                connection_id=connection_id,
-                revision_id=revision_id,
-                config=config,
-                replace=replace,
-                now=utc_text(self._clock.now()),
-            )
-
-    def provider_connections(
-        self,
-        *,
-        organization_id: str,
-    ) -> tuple[ProviderConnectionAuthority, ...]:
-        """Return active provider connections from SQLite authority."""
-        with self._connect() as connection:
-            return active_provider_connections(
-                connection,
-                organization_id=organization_id,
-            )
-
-    def alias_provider_connections(
-        self,
-        *,
-        organization_id: str,
-        alias_id: str,
-        alias_revision_id: str,
-    ) -> tuple[ProviderConnectionAuthority, ...]:
-        """Return exact provider revisions frozen into one alias revision."""
-        with self._connect() as connection:
-            return bound_provider_connections(
-                connection,
-                organization_id=organization_id,
-                alias_id=alias_id,
-                alias_revision_id=alias_revision_id,
-            )
-
-    def disable_provider_connection(
-        self,
-        *,
-        organization_id: str,
-        connection_id: str,
-    ) -> bool:
-        """Disable an unreferenced serving provider connection."""
-        with self._transaction() as connection:
-            return disable_provider_connection(
-                connection,
-                organization_id=organization_id,
-                connection_id=connection_id,
-                now=utc_text(self._clock.now()),
             )
 
     def create_identity(

--- a/wmo/runtime/gateway/sqlite/store.py
+++ b/wmo/runtime/gateway/sqlite/store.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from wmo.common.core.artifacts import Sha256, sha256_json
+from wmo.common.models import ConnectionConfig
 from wmo.runtime.gateway.auth import (
     FingerprintPepperFile,
     GatewayAuthError,
@@ -31,6 +32,15 @@ from wmo.runtime.gateway.contracts import (
 )
 from wmo.runtime.gateway.interfaces import GatewayClock
 from wmo.runtime.gateway.sqlite.migrations import connect_database, initialize_database
+from wmo.runtime.gateway.sqlite.provider_authority import (
+    ProviderConnectionAuthority,
+    ProviderConnectionBinding,
+    active_provider_connections,
+    bind_alias_provider_connections,
+    bound_provider_connections,
+    disable_provider_connection,
+    upsert_provider_connection,
+)
 
 
 class GatewayStoreError(ValueError):
@@ -121,6 +131,70 @@ class SQLiteGatewayStore:
                 ) VALUES (?, ?, ?, ?, ?)
                 """,
                 (organization_id, slug, display_name, now, now),
+            )
+
+    def upsert_provider_connection(
+        self,
+        *,
+        organization_id: str,
+        connection_id: str,
+        revision_id: str,
+        config: ConnectionConfig,
+        replace: bool = False,
+    ) -> tuple[bool, ProviderConnectionAuthority]:
+        """Create or explicitly revise one secret-free serving connection."""
+        with self._transaction() as connection:
+            return upsert_provider_connection(
+                connection,
+                organization_id=organization_id,
+                connection_id=connection_id,
+                revision_id=revision_id,
+                config=config,
+                replace=replace,
+                now=utc_text(self._clock.now()),
+            )
+
+    def provider_connections(
+        self,
+        *,
+        organization_id: str,
+    ) -> tuple[ProviderConnectionAuthority, ...]:
+        """Return active provider connections from SQLite authority."""
+        with self._connect() as connection:
+            return active_provider_connections(
+                connection,
+                organization_id=organization_id,
+            )
+
+    def alias_provider_connections(
+        self,
+        *,
+        organization_id: str,
+        alias_id: str,
+        alias_revision_id: str,
+    ) -> tuple[ProviderConnectionAuthority, ...]:
+        """Return exact provider revisions frozen into one alias revision."""
+        with self._connect() as connection:
+            return bound_provider_connections(
+                connection,
+                organization_id=organization_id,
+                alias_id=alias_id,
+                alias_revision_id=alias_revision_id,
+            )
+
+    def disable_provider_connection(
+        self,
+        *,
+        organization_id: str,
+        connection_id: str,
+    ) -> bool:
+        """Disable an unreferenced serving provider connection."""
+        with self._transaction() as connection:
+            return disable_provider_connection(
+                connection,
+                organization_id=organization_id,
+                connection_id=connection_id,
+                now=utc_text(self._clock.now()),
             )
 
     def create_identity(
@@ -347,6 +421,7 @@ class SQLiteGatewayStore:
         target: GatewayTarget,
         snapshot_ref: str,
         catalog_sha256: Sha256,
+        provider_connections: tuple[ProviderConnectionBinding, ...] = (),
     ) -> None:
         """Create and atomically activate one immutable alias revision.
 
@@ -358,6 +433,7 @@ class SQLiteGatewayStore:
             target: Direct pool or frozen project activation target.
             snapshot_ref: Registered catalog snapshot reference.
             catalog_sha256: Exact normalized catalog digest.
+            provider_connections: Exact active connection revisions used by the snapshot.
         """
         if isinstance(target, ProjectTarget) and target.catalog_sha256 != catalog_sha256:
             raise GatewayStoreError("project target catalog digest differs from alias activation")
@@ -429,6 +505,14 @@ class SQLiteGatewayStore:
                     snapshot_ref,
                     now,
                 ),
+            )
+            bind_alias_provider_connections(
+                connection,
+                organization_id=organization_id,
+                alias_id=alias_id,
+                alias_revision_id=revision_id,
+                bindings=provider_connections,
+                now=now,
             )
             connection.execute(
                 """

--- a/wmo/runtime/gateway/sqlite/store.py
+++ b/wmo/runtime/gateway/sqlite/store.py
@@ -559,8 +559,10 @@ class SQLiteGatewayStore:
         """
         if deadline_monotonic <= self._clock.monotonic():
             raise GatewayStoreError("request deadline has already expired")
-        organization_id, identity_id, key_id = self._authenticate(raw_key)
-        with self._connect() as connection:
+        with self._transaction() as connection:
+            organization_id, identity_id, key_id = self._authenticate_in_transaction(
+                connection, raw_key
+            )
             row = connection.execute(
                 """
                 SELECT a.alias_id, a.alias_name, a.active_revision_id,
@@ -615,8 +617,8 @@ class SQLiteGatewayStore:
         Returns:
             Granted public alias names in stable order.
         """
-        organization_id, identity_id, _ = self._authenticate(raw_key)
-        with self._connect() as connection:
+        with self._transaction() as connection:
+            organization_id, identity_id, _ = self._authenticate_in_transaction(connection, raw_key)
             rows = connection.execute(
                 """
                 SELECT a.alias_name
@@ -635,27 +637,39 @@ class SQLiteGatewayStore:
         """Rotate future key fingerprints while retaining old key authentication."""
         return self._pepper.rotate()
 
-    def _authenticate(self, raw_key: str) -> tuple[str, str, str]:
-        """Authenticate one key without placing its raw value in SQL or logs."""
+    def _authenticate_in_transaction(
+        self, connection: sqlite3.Connection, raw_key: str
+    ) -> tuple[str, str, str]:
+        """Authenticate one key inside the caller's authority transaction.
+
+        Args:
+            connection: Immediate transaction retained through the authority read.
+            raw_key: Caller key that must never enter SQLite or logs.
+
+        Returns:
+            Organization, identity, and virtual-key IDs for active authority.
+
+        Raises:
+            InvalidVirtualKeyError: The key or its owning authority is inactive.
+        """
         try:
             prefix = key_prefix(raw_key)
         except GatewayAuthError as exc:
             raise InvalidVirtualKeyError("virtual key is invalid") from exc
-        with self._connect() as connection:
-            rows = connection.execute(
-                """
-                SELECT k.organization_id, k.identity_id, k.key_id,
-                       k.fingerprint_version, k.fingerprint_sha256,
-                       k.expires_at, k.revoked_at, i.active AS identity_active,
-                       o.active AS organization_active
-                FROM virtual_keys AS k
-                JOIN identities AS i
-                  ON i.organization_id = k.organization_id AND i.identity_id = k.identity_id
-                JOIN organizations AS o ON o.organization_id = k.organization_id
-                WHERE k.prefix = ?
-                """,
-                (prefix,),
-            ).fetchall()
+        rows = connection.execute(
+            """
+            SELECT k.organization_id, k.identity_id, k.key_id,
+                   k.fingerprint_version, k.fingerprint_sha256,
+                   k.expires_at, k.revoked_at, i.active AS identity_active,
+                   o.active AS organization_active
+            FROM virtual_keys AS k
+            JOIN identities AS i
+              ON i.organization_id = k.organization_id AND i.identity_id = k.identity_id
+            JOIN organizations AS o ON o.organization_id = k.organization_id
+            WHERE k.prefix = ?
+            """,
+            (prefix,),
+        ).fetchall()
         now = self._clock.now()
         selected: sqlite3.Row | None = None
         for row in rows:
@@ -680,14 +694,13 @@ class SQLiteGatewayStore:
         organization_id = str(selected["organization_id"])
         identity_id = str(selected["identity_id"])
         key_id = str(selected["key_id"])
-        with self._transaction() as connection:
-            connection.execute(
-                """
-                UPDATE virtual_keys SET last_used_at = ?
-                WHERE organization_id = ? AND key_id = ?
-                """,
-                (utc_text(now), organization_id, key_id),
-            )
+        connection.execute(
+            """
+            UPDATE virtual_keys SET last_used_at = ?
+            WHERE organization_id = ? AND key_id = ?
+            """,
+            (utc_text(now), organization_id, key_id),
+        )
         return organization_id, identity_id, key_id
 
     @contextmanager

--- a/wmo/runtime/gateway/sqlite/store.py
+++ b/wmo/runtime/gateway/sqlite/store.py
@@ -1,0 +1,799 @@
+"""Transactional SQLite authority for organizations, keys, grants, and aliases."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+
+from wmo.common.core.artifacts import Sha256, sha256_json
+from wmo.runtime.gateway.auth import (
+    FingerprintPepperFile,
+    GatewayAuthError,
+    IssuedVirtualKey,
+    fingerprint_virtual_key,
+    issue_key_material,
+    key_prefix,
+    utc_text,
+)
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    GatewayRequest,
+    GatewayTarget,
+    ProjectTarget,
+)
+from wmo.runtime.gateway.interfaces import GatewayClock
+from wmo.runtime.gateway.sqlite.migrations import connect_database, initialize_database
+
+
+class GatewayStoreError(ValueError):
+    """A control-store mutation or lookup violates gateway authority invariants."""
+
+
+class InvalidVirtualKeyError(GatewayStoreError):
+    """A virtual key is unknown, expired, revoked, or attached to disabled authority."""
+
+
+class AliasNotGrantedError(GatewayStoreError):
+    """The authenticated identity has no active grant for the requested alias."""
+
+
+class OperationConflictError(GatewayStoreError):
+    """An operation ID was reused for different mutation input."""
+
+
+class OperationReplayUnavailableError(GatewayStoreError):
+    """A completed one-time key operation cannot reveal its raw key again."""
+
+
+class SystemGatewayClock:
+    """Production wall and monotonic clock implementation."""
+
+    def now(self) -> datetime:
+        """Return the current UTC wall-clock time."""
+        return datetime.now(UTC)
+
+    def monotonic(self) -> float:
+        """Return the process monotonic clock."""
+        return time.monotonic()
+
+
+class SQLiteGatewayStore:
+    """SQLite implementation of gateway authority and management operations."""
+
+    def __init__(
+        self,
+        database_path: Path,
+        *,
+        pepper_path: Path | None = None,
+        clock: GatewayClock | None = None,
+        busy_timeout_ms: int = 5_000,
+    ) -> None:
+        """Initialize private database and fingerprint-pepper state.
+
+        Args:
+            database_path: Local gateway SQLite path.
+            pepper_path: Optional HMAC pepper path outside SQLite.
+            clock: Injectable time source.
+            busy_timeout_ms: Maximum SQLite lock wait.
+        """
+        self.database_path = database_path
+        self._busy_timeout_ms = busy_timeout_ms
+        self._clock = SystemGatewayClock() if clock is None else clock
+        self._pepper = FingerprintPepperFile(
+            pepper_path or database_path.with_name("gateway-key-pepper.json")
+        )
+        initialize_database(database_path, busy_timeout_ms=busy_timeout_ms)
+        self._pepper.current()
+
+    @property
+    def pepper_path(self) -> Path:
+        """Return the user-only virtual-key pepper path."""
+        return self._pepper.path
+
+    def create_organization(
+        self,
+        *,
+        organization_id: str,
+        slug: str,
+        display_name: str,
+    ) -> None:
+        """Create one explicit tenant without adding identities or seed data.
+
+        Args:
+            organization_id: Stable tenant ID.
+            slug: Unique operator-facing slug.
+            display_name: Operator-facing tenant name.
+        """
+        now = utc_text(self._clock.now())
+        with self._transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO organizations (
+                    organization_id, slug, display_name, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (organization_id, slug, display_name, now, now),
+            )
+
+    def create_identity(
+        self,
+        *,
+        organization_id: str,
+        identity_id: str,
+        display_name: str,
+        description: str | None = None,
+        operation_id: str | None = None,
+    ) -> str:
+        """Create one identity with optional mutation idempotency.
+
+        Args:
+            organization_id: Owning tenant.
+            identity_id: Stable identity ID.
+            display_name: Operator-facing identity name.
+            description: Optional content-free identity description.
+            operation_id: Optional retry-safe operation ID.
+
+        Returns:
+            The created or previously receipted identity ID.
+        """
+        request_sha256 = sha256_json(
+            {
+                "organization_id": organization_id,
+                "identity_id": identity_id,
+                "display_name": display_name,
+                "description": description,
+            }
+        )
+        now = utc_text(self._clock.now())
+        with self._transaction() as connection:
+            replay = self._operation_replay(
+                connection,
+                organization_id=organization_id,
+                operation_id=operation_id,
+                operation_kind="create_identity",
+                request_sha256=request_sha256,
+            )
+            if replay is not None:
+                return replay
+            connection.execute(
+                """
+                INSERT INTO identities (
+                    identity_id, organization_id, display_name, description, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (identity_id, organization_id, display_name, description, now, now),
+            )
+            self._record_operation(
+                connection,
+                organization_id=organization_id,
+                operation_id=operation_id,
+                operation_kind="create_identity",
+                request_sha256=request_sha256,
+                resource_kind="identity",
+                resource_id=identity_id,
+                created_at=now,
+            )
+        return identity_id
+
+    def issue_virtual_key(
+        self,
+        *,
+        organization_id: str,
+        identity_id: str,
+        key_id: str,
+        expires_at: datetime | None = None,
+        operation_id: str | None = None,
+    ) -> IssuedVirtualKey:
+        """Issue a 256-bit virtual key and persist only its HMAC fingerprint.
+
+        Args:
+            organization_id: Owning tenant.
+            identity_id: Credential owner.
+            key_id: Stable non-secret credential ID.
+            expires_at: Optional timezone-aware expiry.
+            operation_id: Optional retry-safe operation ID.
+
+        Returns:
+            One-time receipt containing the raw key.
+
+        Raises:
+            OperationReplayUnavailableError: A retry names an already issued key operation.
+        """
+        expires_text = None if expires_at is None else utc_text(expires_at)
+        if expires_at is not None and expires_at <= self._clock.now():
+            raise GatewayStoreError("virtual key expiry must be in the future")
+        request_sha256 = sha256_json(
+            {
+                "organization_id": organization_id,
+                "identity_id": identity_id,
+                "key_id": key_id,
+                "expires_at": expires_text,
+            }
+        )
+        prefix, raw_key = issue_key_material()
+        pepper = self._pepper.current()
+        fingerprint = fingerprint_virtual_key(raw_key, pepper)
+        created_at = self._clock.now()
+        created_text = utc_text(created_at)
+        with self._transaction() as connection:
+            replay = self._operation_replay(
+                connection,
+                organization_id=organization_id,
+                operation_id=operation_id,
+                operation_kind="issue_virtual_key",
+                request_sha256=request_sha256,
+            )
+            if replay is not None:
+                raise OperationReplayUnavailableError(
+                    f"virtual key {replay!r} was already issued and cannot be revealed again"
+                )
+            connection.execute(
+                """
+                INSERT INTO virtual_keys (
+                    key_id, organization_id, identity_id, prefix, fingerprint_version,
+                    fingerprint_sha256, expires_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key_id,
+                    organization_id,
+                    identity_id,
+                    prefix,
+                    pepper.version,
+                    fingerprint,
+                    expires_text,
+                    created_text,
+                ),
+            )
+            self._record_operation(
+                connection,
+                organization_id=organization_id,
+                operation_id=operation_id,
+                operation_kind="issue_virtual_key",
+                request_sha256=request_sha256,
+                resource_kind="virtual_key",
+                resource_id=key_id,
+                created_at=created_text,
+            )
+        return IssuedVirtualKey(
+            key_id=key_id,
+            organization_id=organization_id,
+            identity_id=identity_id,
+            prefix=prefix,
+            raw_key=raw_key,
+            expires_at=expires_at,
+            created_at=created_at,
+        )
+
+    def revoke_virtual_key(self, *, organization_id: str, key_id: str) -> bool:
+        """Revoke a key idempotently.
+
+        Args:
+            organization_id: Owning tenant.
+            key_id: Stable key ID.
+
+        Returns:
+            True when an active key changed state.
+        """
+        with self._transaction() as connection:
+            result = connection.execute(
+                """
+                UPDATE virtual_keys SET revoked_at = ?
+                WHERE organization_id = ? AND key_id = ? AND revoked_at IS NULL
+                """,
+                (utc_text(self._clock.now()), organization_id, key_id),
+            )
+        return result.rowcount == 1
+
+    def disable_identity(self, *, organization_id: str, identity_id: str) -> bool:
+        """Disable an identity and therefore all of its keys.
+
+        Args:
+            organization_id: Owning tenant.
+            identity_id: Stable identity ID.
+
+        Returns:
+            True when an active identity changed state.
+        """
+        with self._transaction() as connection:
+            result = connection.execute(
+                """
+                UPDATE identities SET active = 0, updated_at = ?
+                WHERE organization_id = ? AND identity_id = ? AND active = 1
+                """,
+                (utc_text(self._clock.now()), organization_id, identity_id),
+            )
+        return result.rowcount == 1
+
+    def register_catalog_snapshot(
+        self,
+        *,
+        organization_id: str,
+        snapshot_ref: str,
+        catalog_sha256: Sha256,
+    ) -> None:
+        """Register an immutable catalog snapshot reference without catalog content.
+
+        Args:
+            organization_id: Owning tenant.
+            snapshot_ref: Content-addressed external snapshot reference.
+            catalog_sha256: Normalized secret-free catalog digest.
+        """
+        with self._transaction() as connection:
+            connection.execute(
+                """
+                INSERT INTO catalog_snapshot_refs (
+                    snapshot_ref, organization_id, catalog_sha256, created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (snapshot_ref, organization_id, catalog_sha256, utc_text(self._clock.now())),
+            )
+
+    def activate_alias_revision(
+        self,
+        *,
+        organization_id: str,
+        alias_id: str,
+        alias_name: str,
+        revision_id: str,
+        target: GatewayTarget,
+        snapshot_ref: str,
+        catalog_sha256: Sha256,
+    ) -> None:
+        """Create and atomically activate one immutable alias revision.
+
+        Args:
+            organization_id: Owning tenant.
+            alias_id: Stable alias resource ID.
+            alias_name: Public model string.
+            revision_id: Immutable revision ID.
+            target: Direct pool or frozen project activation target.
+            snapshot_ref: Registered catalog snapshot reference.
+            catalog_sha256: Exact normalized catalog digest.
+        """
+        if isinstance(target, ProjectTarget) and target.catalog_sha256 != catalog_sha256:
+            raise GatewayStoreError("project target catalog digest differs from alias activation")
+        now = utc_text(self._clock.now())
+        with self._transaction() as connection:
+            snapshot = connection.execute(
+                """
+                SELECT 1 FROM catalog_snapshot_refs
+                WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
+                """,
+                (organization_id, snapshot_ref, catalog_sha256),
+            ).fetchone()
+            if snapshot is None:
+                raise GatewayStoreError("catalog snapshot reference is not registered")
+            alias_row = connection.execute(
+                """
+                SELECT alias_name FROM gateway_aliases
+                WHERE organization_id = ? AND alias_id = ?
+                """,
+                (organization_id, alias_id),
+            ).fetchone()
+            if alias_row is None:
+                connection.execute(
+                    """
+                    INSERT INTO gateway_aliases (
+                        alias_id, organization_id, alias_name, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (alias_id, organization_id, alias_name, now, now),
+                )
+                revision_number = 1
+            else:
+                if str(alias_row["alias_name"]) != alias_name:
+                    raise GatewayStoreError("alias ID cannot be renamed")
+                revision_number = int(
+                    connection.execute(
+                        """
+                        SELECT COALESCE(MAX(revision_number), 0) + 1
+                        FROM alias_revisions WHERE organization_id = ? AND alias_id = ?
+                        """,
+                        (organization_id, alias_id),
+                    ).fetchone()[0]
+                )
+            pool_id: str | None = None
+            project_ref: str | None = None
+            activation_ref: str | None = None
+            if isinstance(target, DirectTarget):
+                pool_id = target.pool_id
+            else:
+                project_ref = target.project_ref
+                activation_ref = target.activation_ref
+            connection.execute(
+                """
+                INSERT INTO alias_revisions (
+                    revision_id, organization_id, alias_id, revision_number, target_kind,
+                    pool_id, project_ref, activation_ref, catalog_sha256, snapshot_ref, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    revision_id,
+                    organization_id,
+                    alias_id,
+                    revision_number,
+                    target.kind,
+                    pool_id,
+                    project_ref,
+                    activation_ref,
+                    catalog_sha256,
+                    snapshot_ref,
+                    now,
+                ),
+            )
+            connection.execute(
+                """
+                DELETE FROM project_activation_bindings
+                WHERE organization_id = ? AND alias_id = ?
+                """,
+                (organization_id, alias_id),
+            )
+            if isinstance(target, ProjectTarget):
+                connection.execute(
+                    """
+                    INSERT INTO project_activation_bindings (
+                        organization_id, project_ref, activation_ref,
+                        alias_id, revision_id, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        organization_id,
+                        target.project_ref,
+                        target.activation_ref,
+                        alias_id,
+                        revision_id,
+                        now,
+                    ),
+                )
+            connection.execute(
+                """
+                UPDATE gateway_aliases
+                SET active_revision_id = ?, active = 1, updated_at = ?
+                WHERE organization_id = ? AND alias_id = ?
+                """,
+                (revision_id, now, organization_id, alias_id),
+            )
+
+    def disable_alias(self, *, organization_id: str, alias_id: str) -> bool:
+        """Disable one alias and release its active project binding.
+
+        Args:
+            organization_id: Owning tenant.
+            alias_id: Stable alias resource ID.
+
+        Returns:
+            True when an active alias changed state.
+        """
+        now = utc_text(self._clock.now())
+        with self._transaction() as connection:
+            connection.execute(
+                """
+                DELETE FROM project_activation_bindings
+                WHERE organization_id = ? AND alias_id = ?
+                """,
+                (organization_id, alias_id),
+            )
+            result = connection.execute(
+                """
+                UPDATE gateway_aliases SET active = 0, updated_at = ?
+                WHERE organization_id = ? AND alias_id = ? AND active = 1
+                """,
+                (now, organization_id, alias_id),
+            )
+        return result.rowcount == 1
+
+    def grant_alias(self, *, organization_id: str, identity_id: str, alias_id: str) -> bool:
+        """Grant one identity one alias, returning whether a row was added.
+
+        Args:
+            organization_id: Owning tenant.
+            identity_id: Granted identity.
+            alias_id: Granted alias resource.
+
+        Returns:
+            True when the grant did not already exist.
+        """
+        with self._transaction() as connection:
+            result = connection.execute(
+                """
+                INSERT OR IGNORE INTO identity_alias_grants (
+                    organization_id, identity_id, alias_id, created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (organization_id, identity_id, alias_id, utc_text(self._clock.now())),
+            )
+        return result.rowcount == 1
+
+    def revoke_alias_grant(self, *, organization_id: str, identity_id: str, alias_id: str) -> bool:
+        """Remove one grant idempotently.
+
+        Args:
+            organization_id: Owning tenant.
+            identity_id: Previously granted identity.
+            alias_id: Previously granted alias.
+
+        Returns:
+            True when a grant was removed.
+        """
+        with self._transaction() as connection:
+            result = connection.execute(
+                """
+                DELETE FROM identity_alias_grants
+                WHERE organization_id = ? AND identity_id = ? AND alias_id = ?
+                """,
+                (organization_id, identity_id, alias_id),
+            )
+        return result.rowcount == 1
+
+    def authorize_request(
+        self,
+        *,
+        raw_key: str,
+        alias: str,
+        request: GatewayRequest,
+        deadline_monotonic: float,
+    ) -> AuthorizationSnapshot:
+        """Authenticate and authorize before any model or provider work.
+
+        Args:
+            raw_key: Caller virtual key.
+            alias: Requested public model alias.
+            request: Canonical content-bearing request used only for its digest.
+            deadline_monotonic: Absolute request-wide monotonic deadline.
+
+        Returns:
+            Immutable content-free authority snapshot.
+
+        Raises:
+            InvalidVirtualKeyError: Authentication fails.
+            AliasNotGrantedError: No active grant resolves the alias.
+        """
+        if deadline_monotonic <= self._clock.monotonic():
+            raise GatewayStoreError("request deadline has already expired")
+        organization_id, identity_id, key_id = self._authenticate(raw_key)
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT a.alias_id, a.alias_name, a.active_revision_id,
+                       r.target_kind, r.pool_id, r.project_ref, r.activation_ref, r.catalog_sha256
+                FROM identity_alias_grants AS g
+                JOIN identities AS i
+                  ON i.organization_id = g.organization_id AND i.identity_id = g.identity_id
+                JOIN gateway_aliases AS a
+                  ON a.organization_id = g.organization_id AND a.alias_id = g.alias_id
+                JOIN alias_revisions AS r
+                  ON r.organization_id = a.organization_id
+                 AND r.alias_id = a.alias_id
+                 AND r.revision_id = a.active_revision_id
+                WHERE g.organization_id = ? AND g.identity_id = ?
+                  AND a.alias_name = ? AND i.active = 1 AND a.active = 1
+                """,
+                (organization_id, identity_id, alias),
+            ).fetchone()
+        if row is None:
+            raise AliasNotGrantedError("requested model alias is not granted")
+        target: GatewayTarget
+        if str(row["target_kind"]) == "direct":
+            target = DirectTarget(pool_id=str(row["pool_id"]))
+        else:
+            target = ProjectTarget(
+                project_ref=str(row["project_ref"]),
+                activation_ref=str(row["activation_ref"]),
+                catalog_sha256=str(row["catalog_sha256"]),
+            )
+        caller_operation = _caller_operation_sha256(request)
+        return AuthorizationSnapshot(
+            request_id=f"request-{uuid.uuid4().hex}",
+            organization_id=organization_id,
+            identity_id=identity_id,
+            virtual_key_id=key_id,
+            alias=alias,
+            alias_revision_id=str(row["active_revision_id"]),
+            target=target,
+            catalog_sha256=str(row["catalog_sha256"]),
+            canonical_request_sha256=sha256_json(request),
+            deadline_monotonic=deadline_monotonic,
+            surface=request.surface,
+            caller_operation_sha256=caller_operation,
+        )
+
+    def granted_aliases(self, *, raw_key: str) -> tuple[str, ...]:
+        """List only active aliases granted to the key-derived identity.
+
+        Args:
+            raw_key: Caller virtual key.
+
+        Returns:
+            Granted public alias names in stable order.
+        """
+        organization_id, identity_id, _ = self._authenticate(raw_key)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT a.alias_name
+                FROM identity_alias_grants AS g
+                JOIN gateway_aliases AS a
+                  ON a.organization_id = g.organization_id AND a.alias_id = g.alias_id
+                WHERE g.organization_id = ? AND g.identity_id = ?
+                  AND a.active = 1 AND a.active_revision_id IS NOT NULL
+                ORDER BY a.alias_name
+                """,
+                (organization_id, identity_id),
+            ).fetchall()
+        return tuple(str(row["alias_name"]) for row in rows)
+
+    def rotate_fingerprint_pepper(self) -> int:
+        """Rotate future key fingerprints while retaining old key authentication."""
+        return self._pepper.rotate()
+
+    def _authenticate(self, raw_key: str) -> tuple[str, str, str]:
+        """Authenticate one key without placing its raw value in SQL or logs."""
+        try:
+            prefix = key_prefix(raw_key)
+        except GatewayAuthError as exc:
+            raise InvalidVirtualKeyError("virtual key is invalid") from exc
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT k.organization_id, k.identity_id, k.key_id,
+                       k.fingerprint_version, k.fingerprint_sha256,
+                       k.expires_at, k.revoked_at, i.active AS identity_active,
+                       o.active AS organization_active
+                FROM virtual_keys AS k
+                JOIN identities AS i
+                  ON i.organization_id = k.organization_id AND i.identity_id = k.identity_id
+                JOIN organizations AS o ON o.organization_id = k.organization_id
+                WHERE k.prefix = ?
+                """,
+                (prefix,),
+            ).fetchall()
+        now = self._clock.now()
+        selected: sqlite3.Row | None = None
+        for row in rows:
+            try:
+                pepper = self._pepper.key(int(row["fingerprint_version"]))
+            except GatewayAuthError:
+                continue
+            fingerprint = fingerprint_virtual_key(raw_key, pepper)
+            if hmac.compare_digest(fingerprint, str(row["fingerprint_sha256"])):
+                selected = row
+        if selected is None:
+            raise InvalidVirtualKeyError("virtual key is invalid")
+        expires_at = selected["expires_at"]
+        expired = expires_at is not None and datetime.fromisoformat(str(expires_at)) <= now
+        if (
+            selected["revoked_at"] is not None
+            or expired
+            or int(selected["identity_active"]) != 1
+            or int(selected["organization_active"]) != 1
+        ):
+            raise InvalidVirtualKeyError("virtual key is invalid")
+        organization_id = str(selected["organization_id"])
+        identity_id = str(selected["identity_id"])
+        key_id = str(selected["key_id"])
+        with self._transaction() as connection:
+            connection.execute(
+                """
+                UPDATE virtual_keys SET last_used_at = ?
+                WHERE organization_id = ? AND key_id = ?
+                """,
+                (utc_text(now), organization_id, key_id),
+            )
+        return organization_id, identity_id, key_id
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open and close one configured read connection."""
+        connection = connect_database(self.database_path, busy_timeout_ms=self._busy_timeout_ms)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        """Run one explicit immediate transaction with rollback on failure."""
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                yield connection
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+            else:
+                connection.execute("COMMIT")
+
+    @staticmethod
+    def _operation_replay(
+        connection: sqlite3.Connection,
+        *,
+        organization_id: str,
+        operation_id: str | None,
+        operation_kind: str,
+        request_sha256: Sha256,
+    ) -> str | None:
+        """Return a matching receipted resource or reject operation-ID drift."""
+        if operation_id is None:
+            return None
+        row = connection.execute(
+            """
+            SELECT operation_kind, request_sha256, resource_id
+            FROM operation_receipts
+            WHERE organization_id = ? AND operation_id = ?
+            """,
+            (organization_id, operation_id),
+        ).fetchone()
+        if row is None:
+            return None
+        if (
+            str(row["operation_kind"]) != operation_kind
+            or str(row["request_sha256"]) != request_sha256
+        ):
+            raise OperationConflictError("operation ID was reused with different input")
+        return str(row["resource_id"])
+
+    @staticmethod
+    def _record_operation(
+        connection: sqlite3.Connection,
+        *,
+        organization_id: str,
+        operation_id: str | None,
+        operation_kind: str,
+        request_sha256: Sha256,
+        resource_kind: str,
+        resource_id: str,
+        created_at: str,
+    ) -> None:
+        """Persist a content-free operation receipt inside its mutation transaction."""
+        if operation_id is None:
+            return
+        connection.execute(
+            """
+            INSERT INTO operation_receipts (
+                organization_id, operation_id, operation_kind, request_sha256,
+                resource_kind, resource_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                organization_id,
+                operation_id,
+                operation_kind,
+                request_sha256,
+                resource_kind,
+                resource_id,
+                created_at,
+            ),
+        )
+
+
+def _caller_operation_sha256(request: GatewayRequest) -> Sha256 | None:
+    """Hash an opted-in caller operation without retaining the raw identifier.
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        Namespaced caller-operation digest, or ``None`` for ordinary requests.
+
+    Raises:
+        GatewayStoreError: Both supported headers name different operations.
+    """
+    if (
+        request.idempotency_key is not None
+        and request.client_request_id is not None
+        and request.idempotency_key != request.client_request_id
+    ):
+        raise GatewayStoreError("idempotency and client request IDs must match when both are set")
+    value = request.idempotency_key or request.client_request_id
+    if value is None:
+        return None
+    return hashlib.sha256(f"gateway-caller-operation-v1\0{value}".encode()).hexdigest()

--- a/wmo/runtime/gateway/sqlite/store_test.py
+++ b/wmo/runtime/gateway/sqlite/store_test.py
@@ -10,12 +10,17 @@ from pathlib import Path
 
 import pytest
 
+from wmo.common.models import ConnectionConfig
 from wmo.runtime.gateway.contracts import (
     DirectTarget,
     GatewayApiSurface,
     GatewayMessage,
     GatewayRequest,
     ProjectTarget,
+)
+from wmo.runtime.gateway.sqlite.provider_authority import (
+    ProviderAuthorityError,
+    ProviderConnectionBinding,
 )
 from wmo.runtime.gateway.sqlite.store import (
     AliasNotGrantedError,
@@ -335,3 +340,105 @@ def test_cross_tenant_grant_is_rejected_by_composite_foreign_keys(tmp_path: Path
         store.grant_alias(
             organization_id="org-one", identity_id="identity-one", alias_id="alias-two"
         )
+
+
+def test_provider_revisions_are_sqlite_authority_and_alias_bindings_remain_frozen(
+    tmp_path: Path,
+) -> None:
+    """Alias revisions retain exact provider metadata after the active connection changes."""
+    store = SQLiteGatewayStore(tmp_path / "gateway.db")
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    original = ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")
+    changed, first = store.upsert_provider_connection(
+        organization_id="org-one",
+        connection_id="primary",
+        revision_id="provider-revision-one",
+        config=original,
+    )
+    assert changed
+    store.register_catalog_snapshot(
+        organization_id="org-one", snapshot_ref="snapshot-one", catalog_sha256=_DIGEST
+    )
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_name="coding",
+        revision_id="alias-revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+        provider_connections=(
+            ProviderConnectionBinding(
+                connection_id="primary",
+                connection_revision_id=first.revision_id,
+                connection_sha256=first.connection_sha256,
+            ),
+        ),
+    )
+
+    replacement = ConnectionConfig(provider="openai", api_key_env="SECONDARY_OPENAI_KEY")
+    changed, second = store.upsert_provider_connection(
+        organization_id="org-one",
+        connection_id="primary",
+        revision_id="provider-revision-two",
+        config=replacement,
+        replace=True,
+    )
+
+    assert changed
+    assert second.revision_number == 2
+    assert store.provider_connections(organization_id="org-one") == (second,)
+    assert store.alias_provider_connections(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_revision_id="alias-revision-one",
+    ) == (first,)
+    with pytest.raises(ProviderAuthorityError, match="active alias"):
+        store.disable_provider_connection(
+            organization_id="org-one",
+            connection_id="primary",
+        )
+
+
+def test_alias_activation_rejects_stale_provider_binding_atomically(tmp_path: Path) -> None:
+    """A stale connection revision cannot create either an alias or a partial binding."""
+    store = SQLiteGatewayStore(tmp_path / "gateway.db")
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    _, authority = store.upsert_provider_connection(
+        organization_id="org-one",
+        connection_id="primary",
+        revision_id="provider-revision-one",
+        config=ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY"),
+    )
+    store.register_catalog_snapshot(
+        organization_id="org-one", snapshot_ref="snapshot-one", catalog_sha256=_DIGEST
+    )
+
+    with pytest.raises(ProviderAuthorityError, match="differs"):
+        store.activate_alias_revision(
+            organization_id="org-one",
+            alias_id="alias-one",
+            alias_name="coding",
+            revision_id="alias-revision-one",
+            target=DirectTarget(pool_id="pool-one"),
+            snapshot_ref="snapshot-one",
+            catalog_sha256=_DIGEST,
+            provider_connections=(
+                ProviderConnectionBinding(
+                    connection_id="primary",
+                    connection_revision_id="stale-revision",
+                    connection_sha256=authority.connection_sha256,
+                ),
+            ),
+        )
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM gateway_aliases").fetchone()[0] == 0
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM alias_revision_provider_connections"
+            ).fetchone()[0]
+            == 0
+        )
+    finally:
+        connection.close()

--- a/wmo/runtime/gateway/sqlite/store_test.py
+++ b/wmo/runtime/gateway/sqlite/store_test.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -127,6 +129,53 @@ def test_key_derived_authority_is_deny_by_default_and_revocation_is_immediate(
     assert store.revoke_virtual_key(organization_id="org-one", key_id="key-one")
     with pytest.raises(InvalidVirtualKeyError, match="invalid"):
         store.granted_aliases(raw_key=raw_key)
+
+
+def test_authorization_serializes_with_concurrent_key_revocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A completed revocation cannot be followed by stale authority issuance."""
+    store, clock, raw_key = _configured_store(tmp_path)
+    authenticated = threading.Event()
+    release_authorization = threading.Event()
+    original = store._authenticate_in_transaction
+
+    def pause_after_authentication(
+        connection: sqlite3.Connection, candidate_key: str
+    ) -> tuple[str, str, str]:
+        """Pause after the credential read while retaining the authority transaction."""
+        authority = original(connection, candidate_key)
+        authenticated.set()
+        assert release_authorization.wait(timeout=5)
+        return authority
+
+    monkeypatch.setattr(store, "_authenticate_in_transaction", pause_after_authentication)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        authorization = executor.submit(
+            store.authorize_request,
+            raw_key=raw_key,
+            alias="coding",
+            request=_request(),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
+        assert authenticated.wait(timeout=5)
+        revocation = executor.submit(
+            store.revoke_virtual_key,
+            organization_id="org-one",
+            key_id="key-one",
+        )
+        assert not revocation.done()
+        release_authorization.set()
+        assert authorization.result(timeout=5).virtual_key_id == "key-one"
+        assert revocation.result(timeout=5)
+
+    with pytest.raises(InvalidVirtualKeyError, match="invalid"):
+        store.authorize_request(
+            raw_key=raw_key,
+            alias="coding",
+            request=_request(),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
 
 
 def test_expiry_identity_disable_and_pepper_rotation_fail_closed(tmp_path: Path) -> None:

--- a/wmo/runtime/gateway/sqlite/store_test.py
+++ b/wmo/runtime/gateway/sqlite/store_test.py
@@ -1,0 +1,288 @@
+"""Tests for transactional SQLite gateway authority."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmo.runtime.gateway.contracts import (
+    DirectTarget,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    ProjectTarget,
+)
+from wmo.runtime.gateway.sqlite.store import (
+    AliasNotGrantedError,
+    InvalidVirtualKeyError,
+    OperationConflictError,
+    OperationReplayUnavailableError,
+    SQLiteGatewayStore,
+)
+
+_DIGEST = "a" * 64
+
+
+class FakeClock:
+    """Controllable wall and monotonic clock for authority tests."""
+
+    def __init__(self) -> None:
+        """Initialize a fixed UTC instant and monotonic value."""
+        self.wall = datetime(2026, 8, 18, 20, 0, tzinfo=UTC)
+        self.monotonic_value = 100.0
+
+    def now(self) -> datetime:
+        """Return the controlled wall time."""
+        return self.wall
+
+    def monotonic(self) -> float:
+        """Return the controlled monotonic time."""
+        return self.monotonic_value
+
+    def advance(self, seconds: float) -> None:
+        """Advance both clocks by the same duration.
+
+        Args:
+            seconds: Positive elapsed seconds.
+        """
+        self.wall += timedelta(seconds=seconds)
+        self.monotonic_value += seconds
+
+
+def _request(content: str = "content-canary") -> GatewayRequest:
+    """Create one canonical request with a canary that must not persist."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content=content),),
+    )
+
+
+def _configured_store(tmp_path: Path) -> tuple[SQLiteGatewayStore, FakeClock, str]:
+    """Create explicit organization, identity, snapshot, alias, grant, and key state."""
+    clock = FakeClock()
+    store = SQLiteGatewayStore(tmp_path / "gateway.db", clock=clock)
+    store.create_organization(
+        organization_id="org-one", slug="one", display_name="Organization One"
+    )
+    store.create_identity(
+        organization_id="org-one", identity_id="identity-one", display_name="Identity One"
+    )
+    store.register_catalog_snapshot(
+        organization_id="org-one", snapshot_ref="snapshot-one", catalog_sha256=_DIGEST
+    )
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-coding",
+        alias_name="coding",
+        revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-coding"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+    )
+    store.grant_alias(
+        organization_id="org-one", identity_id="identity-one", alias_id="alias-coding"
+    )
+    issued = store.issue_virtual_key(
+        organization_id="org-one", identity_id="identity-one", key_id="key-one"
+    )
+    return store, clock, issued.raw_key
+
+
+def test_key_derived_authority_is_deny_by_default_and_revocation_is_immediate(
+    tmp_path: Path,
+) -> None:
+    """A key derives authority, grants gate aliases, and revocation affects the next lookup."""
+    store, clock, raw_key = _configured_store(tmp_path)
+
+    snapshot = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request(),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+
+    assert snapshot.organization_id == "org-one"
+    assert snapshot.identity_id == "identity-one"
+    assert snapshot.alias_revision_id == "revision-one"
+    assert isinstance(snapshot.target, DirectTarget)
+    assert store.granted_aliases(raw_key=raw_key) == ("coding",)
+
+    store.revoke_alias_grant(
+        organization_id="org-one", identity_id="identity-one", alias_id="alias-coding"
+    )
+    with pytest.raises(AliasNotGrantedError, match="not granted"):
+        store.authorize_request(
+            raw_key=raw_key,
+            alias="coding",
+            request=_request(),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
+
+    store.grant_alias(
+        organization_id="org-one", identity_id="identity-one", alias_id="alias-coding"
+    )
+    assert store.revoke_virtual_key(organization_id="org-one", key_id="key-one")
+    with pytest.raises(InvalidVirtualKeyError, match="invalid"):
+        store.granted_aliases(raw_key=raw_key)
+
+
+def test_expiry_identity_disable_and_pepper_rotation_fail_closed(tmp_path: Path) -> None:
+    """Expiry and identity state deny old keys while pepper rotation preserves fingerprints."""
+    clock = FakeClock()
+    store = SQLiteGatewayStore(tmp_path / "gateway.db", clock=clock)
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.create_identity(organization_id="org-one", identity_id="identity-one", display_name="One")
+    expiring = store.issue_virtual_key(
+        organization_id="org-one",
+        identity_id="identity-one",
+        key_id="key-expiring",
+        expires_at=clock.now() + timedelta(seconds=5),
+    )
+    assert store.rotate_fingerprint_pepper() == 2
+    assert store.granted_aliases(raw_key=expiring.raw_key) == ()
+    clock.advance(5)
+    with pytest.raises(InvalidVirtualKeyError):
+        store.granted_aliases(raw_key=expiring.raw_key)
+
+    active = store.issue_virtual_key(
+        organization_id="org-one", identity_id="identity-one", key_id="key-active"
+    )
+    assert store.disable_identity(organization_id="org-one", identity_id="identity-one")
+    with pytest.raises(InvalidVirtualKeyError):
+        store.granted_aliases(raw_key=active.raw_key)
+
+
+def test_operation_receipts_are_atomic_and_one_time_key_replay_stays_secret(
+    tmp_path: Path,
+) -> None:
+    """Mutation retries converge while raw one-time key material never replays."""
+    store = SQLiteGatewayStore(tmp_path / "gateway.db")
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    assert (
+        store.create_identity(
+            organization_id="org-one",
+            identity_id="identity-one",
+            display_name="Identity",
+            operation_id="operation-identity",
+        )
+        == "identity-one"
+    )
+    assert (
+        store.create_identity(
+            organization_id="org-one",
+            identity_id="identity-one",
+            display_name="Identity",
+            operation_id="operation-identity",
+        )
+        == "identity-one"
+    )
+    with pytest.raises(OperationConflictError, match="different input"):
+        store.create_identity(
+            organization_id="org-one",
+            identity_id="identity-one",
+            display_name="Changed",
+            operation_id="operation-identity",
+        )
+
+    issued = store.issue_virtual_key(
+        organization_id="org-one",
+        identity_id="identity-one",
+        key_id="key-one",
+        operation_id="operation-key",
+    )
+    with pytest.raises(OperationReplayUnavailableError, match="cannot be revealed"):
+        store.issue_virtual_key(
+            organization_id="org-one",
+            identity_id="identity-one",
+            key_id="key-one",
+            operation_id="operation-key",
+        )
+
+    durable = (tmp_path / "gateway.db").read_bytes()
+    wal = tmp_path / "gateway.db-wal"
+    if wal.exists():
+        durable += wal.read_bytes()
+    assert issued.raw_key.encode() not in durable
+
+
+def test_project_activation_binding_is_unique_per_tenant_and_revisions_are_immutable(
+    tmp_path: Path,
+) -> None:
+    """Database constraints prevent two active aliases for one project activation."""
+    store = SQLiteGatewayStore(tmp_path / "gateway.db")
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.register_catalog_snapshot(
+        organization_id="org-one", snapshot_ref="snapshot-one", catalog_sha256=_DIGEST
+    )
+    target = ProjectTarget(
+        project_ref="project-one", activation_ref="activation-one", catalog_sha256=_DIGEST
+    )
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_name="first",
+        revision_id="revision-one",
+        target=target,
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        store.activate_alias_revision(
+            organization_id="org-one",
+            alias_id="alias-two",
+            alias_name="second",
+            revision_id="revision-two",
+            target=target,
+            snapshot_ref="snapshot-one",
+            catalog_sha256=_DIGEST,
+        )
+
+    store.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="alias-one",
+        alias_name="first",
+        revision_id="revision-three",
+        target=DirectTarget(pool_id="pool-one"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+    )
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM alias_revisions WHERE alias_id = 'alias-one'"
+            ).fetchone()[0]
+            == 2
+        )
+    finally:
+        connection.close()
+
+
+def test_cross_tenant_grant_is_rejected_by_composite_foreign_keys(tmp_path: Path) -> None:
+    """An identity cannot be granted another tenant's alias through mismatched IDs."""
+    store = SQLiteGatewayStore(tmp_path / "gateway.db")
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.create_organization(organization_id="org-two", slug="two", display_name="Two")
+    store.create_identity(
+        organization_id="org-one", identity_id="identity-one", display_name="Identity"
+    )
+    store.register_catalog_snapshot(
+        organization_id="org-two", snapshot_ref="snapshot-two", catalog_sha256=_DIGEST
+    )
+    store.activate_alias_revision(
+        organization_id="org-two",
+        alias_id="alias-two",
+        alias_name="two",
+        revision_id="revision-two",
+        target=DirectTarget(pool_id="pool-two"),
+        snapshot_ref="snapshot-two",
+        catalog_sha256=_DIGEST,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store.grant_alias(
+            organization_id="org-one", identity_id="identity-one", alias_id="alias-two"
+        )


### PR DESCRIPTION
## Summary

- make SQLite WAL the authority for gateway organizations, identities, virtual keys, grants, aliases, immutable alias revisions, provider connections, provider revisions, attempts, receipts, and usage
- persist only secret references and key fingerprints; provider credentials remain environment-backed and raw virtual keys remain one-time outputs
- add guarded forward migrations, pre-migration backups, frozen deployment pricing and billing ownership, crash reconciliation, and fail-closed keyed replay
- split provider authority into a focused store facade while keeping serving content out of durable state

## Boundary

This layer owns mutable serving authority only. Builds, policies, evaluations, datasets, and immutable project artifacts remain in the existing artifact store. HTTP composition and provider execution are owned downstream.

## Stack

- base: `agent/gateway-contracts-catalog` at `ffbd78c9`
- head: `9bef346f`

This PR is ready for review and must not be merged independently of its stack.
