### PR TITLE
feat(gateway): compose launch data plane

### DIFF
--- a/wmo/runtime/gateway/aggregation.py
+++ b/wmo/runtime/gateway/aggregation.py
@@ -1,0 +1,49 @@
+"""Bounded semantic event retention for non-streaming and continuation assembly."""
+
+from __future__ import annotations
+
+from wmo.runtime.gateway.contracts import GatewayEvent
+
+
+class GatewayAggregationOverflowError(ValueError):
+    """Provider output exceeded the launch data-plane retention ceiling."""
+
+
+class BoundedGatewayEvents:
+    """Retain normalized events under fixed count and serialized-byte ceilings."""
+
+    def __init__(
+        self,
+        *,
+        maximum_events: int = 100_000,
+        maximum_bytes: int = 64 * 1024 * 1024,
+    ) -> None:
+        """Create empty bounded event state.
+
+        Args:
+            maximum_events: Maximum normalized events retained for one response.
+            maximum_bytes: Maximum UTF-8 serialized event bytes retained.
+        """
+        if maximum_events < 1 or maximum_bytes < 1:
+            raise ValueError("gateway event bounds must be positive")
+        self._maximum_events = maximum_events
+        self._maximum_bytes = maximum_bytes
+        self._events: list[GatewayEvent] = []
+        self._bytes = 0
+
+    def append(self, event: GatewayEvent) -> None:
+        """Retain one event or fail before process-local state becomes unbounded."""
+        event_bytes = len(event.model_dump_json().encode("utf-8"))
+        if (
+            len(self._events) >= self._maximum_events
+            or self._bytes + event_bytes > self._maximum_bytes
+        ):
+            raise GatewayAggregationOverflowError(
+                "provider output exceeded the bounded gateway aggregation limit"
+            )
+        self._events.append(event)
+        self._bytes += event_bytes
+
+    def snapshot(self) -> tuple[GatewayEvent, ...]:
+        """Return the retained immutable event sequence."""
+        return tuple(self._events)

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -41,8 +41,18 @@ from wmo.runtime.gateway.execution import (
     GatewayExecutionStream,
     GatewayExecutor,
 )
-from wmo.runtime.gateway.openai.requests import decode_chat
-from wmo.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
+from wmo.runtime.gateway.openai.requests import decode_chat, decode_responses
+from wmo.runtime.gateway.openai.state import (
+    BoundedContinuationStore,
+    ContinuationState,
+    ProtocolNamespace,
+)
+from wmo.runtime.gateway.routing import (
+    CatalogRouteResolver,
+    GatewayRoute,
+    GatewayRoutingError,
+    project_episode_identity,
+)
 from wmo.runtime.gateway.service import GatewayDrainingError, GatewayService, create_gateway_app
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.models.providers import RequestDeadline
@@ -314,6 +324,28 @@ class _ProjectResolver:
         )
 
 
+class _FailOnceContinuationStore(BoundedContinuationStore):
+    """Reject the first continuation write, then retain subsequent state normally."""
+
+    def __init__(self) -> None:
+        """Initialize one deterministic fallible continuation store."""
+        super().__init__()
+        self.calls = 0
+
+    async def remember(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        response_id: str,
+        state: ContinuationState,
+    ) -> None:
+        """Fail the first retention attempt before delegating later calls."""
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("continuation write failed")
+        await super().remember(namespace=namespace, response_id=response_id, state=state)
+
+
 def _catalog() -> tuple[NormalizedGatewayCatalog, ExactModelDeployment]:
     """Build one launch-safe singleton gateway catalog."""
     deployment = ExactModelDeployment(
@@ -348,6 +380,7 @@ def _service(
     provider: _Provider,
     *,
     terminal_flusher: Callable[[], object] | None = None,
+    continuation_store: BoundedContinuationStore | None = None,
 ) -> tuple[GatewayService, _ControlStore, _Ledger, ExecutionSnapshot]:
     """Compose the full launch data plane with deterministic injected dependencies."""
     catalog, deployment = _catalog()
@@ -393,6 +426,7 @@ def _service(
         ),
         clock=_Clock(),
         readiness_probe=readiness_probe,
+        continuation_store=continuation_store,
         terminal_flusher=flush,
     )
     control.raw_keys_seen.clear()
@@ -553,6 +587,14 @@ def test_project_route_rejects_ambiguous_matching_deployments() -> None:
             )
 
     asyncio.run(scenario())
+
+
+def test_project_episode_identity_cannot_collide_through_component_delimiters() -> None:
+    """Tenant and episode component boundaries survive arbitrary delimiter-like text."""
+    first = project_episode_identity(("a", "b\x1fc", "d", "e"))
+    second = project_episode_identity(("a\x1fb", "c", "d", "e"))
+
+    assert first != second
 
 
 def test_executor_rejects_runtime_client_drift_before_attempt_or_network() -> None:
@@ -804,5 +846,43 @@ def test_http_boundary_authenticates_before_json_decode_and_returns_openai_400()
         assert malformed.status_code == 400
         assert malformed.json()["error"]["code"] == "invalid_json"
         assert control.raw_keys_seen == ["caller-secret"]
+
+    asyncio.run(scenario())
+
+
+def test_responses_replay_commits_only_after_continuation_retention_succeeds() -> None:
+    """A failed continuation write abandons replay ownership so a keyed retry redispatches."""
+
+    async def scenario() -> None:
+        """Fail first retention, then prove the retry executes and completes normally."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        continuations = _FailOnceContinuationStore()
+        service, _control, _ledger, _proof = _service(
+            provider,
+            continuation_store=continuations,
+        )
+        decoded = decode_responses(
+            {"model": "public-model", "input": "hello"},
+            idempotency_key="operation-one",
+        )
+
+        with pytest.raises(RuntimeError, match="continuation write failed"):
+            await service.complete(raw_key="caller-secret", decoded=decoded)
+        response = await service.complete(raw_key="caller-secret", decoded=decoded)
+
+        assert response.status_code == 200
+        assert len(provider.streams) == 2
+        assert continuations.calls == 2
 
     asyncio.run(scenario())

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -889,6 +889,47 @@ def test_responses_replay_commits_only_after_continuation_retention_succeeds() -
     asyncio.run(scenario())
 
 
+def test_responses_continuation_preserves_public_previous_response_id() -> None:
+    """A gateway-local continuation still reports its public parent response identity."""
+
+    async def scenario() -> None:
+        """Complete one response, continue it, and inspect the second public envelope."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        service, _control, _ledger, _proof = _service(provider)
+        first = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_responses({"model": "public-model", "input": "first"}),
+        )
+        first_body = json.loads(bytes(first.body))
+        second = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_responses(
+                {
+                    "model": "public-model",
+                    "input": "second",
+                    "previous_response_id": first_body["id"],
+                }
+            ),
+        )
+        second_body = json.loads(bytes(second.body))
+
+        assert second_body["previous_response_id"] == first_body["id"]
+        assert len(provider.streams) == 2
+
+    asyncio.run(scenario())
+
+
 def test_streaming_responses_withholds_success_until_continuation_and_replay_commit() -> None:
     """A keyed stream exposes success only after retention and exact replay are durable."""
 

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -41,6 +41,7 @@ from wmo.runtime.gateway.execution import (
     GatewayExecutionStream,
     GatewayExecutor,
 )
