### PR TITLE
Add true launch provider streaming

### DIFF
--- a/wmo/runtime/gateway/interfaces.py
+++ b/wmo/runtime/gateway/interfaces.py
@@ -78,6 +78,11 @@ class AttemptLedger(Protocol):
 class ProviderStream(Protocol):
     """True provider stream yielding normalized events in provider order."""
 
+    @property
+    def committed(self) -> bool:
+        """Return whether an outward semantic event has committed this provider route."""
+        ...
+
     def __aiter__(self) -> AsyncIterator[GatewayEvent]:
         """Iterate normalized provider events until one terminal event."""
         ...

--- a/wmo/runtime/models/providers/anthropic.py
+++ b/wmo/runtime/models/providers/anthropic.py
@@ -15,6 +15,8 @@ from wmo.common.models import (
     ToolChoice,
     Usage,
 )
+from wmo.runtime.gateway.contracts import GatewayRequest
+from wmo.runtime.models.providers.async_transport import RequestDeadline
 from wmo.runtime.models.providers.base import (
     DEFAULT_MAXIMUM_OUTPUT_TOKENS,
     ProviderHttpClient,
@@ -27,6 +29,10 @@ from wmo.runtime.models.providers.errors import (
     require_integer,
     require_object,
     require_string,
+)
+from wmo.runtime.models.providers.streaming import (
+    NormalizedProviderStream,
+    start_anthropic_messages_stream,
 )
 
 ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
@@ -141,6 +147,40 @@ def anthropic_messages_response(
 
 class AnthropicClient(ProviderHttpClient):
     """Calls one Anthropic Messages model, which intentionally has no embedding method."""
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+    ) -> NormalizedProviderStream:
+        """Start one true native Messages stream under the gateway deadline.
+
+        Args:
+            request: Canonical streaming gateway request.
+            deadline: Immutable request-wide deadline.
+            idempotency_key: Stable identity for safe pre-commit opening retries.
+
+        Returns:
+            A cancellable provider-neutral event stream.
+
+        Raises:
+            ValueError: The canonical request did not ask for streaming.
+        """
+        if not request.stream:
+            raise ValueError("gateway provider stream requires request.stream")
+        return await start_anthropic_messages_stream(
+            self._transport,
+            f"{self._base_url}/{self._request_path(self._completion_path())}",
+            headers=self._headers(),
+            request=request,
+            model_id=self._model.model_id,
+            deadline=deadline,
+            idempotency_key=idempotency_key,
+            retry_policy=self._retry_policy,
+            timeout_seconds=self._timeout_seconds,
+        )
 
     def _headers(self) -> dict[str, str]:
         """Build native Anthropic Messages headers with the versioned API key scheme."""

--- a/wmo/runtime/models/providers/async_transport.py
+++ b/wmo/runtime/models/providers/async_transport.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 from uuid import uuid4
@@ -127,6 +127,40 @@ class AsyncJsonHttpTransport(Protocol):
         ...
 
 
+@runtime_checkable
+class AsyncHttpByteStream(Protocol):
+    """One open provider response whose body is consumed incrementally."""
+
+    @property
+    def status_code(self) -> int:
+        """Return the provider HTTP status without reading response content."""
+        ...
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        """Yield response bytes in upstream order without buffering the body."""
+        ...
+
+    async def aclose(self) -> None:
+        """Close the active response and any transport-owned client."""
+        ...
+
+
+@runtime_checkable
+class AsyncStreamingHttpTransport(Protocol):
+    """Cancellable transport seam for one incrementally consumed JSON request."""
+
+    async def stream(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> AsyncHttpByteStream:
+        """Open one bounded response stream without reading its body."""
+        ...
+
+
 class HttpxAsyncJsonTransport:
     """Production async transport backed by ``httpx.AsyncClient``."""
 
@@ -221,6 +255,90 @@ class HttpxAsyncJsonTransport:
         except httpx.TransportError as exc:
             raise ProviderTransportError("provider transport request failed") from exc
         return _decoded_response(response)
+
+    async def stream(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        timeout_seconds: float,
+    ) -> AsyncHttpByteStream:
+        """Open one cancellable HTTP response without buffering provider events.
+
+        Args:
+            url: Absolute provider endpoint URL.
+            headers: Provider headers, including resolved authentication.
+            payload: Complete JSON request body.
+            timeout_seconds: Remaining bound for opening the response.
+
+        Returns:
+            An open byte stream whose lifecycle belongs to the caller.
+
+        Raises:
+            ProviderTransportError: The request cannot establish a response stream.
+        """
+        client = self._client or httpx.AsyncClient()
+        owns_client = self._client is None
+        try:
+            request = client.build_request(
+                "POST",
+                url,
+                headers=dict(headers),
+                json=payload,
+                timeout=timeout_seconds,
+            )
+            response = await client.send(request, stream=True)
+        except httpx.TimeoutException as exc:
+            if owns_client:
+                await client.aclose()
+            raise ProviderTransportError("provider request timed out") from exc
+        except httpx.TransportError as exc:
+            if owns_client:
+                await client.aclose()
+            raise ProviderTransportError("provider transport request failed") from exc
+        except BaseException:
+            if owns_client:
+                await client.aclose()
+            raise
+        return _HttpxByteStream(response, client if owns_client else None)
+
+
+class _HttpxByteStream:
+    """Incremental HTTPX response that closes an optionally owned client exactly once."""
+
+    def __init__(
+        self,
+        response: httpx.Response,
+        owned_client: httpx.AsyncClient | None,
+    ) -> None:
+        """Bind one response and its optional short-lived client.
+
+        Args:
+            response: Open streaming HTTPX response.
+            owned_client: Client created for this response, or ``None`` when caller-owned.
+        """
+        self._response = response
+        self._owned_client = owned_client
+        self._closed = False
+
+    @property
+    def status_code(self) -> int:
+        """Return the response status without consuming the provider body."""
+        return self._response.status_code
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        """Yield decoded-transfer bytes directly from HTTPX."""
+        return self._response.aiter_bytes()
+
+    async def aclose(self) -> None:
+        """Close the response and transport-owned client idempotently."""
+        if self._closed:
+            return
+        self._closed = True
+        await self._response.aclose()
+        if self._owned_client is not None:
+            await self._owned_client.aclose()
 
 
 class SyncJsonTransportAdapter:

--- a/wmo/runtime/models/providers/async_transport.py
+++ b/wmo/runtime/models/providers/async_transport.py
@@ -329,7 +329,17 @@ class _HttpxByteStream:
 
     def __aiter__(self) -> AsyncIterator[bytes]:
         """Yield decoded-transfer bytes directly from HTTPX."""
-        return self._response.aiter_bytes()
+        return self._iter_bytes()
+
+    async def _iter_bytes(self) -> AsyncIterator[bytes]:
+        """Translate read-time HTTPX failures into the sanitized transport taxonomy."""
+        try:
+            async for chunk in self._response.aiter_bytes():
+                yield chunk
+        except httpx.TimeoutException as exc:
+            raise ProviderTransportError("provider response stream timed out") from exc
+        except httpx.TransportError as exc:
+            raise ProviderTransportError("provider response stream failed") from exc
 
     async def aclose(self) -> None:
         """Close the response and transport-owned client idempotently."""

--- a/wmo/runtime/models/providers/openai.py
+++ b/wmo/runtime/models/providers/openai.py
@@ -25,7 +25,8 @@ from wmo.common.models import (
     ToolCall,
     Usage,
 )
-from wmo.runtime.models.providers.async_transport import AsyncJsonHttpTransport
+from wmo.runtime.gateway.contracts import GatewayRequest
+from wmo.runtime.models.providers.async_transport import AsyncJsonHttpTransport, RequestDeadline
 from wmo.runtime.models.providers.base import DEFAULT_RETRY_POLICY, DEFAULT_TIMEOUT_SECONDS
 from wmo.runtime.models.providers.errors import (
     ProviderRefusalError,
@@ -34,6 +35,10 @@ from wmo.runtime.models.providers.errors import (
     ProviderRetryableResponseError,
 )
 from wmo.runtime.models.providers.openai_compatible import OpenAIEmbeddingMixin
+from wmo.runtime.models.providers.streaming import (
+    NormalizedProviderStream,
+    start_openai_responses_stream,
+)
 from wmo.runtime.models.providers.transport import JsonHttpTransport, RetryPolicy
 
 OPENAI_BASE_URL = "https://api.openai.com/v1"
@@ -218,6 +223,42 @@ class OpenAIClient(OpenAIEmbeddingMixin):
         )
         self._supports_temperature = supports_temperature
         self._reasoning_effort = reasoning_effort
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+    ) -> NormalizedProviderStream:
+        """Start one true native Responses stream under the gateway deadline.
+
+        Args:
+            request: Canonical streaming gateway request.
+            deadline: Immutable request-wide deadline.
+            idempotency_key: Stable identity for safe pre-commit opening retries.
+
+        Returns:
+            A cancellable provider-neutral event stream.
+
+        Raises:
+            ValueError: The canonical request did not ask for streaming.
+        """
+        if not request.stream:
+            raise ValueError("gateway provider stream requires request.stream")
+        return await start_openai_responses_stream(
+            self._transport,
+            f"{self._base_url}/{self._request_path(self._completion_path())}",
+            headers=self._headers(),
+            request=request,
+            model_id=self._model.model_id,
+            deadline=deadline,
+            idempotency_key=idempotency_key,
+            retry_policy=self._retry_policy,
+            timeout_seconds=self._timeout_seconds,
+            supports_temperature=self._supports_temperature,
+            reasoning_effort=self._reasoning_effort,
+        )
 
     def _completion_path(self) -> str:
         """Return the native non-streaming Responses route."""

--- a/wmo/runtime/models/providers/openai_compatible.py
+++ b/wmo/runtime/models/providers/openai_compatible.py
@@ -20,6 +20,8 @@ from wmo.common.models import (
     ToolCall,
     Usage,
 )
+from wmo.runtime.gateway.contracts import GatewayRequest
+from wmo.runtime.models.providers.async_transport import RequestDeadline
 from wmo.runtime.models.providers.base import ProviderHttpClient
 from wmo.runtime.models.providers.errors import (
     ProviderRefusalError,
@@ -29,6 +31,10 @@ from wmo.runtime.models.providers.errors import (
     require_integer,
     require_object,
     require_string,
+)
+from wmo.runtime.models.providers.streaming import (
+    NormalizedProviderStream,
+    start_openai_compatible_stream,
 )
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -198,7 +204,41 @@ class OpenAIEmbeddingMixin(ProviderHttpClient):
 
 
 class OpenAICompatibleClient(OpenAIEmbeddingMixin):
-    """Calls one explicit OpenAI-compatible connection without streaming or failover."""
+    """Calls one explicit OpenAI-compatible connection without cross-provider failover."""
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+    ) -> NormalizedProviderStream:
+        """Start one true Chat Completions stream under the gateway deadline.
+
+        Args:
+            request: Canonical streaming gateway request.
+            deadline: Immutable request-wide deadline.
+            idempotency_key: Stable identity for safe pre-commit opening retries.
+
+        Returns:
+            A cancellable provider-neutral event stream.
+
+        Raises:
+            ValueError: The canonical request did not ask for streaming.
+        """
+        if not request.stream:
+            raise ValueError("gateway provider stream requires request.stream")
+        return await start_openai_compatible_stream(
+            self._transport,
+            f"{self._base_url}/{self._request_path(self._completion_path())}",
+            headers=self._headers(),
+            request=request,
+            model_id=self._model.model_id,
+            deadline=deadline,
+            idempotency_key=idempotency_key,
+            retry_policy=self._retry_policy,
+            timeout_seconds=self._timeout_seconds,
+        )
 
     def _completion_path(self) -> str:
         """Return the shared Chat Completions route."""

--- a/wmo/runtime/models/providers/stream_attempts.py
+++ b/wmo/runtime/models/providers/stream_attempts.py
@@ -1,0 +1,128 @@
+"""Single-budget response opening and pre-semantic streaming retry control."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.runtime.models.providers.async_transport import (
+    AsyncHttpByteStream,
+    AsyncStreamingHttpTransport,
+    ProviderDeadlineExceeded,
+    RequestDeadline,
+)
+from wmo.runtime.models.providers.errors import ProviderResponseError
+from wmo.runtime.models.providers.transport import (
+    ProviderTransportError,
+    RetryPolicy,
+    classify_retry,
+)
+
+
+class StreamAttemptController:
+    """One retry budget shared by response opening and pre-semantic stream failures."""
+
+    def __init__(
+        self,
+        transport: AsyncStreamingHttpTransport,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        payload: JsonObject,
+        deadline: RequestDeadline,
+        retry_policy: RetryPolicy,
+        timeout_seconds: float,
+    ) -> None:
+        """Bind immutable request data and one monotonic retry state.
+
+        Args:
+            transport: Incremental async HTTP transport.
+            url: Exact provider endpoint.
+            headers: Stable authenticated and idempotency headers.
+            payload: Immutable streaming request body.
+            deadline: Request-wide deadline shared by attempts and backoff.
+            retry_policy: Total same-endpoint attempt and delay limits.
+            timeout_seconds: Per-opening timeout ceiling.
+        """
+        self._transport = transport
+        self._url = url
+        self._headers = headers
+        self._payload = payload
+        self._deadline = deadline
+        self._retry_policy = retry_policy
+        self._timeout_seconds = timeout_seconds
+        self._attempts = 0
+        self._next_delay = retry_policy.initial_delay_seconds
+
+    async def open(
+        self,
+        previous_error: Exception | None = None,
+    ) -> AsyncHttpByteStream:
+        """Open the next successful response within the one shared attempt budget.
+
+        Args:
+            previous_error: Optional pre-semantic body failure from the active attempt.
+
+        Returns:
+            One successful open response stream.
+
+        Raises:
+            Exception: The last non-retryable or budget-exhausting provider failure.
+        """
+        error = previous_error
+        while True:
+            if error is not None:
+                if not self.can_retry(error):
+                    raise error
+                await self._backoff(error)
+            self._attempts += 1
+            try:
+                return await self._open_once()
+            except Exception as exc:  # noqa: BLE001 - the shared classifier owns policy.
+                error = exc
+
+    def can_retry(self, error: Exception) -> bool:
+        """Return whether a pre-semantic failure can consume another attempt.
+
+        Args:
+            error: Sanitized transport or malformed-response failure.
+
+        Returns:
+            Whether another same-endpoint attempt remains and is safe before commitment.
+        """
+        retryable = isinstance(error, ProviderResponseError) or classify_retry(error).retryable
+        return retryable and self._attempts < self._retry_policy.maximum_attempts
+
+    async def _open_once(self) -> AsyncHttpByteStream:
+        """Open and status-check one response attempt under remaining request time."""
+        timeout_seconds = self._deadline.attempt_timeout(self._timeout_seconds)
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                upstream = await self._transport.stream(
+                    self._url,
+                    headers=self._headers,
+                    payload=self._payload,
+                    timeout_seconds=timeout_seconds,
+                )
+        except TimeoutError as exc:
+            if self._deadline.remaining_seconds() <= 0:
+                raise ProviderDeadlineExceeded("provider request deadline exceeded") from exc
+            raise ProviderTransportError("provider request timed out") from exc
+        if 200 <= upstream.status_code < 300:
+            return upstream
+        status_code = upstream.status_code
+        await upstream.aclose()
+        raise ProviderTransportError(
+            f"provider returned HTTP {status_code}",
+            status_code=status_code,
+        )
+
+    async def _backoff(self, previous_error: Exception) -> None:
+        """Apply the next bounded delay without refreshing the request deadline."""
+        delay = self._next_delay
+        if self._deadline.remaining_seconds() <= delay:
+            raise ProviderDeadlineExceeded("provider request deadline exceeded") from previous_error
+        if delay > 0:
+            await asyncio.sleep(delay)
+        self._next_delay = min(delay * 2, self._retry_policy.maximum_delay_seconds)

--- a/wmo/runtime/models/providers/streaming.py
+++ b/wmo/runtime/models/providers/streaming.py
@@ -43,6 +43,10 @@ from wmo.runtime.models.providers.streaming_requests import (
     openai_compatible_stream_payload,
     openai_responses_stream_payload,
 )
+from wmo.runtime.models.providers.streaming_usage import (
+    openai_compatible_usage as _openai_compatible_usage,
+)
+from wmo.runtime.models.providers.streaming_usage import openai_usage as _openai_usage
 from wmo.runtime.models.providers.transport import ProviderTransportError, RetryPolicy
 
 _MAXIMUM_SSE_EVENT_BYTES = 4_000_000
@@ -906,62 +910,6 @@ def _provider_refusal_failure() -> GatewayFailure:
         safe_message="provider refused the request",
         safe_details={"signal": "content_policy"},
     )
-
-
-def _openai_usage(value: JsonValue | None) -> GatewayUsage | None:
-    """Normalize native Responses usage including cached and reasoning subsets."""
-    if value is None:
-        return None
-    usage = require_object(value, "OpenAI usage")
-    return GatewayUsage(
-        input_tokens=require_integer(usage.get("input_tokens"), "OpenAI input_tokens"),
-        output_tokens=require_integer(usage.get("output_tokens"), "OpenAI output_tokens"),
-        cached_input_tokens=_optional_usage_detail(
-            usage.get("input_tokens_details"),
-            field_name="cached_tokens",
-            label="OpenAI cached_tokens",
-        ),
-        reasoning_tokens=_optional_usage_detail(
-            usage.get("output_tokens_details"),
-            field_name="reasoning_tokens",
-            label="OpenAI reasoning_tokens",
-        ),
-    )
-
-
-def _openai_compatible_usage(value: JsonValue) -> GatewayUsage:
-    """Normalize Chat usage including optional cached and reasoning subsets."""
-    usage = require_object(value, "OpenAI-compatible usage")
-    return GatewayUsage(
-        input_tokens=require_integer(usage.get("prompt_tokens"), "prompt_tokens"),
-        output_tokens=require_integer(usage.get("completion_tokens"), "completion_tokens"),
-        cached_input_tokens=_optional_usage_detail(
-            usage.get("prompt_tokens_details"),
-            field_name="cached_tokens",
-            label="cached_tokens",
-        ),
-        reasoning_tokens=_optional_usage_detail(
-            usage.get("completion_tokens_details"),
-            field_name="reasoning_tokens",
-            label="reasoning_tokens",
-        ),
-    )
-
-
-def _optional_usage_detail(
-    value: JsonValue | None,
-    *,
-    field_name: str,
-    label: str,
-) -> int | None:
-    """Preserve an absent provider token subset as unknown instead of zero."""
-    if value is None:
-        return None
-    details = require_object(value, f"{label} details")
-    raw_count = details.get(field_name)
-    if raw_count is None:
-        return None
-    return require_integer(raw_count, label)
 
 
 def _json_object(raw: str) -> JsonObject:

--- a/wmo/runtime/models/providers/streaming.py
+++ b/wmo/runtime/models/providers/streaming.py
@@ -1,0 +1,917 @@
+"""True upstream streaming and provider-neutral event normalization for launch adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import cast
+
+from pydantic import JsonValue, ValidationError
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import ToolCall
+from wmo.runtime.gateway.contracts import (
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRequest,
+    GatewayUsage,
+)
+from wmo.runtime.models.providers.async_transport import (
+    AsyncHttpByteStream,
+    AsyncJsonHttpTransport,
+    AsyncStreamingHttpTransport,
+    ProviderDeadlineExceeded,
+    RequestDeadline,
+    run_with_retry_async,
+)
+from wmo.runtime.models.providers.errors import (
+    ProviderCapabilityError,
+    ProviderResponseError,
+    normalized_provider_failure,
+    require_array,
+    require_integer,
+    require_object,
+    require_string,
+)
+from wmo.runtime.models.providers.streaming_requests import (
+    anthropic_messages_stream_payload,
+    openai_compatible_stream_payload,
+    openai_responses_stream_payload,
+)
+from wmo.runtime.models.providers.transport import ProviderTransportError, RetryPolicy
+
+_MAXIMUM_SSE_EVENT_BYTES = 4_000_000
+_CANCELLATION_BOUND_SECONDS = 1.0
+_SEMANTIC_KINDS = {
+    GatewayEventKind.TEXT_DELTA,
+    GatewayEventKind.REFUSAL_DELTA,
+    GatewayEventKind.TOOL_CALL_STARTED,
+    GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+}
+_TERMINAL_KINDS = {
+    GatewayEventKind.COMPLETED,
+    GatewayEventKind.INCOMPLETE,
+    GatewayEventKind.FAILED,
+}
+
+
+@dataclass(frozen=True)
+class _SseEvent:
+    """One decoded server-sent event before provider-specific JSON parsing."""
+
+    event: str | None
+    data: str
+
+
+@dataclass
+class _ToolAccumulator:
+    """Provider-order state for one incrementally emitted function call."""
+
+    index: int
+    call_id: str
+    name: str
+    raw_arguments: str = ""
+    completed: bool = False
+
+    def complete(self) -> ToolCall:
+        """Parse the accumulated raw JSON once the provider closes the call.
+
+        Returns:
+            A complete tool call retaining provider-order argument text.
+
+        Raises:
+            ProviderResponseError: The raw arguments are not one JSON object.
+        """
+        try:
+            arguments = json.loads(self.raw_arguments)
+        except json.JSONDecodeError as exc:
+            raise ProviderResponseError("streamed tool arguments are not valid JSON") from exc
+        if not isinstance(arguments, dict):
+            raise ProviderResponseError("streamed tool arguments must decode to an object")
+        try:
+            return ToolCall(
+                call_id=self.call_id,
+                name=self.name,
+                arguments=arguments,
+                raw_arguments=self.raw_arguments,
+            )
+        except ValidationError as exc:
+            raise ProviderResponseError("streamed tool call is incomplete") from exc
+
+
+class _EventFactory:
+    """Assign monotonically increasing sequence numbers to normalized events."""
+
+    def __init__(self) -> None:
+        """Start one provider stream at sequence zero."""
+        self._next_sequence = 0
+
+    def create(self, kind: GatewayEventKind, **payload: object) -> GatewayEvent:
+        """Build one event and reserve its sequence number.
+
+        Args:
+            kind: Provider-neutral event category.
+            **payload: Fields required by the selected event kind.
+
+        Returns:
+            A validated event with the next sequence number.
+        """
+        event = GatewayEvent.model_validate(
+            {
+                "kind": kind,
+                "sequence_number": self._next_sequence,
+                **payload,
+            }
+        )
+        self._next_sequence += 1
+        return event
+
+
+class _SseDecoder:
+    """Incrementally decode UTF-8 SSE frames under one absolute request deadline."""
+
+    def __init__(
+        self,
+        upstream: AsyncHttpByteStream,
+        *,
+        deadline: RequestDeadline,
+        phase_timeout_seconds: float,
+    ) -> None:
+        """Bind one open byte stream and its per-phase timeout ceiling.
+
+        Args:
+            upstream: Open provider response stream.
+            deadline: Immutable request-wide deadline.
+            phase_timeout_seconds: Maximum wait for each next chunk.
+        """
+        self._upstream = upstream
+        self._deadline = deadline
+        self._phase_timeout_seconds = phase_timeout_seconds
+
+    async def events(self) -> AsyncIterator[_SseEvent]:
+        """Yield complete SSE events while preserving provider data-line order.
+
+        Yields:
+            Decoded event names and joined data fields.
+
+        Raises:
+            ProviderDeadlineExceeded: No request-wide time remains.
+            ProviderResponseError: UTF-8, framing, or event size is invalid.
+        """
+        buffer = b""
+        event_name: str | None = None
+        data_lines: list[str] = []
+        iterator = self._upstream.__aiter__()
+        while True:
+            try:
+                chunk = await _next_with_deadline(
+                    iterator,
+                    deadline=self._deadline,
+                    maximum_seconds=self._phase_timeout_seconds,
+                )
+            except StopAsyncIteration:
+                break
+            buffer += chunk
+            if len(buffer) > _MAXIMUM_SSE_EVENT_BYTES:
+                raise ProviderResponseError("provider stream event exceeds the size limit")
+            while b"\n" in buffer:
+                raw_line, buffer = buffer.split(b"\n", 1)
+                line = _decode_sse_line(raw_line)
+                if line == "":
+                    if data_lines:
+                        yield _SseEvent(event_name, "\n".join(data_lines))
+                    event_name = None
+                    data_lines = []
+                    continue
+                if line.startswith(":"):
+                    continue
+                field_name, _, raw_value = line.partition(":")
+                value = raw_value[1:] if raw_value.startswith(" ") else raw_value
+                if field_name == "event":
+                    event_name = value
+                elif field_name == "data":
+                    data_lines.append(value)
+        if buffer:
+            line = _decode_sse_line(buffer)
+            if line.startswith("data:"):
+                value = line[5:]
+                data_lines.append(value[1:] if value.startswith(" ") else value)
+            elif line and not line.startswith(":"):
+                raise ProviderResponseError("provider stream ended with an incomplete SSE field")
+        if data_lines:
+            yield _SseEvent(event_name, "\n".join(data_lines))
+
+
+class NormalizedProviderStream:
+    """Cancellable normalized provider stream with first-semantic-event commitment."""
+
+    def __init__(
+        self,
+        upstream: AsyncHttpByteStream,
+        events: AsyncIterator[GatewayEvent],
+        *,
+        deadline: RequestDeadline,
+        phase_timeout_seconds: float,
+    ) -> None:
+        """Bind normalized events to their active upstream response.
+
+        Args:
+            upstream: Open provider byte stream to close on every terminal path.
+            events: Provider-specific normalized event iterator.
+            deadline: Immutable request-wide deadline.
+            phase_timeout_seconds: Maximum wait for one normalized event.
+        """
+        self._upstream = upstream
+        self._events = events
+        self._deadline = deadline
+        self._phase_timeout_seconds = phase_timeout_seconds
+        self._committed = False
+        self._done = False
+        self._last_sequence = -1
+
+    @property
+    def committed(self) -> bool:
+        """Return whether an outward semantic event has made the route immutable."""
+        return self._committed
+
+    def __aiter__(self) -> AsyncIterator[GatewayEvent]:
+        """Return this one-pass normalized iterator."""
+        return self
+
+    async def __anext__(self) -> GatewayEvent:
+        """Return the next event, normalizing terminal failures without provider content."""
+        if self._done:
+            raise StopAsyncIteration
+        try:
+            event = await _next_with_deadline(
+                self._events,
+                deadline=self._deadline,
+                maximum_seconds=self._phase_timeout_seconds,
+            )
+        except StopAsyncIteration:
+            event = GatewayEvent(
+                kind=GatewayEventKind.FAILED,
+                sequence_number=self._last_sequence + 1,
+                failure=GatewayFailure(
+                    failure_class=GatewayFailureClass.MALFORMED_RESPONSE,
+                    safe_message="provider stream ended without a terminal event",
+                    failover_eligible=True,
+                ),
+            )
+        except asyncio.CancelledError:
+            await self._close()
+            self._done = True
+            raise
+        except BaseException as exc:  # noqa: BLE001 - public failure taxonomy owns conversion.
+            event = GatewayEvent(
+                kind=GatewayEventKind.FAILED,
+                sequence_number=self._last_sequence + 1,
+                failure=normalized_provider_failure(exc),
+            )
+        self._last_sequence = event.sequence_number
+        if event.kind in _SEMANTIC_KINDS:
+            self._committed = True
+        if event.kind in _TERMINAL_KINDS:
+            self._done = True
+            await self._close()
+        return event
+
+    async def cancel(self) -> None:
+        """Close active upstream work within the adapter cancellation bound."""
+        self._done = True
+        await self._close()
+
+    async def _close(self) -> None:
+        """Bound response cleanup independently of a spent request deadline."""
+        with suppress(Exception):
+            async with asyncio.timeout(_CANCELLATION_BOUND_SECONDS):
+                await self._upstream.aclose()
+
+
+async def start_openai_responses_stream(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    request: GatewayRequest,
+    model_id: str,
+    deadline: RequestDeadline,
+    idempotency_key: str,
+    retry_policy: RetryPolicy,
+    timeout_seconds: float,
+    supports_temperature: bool,
+    reasoning_effort: str | None,
+) -> NormalizedProviderStream:
+    """Open and normalize one native OpenAI Responses stream.
+
+    Args:
+        transport: Async provider transport supporting incremental responses.
+        url: Native Responses endpoint.
+        headers: Authenticated provider headers.
+        request: Canonical gateway request.
+        model_id: Exact provider model identifier.
+        deadline: Immutable request-wide deadline.
+        idempotency_key: Stable identity reused by safe opening retries.
+        retry_policy: Same-endpoint retry bounds before response commitment.
+        timeout_seconds: Per-phase timeout ceiling.
+        supports_temperature: Whether this model accepts explicit temperature.
+        reasoning_effort: Optional catalog-pinned reasoning effort.
+
+    Returns:
+        A true upstream normalized stream.
+    """
+    payload = openai_responses_stream_payload(
+        model_id,
+        request,
+        supports_temperature=supports_temperature,
+        reasoning_effort=reasoning_effort,
+    )
+    return await _start_stream(
+        transport,
+        url,
+        headers=headers,
+        payload=payload,
+        deadline=deadline,
+        idempotency_key=idempotency_key,
+        retry_policy=retry_policy,
+        timeout_seconds=timeout_seconds,
+        decoder=_openai_responses_events,
+    )
+
+
+async def start_anthropic_messages_stream(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    request: GatewayRequest,
+    model_id: str,
+    deadline: RequestDeadline,
+    idempotency_key: str,
+    retry_policy: RetryPolicy,
+    timeout_seconds: float,
+) -> NormalizedProviderStream:
+    """Open and normalize one native Anthropic Messages stream.
+
+    Args:
+        transport: Async provider transport supporting incremental responses.
+        url: Native Messages endpoint.
+        headers: Authenticated provider headers.
+        request: Canonical gateway request.
+        model_id: Exact provider model identifier.
+        deadline: Immutable request-wide deadline.
+        idempotency_key: Stable identity reused by safe opening retries.
+        retry_policy: Same-endpoint retry bounds before response commitment.
+        timeout_seconds: Per-phase timeout ceiling.
+
+    Returns:
+        A true upstream normalized stream.
+    """
+    payload = anthropic_messages_stream_payload(model_id, request)
+    return await _start_stream(
+        transport,
+        url,
+        headers=headers,
+        payload=payload,
+        deadline=deadline,
+        idempotency_key=idempotency_key,
+        retry_policy=retry_policy,
+        timeout_seconds=timeout_seconds,
+        decoder=_anthropic_messages_events,
+    )
+
+
+async def start_openai_compatible_stream(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    request: GatewayRequest,
+    model_id: str,
+    deadline: RequestDeadline,
+    idempotency_key: str,
+    retry_policy: RetryPolicy,
+    timeout_seconds: float,
+) -> NormalizedProviderStream:
+    """Open and normalize one generic OpenAI-compatible Chat stream.
+
+    Args:
+        transport: Async provider transport supporting incremental responses.
+        url: Chat Completions endpoint.
+        headers: Authenticated provider headers.
+        request: Canonical gateway request.
+        model_id: Exact provider model identifier.
+        deadline: Immutable request-wide deadline.
+        idempotency_key: Stable identity reused by safe opening retries.
+        retry_policy: Same-endpoint retry bounds before response commitment.
+        timeout_seconds: Per-phase timeout ceiling.
+
+    Returns:
+        A true upstream normalized stream.
+    """
+    payload = openai_compatible_stream_payload(model_id, request)
+    return await _start_stream(
+        transport,
+        url,
+        headers=headers,
+        payload=payload,
+        deadline=deadline,
+        idempotency_key=idempotency_key,
+        retry_policy=retry_policy,
+        timeout_seconds=timeout_seconds,
+        decoder=_openai_compatible_events,
+    )
+
+
+async def _start_stream(
+    transport: AsyncJsonHttpTransport,
+    url: str,
+    *,
+    headers: Mapping[str, str],
+    payload: JsonObject,
+    deadline: RequestDeadline,
+    idempotency_key: str,
+    retry_policy: RetryPolicy,
+    timeout_seconds: float,
+    decoder: Callable[[_SseDecoder], AsyncIterator[GatewayEvent]],
+) -> NormalizedProviderStream:
+    """Open one successful response stream with bounded pre-commit retries."""
+    if not isinstance(transport, AsyncStreamingHttpTransport):
+        raise ProviderCapabilityError(capability="async_streaming_transport")
+    request_headers = {
+        name: value for name, value in headers.items() if name.lower() != "idempotency-key"
+    }
+    request_headers["Idempotency-Key"] = idempotency_key
+
+    async def open_attempt(attempt_timeout: float) -> AsyncHttpByteStream:
+        """Open one response and reject its status before reading provider content."""
+        upstream = await transport.stream(
+            url,
+            headers=request_headers,
+            payload=payload,
+            timeout_seconds=attempt_timeout,
+        )
+        if 200 <= upstream.status_code < 300:
+            return upstream
+        status_code = upstream.status_code
+        await upstream.aclose()
+        raise ProviderTransportError(
+            f"provider returned HTTP {status_code}",
+            status_code=status_code,
+        )
+
+    upstream = await run_with_retry_async(
+        open_attempt,
+        policy=retry_policy,
+        deadline=deadline,
+        attempt_timeout_seconds=timeout_seconds,
+    )
+    sse = _SseDecoder(
+        upstream,
+        deadline=deadline,
+        phase_timeout_seconds=timeout_seconds,
+    )
+    return NormalizedProviderStream(
+        upstream,
+        decoder(sse),
+        deadline=deadline,
+        phase_timeout_seconds=timeout_seconds,
+    )
+
+
+async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEvent]:
+    """Map native Responses lifecycle events to provider-neutral events."""
+    factory = _EventFactory()
+    tools: dict[int, _ToolAccumulator] = {}
+    async for frame in sse.events():
+        if frame.data == "[DONE]":
+            raise ProviderResponseError("OpenAI Responses stream ended before a terminal event")
+        payload = _json_object(frame.data)
+        event_type = payload.get("type") or frame.event
+        if event_type == "response.output_text.delta":
+            delta = _optional_string(payload.get("delta"), "OpenAI text delta")
+            if delta:
+                yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=delta)
+        elif event_type == "response.refusal.delta":
+            delta = _optional_string(payload.get("delta"), "OpenAI refusal delta")
+            yield factory.create(GatewayEventKind.REFUSAL_DELTA, text_delta=delta)
+        elif event_type == "response.output_item.added":
+            item = require_object(payload.get("item"), "OpenAI output item")
+            if item.get("type") == "function_call":
+                index = require_integer(payload.get("output_index"), "OpenAI output_index")
+                call_id = require_string(
+                    item.get("call_id") or item.get("id"), "OpenAI function call ID"
+                )
+                name = require_string(item.get("name"), "OpenAI function call name")
+                tool = _ToolAccumulator(index=index, call_id=call_id, name=name)
+                tools[index] = tool
+                yield factory.create(
+                    GatewayEventKind.TOOL_CALL_STARTED,
+                    tool_call_index=index,
+                    tool_call_id=call_id,
+                    tool_name=name,
+                )
+                initial = item.get("arguments")
+                if isinstance(initial, str) and initial:
+                    tool.raw_arguments += initial
+                    yield factory.create(
+                        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                        tool_call_index=index,
+                        raw_arguments_delta=initial,
+                    )
+            elif item.get("type") not in {"message", "reasoning"}:
+                raise ProviderResponseError("OpenAI stream emitted an unsupported output item")
+        elif event_type == "response.function_call_arguments.delta":
+            index = require_integer(payload.get("output_index"), "OpenAI output_index")
+            tool = _require_tool(tools, index)
+            delta = _optional_string(payload.get("delta"), "OpenAI argument delta")
+            tool.raw_arguments += delta
+            yield factory.create(
+                GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                tool_call_index=index,
+                raw_arguments_delta=delta,
+            )
+        elif event_type in {
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        }:
+            index = require_integer(payload.get("output_index"), "OpenAI output_index")
+            if index in tools and not tools[index].completed:
+                tool = tools[index]
+                final_arguments = payload.get("arguments")
+                if event_type == "response.output_item.done":
+                    item = payload.get("item")
+                    if isinstance(item, dict):
+                        final_arguments = item.get("arguments", final_arguments)
+                if isinstance(final_arguments, str):
+                    if tool.raw_arguments and tool.raw_arguments != final_arguments:
+                        raise ProviderResponseError(
+                            "OpenAI tool argument fragments changed at done"
+                        )
+                    if not tool.raw_arguments and final_arguments:
+                        tool.raw_arguments = final_arguments
+                        yield factory.create(
+                            GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                            tool_call_index=index,
+                            raw_arguments_delta=final_arguments,
+                        )
+                tool.completed = True
+                yield factory.create(
+                    GatewayEventKind.TOOL_CALL_COMPLETED,
+                    tool_call=tool.complete(),
+                )
+        elif event_type in {"response.completed", "response.incomplete"}:
+            response = require_object(payload.get("response"), "OpenAI terminal response")
+            async for event in _finish_open_tools(factory, tools):
+                yield event
+            usage = _openai_usage(response.get("usage"))
+            if usage is not None:
+                yield factory.create(GatewayEventKind.USAGE, usage=usage)
+            terminal = (
+                GatewayEventKind.INCOMPLETE
+                if event_type == "response.incomplete" or response.get("status") == "incomplete"
+                else GatewayEventKind.COMPLETED
+            )
+            yield factory.create(terminal)
+            return
+        elif event_type == "response.failed":
+            yield factory.create(
+                GatewayEventKind.FAILED,
+                failure=GatewayFailure(
+                    failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+                    safe_message="provider stream failed",
+                    failover_eligible=True,
+                ),
+            )
+            return
+    raise ProviderResponseError("OpenAI Responses stream ended without a terminal event")
+
+
+async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayEvent]:
+    """Map native Anthropic Messages events to provider-neutral events."""
+    factory = _EventFactory()
+    tools: dict[int, _ToolAccumulator] = {}
+    input_tokens = 0
+    output_tokens = 0
+    cache_read = 0
+    cache_write = 0
+    stop_reason: str | None = None
+    refusal_seen = False
+    async for frame in sse.events():
+        payload = _json_object(frame.data)
+        event_type = payload.get("type") or frame.event
+        if event_type == "message_start":
+            message = require_object(payload.get("message"), "Anthropic message_start.message")
+            usage = require_object(message.get("usage"), "Anthropic message_start.usage")
+            input_tokens = require_integer(usage.get("input_tokens"), "Anthropic input_tokens")
+            cache_read = require_integer(
+                usage.get("cache_read_input_tokens"), "Anthropic cache_read_input_tokens"
+            )
+            cache_write = require_integer(
+                usage.get("cache_creation_input_tokens"),
+                "Anthropic cache_creation_input_tokens",
+            )
+        elif event_type == "content_block_start":
+            index = require_integer(payload.get("index"), "Anthropic content index")
+            block = require_object(payload.get("content_block"), "Anthropic content block")
+            block_type = block.get("type")
+            if block_type == "tool_use":
+                call_id = require_string(block.get("id"), "Anthropic tool ID")
+                name = require_string(block.get("name"), "Anthropic tool name")
+                tools[index] = _ToolAccumulator(index=index, call_id=call_id, name=name)
+                yield factory.create(
+                    GatewayEventKind.TOOL_CALL_STARTED,
+                    tool_call_index=index,
+                    tool_call_id=call_id,
+                    tool_name=name,
+                )
+            elif block_type == "text":
+                text = _optional_string(block.get("text"), "Anthropic initial text")
+                if text:
+                    yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=text)
+            elif block_type == "refusal":
+                refusal_seen = True
+                yield factory.create(
+                    GatewayEventKind.REFUSAL_DELTA,
+                    text_delta=_optional_string(block.get("refusal"), "Anthropic refusal"),
+                )
+            else:
+                raise ProviderResponseError("Anthropic stream emitted an unsupported content block")
+        elif event_type == "content_block_delta":
+            index = require_integer(payload.get("index"), "Anthropic content index")
+            delta = require_object(payload.get("delta"), "Anthropic content delta")
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                text = _optional_string(delta.get("text"), "Anthropic text delta")
+                if text:
+                    yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=text)
+            elif delta_type == "input_json_delta":
+                fragment = _optional_string(delta.get("partial_json"), "Anthropic argument delta")
+                tool = _require_tool(tools, index)
+                tool.raw_arguments += fragment
+                yield factory.create(
+                    GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                    tool_call_index=index,
+                    raw_arguments_delta=fragment,
+                )
+            elif delta_type == "refusal_delta":
+                refusal_seen = True
+                yield factory.create(
+                    GatewayEventKind.REFUSAL_DELTA,
+                    text_delta=_optional_string(delta.get("refusal"), "Anthropic refusal delta"),
+                )
+            else:
+                raise ProviderResponseError("Anthropic stream emitted an unsupported content delta")
+        elif event_type == "content_block_stop":
+            index = require_integer(payload.get("index"), "Anthropic content index")
+            if index in tools and not tools[index].completed:
+                tool = tools[index]
+                tool.completed = True
+                yield factory.create(
+                    GatewayEventKind.TOOL_CALL_COMPLETED,
+                    tool_call=tool.complete(),
+                )
+        elif event_type == "message_delta":
+            delta = require_object(payload.get("delta"), "Anthropic message delta")
+            raw_reason = delta.get("stop_reason")
+            stop_reason = raw_reason if isinstance(raw_reason, str) else stop_reason
+            usage = require_object(payload.get("usage"), "Anthropic message_delta.usage")
+            output_tokens = require_integer(usage.get("output_tokens"), "Anthropic output_tokens")
+            if stop_reason == "refusal" and not refusal_seen:
+                refusal_seen = True
+                yield factory.create(GatewayEventKind.REFUSAL_DELTA, text_delta="")
+        elif event_type == "message_stop":
+            async for event in _finish_open_tools(factory, tools):
+                yield event
+            yield factory.create(
+                GatewayEventKind.USAGE,
+                usage=GatewayUsage(
+                    input_tokens=input_tokens + cache_read + cache_write,
+                    output_tokens=output_tokens,
+                    cached_input_tokens=cache_read,
+                ),
+            )
+            terminal = (
+                GatewayEventKind.INCOMPLETE
+                if stop_reason == "max_tokens"
+                else GatewayEventKind.COMPLETED
+            )
+            yield factory.create(terminal)
+            return
+        elif event_type == "error":
+            yield factory.create(
+                GatewayEventKind.FAILED,
+                failure=GatewayFailure(
+                    failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+                    safe_message="provider stream failed",
+                    failover_eligible=True,
+                ),
+            )
+            return
+        elif event_type == "ping":
+            continue
+        else:
+            raise ProviderResponseError("Anthropic stream emitted an unsupported event")
+    raise ProviderResponseError("Anthropic stream ended without a terminal event")
+
+
+async def _openai_compatible_events(sse: _SseDecoder) -> AsyncIterator[GatewayEvent]:
+    """Map generic Chat Completions chunks to provider-neutral events."""
+    factory = _EventFactory()
+    tools: dict[int, _ToolAccumulator] = {}
+    usage: GatewayUsage | None = None
+    finish_reason: str | None = None
+    refusal_seen = False
+    async for frame in sse.events():
+        if frame.data == "[DONE]":
+            async for event in _finish_open_tools(factory, tools):
+                yield event
+            if usage is not None:
+                yield factory.create(GatewayEventKind.USAGE, usage=usage)
+            terminal = (
+                GatewayEventKind.INCOMPLETE
+                if finish_reason == "length"
+                else GatewayEventKind.COMPLETED
+            )
+            yield factory.create(terminal)
+            return
+        payload = _json_object(frame.data)
+        if payload.get("error") is not None:
+            yield factory.create(
+                GatewayEventKind.FAILED,
+                failure=GatewayFailure(
+                    failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+                    safe_message="provider stream failed",
+                    failover_eligible=True,
+                ),
+            )
+            return
+        raw_usage = payload.get("usage")
+        if raw_usage is not None:
+            usage = _openai_compatible_usage(raw_usage)
+        choices = require_array(payload.get("choices"), "OpenAI-compatible choices")
+        if not choices:
+            continue
+        if len(choices) != 1:
+            raise ProviderResponseError("OpenAI-compatible stream must contain one choice")
+        choice = require_object(choices[0], "OpenAI-compatible choice")
+        delta = require_object(choice.get("delta"), "OpenAI-compatible delta")
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=content)
+        refusal = delta.get("refusal")
+        if isinstance(refusal, str):
+            refusal_seen = True
+            yield factory.create(GatewayEventKind.REFUSAL_DELTA, text_delta=refusal)
+        raw_tools = delta.get("tool_calls")
+        if raw_tools is not None:
+            for value in require_array(raw_tools, "OpenAI-compatible tool_calls"):
+                item = require_object(value, "OpenAI-compatible tool call")
+                index = require_integer(item.get("index"), "OpenAI-compatible tool index")
+                function = require_object(item.get("function"), "OpenAI-compatible tool function")
+                tool = tools.get(index)
+                if tool is None:
+                    call_id = require_string(item.get("id"), "OpenAI-compatible tool ID")
+                    name = require_string(function.get("name"), "OpenAI-compatible tool name")
+                    tool = _ToolAccumulator(index=index, call_id=call_id, name=name)
+                    tools[index] = tool
+                    yield factory.create(
+                        GatewayEventKind.TOOL_CALL_STARTED,
+                        tool_call_index=index,
+                        tool_call_id=call_id,
+                        tool_name=name,
+                    )
+                fragment = function.get("arguments")
+                if fragment is not None:
+                    raw_fragment = _optional_string(fragment, "OpenAI-compatible argument delta")
+                    tool.raw_arguments += raw_fragment
+                    yield factory.create(
+                        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                        tool_call_index=index,
+                        raw_arguments_delta=raw_fragment,
+                    )
+        raw_finish_reason = choice.get("finish_reason")
+        if isinstance(raw_finish_reason, str):
+            finish_reason = raw_finish_reason
+            if finish_reason in {"content_filter", "safety"} and not refusal_seen:
+                refusal_seen = True
+                yield factory.create(GatewayEventKind.REFUSAL_DELTA, text_delta="")
+    raise ProviderResponseError("OpenAI-compatible stream ended without [DONE]")
+
+
+async def _finish_open_tools(
+    factory: _EventFactory,
+    tools: Mapping[int, _ToolAccumulator],
+) -> AsyncIterator[GatewayEvent]:
+    """Complete every still-open tool call in provider index order."""
+    for index in sorted(tools):
+        tool = tools[index]
+        if not tool.completed:
+            tool.completed = True
+            yield factory.create(
+                GatewayEventKind.TOOL_CALL_COMPLETED,
+                tool_call=tool.complete(),
+            )
+
+
+def _openai_usage(value: JsonValue | None) -> GatewayUsage | None:
+    """Normalize native Responses usage including cached and reasoning subsets."""
+    if value is None:
+        return None
+    usage = require_object(value, "OpenAI usage")
+    input_details = require_object(
+        usage.get("input_tokens_details") or {}, "OpenAI input token details"
+    )
+    output_details = require_object(
+        usage.get("output_tokens_details") or {}, "OpenAI output token details"
+    )
+    return GatewayUsage(
+        input_tokens=require_integer(usage.get("input_tokens"), "OpenAI input_tokens"),
+        output_tokens=require_integer(usage.get("output_tokens"), "OpenAI output_tokens"),
+        cached_input_tokens=require_integer(
+            input_details.get("cached_tokens"), "OpenAI cached_tokens"
+        ),
+        reasoning_tokens=require_integer(
+            output_details.get("reasoning_tokens"), "OpenAI reasoning_tokens"
+        ),
+    )
+
+
+def _openai_compatible_usage(value: JsonValue) -> GatewayUsage:
+    """Normalize Chat usage including optional cached and reasoning subsets."""
+    usage = require_object(value, "OpenAI-compatible usage")
+    input_details = require_object(
+        usage.get("prompt_tokens_details") or {}, "OpenAI-compatible prompt details"
+    )
+    output_details = require_object(
+        usage.get("completion_tokens_details") or {}, "OpenAI-compatible completion details"
+    )
+    return GatewayUsage(
+        input_tokens=require_integer(usage.get("prompt_tokens"), "prompt_tokens"),
+        output_tokens=require_integer(usage.get("completion_tokens"), "completion_tokens"),
+        cached_input_tokens=require_integer(input_details.get("cached_tokens"), "cached_tokens"),
+        reasoning_tokens=require_integer(
+            output_details.get("reasoning_tokens"), "reasoning_tokens"
+        ),
+    )
+
+
+def _json_object(raw: str) -> JsonObject:
+    """Decode one SSE data value as a JSON object without retaining it in errors."""
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderResponseError("provider stream event is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ProviderResponseError("provider stream event must be a JSON object")
+    return cast("JsonObject", value)
+
+
+def _decode_sse_line(raw_line: bytes) -> str:
+    """Decode one complete SSE line as strict UTF-8."""
+    if raw_line.endswith(b"\r"):
+        raw_line = raw_line[:-1]
+    try:
+        return raw_line.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ProviderResponseError("provider stream contains invalid UTF-8") from exc
+
+
+def _optional_string(value: JsonValue | None, label: str) -> str:
+    """Accept one optional string while rejecting every other wire type."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ProviderResponseError(f"{label} must be text")
+    return value
+
+
+def _require_tool(
+    tools: Mapping[int, _ToolAccumulator],
+    index: int,
+) -> _ToolAccumulator:
+    """Return one previously started provider tool call."""
+    try:
+        return tools[index]
+    except KeyError as exc:
+        raise ProviderResponseError("provider emitted arguments before a tool start") from exc
+
+
+async def _next_with_deadline[ValueT](
+    iterator: AsyncIterator[ValueT],
+    *,
+    deadline: RequestDeadline,
+    maximum_seconds: float,
+) -> ValueT:
+    """Await one stream phase under the lesser phase and request-wide bounds."""
+    timeout_seconds = deadline.attempt_timeout(maximum_seconds)
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            return await anext(iterator)
+    except TimeoutError as exc:
+        raise ProviderDeadlineExceeded("provider request deadline exceeded") from exc

--- a/wmo/runtime/models/providers/streaming.py
+++ b/wmo/runtime/models/providers/streaming.py
@@ -587,6 +587,7 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
                 tool.completed = True
                 yield factory.create(
                     GatewayEventKind.TOOL_CALL_COMPLETED,
+                    tool_call_index=index,
                     tool_call=tool.complete(),
                 )
         elif event_type in {"response.completed", "response.incomplete"}:
@@ -724,6 +725,7 @@ async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayE
                 tool.completed = True
                 yield factory.create(
                     GatewayEventKind.TOOL_CALL_COMPLETED,
+                    tool_call_index=index,
                     tool_call=tool.complete(),
                 )
         elif event_type == "message_delta":
@@ -876,6 +878,7 @@ async def _finish_open_tools(
             tool.completed = True
             yield factory.create(
                 GatewayEventKind.TOOL_CALL_COMPLETED,
+                tool_call_index=index,
                 tool_call=tool.complete(),
             )
 

--- a/wmo/runtime/models/providers/streaming.py
+++ b/wmo/runtime/models/providers/streaming.py
@@ -510,6 +510,7 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
     """Map native Responses lifecycle events to provider-neutral events."""
     factory = _EventFactory()
     tools: dict[int, _ToolAccumulator] = {}
+    refusal_seen = False
     async for frame in sse.events():
         if frame.data == "[DONE]":
             raise ProviderResponseError("OpenAI Responses stream ended before a terminal event")
@@ -521,6 +522,7 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
                 yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=delta)
         elif event_type == "response.refusal.delta":
             delta = _optional_string(payload.get("delta"), "OpenAI refusal delta")
+            refusal_seen = True
             yield factory.create(GatewayEventKind.REFUSAL_DELTA, text_delta=delta)
         elif event_type == "response.output_item.added":
             item = require_object(payload.get("item"), "OpenAI output item")
@@ -601,7 +603,13 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
                 event_type == "response.incomplete" or response.get("status") == "incomplete"
             )
             if not is_incomplete:
-                yield factory.create(GatewayEventKind.COMPLETED)
+                if refusal_seen:
+                    yield factory.create(
+                        GatewayEventKind.FAILED,
+                        failure=_provider_refusal_failure(),
+                    )
+                else:
+                    yield factory.create(GatewayEventKind.COMPLETED)
                 return
             details = require_object(
                 response.get("incomplete_details"), "OpenAI incomplete details"
@@ -612,11 +620,7 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
             elif reason in {"content_filter", "safety"}:
                 yield factory.create(
                     GatewayEventKind.FAILED,
-                    failure=GatewayFailure(
-                        failure_class=GatewayFailureClass.REFUSAL,
-                        safe_message="provider refused the request",
-                        safe_details={"signal": "content_policy"},
-                    ),
+                    failure=_provider_refusal_failure(),
                 )
             else:
                 yield factory.create(
@@ -748,12 +752,18 @@ async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayE
                     cached_input_tokens=cache_read,
                 ),
             )
-            terminal = (
-                GatewayEventKind.INCOMPLETE
-                if stop_reason == "max_tokens"
-                else GatewayEventKind.COMPLETED
-            )
-            yield factory.create(terminal)
+            if refusal_seen or stop_reason == "refusal":
+                yield factory.create(
+                    GatewayEventKind.FAILED,
+                    failure=_provider_refusal_failure(),
+                )
+            else:
+                terminal = (
+                    GatewayEventKind.INCOMPLETE
+                    if stop_reason == "max_tokens"
+                    else GatewayEventKind.COMPLETED
+                )
+                yield factory.create(terminal)
             return
         elif event_type == "error":
             yield factory.create(
@@ -785,12 +795,18 @@ async def _openai_compatible_events(sse: _SseDecoder) -> AsyncIterator[GatewayEv
                 yield event
             if usage is not None:
                 yield factory.create(GatewayEventKind.USAGE, usage=usage)
-            terminal = (
-                GatewayEventKind.INCOMPLETE
-                if finish_reason == "length"
-                else GatewayEventKind.COMPLETED
-            )
-            yield factory.create(terminal)
+            if refusal_seen or finish_reason in {"content_filter", "safety"}:
+                yield factory.create(
+                    GatewayEventKind.FAILED,
+                    failure=_provider_refusal_failure(),
+                )
+            else:
+                terminal = (
+                    GatewayEventKind.INCOMPLETE
+                    if finish_reason == "length"
+                    else GatewayEventKind.COMPLETED
+                )
+                yield factory.create(terminal)
             return
         payload = _json_object(frame.data)
         if payload.get("error") is not None:
@@ -881,6 +897,15 @@ async def _finish_open_tools(
                 tool_call_index=index,
                 tool_call=tool.complete(),
             )
+
+
+def _provider_refusal_failure() -> GatewayFailure:
+    """Return the shared sanitized terminal classification for provider refusals."""
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.REFUSAL,
+        safe_message="provider refused the request",
+        safe_details={"signal": "content_policy"},
+    )
 
 
 def _openai_usage(value: JsonValue | None) -> GatewayUsage | None:

--- a/wmo/runtime/models/providers/streaming.py
+++ b/wmo/runtime/models/providers/streaming.py
@@ -27,7 +27,6 @@ from wmo.runtime.models.providers.async_transport import (
     AsyncStreamingHttpTransport,
     ProviderDeadlineExceeded,
     RequestDeadline,
-    run_with_retry_async,
 )
 from wmo.runtime.models.providers.errors import (
     ProviderCapabilityError,
@@ -38,6 +37,7 @@ from wmo.runtime.models.providers.errors import (
     require_object,
     require_string,
 )
+from wmo.runtime.models.providers.stream_attempts import StreamAttemptController
 from wmo.runtime.models.providers.streaming_requests import (
     anthropic_messages_stream_payload,
     openai_compatible_stream_payload,
@@ -166,6 +166,7 @@ class _SseDecoder:
         buffer = b""
         event_name: str | None = None
         data_lines: list[str] = []
+        current_event_bytes = 0
         iterator = self._upstream.__aiter__()
         while True:
             try:
@@ -177,16 +178,18 @@ class _SseDecoder:
             except StopAsyncIteration:
                 break
             buffer += chunk
-            if len(buffer) > _MAXIMUM_SSE_EVENT_BYTES:
-                raise ProviderResponseError("provider stream event exceeds the size limit")
             while b"\n" in buffer:
                 raw_line, buffer = buffer.split(b"\n", 1)
+                current_event_bytes += len(raw_line) + 1
+                if current_event_bytes > _MAXIMUM_SSE_EVENT_BYTES:
+                    raise ProviderResponseError("provider stream event exceeds the size limit")
                 line = _decode_sse_line(raw_line)
                 if line == "":
                     if data_lines:
                         yield _SseEvent(event_name, "\n".join(data_lines))
                     event_name = None
                     data_lines = []
+                    current_event_bytes = 0
                     continue
                 if line.startswith(":"):
                     continue
@@ -196,7 +199,12 @@ class _SseDecoder:
                     event_name = value
                 elif field_name == "data":
                     data_lines.append(value)
+            if current_event_bytes + len(buffer) > _MAXIMUM_SSE_EVENT_BYTES:
+                raise ProviderResponseError("provider stream event exceeds the size limit")
         if buffer:
+            current_event_bytes += len(buffer)
+            if current_event_bytes > _MAXIMUM_SSE_EVENT_BYTES:
+                raise ProviderResponseError("provider stream event exceeds the size limit")
             line = _decode_sse_line(buffer)
             if line.startswith("data:"):
                 value = line[5:]
@@ -217,6 +225,8 @@ class NormalizedProviderStream:
         *,
         deadline: RequestDeadline,
         phase_timeout_seconds: float,
+        attempt_controller: StreamAttemptController,
+        decoder: Callable[[_SseDecoder], AsyncIterator[GatewayEvent]],
     ) -> None:
         """Bind normalized events to their active upstream response.
 
@@ -225,11 +235,15 @@ class NormalizedProviderStream:
             events: Provider-specific normalized event iterator.
             deadline: Immutable request-wide deadline.
             phase_timeout_seconds: Maximum wait for one normalized event.
+            attempt_controller: Shared pre-semantic same-endpoint retry state.
+            decoder: Provider-specific event decoder used for a retried response.
         """
         self._upstream = upstream
         self._events = events
         self._deadline = deadline
         self._phase_timeout_seconds = phase_timeout_seconds
+        self._attempt_controller = attempt_controller
+        self._decoder = decoder
         self._committed = False
         self._done = False
         self._last_sequence = -1
@@ -268,6 +282,25 @@ class NormalizedProviderStream:
             self._done = True
             raise
         except BaseException as exc:  # noqa: BLE001 - public failure taxonomy owns conversion.
+            if (
+                isinstance(exc, Exception)
+                and self._last_sequence < 0
+                and self._attempt_controller.can_retry(exc)
+            ):
+                await self._close()
+                try:
+                    upstream = await self._attempt_controller.open(exc)
+                except Exception as retry_exc:  # noqa: BLE001 - normalize final retry failure.
+                    exc = retry_exc
+                else:
+                    self._upstream = upstream
+                    sse = _SseDecoder(
+                        upstream,
+                        deadline=self._deadline,
+                        phase_timeout_seconds=self._phase_timeout_seconds,
+                    )
+                    self._events = self._decoder(sse)
+                    return await self.__anext__()
             event = GatewayEvent(
                 kind=GatewayEventKind.FAILED,
                 sequence_number=self._last_sequence + 1,
@@ -448,29 +481,16 @@ async def _start_stream(
     }
     request_headers["Idempotency-Key"] = idempotency_key
 
-    async def open_attempt(attempt_timeout: float) -> AsyncHttpByteStream:
-        """Open one response and reject its status before reading provider content."""
-        upstream = await transport.stream(
-            url,
-            headers=request_headers,
-            payload=payload,
-            timeout_seconds=attempt_timeout,
-        )
-        if 200 <= upstream.status_code < 300:
-            return upstream
-        status_code = upstream.status_code
-        await upstream.aclose()
-        raise ProviderTransportError(
-            f"provider returned HTTP {status_code}",
-            status_code=status_code,
-        )
-
-    upstream = await run_with_retry_async(
-        open_attempt,
-        policy=retry_policy,
+    attempt_controller = StreamAttemptController(
+        transport,
+        url,
+        headers=request_headers,
+        payload=payload,
         deadline=deadline,
-        attempt_timeout_seconds=timeout_seconds,
+        retry_policy=retry_policy,
+        timeout_seconds=timeout_seconds,
     )
+    upstream = await attempt_controller.open()
     sse = _SseDecoder(
         upstream,
         deadline=deadline,
@@ -481,6 +501,8 @@ async def _start_stream(
         decoder(sse),
         deadline=deadline,
         phase_timeout_seconds=timeout_seconds,
+        attempt_controller=attempt_controller,
+        decoder=decoder,
     )
 
 
@@ -504,6 +526,8 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
             item = require_object(payload.get("item"), "OpenAI output item")
             if item.get("type") == "function_call":
                 index = require_integer(payload.get("output_index"), "OpenAI output_index")
+                if index in tools:
+                    raise ProviderResponseError("OpenAI stream repeated a tool-call start")
                 call_id = require_string(
                     item.get("call_id") or item.get("id"), "OpenAI function call ID"
                 )
@@ -572,12 +596,36 @@ async def _openai_responses_events(sse: _SseDecoder) -> AsyncIterator[GatewayEve
             usage = _openai_usage(response.get("usage"))
             if usage is not None:
                 yield factory.create(GatewayEventKind.USAGE, usage=usage)
-            terminal = (
-                GatewayEventKind.INCOMPLETE
-                if event_type == "response.incomplete" or response.get("status") == "incomplete"
-                else GatewayEventKind.COMPLETED
+            is_incomplete = (
+                event_type == "response.incomplete" or response.get("status") == "incomplete"
             )
-            yield factory.create(terminal)
+            if not is_incomplete:
+                yield factory.create(GatewayEventKind.COMPLETED)
+                return
+            details = require_object(
+                response.get("incomplete_details"), "OpenAI incomplete details"
+            )
+            reason = require_string(details.get("reason"), "OpenAI incomplete reason")
+            if reason == "max_output_tokens":
+                yield factory.create(GatewayEventKind.INCOMPLETE)
+            elif reason in {"content_filter", "safety"}:
+                yield factory.create(
+                    GatewayEventKind.FAILED,
+                    failure=GatewayFailure(
+                        failure_class=GatewayFailureClass.REFUSAL,
+                        safe_message="provider refused the request",
+                        safe_details={"signal": "content_policy"},
+                    ),
+                )
+            else:
+                yield factory.create(
+                    GatewayEventKind.FAILED,
+                    failure=GatewayFailure(
+                        failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+                        safe_message="provider ended the stream incompletely",
+                        failover_eligible=True,
+                    ),
+                )
             return
         elif event_type == "response.failed":
             yield factory.create(
@@ -623,6 +671,8 @@ async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayE
             if block_type == "tool_use":
                 call_id = require_string(block.get("id"), "Anthropic tool ID")
                 name = require_string(block.get("name"), "Anthropic tool name")
+                if index in tools:
+                    raise ProviderResponseError("Anthropic stream repeated a tool-call start")
                 tools[index] = _ToolAccumulator(index=index, call_id=call_id, name=name)
                 yield factory.create(
                     GatewayEventKind.TOOL_CALL_STARTED,
@@ -786,6 +836,17 @@ async def _openai_compatible_events(sse: _SseDecoder) -> AsyncIterator[GatewayEv
                         tool_call_id=call_id,
                         tool_name=name,
                     )
+                else:
+                    repeated_id = item.get("id")
+                    if repeated_id is not None and repeated_id != tool.call_id:
+                        raise ProviderResponseError(
+                            "OpenAI-compatible stream changed a tool-call ID"
+                        )
+                    repeated_name = function.get("name")
+                    if repeated_name is not None and repeated_name != tool.name:
+                        raise ProviderResponseError(
+                            "OpenAI-compatible stream changed a tool-call name"
+                        )
                 fragment = function.get("arguments")
                 if fragment is not None:
                     raw_fragment = _optional_string(fragment, "OpenAI-compatible argument delta")
@@ -824,20 +885,18 @@ def _openai_usage(value: JsonValue | None) -> GatewayUsage | None:
     if value is None:
         return None
     usage = require_object(value, "OpenAI usage")
-    input_details = require_object(
-        usage.get("input_tokens_details") or {}, "OpenAI input token details"
-    )
-    output_details = require_object(
-        usage.get("output_tokens_details") or {}, "OpenAI output token details"
-    )
     return GatewayUsage(
         input_tokens=require_integer(usage.get("input_tokens"), "OpenAI input_tokens"),
         output_tokens=require_integer(usage.get("output_tokens"), "OpenAI output_tokens"),
-        cached_input_tokens=require_integer(
-            input_details.get("cached_tokens"), "OpenAI cached_tokens"
+        cached_input_tokens=_optional_usage_detail(
+            usage.get("input_tokens_details"),
+            field_name="cached_tokens",
+            label="OpenAI cached_tokens",
         ),
-        reasoning_tokens=require_integer(
-            output_details.get("reasoning_tokens"), "OpenAI reasoning_tokens"
+        reasoning_tokens=_optional_usage_detail(
+            usage.get("output_tokens_details"),
+            field_name="reasoning_tokens",
+            label="OpenAI reasoning_tokens",
         ),
     )
 
@@ -845,20 +904,36 @@ def _openai_usage(value: JsonValue | None) -> GatewayUsage | None:
 def _openai_compatible_usage(value: JsonValue) -> GatewayUsage:
     """Normalize Chat usage including optional cached and reasoning subsets."""
     usage = require_object(value, "OpenAI-compatible usage")
-    input_details = require_object(
-        usage.get("prompt_tokens_details") or {}, "OpenAI-compatible prompt details"
-    )
-    output_details = require_object(
-        usage.get("completion_tokens_details") or {}, "OpenAI-compatible completion details"
-    )
     return GatewayUsage(
         input_tokens=require_integer(usage.get("prompt_tokens"), "prompt_tokens"),
         output_tokens=require_integer(usage.get("completion_tokens"), "completion_tokens"),
-        cached_input_tokens=require_integer(input_details.get("cached_tokens"), "cached_tokens"),
-        reasoning_tokens=require_integer(
-            output_details.get("reasoning_tokens"), "reasoning_tokens"
+        cached_input_tokens=_optional_usage_detail(
+            usage.get("prompt_tokens_details"),
+            field_name="cached_tokens",
+            label="cached_tokens",
+        ),
+        reasoning_tokens=_optional_usage_detail(
+            usage.get("completion_tokens_details"),
+            field_name="reasoning_tokens",
+            label="reasoning_tokens",
         ),
     )
+
+
+def _optional_usage_detail(
+    value: JsonValue | None,
+    *,
+    field_name: str,
+    label: str,
+) -> int | None:
+    """Preserve an absent provider token subset as unknown instead of zero."""
+    if value is None:
+        return None
+    details = require_object(value, f"{label} details")
+    raw_count = details.get(field_name)
+    if raw_count is None:
+        return None
+    return require_integer(raw_count, label)
 
 
 def _json_object(raw: str) -> JsonObject:
@@ -914,4 +989,6 @@ async def _next_with_deadline[ValueT](
         async with asyncio.timeout(timeout_seconds):
             return await anext(iterator)
     except TimeoutError as exc:
-        raise ProviderDeadlineExceeded("provider request deadline exceeded") from exc
+        if deadline.remaining_seconds() <= 0:
+            raise ProviderDeadlineExceeded("provider request deadline exceeded") from exc
+        raise ProviderTransportError("provider response stream timed out") from exc

--- a/wmo/runtime/models/providers/streaming_requests.py
+++ b/wmo/runtime/models/providers/streaming_requests.py
@@ -1,0 +1,301 @@
+"""Canonical gateway request translation for launch-provider streaming protocols."""
+
+from __future__ import annotations
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.runtime.gateway.contracts import (
+    GatewayMessage,
+    GatewayNamedToolChoice,
+    GatewayRequest,
+)
+from wmo.runtime.models.providers.errors import ProviderCapabilityError, ProviderResponseError
+
+
+def openai_responses_stream_payload(
+    model_id: str,
+    request: GatewayRequest,
+    *,
+    supports_temperature: bool,
+    reasoning_effort: str | None,
+) -> JsonObject:
+    """Translate one canonical request to native streaming Responses JSON.
+
+    Args:
+        model_id: Exact OpenAI model identifier.
+        request: Canonical gateway request.
+        supports_temperature: Whether this exact model accepts explicit temperature.
+        reasoning_effort: Optional catalog-pinned reasoning effort.
+
+    Returns:
+        Native Responses request with storage disabled and streaming enabled.
+
+    Raises:
+        ProviderCapabilityError: The request uses unsupported stop sequences.
+        ProviderResponseError: An instruction message has no text.
+    """
+    if request.stop:
+        raise ProviderCapabilityError(capability="stop_sequences")
+    instructions: list[str] = []
+    items: list[JsonObject] = []
+    for message in request.messages:
+        if message.role in {"system", "developer"}:
+            if message.content is None:
+                raise ProviderResponseError("instruction messages require text")
+            instructions.append(message.content)
+        else:
+            items.extend(_responses_items(message))
+    payload: JsonObject = {
+        "model": model_id,
+        "input": items,
+        "store": False,
+        "stream": True,
+    }
+    if instructions:
+        payload["instructions"] = "\n\n".join(instructions)
+    _add_openai_tools(payload, request, responses=True)
+    if request.parallel_tool_calls is not None:
+        payload["parallel_tool_calls"] = request.parallel_tool_calls
+    if request.structured_text is not None:
+        format_payload: JsonObject = {
+            "type": "json_schema",
+            "name": request.structured_text.name,
+            "schema": request.structured_text.json_schema,
+            "strict": request.structured_text.strict,
+        }
+        if request.structured_text.description is not None:
+            format_payload["description"] = request.structured_text.description
+        payload["text"] = {"format": format_payload}
+    if request.maximum_output_tokens is not None:
+        payload["max_output_tokens"] = request.maximum_output_tokens
+    if request.temperature is not None and supports_temperature:
+        payload["temperature"] = request.temperature
+    if reasoning_effort is not None:
+        payload["reasoning"] = {"effort": reasoning_effort}
+    return payload
+
+
+def anthropic_messages_stream_payload(model_id: str, request: GatewayRequest) -> JsonObject:
+    """Translate one canonical request to native streaming Messages JSON.
+
+    Args:
+        model_id: Exact Anthropic model identifier.
+        request: Canonical gateway request.
+
+    Returns:
+        Native Messages request with streaming enabled.
+
+    Raises:
+        ProviderCapabilityError: Structured text is requested on this adapter.
+        ProviderResponseError: Instruction or message content is malformed.
+    """
+    if request.structured_text is not None:
+        raise ProviderCapabilityError(capability="structured_text")
+    system_parts: list[str] = []
+    messages: list[JsonObject] = []
+    for message in request.messages:
+        if message.role in {"system", "developer"}:
+            if message.content is None:
+                raise ProviderResponseError("instruction messages require text")
+            system_parts.append(message.content)
+            continue
+        role, blocks = _anthropic_blocks(message)
+        if messages and messages[-1].get("role") == role:
+            existing = messages[-1].get("content")
+            if not isinstance(existing, list):
+                raise ProviderResponseError("Anthropic message content is malformed")
+            existing.extend(blocks)
+        else:
+            messages.append({"role": role, "content": blocks})
+    payload: JsonObject = {
+        "model": model_id,
+        "messages": messages,
+        "max_tokens": request.maximum_output_tokens or 4096,
+        "stream": True,
+    }
+    if system_parts:
+        payload["system"] = "\n\n".join(system_parts)
+    if request.tools:
+        payload["tools"] = [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.parameters,
+            }
+            for tool in request.tools
+        ]
+    if request.tool_choice is not None:
+        if isinstance(request.tool_choice, GatewayNamedToolChoice):
+            payload["tool_choice"] = {"type": "tool", "name": request.tool_choice.name}
+        else:
+            mapping = {"auto": "auto", "none": "none", "required": "any"}
+            payload["tool_choice"] = {"type": mapping[request.tool_choice]}
+    if request.temperature is not None:
+        payload["temperature"] = request.temperature
+    if request.stop:
+        payload["stop_sequences"] = list(request.stop)
+    return payload
+
+
+def openai_compatible_stream_payload(model_id: str, request: GatewayRequest) -> JsonObject:
+    """Translate one canonical request to streaming Chat Completions JSON.
+
+    Args:
+        model_id: Exact provider model identifier.
+        request: Canonical gateway request.
+
+    Returns:
+        Chat Completions request that always asks the provider for terminal usage.
+    """
+    payload: JsonObject = {
+        "model": model_id,
+        "messages": [_openai_message(message) for message in request.messages],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    _add_openai_tools(payload, request, responses=False)
+    if request.parallel_tool_calls is not None:
+        payload["parallel_tool_calls"] = request.parallel_tool_calls
+    if request.structured_text is not None:
+        schema: JsonObject = {
+            "name": request.structured_text.name,
+            "schema": request.structured_text.json_schema,
+            "strict": request.structured_text.strict,
+        }
+        if request.structured_text.description is not None:
+            schema["description"] = request.structured_text.description
+        payload["response_format"] = {"type": "json_schema", "json_schema": schema}
+    if request.maximum_output_tokens is not None:
+        payload["max_tokens"] = request.maximum_output_tokens
+    if request.temperature is not None:
+        payload["temperature"] = request.temperature
+    if request.stop:
+        payload["stop"] = list(request.stop)
+    return payload
+
+
+def _responses_items(message: GatewayMessage) -> list[JsonObject]:
+    """Translate one non-instruction gateway message to Responses input items."""
+    if message.role == "tool":
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": message.tool_call_id or "",
+                "output": message.content or "",
+            }
+        ]
+    if message.role == "user":
+        return [{"role": "user", "content": message.content or ""}]
+    if message.role != "assistant":
+        raise ProviderResponseError("unsupported Responses message role")
+    items: list[JsonObject] = []
+    if message.content is not None:
+        items.append({"role": "assistant", "content": message.content})
+    items.extend(
+        {
+            "type": "function_call",
+            "call_id": call.call_id,
+            "name": call.name,
+            "arguments": call.arguments_json(),
+        }
+        for call in message.tool_calls
+    )
+    return items
+
+
+def _anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
+    """Translate one non-instruction gateway message to Anthropic content blocks."""
+    if message.role == "tool":
+        return (
+            "user",
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message.tool_call_id or "",
+                    "content": message.content or "",
+                }
+            ],
+        )
+    if message.role == "user":
+        return "user", [{"type": "text", "text": message.content or ""}]
+    if message.role != "assistant":
+        raise ProviderResponseError("unsupported Anthropic message role")
+    blocks: list[JsonObject] = []
+    if message.content is not None:
+        blocks.append({"type": "text", "text": message.content})
+    blocks.extend(
+        {
+            "type": "tool_use",
+            "id": call.call_id,
+            "name": call.name,
+            "input": call.arguments,
+        }
+        for call in message.tool_calls
+    )
+    return "assistant", blocks
+
+
+def _openai_message(message: GatewayMessage) -> JsonObject:
+    """Translate one gateway message to OpenAI Chat wire JSON."""
+    if message.role == "tool":
+        return {
+            "role": "tool",
+            "content": message.content or "",
+            "tool_call_id": message.tool_call_id or "",
+        }
+    payload: JsonObject = {"role": message.role, "content": message.content or ""}
+    if message.tool_calls:
+        payload["tool_calls"] = [
+            {
+                "id": call.call_id,
+                "type": "function",
+                "function": {"name": call.name, "arguments": call.arguments_json()},
+            }
+            for call in message.tool_calls
+        ]
+    return payload
+
+
+def _add_openai_tools(
+    payload: JsonObject,
+    request: GatewayRequest,
+    *,
+    responses: bool,
+) -> None:
+    """Add Responses-native or Chat-native tools and tool choice in place."""
+    if request.tools:
+        if responses:
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                    "strict": tool.strict,
+                }
+                for tool in request.tools
+            ]
+        else:
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                        "strict": tool.strict,
+                    },
+                }
+                for tool in request.tools
+            ]
+    if request.tool_choice is not None:
+        if isinstance(request.tool_choice, GatewayNamedToolChoice):
+            payload["tool_choice"] = (
+                {"type": "function", "name": request.tool_choice.name}
+                if responses
+                else {
+                    "type": "function",
+                    "function": {"name": request.tool_choice.name},
+                }
+            )
+        else:
+            payload["tool_choice"] = request.tool_choice

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -290,6 +290,7 @@ def test_openai_responses_stream_preserves_raw_tools_usage_and_commitment() -> N
         GatewayEventKind.COMPLETED,
     ]
     assert events[3].tool_call is not None
+    assert events[3].tool_call_index == 0
     assert events[3].tool_call.arguments_json() == raw_arguments
     assert events[5].usage is not None
     assert events[5].usage.cached_input_tokens == 4
@@ -444,6 +445,7 @@ def test_anthropic_stream_normalizes_cache_usage_and_tool_fragments() -> None:
         GatewayEventKind.COMPLETED,
     ]
     assert events[3].tool_call is not None
+    assert events[3].tool_call_index == 0
     assert events[3].tool_call.arguments_json() == '{"x":1}'
     assert events[4].usage is not None
     assert events[4].usage.input_tokens == 15
@@ -591,6 +593,7 @@ def test_openai_compatible_stream_preserves_provider_order_tool_arguments() -> N
         GatewayEventKind.COMPLETED,
     ]
     assert events[3].tool_call is not None
+    assert events[3].tool_call_index == 0
     assert events[3].tool_call.arguments_json() == raw_arguments
 
 

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -511,11 +511,13 @@ def test_openai_compatible_stream_emits_refusal_reasoning_usage_and_terminal() -
     assert [event.kind for event in events] == [
         GatewayEventKind.REFUSAL_DELTA,
         GatewayEventKind.USAGE,
-        GatewayEventKind.COMPLETED,
+        GatewayEventKind.FAILED,
     ]
     assert events[1].usage is not None
     assert events[1].usage.cached_input_tokens == 5
     assert events[1].usage.reasoning_tokens == 1
+    assert events[2].failure is not None
+    assert events[2].failure.failure_class is GatewayFailureClass.REFUSAL
 
 
 def test_openai_compatible_stream_preserves_provider_order_tool_arguments() -> None:
@@ -864,7 +866,9 @@ def test_launch_adapters_emit_refusal_as_semantic_commit(provider: str) -> None:
     events, committed = asyncio.run(scenario())
 
     assert events[0].kind is GatewayEventKind.REFUSAL_DELTA
-    assert events[-1].kind is GatewayEventKind.COMPLETED
+    assert events[-1].kind is GatewayEventKind.FAILED
+    assert events[-1].failure is not None
+    assert events[-1].failure.failure_class is GatewayFailureClass.REFUSAL
     assert committed is True
 
 

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator, Mapping, Sequence
 import httpx
 import pytest
 
-from wmo.common.models import ModelSnapshot
+from wmo.common.models import BillingSource, ModelSnapshot
 from wmo.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayEvent,
@@ -105,6 +105,7 @@ def _snapshot(provider: str) -> ModelSnapshot:
     return ModelSnapshot(
         provider=provider,
         model_id="exact-model",
+        billing_source=BillingSource.CUSTOMER_MANAGED,
         capabilities_sha256="a" * 64,
         connection_sha256="b" * 64,
     )

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -24,9 +24,14 @@ from wmo.runtime.models.providers.async_transport import (
     HttpxAsyncJsonTransport,
     RequestDeadline,
 )
+from wmo.runtime.models.providers.errors import ProviderResponseError
 from wmo.runtime.models.providers.openai import OpenAIClient
 from wmo.runtime.models.providers.openai_compatible import OpenAICompatibleClient
-from wmo.runtime.models.providers.streaming import NormalizedProviderStream
+from wmo.runtime.models.providers.streaming import (
+    _MAXIMUM_SSE_EVENT_BYTES,
+    NormalizedProviderStream,
+    _SseDecoder,
+)
 from wmo.runtime.models.providers.transport import RetryPolicy
 
 
@@ -41,6 +46,11 @@ class _ChunkStream(httpx.AsyncByteStream):
         """
         self._chunks = tuple(chunks)
         self.closed = False
+
+    @property
+    def status_code(self) -> int:
+        """Expose a successful status when used directly as the decoder byte seam."""
+        return 200
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         """Yield every scripted response fragment in order."""
@@ -70,6 +80,24 @@ class _HangingStream(httpx.AsyncByteStream):
     async def aclose(self) -> None:
         """Release the blocked iterator and record cancellation."""
         self.closed.set()
+
+
+class _ReadFailureStream(httpx.AsyncByteStream):
+    """HTTPX fixture stream that raises one read-time transport failure."""
+
+    def __init__(self) -> None:
+        """Create one initially open failing stream."""
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        """Raise the same HTTPX error a disconnected response body produces."""
+        if False:
+            yield b""
+        raise httpx.ReadError("private-read-error-canary")
+
+    async def aclose(self) -> None:
+        """Record response closure after the read error."""
+        self.closed = True
 
 
 def _snapshot(provider: str) -> ModelSnapshot:
@@ -150,7 +178,12 @@ def _provider_surface(provider: str) -> GatewayApiSurface:
 def _sse(payload: Mapping[str, object], *, event: str | None = None) -> bytes:
     """Encode one provider fixture as a complete SSE event."""
     prefix = b"" if event is None else f"event: {event}\n".encode()
-    return prefix + b"data: " + json.dumps(payload, separators=(",", ":")).encode() + b"\n\n"
+    return (
+        prefix
+        + b"data: "
+        + json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode()
+        + b"\n\n"
+    )
 
 
 async def _collect(stream: NormalizedProviderStream) -> list[GatewayEvent]:
@@ -215,7 +248,8 @@ def test_openai_responses_stream_preserves_raw_tools_usage_and_commitment() -> N
             ),
         )
     )