+from wmo.runtime.gateway.openai.errors import OpenAIProtocolError
 from wmo.runtime.gateway.openai.requests import decode_chat, decode_responses
 from wmo.runtime.gateway.openai.state import (
     BoundedContinuationStore,
@@ -884,5 +885,110 @@ def test_responses_replay_commits_only_after_continuation_retention_succeeds() -
         assert response.status_code == 200
         assert len(provider.streams) == 2
         assert continuations.calls == 2
+
+    asyncio.run(scenario())
+
+
+def test_streaming_responses_withholds_success_until_continuation_and_replay_commit() -> None:
+    """A keyed stream exposes success only after retention and exact replay are durable."""
+
+    async def consume(response: StreamingResponse) -> bytes:
+        """Consume one public streaming response into exact emitted bytes.
+
+        Args:
+            response: Streaming response returned by the gateway service.
+
+        Returns:
+            Concatenated public SSE frames emitted before completion or failure.
+        """
+        frames: list[bytes] = []
+        async for frame in cast(AsyncIterator[bytes], response.body_iterator):
+            frames.append(frame)
+        return b"".join(frames)
+
+    async def scenario() -> None:
+        """Fail first retention, then prove visible success is replayed without redispatch."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        continuations = _FailOnceContinuationStore()
+        service, _control, _ledger, _proof = _service(
+            provider,
+            continuation_store=continuations,
+        )
+        decoded = decode_responses(
+            {"model": "public-model", "input": "hello", "stream": True},
+            idempotency_key="stream-operation-one",
+        )
+
+        failed = await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert isinstance(failed, StreamingResponse)
+        emitted = bytearray()
+        with pytest.raises(RuntimeError, match="continuation write failed"):
+            async for frame in cast(AsyncIterator[bytes], failed.body_iterator):
+                emitted.extend(frame)
+        assert b"hello" in emitted
+        assert b"response.completed" not in emitted
+
+        completed = await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert isinstance(completed, StreamingResponse)
+        completed_body = await consume(completed)
+        assert b"response.completed" in completed_body
+        assert len(provider.streams) == 2
+
+        replay = await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert replay.status_code == 200
+        assert b"response.completed" in replay.body
+        assert len(provider.streams) == 2
+        assert continuations.calls == 2
+
+    asyncio.run(scenario())
+
+
+def test_keyed_stream_capture_overflow_never_exposes_success_before_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreplayable keyed stream fails before its terminal frame becomes visible."""
+    monkeypatch.setattr("wmo.runtime.gateway.service._STREAM_REPLAY_CAPTURE_BYTES", 1)
+
+    async def scenario() -> None:
+        """Overflow two attempts and prove neither emits a terminal success frame."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        service, _control, _ledger, _proof = _service(provider)
+        decoded = decode_responses(
+            {"model": "public-model", "input": "hello", "stream": True},
+            idempotency_key="overflow-operation-one",
+        )
+
+        for expected_dispatches in (1, 2):
+            response = await service.complete(raw_key="caller-secret", decoded=decoded)
+            assert isinstance(response, StreamingResponse)
+            emitted = bytearray()
+            with pytest.raises(OpenAIProtocolError) as captured:
+                async for frame in cast(AsyncIterator[bytes], response.body_iterator):
+                    emitted.extend(frame)
+            assert captured.value.detail.code == "idempotency_replay_unavailable"
+            assert b"response.completed" not in emitted
+            assert len(provider.streams) == expected_dispatches
 
     asyncio.run(scenario())

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -41,13 +41,6 @@ from wmo.runtime.gateway.execution import (
     GatewayExecutionStream,
     GatewayExecutor,
 )
-from wmo.runtime.gateway.openai.errors import OpenAIProtocolError
-from wmo.runtime.gateway.openai.requests import decode_chat, decode_responses
-from wmo.runtime.gateway.openai.state import (
-    BoundedContinuationStore,
-    ContinuationState,
-    ProtocolNamespace,
-)
 from wmo.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoute,
@@ -57,6 +50,13 @@ from wmo.runtime.gateway.routing import (
 from wmo.runtime.gateway.service import GatewayDrainingError, GatewayService, create_gateway_app
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.models.providers import RequestDeadline
+from wmo.runtime.openai_protocol.errors import OpenAIProtocolError
+from wmo.runtime.openai_protocol.requests import decode_chat, decode_responses
+from wmo.runtime.openai_protocol.state import (
+    BoundedContinuationStore,
+    ContinuationState,
+    ProtocolNamespace,
+)
 
 _DIGEST = "a" * 64
 

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -1,0 +1,808 @@
+"""End-to-end data-plane routing, execution, and lifecycle regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Callable
+from datetime import UTC, datetime
+from typing import cast
+
+import httpx
+import pytest
+from fastapi.responses import StreamingResponse
+
+from wmo.common.models import BillingSource, ModelCapabilities, ModelClient, ModelSnapshot
+from wmo.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
+from wmo.common.models.gateway_catalog import (
+    ExactModelDeployment,
+    ExactModelPool,
+    NormalizedGatewayCatalog,
+)
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayTarget,
+    GatewayUsage,
+    ProjectSelection,
+    ProjectTarget,
+)
+from wmo.runtime.gateway.execution import (
+    GatewayExecutionError,
+    GatewayExecutionStream,
+    GatewayExecutor,
+)
+from wmo.runtime.gateway.openai.requests import decode_chat
+from wmo.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
+from wmo.runtime.gateway.service import GatewayDrainingError, GatewayService, create_gateway_app
+from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.models.providers import RequestDeadline
+
+_DIGEST = "a" * 64
+
+
+class _Clock:
+    """Real monotonic test clock with a fixed wall timestamp."""
+
+    def now(self) -> datetime:
+        """Return a stable timezone-aware timestamp."""
+        return datetime(2026, 8, 18, tzinfo=UTC)
+
+    def monotonic(self) -> float:
+        """Return the process monotonic clock used by provider deadlines."""
+        return time.monotonic()
+
+
+class _ControlStore:
+    """Authorize one public alias without retaining the presented key."""
+
+    def __init__(self, catalog_sha256: str) -> None:
+        self._catalog_sha256 = catalog_sha256
+        self.raw_keys_seen: list[str] = []
+
+    def authorize_request(
+        self,
+        *,
+        raw_key: str,
+        alias: str,
+        request: GatewayRequest,
+        deadline_monotonic: float,
+    ) -> AuthorizationSnapshot:
+        """Return one frozen direct-target authority snapshot."""
+        self.raw_keys_seen.append(raw_key)
+        return AuthorizationSnapshot(
+            request_id="request-one",
+            organization_id="organization-one",
+            identity_id="identity-one",
+            virtual_key_id="key-one",
+            alias=alias,
+            alias_revision_id="revision-one",
+            target=DirectTarget(pool_id="pool-one"),
+            surface=request.surface,
+            catalog_sha256=self._catalog_sha256,
+            canonical_request_sha256=_DIGEST,
+            deadline_monotonic=deadline_monotonic,
+        )
+
+    def authenticate_key(self, *, raw_key: str) -> None:
+        """Authenticate one key without loading grants or request content."""
+        self.raw_keys_seen.append(raw_key)
+
+    def granted_aliases(self, *, raw_key: str) -> tuple[str, ...]:
+        """Return the only granted public alias."""
+        self.raw_keys_seen.append(raw_key)
+        return ("public-model",)
+
+
+class _Ledger:
+    """Capture content-free request and attempt accounting calls."""
+
+    def __init__(self) -> None:
+        self.accepted: list[AuthorizationSnapshot] = []
+        self.started: list[ExecutionSnapshot] = []
+        self.routes: list[tuple[str | None, str | None]] = []
+        self.finished: list[tuple[GatewayEvent | None, GatewayFailure | None]] = []
+        self.fail_finishes = False
+
+    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
+        """Capture accepted authority only."""
+        self.accepted.append(authorization)
+
+    def start_attempt(
+        self,
+        *,
+        snapshot: ExecutionSnapshot,
+        deployment: ExactModelDeployment,
+        route_depth: int,
+    ) -> str:
+        """Capture dispatch identity and return a deterministic attempt ID."""
+        del deployment, route_depth
+        self.started.append(snapshot)
+        return f"attempt-{len(self.started)}"
+
+    def record_route_context(
+        self,
+        *,
+        attempt_id: str,
+        route_reason: str | None,
+        fallback_reason: str | None,
+    ) -> None:
+        """Capture sanitized route context."""
+        del attempt_id
+        self.routes.append((route_reason, fallback_reason))
+
+    def finish_attempt(
+        self,
+        *,
+        attempt_id: str,
+        terminal_event: GatewayEvent | None,
+        failure: GatewayFailure | None,
+        finalize_request: bool = True,
+    ) -> None:
+        """Capture one terminal settlement."""
+        del attempt_id, finalize_request
+        if self.fail_finishes:
+            raise RuntimeError("terminal ledger unavailable")
+        self.finished.append((terminal_event, failure))
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Capture accepted work that failed before provider dispatch."""
+        del authorization
+        self.finished.append((None, failure))
+
+
+class _EventStream:
+    """Yield a fixed normalized provider event sequence."""
+
+    def __init__(self, events: tuple[GatewayEvent, ...]) -> None:
+        self._events = iter(events)
+        self._committed = False
+        self.cancelled = False
+
+    @property
+    def committed(self) -> bool:
+        """Return whether a semantic event has been yielded."""
+        return self._committed
+
+    def __aiter__(self) -> AsyncIterator[GatewayEvent]:
+        """Return this asynchronous iterator."""
+        return self
+
+    async def __anext__(self) -> GatewayEvent:
+        """Yield the next normalized event."""
+        try:
+            event = next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+        self._committed = True
+        return event
+
+    async def cancel(self) -> None:
+        """Record bounded upstream cancellation."""
+        self.cancelled = True
+
+
+class _BlockingStream:
+    """Block provider reads until lifecycle cancellation releases them."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.released = asyncio.Event()
+        self.cancelled = False
+
+    @property
+    def committed(self) -> bool:
+        """Return false because no semantic event is emitted."""
+        return False
+
+    def __aiter__(self) -> AsyncIterator[GatewayEvent]:
+        """Return this asynchronous iterator."""
+        return self
+
+    async def __anext__(self) -> GatewayEvent:
+        """Wait until cancellation, then end the provider stream."""
+        self.entered.set()
+        await self.released.wait()
+        raise StopAsyncIteration
+
+    async def cancel(self) -> None:
+        """Release the pending read and record cancellation."""
+        self.cancelled = True
+        self.released.set()
+
+
+class _HungCancelStream(_BlockingStream):
+    """Suppress cancellation until the test explicitly releases cleanup."""
+
+    async def cancel(self) -> None:
+        """Remain blocked even after task cancellation until externally released."""
+        self.cancelled = True
+        while not self.released.is_set():
+            try:
+                await self.released.wait()
+            except asyncio.CancelledError:
+                continue
+
+
+class _Provider:
+    """Return injected normalized streams while capturing execution identity."""
+
+    def __init__(self, factory: Callable[[], _EventStream | _BlockingStream]) -> None:
+        self._factory = factory
+        self.streams: list[_EventStream | _BlockingStream] = []
+        self.idempotency_keys: list[str] = []
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+    ) -> _EventStream | _BlockingStream:
+        """Open one injected stream under the request-wide deadline."""
+        assert request.stream and request.include_usage
+        assert deadline.remaining_seconds() > 0
+        self.idempotency_keys.append(idempotency_key)
+        stream = self._factory()
+        self.streams.append(stream)
+        return stream
+
+
+class _RuntimeCatalog:
+    """Resolve the launch deployment to one injected async provider."""
+
+    def __init__(self, provider: _Provider) -> None:
+        self._provider = provider
+
+    def resolve(self, alias: str) -> ResolvedModel:
+        """Return one stable resolved model for the expected source alias."""
+        assert alias == "source-one"
+        capabilities = ModelCapabilities()
+        return ResolvedModel(
+            alias=alias,
+            snapshot=ModelSnapshot(
+                provider="openai",
+                model_id="provider-model",
+                revision=None,
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities_sha256=capabilities.identity_sha256(),
+                connection_sha256="b" * 64,
+            ),
+            capabilities=capabilities,
+            client=cast(ModelClient, self._provider),
+            embedding_client=None,
+        )
+
+
+class _ProjectResolver:
+    """Return one learned selection without executing provider completion."""
+
+    def __init__(self) -> None:
+        self.episodes: list[tuple[str, str, str, str]] = []
+
+    async def select(
+        self,
+        *,
+        target: GatewayTarget,
+        request: GatewayRequest,
+        episode_namespace: tuple[str, str, str, str],
+        deadline_monotonic: float,
+    ) -> ProjectSelection:
+        """Return one exact model chosen through the selection-only seam."""
+        del request, deadline_monotonic
+        assert isinstance(target, ProjectTarget)
+        self.episodes.append(episode_namespace)
+        return ProjectSelection(
+            exact_model_id="exact-one",
+            selected_alias="source-one",
+            activation_ref=target.activation_ref,
+            fallback_reason="embedding_error",
+        )
+
+
+def _catalog() -> tuple[NormalizedGatewayCatalog, ExactModelDeployment]:
+    """Build one launch-safe singleton gateway catalog."""
+    deployment = ExactModelDeployment(
+        deployment_id="deployment-one",
+        source_alias="source-one",
+        exact_model_id="exact-one",
+        connection="connection-one",
+        provider="openai",
+        provider_model="provider-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(
+            capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+        ),
+    )
+    return (
+        NormalizedGatewayCatalog(
+            deployments=(deployment,),
+            pools=(
+                ExactModelPool(
+                    pool_id="pool-one",
+                    exact_model_id="exact-one",
+                    deployment_ids=("deployment-one",),
+                ),
+            ),
+        ),
+        deployment,
+    )
+
+
+def _service(
+    provider: _Provider,
+    *,
+    terminal_flusher: Callable[[], object] | None = None,
+) -> tuple[GatewayService, _ControlStore, _Ledger, ExecutionSnapshot]:
+    """Compose the full launch data plane with deterministic injected dependencies."""
+    catalog, deployment = _catalog()
+    control = _ControlStore(catalog.identity_sha256())
+    ledger = _Ledger()
+    routes = CatalogRouteResolver({("revision-one", catalog.identity_sha256()): catalog})
+    authorization = control.authorize_request(
+        raw_key="preflight-not-a-caller-secret",
+        alias="public-model",
+        request=GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="readiness"),),
+        ),
+        deadline_monotonic=time.monotonic() + 30,
+    )
+    proof = ExecutionSnapshot(
+        authorization=authorization,
+        exact_model_id=deployment.exact_model_id,
+        pool_id="pool-one",
+        deployment_ids=(deployment.deployment_id,),
+    )
+
+    async def readiness_probe() -> ExecutionSnapshot:
+        """Return credential-free proof of one granted frozen route."""
+        return proof
+
+    async def flush() -> None:
+        """Run the optional test terminal-flush callback."""
+        if terminal_flusher is not None:
+            terminal_flusher()
+
+    service = GatewayService(
+        control_store=control,
+        ledger=ledger,
+        routes=routes,
+        executor=GatewayExecutor(
+            {
+                ("revision-one", catalog.identity_sha256()): cast(
+                    RuntimeModelCatalog, _RuntimeCatalog(provider)
+                )
+            },
+            ledger,
+        ),
+        clock=_Clock(),
+        readiness_probe=readiness_probe,
+        terminal_flusher=flush,
+    )
+    control.raw_keys_seen.clear()
+    return service, control, ledger, proof
+
+
+def test_direct_request_routes_streams_and_accounts_before_public_completion() -> None:
+    """A public non-stream request executes through true streaming with durable accounting."""
+
+    async def scenario() -> None:
+        """Exercise one completed request on a dedicated event loop."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(
+                        kind=GatewayEventKind.COMPLETED,
+                        sequence_number=1,
+                        usage=GatewayUsage(input_tokens=3, output_tokens=1),
+                    ),
+                )
+            )
+        )
+        service, control, ledger, proof = _service(provider)
+
+        assert await service.preflight() == proof
+        response = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            ),
+        )
+        body = json.loads(cast(bytes, response.body))
+
+        assert response.status_code == 200
+        assert body["choices"][0]["message"]["content"] == "hello"
+        assert body["usage"]["total_tokens"] == 4
+        assert provider.idempotency_keys == ["request-one"]
+        assert control.raw_keys_seen == ["caller-secret"]
+        assert ledger.routes == [("direct", None)]
+        assert ledger.finished[0][0] is not None
+        assert ledger.finished[0][0].kind is GatewayEventKind.COMPLETED
+
+    asyncio.run(scenario())
+
+
+def test_project_route_uses_selection_only_and_preserves_fallback_context() -> None:
+    """Project targets resolve to one singleton deployment through the selection-only seam."""
+
+    async def scenario() -> None:
+        """Resolve one learned route on a dedicated event loop."""
+        catalog, _ = _catalog()
+        project = _ProjectResolver()
+        routes = CatalogRouteResolver(
+            {("revision-one", catalog.identity_sha256()): catalog},
+            project_resolver=project,
+        )
+        request = GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(GatewayMessage(role="user", content="route"),),
+        )
+        authorization = AuthorizationSnapshot(
+            request_id="request-project",
+            organization_id="organization-one",
+            identity_id="identity-one",
+            virtual_key_id="key-one",
+            alias="project-model",
+            alias_revision_id="revision-one",
+            target=ProjectTarget(
+                project_ref="project-one",
+                activation_ref="activation-one",
+                catalog_sha256=catalog.identity_sha256(),
+            ),
+            surface=request.surface,
+            catalog_sha256=catalog.identity_sha256(),
+            canonical_request_sha256=_DIGEST,
+            deadline_monotonic=time.monotonic() + 30,
+        )
+        episode = ("organization-one", "identity-one", "revision-one", "episode-one")
+
+        route = await routes.resolve(
+            authorization=authorization,
+            request=request,
+            episode_namespace=episode,
+        )
+
+        assert route.deployment.deployment_id == "deployment-one"
+        assert route.route_reason == "learned_router"
+        assert route.fallback_reason == "embedding_error"
+        assert project.episodes == [episode]
+
+    asyncio.run(scenario())
+
+
+def test_project_route_rejects_ambiguous_matching_deployments() -> None:
+    """Learned selection cannot silently choose catalog order among matching deployments."""
+
+    async def scenario() -> None:
+        """Resolve one intentionally ambiguous project catalog."""
+        catalog, first = _catalog()
+        second = first.model_copy(
+            update={
+                "deployment_id": "deployment-two",
+                "connection": "connection-two",
+                "connection_sha256": "d" * 64,
+            }
+        )
+        ambiguous = NormalizedGatewayCatalog(
+            deployments=(first, second),
+            pools=(
+                *catalog.pools,
+                ExactModelPool(
+                    pool_id="pool-two",
+                    exact_model_id="exact-one",
+                    deployment_ids=("deployment-two",),
+                ),
+            ),
+        )
+        project = _ProjectResolver()
+        routes = CatalogRouteResolver(
+            {("revision-one", ambiguous.identity_sha256()): ambiguous},
+            project_resolver=project,
+        )
+        request = GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(GatewayMessage(role="user", content="route"),),
+        )
+        authorization = AuthorizationSnapshot(
+            request_id="request-project",
+            organization_id="organization-one",
+            identity_id="identity-one",
+            virtual_key_id="key-one",
+            alias="project-model",
+            alias_revision_id="revision-one",
+            target=ProjectTarget(
+                project_ref="project-one",
+                activation_ref="activation-one",
+                catalog_sha256=ambiguous.identity_sha256(),
+            ),
+            surface=request.surface,
+            catalog_sha256=ambiguous.identity_sha256(),
+            canonical_request_sha256=_DIGEST,
+            deadline_monotonic=time.monotonic() + 30,
+        )
+
+        with pytest.raises(GatewayRoutingError, match="unambiguous frozen deployment"):
+            await routes.resolve(
+                authorization=authorization,
+                request=request,
+                episode_namespace=("org", "identity", "revision", "episode"),
+            )
+
+    asyncio.run(scenario())
+
+
+def test_executor_rejects_runtime_client_drift_before_attempt_or_network() -> None:
+    """Revision-scoped execution verifies the frozen provider client before dispatch."""
+
+    async def scenario() -> None:
+        """Attempt execution with a runtime model that differs from frozen deployment identity."""
+        catalog, deployment = _catalog()
+        provider = _Provider(
+            lambda: _EventStream(
+                (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=0),)
+            )
+        )
+        ledger = _Ledger()
+        authorization = _ControlStore(catalog.identity_sha256()).authorize_request(
+            raw_key="caller-secret",
+            alias="public-model",
+            request=GatewayRequest(
+                surface=GatewayApiSurface.CHAT_COMPLETIONS,
+                messages=(GatewayMessage(role="user", content="drift"),),
+            ),
+            deadline_monotonic=time.monotonic() + 30,
+        )
+        route = GatewayRoute(
+            snapshot=ExecutionSnapshot(
+                authorization=authorization,
+                exact_model_id="exact-one",
+                pool_id="pool-one",
+                deployment_ids=("deployment-one",),
+            ),
+            deployment=deployment.model_copy(update={"provider_model": "different-model"}),
+            route_reason="direct",
+        )
+        executor = GatewayExecutor(
+            {
+                ("revision-one", catalog.identity_sha256()): cast(
+                    RuntimeModelCatalog, _RuntimeCatalog(provider)
+                )
+            },
+            ledger,
+        )
+
+        with pytest.raises(GatewayExecutionError, match="provider execution failed"):
+            await executor.start(
+                route=route,
+                request=GatewayRequest(
+                    surface=GatewayApiSurface.CHAT_COMPLETIONS,
+                    messages=(GatewayMessage(role="user", content="drift"),),
+                ),
+            )
+
+        assert ledger.started == []
+        assert provider.streams == []
+
+    asyncio.run(scenario())
+
+
+def test_lifecycle_stops_admission_cancels_upstream_and_flushes_terminals() -> None:
+    """Bounded drain cancels stragglers, settles attempts, flushes, and rejects new work."""
+
+    async def scenario() -> None:
+        """Drain one blocked stream on a dedicated event loop."""
+        blocking = _BlockingStream()
+        provider = _Provider(lambda: blocking)
+        flushes: list[bool] = []
+        service, _control, ledger, _proof = _service(
+            provider,
+            terminal_flusher=lambda: flushes.append(True),
+        )
+        response = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hold"}],
+                    "stream": True,
+                }
+            ),
+        )
+        assert isinstance(response, StreamingResponse)
+
+        async def consume() -> None:
+            """Consume the public stream until lifecycle cancellation ends it."""
+            async for _frame in cast(AsyncIterator[bytes], response.body_iterator):
+                pass
+
+        consumer = asyncio.create_task(consume())
+        await blocking.entered.wait()
+
+        assert await service.drain(timeout_seconds=0.01) is False
+        await consumer
+        assert blocking.cancelled
+        assert flushes == [True]
+        assert ledger.finished[0][1] is not None
+        assert ledger.finished[0][1].failure_class.value == "cancelled"
+        with pytest.raises(GatewayDrainingError):
+            await service.complete(
+                raw_key="caller-secret",
+                decoded=decode_chat(
+                    {
+                        "model": "public-model",
+                        "messages": [{"role": "user", "content": "late"}],
+                    }
+                ),
+            )
+
+    asyncio.run(scenario())
+
+
+def test_terminal_ledger_failure_releases_admission_and_latches_readiness() -> None:
+    """Lost accounting fails readiness without leaking the sole provider permit."""
+
+    async def scenario() -> None:
+        """Fail one terminal write, then prove a second request can execute."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=0),)
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+        service._executor._permits = asyncio.Semaphore(1)  # noqa: SLF001 - admission regression
+        ledger.fail_finishes = True
+        decoded = decode_chat(
+            {
+                "model": "public-model",
+                "messages": [{"role": "user", "content": "account"}],
+            }
+        )
+
+        with pytest.raises(RuntimeError, match="terminal ledger unavailable"):
+            await service.complete(raw_key="caller-secret", decoded=decoded)
+        with pytest.raises(GatewayExecutionError, match="accounting is unhealthy"):
+            await service.preflight()
+
+        ledger.fail_finishes = False
+        response = await asyncio.wait_for(
+            service.complete(raw_key="caller-secret", decoded=decoded),
+            timeout=0.5,
+        )
+        assert response.status_code == 200
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_abort_and_cancel_have_one_terminal_owner() -> None:
+    """Disconnect and drain races write, cancel, and release exactly once."""
+
+    async def scenario() -> None:
+        """Race two settlement reasons against one active provider stream."""
+        ledger = _Ledger()
+        upstream = _BlockingStream()
+        releases: list[bool] = []
+        stream = GatewayExecutionStream(
+            upstream,
+            ledger=ledger,
+            attempt_id="attempt-one",
+            release=lambda: releases.append(True),
+            accounting_failure=lambda: None,
+        )
+        failure = GatewayFailure(
+            failure_class=GatewayFailureClass.INTERNAL,
+            safe_message="internal stream failure",
+        )
+
+        await asyncio.gather(stream.cancel(), stream.abort(failure))
+
+        assert upstream.cancelled
+        assert len(ledger.finished) == 1
+        assert releases == [True]
+
+    asyncio.run(scenario())
+
+
+def test_hung_provider_cancel_cannot_skip_bounded_drain_flush() -> None:
+    """Cancellation-suppressing cleanup cannot prevent drain from reaching its flusher."""
+
+    async def scenario() -> None:
+        """Release hung cleanup only after bounded drain has returned."""
+        upstream = _HungCancelStream()
+        provider = _Provider(lambda: upstream)
+        flushes: list[bool] = []
+        service, _control, ledger, _proof = _service(
+            provider,
+            terminal_flusher=lambda: flushes.append(True),
+        )
+        response = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hold"}],
+                    "stream": True,
+                }
+            ),
+        )
+        assert isinstance(response, StreamingResponse)
+
+        async def consume() -> None:
+            """Keep the public stream active through lifecycle drain."""
+            async for _frame in cast(AsyncIterator[bytes], response.body_iterator):
+                pass
+
+        consumer = asyncio.create_task(consume())
+        await upstream.entered.wait()
+        started = time.monotonic()
+        assert await service.drain(timeout_seconds=0.01) is False
+        assert time.monotonic() - started < 4.0
+        assert flushes == [True]
+        assert len(ledger.finished) == 1
+        assert ledger.finished[0][1] is not None
+        assert ledger.finished[0][1].failure_class is GatewayFailureClass.CANCELLED
+        assert service._executor._permits._value == 64  # noqa: SLF001 - permit regression
+        service._executor.require_healthy()  # noqa: SLF001 - cancellation is not ledger loss
+        upstream.released.set()
+        result = (await asyncio.wait_for(asyncio.gather(consumer, return_exceptions=True), 1.0))[0]
+        assert isinstance(result, asyncio.CancelledError)
+
+    asyncio.run(scenario())
+
+
+def test_http_boundary_authenticates_before_json_decode_and_returns_openai_400() -> None:
+    """Malformed bodies never outrank Bearer authentication and use a public 400 envelope."""
+
+    async def scenario() -> None:
+        """Exercise malformed JSON through the black-box ASGI application."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=0),)
+            )
+        )
+        service, control, _ledger, _proof = _service(provider)
+        transport = httpx.ASGITransport(app=create_gateway_app(service))
+        async with httpx.AsyncClient(transport=transport, base_url="http://gateway") as client:
+            unauthenticated = await client.post(
+                "/v1/chat/completions",
+                content="{",
+                headers={"content-type": "application/json"},
+            )
+            malformed = await client.post(
+                "/v1/chat/completions",
+                content="{",
+                headers={
+                    "authorization": "Bearer caller-secret",
+                    "content-type": "application/json",
+                },
+            )
+
+        assert unauthenticated.status_code == 401
+        assert malformed.status_code == 400
+        assert malformed.json()["error"]["code"] == "invalid_json"
+        assert control.raw_keys_seen == ["caller-secret"]
+
+    asyncio.run(scenario())

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from datetime import UTC, datetime
 from typing import cast
 
@@ -1031,5 +1031,47 @@ def test_keyed_stream_capture_overflow_never_exposes_success_before_redispatch(
             assert captured.value.detail.code == "idempotency_replay_unavailable"
             assert b"response.completed" not in emitted
             assert len(provider.streams) == expected_dispatches
+
+    asyncio.run(scenario())
+
+
+def test_cancelling_terminal_delivery_preserves_completed_keyed_replay() -> None:
+    """Closing after visible stream success cannot erase the completed replay."""
+
+    async def scenario() -> None:
+        """Close terminal delivery, then replay without a second provider dispatch."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        service, _control, _ledger, _proof = _service(provider)
+        decoded = decode_responses(
+            {"model": "public-model", "input": "hello", "stream": True},
+            idempotency_key="terminal-delivery-operation",
+        )
+
+        response = await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert isinstance(response, StreamingResponse)
+        iterator = cast(AsyncGenerator[bytes, None], response.body_iterator)
+        emitted = bytearray()
+        async for frame in iterator:
+            emitted.extend(frame)
+            if b"response.completed" in frame:
+                await iterator.aclose()
+                break
+
+        assert b"response.completed" in emitted
+        replay = await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert replay.status_code == 200
+        assert b"response.completed" in replay.body
+        assert len(provider.streams) == 1
 
     asyncio.run(scenario())

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -1,0 +1,340 @@
+"""Compose one authorized singleton route with provider execution and accounting."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Mapping
+from typing import cast
+
+from wmo.runtime.gateway.contracts import (
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRequest,
+    GatewayUsage,
+)
+from wmo.runtime.gateway.interfaces import AttemptLedger, ProviderStream
+from wmo.runtime.gateway.routing import GatewayRoute
+from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.models.providers import (
+    AsyncGatewayProvider,
+    RequestDeadline,
+    preflight_gateway_request,
+    require_gateway_provider,
+)
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
+from wmo.runtime.models.providers.errors import normalized_provider_failure
+
+
+class GatewayExecutionError(RuntimeError):
+    """A route failed before a normalized provider stream could be returned."""
+
+    def __init__(self, failure: GatewayFailure) -> None:
+        """Retain one sanitized failure for the public protocol boundary."""
+        super().__init__(failure.safe_message)
+        self.failure = failure
+
+
+class GatewayExecutionStream:
+    """Account one normalized provider stream through its single terminal state."""
+
+    def __init__(
+        self,
+        stream: ProviderStream,
+        *,
+        ledger: AttemptLedger,
+        attempt_id: str,
+        release: Callable[[], None],
+        accounting_failure: Callable[[], None],
+    ) -> None:
+        """Bind provider iteration to durable terminal accounting.
+
+        Args:
+            stream: Active normalized provider stream.
+            ledger: Content-free attempt ledger.
+            attempt_id: Durable attempt identity.
+            release: Callback releasing one execution admission permit.
+            accounting_failure: Callback latching terminal accounting failures.
+        """
+        self._stream = stream
+        self._iterator = stream.__aiter__()
+        self._ledger = ledger
+        self._attempt_id = attempt_id
+        self._release = release
+        self._accounting_failure = accounting_failure
+        self._latest_usage: GatewayUsage | None = None
+        self._last_sequence = -1
+        self._settled = False
+        self._settlement_lock = asyncio.Lock()
+
+    @property
+    def committed(self) -> bool:
+        """Return whether semantic provider output has committed this route."""
+        return self._stream.committed
+
+    def __aiter__(self) -> AsyncIterator[GatewayEvent]:
+        """Return this one-pass accounted event iterator."""
+        return self
+
+    async def __anext__(self) -> GatewayEvent:
+        """Return the next event after persisting terminal accounting."""
+        if self._settled:
+            raise StopAsyncIteration
+        try:
+            event = await self._iterator.__anext__()
+        except StopAsyncIteration as exc:
+            async with self._settlement_lock:
+                if self._settled:
+                    raise
+                failure = GatewayFailure(
+                    failure_class=GatewayFailureClass.MALFORMED_RESPONSE,
+                    safe_message="provider stream ended without a terminal event",
+                )
+                try:
+                    self._ledger.finish_attempt(
+                        attempt_id=self._attempt_id,
+                        terminal_event=None,
+                        failure=failure,
+                    )
+                except BaseException:
+                    self._accounting_failure()
+                    raise
+                finally:
+                    self._settle()
+                raise GatewayExecutionError(failure) from exc
+        self._last_sequence = event.sequence_number
+        if event.usage is not None:
+            self._latest_usage = event.usage
+        if event.kind in {
+            GatewayEventKind.COMPLETED,
+            GatewayEventKind.INCOMPLETE,
+            GatewayEventKind.FAILED,
+        }:
+            terminal = (
+                event
+                if self._latest_usage is None or event.usage is not None
+                else event.model_copy(update={"usage": self._latest_usage})
+            )
+            async with self._settlement_lock:
+                if self._settled:
+                    raise StopAsyncIteration
+                try:
+                    self._ledger.finish_attempt(
+                        attempt_id=self._attempt_id,
+                        terminal_event=terminal,
+                        failure=event.failure,
+                    )
+                except BaseException:
+                    self._accounting_failure()
+                    raise
+                finally:
+                    self._settle()
+                return terminal
+        if self._settled:
+            raise StopAsyncIteration
+        return event
+
+    async def cancel(self) -> None:
+        """Cancel upstream work and durably retain observed usage if available."""
+        await self.abort(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.CANCELLED,
+                safe_message="provider request was cancelled",
+            )
+        )
+
+    async def abort(self, failure: GatewayFailure) -> None:
+        """Cancel upstream work and settle it with the supplied primary failure.
+
+        Args:
+            failure: Sanitized reason the owning gateway stopped this attempt.
+        """
+        accounting_error: BaseException | None = None
+        owns_cancel = False
+        async with self._settlement_lock:
+            if self._settled:
+                return
+            owns_cancel = True
+            terminal = GatewayEvent(
+                kind=GatewayEventKind.FAILED,
+                sequence_number=self._last_sequence + 1,
+                failure=failure,
+                usage=self._latest_usage,
+            )
+            try:
+                self._ledger.finish_attempt(
+                    attempt_id=self._attempt_id,
+                    terminal_event=terminal,
+                    failure=failure,
+                )
+            except Exception as exc:  # noqa: BLE001 - latch any durable ledger failure
+                accounting_error = exc
+                self._accounting_failure()
+            finally:
+                self._settle()
+        if owns_cancel:
+            await self._stream.cancel()
+        if accounting_error is not None:
+            raise accounting_error
+
+    def _settle(self) -> None:
+        """Release execution admission exactly once."""
+        if self._settled:
+            return
+        self._settled = True
+        self._release()
+
+
+class GatewayExecutor:
+    """Open provider streams only after preflight, admission, and durable dispatch."""
+
+    def __init__(
+        self,
+        catalogs: Mapping[tuple[str, str], RuntimeModelCatalog],
+        ledger: AttemptLedger,
+        *,
+        maximum_active_requests: int = 64,
+    ) -> None:
+        """Bind runtime providers, ledger, and finite request admission.
+
+        Args:
+            catalogs: Revision and catalog digests mapped to frozen runtime catalogs.
+            ledger: Content-free request and attempt ledger.
+            maximum_active_requests: Maximum active upstream streams.
+        """
+        if maximum_active_requests < 1:
+            raise ValueError("maximum_active_requests must be at least one")
+        self._catalogs = dict(catalogs)
+        self._ledger = ledger
+        self._permits = asyncio.Semaphore(maximum_active_requests)
+        self._accounting_healthy = True
+
+    def require_healthy(self) -> None:
+        """Fail readiness after any durable terminal accounting write is lost."""
+        if not self._accounting_healthy:
+            raise GatewayExecutionError(
+                GatewayFailure(
+                    failure_class=GatewayFailureClass.INTERNAL,
+                    safe_message="gateway terminal accounting is unhealthy",
+                )
+            )
+
+    def mark_accounting_unhealthy(self) -> None:
+        """Latch an unhealthy state after a terminal accounting failure."""
+        self._accounting_healthy = False
+
+    async def start(
+        self,
+        *,
+        route: GatewayRoute,
+        request: GatewayRequest,
+    ) -> GatewayExecutionStream:
+        """Durably start one singleton provider stream under the request deadline.
+
+        Args:
+            route: Frozen exact model and deployment route.
+            request: Canonical public request.
+
+        Returns:
+            Accounted normalized provider stream.
+
+        Raises:
+            GatewayExecutionError: Preflight, admission, or provider opening fails.
+        """
+        deadline = RequestDeadline(route.snapshot.authorization.deadline_monotonic)
+        provider_request = request.model_copy(update={"stream": True, "include_usage": True})
+        try:
+            require_gateway_provider(route.deployment.provider)
+            preflight_gateway_request(
+                provider_request,
+                route.deployment.gateway.capabilities,
+            )
+            await self._acquire(deadline)
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+            raise GatewayExecutionError(normalized_provider_failure(exc)) from exc
+        attempt_id: str | None = None
+        try:
+            authorization = route.snapshot.authorization
+            catalog = self._catalogs.get(
+                (authorization.alias_revision_id, authorization.catalog_sha256)
+            )
+            if catalog is None:
+                raise ValueError("runtime catalog is not loaded for the authorized revision")
+            resolved = catalog.resolve(route.deployment.source_alias)
+            _require_deployment_identity(route, resolved)
+            stream_method = getattr(resolved.client, "stream", None)
+            if stream_method is None:
+                raise TypeError("resolved gateway deployment has no async stream capability")
+            attempt_id = self._ledger.start_attempt(
+                snapshot=route.snapshot,
+                deployment=route.deployment,
+                route_depth=0,
+            )
+            self._ledger.record_route_context(
+                attempt_id=attempt_id,
+                route_reason=route.route_reason,
+                fallback_reason=route.fallback_reason,
+            )
+            provider = cast(AsyncGatewayProvider, resolved.client)
+            stream = await provider.stream(
+                provider_request,
+                deadline=deadline,
+                idempotency_key=route.snapshot.authorization.request_id,
+            )
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                failure = GatewayFailure(
+                    failure_class=GatewayFailureClass.CANCELLED,
+                    safe_message="provider request was cancelled",
+                )
+            else:
+                failure = normalized_provider_failure(exc)
+            try:
+                if attempt_id is not None:
+                    self._ledger.finish_attempt(
+                        attempt_id=attempt_id,
+                        terminal_event=None,
+                        failure=failure,
+                    )
+            except Exception:  # noqa: BLE001 - preserve the primary provider failure
+                self.mark_accounting_unhealthy()
+            finally:
+                self._permits.release()
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+            raise GatewayExecutionError(failure) from exc
+        return GatewayExecutionStream(
+            stream,
+            ledger=self._ledger,
+            attempt_id=attempt_id,
+            release=self._permits.release,
+            accounting_failure=self.mark_accounting_unhealthy,
+        )
+
+    async def _acquire(self, deadline: RequestDeadline) -> None:
+        """Wait for execution admission within the one request-wide deadline."""
+        try:
+            async with asyncio.timeout(deadline.attempt_timeout()):
+                await self._permits.acquire()
+        except TimeoutError as exc:
+            raise ProviderDeadlineExceeded("gateway execution queue deadline exceeded") from exc
+
+
+def _require_deployment_identity(route: GatewayRoute, resolved: ResolvedModel) -> None:
+    """Fail before accounting or network work when runtime resolution drifts from authority."""
+    deployment = route.deployment
+    served_model = resolved.served_model_id or resolved.snapshot.model_id
+    if (
+        resolved.alias != deployment.source_alias
+        or resolved.snapshot.provider != deployment.provider
+        or served_model != deployment.provider_model
+        or resolved.snapshot.revision != deployment.revision
+        or resolved.snapshot.connection_sha256 != deployment.connection_sha256
+        or (
+            deployment.capabilities is not None and resolved.capabilities != deployment.capabilities
+        )
+    ):
+        raise ValueError("resolved runtime client differs from the frozen gateway deployment")

--- a/wmo/runtime/gateway/interfaces.py
+++ b/wmo/runtime/gateway/interfaces.py
@@ -23,6 +23,10 @@ from wmo.runtime.gateway.contracts import (
 class GatewayControlStore(Protocol):
     """Persistence seam for identities, grants, aliases, and immutable revisions."""
 
+    def authenticate_key(self, *, raw_key: str) -> None:
+        """Validate a virtual key before parsing a full content-bearing request."""
+        ...
+
     def authorize_request(
         self,
         *,
@@ -70,8 +74,28 @@ class AttemptLedger(Protocol):
         attempt_id: AttemptId,
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
+        finalize_request: bool = True,
     ) -> None:
-        """Idempotently settle one attempt with content-free terminal accounting."""
+        """Settle one physical attempt and optionally finalize its parent request."""
+        ...
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Terminalize accepted work that failed before a provider dispatch existed."""
+        ...
+
+    def record_route_context(
+        self,
+        *,
+        attempt_id: AttemptId,
+        route_reason: str | None,
+        fallback_reason: str | None,
+    ) -> None:
+        """Attach display-safe selection context to one dispatched attempt."""
         ...
 
 
@@ -100,7 +124,7 @@ class ProjectTargetResolver(Protocol):
         *,
         target: GatewayTarget,
         request: GatewayRequest,
-        episode_namespace: tuple[ArtifactId, ArtifactId],
+        episode_namespace: tuple[ArtifactId, ArtifactId, ArtifactId, str],
         deadline_monotonic: float,
     ) -> ProjectSelection:
         """Resolve one direct or project target to a frozen exact logical model."""

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -200,6 +200,8 @@ class SQLiteAttemptLedger:
                 raise GatewayLedgerError("attempt request was not durably accepted")
             if str(request["organization_id"]) != snapshot.authorization.organization_id:
                 raise GatewayLedgerError("attempt authority differs from accepted request")
+            if request["terminal_state"] is not None:
+                raise GatewayLedgerError("attempt request is already terminal")
             connection.execute(
                 """
                 INSERT INTO gateway_attempts (
@@ -270,6 +272,7 @@ class SQLiteAttemptLedger:
         attempt_id: AttemptId,
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
+        finalize_request: bool = True,
     ) -> None:
         """Idempotently settle one attempt with normalized content-free fields.
 
@@ -277,6 +280,7 @@ class SQLiteAttemptLedger:
             attempt_id: Stable attempt ID.
             terminal_event: Provider terminal event, possibly carrying usage.
             failure: Sanitized failure when no successful terminal event exists.
+            finalize_request: Whether this attempt is the final route for its parent request.
         """
         state, normalized_failure, usage = _terminal_values(terminal_event, failure)
         with self._transaction() as connection:
@@ -323,7 +327,7 @@ class SQLiteAttemptLedger:
                     attempt_id,
                 ),
             )
-            if state in {"completed", "failed", "cancelled", "incomplete"}:
+            if finalize_request and state in {"completed", "failed", "cancelled", "incomplete"}:
                 connection.execute(
                     """
                     UPDATE gateway_requests SET terminal_state = ?, terminal_at = ?
@@ -331,6 +335,45 @@ class SQLiteAttemptLedger:
                     """,
                     (state, utc_text(self._clock.now()), str(row["request_id"])),
                 )
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Idempotently terminalize accepted work that never reached dispatch.
+
+        Args:
+            authorization: Frozen authority identifying the accepted request.
+            failure: Sanitized pre-dispatch terminal failure.
+        """
+        state, normalized_failure, _ = _terminal_values(None, failure)
+        del normalized_failure
+        with self._transaction() as connection:
+            row = connection.execute(
+                """
+                SELECT organization_id, terminal_state FROM gateway_requests
+                WHERE request_id = ?
+                """,
+                (authorization.request_id,),
+            ).fetchone()
+            if row is None:
+                raise GatewayLedgerError("request was not durably accepted")
+            if str(row["organization_id"]) != authorization.organization_id:
+                raise GatewayLedgerError("request authority differs from accepted request")
+            current = row["terminal_state"]
+            if current is not None:
+                if str(current) == state:
+                    return
+                raise GatewayLedgerError("request is already settled with another terminal state")
+            connection.execute(
+                """
+                UPDATE gateway_requests SET terminal_state = ?, terminal_at = ?
+                WHERE request_id = ? AND terminal_state IS NULL
+                """,
+                (state, utc_text(self._clock.now()), authorization.request_id),
+            )
 
     def reconcile_crashed_requests(self, *, cleanup_grace: timedelta) -> tuple[int, int]:
         """Settle expired pre-dispatch and dispatched work after a crash.

--- a/wmo/runtime/gateway/ledger_test.py
+++ b/wmo/runtime/gateway/ledger_test.py
@@ -26,6 +26,7 @@ from wmo.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from wmo.runtime.gateway.ledger import (
+    GatewayLedgerError,
     IdempotencyConflictError,
     IdempotencyReplayUnavailableError,
     SQLiteAttemptLedger,
@@ -342,6 +343,110 @@ def test_failed_attempt_terminalizes_its_parent_request(tmp_path: Path) -> None:
         connection.close()
     assert request_state == "failed"
     assert attempt_state == "failed"
+
+
+def test_predispatch_failure_terminalizes_real_sqlite_request(tmp_path: Path) -> None:
+    """Accepted routing failures cannot remain unterminated without an attempt row."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("routing-failure"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+
+    ledger.finish_request(
+        authorization=authorization,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.INTERNAL,
+            safe_message="route activation failed",
+        ),
+    )
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        request_state = connection.execute(
+            "SELECT terminal_state FROM gateway_requests WHERE request_id = ?",
+            (authorization.request_id,),
+        ).fetchone()[0]
+        attempt_count = connection.execute(
+            "SELECT COUNT(*) FROM gateway_attempts WHERE request_id = ?",
+            (authorization.request_id,),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert request_state == "failed"
+    assert attempt_count == 0
+
+
+def test_intermediate_attempt_can_settle_without_finalizing_parent(tmp_path: Path) -> None:
+    """The physical-attempt seam leaves parent finalization to a later route owner."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("future-waterfall"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization), deployment=_deployment(), route_depth=0
+    )
+
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="retry on sibling route",
+        ),
+        finalize_request=False,
+    )
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        states = connection.execute(
+            """
+            SELECT r.terminal_state, a.state
+            FROM gateway_requests AS r
+            JOIN gateway_attempts AS a ON a.request_id = r.request_id
+            WHERE r.request_id = ?
+            """,
+            (authorization.request_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert states == (None, "failed")
+
+
+def test_terminal_parent_rejects_late_attempt_dispatch(tmp_path: Path) -> None:
+    """No retry path can dispatch after durable request terminalization."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("late-dispatch"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    ledger.finish_request(
+        authorization=authorization,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.INTERNAL,
+            safe_message="route failed before dispatch",
+        ),
+    )
+
+    with pytest.raises(GatewayLedgerError, match="already terminal"):
+        ledger.start_attempt(
+            snapshot=_execution(authorization),
+            deployment=_deployment(),
+            route_depth=0,
+        )
 
 
 def test_idempotency_is_opt_in_and_restart_replay_fails_closed(tmp_path: Path) -> None:

--- a/wmo/runtime/gateway/response.py
+++ b/wmo/runtime/gateway/response.py
@@ -16,8 +16,8 @@ from wmo.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayUsage,
 )
-from wmo.runtime.gateway.openai.errors import OpenAIProtocolError
-from wmo.runtime.gateway.openai.streaming import (
+from wmo.runtime.openai_protocol.errors import OpenAIProtocolError
+from wmo.runtime.openai_protocol.streaming import (
     ChatSseEncoder,
     ResponsesSseEncoder,
     stable_public_id,

--- a/wmo/runtime/gateway/response.py
+++ b/wmo/runtime/gateway/response.py
@@ -1,0 +1,191 @@
+"""Bounded public response assembly from normalized gateway events."""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.common.models import AssistantAction
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayUsage,
+)
+from wmo.runtime.gateway.openai.errors import OpenAIProtocolError
+from wmo.runtime.gateway.openai.streaming import (
+    ChatSseEncoder,
+    ResponsesSseEncoder,
+    stable_public_id,
+)
+
+
+def stream_encoder(
+    *,
+    request: GatewayRequest,
+    authorization: AuthorizationSnapshot,
+    created_at: float,
+) -> ChatSseEncoder | ResponsesSseEncoder:
+    """Create the surface-specific stateful SSE encoder."""
+    if request.surface == GatewayApiSurface.CHAT_COMPLETIONS:
+        return ChatSseEncoder(
+            request_id=authorization.request_id,
+            model=authorization.alias,
+            created_at=int(created_at),
+            include_usage=request.include_usage,
+        )
+    return ResponsesSseEncoder(
+        request_id=authorization.request_id,
+        model=authorization.alias,
+        created_at=created_at,
+        request=request,
+    )
+
+
+def capture_frame(
+    buffer: bytearray,
+    data: bytes,
+    replayable: bool,
+    *,
+    maximum_bytes: int,
+) -> bool:
+    """Append one frame while it remains within the replay capture ceiling."""
+    if not replayable or len(buffer) + len(data) > maximum_bytes:
+        return False
+    buffer.extend(data)
+    return True
+
+
+def is_terminal(event: GatewayEvent) -> bool:
+    """Return whether one normalized event ends provider execution."""
+    return event.kind in {
+        GatewayEventKind.COMPLETED,
+        GatewayEventKind.INCOMPLETE,
+        GatewayEventKind.FAILED,
+    }
+
+
+def completed_body(
+    *,
+    request: GatewayRequest,
+    request_id: str,
+    model: str,
+    created_at: float,
+    events: tuple[GatewayEvent, ...],
+) -> JsonObject:
+    """Build one non-streaming public result from bounded normalized events."""
+    if request.surface == GatewayApiSurface.RESPONSES:
+        encoder = ResponsesSseEncoder(
+            request_id=request_id,
+            model=model,
+            created_at=created_at,
+            request=request,
+        )
+        encoder.start()
+        frames: tuple[str, ...] = ()
+        for event in events:
+            produced = encoder.feed(event)
+            if is_terminal(event):
+                frames = produced
+        if not frames:
+            raise OpenAIProtocolError(
+                status_code=502,
+                code="all_routes_failed",
+                message="Responses encoding produced no terminal result.",
+                error_type="api_error",
+            )
+        payload = json.loads(frames[-1].partition("data: ")[2])
+        return cast(JsonObject, payload["response"])
+    terminal = next(event for event in reversed(events) if is_terminal(event))
+    text = "".join(
+        event.text_delta or "" for event in events if event.kind == GatewayEventKind.TEXT_DELTA
+    )
+    refusal = "".join(
+        event.text_delta or "" for event in events if event.kind == GatewayEventKind.REFUSAL_DELTA
+    )
+    tool_calls = tuple(
+        event.tool_call
+        for event in events
+        if event.kind == GatewayEventKind.TOOL_CALL_COMPLETED and event.tool_call is not None
+    )
+    message: JsonObject = {
+        "role": "assistant",
+        "content": text or None,
+        "refusal": refusal or None,
+        "tool_calls": [
+            {
+                "id": tool.call_id,
+                "type": "function",
+                "function": {"name": tool.name, "arguments": tool.arguments_json()},
+            }
+            for tool in tool_calls
+        ]
+        or None,
+    }
+    usage = next((event.usage for event in reversed(events) if event.usage is not None), None)
+    return {
+        "id": stable_public_id("chatcmpl", request_id),
+        "object": "chat.completion",
+        "created": int(created_at),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": (
+                    "length"
+                    if terminal.kind == GatewayEventKind.INCOMPLETE
+                    else "tool_calls"
+                    if tool_calls
+                    else "stop"
+                ),
+                "logprobs": None,
+            }
+        ],
+        "usage": chat_usage(usage),
+    }
+
+
+def chat_usage(usage: GatewayUsage | None) -> JsonObject | None:
+    """Encode normalized usage in the Chat completion shape."""
+    if usage is None:
+        return None
+    details: JsonObject = {}
+    if usage.cached_input_tokens is not None:
+        details["cached_tokens"] = usage.cached_input_tokens
+    output_details: JsonObject = {}
+    if usage.reasoning_tokens is not None:
+        output_details["reasoning_tokens"] = usage.reasoning_tokens
+    return {
+        "prompt_tokens": usage.input_tokens,
+        "completion_tokens": usage.output_tokens,
+        "total_tokens": usage.input_tokens + usage.output_tokens,
+        "prompt_tokens_details": details or None,
+        "completion_tokens_details": output_details or None,
+    }
+
+
+def assistant_message(events: tuple[GatewayEvent, ...]) -> GatewayMessage | None:
+    """Build continuation history without converting typed refusals into assistant text."""
+    if any(event.kind == GatewayEventKind.REFUSAL_DELTA for event in events):
+        return None
+    text = "".join(
+        event.text_delta or "" for event in events if event.kind == GatewayEventKind.TEXT_DELTA
+    )
+    tool_calls = tuple(
+        event.tool_call
+        for event in events
+        if event.kind == GatewayEventKind.TOOL_CALL_COMPLETED and event.tool_call is not None
+    )
+    if not text and not tool_calls:
+        return None
+    action = AssistantAction(content=text or None, tool_calls=tool_calls)
+    return GatewayMessage(
+        role="assistant",
+        content=action.content,
+        tool_calls=action.tool_calls,
+    )