-    upstream = _ChunkStream((frames[:41], frames[41:177], frames[177:]))
+    unicode_offset = frames.index("ü".encode())
+    upstream = _ChunkStream((frames[: unicode_offset + 1], frames[unicode_offset + 1 :]))
     observed_payloads: list[dict[str, object]] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -263,6 +297,58 @@ def test_openai_responses_stream_preserves_raw_tools_usage_and_commitment() -> N
     assert observed_payloads[0]["store"] is False
     assert observed_payloads[0]["instructions"] == "Be precise."
     assert upstream.closed is True
+
+
+@pytest.mark.parametrize(
+    ("reason", "terminal_kind", "failure_class"),
+    [
+        ("max_output_tokens", GatewayEventKind.INCOMPLETE, None),
+        ("content_filter", GatewayEventKind.FAILED, GatewayFailureClass.REFUSAL),
+        ("unsupported_reason", GatewayEventKind.FAILED, GatewayFailureClass.PROVIDER_INTERNAL),
+    ],
+)
+def test_openai_incomplete_reasons_do_not_conflate_filtering_with_length(
+    reason: str,
+    terminal_kind: GatewayEventKind,
+    failure_class: GatewayFailureClass | None,
+) -> None:
+    """Only output-budget exhaustion maps to the public incomplete terminal."""
+    frames = _sse(
+        {
+            "type": "response.incomplete",
+            "response": {
+                "status": "incomplete",
+                "incomplete_details": {"reason": reason},
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        }
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return one native incomplete terminal reason."""
+        del request
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> tuple[list[GatewayEvent], bool]:
+        """Consume usage and the classified terminal event."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client("openai", http_client)
+            stream = await client.stream(
+                _request(GatewayApiSurface.RESPONSES),
+                deadline=RequestDeadline.after(1),
+                idempotency_key=f"incomplete-{reason}",
+            )
+            return await _collect(stream), stream.committed
+
+    events, committed = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [GatewayEventKind.USAGE, terminal_kind]
+    assert committed is False
+    if failure_class is None:
+        assert events[-1].failure is None
+    else:
+        assert events[-1].failure is not None
+        assert events[-1].failure.failure_class is failure_class
 
 
 def test_anthropic_stream_normalizes_cache_usage_and_tool_fragments() -> None:
@@ -576,6 +662,118 @@ def test_stream_open_retry_reuses_stable_idempotency_before_commit() -> None:
     assert success_stream.closed is True
 
 
+@pytest.mark.parametrize("failure_mode", ["first_byte", "read_disconnect", "malformed"])
+def test_presemantic_body_failures_share_the_opening_retry_budget(failure_mode: str) -> None:
+    """First-byte, read, and malformed pre-semantic failures safely reopen one endpoint."""
+    if failure_mode == "first_byte":
+        first_stream: _HangingStream | _ReadFailureStream | _ChunkStream = _HangingStream()
+    elif failure_mode == "read_disconnect":
+        first_stream = _ReadFailureStream()
+    else:
+        first_stream = _ChunkStream((b"data: not-json\n\n",))
+    success_stream = _ChunkStream(
+        (
+            b"".join(
+                (
+                    _sse(
+                        {
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": "recovered"},
+                                    "finish_reason": "stop",
+                                }
+                            ]
+                        }
+                    ),
+                    b"data: [DONE]\n\n",
+                )
+            ),
+        )
+    )
+    calls = 0
+    identities: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return one pre-semantic failure followed by a valid stream."""
+        nonlocal calls
+        calls += 1
+        identities.append(request.headers["Idempotency-Key"])
+        return httpx.Response(200, stream=first_stream if calls == 1 else success_stream)
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume the successful retry without observing the failed attempt."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAICompatibleClient(
+                model=_snapshot("openai-compatible"),
+                api_key="fixture-key",
+                base_url="https://compatible.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=2,
+                    initial_delay_seconds=0,
+                    maximum_delay_seconds=0,
+                ),
+                timeout_seconds=0.02,
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(1),
+                idempotency_key="stable-body-retry",
+            )
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert calls == 2
+    assert identities == ["stable-body-retry", "stable-body-retry"]
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.COMPLETED,
+    ]
+    if isinstance(first_stream, _HangingStream):
+        assert first_stream.closed.is_set()
+    else:
+        assert first_stream.closed is True
+    assert success_stream.closed is True
+
+
+def test_exhausted_read_disconnect_is_transport_failure_and_closes_response() -> None:
+    """A final body-read disconnect is sanitized as retryable transport, not internal."""
+    upstream = _ReadFailureStream()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return one response whose body disconnects on the first read."""
+        del request
+        return httpx.Response(200, stream=upstream)
+
+    async def scenario() -> GatewayEvent:
+        """Consume the only allowed attempt through its normalized failure."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAICompatibleClient(
+                model=_snapshot("openai-compatible"),
+                api_key="fixture-key",
+                base_url="https://compatible.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(1),
+                idempotency_key="read-failure",
+            )
+            return await anext(stream)
+
+    event = asyncio.run(scenario())
+
+    assert event.kind is GatewayEventKind.FAILED
+    assert event.failure is not None
+    assert event.failure.failure_class is GatewayFailureClass.TRANSPORT
+    assert event.failure.retryable_same_deployment is True
+    assert "canary" not in event.failure.safe_message
+    assert upstream.closed is True
+
+
 @pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])
 def test_launch_adapters_emit_refusal_as_semantic_commit(provider: str) -> None:
     """Every launch adapter commits on its native refusal signal without leaking an error body."""
@@ -712,6 +910,111 @@ def test_launch_adapters_sanitize_native_stream_errors(provider: str) -> None:
     assert committed is False
 
 
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])
+def test_launch_adapters_reject_duplicate_or_conflicting_tool_starts(provider: str) -> None:
+    """Tool accumulator identity cannot be overwritten or spliced after commitment."""
+    if provider == "openai":
+        start = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "lookup",
+                "arguments": "",
+            },
+        }
+        frames = _sse(start) + _sse(start)
+    elif provider == "anthropic":
+        start = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "lookup",
+                "input": {},
+            },
+        }
+        frames = _sse(start) + _sse(start)
+    else:
+        frames = b"".join(
+            (
+                _sse(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call-1",
+                                            "function": {
+                                                "name": "lookup",
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call-conflict",
+                                            "function": {"name": "lookup"},
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                ),
+            )
+        )
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return malformed repeated tool metadata from one provider attempt."""
+        nonlocal calls
+        del request
+        calls += 1
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> tuple[list[GatewayEvent], bool]:
+        """Consume the tool start and its terminal malformed-response failure."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client(provider, http_client)
+            stream = await client.stream(
+                _request(_provider_surface(provider)),
+                deadline=RequestDeadline.after(1),
+                idempotency_key=f"duplicate-{provider}",
+            )
+            events = await _collect(stream)
+            return events, stream.committed
+
+    events, committed = asyncio.run(scenario())
+
+    assert calls == 1
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TOOL_CALL_STARTED,
+        GatewayEventKind.FAILED,
+    ]
+    assert events[-1].failure is not None
+    assert events[-1].failure.failure_class is GatewayFailureClass.MALFORMED_RESPONSE
+    assert committed is True
+
+
 def test_first_byte_deadline_returns_sanitized_timeout_and_closes_upstream() -> None:
     """A spent first-byte phase fails before commitment and closes active HTTP work."""
     upstream = _HangingStream()
@@ -746,6 +1049,47 @@ def test_first_byte_deadline_returns_sanitized_timeout_and_closes_upstream() -> 
     assert event.failure.failure_class is GatewayFailureClass.TIMEOUT
     assert committed is False
     assert upstream.closed.is_set()
+
+
+def test_sse_size_limit_tracks_one_multiline_event_across_chunks() -> None:
+    """Accumulated data lines cannot evade the per-event size limit through fragmentation."""
+    half = _MAXIMUM_SSE_EVENT_BYTES // 2 + 16
+    upstream = _ChunkStream(
+        (
+            b"data: " + b"a" * half + b"\n",
+            b"data: " + b"b" * half + b"\n\n",
+        )
+    )
+
+    async def scenario() -> None:
+        """Consume the oversized logical event and require focused rejection."""
+        decoder = _SseDecoder(
+            upstream,
+            deadline=RequestDeadline.after(1),
+            phase_timeout_seconds=1,
+        )
+        with pytest.raises(ProviderResponseError, match="size limit"):
+            async for _event in decoder.events():
+                pass
+
+    asyncio.run(scenario())
+
+
+def test_sse_size_limit_allows_one_large_chunk_of_small_events() -> None:
+    """Socket batching does not reject many independently bounded keepalive frames."""
+    keepalive = b": " + b"x" * (_MAXIMUM_SSE_EVENT_BYTES // 4) + b"\n\n"
+    upstream = _ChunkStream((keepalive * 5 + b"data: {}\n\n",))
+
+    async def scenario() -> list[str]:
+        """Decode the only data-bearing event after the large keepalive batch."""
+        decoder = _SseDecoder(
+            upstream,
+            deadline=RequestDeadline.after(5),
+            phase_timeout_seconds=5,
+        )
+        return [event.data async for event in decoder.events()]
+
+    assert asyncio.run(scenario()) == ["{}"]
 
 
 @pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -1,0 +1,775 @@
+"""Deterministic launch-provider streaming, usage, deadline, and cancellation tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Mapping, Sequence
+
+import httpx
+import pytest
+
+from wmo.common.models import ModelSnapshot
+from wmo.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailureClass,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
+from wmo.runtime.models.providers.anthropic import AnthropicClient
+from wmo.runtime.models.providers.async_transport import (
+    HttpxAsyncJsonTransport,
+    RequestDeadline,
+)
+from wmo.runtime.models.providers.openai import OpenAIClient
+from wmo.runtime.models.providers.openai_compatible import OpenAICompatibleClient
+from wmo.runtime.models.providers.streaming import NormalizedProviderStream
+from wmo.runtime.models.providers.transport import RetryPolicy
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    """HTTPX fixture stream that yields exact byte fragments and records closure."""
+
+    def __init__(self, chunks: Sequence[bytes]) -> None:
+        """Store provider-order response chunks.
+
+        Args:
+            chunks: Exact byte fragments exposed to the transport.
+        """
+        self._chunks = tuple(chunks)
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        """Yield every scripted response fragment in order."""
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        """Record response closure."""
+        self.closed = True
+
+
+class _HangingStream(httpx.AsyncByteStream):
+    """HTTPX fixture stream that blocks until response cancellation closes it."""
+
+    def __init__(self) -> None:
+        """Create one initially open blocking stream."""
+        self.started = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        """Block the first-byte phase until closure."""
+        self.started.set()
+        await self.closed.wait()
+        if False:
+            yield b""
+
+    async def aclose(self) -> None:
+        """Release the blocked iterator and record cancellation."""
+        self.closed.set()
+
+
+def _snapshot(provider: str) -> ModelSnapshot:
+    """Build one immutable provider identity fixture."""
+    return ModelSnapshot(
+        provider=provider,
+        model_id="exact-model",
+        capabilities_sha256="a" * 64,
+        connection_sha256="b" * 64,
+    )
+
+
+def _request(surface: GatewayApiSurface) -> GatewayRequest:
+    """Build one canonical streaming request with a strict function tool."""
+    return GatewayRequest(
+        surface=surface,
+        messages=(
+            GatewayMessage(role="developer", content="Be precise."),
+            GatewayMessage(role="user", content="Use the tool."),
+        ),
+        tools=(
+            GatewayToolDefinition(
+                name="lookup",
+                parameters={"type": "object"},
+                strict=True,
+            ),
+        ),
+        parallel_tool_calls=True,
+        stream=True,
+        include_usage=True,
+    )
+
+
+def _provider_client(
+    provider: str,
+    http_client: httpx.AsyncClient,
+) -> OpenAIClient | AnthropicClient | OpenAICompatibleClient:
+    """Construct one launch adapter over a caller-owned mock HTTP client.
+
+    Args:
+        provider: Stable launch provider family.
+        http_client: Mock-backed HTTPX client.
+
+    Returns:
+        The corresponding launch adapter.
+    """
+    transport = HttpxAsyncJsonTransport(http_client)
+    if provider == "openai":
+        return OpenAIClient(
+            model=_snapshot(provider),
+            api_key="fixture-key",
+            transport=transport,
+        )
+    if provider == "anthropic":
+        return AnthropicClient(
+            model=_snapshot(provider),
+            api_key="fixture-key",
+            base_url="https://anthropic.test/v1",
+            transport=transport,
+        )
+    if provider == "openai-compatible":
+        return OpenAICompatibleClient(
+            model=_snapshot(provider),
+            api_key="fixture-key",
+            base_url="https://compatible.test/v1",
+            transport=transport,
+        )
+    raise AssertionError(f"unknown provider fixture {provider!r}")
+
+
+def _provider_surface(provider: str) -> GatewayApiSurface:
+    """Return the canonical public surface used by one provider fixture."""
+    return (
+        GatewayApiSurface.RESPONSES if provider == "openai" else GatewayApiSurface.CHAT_COMPLETIONS
+    )
+
+
+def _sse(payload: Mapping[str, object], *, event: str | None = None) -> bytes:
+    """Encode one provider fixture as a complete SSE event."""
+    prefix = b"" if event is None else f"event: {event}\n".encode()
+    return prefix + b"data: " + json.dumps(payload, separators=(",", ":")).encode() + b"\n\n"
+
+
+async def _collect(stream: NormalizedProviderStream) -> list[GatewayEvent]:
+    """Consume one normalized stream through its terminal event."""
+    return [event async for event in stream]
+
+
+def test_openai_responses_stream_preserves_raw_tools_usage_and_commitment() -> None:
+    """Responses streaming keeps raw tool order and provider-specific token subsets."""
+    raw_arguments = '{ "city": "Zürich" }'
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {
+                        "type": "function_call",
+                        "id": "fc-1",
+                        "call_id": "call-1",
+                        "name": "lookup",
+                        "arguments": "",
+                    },
+                },
+                event="response.output_item.added",
+            ),
+            _sse(
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": 0,
+                    "delta": '{ "city": ',
+                }
+            ),
+            _sse(
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": 0,
+                    "delta": '"Zürich" }',
+                }
+            ),
+            _sse(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "output_index": 0,
+                    "arguments": raw_arguments,
+                }
+            ),
+            _sse({"type": "response.output_text.delta", "delta": "done"}),
+            _sse(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {
+                            "input_tokens": 12,
+                            "output_tokens": 7,
+                            "input_tokens_details": {"cached_tokens": 4},
+                            "output_tokens_details": {"reasoning_tokens": 3},
+                        },
+                    },
+                }
+            ),
+        )
+    )
+    upstream = _ChunkStream((frames[:41], frames[41:177], frames[177:]))
+    observed_payloads: list[dict[str, object]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Record the streaming request and return fragmented native events."""
+        observed_payloads.append(json.loads(request.content))
+        return httpx.Response(200, stream=upstream)
+
+    async def scenario() -> list[GatewayEvent]:
+        """Open the Responses stream and inspect commitment around its first event."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAIClient(
+                model=_snapshot("openai"),
+                api_key="fixture-key",
+                transport=HttpxAsyncJsonTransport(http_client),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.RESPONSES),
+                deadline=RequestDeadline.after(2),
+                idempotency_key="attempt-1",
+            )
+            assert stream.committed is False
+            first = await anext(stream)
+            assert first.kind is GatewayEventKind.TOOL_CALL_STARTED
+            assert stream.committed is True
+            return [first, *await _collect(stream)]
+
+    events = asyncio.run(scenario())
+
+    assert [event.sequence_number for event in events] == list(range(len(events)))
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TOOL_CALL_STARTED,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_CALL_COMPLETED,
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[3].tool_call is not None
+    assert events[3].tool_call.arguments_json() == raw_arguments
+    assert events[5].usage is not None
+    assert events[5].usage.cached_input_tokens == 4
+    assert events[5].usage.reasoning_tokens == 3
+    assert observed_payloads[0]["stream"] is True
+    assert observed_payloads[0]["store"] is False
+    assert observed_payloads[0]["instructions"] == "Be precise."
+    assert upstream.closed is True
+
+
+def test_anthropic_stream_normalizes_cache_usage_and_tool_fragments() -> None:
+    """Messages streaming adds cache units to total input and keeps raw input JSON."""
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 10,
+                            "cache_read_input_tokens": 3,
+                            "cache_creation_input_tokens": 2,
+                        }
+                    },
+                },
+                event="message_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "lookup",
+                        "input": {},
+                    },
+                },
+                event="content_block_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"x":'},
+                },
+                event="content_block_delta",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": "1}"},
+                },
+                event="content_block_delta",
+            ),
+            _sse({"type": "content_block_stop", "index": 0}, event="content_block_stop"),
+            _sse(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 5},
+                },
+                event="message_delta",
+            ),
+            _sse({"type": "message_stop"}, event="message_stop"),
+        )
+    )
+    upstream = _ChunkStream((frames,))
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Require native streaming and return the Anthropic fixture."""
+        assert json.loads(request.content)["stream"] is True
+        return httpx.Response(200, stream=upstream)
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume one native Messages stream."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = AnthropicClient(
+                model=_snapshot("anthropic"),
+                api_key="fixture-key",
+                base_url="https://anthropic.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(2),
+                idempotency_key="attempt-2",
+            )
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TOOL_CALL_STARTED,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_CALL_COMPLETED,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[3].tool_call is not None
+    assert events[3].tool_call.arguments_json() == '{"x":1}'
+    assert events[4].usage is not None
+    assert events[4].usage.input_tokens == 15
+    assert events[4].usage.output_tokens == 5
+    assert events[4].usage.cached_input_tokens == 3
+
+
+def test_openai_compatible_stream_emits_refusal_reasoning_usage_and_terminal() -> None:
+    """Generic Chat streaming retains refusal semantics and reported reasoning units."""
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"refusal": "cannot comply"},
+                            "finish_reason": "content_filter",
+                        }
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 8,
+                        "completion_tokens": 2,
+                        "prompt_tokens_details": {"cached_tokens": 5},
+                        "completion_tokens_details": {"reasoning_tokens": 1},
+                    },
+                }
+            ),
+            b"data: [DONE]\n\n",
+        )
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Verify usage was requested and return a refusal stream."""
+        payload = json.loads(request.content)
+        assert payload["stream"] is True
+        assert payload["stream_options"] == {"include_usage": True}
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume one generic compatible refusal stream."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAICompatibleClient(
+                model=_snapshot("openai-compatible"),
+                api_key="fixture-key",
+                base_url="https://compatible.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(2),
+                idempotency_key="attempt-3",
+            )
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.REFUSAL_DELTA,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[1].usage is not None
+    assert events[1].usage.cached_input_tokens == 5
+    assert events[1].usage.reasoning_tokens == 1
+
+
+def test_openai_compatible_stream_preserves_provider_order_tool_arguments() -> None:
+    """Generic Chat tool fragments remain byte-for-byte ordered through completion."""
+    raw_arguments = '{"b": 2, "a": 1}'
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call-1",
+                                        "function": {
+                                            "name": "lookup",
+                                            "arguments": '{"b":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "function": {"arguments": ' 2, "a": 1}'},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                }
+            ),
+            b"data: [DONE]\n\n",
+        )
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return incrementally fragmented generic Chat tool arguments."""
+        del request
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume one compatible tool stream."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client("openai-compatible", http_client)
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(1),
+                idempotency_key="compatible-tool",
+            )
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TOOL_CALL_STARTED,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+        GatewayEventKind.TOOL_CALL_COMPLETED,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[3].tool_call is not None
+    assert events[3].tool_call.arguments_json() == raw_arguments
+
+
+def test_stream_open_retry_reuses_stable_idempotency_before_commit() -> None:
+    """Safe same-endpoint opening retries keep one identity before semantic output."""
+    calls = 0
+    identities: list[str] = []
+    failed_stream = _ChunkStream(())
+    success_stream = _ChunkStream(
+        (
+            b"".join(
+                (
+                    _sse(
+                        {
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": "ok"},
+                                    "finish_reason": "stop",
+                                }
+                            ]
+                        }
+                    ),
+                    b"data: [DONE]\n\n",
+                )
+            ),
+        )
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Fail one opening attempt, then return a valid streaming response."""
+        nonlocal calls
+        calls += 1
+        identities.append(request.headers["Idempotency-Key"])
+        if calls == 1:
+            return httpx.Response(503, stream=failed_stream)
+        return httpx.Response(200, stream=success_stream)
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume the stream opened by the safe retry."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAICompatibleClient(
+                model=_snapshot("openai-compatible"),
+                api_key="fixture-key",
+                base_url="https://compatible.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=2,
+                    initial_delay_seconds=0,
+                    maximum_delay_seconds=0,
+                ),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(1),
+                idempotency_key="stable-attempt",
+            )
+            assert stream.committed is False
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert calls == 2
+    assert identities == ["stable-attempt", "stable-attempt"]
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert failed_stream.closed is True
+    assert success_stream.closed is True
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])
+def test_launch_adapters_emit_refusal_as_semantic_commit(provider: str) -> None:
+    """Every launch adapter commits on its native refusal signal without leaking an error body."""
+    if provider == "openai":
+        frames = b"".join(
+            (
+                _sse({"type": "response.refusal.delta", "delta": "declined"}),
+                _sse(
+                    {
+                        "type": "response.completed",
+                        "response": {"status": "completed", "usage": None},
+                    }
+                ),
+            )
+        )
+    elif provider == "anthropic":
+        frames = b"".join(
+            (
+                _sse(
+                    {
+                        "type": "message_start",
+                        "message": {
+                            "usage": {
+                                "input_tokens": 1,
+                                "cache_read_input_tokens": 0,
+                                "cache_creation_input_tokens": 0,
+                            }
+                        },
+                    }
+                ),
+                _sse(
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "refusal", "refusal": "declined"},
+                    }
+                ),
+                _sse(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "refusal"},
+                        "usage": {"output_tokens": 1},
+                    }
+                ),
+                _sse({"type": "message_stop"}),
+            )
+        )
+    else:
+        frames = b"".join(
+            (
+                _sse(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"refusal": "declined"},
+                                "finish_reason": "content_filter",
+                            }
+                        ]
+                    }
+                ),
+                b"data: [DONE]\n\n",
+            )
+        )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return the selected provider's native refusal fixture."""
+        del request
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> tuple[list[GatewayEvent], bool]:
+        """Read the refusal event before consuming its terminal continuation."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client(provider, http_client)
+            stream = await client.stream(
+                _request(_provider_surface(provider)),
+                deadline=RequestDeadline.after(1),
+                idempotency_key=f"refusal-{provider}",
+            )
+            first = await anext(stream)
+            committed = stream.committed
+            return [first, *await _collect(stream)], committed
+
+    events, committed = asyncio.run(scenario())
+
+    assert events[0].kind is GatewayEventKind.REFUSAL_DELTA
+    assert events[-1].kind is GatewayEventKind.COMPLETED
+    assert committed is True
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])
+def test_launch_adapters_sanitize_native_stream_errors(provider: str) -> None:
+    """Every launch adapter converts native error events without exposing provider content."""
+    canary = "private-provider-error-canary"
+    if provider == "openai":
+        frames = _sse(
+            {
+                "type": "response.failed",
+                "response": {"error": {"message": canary}},
+            }
+        )
+    elif provider == "anthropic":
+        frames = _sse(
+            {
+                "type": "error",
+                "error": {"type": "overloaded_error", "message": canary},
+            }
+        )
+    else:
+        frames = _sse({"error": {"message": canary}})
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return the selected provider's native error fixture."""
+        del request
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> tuple[GatewayEvent, bool]:
+        """Consume one sanitized provider failure."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client(provider, http_client)
+            stream = await client.stream(
+                _request(_provider_surface(provider)),
+                deadline=RequestDeadline.after(1),
+                idempotency_key=f"error-{provider}",
+            )
+            return await anext(stream), stream.committed
+
+    event, committed = asyncio.run(scenario())
+
+    assert event.kind is GatewayEventKind.FAILED
+    assert event.failure is not None
+    assert event.failure.failure_class is GatewayFailureClass.PROVIDER_INTERNAL
+    assert canary not in event.failure.safe_message
+    assert committed is False
+
+
+def test_first_byte_deadline_returns_sanitized_timeout_and_closes_upstream() -> None:
+    """A spent first-byte phase fails before commitment and closes active HTTP work."""
+    upstream = _HangingStream()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return a response whose first body byte never arrives."""
+        del request
+        return httpx.Response(200, stream=upstream)
+
+    async def scenario() -> tuple[GatewayEvent, bool]:
+        """Wait through one bounded first-byte phase."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = OpenAICompatibleClient(
+                model=_snapshot("openai-compatible"),
+                api_key="fixture-key",
+                base_url="https://compatible.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+                timeout_seconds=0.02,
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(0.02),
+                idempotency_key="attempt-timeout",
+            )
+            event = await anext(stream)
+            return event, stream.committed
+
+    event, committed = asyncio.run(scenario())
+
+    assert event.kind is GatewayEventKind.FAILED
+    assert event.failure is not None
+    assert event.failure.failure_class is GatewayFailureClass.TIMEOUT
+    assert committed is False
+    assert upstream.closed.is_set()
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "openai-compatible"])
+def test_explicit_cancellation_closes_each_launch_stream_within_bound(provider: str) -> None:
+    """Client disconnect cancellation closes each launch provider response immediately."""
+    upstream = _HangingStream()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Return one open response that can only finish through cancellation."""
+        del request
+        return httpx.Response(200, stream=upstream)
+
+    async def scenario() -> None:
+        """Cancel before reading and prove the response lifecycle is closed."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = _provider_client(provider, http_client)
+            stream = await client.stream(
+                _request(_provider_surface(provider)),
+                deadline=RequestDeadline.after(1),
+                idempotency_key=f"cancel-{provider}",
+            )
+            await stream.cancel()
+            assert stream.committed is False
+
+    asyncio.run(scenario())
+
+    assert upstream.closed.is_set()

--- a/wmo/runtime/models/providers/streaming_usage.py
+++ b/wmo/runtime/models/providers/streaming_usage.py
@@ -1,0 +1,85 @@
+"""Provider-stream usage normalization shared by launch adapters."""
+
+from pydantic import JsonValue
+
+from wmo.runtime.gateway.contracts import GatewayUsage
+from wmo.runtime.models.providers.errors import require_integer, require_object
+
+
+def openai_usage(value: JsonValue | None) -> GatewayUsage | None:
+    """Normalize native Responses usage including cached and reasoning subsets.
+
+    Args:
+        value: Optional provider usage object.
+
+    Returns:
+        Normalized usage, or ``None`` when the provider omitted usage.
+    """
+    if value is None:
+        return None
+    usage = require_object(value, "OpenAI usage")
+    return GatewayUsage(
+        input_tokens=require_integer(usage.get("input_tokens"), "OpenAI input_tokens"),
+        output_tokens=require_integer(usage.get("output_tokens"), "OpenAI output_tokens"),
+        cached_input_tokens=_optional_usage_detail(
+            usage.get("input_tokens_details"),
+            field_name="cached_tokens",
+            label="OpenAI cached_tokens",
+        ),
+        reasoning_tokens=_optional_usage_detail(
+            usage.get("output_tokens_details"),
+            field_name="reasoning_tokens",
+            label="OpenAI reasoning_tokens",
+        ),
+    )
+
+
+def openai_compatible_usage(value: JsonValue) -> GatewayUsage:
+    """Normalize Chat usage including optional cached and reasoning subsets.
+
+    Args:
+        value: Provider usage object.
+
+    Returns:
+        Normalized token accounting.
+    """
+    usage = require_object(value, "OpenAI-compatible usage")
+    return GatewayUsage(
+        input_tokens=require_integer(usage.get("prompt_tokens"), "prompt_tokens"),
+        output_tokens=require_integer(usage.get("completion_tokens"), "completion_tokens"),
+        cached_input_tokens=_optional_usage_detail(
+            usage.get("prompt_tokens_details"),
+            field_name="cached_tokens",
+            label="cached_tokens",
+        ),
+        reasoning_tokens=_optional_usage_detail(
+            usage.get("completion_tokens_details"),
+            field_name="reasoning_tokens",
+            label="reasoning_tokens",
+        ),
+    )
+
+
+def _optional_usage_detail(
+    value: JsonValue | None,
+    *,
+    field_name: str,
+    label: str,
+) -> int | None:
+    """Preserve an absent provider token subset as unknown instead of zero.
+
+    Args:
+        value: Optional provider detail object.
+        field_name: Numeric field within the detail object.
+        label: Sanitized validation label.
+
+    Returns:
+        The normalized count, or ``None`` when absent.
+    """
+    if value is None:
+        return None
+    details = require_object(value, f"{label} details")
+    raw_count = details.get(field_name)
+    if raw_count is None:
+        return None
+    return require_integer(raw_count, label)


### PR DESCRIPTION
## Summary

- add incremental provider streaming for OpenAI, Anthropic, and OpenAI-compatible transports
- normalize text, refusal, indexed tool calls, raw tool arguments, usage, and terminal events for the shared neutral protocol
- keep one request-wide deadline and one retry owner while preserving synchronous optimizer compatibility
- retain provider-specific usage semantics and fail closed after semantic commitment

## Boundary

Provider adapters emit normalized model events only. They do not encode OpenAI HTTP/SSE responses or own authentication, failover, persistence, or accounting.

## Stack

- base: `agent/gateway-provider-execution` at `5745a46d`
- head: `b2a938c1`

This PR is ready for review and must not be merged independently of its stack.