--- a/wmo/runtime/gateway/routing.py
+++ b/wmo/runtime/gateway/routing.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from wmo.common.core.artifacts import ContractModel
+from wmo.common.core.artifacts import ArtifactId, ContractModel, stable_id
 from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolChoice
 from wmo.common.models.gateway_catalog import (
     ExactModelDeployment,
@@ -256,7 +256,7 @@ class RouterProjectTargetResolver:
         deadline = RequestDeadline(deadline_monotonic)
         await self._acquire(deadline)
         model_request = gateway_model_request(request)
-        episode_id = "\x1f".join(episode_namespace)
+        episode_id = project_episode_identity(episode_namespace)
         task = asyncio.create_task(
             asyncio.to_thread(
                 runtime._select_unretained,
@@ -351,4 +351,27 @@ def gateway_model_request(request: GatewayRequest) -> ModelRequest:
         tool_choice=choice,
         temperature=request.temperature,
         maximum_output_tokens=request.maximum_output_tokens,
+    )
+
+
+def project_episode_identity(
+    namespace: tuple[ArtifactId, ArtifactId, ArtifactId, str],
+) -> str:
+    """Encode tenant-scoped episode components without delimiter collisions.
+
+    Args:
+        namespace: Organization, identity, alias revision, and caller episode key.
+
+    Returns:
+        Stable content-addressed identity with explicit component boundaries.
+    """
+    organization_id, identity_id, alias_revision_id, episode_key = namespace
+    return stable_id(
+        "gateway-project-episode",
+        {
+            "organization_id": organization_id,
+            "identity_id": identity_id,
+            "alias_revision_id": alias_revision_id,
+            "episode_key": episode_key,
+        },
     )

--- a/wmo/runtime/gateway/routing.py
+++ b/wmo/runtime/gateway/routing.py
@@ -1,0 +1,354 @@
+"""Resolve authorized direct and project targets without executing provider work."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from wmo.common.core.artifacts import ContractModel
+from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolChoice
+from wmo.common.models.gateway_catalog import (
+    ExactModelDeployment,
+    ExactModelPool,
+    NormalizedGatewayCatalog,
+)
+from wmo.common.tasks import ToolSchema
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayNamedToolChoice,
+    GatewayRequest,
+    ProjectSelection,
+    ProjectTarget,
+)
+from wmo.runtime.gateway.interfaces import ProjectTargetResolver
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded, RequestDeadline
+from wmo.runtime.router.runtime import RouterRuntime
+
+
+class GatewayRoutingError(ValueError):
+    """An authorized target cannot resolve inside its frozen catalog snapshot."""
+
+
+class GatewayRoute(ContractModel):
+    """One immutable singleton route ready for provider execution."""
+
+    snapshot: ExecutionSnapshot
+    deployment: ExactModelDeployment
+    route_reason: str
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _CatalogView:
+    """One revision-scoped catalog plus its indexed pools and deployments."""
+
+    catalog: NormalizedGatewayCatalog
+    pools: Mapping[str, ExactModelPool]
+    deployments: Mapping[str, ExactModelDeployment]
+
+
+class CatalogRouteResolver:
+    """Resolve direct pools or injected project selections against one exact catalog."""
+
+    def __init__(
+        self,
+        catalogs: Mapping[tuple[str, str], NormalizedGatewayCatalog],
+        *,
+        project_resolver: ProjectTargetResolver | None = None,
+    ) -> None:
+        """Index one immutable catalog and optional learned-selection seam.
+
+        Args:
+            catalogs: Alias-revision and digest pairs mapped to normalized snapshots.
+            project_resolver: Optional resolver for project-backed targets.
+        """
+        self._project_resolver = project_resolver
+        self._catalogs: dict[tuple[str, str], _CatalogView] = {}
+        for key, catalog in catalogs.items():
+            revision_id, catalog_sha256 = key
+            if catalog.identity_sha256() != catalog_sha256:
+                raise ValueError(f"catalog for alias revision {revision_id!r} has the wrong digest")
+            self._catalogs[key] = _CatalogView(
+                catalog=catalog,
+                pools={pool.pool_id: pool for pool in catalog.pools},
+                deployments={
+                    deployment.deployment_id: deployment for deployment in catalog.deployments
+                },
+            )
+
+    async def resolve(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        request: GatewayRequest,
+        episode_namespace: tuple[str, str, str, str],
+    ) -> GatewayRoute:
+        """Resolve authorized authority into one singleton provider deployment.
+
+        Args:
+            authorization: Frozen authenticated alias revision and target.
+            request: Canonical request visible to learned selection.
+            episode_namespace: Tenant-isolated sticky selection identity.
+
+        Returns:
+            Frozen exact model, pool, and one launch deployment.
+
+        Raises:
+            GatewayRoutingError: Catalog identity or target resolution is invalid.
+        """
+        view = self._catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
+        if view is None:
+            raise GatewayRoutingError("authorized catalog snapshot is not active for this revision")
+        target = authorization.target
+        if isinstance(target, DirectTarget):
+            pool = self._pool(view, target.pool_id)
+            return self._route(
+                view=view,
+                authorization=authorization,
+                pool=pool,
+                route_reason="direct",
+                fallback_reason=None,
+            )
+        if target.catalog_sha256 != authorization.catalog_sha256:
+            raise GatewayRoutingError("project target catalog differs from authorized authority")
+        selection = await self._select_project(
+            target=target,
+            request=request,
+            episode_namespace=episode_namespace,
+            deadline_monotonic=authorization.deadline_monotonic,
+        )
+        deployments = tuple(
+            item
+            for item in view.catalog.deployments
+            if item.source_alias == selection.selected_alias
+            and item.exact_model_id == selection.exact_model_id
+        )
+        if len(deployments) != 1:
+            raise GatewayRoutingError(
+                "project selection requires one unambiguous frozen deployment"
+            )
+        deployment = deployments[0]
+        pools = tuple(
+            item
+            for item in view.catalog.pools
+            if item.exact_model_id == selection.exact_model_id
+            and item.deployment_ids == (deployment.deployment_id,)
+        )
+        if len(pools) != 1:
+            raise GatewayRoutingError(
+                "project selection requires one unambiguous singleton exact-model pool"
+            )
+        pool = pools[0]
+        return self._route(
+            view=view,
+            authorization=authorization,
+            pool=pool,
+            route_reason="learned_router",
+            fallback_reason=selection.fallback_reason,
+        )
+
+    async def _select_project(
+        self,
+        *,
+        target: ProjectTarget,
+        request: GatewayRequest,
+        episode_namespace: tuple[str, str, str, str],
+        deadline_monotonic: float,
+    ) -> ProjectSelection:
+        """Call the injected selection-only project bridge."""
+        if self._project_resolver is None:
+            raise GatewayRoutingError("project target is not activated in this process")
+        try:
+            return await self._project_resolver.select(
+                target=target,
+                request=request,
+                episode_namespace=episode_namespace,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except (GatewayRoutingError, ProviderDeadlineExceeded):
+            raise
+        except Exception as exc:
+            raise GatewayRoutingError("project selection failed") from exc
+
+    def _pool(self, view: _CatalogView, pool_id: str) -> ExactModelPool:
+        """Return one named frozen pool or fail closed."""
+        pool = view.pools.get(pool_id)
+        if pool is None:
+            raise GatewayRoutingError("authorized direct pool is absent from the frozen catalog")
+        return pool
+
+    def _route(
+        self,
+        *,
+        view: _CatalogView,
+        authorization: AuthorizationSnapshot,
+        pool: ExactModelPool,
+        route_reason: str,
+        fallback_reason: str | None,
+    ) -> GatewayRoute:
+        """Build the launch singleton execution route."""
+        if len(pool.deployment_ids) != 1:
+            raise GatewayRoutingError("multi-deployment pools require the post-launch waterfall")
+        deployment = view.deployments.get(pool.deployment_ids[0])
+        if deployment is None or deployment.exact_model_id != pool.exact_model_id:
+            raise GatewayRoutingError("frozen pool deployment identity is invalid")
+        return GatewayRoute(
+            snapshot=ExecutionSnapshot(
+                authorization=authorization,
+                exact_model_id=pool.exact_model_id,
+                pool_id=pool.pool_id,
+                deployment_ids=pool.deployment_ids,
+            ),
+            deployment=deployment,
+            route_reason=route_reason,
+            fallback_reason=fallback_reason,
+        )
+
+
+class RouterProjectTargetResolver:
+    """Run synchronous ``RouterRuntime.select`` in a bounded selection worker lane."""
+
+    def __init__(
+        self,
+        activations: Mapping[tuple[str, str], RouterRuntime],
+        exact_models_by_alias: Mapping[tuple[str, str, str, str], str],
+        *,
+        maximum_outstanding_selections: int = 4,
+    ) -> None:
+        """Bind frozen activations and an exact-model projection.
+
+        Args:
+            activations: Project and activation references mapped to verified runtimes.
+            exact_models_by_alias: Project, activation, catalog, and candidate alias mappings.
+            maximum_outstanding_selections: Running plus detached selection calls allowed.
+        """
+        if maximum_outstanding_selections < 1:
+            raise ValueError("maximum_outstanding_selections must be at least one")
+        self._activations = dict(activations)
+        self._exact_models_by_alias = dict(exact_models_by_alias)
+        self._permits = asyncio.Semaphore(maximum_outstanding_selections)
+
+    async def select(
+        self,
+        *,
+        target: ProjectTarget,
+        request: GatewayRequest,
+        episode_namespace: tuple[str, str, str, str],
+        deadline_monotonic: float,
+    ) -> ProjectSelection:
+        """Select one logical model without invoking ``RouterRuntime.complete``.
+
+        Args:
+            target: Frozen project activation target.
+            request: Canonical gateway request converted only for learned selection.
+            episode_namespace: Tenant-isolated sticky episode identity.
+            deadline_monotonic: Absolute request-wide deadline.
+
+        Returns:
+            Exact logical model and content-free learned selection details.
+        """
+        runtime = self._activations.get((target.project_ref, target.activation_ref))
+        if runtime is None:
+            raise GatewayRoutingError("project activation is not loaded")
+        deadline = RequestDeadline(deadline_monotonic)
+        await self._acquire(deadline)
+        model_request = gateway_model_request(request)
+        episode_id = "\x1f".join(episode_namespace)
+        task = asyncio.create_task(
+            asyncio.to_thread(
+                runtime._select_unretained,
+                model_request,
+                episode_id=episode_id,
+            )
+        )
+        task.add_done_callback(self._release_permit)
+        try:
+            async with asyncio.timeout(deadline.attempt_timeout()):
+                prepared = await asyncio.shield(task)
+        except TimeoutError as exc:
+            raise ProviderDeadlineExceeded("router selection deadline exceeded") from exc
+        deadline.attempt_timeout()
+        decision = runtime._retain_prepared_selection(
+            model_request,
+            episode_id=episode_id,
+            prepared=prepared,
+        )
+        exact_model_id = self._exact_models_by_alias.get(
+            (
+                target.project_ref,
+                target.activation_ref,
+                target.catalog_sha256,
+                decision.selected_alias,
+            )
+        )
+        if exact_model_id is None:
+            raise GatewayRoutingError("router selected alias has no frozen exact-model identity")
+        return ProjectSelection(
+            exact_model_id=exact_model_id,
+            selected_alias=decision.selected_alias,
+            activation_ref=target.activation_ref,
+            fallback_reason=decision.fallback_reason,
+        )
+
+    async def _acquire(self, deadline: RequestDeadline) -> None:
+        """Wait for one selection permit inside the request-wide deadline."""
+        try:
+            async with asyncio.timeout(deadline.attempt_timeout()):
+                await self._permits.acquire()
+        except TimeoutError as exc:
+            raise ProviderDeadlineExceeded("router selection queue deadline exceeded") from exc
+
+    def _release_permit(self, task: asyncio.Task[object]) -> None:
+        """Release bounded capacity only after the synchronous selection stops."""
+        del task
+        self._permits.release()
+
+
+def gateway_model_request(request: GatewayRequest) -> ModelRequest:
+    """Project canonical gateway content into the existing learned-selector contract.
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        Existing request shape consumed by ``RouterRuntime.select`` only.
+    """
+    messages: list[ModelMessage] = []
+    for message in request.messages:
+        role = "system" if message.role == "developer" else message.role
+        action = (
+            AssistantAction(content=message.content, tool_calls=message.tool_calls)
+            if message.role == "assistant"
+            else None
+        )
+        messages.append(
+            ModelMessage(
+                role=role,
+                content=message.content,
+                tool_call_id=message.tool_call_id,
+                assistant_action=action,
+            )
+        )
+    tools = tuple(
+        ToolSchema(
+            name=tool.name,
+            description=tool.description or tool.name,
+            input_schema=tool.parameters,
+        )
+        for tool in request.tools
+    )
+    choice = (
+        ToolChoice(name=request.tool_choice.name)
+        if isinstance(request.tool_choice, GatewayNamedToolChoice)
+        else request.tool_choice
+    )
+    return ModelRequest(
+        messages=tuple(messages),
+        tools=tools,
+        tool_choice=choice,
+        temperature=request.temperature,
+        maximum_output_tokens=request.maximum_output_tokens,
+    )

--- a/wmo/runtime/gateway/routing.py
+++ b/wmo/runtime/gateway/routing.py
@@ -252,28 +252,34 @@ class RouterProjectTargetResolver:
         if runtime is None:
             raise GatewayRoutingError("project activation is not loaded")
         deadline = RequestDeadline(deadline_monotonic)
-        await self._acquire(deadline)
+        deadline.attempt_timeout()
         model_request = gateway_model_request(request)
         episode_id = project_episode_identity(episode_namespace)
-        task = asyncio.create_task(
-            asyncio.to_thread(
-                runtime._select_unretained,
-                model_request,
-                episode_id=episode_id,
-            )
-        )
-        task.add_done_callback(self._release_permit)
-        try:
-            async with asyncio.timeout(deadline.attempt_timeout()):
-                prepared = await asyncio.shield(task)
-        except TimeoutError as exc:
-            raise ProviderDeadlineExceeded("router selection deadline exceeded") from exc
-        deadline.attempt_timeout()
-        decision = runtime._retain_prepared_selection(
+        decision = runtime._reuse_sticky_selection(  # noqa: SLF001 - selection-only bridge.
             model_request,
             episode_id=episode_id,
-            prepared=prepared,
         )
+        if decision is None:
+            await self._acquire(deadline)
+            task = asyncio.create_task(
+                asyncio.to_thread(
+                    runtime._select_unretained,
+                    model_request,
+                    episode_id=episode_id,
+                )
+            )
+            task.add_done_callback(self._release_permit)
+            try:
+                async with asyncio.timeout(deadline.attempt_timeout()):
+                    prepared = await asyncio.shield(task)
+            except TimeoutError as exc:
+                raise ProviderDeadlineExceeded("router selection deadline exceeded") from exc
+            deadline.attempt_timeout()
+            decision = runtime._retain_prepared_selection(
+                model_request,
+                episode_id=episode_id,
+                prepared=prepared,
+            )
         exact_model_id = self._exact_models_by_alias.get(
             (
                 target.project_ref,

--- a/wmo/runtime/gateway/routing.py
+++ b/wmo/runtime/gateway/routing.py
@@ -7,24 +7,22 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 from wmo.common.core.artifacts import ArtifactId, ContractModel, stable_id
-from wmo.common.models import AssistantAction, ModelMessage, ModelRequest, ToolChoice
 from wmo.common.models.gateway_catalog import (
     ExactModelDeployment,
     ExactModelPool,
     NormalizedGatewayCatalog,
 )
-from wmo.common.tasks import ToolSchema
 from wmo.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
     ExecutionSnapshot,
-    GatewayNamedToolChoice,
     GatewayRequest,
     ProjectSelection,
     ProjectTarget,
 )
 from wmo.runtime.gateway.interfaces import ProjectTargetResolver
 from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded, RequestDeadline
+from wmo.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
 from wmo.runtime.router.runtime import RouterRuntime
 
 
@@ -305,53 +303,6 @@ class RouterProjectTargetResolver:
         """Release bounded capacity only after the synchronous selection stops."""
         del task
         self._permits.release()
-
-
-def gateway_model_request(request: GatewayRequest) -> ModelRequest:
-    """Project canonical gateway content into the existing learned-selector contract.
-
-    Args:
-        request: Canonical gateway request.
-
-    Returns:
-        Existing request shape consumed by ``RouterRuntime.select`` only.
-    """
-    messages: list[ModelMessage] = []
-    for message in request.messages:
-        role = "system" if message.role == "developer" else message.role
-        action = (
-            AssistantAction(content=message.content, tool_calls=message.tool_calls)
-            if message.role == "assistant"
-            else None
-        )
-        messages.append(
-            ModelMessage(
-                role=role,
-                content=message.content,
-                tool_call_id=message.tool_call_id,
-                assistant_action=action,
-            )
-        )
-    tools = tuple(
-        ToolSchema(
-            name=tool.name,
-            description=tool.description or tool.name,
-            input_schema=tool.parameters,
-        )
-        for tool in request.tools
-    )
-    choice = (
-        ToolChoice(name=request.tool_choice.name)
-        if isinstance(request.tool_choice, GatewayNamedToolChoice)
-        else request.tool_choice
-    )
-    return ModelRequest(
-        messages=tuple(messages),
-        tools=tools,
-        tool_choice=choice,
-        temperature=request.temperature,
-        maximum_output_tokens=request.maximum_output_tokens,
-    )
 
 
 def project_episode_identity(

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -424,6 +424,7 @@ class GatewayService:
         )
         capture = bytearray()
         replayable = True
+        replay_completed = False
         retainable = True
         terminal = False
         terminal_frames: list[bytes] = []
@@ -482,6 +483,7 @@ class GatewayService:
                             body=bytes(capture),
                         )
                     )
+                    replay_completed = True
                 else:
                     await lease.abandon()
                     if terminal:
@@ -496,7 +498,7 @@ class GatewayService:
         except BaseException as exc:
             if not terminal:
                 await _settle_stream_quietly(stream, exc)
-            if lease is not None:
+            if lease is not None and not replay_completed:
                 await _abandon_quietly(lease)
             raise
         finally:

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -394,7 +394,6 @@ class GatewayService:
             request.model_copy(
                 update={
                     "messages": (*continuation.messages, *request.messages),
-                    "previous_response_id": None,
                 }
             ),
             (

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -33,13 +33,6 @@ from wmo.runtime.gateway.execution import (
 )
 from wmo.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayControlStore
 from wmo.runtime.gateway.ledger import IdempotencyConflictError, IdempotencyReplayUnavailableError
-from wmo.runtime.gateway.response import (
-    assistant_message,
-    capture_frame,
-    completed_body,
-    is_terminal,
-    stream_encoder,
-)
 from wmo.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
 from wmo.runtime.gateway.sqlite.store import (
     AliasNotGrantedError,
@@ -57,6 +50,13 @@ from wmo.runtime.openai_protocol.requests import (
     DecodedGatewayRequest,
     decode_chat,
     decode_responses,
+)
+from wmo.runtime.openai_protocol.response import (
+    assistant_message,
+    capture_frame,
+    completed_body,
+    is_terminal,
+    stream_encoder,
 )
 from wmo.runtime.openai_protocol.state import (
     BoundedContinuationStore,

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -559,17 +559,22 @@ class GatewayService:
             headers=tuple(sorted(headers.items())),
             body=encoded,
         )
-        if lease is not None:
-            await lease.complete(cached)
-        if request.surface == GatewayApiSurface.RESPONSES:
-            await self._remember_continuation(
-                request=request,
-                namespace=namespace,
-                request_id=authorization.request_id,
-                episode=episode,
-                events=retained,
-                response_id=cast(str, body["id"]),
-            )
+        try:
+            if request.surface == GatewayApiSurface.RESPONSES:
+                await self._remember_continuation(
+                    request=request,
+                    namespace=namespace,
+                    request_id=authorization.request_id,
+                    episode=episode,
+                    events=retained,
+                    response_id=cast(str, body["id"]),
+                )
+            if lease is not None:
+                await lease.complete(cached)
+        except BaseException:
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise
         return _cached_response(cached)
 
     async def _remember_continuation(

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -33,28 +33,6 @@ from wmo.runtime.gateway.execution import (
 )
 from wmo.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayControlStore
 from wmo.runtime.gateway.ledger import IdempotencyConflictError, IdempotencyReplayUnavailableError
-from wmo.runtime.gateway.openai.errors import OpenAIProtocolError, public_failure_error
-from wmo.runtime.gateway.openai.headers import (
-    commit_dependent_headers,
-    commit_independent_headers,
-)
-from wmo.runtime.gateway.openai.requests import (
-    DecodedGatewayRequest,
-    decode_chat,
-    decode_responses,
-)
-from wmo.runtime.gateway.openai.state import (
-    BoundedContinuationStore,
-    BoundedReplayStore,
-    CachedResponse,
-    ContinuationState,
-    ProtocolNamespace,
-    ReplayClaimKind,
-    ReplayLease,
-    episode_namespace,
-    replay_key,
-)
-from wmo.runtime.gateway.openai.streaming import stable_public_id
 from wmo.runtime.gateway.response import (
     assistant_message,
     capture_frame,
@@ -70,6 +48,28 @@ from wmo.runtime.gateway.sqlite.store import (
 )
 from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
 from wmo.runtime.models.providers.errors import normalized_provider_failure
+from wmo.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
+from wmo.runtime.openai_protocol.headers import (
+    commit_dependent_headers,
+    commit_independent_headers,
+)
+from wmo.runtime.openai_protocol.requests import (
+    DecodedGatewayRequest,
+    decode_chat,
+    decode_responses,
+)
+from wmo.runtime.openai_protocol.state import (
+    BoundedContinuationStore,
+    BoundedReplayStore,
+    CachedResponse,
+    ContinuationState,
+    ProtocolNamespace,
+    ReplayClaimKind,
+    ReplayLease,
+    episode_namespace,
+    replay_key,
+)
+from wmo.runtime.openai_protocol.streaming import stable_public_id
 
 _STREAM_REPLAY_CAPTURE_BYTES = 64 * 1024 * 1024
 

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -427,6 +427,7 @@ class GatewayService:
         replayable = True
         retainable = True
         terminal = False
+        terminal_frames: list[bytes] = []
         events = BoundedGatewayEvents()
         current_task = asyncio.current_task()
         if current_task is not None:
@@ -449,6 +450,7 @@ class GatewayService:
                     except GatewayAggregationOverflowError:
                         retainable = False
                         replayable = False
+                event_is_terminal = is_terminal(event)
                 for frame in encoder.feed(event):
                     data = frame.encode()
                     replayable = capture_frame(
@@ -457,8 +459,11 @@ class GatewayService:
                         replayable,
                         maximum_bytes=_STREAM_REPLAY_CAPTURE_BYTES,
                     )
-                    yield data
-                if is_terminal(event):
+                    if event_is_terminal:
+                        terminal_frames.append(data)
+                    else:
+                        yield data
+                if event_is_terminal:
                     terminal = True
             if request.surface == GatewayApiSurface.RESPONSES and terminal and retainable:
                 await self._remember_continuation(
@@ -480,6 +485,15 @@ class GatewayService:
                     )
                 else:
                     await lease.abandon()
+                    if terminal:
+                        raise OpenAIProtocolError(
+                            status_code=500,
+                            code="idempotency_replay_unavailable",
+                            message="The completed stream exceeds the bounded replay cache.",
+                            error_type="api_error",
+                        )
+            for data in terminal_frames:
+                yield data
         except BaseException as exc:
             if not terminal:
                 await _settle_stream_quietly(stream, exc)

--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -1,0 +1,884 @@
+"""Authenticated OpenAI-compatible gateway service over routing and provider execution."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import cast
+
+from fastapi import FastAPI, Header, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from wmo.common.core.artifacts import JsonObject
+from wmo.runtime.gateway.aggregation import (
+    BoundedGatewayEvents,
+    GatewayAggregationOverflowError,
+)
+from wmo.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRequest,
+)
+from wmo.runtime.gateway.execution import (
+    GatewayExecutionError,
+    GatewayExecutionStream,
+    GatewayExecutor,
+)
+from wmo.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayControlStore
+from wmo.runtime.gateway.ledger import IdempotencyConflictError, IdempotencyReplayUnavailableError
+from wmo.runtime.gateway.openai.errors import OpenAIProtocolError, public_failure_error
+from wmo.runtime.gateway.openai.headers import (
+    commit_dependent_headers,
+    commit_independent_headers,
+)
+from wmo.runtime.gateway.openai.requests import (
+    DecodedGatewayRequest,
+    decode_chat,
+    decode_responses,
+)
+from wmo.runtime.gateway.openai.state import (
+    BoundedContinuationStore,
+    BoundedReplayStore,
+    CachedResponse,
+    ContinuationState,
+    ProtocolNamespace,
+    ReplayClaimKind,
+    ReplayLease,
+    episode_namespace,
+    replay_key,
+)
+from wmo.runtime.gateway.openai.streaming import stable_public_id
+from wmo.runtime.gateway.response import (
+    assistant_message,
+    capture_frame,
+    completed_body,
+    is_terminal,
+    stream_encoder,
+)
+from wmo.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
+from wmo.runtime.gateway.sqlite.store import (
+    AliasNotGrantedError,
+    GatewayStoreError,
+    InvalidVirtualKeyError,
+)
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
+from wmo.runtime.models.providers.errors import normalized_provider_failure
+
+_STREAM_REPLAY_CAPTURE_BYTES = 64 * 1024 * 1024
+
+
+class GatewayDrainingError(RuntimeError):
+    """The lifecycle stopped accepting new data-plane requests."""
+
+
+class GatewayService:
+    """Compose protocol, authority, routing, execution, and bounded process-local state."""
+
+    def __init__(
+        self,
+        *,
+        control_store: GatewayControlStore,
+        ledger: AttemptLedger,
+        routes: CatalogRouteResolver,
+        executor: GatewayExecutor,
+        clock: GatewayClock,
+        readiness_probe: Callable[[], Awaitable[ExecutionSnapshot]],
+        request_timeout_seconds: float = 120,
+        replay_store: BoundedReplayStore | None = None,
+        continuation_store: BoundedContinuationStore | None = None,
+        wall_clock: Callable[[], float] = time.time,
+        terminal_flusher: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        """Bind all injected gateway dependencies without registering public CLI behavior.
+
+        Args:
+            control_store: Key, grant, alias, and revision authority.
+            ledger: Durable content-free request and attempt accounting.
+            routes: Frozen direct and project target resolver.
+            executor: Async singleton provider executor.
+            clock: Shared monotonic and wall clock.
+            request_timeout_seconds: One total budget beginning before authorization.
+            replay_store: Optional bounded in-process response replay state.
+            continuation_store: Optional bounded Responses continuation state.
+            wall_clock: Injectable epoch clock for public object timestamps.
+            readiness_probe: Credential-free proof that one granted alias can route.
+            terminal_flusher: Hook that flushes queued terminal accounting after drain.
+        """
+        if request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+        self._control = control_store
+        self._ledger = ledger
+        self._routes = routes
+        self._executor = executor
+        self._clock = clock
+        self._request_timeout_seconds = request_timeout_seconds
+        self._replays = replay_store or BoundedReplayStore()
+        self._continuations = continuation_store or BoundedContinuationStore()
+        self._wall_clock = wall_clock
+        self._readiness_probe = readiness_probe
+        self._terminal_flusher = terminal_flusher or _flush_synchronous_ledger
+        self._accepting = True
+        self._active_requests = 0
+        self._active_streams: set[GatewayExecutionStream] = set()
+        self._active_tasks: set[asyncio.Task[object]] = set()
+        self._cleanup_tasks: set[asyncio.Task[object]] = set()
+        self._lifecycle = asyncio.Condition()
+
+    async def __aenter__(self) -> GatewayService:
+        """Preflight the service before an owning lifecycle exposes readiness."""
+        await self.preflight()
+        return self
+
+    async def __aexit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        """Stop admission and drain all owned work on lifecycle exit."""
+        del exception_type, exception, traceback
+        await self.drain(timeout_seconds=5.0)
+
+    async def preflight(self) -> ExecutionSnapshot:
+        """Return proof that a granted alias routes without credentials or provider work."""
+        async with self._lifecycle:
+            if not self._accepting:
+                raise GatewayDrainingError("gateway is not accepting new requests")
+        self._executor.require_healthy()
+        return await self._readiness_probe()
+
+    async def stop_accepting(self) -> None:
+        """Atomically reject new data-plane requests while existing work continues."""
+        async with self._lifecycle:
+            self._accepting = False
+            self._lifecycle.notify_all()
+
+    async def drain(self, *, timeout_seconds: float) -> bool:
+        """Drain active requests, cancel stragglers, and flush terminal attempt writes.
+
+        Args:
+            timeout_seconds: Positive graceful wait before upstream cancellation.
+
+        Returns:
+            ``True`` when every request completed gracefully, otherwise ``False`` after bounded
+            cancellation and terminal flush.
+        """
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        await self.stop_accepting()
+        graceful = True
+        try:
+            try:
+                async with asyncio.timeout(timeout_seconds):
+                    async with self._lifecycle:
+                        await self._lifecycle.wait_for(lambda: self._active_requests == 0)
+            except TimeoutError:
+                graceful = False
+                async with self._lifecycle:
+                    streams = tuple(self._active_streams)
+                    current = asyncio.current_task()
+                    tasks = tuple(task for task in self._active_tasks if task is not current)
+                cleanup_tasks = {asyncio.create_task(_cancel_quietly(stream)) for stream in streams}
+                pending: set[asyncio.Task[None]] = set()
+                if cleanup_tasks:
+                    _done, pending = await asyncio.wait(
+                        cleanup_tasks,
+                        timeout=1.0,
+                    )
+                if pending:
+                    for task in pending:
+                        task.cancel()
+                        self._cleanup_tasks.add(cast(asyncio.Task[object], task))
+                        task.add_done_callback(self._discard_cleanup_task)
+                for task in tasks:
+                    task.cancel()
+                if tasks:
+                    _done, pending_requests = await asyncio.wait(tasks, timeout=1.0)
+                    del pending_requests
+                try:
+                    async with asyncio.timeout(1.0):
+                        async with self._lifecycle:
+                            await self._lifecycle.wait_for(lambda: self._active_requests == 0)
+                except TimeoutError:
+                    graceful = False
+        finally:
+            flush_task = asyncio.ensure_future(self._terminal_flusher())
+            try:
+                async with asyncio.timeout(1.0):
+                    await asyncio.shield(flush_task)
+            except TimeoutError:
+                graceful = False
+                flush_task.cancel()
+                await asyncio.gather(flush_task, return_exceptions=True)
+            except BaseException:
+                flush_task.cancel()
+                await asyncio.gather(flush_task, return_exceptions=True)
+                raise
+        return graceful
+
+    def _discard_cleanup_task(self, task: asyncio.Task[object]) -> None:
+        """Forget one bounded cleanup task only after it actually exits."""
+        self._cleanup_tasks.discard(task)
+
+    def models(self, *, raw_key: str) -> tuple[str, ...]:
+        """Return only aliases granted to one authenticated key-derived identity."""
+        return self._control.granted_aliases(raw_key=raw_key)
+
+    def authenticate(self, *, raw_key: str) -> None:
+        """Authenticate a key before the HTTP boundary performs full protocol decoding."""
+        self._control.authenticate_key(raw_key=raw_key)
+
+    async def complete(
+        self,
+        *,
+        raw_key: str,
+        decoded: DecodedGatewayRequest,
+    ) -> Response:
+        """Authorize and execute one decoded Chat or Responses request.
+
+        Args:
+            raw_key: Presented virtual key.
+            decoded: Validated public alias and canonical request.
+
+        Returns:
+            Streaming or completed OpenAI-compatible HTTP response.
+        """
+        await self._enter_request()
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            async with self._lifecycle:
+                self._active_tasks.add(current_task)
+        streaming = False
+        try:
+            response = await self._complete_admitted(raw_key=raw_key, decoded=decoded)
+            streaming = isinstance(response, StreamingResponse)
+        finally:
+            if current_task is not None:
+                async with self._lifecycle:
+                    self._active_tasks.discard(current_task)
+            if not streaming:
+                await self._leave_request()
+        return response
+
+    async def _complete_admitted(
+        self,
+        *,
+        raw_key: str,
+        decoded: DecodedGatewayRequest,
+    ) -> Response:
+        """Execute one request after lifecycle admission has been reserved."""
+        deadline = self._clock.monotonic() + self._request_timeout_seconds
+        authorization = self._control.authorize_request(
+            raw_key=raw_key,
+            alias=decoded.alias,
+            request=decoded.request,
+            deadline_monotonic=deadline,
+        )
+        namespace = _protocol_namespace(authorization)
+        execution_request, episode = await self._continued_request(
+            namespace=namespace,
+            authorization=authorization,
+            request=decoded.request,
+        )
+        caller_operation = decoded.request.idempotency_key or decoded.request.client_request_id
+        key = replay_key(
+            namespace=namespace,
+            surface=decoded.request.surface,
+            caller_operation=caller_operation,
+            canonical_request_sha256=authorization.canonical_request_sha256,
+        )
+        lease = None if key is None else await self._replays.claim(key)
+        if lease is not None and lease.kind != ReplayClaimKind.OWNER:
+            return _cached_response(await lease.result())
+        accepted = False
+        try:
+            self._ledger.accept_request(authorization=authorization)
+            accepted = True
+            route = await self._routes.resolve(
+                authorization=authorization,
+                request=execution_request,
+                episode_namespace=episode,
+            )
+            stream = await self._executor.start(route=route, request=execution_request)
+        except BaseException as exc:
+            if accepted:
+                _finish_request_quietly(
+                    self._ledger,
+                    authorization=authorization,
+                    failure=_failure_for_exception(exc),
+                    accounting_failure=self._executor.mark_accounting_unhealthy,
+                )
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise
+        headers = commit_independent_headers(
+            request_id=authorization.request_id,
+            client_request_id=decoded.request.client_request_id,
+            alias=authorization.alias,
+            alias_revision=authorization.alias_revision_id,
+        )
+        if decoded.request.stream:
+            async with self._lifecycle:
+                self._active_streams.add(stream)
+            return StreamingResponse(
+                self._stream_body(
+                    request=execution_request,
+                    authorization=authorization,
+                    namespace=namespace,
+                    route=route,
+                    stream=stream,
+                    lease=lease,
+                    headers=headers,
+                    episode=episode,
+                ),
+                status_code=200,
+                media_type="text/event-stream",
+                headers=headers,
+            )
+        return await self._completed_response(
+            request=execution_request,
+            authorization=authorization,
+            namespace=namespace,
+            route=route,
+            stream=stream,
+            lease=lease,
+            headers=headers,
+            episode=episode,
+        )
+
+    async def _enter_request(self) -> None:
+        """Reserve one lifecycle admission or reject while draining."""
+        async with self._lifecycle:
+            if not self._accepting:
+                raise GatewayDrainingError("gateway is draining")
+            self._active_requests += 1
+
+    async def _leave_request(self) -> None:
+        """Release one lifecycle admission and wake bounded drain waiters."""
+        async with self._lifecycle:
+            if self._active_requests <= 0:
+                return
+            self._active_requests -= 1
+            self._lifecycle.notify_all()
+
+    async def _continued_request(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        authorization: AuthorizationSnapshot,
+        request: GatewayRequest,
+    ) -> tuple[GatewayRequest, tuple[str, str, str, str]]:
+        """Resolve optional Responses history and derive tenant-isolated affinity."""
+        caller_key = request.idempotency_key or request.client_request_id
+        if request.previous_response_id is None:
+            return (
+                request,
+                episode_namespace(
+                    namespace=namespace,
+                    caller_episode_key=caller_key,
+                    request_id=authorization.request_id,
+                ),
+            )
+        continuation = await self._continuations.resolve(
+            namespace=namespace,
+            previous_response_id=request.previous_response_id,
+        )
+        return (
+            request.model_copy(
+                update={
+                    "messages": (*continuation.messages, *request.messages),
+                    "previous_response_id": None,
+                }
+            ),
+            (
+                namespace.organization_id,
+                namespace.identity_id,
+                namespace.alias_revision_id,
+                continuation.episode_key,
+            ),
+        )
+
+    async def _stream_body(
+        self,
+        *,
+        request: GatewayRequest,
+        authorization: AuthorizationSnapshot,
+        namespace: ProtocolNamespace,
+        route: GatewayRoute,
+        stream: GatewayExecutionStream,
+        lease: ReplayLease | None,
+        headers: dict[str, str],
+        episode: tuple[str, str, str, str],
+    ) -> AsyncIterator[bytes]:
+        """Encode true provider events while capturing only a bounded replay result."""
+        encoder = stream_encoder(
+            request=request,
+            authorization=authorization,
+            created_at=self._wall_clock(),
+        )
+        capture = bytearray()
+        replayable = True
+        retainable = True
+        terminal = False
+        events = BoundedGatewayEvents()
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            async with self._lifecycle:
+                self._active_tasks.add(current_task)
+        try:
+            for frame in encoder.start():
+                data = frame.encode()
+                replayable = capture_frame(
+                    capture,
+                    data,
+                    replayable,
+                    maximum_bytes=_STREAM_REPLAY_CAPTURE_BYTES,
+                )
+                yield data
+            async for event in stream:
+                if retainable:
+                    try:
+                        events.append(event)
+                    except GatewayAggregationOverflowError:
+                        retainable = False
+                        replayable = False
+                for frame in encoder.feed(event):
+                    data = frame.encode()
+                    replayable = capture_frame(
+                        capture,
+                        data,
+                        replayable,
+                        maximum_bytes=_STREAM_REPLAY_CAPTURE_BYTES,
+                    )
+                    yield data
+                if is_terminal(event):
+                    terminal = True
+            if request.surface == GatewayApiSurface.RESPONSES and terminal and retainable:
+                await self._remember_continuation(
+                    request=request,
+                    namespace=namespace,
+                    request_id=authorization.request_id,
+                    episode=episode,
+                    events=events.snapshot(),
+                )
+            if lease is not None:
+                if replayable and terminal:
+                    await lease.complete(
+                        CachedResponse(
+                            status_code=200,
+                            media_type="text/event-stream",
+                            headers=tuple(sorted(headers.items())),
+                            body=bytes(capture),
+                        )
+                    )
+                else:
+                    await lease.abandon()
+        except BaseException as exc:
+            if not terminal:
+                await _settle_stream_quietly(stream, exc)
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise
+        finally:
+            async with self._lifecycle:
+                self._active_streams.discard(stream)
+                if current_task is not None:
+                    self._active_tasks.discard(current_task)
+            await self._leave_request()
+
+    async def _completed_response(
+        self,
+        *,
+        request: GatewayRequest,
+        authorization: AuthorizationSnapshot,
+        namespace: ProtocolNamespace,
+        route: GatewayRoute,
+        stream: GatewayExecutionStream,
+        lease: ReplayLease | None,
+        headers: dict[str, str],
+        episode: tuple[str, str, str, str],
+    ) -> Response:
+        """Consume one true upstream stream into a non-streaming public response."""
+        events = BoundedGatewayEvents()
+        try:
+            async for event in stream:
+                events.append(event)
+        except BaseException as exc:
+            await _settle_stream_quietly(stream, exc)
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise
+        retained = events.snapshot()
+        terminal = next((event for event in reversed(retained) if is_terminal(event)), None)
+        if terminal is None:
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise OpenAIProtocolError(
+                status_code=502,
+                code="all_routes_failed",
+                message="Provider stream ended without a terminal result.",
+                error_type="api_error",
+            )
+        if terminal.kind == GatewayEventKind.FAILED:
+            if lease is not None:
+                await _abandon_quietly(lease)
+            raise public_failure_error(
+                terminal.failure
+                or GatewayFailure(
+                    failure_class=GatewayFailureClass.INTERNAL,
+                    safe_message="Provider execution failed.",
+                )
+            )
+        body = completed_body(
+            request=request,
+            request_id=authorization.request_id,
+            model=authorization.alias,
+            created_at=self._wall_clock(),
+            events=retained,
+        )
+        headers.update(
+            commit_dependent_headers(
+                exact_model_id=route.snapshot.exact_model_id,
+                provider=route.deployment.provider,
+                deployment_id=route.deployment.deployment_id,
+                route_depth=0,
+                route_reason=route.route_reason,
+            )
+        )
+        encoded = json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode()
+        cached = CachedResponse(
+            status_code=200,
+            media_type="application/json",
+            headers=tuple(sorted(headers.items())),
+            body=encoded,
+        )
+        if lease is not None:
+            await lease.complete(cached)
+        if request.surface == GatewayApiSurface.RESPONSES:
+            await self._remember_continuation(
+                request=request,
+                namespace=namespace,
+                request_id=authorization.request_id,
+                episode=episode,
+                events=retained,
+                response_id=cast(str, body["id"]),
+            )
+        return _cached_response(cached)
+
+    async def _remember_continuation(
+        self,
+        *,
+        request: GatewayRequest,
+        namespace: ProtocolNamespace,
+        request_id: str,
+        episode: tuple[str, str, str, str],
+        events: tuple[GatewayEvent, ...],
+        response_id: str | None = None,
+    ) -> None:
+        """Retain completed Responses history only in bounded process memory."""
+        terminal = next((event for event in reversed(events) if is_terminal(event)), None)
+        if terminal is None or terminal.kind == GatewayEventKind.FAILED:
+            return
+        assistant = assistant_message(events)
+        if assistant is None:
+            return
+        await self._continuations.remember(
+            namespace=namespace,
+            response_id=response_id or stable_public_id("resp", request_id),
+            state=ContinuationState(
+                episode_key=episode[-1],
+                messages=(*request.messages, assistant),
+            ),
+        )
+
+
+def create_gateway_app(service: GatewayService) -> FastAPI:
+    """Create the inert-until-injected authenticated gateway HTTP application."""
+    app = FastAPI()
+
+    @app.get("/v1/models")
+    async def models(authorization: str | None = Header(default=None)) -> Response:
+        """List only aliases granted to the presented virtual key."""
+        try:
+            raw_key = _bearer_key(authorization)
+            aliases = service.models(raw_key=raw_key)
+            return JSONResponse(
+                {
+                    "object": "list",
+                    "data": [
+                        {"id": alias, "object": "model", "created": 0, "owned_by": "wmo"}
+                        for alias in aliases
+                    ],
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
+            return _exception_response(exc)
+
+    @app.post("/v1/chat/completions")
+    async def chat(
+        request: Request,
+        authorization: str | None = Header(default=None),
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+        client_request_id: str | None = Header(default=None, alias="X-Client-Request-Id"),
+    ) -> Response:
+        """Decode, authorize, and serve one Chat Completions request."""
+        return await _dispatch(
+            service,
+            request=request,
+            authorization=authorization,
+            decoder=decode_chat,
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
+        )
+
+    @app.post("/v1/responses")
+    async def responses(
+        request: Request,
+        authorization: str | None = Header(default=None),
+        idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+        client_request_id: str | None = Header(default=None, alias="X-Client-Request-Id"),
+    ) -> Response:
+        """Decode, authorize, and serve one Responses request."""
+        return await _dispatch(
+            service,
+            request=request,
+            authorization=authorization,
+            decoder=decode_responses,
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
+        )
+
+    return app
+
+
+async def _dispatch(
+    service: GatewayService,
+    *,
+    request: Request,
+    authorization: str | None,
+    decoder: Callable[..., DecodedGatewayRequest],
+    idempotency_key: str | None,
+    client_request_id: str | None,
+) -> Response:
+    """Decode one body and translate every sanitized gateway boundary failure."""
+    try:
+        raw_key = _bearer_key(authorization)
+        service.authenticate(raw_key=raw_key)
+        try:
+            payload = await request.json()
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise OpenAIProtocolError(
+                status_code=400,
+                code="invalid_json",
+                message="Request body must contain valid JSON.",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise OpenAIProtocolError(
+                status_code=400,
+                code="invalid_request",
+                message="Request body must be a JSON object.",
+            )
+        decoded = decoder(
+            cast(JsonObject, payload),
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
+        )
+        return await service.complete(
+            raw_key=raw_key,
+            decoded=decoded,
+        )
+    except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
+        return _exception_response(exc)
+
+
+def _bearer_key(value: str | None) -> str:
+    """Extract one non-empty Bearer credential without logging it."""
+    if value is None or not value.startswith("Bearer ") or not value[7:].strip():
+        raise OpenAIProtocolError(
+            status_code=401,
+            code="invalid_key",
+            message="A valid gateway Bearer key is required.",
+            error_type="authentication_error",
+        )
+    return value[7:].strip()
+
+
+def _exception_response(exception: BaseException) -> Response:
+    """Map sanitized protocol, authority, routing, and execution failures to JSON."""
+    error: OpenAIProtocolError
+    if isinstance(exception, OpenAIProtocolError):
+        error = exception
+    elif isinstance(exception, InvalidVirtualKeyError):
+        error = OpenAIProtocolError(
+            status_code=401,
+            code="invalid_key",
+            message="The gateway key is invalid, expired, or revoked.",
+            error_type="authentication_error",
+        )
+    elif isinstance(exception, AliasNotGrantedError):
+        error = OpenAIProtocolError(
+            status_code=403,
+            code="model_not_granted",
+            message="The requested model alias is not granted to this identity.",
+            error_type="permission_error",
+            param="model",
+        )
+    elif isinstance(exception, IdempotencyConflictError):
+        error = OpenAIProtocolError(
+            status_code=409,
+            code="idempotency_conflict",
+            message="The caller operation was reused with different request content.",
+            param="Idempotency-Key",
+        )
+    elif isinstance(exception, IdempotencyReplayUnavailableError):
+        error = OpenAIProtocolError(
+            status_code=409,
+            code="idempotency_replay_unavailable",
+            message="The completed keyed result is unavailable after restart.",
+            error_type="api_error",
+            param="Idempotency-Key",
+        )
+    elif isinstance(exception, GatewayExecutionError):
+        error = public_failure_error(exception.failure)
+    elif isinstance(exception, ProviderDeadlineExceeded):
+        error = public_failure_error(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.TIMEOUT,
+                safe_message="Gateway request deadline exceeded.",
+            )
+        )
+    elif isinstance(exception, (GatewayRoutingError, GatewayStoreError)):
+        error = OpenAIProtocolError(
+            status_code=503 if isinstance(exception, GatewayRoutingError) else 400,
+            code=(
+                "unavailable_route"
+                if isinstance(exception, GatewayRoutingError)
+                else "invalid_request"
+            ),
+            message=(
+                "The authorized model route is unavailable."
+                if isinstance(exception, GatewayRoutingError)
+                else "The gateway request is invalid."
+            ),
+            error_type=(
+                "api_error"
+                if isinstance(exception, GatewayRoutingError)
+                else "invalid_request_error"
+            ),
+        )
+    elif isinstance(exception, GatewayAggregationOverflowError):
+        error = OpenAIProtocolError(
+            status_code=502,
+            code="provider_output_too_large",
+            message="Provider output exceeded the gateway response limit.",
+            error_type="api_error",
+        )
+    elif isinstance(exception, asyncio.CancelledError):
+        error = OpenAIProtocolError(
+            status_code=499,
+            code="request_cancelled",
+            message="The gateway request was cancelled.",
+            error_type="api_error",
+        )
+    elif isinstance(exception, GatewayDrainingError):
+        error = OpenAIProtocolError(
+            status_code=503,
+            code="gateway_draining",
+            message="The gateway is draining and is not accepting new requests.",
+            error_type="api_error",
+        )
+    else:
+        error = OpenAIProtocolError(
+            status_code=500,
+            code="internal_error",
+            message="The gateway request failed.",
+            error_type="api_error",
+        )
+    return JSONResponse(error.json_body(), status_code=error.status_code)
+
+
+def _protocol_namespace(authorization: AuthorizationSnapshot) -> ProtocolNamespace:
+    """Build the process-local state namespace from frozen authority."""
+    return ProtocolNamespace(
+        organization_id=authorization.organization_id,
+        identity_id=authorization.identity_id,
+        alias_revision_id=authorization.alias_revision_id,
+    )
+
+
+def _cached_response(cached: CachedResponse) -> Response:
+    """Recreate one exact retained HTTP response."""
+    return Response(
+        content=cached.body,
+        status_code=cached.status_code,
+        media_type=cached.media_type,
+        headers=dict(cached.headers),
+    )
+
+
+async def _flush_synchronous_ledger() -> None:
+    """Represent immediate SQLite terminal writes as an already-flushed queue."""
+
+
+async def _cancel_quietly(stream: GatewayExecutionStream) -> None:
+    """Bound cancellation failures so they cannot replace the primary request error."""
+    try:
+        await stream.cancel()
+    except BaseException:  # noqa: BLE001 - cleanup cannot mask primary failures
+        return
+
+
+async def _settle_stream_quietly(
+    stream: GatewayExecutionStream,
+    exception: BaseException,
+) -> None:
+    """Settle cleanup using cancellation only for an actual caller cancellation."""
+    try:
+        if isinstance(exception, asyncio.CancelledError):
+            await stream.cancel()
+            return
+        await stream.abort(_failure_for_exception(exception))
+    except BaseException:  # noqa: BLE001 - cleanup cannot mask primary failures
+        return
+
+
+async def _abandon_quietly(lease: ReplayLease) -> None:
+    """Release replay ownership even when adjacent cleanup fails."""
+    try:
+        await lease.abandon()
+    except BaseException:  # noqa: BLE001 - cleanup cannot mask primary failures
+        return
+
+
+def _failure_for_exception(exception: BaseException) -> GatewayFailure:
+    """Return one sanitized durable failure for accepted pre-dispatch work."""
+    if isinstance(exception, GatewayExecutionError):
+        return exception.failure
+    if isinstance(exception, asyncio.CancelledError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.CANCELLED,
+            safe_message="gateway request was cancelled before provider dispatch",
+        )
+    return normalized_provider_failure(exception)
+
+
+def _finish_request_quietly(
+    ledger: AttemptLedger,
+    *,
+    authorization: AuthorizationSnapshot,
+    failure: GatewayFailure,
+    accounting_failure: Callable[[], None],
+) -> None:
+    """Attempt durable pre-dispatch finalization without masking the primary failure."""
+    try:
+        ledger.finish_request(authorization=authorization, failure=failure)
+    except BaseException:  # noqa: BLE001 - primary request failure remains authoritative
+        accounting_failure()
+        return

--- a/wmo/runtime/gateway/sqlite/store.py
+++ b/wmo/runtime/gateway/sqlite/store.py
@@ -623,6 +623,18 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             caller_operation_sha256=caller_operation,
         )
 
+    def authenticate_key(self, *, raw_key: str) -> None:
+        """Validate one virtual key without loading grants or request content.
+
+        Args:
+            raw_key: Presented virtual key.
+
+        Raises:
+            InvalidVirtualKeyError: The key is unknown, expired, or revoked.
+        """
+        with self._transaction() as connection:
+            self._authenticate_in_transaction(connection, raw_key)
+
     def granted_aliases(self, *, raw_key: str) -> tuple[str, ...]:
         """List only active aliases granted to the key-derived identity.
 

--- a/wmo/runtime/openai_protocol/__init__.py
+++ b/wmo/runtime/openai_protocol/__init__.py
@@ -7,12 +7,15 @@ from wmo.runtime.openai_protocol.requests import (
     decode_chat,
     decode_responses,
 )
+from wmo.runtime.openai_protocol.response import completed_body, stream_encoder
 
 __all__ = [
     "DecodedGatewayRequest",
     "OpenAIProtocolError",
     "decode_chat",
     "decode_responses",
+    "completed_body",
     "model_request",
     "model_response_events",
+    "stream_encoder",
 ]

--- a/wmo/runtime/openai_protocol/response.py
+++ b/wmo/runtime/openai_protocol/response.py
@@ -1,4 +1,4 @@
-"""Bounded public response assembly from normalized gateway events."""
+"""OpenAI response assembly from normalized serving events."""
 
 from __future__ import annotations
 

--- a/wmo/runtime/openai_protocol/state.py
+++ b/wmo/runtime/openai_protocol/state.py
@@ -215,13 +215,12 @@ class BoundedReplayStore:
             self._evict_completed()
 
     async def _abandon(self, key: ReplayKey, future: asyncio.Future[CachedResponse]) -> None:
-        """Remove one matching in-flight entry and cancel its joiners."""
+        """Remove matching in-flight work without erasing a published result."""
         async with self._lock:
             entry = self._entries.get(key)
-            if entry is not None and entry.future is future:
+            if entry is not None and entry.future is future and not future.done():
                 self._entries.pop(key)
-                if not future.done():
-                    future.cancel()
+                future.cancel()
 
     def _expire(self, now: float) -> None:
         """Drop completed expired entries without evicting active work."""

--- a/wmo/runtime/openai_protocol/state_test.py
+++ b/wmo/runtime/openai_protocol/state_test.py
@@ -55,6 +55,7 @@ def test_opt_in_replay_joins_inflight_replays_completion_and_rejects_body_drift(
         )
         await owner.complete(response)
         assert await join.result() == response
+        await owner.abandon()
         replay = await store.claim(key)
         assert replay.kind == ReplayClaimKind.REPLAY
         assert await replay.result() == response

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import threading
+import time
 import uuid
+from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -13,28 +16,22 @@ from wmo.common.core.artifacts import (
     ArtifactId,
     ContractModel,
     Sha256,
-    canonical_json_bytes,
     envelope_matches_manifest,
     sha256_json,
-    stable_id,
 )
 from wmo.common.models import (
-    BillingSource,
     CandidateTokenPrice,
     IdempotentModelClient,
     ModelAlias,
     ModelRequest,
     ModelResponse,
-    NumericMeasurement,
     OperationEconomics,
-    Usage,
 )
 from wmo.common.project import ArtifactCorruptionError, ArtifactStore
 from wmo.common.routing import (
     KnnRouterPolicy,
     RouterFeatureExtractor,
     RoutingDecision,
-    router_feature_token_upper_bound,
 )
 from wmo.common.routing.bank import KnnBankManifest, KnnEvidenceBank, bank_bytes, load_knn_bank
 from wmo.common.routing.decision import policy_content_sha256, select_from_bank
@@ -47,6 +44,36 @@ from wmo.runtime.router.economics import (
     RoutedSpendDisposition,
     routed_completion_economics,
     zero_operation_economics,
+)
+from wmo.runtime.router.runtime_support import (
+    candidate_completion_economics as _candidate_completion_economics,
+)
+from wmo.runtime.router.runtime_support import (
+    candidate_reservation_economics as _candidate_reservation_economics,
+)
+from wmo.runtime.router.runtime_support import (
+    candidate_success_disposition as _candidate_success_disposition,
+)
+from wmo.runtime.router.runtime_support import (
+    decision_content_id as _decision_content_id,
+)
+from wmo.runtime.router.runtime_support import eligible_decision as _eligible_decision
+from wmo.runtime.router.runtime_support import (
+    embedding_economics as _embedding_economics,
+)
+from wmo.runtime.router.runtime_support import fallback_decision as _fallback_decision
+from wmo.runtime.router.runtime_support import (
+    requires_tool_protocol as _requires_tool_protocol,
+)
+from wmo.runtime.router.runtime_support import (
+    runtime_provider_operation as _runtime_provider_operation,
+)
+from wmo.runtime.router.runtime_support import (
+    sealed_bank as _sealed_bank,
+)
+from wmo.runtime.router.runtime_support import sticky_decision as _sticky_decision
+from wmo.runtime.router.runtime_support import (
+    validate_idempotency_key as _validate_idempotency_key,
 )
 
 
@@ -73,6 +100,16 @@ class RoutedModelResponse(ContractModel):
 DecisionSink = Callable[[RoutingDecision], None]
 
 
+@dataclass(frozen=True)
+class _PreparedSelection:
+    """One unretained decision and its exact physical embedding evidence."""
+
+    decision: RoutingDecision
+    request_key: tuple[Sha256, Sha256]
+    economics: OperationEconomics
+    disposition: RoutedSpendDisposition
+
+
 class RouterRuntime:
     """Select and call pinned model aliases without importing offline optimizer code."""
 
@@ -88,19 +125,30 @@ class RouterRuntime:
         pricing_candidate_aliases: tuple[ModelAlias, ...],
         pricing_candidate_prices: tuple[CandidateTokenPrice, ...] | None = None,
         decision_sink: DecisionSink | None = None,
+        decision_capacity: int = 4_096,
+        decision_ttl_seconds: float = 24 * 60 * 60,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
+        if decision_capacity < 1 or decision_ttl_seconds <= 0:
+            raise ValueError("router decision bounds must be positive")
         self.policy = policy
         self.manifest = manifest
-        self.bank = bank
+        self.bank = _sealed_bank(bank)
         self.catalog = catalog
         self._extractor = RouterFeatureExtractor()
         self._decision_sink = decision_sink
-        self._episode_decisions: dict[str, RoutingDecision] = {}
-        self._request_decisions: dict[tuple[Sha256, Sha256], RoutingDecision] = {}
+        self._episode_decisions: OrderedDict[str, RoutingDecision] = OrderedDict()
+        self._request_decisions: OrderedDict[tuple[Sha256, Sha256], RoutingDecision] = OrderedDict()
         self._request_embedding_economics: dict[tuple[Sha256, Sha256], OperationEconomics] = {}
         self._request_embedding_dispositions: dict[
             tuple[Sha256, Sha256], RoutedSpendDisposition
         ] = {}
+        self._episode_expiry: dict[str, float] = {}
+        self._request_expiry: dict[tuple[Sha256, Sha256], float] = {}
+        self._selection_inflight: dict[tuple[Sha256, Sha256], threading.Event] = {}
+        self._decision_capacity = decision_capacity
+        self._decision_ttl_seconds = decision_ttl_seconds
+        self._clock = clock
         self._episode_lock = threading.Lock()
         self._resolved: dict[str, ResolvedModel] = {}
         self._expected_models = {
@@ -112,7 +160,7 @@ class RouterRuntime:
                 "router embedder alias overlaps a candidate with a different frozen identity"
             )
         self._expected_models[policy.embedder_alias] = policy.embedder
-        self._bank_sha256 = hashlib.sha256(bank_bytes(bank)).hexdigest()
+        self._bank_sha256 = hashlib.sha256(bank_bytes(self.bank)).hexdigest()
         self._require_activation_identity(
             pricing_snapshot_id, pricing_snapshot_sha256, pricing_candidate_aliases
         )
@@ -252,19 +300,26 @@ class RouterRuntime:
             decision_sink=decision_sink,
         )
 
-    def select(self, request: ModelRequest, *, episode_id: str | None = None) -> RoutingDecision:
+    def select(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str | None = None,
+        retain: bool = True,
+    ) -> RoutingDecision:
         """Return one sticky guarded decision with conservative request-time fallback.
 
         Args:
             request: Provider-neutral request visible before candidate execution.
             episode_id: Optional caller-owned identity for sticky whole-episode routing.
+            retain: Whether to publish the decision into process-local sticky state.
 
         Returns:
             Exact immutable decision selected or cached for the episode.
 
         Raises:
             ValueError: The episode identity is malformed.
-            RouterRuntimeIntegrityError: The immutable evidence bank has mutated.
+            RouterRuntimeIntegrityError: Frozen selection state is invalid.
         """
         if episode_id is not None and (not episode_id.strip() or len(episode_id) > 512):
             raise ValueError("episode_id must be 1 to 512 non-blank characters")
@@ -272,65 +327,168 @@ class RouterRuntime:
         identity_sha256 = hashlib.sha256(identity.encode("utf-8")).hexdigest()
         feature = self._extractor.from_request(request)
         request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
+        request_key = (identity_sha256, request_sha256)
+        if not retain:
+            return self._select_unretained(request, episode_id=identity).decision
+        while True:
+            with self._episode_lock:
+                self._expire_decisions()
+                existing = self._request_decisions.get(request_key)
+                if existing is not None:
+                    self._request_decisions.move_to_end(request_key)
+                    return existing
+                episode_decision = self._episode_decisions.get(identity_sha256)
+                if episode_decision is not None:
+                    decision = _sticky_decision(episode_decision, request_sha256)
+                    return self._publish_decision(
+                        request=request,
+                        decision=decision,
+                        request_key=request_key,
+                        identity=identity,
+                        embedding_economics=zero_operation_economics(),
+                        embedding_disposition=RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
+                    )
+                waiter = self._selection_inflight.get(request_key)
+                if waiter is None:
+                    if len(self._selection_inflight) >= self._decision_capacity:
+                        raise RouterRuntimeIntegrityError(
+                            "router selection admission capacity is exhausted"
+                        )
+                    waiter = threading.Event()
+                    self._selection_inflight[request_key] = waiter
+                    break
+            waiter.wait()
+        try:
+            prepared = self._select_unretained(request, episode_id=identity)
+            proposed = prepared.decision
+            with self._episode_lock:
+                self._expire_decisions()
+                existing = self._request_decisions.get(request_key)
+                if existing is not None:
+                    return existing
+                episode_decision = self._episode_decisions.get(identity_sha256)
+                decision = (
+                    _sticky_decision(episode_decision, request_sha256)
+                    if episode_decision is not None
+                    else proposed
+                )
+                return self._publish_decision(
+                    request=request,
+                    decision=decision,
+                    request_key=request_key,
+                    identity=identity,
+                    embedding_economics=prepared.economics,
+                    embedding_disposition=prepared.disposition,
+                )
+        finally:
+            with self._episode_lock:
+                completed = self._selection_inflight.pop(request_key, None)
+                if completed is not None:
+                    completed.set()
+
+    def _select_unretained(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str,
+    ) -> _PreparedSelection:
+        """Compute a selection bundle without mutating sticky or recorder state.
+
+        Args:
+            request: Exact request visible to learned selection.
+            episode_id: Stable caller-owned sticky identity.
+
+        Returns:
+            Opaque decision and exact physical embedding evidence.
+
+        Raises:
+            ValueError: The episode identity is invalid.
+        """
+        if not episode_id.strip() or len(episode_id) > 512:
+            raise ValueError("episode_id must be 1 to 512 non-blank characters")
+        identity_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
+        feature = self._extractor.from_request(request)
+        request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
+        decision, economics, disposition = self._embedded_decision(
+            feature=feature,
+            request_sha256=request_sha256,
+            identity=episode_id,
+        )
+        decision = _eligible_decision(
+            request,
+            decision,
+            request_sha256,
+            episode_id,
+            policy=self.policy,
+            bank=self.bank,
+            resolve=self._resolve,
+        )
+        return _PreparedSelection(
+            decision=decision,
+            request_key=(identity_sha256, request_sha256),
+            economics=economics,
+            disposition=disposition,
+        )
+
+    def _retain_prepared_selection(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str,
+        prepared: _PreparedSelection,
+    ) -> RoutingDecision:
+        """Atomically publish one worker-owned prepared selection bundle.
+
+        Args:
+            request: Exact request used to produce the bundle.
+            episode_id: Stable caller-owned sticky identity.
+            prepared: Opaque decision and physical embedding evidence.
+
+        Returns:
+            Exact retained decision after reconciling concurrent episode state.
+
+        Raises:
+            ValueError: The bundle does not bind this request and episode.
+        """
+        if not episode_id.strip() or len(episode_id) > 512:
+            raise ValueError("episode_id must be 1 to 512 non-blank characters")
+        identity_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
+        feature = self._extractor.from_request(request)
+        request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
+        decision = prepared.decision
+        if (
+            prepared.request_key != (identity_sha256, request_sha256)
+            or decision.policy_id != self.policy.policy_id
+            or decision.policy_sha256 != policy_content_sha256(self.policy)
+            or decision.request_sha256 != request_sha256
+            or decision.episode_id_sha256 != identity_sha256
+            or decision.decision_id != _decision_content_id(decision)
+        ):
+            raise ValueError("unretained routing decision does not match this request")
+        request_key = (identity_sha256, request_sha256)
         with self._episode_lock:
-            self._require_bank_integrity()
-            request_key = (identity_sha256, request_sha256)
+            self._expire_decisions()
             existing = self._request_decisions.get(request_key)
             if existing is not None:
+                self._request_decisions.move_to_end(request_key)
+                self._request_expiry[request_key] = self._expiry()
+                self._request_embedding_economics[request_key] = prepared.economics
+                self._request_embedding_dispositions[request_key] = prepared.disposition
                 return existing
             episode_decision = self._episode_decisions.get(identity_sha256)
-            embedding_economics = zero_operation_economics()
-            embedding_disposition = RoutedSpendDisposition.DEFINITELY_NOT_INCURRED
-            if episode_decision is not None:
-                decision = self._sticky_decision(episode_decision, request_sha256)
-            else:
-                embedding_economics = _embedding_economics(
-                    feature,
-                    input_usd_per_million_tokens=self._embedder_input_price,
-                )
-                try:
-                    embedded = self._embedder.embed((feature,))
-                    if len(embedded) != 1:
-                        raise ValueError("embedder returned a non-singleton result")
-                    vector = np.asarray(embedded[0].values, dtype=np.float64)
-                    if (
-                        vector.shape != (self.manifest.embedding_dimension,)
-                        or not np.all(np.isfinite(vector))
-                        or float(np.linalg.norm(vector)) == 0
-                    ):
-                        raise ValueError("embedder returned an invalid router vector")
-                except Exception:  # noqa: BLE001 - request-time embedding failures fall back
-                    embedding_disposition = RoutedSpendDisposition.RESERVED_AMBIGUOUS
-                    decision = self._fallback_decision(request_sha256, identity, "embedding_error")
-                else:
-                    embedding_disposition = RoutedSpendDisposition.LOCALLY_PRICED
-                    decision = select_from_bank(
-                        self.policy,
-                        self.manifest,
-                        self.bank,
-                        vector,
-                        request_sha256=request_sha256,
-                        episode_id=identity,
-                    )
-            decision = self._eligible_decision(request, decision, request_sha256, identity)
-            self._record(decision)
-            if (
-                episode_decision is None
-                or decision.selected_alias != episode_decision.selected_alias
-            ):
-                if episode_decision is not None:
-                    stale_request_keys = tuple(
-                        key for key in self._request_decisions if key[0] == identity_sha256
-                    )
-                    for stale_key in stale_request_keys:
-                        del self._request_decisions[stale_key]
-                        self._request_embedding_economics.pop(stale_key, None)
-                        self._request_embedding_dispositions.pop(stale_key, None)
-                self._episode_decisions[identity_sha256] = decision
-            self._request_decisions[request_key] = decision
-            self._request_embedding_economics[request_key] = embedding_economics
-            self._request_embedding_dispositions[request_key] = embedding_disposition
-            return decision
+            selected = (
+                _sticky_decision(episode_decision, request_sha256)
+                if episode_decision is not None
+                else decision
+            )
+            return self._publish_decision(
+                request=request,
+                decision=selected,
+                request_key=request_key,
+                identity=episode_id,
+                embedding_economics=prepared.economics,
+                embedding_disposition=prepared.disposition,
+            )
 
     def embedding_reservation(self, request: ModelRequest) -> BillingSourceEconomics:
         """Return the source-attributed reservation before router embedding dispatch.
@@ -503,6 +661,7 @@ class RouterRuntime:
             raise ValueError("routing decision does not match this policy, request, or episode")
         self._require_bank_integrity()
         with self._episode_lock:
+            self._expire_decisions()
             request_key = (expected_episode_sha256, request_sha256)
             cached = self._request_decisions.get(request_key)
             episode_decision = self._episode_decisions.get(expected_episode_sha256)
@@ -517,11 +676,12 @@ class RouterRuntime:
                 ):
                     raise ValueError("routing decision conflicts with the cached episode model")
                 if episode_decision is None:
-                    self._episode_decisions[expected_episode_sha256] = selected
-                self._request_decisions[request_key] = selected
-                self._request_embedding_economics[request_key] = zero_operation_economics()
-                self._request_embedding_dispositions[request_key] = (
-                    RoutedSpendDisposition.DEFINITELY_NOT_INCURRED
+                    self._insert_episode(expected_episode_sha256, selected)
+                self._insert_request(
+                    request_key,
+                    selected,
+                    zero_operation_economics(),
+                    RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
                 )
                 cached = selected
             if cached != selected:
@@ -650,330 +810,148 @@ class RouterRuntime:
             self._resolved[alias] = resolved
         return resolved
 
-    def _eligible_decision(
+    def _embedded_decision(
         self,
+        *,
+        feature: str,
+        request_sha256: Sha256,
+        identity: str,
+    ) -> tuple[RoutingDecision, OperationEconomics, RoutedSpendDisposition]:
+        """Select outside the shared lock and retain exact embedding accounting."""
+        economics = _embedding_economics(
+            feature,
+            input_usd_per_million_tokens=self._embedder_input_price,
+        )
+        try:
+            embedded = self._embedder.embed((feature,))
+            if len(embedded) != 1:
+                raise ValueError("embedder returned a non-singleton result")
+            vector = np.asarray(embedded[0].values, dtype=np.float64)
+            if (
+                vector.shape != (self.manifest.embedding_dimension,)
+                or not np.all(np.isfinite(vector))
+                or float(np.linalg.norm(vector)) == 0
+            ):
+                raise ValueError("embedder returned an invalid router vector")
+        except Exception:  # noqa: BLE001 - request-time embedding failures fall back
+            return (
+                _fallback_decision(self.policy, request_sha256, identity, "embedding_error"),
+                economics,
+                RoutedSpendDisposition.RESERVED_AMBIGUOUS,
+            )
+        return (
+            select_from_bank(
+                self.policy,
+                self.manifest,
+                self.bank,
+                vector,
+                request_sha256=request_sha256,
+                episode_id=identity,
+            ),
+            economics,
+            RoutedSpendDisposition.LOCALLY_PRICED,
+        )
+
+    def _publish_decision(
+        self,
+        *,
         request: ModelRequest,
         decision: RoutingDecision,
-        request_sha256: Sha256,
-        episode_id: str,
+        request_key: tuple[Sha256, Sha256],
+        identity: str,
+        embedding_economics: OperationEconomics,
+        embedding_disposition: RoutedSpendDisposition,
     ) -> RoutingDecision:
-        """Use a frozen eligible candidate when the original selection cannot serve the request.
-
-        Args:
-            request: Provider-neutral request whose capabilities must be supported.
-            decision: Original guarded routing decision.
-            request_sha256: Frozen feature identity for the request.
-            episode_id: Stable caller identity used by fallback decisions.
-
-        Returns:
-            The original decision when eligible, otherwise a guarded fallback decision.
-        """
-        if _supports_request(self._resolve(decision.selected_alias), request):
-            return decision
-        eligible = tuple(
-            candidate.alias
-            for candidate in self.policy.candidates
-            if _supports_request(self._resolve(candidate.alias), request)
-        )
-        if not eligible:
-            return decision
-        alias = (
-            self.policy.baseline_alias
-            if self.policy.baseline_alias in eligible
-            else min(
-                eligible,
-                key=lambda item: (
-                    self.bank.complete_weighted_cost(item) is None,
-                    self.bank.complete_weighted_cost(item) or 0.0,
-                    item,
-                ),
-            )
-        )
-        return self._fallback_decision(
+        """Validate, record, and retain one decision while the caller holds the lock."""
+        identity_sha256, request_sha256 = request_key
+        episode_decision = self._episode_decisions.get(identity_sha256)
+        decision = _eligible_decision(
+            request,
+            decision,
             request_sha256,
-            episode_id,
-            "capability_eligibility",
-            selected_alias=alias,
+            identity,
+            policy=self.policy,
+            bank=self.bank,
+            resolve=self._resolve,
         )
+        self._record(decision)
+        if episode_decision is None or decision.selected_alias != episode_decision.selected_alias:
+            if episode_decision is not None:
+                self._remove_episode_requests(identity_sha256)
+            self._insert_episode(identity_sha256, decision)
+        else:
+            self._episode_decisions.move_to_end(identity_sha256)
+            self._episode_expiry[identity_sha256] = self._expiry()
+        self._insert_request(
+            request_key,
+            decision,
+            embedding_economics,
+            embedding_disposition,
+        )
+        return decision
 
-    def _fallback_decision(
+    def _expiry(self) -> float:
+        """Return one deadline for newly retained process-local decisions."""
+        return self._clock() + self._decision_ttl_seconds
+
+    def _insert_episode(self, key: str, decision: RoutingDecision) -> None:
+        """Insert one episode decision with TTL and bounded least-recent eviction."""
+        self._episode_decisions[key] = decision
+        self._episode_decisions.move_to_end(key)
+        self._episode_expiry[key] = self._expiry()
+        while len(self._episode_decisions) > self._decision_capacity:
+            stale_key, _ = self._episode_decisions.popitem(last=False)
+            self._episode_expiry.pop(stale_key, None)
+            self._remove_episode_requests(stale_key)
+
+    def _insert_request(
         self,
-        request_sha256: str,
-        episode_id: str,
-        reason: str,
-        *,
-        selected_alias: str | None = None,
-    ) -> RoutingDecision:
-        alias = selected_alias or self.policy.baseline_alias
-        episode_id_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
-        provisional = RoutingDecision(
-            decision_id="routing-decision-provisional",
-            policy_id=self.policy.policy_id,
-            policy_sha256=policy_content_sha256(self.policy),
-            request_sha256=request_sha256,
-            episode_id_sha256=episode_id_sha256,
-            selected_alias=alias,
-            baseline_alias=self.policy.baseline_alias,
-            neighbor_count=0,
-            paired_count=0,
-            fallback_reason=reason,
-        )
-        return provisional.model_copy(update={"decision_id": _decision_content_id(provisional)})
+        key: tuple[Sha256, Sha256],
+        decision: RoutingDecision,
+        embedding_economics: OperationEconomics,
+        embedding_disposition: RoutedSpendDisposition,
+    ) -> None:
+        """Insert one request decision with TTL and bounded least-recent eviction."""
+        self._request_decisions[key] = decision
+        self._request_embedding_economics[key] = embedding_economics
+        self._request_embedding_dispositions[key] = embedding_disposition
+        self._request_decisions.move_to_end(key)
+        self._request_expiry[key] = self._expiry()
+        while len(self._request_decisions) > self._decision_capacity:
+            stale_key, _ = self._request_decisions.popitem(last=False)
+            self._request_expiry.pop(stale_key, None)
+            self._request_embedding_economics.pop(stale_key, None)
+            self._request_embedding_dispositions.pop(stale_key, None)
 
-    def _sticky_decision(
-        self, episode_decision: RoutingDecision, request_sha256: Sha256
-    ) -> RoutingDecision:
-        """Bind a later episode turn to the original selected alias and evidence."""
-        material = episode_decision.model_copy(update={"request_sha256": request_sha256})
-        identity_material = material.model_dump(mode="json")
-        del identity_material["decision_id"]
-        return material.model_copy(
-            update={"decision_id": stable_id("routing-decision", identity_material)}
+    def _remove_episode_requests(self, identity_sha256: Sha256) -> None:
+        """Remove retained request variants belonging to one episode identity."""
+        stale_keys = tuple(key for key in self._request_decisions if key[0] == identity_sha256)
+        for stale_key in stale_keys:
+            self._request_decisions.pop(stale_key, None)
+            self._request_expiry.pop(stale_key, None)
+            self._request_embedding_economics.pop(stale_key, None)
+            self._request_embedding_dispositions.pop(stale_key, None)
+
+    def _expire_decisions(self) -> None:
+        """Discard expired process-local decisions while the caller holds the lock."""
+        now = self._clock()
+        expired_episodes = tuple(
+            key for key, expires_at in self._episode_expiry.items() if expires_at <= now
         )
+        for key in expired_episodes:
+            self._episode_decisions.pop(key, None)
+            self._episode_expiry.pop(key, None)
+            self._remove_episode_requests(key)
+        expired_requests = tuple(
+            key for key, expires_at in self._request_expiry.items() if expires_at <= now
+        )
+        for key in expired_requests:
+            self._request_decisions.pop(key, None)
+            self._request_expiry.pop(key, None)
+            self._request_embedding_economics.pop(key, None)
+            self._request_embedding_dispositions.pop(key, None)
 
     def _record(self, decision: RoutingDecision) -> RoutingDecision:
         if self._decision_sink is not None:
             self._decision_sink(decision)
         return decision
-
-
-def _embedding_economics(
-    feature: str,
-    *,
-    input_usd_per_million_tokens: float | None,
-) -> OperationEconomics:
-    """Estimate one successful online router embedding from its request-visible feature.
-
-    Args:
-        feature: Exact provider input rendered by the router feature extractor.
-        input_usd_per_million_tokens: Active explicit embedding price when declared.
-
-    Returns:
-        Conservative usage and locally priced cost without a model alias.
-    """
-    tokens = router_feature_token_upper_bound(feature)
-    cost = (
-        None
-        if input_usd_per_million_tokens is None
-        else NumericMeasurement(
-            value=tokens * input_usd_per_million_tokens / 1_000_000,
-            provenance="estimated",
-        )
-    )
-    return OperationEconomics(
-        usage=Usage(input_tokens=tokens, output_tokens=0),
-        cost_usd=cost,
-    )
-
-
-def _candidate_reservation_economics(
-    request: ModelRequest,
-    resolved: ResolvedModel,
-    price: CandidateTokenPrice | None,
-) -> OperationEconomics:
-    """Build a conservative candidate reservation before provider dispatch.
-
-    Args:
-        request: Exact provider-neutral request to be dispatched.
-        resolved: Frozen selected model and declared capability bounds.
-        price: Fit-time token prices for the selected private alias, when available.
-
-    Returns:
-        Alias-free maximum usage and cost, or explicitly unknown economics when no output bound
-        can be proven.
-    """
-    maximum_output_tokens = (
-        request.maximum_output_tokens or resolved.capabilities.maximum_output_tokens
-    )
-    if maximum_output_tokens is None:
-        return OperationEconomics()
-    request_bytes = len(canonical_json_bytes(request))
-    framing = 64 * (len(request.messages) + len(request.tools) + 1)
-    maximum_input_tokens = request_bytes + framing
-    usage = Usage(
-        input_tokens=maximum_input_tokens,
-        output_tokens=maximum_output_tokens,
-    )
-    if price is None:
-        return OperationEconomics(usage=usage)
-    input_rate = max(
-        price.input_usd_per_million_tokens,
-        price.cached_input_usd_per_million_tokens or 0.0,
-        price.cache_write_usd_per_million_tokens or 0.0,
-    )
-    cost = (
-        maximum_input_tokens * input_rate
-        + maximum_output_tokens * price.output_usd_per_million_tokens
-    ) / 1_000_000
-    return OperationEconomics(
-        usage=usage,
-        cost_usd=NumericMeasurement(value=cost, provenance="estimated"),
-    )
-
-
-def _candidate_success_disposition(
-    observed: OperationEconomics,
-    reconciled: OperationEconomics,
-) -> RoutedSpendDisposition:
-    """Classify candidate accounting as provider-observed or locally priced."""
-    if reconciled != observed or (
-        reconciled.cost_usd is not None and reconciled.cost_usd.provenance == "estimated"
-    ):
-        return RoutedSpendDisposition.LOCALLY_PRICED
-    return RoutedSpendDisposition.OBSERVED
-
-
-def _runtime_provider_operation(
-    decision: RoutingDecision,
-    *,
-    operation_ordinal: int,
-    component: RoutedProviderComponent,
-    billing_source: BillingSource,
-    disposition: RoutedSpendDisposition,
-    economics: OperationEconomics,
-) -> RoutedProviderOperation:
-    """Build one direct-runtime operation without exposing the selected alias."""
-    operation_id = stable_id(
-        "routed-operation",
-        {
-            "decision_id": decision.decision_id,
-            "operation_ordinal": operation_ordinal,
-            "component": component.value,
-        },
-    )
-    return RoutedProviderOperation(
-        operation_id=operation_id,
-        operation_ordinal=operation_ordinal,
-        component=component,
-        billing_source=billing_source,
-        disposition=disposition,
-        operation_count=(0 if disposition == RoutedSpendDisposition.DEFINITELY_NOT_INCURRED else 1),
-        economics=economics,
-    )
-
-
-def _candidate_completion_economics(
-    economics: OperationEconomics,
-    price: CandidateTokenPrice | None,
-) -> OperationEconomics:
-    """Retain measured candidate cost or locally price its observed token usage.
-
-    Args:
-        economics: Provider response economics.
-        price: Fit-time selected-candidate price, kept private from the result.
-
-    Returns:
-        Reconciled alias-free candidate economics.
-
-    Raises:
-        ValueError: Provider cache counters exceed the reported input total.
-    """
-    usage = economics.usage
-    if economics.cost_usd is not None or usage is None or price is None:
-        return economics
-    cached = usage.cached_input_tokens
-    written = usage.cache_write_input_tokens
-    if cached is not None and cached > usage.input_tokens:
-        raise ValueError("candidate cached input exceeds total input usage")
-    if written is not None and written > usage.input_tokens:
-        raise ValueError("candidate cache-write input exceeds total input usage")
-    if cached is not None and written is not None and cached + written > usage.input_tokens:
-        raise ValueError("candidate cache counters overlap beyond total input usage")
-    input_cost = _candidate_input_cost_usd(price, usage)
-    output_cost = usage.output_tokens * price.output_usd_per_million_tokens / 1_000_000
-    return economics.model_copy(
-        update={
-            "cost_usd": NumericMeasurement(
-                value=input_cost + output_cost,
-                provenance="estimated",
-            )
-        }
-    )
-
-
-def _candidate_input_cost_usd(price: CandidateTokenPrice, usage: Usage) -> float:
-    """Conservatively price mutually exclusive ordinary, cached, and cache-write input.
-
-    Args:
-        price: Frozen candidate price units.
-        usage: Provider-reported input and cache token counts.
-
-    Returns:
-        Locally priced input cost in USD.
-    """
-    base = price.input_usd_per_million_tokens
-    cached_price = price.cached_input_usd_per_million_tokens
-    write_price = price.cache_write_usd_per_million_tokens
-    cached = usage.cached_input_tokens
-    written = usage.cache_write_input_tokens
-    if cached is not None and written is not None:
-        ordinary = usage.input_tokens - cached - written
-        total = (
-            ordinary * base
-            + cached * (cached_price if cached_price is not None else base)
-            + written * (write_price if write_price is not None else base)
-        )
-    elif cached is not None:
-        ordinary_price = max(base, write_price if write_price is not None else base)
-        total = (
-            cached * (cached_price if cached_price is not None else base)
-            + (usage.input_tokens - cached) * ordinary_price
-        )
-    elif written is not None:
-        ordinary_price = max(base, cached_price if cached_price is not None else base)
-        total = (
-            written * (write_price if write_price is not None else base)
-            + (usage.input_tokens - written) * ordinary_price
-        )
-    else:
-        total = usage.input_tokens * max(
-            base,
-            cached_price if cached_price is not None else base,
-            write_price if write_price is not None else base,
-        )
-    return total / 1_000_000
-
-
-def _requires_tool_protocol(request: ModelRequest) -> bool:
-    """Return whether preserving this request requires structured tool support."""
-    return bool(
-        request.tools
-        or request.tool_choice is not None
-        or any(
-            message.role == "tool"
-            or (message.assistant_action is not None and bool(message.assistant_action.tool_calls))
-            for message in request.messages
-        )
-    )
-
-
-def _decision_content_id(decision: RoutingDecision) -> str:
-    """Return the canonical content identity for a routing decision."""
-    material = decision.model_dump(mode="json")
-    del material["decision_id"]
-    return stable_id("routing-decision", material)
-
-
-def _validate_idempotency_key(value: str) -> None:
-    """Reject keys that cannot safely cross an HTTP provider boundary."""
-    if not value or len(value) > 512 or value.strip() != value:
-        raise ValueError("idempotency key must be 1 to 512 non-blank characters")
-    if any(ord(character) < 33 or ord(character) > 126 for character in value):
-        raise ValueError("idempotency key must contain only visible ASCII characters")
-
-
-def _supports_request(resolved: ResolvedModel, request: ModelRequest) -> bool:
-    """Check whether a resolved model proves every requested protocol capability.
-
-    Args:
-        resolved: Frozen runtime model and its declared capabilities.
-        request: Provider-neutral request to evaluate.
-
-    Returns:
-        True when tool and output-token requirements are both proven.
-    """
-    if _requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
-        return False
-    requested = request.maximum_output_tokens
-    available = resolved.capabilities.maximum_output_tokens
-    return requested is None or (available is not None and requested <= available)

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -665,7 +665,7 @@ class RouterRuntime:
             request_key = (expected_episode_sha256, request_sha256)
             cached = self._request_decisions.get(request_key)
             episode_decision = self._episode_decisions.get(expected_episode_sha256)
-            if cached is None and decision is not None:
+            if cached is None:
                 if selected.decision_id != _decision_content_id(selected):
                     raise ValueError(
                         "routing decision does not match this policy, request, or episode"

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -8,7 +8,6 @@ import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
-from dataclasses import dataclass
 
 import numpy as np
 
@@ -45,6 +44,7 @@ from wmo.runtime.router.economics import (
     routed_completion_economics,
     zero_operation_economics,
 )
+from wmo.runtime.router.runtime_selection import PreparedSelection, retained_selection
 from wmo.runtime.router.runtime_support import (
     candidate_completion_economics as _candidate_completion_economics,
 )
@@ -100,14 +100,7 @@ class RoutedModelResponse(ContractModel):
 DecisionSink = Callable[[RoutingDecision], None]
 
 
-@dataclass(frozen=True)
-class _PreparedSelection:
-    """One unretained decision and its exact physical embedding evidence."""
-
-    decision: RoutingDecision
-    request_key: tuple[Sha256, Sha256]
-    economics: OperationEconomics
-    disposition: RoutedSpendDisposition
+_PreparedSelection = PreparedSelection
 
 
 class RouterRuntime:
@@ -324,67 +317,26 @@ class RouterRuntime:
         if episode_id is not None and (not episode_id.strip() or len(episode_id) > 512):
             raise ValueError("episode_id must be 1 to 512 non-blank characters")
         identity = episode_id or f"request-{uuid.uuid4().hex}"
-        identity_sha256 = hashlib.sha256(identity.encode("utf-8")).hexdigest()
-        feature = self._extractor.from_request(request)
-        request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
-        request_key = (identity_sha256, request_sha256)
         if not retain:
             return self._select_unretained(request, episode_id=identity).decision
-        while True:
-            with self._episode_lock:
-                self._expire_decisions()
-                existing = self._request_decisions.get(request_key)
-                if existing is not None:
-                    self._request_decisions.move_to_end(request_key)
-                    return existing
-                episode_decision = self._episode_decisions.get(identity_sha256)
-                if episode_decision is not None:
-                    decision = _sticky_decision(episode_decision, request_sha256)
-                    return self._publish_decision(
-                        request=request,
-                        decision=decision,
-                        request_key=request_key,
-                        identity=identity,
-                        embedding_economics=zero_operation_economics(),
-                        embedding_disposition=RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
-                    )
-                waiter = self._selection_inflight.get(request_key)
-                if waiter is None:
-                    if len(self._selection_inflight) >= self._decision_capacity:
-                        raise RouterRuntimeIntegrityError(
-                            "router selection admission capacity is exhausted"
-                        )
-                    waiter = threading.Event()
-                    self._selection_inflight[request_key] = waiter
-                    break
-            waiter.wait()
-        try:
-            prepared = self._select_unretained(request, episode_id=identity)
-            proposed = prepared.decision
-            with self._episode_lock:
-                self._expire_decisions()
-                existing = self._request_decisions.get(request_key)
-                if existing is not None:
-                    return existing
-                episode_decision = self._episode_decisions.get(identity_sha256)
-                decision = (
-                    _sticky_decision(episode_decision, request_sha256)
-                    if episode_decision is not None
-                    else proposed
-                )
-                return self._publish_decision(
-                    request=request,
-                    decision=decision,
-                    request_key=request_key,
-                    identity=identity,
-                    embedding_economics=prepared.economics,
-                    embedding_disposition=prepared.disposition,
-                )
-        finally:
-            with self._episode_lock:
-                completed = self._selection_inflight.pop(request_key, None)
-                if completed is not None:
-                    completed.set()
+        return self._select_retained(request, episode_id=identity).decision
+
+    def _select_retained(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str,
+    ) -> _PreparedSelection:
+        """Return one retained decision with detached exact embedding evidence.
+
+        Args:
+            request: Provider-neutral request visible to selection.
+            episode_id: Exact non-empty sticky identity for this selection.
+
+        Returns:
+            Retained decision plus the physical evidence incurred by its selection.
+        """
+        return retained_selection(self, request, episode_id=episode_id)
 
     def _select_unretained(
         self,
@@ -636,13 +588,20 @@ class RouterRuntime:
         Raises:
             ValueError: A supplied decision does not bind this request, episode, or policy.
         """
-        selected = decision or self.select(request, episode_id=episode_id)
+        prepared: _PreparedSelection | None = None
+        if decision is None:
+            identity = episode_id or f"request-{uuid.uuid4().hex}"
+            prepared = self._select_retained(request, episode_id=identity)
+            selected = prepared.decision
+        else:
+            selected = decision
         if provider_idempotency_key is not None:
             _validate_idempotency_key(provider_idempotency_key)
         resolved, embedding_economics, embedding_disposition = self._prepare_completion(
             request,
             episode_id=episode_id,
             decision=selected,
+            prepared=prepared,
         )
         client = resolved.client
         if provider_idempotency_key is not None and isinstance(client, IdempotentModelClient):
@@ -681,6 +640,7 @@ class RouterRuntime:
         *,
         episode_id: str | None,
         decision: RoutingDecision,
+        prepared: _PreparedSelection | None = None,
     ) -> tuple[ResolvedModel, OperationEconomics, RoutedSpendDisposition]:
         """Validate request pins and capability before candidate provider dispatch."""
         selected = decision
@@ -700,38 +660,44 @@ class RouterRuntime:
         ):
             raise ValueError("routing decision does not match this policy, request, or episode")
         self._require_bank_integrity()
-        with self._episode_lock:
-            self._expire_decisions()
-            request_key = (expected_episode_sha256, request_sha256)
-            cached = self._request_decisions.get(request_key)
-            episode_decision = self._episode_decisions.get(expected_episode_sha256)
-            if cached is None:
-                if selected.decision_id != _decision_content_id(selected):
-                    raise ValueError(
-                        "routing decision does not match this policy, request, or episode"
+        request_key = (expected_episode_sha256, request_sha256)
+        if prepared is not None:
+            if prepared.request_key != request_key or prepared.decision != selected:
+                raise ValueError("prepared routing decision does not match this request")
+            embedding_economics = prepared.economics
+            embedding_disposition = prepared.disposition
+        else:
+            with self._episode_lock:
+                self._expire_decisions()
+                cached = self._request_decisions.get(request_key)
+                episode_decision = self._episode_decisions.get(expected_episode_sha256)
+                if cached is None:
+                    if selected.decision_id != _decision_content_id(selected):
+                        raise ValueError(
+                            "routing decision does not match this policy, request, or episode"
+                        )
+                    if (
+                        episode_decision is not None
+                        and episode_decision.selected_alias != selected.selected_alias
+                    ):
+                        raise ValueError("routing decision conflicts with the cached episode model")
+                    if episode_decision is None:
+                        self._insert_episode(expected_episode_sha256, selected)
+                    self._insert_request(
+                        request_key,
+                        selected,
+                        zero_operation_economics(),
+                        RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
                     )
-                if (
-                    episode_decision is not None
-                    and episode_decision.selected_alias != selected.selected_alias
-                ):
-                    raise ValueError("routing decision conflicts with the cached episode model")
-                if episode_decision is None:
-                    self._insert_episode(expected_episode_sha256, selected)
-                self._insert_request(
-                    request_key,
-                    selected,
-                    zero_operation_economics(),
-                    RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
+                    cached = selected
+                if cached != selected:
+                    raise ValueError("routing decision is not the exact cached episode decision")
+                embedding_economics = self._request_embedding_economics.get(
+                    request_key, zero_operation_economics()
                 )
-                cached = selected
-            if cached != selected:
-                raise ValueError("routing decision is not the exact cached episode decision")
-            embedding_economics = self._request_embedding_economics.get(
-                request_key, zero_operation_economics()
-            )
-            embedding_disposition = self._request_embedding_dispositions.get(
-                request_key, RoutedSpendDisposition.DEFINITELY_NOT_INCURRED
-            )
+                embedding_disposition = self._request_embedding_dispositions.get(
+                    request_key, RoutedSpendDisposition.DEFINITELY_NOT_INCURRED
+                )
         resolved = self._resolve(selected.selected_alias)
         if _requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
             raise RouterModelCapabilityError(

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -430,6 +430,46 @@ class RouterRuntime:
             disposition=disposition,
         )
 
+    def _reuse_sticky_selection(
+        self,
+        request: ModelRequest,
+        *,
+        episode_id: str,
+    ) -> RoutingDecision | None:
+        """Reuse one retained episode decision without provider work.
+
+        Args:
+            request: Provider-neutral request visible before execution.
+            episode_id: Stable caller-owned episode identity.
+
+        Returns:
+            One cached or sticky decision, or ``None`` when selection needs an embedding.
+        """
+        if not episode_id.strip() or len(episode_id) > 512:
+            raise ValueError("episode_id must be 1 to 512 non-blank characters")
+        identity_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
+        feature = self._extractor.from_request(request)
+        request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
+        request_key = (identity_sha256, request_sha256)
+        with self._episode_lock:
+            self._expire_decisions()
+            existing = self._request_decisions.get(request_key)
+            if existing is not None:
+                self._request_decisions.move_to_end(request_key)
+                return existing
+            episode_decision = self._episode_decisions.get(identity_sha256)
+            if episode_decision is None:
+                return None
+            decision = _sticky_decision(episode_decision, request_sha256)
+            return self._publish_decision(
+                request=request,
+                decision=decision,
+                request_key=request_key,
+                identity=episode_id,
+                embedding_economics=zero_operation_economics(),
+                embedding_disposition=RoutedSpendDisposition.DEFINITELY_NOT_INCURRED,
+            )
+
     def _retain_prepared_selection(
         self,
         request: ModelRequest,

--- a/wmo/runtime/router/runtime_selection.py
+++ b/wmo/runtime/router/runtime_selection.py
@@ -1,0 +1,133 @@
+"""Bounded single-flight publication for retained router selections."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from wmo.common.core.artifacts import Sha256
+from wmo.common.models import ModelRequest, OperationEconomics
+from wmo.common.routing import RoutingDecision
+from wmo.runtime.router.economics import RoutedSpendDisposition, zero_operation_economics
+from wmo.runtime.router.runtime_support import sticky_decision
+
+if TYPE_CHECKING:
+    from wmo.runtime.router.runtime import RouterRuntime
+
+
+@dataclass(frozen=True)
+class PreparedSelection:
+    """One decision and the exact physical evidence incurred while selecting it."""
+
+    decision: RoutingDecision
+    request_key: tuple[Sha256, Sha256]
+    economics: OperationEconomics
+    disposition: RoutedSpendDisposition
+
+
+def retained_selection(
+    runtime: RouterRuntime,
+    request: ModelRequest,
+    *,
+    episode_id: str,
+) -> PreparedSelection:
+    """Return one retained decision with detached exact embedding evidence.
+
+    Args:
+        runtime: Active router selector whose bounded state owns publication.
+        request: Provider-neutral request visible to selection.
+        episode_id: Exact non-empty sticky identity for this selection.
+
+    Returns:
+        Retained decision plus the physical evidence incurred by its selection.
+
+    Raises:
+        RouterRuntimeIntegrityError: Selection admission capacity is exhausted.
+    """
+    identity_sha256 = hashlib.sha256(episode_id.encode("utf-8")).hexdigest()
+    feature = runtime._extractor.from_request(request)  # noqa: SLF001
+    request_sha256 = hashlib.sha256(feature.encode("utf-8")).hexdigest()
+    request_key = (identity_sha256, request_sha256)
+    while True:
+        with runtime._episode_lock:  # noqa: SLF001
+            runtime._expire_decisions()  # noqa: SLF001
+            existing = runtime._request_decisions.get(request_key)  # noqa: SLF001
+            if existing is not None:
+                runtime._request_decisions.move_to_end(request_key)  # noqa: SLF001
+                return PreparedSelection(
+                    decision=existing,
+                    request_key=request_key,
+                    economics=runtime._request_embedding_economics[request_key],  # noqa: SLF001
+                    disposition=runtime._request_embedding_dispositions[request_key],  # noqa: SLF001
+                )
+            episode_decision = runtime._episode_decisions.get(identity_sha256)  # noqa: SLF001
+            if episode_decision is not None:
+                decision = sticky_decision(episode_decision, request_sha256)
+                economics = zero_operation_economics()
+                disposition = RoutedSpendDisposition.DEFINITELY_NOT_INCURRED
+                published = runtime._publish_decision(  # noqa: SLF001
+                    request=request,
+                    decision=decision,
+                    request_key=request_key,
+                    identity=episode_id,
+                    embedding_economics=economics,
+                    embedding_disposition=disposition,
+                )
+                return PreparedSelection(
+                    decision=published,
+                    request_key=request_key,
+                    economics=economics,
+                    disposition=disposition,
+                )
+            waiter = runtime._selection_inflight.get(request_key)  # noqa: SLF001
+            if waiter is None:
+                if len(runtime._selection_inflight) >= runtime._decision_capacity:  # noqa: SLF001
+                    from wmo.runtime.router.runtime import RouterRuntimeIntegrityError
+
+                    raise RouterRuntimeIntegrityError(
+                        "router selection admission capacity is exhausted"
+                    )
+                waiter = threading.Event()
+                runtime._selection_inflight[request_key] = waiter  # noqa: SLF001
+                break
+        waiter.wait()
+    try:
+        prepared = runtime._select_unretained(request, episode_id=episode_id)  # noqa: SLF001
+        proposed = prepared.decision
+        with runtime._episode_lock:  # noqa: SLF001
+            runtime._expire_decisions()  # noqa: SLF001
+            existing = runtime._request_decisions.get(request_key)  # noqa: SLF001
+            if existing is not None:
+                return PreparedSelection(
+                    decision=existing,
+                    request_key=request_key,
+                    economics=runtime._request_embedding_economics[request_key],  # noqa: SLF001
+                    disposition=runtime._request_embedding_dispositions[request_key],  # noqa: SLF001
+                )
+            episode_decision = runtime._episode_decisions.get(identity_sha256)  # noqa: SLF001
+            decision = (
+                sticky_decision(episode_decision, request_sha256)
+                if episode_decision is not None
+                else proposed
+            )
+            published = runtime._publish_decision(  # noqa: SLF001
+                request=request,
+                decision=decision,
+                request_key=request_key,
+                identity=episode_id,
+                embedding_economics=prepared.economics,
+                embedding_disposition=prepared.disposition,
+            )
+            return PreparedSelection(
+                decision=published,
+                request_key=request_key,
+                economics=prepared.economics,
+                disposition=prepared.disposition,
+            )
+    finally:
+        with runtime._episode_lock:  # noqa: SLF001
+            completed = runtime._selection_inflight.pop(request_key, None)  # noqa: SLF001
+            if completed is not None:
+                completed.set()

--- a/wmo/runtime/router/runtime_support.py
+++ b/wmo/runtime/router/runtime_support.py
@@ -1,0 +1,450 @@
+"""Pure accounting, capability, identity, and bank helpers for router runtime."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+
+import numpy as np
+
+from wmo.common.core.artifacts import canonical_json_bytes, stable_id
+from wmo.common.models import (
+    BillingSource,
+    CandidateTokenPrice,
+    ModelRequest,
+    NumericMeasurement,
+    OperationEconomics,
+    Usage,
+)
+from wmo.common.routing import KnnRouterPolicy, RoutingDecision, router_feature_token_upper_bound
+from wmo.common.routing.bank import KnnEvidenceBank
+from wmo.common.routing.decision import policy_content_sha256
+from wmo.runtime.models import ResolvedModel
+from wmo.runtime.router.economics import (
+    RoutedProviderComponent,
+    RoutedProviderOperation,
+    RoutedSpendDisposition,
+)
+
+
+def embedding_economics(
+    feature: str,
+    *,
+    input_usd_per_million_tokens: float | None,
+) -> OperationEconomics:
+    """Estimate one successful online router embedding from its visible feature.
+
+    Args:
+        feature: Canonical router feature sent to the embedding provider.
+        input_usd_per_million_tokens: Optional frozen input-token price.
+
+    Returns:
+        Conservative usage and cost economics for one embedding dispatch.
+    """
+    tokens = router_feature_token_upper_bound(feature)
+    cost = (
+        None
+        if input_usd_per_million_tokens is None
+        else NumericMeasurement(
+            value=tokens * input_usd_per_million_tokens / 1_000_000,
+            provenance="estimated",
+        )
+    )
+    return OperationEconomics(
+        usage=Usage(input_tokens=tokens, output_tokens=0),
+        cost_usd=cost,
+    )
+
+
+def candidate_reservation_economics(
+    request: ModelRequest,
+    resolved: ResolvedModel,
+    price: CandidateTokenPrice | None,
+) -> OperationEconomics:
+    """Build a conservative candidate reservation before provider dispatch.
+
+    Args:
+        request: Provider-neutral request to reserve.
+        resolved: Frozen selected runtime model.
+        price: Optional frozen candidate token price.
+
+    Returns:
+        Conservative usage and cost reservation for the candidate dispatch.
+    """
+    maximum_output_tokens = (
+        request.maximum_output_tokens or resolved.capabilities.maximum_output_tokens
+    )
+    if maximum_output_tokens is None:
+        return OperationEconomics()
+    request_bytes = len(canonical_json_bytes(request))
+    framing = 64 * (len(request.messages) + len(request.tools) + 1)
+    maximum_input_tokens = request_bytes + framing
+    usage = Usage(
+        input_tokens=maximum_input_tokens,
+        output_tokens=maximum_output_tokens,
+    )
+    if price is None:
+        return OperationEconomics(usage=usage)
+    input_rate = max(
+        price.input_usd_per_million_tokens,
+        price.cached_input_usd_per_million_tokens or 0.0,
+        price.cache_write_usd_per_million_tokens or 0.0,
+    )
+    cost = (
+        maximum_input_tokens * input_rate
+        + maximum_output_tokens * price.output_usd_per_million_tokens
+    ) / 1_000_000
+    return OperationEconomics(
+        usage=usage,
+        cost_usd=NumericMeasurement(value=cost, provenance="estimated"),
+    )
+
+
+def candidate_success_disposition(
+    observed: OperationEconomics,
+    reconciled: OperationEconomics,
+) -> RoutedSpendDisposition:
+    """Classify candidate accounting as provider-observed or locally priced.
+
+    Args:
+        observed: Economics reported by the provider.
+        reconciled: Economics after applying frozen local pricing when needed.
+
+    Returns:
+        The durable disposition describing the source of the final economics.
+    """
+    if reconciled != observed or (
+        reconciled.cost_usd is not None and reconciled.cost_usd.provenance == "estimated"
+    ):
+        return RoutedSpendDisposition.LOCALLY_PRICED
+    return RoutedSpendDisposition.OBSERVED
+
+
+def runtime_provider_operation(
+    decision: RoutingDecision,
+    *,
+    operation_ordinal: int,
+    component: RoutedProviderComponent,
+    billing_source: BillingSource,
+    disposition: RoutedSpendDisposition,
+    economics: OperationEconomics,
+) -> RoutedProviderOperation:
+    """Build one direct-runtime operation without exposing the selected alias.
+
+    Args:
+        decision: Frozen routing decision owning the operation.
+        operation_ordinal: Stable position inside the routed completion.
+        component: Router or selected-candidate operation type.
+        billing_source: Frozen credential-ownership classification.
+        disposition: Durable accounting disposition.
+        economics: Settled usage and cost evidence.
+
+    Returns:
+        Alias-free durable provider-operation evidence.
+    """
+    operation_id = stable_id(
+        "routed-operation",
+        {
+            "decision_id": decision.decision_id,
+            "operation_ordinal": operation_ordinal,
+            "component": component.value,
+        },
+    )
+    return RoutedProviderOperation(
+        operation_id=operation_id,
+        operation_ordinal=operation_ordinal,
+        component=component,
+        billing_source=billing_source,
+        disposition=disposition,
+        operation_count=(0 if disposition == RoutedSpendDisposition.DEFINITELY_NOT_INCURRED else 1),
+        economics=economics,
+    )
+
+
+def candidate_completion_economics(
+    economics: OperationEconomics,
+    price: CandidateTokenPrice | None,
+) -> OperationEconomics:
+    """Retain measured candidate cost or locally price observed token usage.
+
+    Args:
+        economics: Provider-observed candidate economics.
+        price: Optional frozen candidate token price.
+
+    Returns:
+        Original economics when complete, otherwise locally priced token usage.
+
+    Raises:
+        ValueError: Provider cache counters are inconsistent with total input usage.
+    """
+    usage = economics.usage
+    if economics.cost_usd is not None or usage is None or price is None:
+        return economics
+    cached = usage.cached_input_tokens
+    written = usage.cache_write_input_tokens
+    if cached is not None and cached > usage.input_tokens:
+        raise ValueError("candidate cached input exceeds total input usage")
+    if written is not None and written > usage.input_tokens:
+        raise ValueError("candidate cache-write input exceeds total input usage")
+    if cached is not None and written is not None and cached + written > usage.input_tokens:
+        raise ValueError("candidate cache counters overlap beyond total input usage")
+    input_cost = _candidate_input_cost_usd(price, usage)
+    output_cost = usage.output_tokens * price.output_usd_per_million_tokens / 1_000_000
+    return economics.model_copy(
+        update={
+            "cost_usd": NumericMeasurement(
+                value=input_cost + output_cost,
+                provenance="estimated",
+            )
+        }
+    )
+
+
+def _candidate_input_cost_usd(price: CandidateTokenPrice, usage: Usage) -> float:
+    """Conservatively price ordinary, cached, and cache-write input.
+
+    Args:
+        price: Frozen candidate token price.
+        usage: Provider-observed token counters.
+
+    Returns:
+        Input-token cost in US dollars.
+    """
+    base = price.input_usd_per_million_tokens
+    cached_price = price.cached_input_usd_per_million_tokens
+    write_price = price.cache_write_usd_per_million_tokens
+    cached = usage.cached_input_tokens
+    written = usage.cache_write_input_tokens
+    if cached is not None and written is not None:
+        ordinary = usage.input_tokens - cached - written
+        total = (
+            ordinary * base
+            + cached * (cached_price if cached_price is not None else base)
+            + written * (write_price if write_price is not None else base)
+        )
+    elif cached is not None:
+        ordinary_price = max(base, write_price if write_price is not None else base)
+        total = (
+            cached * (cached_price if cached_price is not None else base)
+            + (usage.input_tokens - cached) * ordinary_price
+        )
+    elif written is not None:
+        ordinary_price = max(base, cached_price if cached_price is not None else base)
+        total = (
+            written * (write_price if write_price is not None else base)
+            + (usage.input_tokens - written) * ordinary_price
+        )
+    else:
+        total = usage.input_tokens * max(
+            base,
+            cached_price if cached_price is not None else base,
+            write_price if write_price is not None else base,
+        )
+    return total / 1_000_000
+
+
+def requires_tool_protocol(request: ModelRequest) -> bool:
+    """Return whether preserving this request requires structured tool support.
+
+    Args:
+        request: Provider-neutral request to inspect.
+
+    Returns:
+        Whether the request requires structured tool-call semantics.
+    """
+    return bool(
+        request.tools
+        or request.tool_choice is not None
+        or any(
+            message.role == "tool"
+            or (message.assistant_action is not None and bool(message.assistant_action.tool_calls))
+            for message in request.messages
+        )
+    )
+
+
+def decision_content_id(decision: RoutingDecision) -> str:
+    """Return the canonical content identity for a routing decision.
+
+    Args:
+        decision: Routing decision whose provisional identifier is excluded.
+
+    Returns:
+        Stable content-addressed decision identifier.
+    """
+    material = decision.model_dump(mode="json")
+    del material["decision_id"]
+    return stable_id("routing-decision", material)
+
+
+def validate_idempotency_key(value: str) -> None:
+    """Reject keys that cannot safely cross an HTTP provider boundary.
+
+    Args:
+        value: Caller-provided provider idempotency key.
+
+    Raises:
+        ValueError: The key is blank, oversized, padded, or not visible ASCII.
+    """
+    if not value or len(value) > 512 or value.strip() != value:
+        raise ValueError("idempotency key must be 1 to 512 non-blank characters")
+    if any(ord(character) < 33 or ord(character) > 126 for character in value):
+        raise ValueError("idempotency key must contain only visible ASCII characters")
+
+
+def supports_request(resolved: ResolvedModel, request: ModelRequest) -> bool:
+    """Return whether a resolved model proves every requested capability.
+
+    Args:
+        resolved: Frozen runtime model binding.
+        request: Provider-neutral request to evaluate.
+
+    Returns:
+        Whether the model proves the required tools and output-token capacity.
+    """
+    if requires_tool_protocol(request) and not resolved.capabilities.supports_tools:
+        return False
+    requested = request.maximum_output_tokens
+    available = resolved.capabilities.maximum_output_tokens
+    return requested is None or (available is not None and requested <= available)
+
+
+def eligible_decision(
+    request: ModelRequest,
+    decision: RoutingDecision,
+    request_sha256: str,
+    episode_id: str,
+    *,
+    policy: KnnRouterPolicy,
+    bank: KnnEvidenceBank,
+    resolve: Callable[[str], ResolvedModel],
+) -> RoutingDecision:
+    """Return the original decision or one capability-eligible frozen fallback.
+
+    Args:
+        request: Provider-neutral request that must be preserved.
+        decision: Initial guarded routing decision.
+        request_sha256: Canonical request-feature digest.
+        episode_id: Caller-owned sticky episode identity.
+        policy: Frozen router policy.
+        bank: Frozen evidence bank used for conservative cost ordering.
+        resolve: Runtime model resolver for frozen candidate aliases.
+
+    Returns:
+        The initial decision when eligible, otherwise a deterministic eligible fallback.
+    """
+    if supports_request(resolve(decision.selected_alias), request):
+        return decision
+    eligible = tuple(
+        candidate.alias
+        for candidate in policy.candidates
+        if supports_request(resolve(candidate.alias), request)
+    )
+    if not eligible:
+        return decision
+    alias = (
+        policy.baseline_alias
+        if policy.baseline_alias in eligible
+        else min(
+            eligible,
+            key=lambda item: (
+                bank.complete_weighted_cost(item) is None,
+                bank.complete_weighted_cost(item) or 0.0,
+                item,
+            ),
+        )
+    )
+    return fallback_decision(
+        policy,
+        request_sha256,
+        episode_id,
+        "capability_eligibility",
+        selected_alias=alias,
+    )
+
+
+def fallback_decision(
+    policy: KnnRouterPolicy,
+    request_sha256: str,
+    episode_id: str,
+    reason: str,
+    *,
+    selected_alias: str | None = None,
+) -> RoutingDecision:
+    """Build one content-addressed conservative routing fallback.
+
+    Args:
+        policy: Frozen router policy.
+        request_sha256: Canonical request-feature digest.
+        episode_id: Caller-owned sticky episode identity.
+        reason: Content-free fallback reason.
+        selected_alias: Optional eligible alias overriding the baseline.
+
+    Returns:
+        Content-addressed conservative routing decision.
+    """
+    alias = selected_alias or policy.baseline_alias
+    provisional = RoutingDecision(
+        decision_id="routing-decision-provisional",
+        policy_id=policy.policy_id,
+        policy_sha256=policy_content_sha256(policy),
+        request_sha256=request_sha256,
+        episode_id_sha256=hashlib.sha256(episode_id.encode("utf-8")).hexdigest(),
+        selected_alias=alias,
+        baseline_alias=policy.baseline_alias,
+        neighbor_count=0,
+        paired_count=0,
+        fallback_reason=reason,
+    )
+    return provisional.model_copy(update={"decision_id": decision_content_id(provisional)})
+
+
+def sticky_decision(
+    episode_decision: RoutingDecision,
+    request_sha256: str,
+) -> RoutingDecision:
+    """Bind a later episode turn to the original selected alias and evidence.
+
+    Args:
+        episode_decision: First retained decision for the sticky episode.
+        request_sha256: Canonical digest for the later turn.
+
+    Returns:
+        Content-addressed later-turn decision with the original selected alias.
+    """
+    material = episode_decision.model_copy(update={"request_sha256": request_sha256})
+    return material.model_copy(update={"decision_id": decision_content_id(material)})
+
+
+def sealed_bank(bank: KnnEvidenceBank) -> KnnEvidenceBank:
+    """Create runtime-owned arrays backed by immutable bytes.
+
+    Args:
+        bank: Validated evidence bank to isolate from caller mutation.
+
+    Returns:
+        Equivalent evidence bank whose arrays cannot be made writable.
+    """
+    sealed = KnnEvidenceBank(
+        task_ids=bank.task_ids,
+        candidate_aliases=bank.candidate_aliases,
+        embeddings=bank.embeddings,
+        scores=bank.scores,
+        candidate_costs=bank.candidate_costs,
+        score_counts=bank.score_counts,
+        cost_counts=bank.cost_counts,
+        workload_weights=bank.workload_weights,
+        novelty_floor=bank.novelty_floor,
+    )
+    for name in (
+        "embeddings",
+        "scores",
+        "candidate_costs",
+        "score_counts",
+        "cost_counts",
+        "workload_weights",
+    ):
+        values = getattr(sealed, name)
+        immutable = np.frombuffer(values.tobytes(), dtype=values.dtype).reshape(values.shape)
+        object.__setattr__(sealed, name, immutable)
+    return sealed

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -702,8 +702,24 @@ def test_project_resolver_retains_failed_embedding_evidence_without_reembedding(
             deadline_monotonic=__import__("time").monotonic() + 1,
         )
     )
+    continued = asyncio.run(
+        resolver.select(
+            target=target,
+            request=request.model_copy(
+                update={
+                    "messages": (
+                        *request.messages,
+                        GatewayMessage(role="user", content="next"),
+                    )
+                }
+            ),
+            episode_namespace=namespace,
+            deadline_monotonic=__import__("time").monotonic() + 1,
+        )
+    )
 
     assert selection.selected_alias == "baseline"
+    assert continued.selected_alias == selection.selected_alias
     assert client.embed_calls == 1
     assert len(runtime._request_decisions) == 1  # noqa: SLF001 - accounting regression
     decision = next(iter(runtime._request_decisions.values()))  # noqa: SLF001

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -39,7 +39,7 @@ from wmo.common.models import (
     Usage,
 )
 from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
-from wmo.common.routing import KnnGuard, KnnRouterPolicy
+from wmo.common.routing import KnnGuard, KnnRouterPolicy, RoutingDecision
 from wmo.common.routing.bank import (
     CandidateEvidenceCount,
     KnnBankManifest,
@@ -785,6 +785,40 @@ def test_cached_selection_and_completion_reuse_sealed_activation_without_rehashi
     with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
         runtime.bank.scores.setflags(write=True)
     assert runtime.select(request, episode_id="episode-a") == decision
+
+
+def test_complete_survives_concurrent_lru_eviction_of_its_internal_selection() -> None:
+    """A valid internally selected decision remains consumable after bounded cache eviction."""
+    policy, manifest, bank, snapshots, client = _fixture()
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _Catalog(snapshots, client)),
+        pricing_snapshot_id=policy.pricing_snapshot_id,
+        pricing_snapshot_sha256=policy.pricing_snapshot_sha256,
+        pricing_candidate_aliases=manifest.candidate_aliases,
+        decision_capacity=1,
+    )
+    original_select = runtime.select
+
+    def select_then_evict(
+        request: ModelRequest,
+        *,
+        episode_id: str | None = None,
+        retain: bool = True,
+    ) -> RoutingDecision:
+        """Evict the returned decision before ``complete`` reaches its cache check."""
+        selected = original_select(request, episode_id=episode_id, retain=retain)
+        original_select(_request(tool_name="evict"), episode_id="other-episode")
+        return selected
+
+    runtime.__dict__["select"] = select_then_evict
+
+    result = runtime.complete(_request(), episode_id="episode-a")
+
+    assert result.decision.episode_id_sha256 == hashlib.sha256(b"episode-a").hexdigest()
+    assert client.complete_calls == 1
 
 
 def test_sticky_decision_identity_hashes_all_retained_evidence() -> None:

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -54,7 +54,11 @@ from wmo.runtime.gateway.contracts import (
     GatewayRequest,
     ProjectTarget,
 )
-from wmo.runtime.gateway.routing import RouterProjectTargetResolver, gateway_model_request
+from wmo.runtime.gateway.routing import (
+    RouterProjectTargetResolver,
+    gateway_model_request,
+    project_episode_identity,
+)
 from wmo.runtime.models import CatalogRoleName, ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
 from wmo.runtime.router import RouterRuntime, RouterRuntimeIntegrityError
@@ -705,7 +709,7 @@ def test_project_resolver_retains_failed_embedding_evidence_without_reembedding(
     decision = next(iter(runtime._request_decisions.values()))  # noqa: SLF001
     operation = runtime.selection_operation(
         gateway_model_request(request),
-        episode_id="\x1f".join(namespace),
+        episode_id=project_episode_identity(namespace),
         decision=decision,
     )
     assert operation.disposition == RoutedSpendDisposition.RESERVED_AMBIGUOUS

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -39,7 +39,7 @@ from wmo.common.models import (
     Usage,
 )
 from wmo.common.project import ArtifactStore, ProjectPaths, artifact_input
-from wmo.common.routing import KnnGuard, KnnRouterPolicy, RoutingDecision
+from wmo.common.routing import KnnGuard, KnnRouterPolicy
 from wmo.common.routing.bank import (
     CandidateEvidenceCount,
     KnnBankManifest,
@@ -66,6 +66,7 @@ from wmo.runtime.router.economics import (
     RoutedProviderComponent,
     RoutedSpendDisposition,
 )
+from wmo.runtime.router.runtime import _PreparedSelection  # noqa: PLC2701
 from wmo.runtime.router.runtime_support import sticky_decision
 
 _TIME = datetime(2026, 8, 12, tzinfo=UTC)
@@ -807,8 +808,8 @@ def test_cached_selection_and_completion_reuse_sealed_activation_without_rehashi
     assert runtime.select(request, episode_id="episode-a") == decision
 
 
-def test_complete_survives_concurrent_lru_eviction_of_its_internal_selection() -> None:
-    """A valid internally selected decision remains consumable after bounded cache eviction."""
+def test_complete_survives_concurrent_repopulation_after_internal_selection_eviction() -> None:
+    """A valid in-flight selection survives conflicting same-episode repopulation."""
     policy, manifest, bank, snapshots, client = _fixture()
     runtime = RouterRuntime(
         policy,
@@ -820,24 +821,32 @@ def test_complete_survives_concurrent_lru_eviction_of_its_internal_selection() -
         pricing_candidate_aliases=manifest.candidate_aliases,
         decision_capacity=1,
     )
-    original_select = runtime.select
+    original_select = runtime._select_retained  # noqa: SLF001 - concurrency boundary regression.
 
-    def select_then_evict(
+    def select_then_repopulate(
         request: ModelRequest,
         *,
-        episode_id: str | None = None,
-        retain: bool = True,
-    ) -> RoutingDecision:
-        """Evict the returned decision before ``complete`` reaches its cache check."""
-        selected = original_select(request, episode_id=episode_id, retain=retain)
+        episode_id: str,
+    ) -> _PreparedSelection:
+        """Evict and replace the returned episode before completion validation."""
+        prepared = original_select(request, episode_id=episode_id)
         original_select(_request(tool_name="evict"), episode_id="other-episode")
-        return selected
+        client.embedding_values = ()
+        replacement = original_select(
+            _request(tool_name="repopulate"),
+            episode_id=episode_id,
+        )
+        client.embedding_values = (Embedding(values=(1.0, 0.0)),)
+        assert prepared.decision.selected_alias == "cheap"
+        assert replacement.decision.selected_alias == "baseline"
+        return prepared
 
-    runtime.__dict__["select"] = select_then_evict
+    runtime.__dict__["_select_retained"] = select_then_repopulate
 
     result = runtime.complete(_request(), episode_id="episode-a")
 
     assert result.decision.episode_id_sha256 == hashlib.sha256(b"episode-a").hexdigest()
+    assert result.decision.selected_alias == "cheap"
     assert client.complete_calls == 1
 
 

--- a/wmo/runtime/router/runtime_test.py
+++ b/wmo/runtime/router/runtime_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import threading
 from collections.abc import Sequence
@@ -47,12 +48,21 @@ from wmo.common.routing.bank import (
 )
 from wmo.common.routing.features import ROUTER_FEATURE_SCHEMA_SHA256
 from wmo.common.tasks import TaskCase, TaskSet
+from wmo.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    ProjectTarget,
+)
+from wmo.runtime.gateway.routing import RouterProjectTargetResolver, gateway_model_request
 from wmo.runtime.models import CatalogRoleName, ResolvedModel, RuntimeModelCatalog
+from wmo.runtime.models.providers.async_transport import ProviderDeadlineExceeded
 from wmo.runtime.router import RouterRuntime, RouterRuntimeIntegrityError
 from wmo.runtime.router.economics import (
     RoutedProviderComponent,
     RoutedSpendDisposition,
 )
+from wmo.runtime.router.runtime_support import sticky_decision
 
 _TIME = datetime(2026, 8, 12, tzinfo=UTC)
 _DIGEST = "a" * 64
@@ -215,8 +225,9 @@ def test_artifact_mutation_and_pricing_or_alias_drift_block_activation() -> None
     )
     bank.scores.setflags(write=True)
     bank.scores[0, 0] = 0.0
-    with pytest.raises(RouterRuntimeIntegrityError, match="bank content has mutated"):
-        runtime.select(_request(), episode_id="episode-a")
+    assert runtime.select(_request(), episode_id="episode-a").selected_alias == "cheap"
+    with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
+        runtime.bank.scores.setflags(write=True)
 
 
 @pytest.mark.parametrize(
@@ -548,8 +559,217 @@ def test_concurrent_first_selection_embeds_and_records_exactly_once() -> None:
     assert recorded == [decisions[0]]
 
 
-def test_cached_selection_and_completion_recheck_integrity_without_consumption() -> None:
-    """Mutation and forged decisions reject while exact retries reuse the frozen decision."""
+def test_distinct_first_selections_embed_outside_the_shared_cache_lock() -> None:
+    """Independent episodes can embed concurrently without serializing on cache state."""
+    runtime, client = _runtime()
+    entered = threading.Barrier(3)
+    decisions: list[object] = []
+
+    def concurrent_embed(texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Wait until both embedding calls are concurrently in flight."""
+        del texts
+        client.embed_calls += 1
+        entered.wait(timeout=1)
+        return (Embedding(values=(1.0, 0.0)),)
+
+    client.__dict__["embed"] = concurrent_embed
+
+    def select(episode_id: str) -> None:
+        """Select one independent episode on a worker thread."""
+        decisions.append(runtime.select(_request(), episode_id=episode_id))
+
+    threads = (
+        threading.Thread(target=select, args=("episode-a",)),
+        threading.Thread(target=select, args=("episode-b",)),
+    )
+    for thread in threads:
+        thread.start()
+    entered.wait(timeout=1)
+    for thread in threads:
+        thread.join(timeout=1)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(decisions) == 2
+    assert client.embed_calls == 2
+
+
+def test_decision_cache_ttl_and_capacity_bound_all_process_local_state() -> None:
+    """Least-recent decisions evict at capacity and expired episodes reselect."""
+    policy, manifest, bank, snapshots, client = _fixture()
+    now = [10.0]
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _Catalog(snapshots, client)),
+        pricing_snapshot_id=policy.pricing_snapshot_id,
+        pricing_snapshot_sha256=policy.pricing_snapshot_sha256,
+        pricing_candidate_aliases=manifest.candidate_aliases,
+        decision_capacity=1,
+        decision_ttl_seconds=5,
+        clock=lambda: now[0],
+    )
+
+    runtime.select(_request(), episode_id="episode-a")
+    runtime.select(_request(), episode_id="episode-b")
+    assert len(runtime._episode_decisions) == 1  # noqa: SLF001 - bounded-state regression
+    assert len(runtime._request_decisions) == 1  # noqa: SLF001 - bounded-state regression
+    assert len(runtime._request_embedding_economics) == 1  # noqa: SLF001
+    assert len(runtime._request_embedding_dispositions) == 1  # noqa: SLF001
+    now[0] = 16.0
+    runtime.select(_request(), episode_id="episode-b")
+
+    assert client.embed_calls == 3
+    assert len(runtime._episode_decisions) == 1  # noqa: SLF001 - bounded-state regression
+    assert len(runtime._request_decisions) == 1  # noqa: SLF001 - bounded-state regression
+    assert set(runtime._request_embedding_economics) == set(  # noqa: SLF001
+        runtime._request_decisions  # noqa: SLF001
+    )
+    assert set(runtime._request_embedding_dispositions) == set(  # noqa: SLF001
+        runtime._request_decisions  # noqa: SLF001
+    )
+
+
+def test_prepared_selections_keep_physical_evidence_local_until_atomic_retain() -> None:
+    """Concurrent-equivalent bundles cannot collide or publish before explicit retain."""
+    runtime, client = _runtime()
+    request = _request()
+    first = runtime._select_unretained(request, episode_id="episode-a")  # noqa: SLF001
+    client.embedding_values = RuntimeError("embed failed")
+    second = runtime._select_unretained(request, episode_id="episode-a")  # noqa: SLF001
+
+    assert first is not second
+    assert first.disposition == RoutedSpendDisposition.LOCALLY_PRICED
+    assert second.disposition == RoutedSpendDisposition.RESERVED_AMBIGUOUS
+    assert runtime._episode_decisions == {}  # noqa: SLF001 - publication boundary
+    assert runtime._request_decisions == {}  # noqa: SLF001 - publication boundary
+
+    retained = runtime._retain_prepared_selection(  # noqa: SLF001
+        request,
+        episode_id="episode-a",
+        prepared=first,
+    )
+    first_operation = runtime.selection_operation(
+        request,
+        episode_id="episode-a",
+        decision=retained,
+    )
+    reconciled = runtime._retain_prepared_selection(  # noqa: SLF001
+        request,
+        episode_id="episode-a",
+        prepared=second,
+    )
+    second_operation = runtime.selection_operation(
+        request,
+        episode_id="episode-a",
+        decision=reconciled,
+    )
+
+    assert reconciled == retained
+    assert first_operation.disposition == RoutedSpendDisposition.LOCALLY_PRICED
+    assert second_operation.disposition == RoutedSpendDisposition.RESERVED_AMBIGUOUS
+    assert client.embed_calls == 2
+
+
+def test_project_resolver_retains_failed_embedding_evidence_without_reembedding() -> None:
+    """A failed physical embed binds ambiguous accounting through gateway selection."""
+    runtime, client = _runtime()
+    client.embedding_values = RuntimeError("embed failed")
+    target = ProjectTarget(
+        project_ref="project-one",
+        activation_ref="activation-one",
+        catalog_sha256=_DIGEST,
+    )
+    resolver = RouterProjectTargetResolver(
+        {("project-one", "activation-one"): runtime},
+        {("project-one", "activation-one", _DIGEST, "baseline"): "exact-baseline"},
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="route"),),
+    )
+    namespace = ("org", "identity", "revision", "episode")
+
+    selection = asyncio.run(
+        resolver.select(
+            target=target,
+            request=request,
+            episode_namespace=namespace,
+            deadline_monotonic=__import__("time").monotonic() + 1,
+        )
+    )
+
+    assert selection.selected_alias == "baseline"
+    assert client.embed_calls == 1
+    assert len(runtime._request_decisions) == 1  # noqa: SLF001 - accounting regression
+    decision = next(iter(runtime._request_decisions.values()))  # noqa: SLF001
+    operation = runtime.selection_operation(
+        gateway_model_request(request),
+        episode_id="\x1f".join(namespace),
+        decision=decision,
+    )
+    assert operation.disposition == RoutedSpendDisposition.RESERVED_AMBIGUOUS
+    assert operation.operation_count == 1
+
+
+def test_timed_out_project_selection_cannot_publish_late_sticky_state() -> None:
+    """A detached blocking embed remains unretained after its request deadline expires."""
+    runtime, client = _runtime()
+    recorded: list[object] = []
+    runtime._decision_sink = recorded.append  # noqa: SLF001 - deadline publication regression
+    entered = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def blocking_embed(texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Hold selection beyond the gateway deadline, then report completion."""
+        del texts
+        entered.set()
+        release.wait(timeout=1)
+        completed.set()
+        return (Embedding(values=(1.0, 0.0)),)
+
+    client.__dict__["embed"] = blocking_embed
+    target = ProjectTarget(
+        project_ref="project-one",
+        activation_ref="activation-one",
+        catalog_sha256=_DIGEST,
+    )
+    resolver = RouterProjectTargetResolver(
+        {("project-one", "activation-one"): runtime},
+        {("project-one", "activation-one", _DIGEST, "cheap"): "exact-cheap"},
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="route"),),
+    )
+
+    async def scenario() -> None:
+        """Expire the wrapper while the unretained worker remains blocked."""
+        selection = asyncio.create_task(
+            resolver.select(
+                target=target,
+                request=request,
+                episode_namespace=("org", "identity", "revision", "episode"),
+                deadline_monotonic=__import__("time").monotonic() + 0.01,
+            )
+        )
+        await asyncio.to_thread(entered.wait, 1)
+        with pytest.raises(ProviderDeadlineExceeded):
+            await selection
+        release.set()
+        await asyncio.to_thread(completed.wait, 1)
+        await asyncio.sleep(0)
+
+    asyncio.run(scenario())
+
+    assert runtime._episode_decisions == {}  # noqa: SLF001 - deadline isolation regression
+    assert runtime._request_decisions == {}  # noqa: SLF001 - deadline isolation regression
+    assert recorded == []
+
+
+def test_cached_selection_and_completion_reuse_sealed_activation_without_rehashing() -> None:
+    """Forged decisions reject while exact retries reuse immutable activation state."""
     runtime, client = _runtime()
     request = _request()
     decision = runtime.select(request, episode_id="episode-a")
@@ -562,10 +782,9 @@ def test_cached_selection_and_completion_recheck_integrity_without_consumption()
     runtime.complete(request, episode_id="episode-a", decision=decision)
     assert len(client.requests) == 2
 
-    runtime.bank.scores.setflags(write=True)
-    runtime.bank.scores[0, 0] = 0.0
-    with pytest.raises(RouterRuntimeIntegrityError, match="bank content has mutated"):
-        runtime.select(request, episode_id="episode-a")
+    with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
+        runtime.bank.scores.setflags(write=True)
+    assert runtime.select(request, episode_id="episode-a") == decision
 
 
 def test_sticky_decision_identity_hashes_all_retained_evidence() -> None:
@@ -581,10 +800,8 @@ def test_sticky_decision_identity_hashes_all_retained_evidence() -> None:
     )
     request_sha256 = "f" * 64
 
-    sticky = runtime._sticky_decision(first, request_sha256)  # noqa: SLF001 - identity probe
-    changed_sticky = runtime._sticky_decision(  # noqa: SLF001 - identity probe
-        changed, request_sha256
-    )
+    sticky = sticky_decision(first, request_sha256)
+    changed_sticky = sticky_decision(changed, request_sha256)
 
     assert sticky != changed_sticky
     assert sticky.decision_id != changed_sticky.decision_id


### PR DESCRIPTION
## Summary

- make the authenticated gateway the sole serving data plane for Chat Completions and Responses
- consume the neutral OpenAI protocol for decoding, errors, headers, response assembly, SSE, tool calls, and continuation lineage
- keep `RouterRuntime` selection-only and bind project selection to exact gateway deployments without a second HTTP application
- own provider execution, replay, continuation, accounting, lifecycle deadlines, and sticky project selection in the gateway

## Boundary

The router retains project-policy loading and exact-model selection. The gateway owns every serving concern after selection. Cross-provider waterfalls and launch compatibility are layered downstream.

## Stack

- base: `agent/gateway-integration-base` at `a87ceadb`
- head: `5c56e170`

This PR is ready for review and must not be merged independently of its stack.
