### PR TITLE
Remove legacy artifact loaders and compatibility shims

### DIFF
--- a/wmo/cli/judge_transcript.py
+++ b/wmo/cli/judge_transcript.py
@@ -160,16 +160,12 @@ def user_input(attributes: dict[str, JsonValue]) -> str | None:
         attributes: Canonical normalized span attributes.
 
     Returns:
-        Latest user content when captured, otherwise the legacy prompt field.
+        Latest user content when captured, otherwise ``None``.
     """
-    text = _last_role_message(
+    return _last_role_message(
         _decoded_json_value(attributes.get("gen_ai.input.messages")),
         frozenset({"user", "human"}),
     )
-    if text is not None:
-        return text
-    prompt = attributes.get("gen_ai.prompt")
-    return prompt.strip() if isinstance(prompt, str) and prompt.strip() else None
 
 
 def _last_role_message(value: JsonValue, roles: frozenset[str]) -> str | None:

--- a/wmo/common/evaluations/build_test.py
+++ b/wmo/common/evaluations/build_test.py
@@ -536,6 +536,8 @@ def _materialization_fixture(
                 dimension_id="dimension-a",
                 raw_score=4,
                 calibrated_score=4.0,
+                min_score=0,
+                max_score=5,
                 rationale="The response met the requested behavior.",
             ),
         ),
@@ -827,6 +829,8 @@ def _persist_calibration(
         score_maps=(
             DimensionScoreMap(
                 dimension_id="dimension-a",
+                min_score=0,
+                max_score=5,
                 calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
             ),
         ),

--- a/wmo/common/judging/judgment.py
+++ b/wmo/common/judging/judgment.py
@@ -20,8 +20,8 @@ class DimensionJudgment(ContractModel):
     dimension_id: ArtifactId
     raw_score: int = Field(ge=0)
     calibrated_score: float = Field(ge=0)
-    min_score: int = Field(default=0, ge=0)
-    max_score: int = Field(default=5, ge=0)
+    min_score: int = Field(ge=0)
+    max_score: int = Field(ge=0)
     rationale: str | None = None
 
     @field_validator("calibrated_score")

--- a/wmo/common/judging/judgment_test.py
+++ b/wmo/common/judging/judgment_test.py
@@ -27,6 +27,8 @@ def _dimension_judgment() -> DimensionJudgment:
         dimension_id="task-success",
         raw_score=4,
         calibrated_score=3.8,
+        min_score=0,
+        max_score=5,
         rationale="The refund request includes the order and reason.",
     )
 
@@ -53,6 +55,8 @@ def test_judgment_rejects_duplicate_dimensions_and_nonfinite_scores() -> None:
             dimension_id="task-success",
             raw_score=4,
             calibrated_score=float("nan"),
+            min_score=0,
+            max_score=5,
             rationale="Invalid score.",
         )
     with pytest.raises(ValidationError, match="equal-weight"):
@@ -78,12 +82,16 @@ def test_dimension_judgment_accepts_missing_null_and_unbounded_rationale() -> No
         dimension_id="task-success",
         raw_score=4,
         calibrated_score=3.8,
+        min_score=0,
+        max_score=5,
     )
     explicit_null = DimensionJudgment.model_validate(
         {
             "dimension_id": "task-success",
             "raw_score": 4,
             "calibrated_score": 3.8,
+            "min_score": 0,
+            "max_score": 5,
             "rationale": None,
         }
     )
@@ -92,6 +100,8 @@ def test_dimension_judgment_accepts_missing_null_and_unbounded_rationale() -> No
         dimension_id="task-success",
         raw_score=4,
         calibrated_score=3.8,
+        min_score=0,
+        max_score=5,
         rationale=long_rationale,
     )
 
@@ -108,6 +118,8 @@ def test_dimension_judgment_rejects_citation_era_fields() -> None:
                 "dimension_id": "task-success",
                 "raw_score": 4,
                 "calibrated_score": 3.8,
+                "min_score": 0,
+                "max_score": 5,
                 "evidence_span_ids": ["span-1"],
                 "feedback": "Retired citation-era field.",
             }

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -33,8 +33,8 @@ class RubricDimension(ContractModel):
     dimension_id: ArtifactId
     name: str = Field(min_length=1, max_length=256)
     description: str = Field(min_length=1)
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
+    max_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
     anchors: tuple[ScoreAnchor, ...]
 
     @model_validator(mode="after")
@@ -238,8 +238,8 @@ class DimensionScoreMap(ContractModel):
     """A monotonic mapping from raw judge scores to expected human scores."""
 
     dimension_id: ArtifactId
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
+    max_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
     calibrated_scores: tuple[float, ...]
 
     @model_validator(mode="after")

--- a/wmo/common/judging/rubric_test.py
+++ b/wmo/common/judging/rubric_test.py
@@ -104,24 +104,6 @@ def test_rubric_rejects_empty_axes_duplicate_ids_and_invalid_ranges() -> None:
         )
 
 
-def test_legacy_zero_to_five_payload_loads_without_range_fields() -> None:
-    """Pre-range rubric cards keep their 0-5 meaning when min_score and max_score are absent."""
-    axis = RubricDimension.model_validate(
-        {
-            "dimension_id": "task-success",
-            "name": "Task success",
-            "description": "Whether the customer received a correct outcome.",
-            "anchors": [
-                {"score": score, "description": f"Score {score} outcome."} for score in range(6)
-            ],
-        }
-    )
-
-    assert axis.min_score == 0
-    assert axis.max_score == 5
-    assert axis.permitted_scores() == (0, 1, 2, 3, 4, 5)
-
-
 def test_rubric_rejects_axes_that_do_not_share_one_range() -> None:
     """A shared schema cannot describe mixed inclusive ranges in one rubric."""
     with pytest.raises(ValidationError, match="same inclusive score range"):

--- a/wmo/common/models/model_test.py
+++ b/wmo/common/models/model_test.py
@@ -109,7 +109,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
 
 def test_completion_support_preserves_provider_identity_for_existing_traces() -> None:
     """Completion eligibility is frozen separately without orphaning old trace snapshots."""
-    legacy_payload = {
+    identity_payload = {
         "supports_tools": False,
         "supports_embeddings": False,
         "context_window_tokens": None,
@@ -119,7 +119,7 @@ def test_completion_support_preserves_provider_identity_for_existing_traces() ->
     supported = ModelCapabilities(supports_completions=True)
     unsupported = ModelCapabilities(supports_completions=False)
 
-    assert unknown.identity_sha256() == sha256_json(legacy_payload)
+    assert unknown.identity_sha256() == sha256_json(identity_payload)
     assert supported.identity_sha256() == unsupported.identity_sha256()
     assert supported.identity_sha256() == unknown.identity_sha256()
     pinned_sampling = ModelCapabilities(supports_temperature=False, reasoning_effort="xhigh")
@@ -131,8 +131,8 @@ def test_completion_support_preserves_provider_identity_for_existing_traces() ->
         )
 
 
-def test_legacy_routed_candidate_payload_reserializes_byte_for_byte() -> None:
-    """Automatic capability freezing cannot add fields to the v1 candidate contract."""
+def test_routed_candidate_payload_reserializes_byte_for_byte() -> None:
+    """Automatic capability freezing cannot add fields to the candidate contract."""
     payload = {
         "alias": "candidate-a",
         "model": {

--- a/wmo/common/project/project.py
+++ b/wmo/common/project/project.py
@@ -20,7 +20,7 @@ from wmo.common.core.files import write_text_atomic
 
 
 def _exclude_absent(value: object) -> bool:
-    """Return whether an optional compatibility field should be omitted from serialization.
+    """Return whether an optional absent field should be omitted from serialization.
 
     Args:
         value: Field value being serialized.

--- a/wmo/common/rollouts/dispatch_failures.py
+++ b/wmo/common/rollouts/dispatch_failures.py
@@ -18,17 +18,6 @@ UNKNOWN_DISPATCH_RESERVED_COST_KEY = "unknown_dispatch_reserved_cost_usd"
 
 _DISPATCH_FAILURE_PHASE = "candidate_or_world_model"
 
-_TRANSPORT_EXCEPTION_TYPES = frozenset(
-    {
-        "ProviderTransportError",
-        "TimeoutError",
-        "ConnectionError",
-        "ConnectionResetError",
-        "OSError",
-    }
-)
-"""Exception types treated as transport-class for evidence persisted without a retry flag."""
-
 
 def unknown_spend_failure(failure: StructuredFailure | None) -> bool:
     """Return whether a persisted failure left its dispatched provider spend unknown.
@@ -57,7 +46,7 @@ def unknown_dispatch_reserved_cost_usd(failure: StructuredFailure | None) -> flo
 
     Returns:
         The nonnegative finite reserved amount persisted with the failure, or ``None`` when
-        the evidence predates reservation persistence or the value is unusable.
+        the value is absent or unusable.
     """
     if failure is None:
         return None
@@ -73,11 +62,9 @@ def unknown_dispatch_reserved_cost_usd(failure: StructuredFailure | None) -> flo
 def retryable_dispatch_failure(failure: StructuredFailure | None) -> bool:
     """Return whether a persisted provider dispatch failure is transport-retryable.
 
-    Only candidate or world-model dispatch failures qualify. Evidence that carries an
-    explicit ``retry_classification`` detail is trusted exactly as classified. Evidence
-    persisted before retry classification existed falls back to the transport-class
-    exception types, so a legacy transient transport failure stays resumable. Budget,
-    validation, and stale-lease failures never qualify.
+    Only candidate or world-model dispatch failures qualify, and only when the
+    persisted failure is marked retryable. Budget, validation, and stale-lease
+    failures never qualify.
 
     Args:
         failure: Structured failure retained by a rollout artifact, or ``None``.
@@ -91,8 +78,4 @@ def retryable_dispatch_failure(failure: StructuredFailure | None) -> bool:
         return False
     if failure.details.get("phase") != _DISPATCH_FAILURE_PHASE:
         return False
-    if failure.retryable:
-        return True
-    if "retry_classification" in failure.details:
-        return False
-    return failure.exception_type in _TRANSPORT_EXCEPTION_TYPES
+    return failure.retryable

--- a/wmo/common/rollouts/dispatch_failures_test.py
+++ b/wmo/common/rollouts/dispatch_failures_test.py
@@ -98,7 +98,7 @@ def test_retryable_dispatch_failure_requires_provider_dispatch_transport_class()
     """Only transport-class provider dispatch failures qualify for resume re-execution."""
     assert retryable_dispatch_failure(None) is False
     assert retryable_dispatch_failure(_failure(retryable=True)) is True
-    assert retryable_dispatch_failure(_failure()) is True
+    assert retryable_dispatch_failure(_failure()) is False
     assert (
         retryable_dispatch_failure(
             _failure(

--- a/wmo/common/routing/embeddings.py
+++ b/wmo/common/routing/embeddings.py
@@ -193,15 +193,15 @@ class FrozenEmbeddingClient(EmbeddingClient):
 
 def load_frozen_embedding_set(
     store: ArtifactStore, artifact_id: ArtifactId
-) -> FrozenEmbeddingSet | ReservedFrozenEmbeddingSet:
-    """Load one manifest-verified completed router embedding artifact.
+) -> ReservedFrozenEmbeddingSet:
+    """Load one manifest-verified reserved router embedding artifact.
 
     Args:
         store: Project-local immutable artifact store.
         artifact_id: Router-embedding artifact identity.
 
     Returns:
-        Parsed frozen embedding set.
+        Parsed reserved frozen embedding set.
 
     Raises:
         ValueError: The artifact type, payload, or bound identity is invalid.
@@ -216,32 +216,26 @@ def load_frozen_embedding_set(
         raise ValueError("router embedding payload is not valid JSON") from exc
     if not isinstance(raw, dict):
         raise ValueError("router embedding payload must be a JSON object")
-    schema_version = raw.get("schema_version")
-    value: FrozenEmbeddingSet | ReservedFrozenEmbeddingSet = (
-        ReservedFrozenEmbeddingSet.model_validate_json(payload)
-        if schema_version == 2
-        else FrozenEmbeddingSet.model_validate_json(payload)
-    )
-    if value.schema_version not in {1, 2}:
+    if raw.get("schema_version") != 2:
         raise ValueError("router embedding set schema version is unsupported")
+    value = ReservedFrozenEmbeddingSet.model_validate_json(payload)
     if value.embedding_set_id != artifact_id:
         raise ValueError("router embedding set identity differs from its artifact")
     if not envelope_matches_manifest(value, stored.manifest):
         raise ValueError("router embedding payload differs from its artifact manifest")
     for item in value.embeddings:
         Embedding(values=item.values)
-    if isinstance(value, ReservedFrozenEmbeddingSet):
-        if len(value.inputs) != 1:
-            raise ValueError("router embedding set needs one exact task-set input")
-        expected_id = _router_embedding_set_id(
-            task_set_input=value.inputs[0],
-            embedder_alias=value.embedder_alias,
-            embedder=value.embedder,
-            reservation=value.reservation,
-            feature_digests=tuple(item.text_sha256 for item in value.embeddings),
-        )
-        if expected_id != artifact_id:
-            raise ValueError("router embedding set content identity is invalid")
+    if len(value.inputs) != 1:
+        raise ValueError("router embedding set needs one exact task-set input")
+    expected_id = _router_embedding_set_id(
+        task_set_input=value.inputs[0],
+        embedder_alias=value.embedder_alias,
+        embedder=value.embedder,
+        reservation=value.reservation,
+        feature_digests=tuple(item.text_sha256 for item in value.embeddings),
+    )
+    if expected_id != artifact_id:
+        raise ValueError("router embedding set content identity is invalid")
     return value
 
 
@@ -390,8 +384,7 @@ def persist_router_embeddings(
     if destination.exists():
         existing = load_frozen_embedding_set(store, embedding_set_id)
         if (
-            not isinstance(existing, ReservedFrozenEmbeddingSet)
-            or existing.inputs != (task_set_input,)
+            existing.inputs != (task_set_input,)
             or existing.embedder_alias != embedder_alias
             or existing.embedder != embedder
             or existing.reservation != reservation

--- a/wmo/common/routing/embeddings_test.py
+++ b/wmo/common/routing/embeddings_test.py
@@ -239,31 +239,6 @@ def test_router_embedding_rejects_symlinked_coordination_ancestor_before_dispatc
     assert tuple(sorted(path.name for path in external.iterdir())) == before
 
 
-def test_legacy_frozen_embedding_payload_reserializes_without_v2_fields() -> None:
-    """Loading a v1 embedding set preserves its exact serialized field set."""
-    payload = {
-        "schema_version": 1,
-        "created_at": "2026-08-12T00:00:00Z",
-        "inputs": [],
-        "code_revision": "legacy",
-        "source": None,
-        "embedding_set_id": "legacy-embeddings",
-        "embedder_alias": "embedder",
-        "embedder": {
-            "provider": "fixture",
-            "model_id": "embedder",
-            "revision": None,
-            "capabilities_sha256": _DIGEST,
-            "connection_sha256": _DIGEST,
-        },
-        "embeddings": [{"text_sha256": _DIGEST, "values": [1.0, 0.0]}],
-    }
-
-    restored = FrozenEmbeddingSet.model_validate(payload)
-
-    assert restored.model_dump(mode="json") == payload
-
-
 def test_router_embedding_under_reservation_fails_before_dispatch(tmp_path: Path) -> None:
     """A rendered feature larger than its ceiling cannot reach the provider.
 
@@ -446,8 +421,15 @@ def test_router_embedding_loader_rejects_manifest_envelope_drift(tmp_path: Path)
         tmp_path: Temporary initialized project root.
     """
     project, _task, model = _project_task_model(tmp_path)
-    payload = FrozenEmbeddingSet(
-        schema_version=1,
+    reservation = router_embedding_reservation(
+        model=model,
+        input_usd_per_million_tokens=2,
+        maximum_attempts_per_feature=2,
+        maximum_input_tokens_per_feature=10_000,
+        feature_count=1,
+    )
+    payload = ReservedFrozenEmbeddingSet(
+        schema_version=2,
         created_at=datetime(2026, 8, 12, tzinfo=UTC),
         inputs=(_artifact_input(),),
         code_revision="payload",
@@ -455,6 +437,8 @@ def test_router_embedding_loader_rejects_manifest_envelope_drift(tmp_path: Path)
         embedder_alias="embedder",
         embedder=model,
         embeddings=(FrozenEmbedding(text_sha256=_DIGEST, values=(1.0, 0.0)),),
+        embedding_dimension=2,
+        reservation=reservation,
     )
     envelope = payload.model_copy(update={"code_revision": "manifest"})
     project.artifacts.write_json(
@@ -465,6 +449,34 @@ def test_router_embedding_loader_rejects_manifest_envelope_drift(tmp_path: Path)
     )
 
     with pytest.raises(ValueError, match="differs from its artifact manifest"):
+        load_frozen_embedding_set(project.artifacts, payload.embedding_set_id)
+
+
+def test_router_embedding_loader_rejects_unreserved_schema(tmp_path: Path) -> None:
+    """Persisted embeddings must carry the reserved schema, not an unreserved payload.
+
+    Args:
+        tmp_path: Temporary initialized project root.
+    """
+    project, _task, model = _project_task_model(tmp_path)
+    payload = FrozenEmbeddingSet(
+        schema_version=1,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        inputs=(_artifact_input(),),
+        code_revision="unreserved",
+        embedding_set_id="unreserved-embeddings",
+        embedder_alias="embedder",
+        embedder=model,
+        embeddings=(FrozenEmbedding(text_sha256=_DIGEST, values=(1.0, 0.0)),),
+    )
+    project.artifacts.write_json(
+        artifact_id=payload.embedding_set_id,
+        artifact_type="router-embeddings",
+        envelope=payload,
+        files={"embeddings.json": payload},
+    )
+
+    with pytest.raises(ValueError, match="schema version is unsupported"):
         load_frozen_embedding_set(project.artifacts, payload.embedding_set_id)
 
 

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -291,8 +291,6 @@ def write_sft_dataset(store: ProjectStore, artifact: SFTDatasetArtifact) -> SFTD
     Raises:
         SFTBuildError: Existing data conflicts or serialized rows violate dataset invariants.
     """
-    if artifact.build_spec is None:
-        raise SFTBuildError("new SFT datasets must persist their deterministic build spec")
     _validate_artifact_rows(artifact)
     files = {
         "dataset.json": artifact.metadata().model_dump(mode="json", exclude_none=False),
@@ -373,40 +371,22 @@ def load_sft_dataset(
 def load_verified_sft_dataset(
     store: ProjectStore,
     dataset_id: ArtifactId,
-    *,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> SFTDatasetArtifact:
     """Reload and rebuild one accepted dataset from its persisted W12 evidence chain.
 
     Args:
         store: Project-local store owning the dataset and every transitive source artifact.
         dataset_id: Stable ID of the previously persisted W12 dataset.
-        legacy_build_spec: Exact original W12 build settings when loading metadata that predates
-            persisted build specifications.
 
     Returns:
         The canonical dataset only when its stored bytes equal a fresh deterministic rebuild.
 
     Raises:
         SFTBuildError: Any dataset, source, evidence, input, partition, build, or fingerprint
-            invariant cannot be reproduced from the immutable project store. Legacy metadata
-            additionally requires its original build settings before it can be verified.
+            invariant cannot be reproduced from the immutable project store.
     """
     loaded = load_sft_dataset(store, dataset_id)
     build_spec = loaded.build_spec
-    if build_spec is None:
-        if legacy_build_spec is None:
-            raise SFTBuildError(
-                f"frozen SFT dataset {dataset_id} predates persisted build specs; "
-                "provide legacy_build_spec with its original W12 settings"
-            )
-        build_spec = legacy_build_spec
-        loaded = loaded.model_copy(update={"build_spec": build_spec})
-    elif legacy_build_spec is not None:
-        raise SFTBuildError(
-            f"frozen SFT dataset {dataset_id} already persists its build spec; "
-            "legacy_build_spec is only valid for legacy metadata"
-        )
     production_sources = tuple(
         ProductionSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
         for source in loaded.sources

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -480,7 +480,7 @@ class SFTInspectionReport(ContractModel):
 class SFTDatasetMetadata(ContractModel):
     """All non-row frozen manifest data persisted beside canonical SFT JSONL examples."""
 
-    build_spec: SFTBuildSpec | None = None
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]
@@ -491,7 +491,7 @@ class SFTDatasetMetadata(ContractModel):
 class SFTDatasetArtifact(ContractModel):
     """Materialized dataset rows plus the immutable metadata required to reload and inspect them."""
 
-    build_spec: SFTBuildSpec | None = None
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]

--- a/wmo/optimize/model/sft/run_manifest.py
+++ b/wmo/optimize/model/sft/run_manifest.py
@@ -30,7 +30,7 @@ from wmo.common.project import (
     artifact_input,
 )
 from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
 from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
 from wmo.optimize.model.sft.training_contracts import (
     TinkerSFTError,
@@ -430,15 +430,12 @@ def load_tinker_sft_run(
 def verified_training_inputs(
     store: ProjectStore,
     dataset_id: ArtifactId,
-    *,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> tuple[SFTDatasetArtifact, ArtifactInput]:
     """Load one recursively verified W12 dataset and its exact manifest input.
 
     Args:
         store: Project store owning the immutable dataset.
         dataset_id: Persisted W12 dataset identity.
-        legacy_build_spec: Explicit settings required only for a legacy dataset.
 
     Returns:
         The verified dataset and exact manifest input used by W13.
@@ -447,11 +444,7 @@ def verified_training_inputs(
         TinkerSFTError: The W12 artifact graph cannot be verified for training.
     """
     try:
-        dataset = load_verified_sft_dataset(
-            store,
-            dataset_id,
-            legacy_build_spec=legacy_build_spec,
-        )
+        dataset = load_verified_sft_dataset(store, dataset_id)
         dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
     except (ArtifactCorruptionError, SFTBuildError) as exc:
         raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -19,7 +19,7 @@ from wmo.common.core.artifacts import (
 from wmo.common.core.locks import file_write_lock
 from wmo.common.models import NumericMeasurement
 from wmo.common.project import ProjectStore
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
 from wmo.optimize.model.sft.run_manifest import (
     _read_model,
@@ -84,7 +84,6 @@ class TinkerSFTOptimizer:
         output_dir: Path,
         created_at: datetime,
         code_revision: str,
-        legacy_build_spec: SFTBuildSpec | None = None,
     ) -> TinkerSFTResult:
         """Train from one persisted dataset without changing catalog, router, or serving state."""
         return train_tinker_sft(
@@ -95,7 +94,6 @@ class TinkerSFTOptimizer:
             backend=self._backend,
             created_at=created_at,
             code_revision=code_revision,
-            legacy_build_spec=legacy_build_spec,
         )
 
 
@@ -108,7 +106,6 @@ def train_tinker_sft(
     backend: TrainerBackend,
     created_at: datetime,
     code_revision: str,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Train a managed LoRA from frozen W12 examples with append-only local provenance.
 
@@ -120,8 +117,6 @@ def train_tinker_sft(
         backend: Concrete Tinker SDK adapter or a deterministic injected fake.
         created_at: Time recorded when this output directory is first initialized.
         code_revision: Exact revision recorded when this output directory is first initialized.
-        legacy_build_spec: Original W12 build settings for a dataset that predates persisted
-            build specifications. The runner rebuilds and verifies the legacy evidence chain.
 
     Returns:
         Completed model-handle and result artifacts containing only training and checkpoint facts.
@@ -129,11 +124,7 @@ def train_tinker_sft(
     Raises:
         TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
     """
-    dataset, dataset_input = verified_training_inputs(
-        store,
-        dataset_id,
-        legacy_build_spec=legacy_build_spec,
-    )
+    dataset, dataset_input = verified_training_inputs(store, dataset_id)
     validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
     manifest_path = output_dir / _MANIFEST_FILE
     with file_write_lock(manifest_path, what="the Tinker SFT run"):

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -24,7 +24,7 @@ from wmo.optimize.model.sft.builder_test import (
 from wmo.optimize.model.sft.builder_test import (
     _write_production_source,
 )
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
 from wmo.optimize.model.sft.rendering import (
     canonical_partitioned_rows_jsonl,
     partitioned_rows_sha256,
@@ -229,28 +229,6 @@ def _persisted_dataset(tmp_path: Path) -> _PersistedDataset:
     return _PersistedDataset(store=store, artifact=artifact)
 
 
-def _legacy_w12_dataset(tmp_path: Path) -> _PersistedDataset:
-    """Persist the exact W12 metadata shape that predates the build-spec field."""
-    store = _fixture_store(tmp_path / "project")
-    sources = (
-        _write_production_source(store, "train-source-a"),
-        _write_production_source(store, "train-source-b"),
-    )
-    artifact = _build_fixture_dataset(store, production=sources)
-    metadata = artifact.metadata().model_dump(mode="json", exclude_none=False)
-    metadata.pop("build_spec")
-    store.artifacts.write(
-        artifact_id=artifact.dataset.dataset_id,
-        artifact_type="sft-dataset",
-        envelope=artifact.dataset,
-        files={
-            "dataset.json": canonical_json_bytes(metadata),
-            "examples.jsonl": canonical_partitioned_rows_jsonl(artifact.rows),
-        },
-    )
-    return _PersistedDataset(store=store, artifact=artifact)
-
-
 def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
     """Return one small deterministic training specification."""
     fields: dict[str, int | float | str | None] = {
@@ -274,7 +252,6 @@ def _run(
     backend: _FakeBackend,
     *,
     spec: TinkerSFTSpec | None = None,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Run the public operation with immutable test provenance."""
     return train_tinker_sft(
@@ -285,7 +262,6 @@ def _run(
         backend=backend,
         created_at=_TIME,
         code_revision="w13-test",
-        legacy_build_spec=legacy_build_spec,
     )
 
 
@@ -329,52 +305,6 @@ def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
         "checkpoint",
     ]
     assert "quality" not in json.dumps(terminal)
-
-
-def test_legacy_w12_dataset_requires_and_verifies_its_original_build_spec(
-    tmp_path: Path,
-) -> None:
-    """Legacy W12 metadata trains only after its original build settings reproduce it."""
-    fixture = _legacy_w12_dataset(tmp_path)
-    missing_backend = _FakeBackend()
-
-    with pytest.raises(TinkerSFTError, match="legacy_build_spec"):
-        _run(fixture, tmp_path / "missing-spec", missing_backend)
-
-    assert missing_backend.open_resume_paths == []
-    assert fixture.artifact.build_spec is not None
-    backend = _FakeBackend()
-
-    result = _run(
-        fixture,
-        tmp_path / "migrated-run",
-        backend,
-        legacy_build_spec=fixture.artifact.build_spec,
-    )
-
-    assert result.dataset_id == fixture.artifact.dataset.dataset_id
-    assert backend.open_resume_paths == [None]
-
-
-def test_legacy_w12_dataset_rejects_a_nonmatching_migration_build_spec(
-    tmp_path: Path,
-) -> None:
-    """A caller-supplied legacy spec cannot rewrite the frozen W12 evidence chain."""
-    fixture = _legacy_w12_dataset(tmp_path)
-    backend = _FakeBackend()
-
-    with pytest.raises(TinkerSFTError, match="does not equal its canonical evidence rebuild"):
-        _run(
-            fixture,
-            tmp_path / "wrong-spec",
-            backend,
-            legacy_build_spec=SFTBuildSpec(
-                held_out_fraction=0.2,
-                representative_sample_count=2,
-            ),
-        )
-
-    assert backend.open_resume_paths == []
 
 
 def test_resume_uses_last_durable_checkpoint_without_replaying_completed_batch(

--- a/wmo/optimize/router/automatic/artifacts.py
+++ b/wmo/optimize/router/automatic/artifacts.py
@@ -306,7 +306,7 @@ def _candidate_bindings(
 def _runtime_capability_bindings(
     preflight: AutomaticRouterPreflight,
 ) -> tuple[RuntimeCandidateCapability, ...]:
-    """Build runtime-owned candidate bindings without extending the legacy policy.
+    """Build runtime-owned candidate bindings from the confirmed catalog selection.
 
     Args:
         preflight: Verified catalog and selected candidate identities.

--- a/wmo/optimize/router/automatic/attribution.py
+++ b/wmo/optimize/router/automatic/attribution.py
@@ -150,7 +150,7 @@ class RouterObservedAttributionSet(ArtifactEnvelope):
 def resolve_router_observed_attributions(
     tasks: Sequence[TaskCase],
     traces: Sequence[Trace],
-    evidence: TraceModelIdentityEvidenceSet | None,
+    evidence: TraceModelIdentityEvidenceSet,
     candidates: Sequence[RoutedCandidateSnapshot],
 ) -> tuple[RouterObservedAttribution, ...]:
     """Resolve one real fit trace per leakage lineage without guessing model identity.
@@ -158,7 +158,7 @@ def resolve_router_observed_attributions(
     Args:
         tasks: Exact completed representative tasks.
         traces: Exact completed normalized traces.
-        evidence: Verified per-model-span provenance, or ``None`` when the dataset has none.
+        evidence: Verified per-model-span provenance.
         candidates: Explicit selected candidate snapshots.
     Returns:
         Deterministic exact-match real fit attributions. Unmatched traces are omitted.
@@ -166,11 +166,10 @@ def resolve_router_observed_attributions(
     Raises:
         RouterAttributionError: Candidate scope or model identity evidence is inconsistent.
     """
-    if evidence is not None:
-        try:
-            require_model_identity_evidence_matches_traces(traces, evidence)
-        except ValueError as exc:
-            raise RouterAttributionError(f"model identity evidence is inconsistent: {exc}") from exc
+    try:
+        require_model_identity_evidence_matches_traces(traces, evidence)
+    except ValueError as exc:
+        raise RouterAttributionError(f"model identity evidence is inconsistent: {exc}") from exc
     ordered_candidates = tuple(sorted(candidates, key=lambda item: item.alias))
     if len(ordered_candidates) < 2 or len({item.alias for item in ordered_candidates}) != len(
         ordered_candidates
@@ -179,11 +178,7 @@ def resolve_router_observed_attributions(
     traces_by_id = {trace.trace_id: trace for trace in traces}
     if len(traces_by_id) != len(traces):
         raise RouterAttributionError("candidate attribution traces repeat trace IDs")
-    evidence_by_key = (
-        None
-        if evidence is None
-        else {(item.trace_id, item.span_id): item for item in evidence.records}
-    )
+    evidence_by_key = {(item.trace_id, item.span_id): item for item in evidence.records}
     selected: list[RouterObservedAttribution] = []
     admitted_lineages: set[str] = set()
     for task in tasks:
@@ -337,7 +332,7 @@ def load_router_observed_attribution_set(
 def _resolve_trace(
     task: TaskCase,
     trace: Trace,
-    evidence_by_key: dict[tuple[str, str], TraceModelIdentityEvidence] | None,
+    evidence_by_key: dict[tuple[str, str], TraceModelIdentityEvidence],
     candidates: tuple[RoutedCandidateSnapshot, ...],
 ) -> RouterObservedAttribution:
     """Resolve every model span in one trace to one common selected alias.
@@ -345,7 +340,7 @@ def _resolve_trace(
     Args:
         task: Fit task whose source trace is being admitted.
         trace: Exact real production trace.
-        evidence_by_key: Verified model-span evidence, or ``None`` for strict snapshot matching.
+        evidence_by_key: Verified model-span evidence keyed by trace and span identity.
         candidates: Exact selected candidate snapshots.
 
     Returns:
@@ -360,14 +355,11 @@ def _resolve_trace(
     for span in trace.spans:
         if span.model is None:
             continue
-        if evidence_by_key is None:
-            evidence = None
-        else:
-            evidence = evidence_by_key.get((trace.trace_id, span.span_id))
-            if evidence is None:
-                raise RouterAttributionError(
-                    f"trace {trace.trace_id!r} span {span.span_id!r} has no identity evidence"
-                )
+        evidence = evidence_by_key.get((trace.trace_id, span.span_id))
+        if evidence is None:
+            raise RouterAttributionError(
+                f"trace {trace.trace_id!r} span {span.span_id!r} has no identity evidence"
+            )
         candidate, mode, attributed_span = _resolve_span(
             span.model, span.span_id, evidence, candidates
         )
@@ -404,7 +396,7 @@ def _resolve_trace(
 def _resolve_span(
     model: ModelSnapshot,
     span_id: str,
-    evidence: TraceModelIdentityEvidence | None,
+    evidence: TraceModelIdentityEvidence,
     candidates: tuple[RoutedCandidateSnapshot, ...],
 ) -> tuple[RoutedCandidateSnapshot, AttributionMatchKind, RouterAttributedSpan]:
     """Resolve one recorded model span under its exact provenance classification.
@@ -412,7 +404,7 @@ def _resolve_span(
     Args:
         model: Recorded immutable model snapshot.
         span_id: Contributing source span identity.
-        evidence: Verified component provenance, or ``None`` when the dataset has none.
+        evidence: Verified component provenance.
         candidates: Exact selected candidate snapshots.
 
     Returns:
@@ -421,12 +413,8 @@ def _resolve_span(
     Raises:
         RouterAttributionError: Declared evidence conflicts or zero/multiple candidates remain.
     """
-    capabilities: IdentityComponentProvenance = (
-        "unspecified" if evidence is None else evidence.capabilities
-    )
-    connection: IdentityComponentProvenance = (
-        "unspecified" if evidence is None else evidence.connection
-    )
+    capabilities: IdentityComponentProvenance = evidence.capabilities
+    connection: IdentityComponentProvenance = evidence.connection
     if evidence is not None and evidence.model != model:
         raise RouterAttributionError(f"span {span_id!r} evidence differs from its model snapshot")
     if "unspecified" in {capabilities, connection}:

--- a/wmo/optimize/router/automatic/attribution_test.py
+++ b/wmo/optimize/router/automatic/attribution_test.py
@@ -115,8 +115,8 @@ def test_unique_inferred_mapping_omits_ambiguous_aliases_and_revision_drift() ->
     )
 
 
-def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> None:
-    """Direct and legacy records never receive provider/model-only inference."""
+def test_unspecified_identity_requires_full_snapshot_equality() -> None:
+    """Direct records never receive provider/model-only inference."""
     recorded = _model("openai", "gpt-test", None, "a", "b")
     trace = _trace((recorded,))
     candidates = _candidates(recorded, _model("anthropic", "other", None, "c", "d"))
@@ -127,22 +127,15 @@ def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> Non
         _evidence(trace, capabilities="unspecified", connection="unspecified"),
         candidates,
     )[0]
-    legacy = resolve_router_observed_attributions(
-        (_task(trace),),
-        (trace,),
-        None,
-        candidates,
-    )[0]
 
     assert unspecified.match_kind == "strict_snapshot"
-    assert legacy.match_kind == "strict_snapshot"
 
     changed = recorded.model_copy(update={"connection_sha256": "e" * 64})
     assert (
         resolve_router_observed_attributions(
             (_task(trace),),
             (trace,),
-            None,
+            _evidence(trace, capabilities="unspecified", connection="unspecified"),
             _candidates(changed, _model("anthropic", "other", None, "c", "d")),
         )
         == ()

--- a/wmo/optimize/router/automatic/execution_contract.py
+++ b/wmo/optimize/router/automatic/execution_contract.py
@@ -21,7 +21,6 @@ from wmo.common.core.artifacts import (
 from wmo.common.models import CompletionCostReservation, ModelSnapshot
 from wmo.common.project import ArtifactStore, artifact_input
 from wmo.common.routing import (
-    ReservedFrozenEmbeddingSet,
     RouterEmbeddingReservation,
     load_frozen_embedding_set,
 )
@@ -304,8 +303,7 @@ def load_router_execution_contract(
         raise ValueError("router execution contract differs from its manifest")
     embedding_set = load_frozen_embedding_set(store, value.router_embedding_input.artifact_id)
     if (
-        not isinstance(embedding_set, ReservedFrozenEmbeddingSet)
-        or artifact_input(store.read(value.router_embedding_input.artifact_id).manifest)
+        artifact_input(store.read(value.router_embedding_input.artifact_id).manifest)
         != value.router_embedding_input
         or embedding_set.reservation != value.router_embedding_reservation
     ):

--- a/wmo/optimize/router/automatic/preflight.py
+++ b/wmo/optimize/router/automatic/preflight.py
@@ -809,12 +809,12 @@ def _observed_traces(
         problems: Mutable aggregate preflight failures.
         tasks: Verified representative tasks.
         traces: Verified normalized production traces.
-        identity_evidence: Verified model-span digest provenance, if the dataset carries it.
+        identity_evidence: Verified model-span digest provenance, when a completed build exists.
         candidates: Exact selected candidate identities.
     Returns:
         One deterministic exact-match trace per attributable fit lineage.
     """
-    if not tasks or not traces or not candidates:
+    if not tasks or not traces or not candidates or identity_evidence is None:
         return ()
     try:
         attributions = resolve_router_observed_attributions(

--- a/wmo/optimize/router/automatic/service.py
+++ b/wmo/optimize/router/automatic/service.py
@@ -185,7 +185,6 @@ def optimize_project_router(
                 if preflight.trace_identity_evidence is None
                 else preflight.trace_identity_evidence.records
             ),
-            include_identity_evidence=preflight.trace_identity_evidence is not None,
         ),
         services=services,
         budget=RouterCompositionBudget(

--- a/wmo/optimize/router/composition.py
+++ b/wmo/optimize/router/composition.py
@@ -77,10 +77,7 @@ from wmo.runtime.router import RouterRuntime
 from wmo.simulation.build import ProjectBuild
 from wmo.simulation.engines.text.bindings import rollout_id_for_binding
 from wmo.simulation.engines.text.errors import SimulationConfigurationError
-from wmo.simulation.engines.text.grounding import (
-    load_completion_contract,
-    unknown_dispatch_worst_case_usd,
-)
+from wmo.simulation.engines.text.grounding import load_completion_contract
 from wmo.simulation.engines.text.resume import reexecutable_dispatch_failure
 from wmo.simulation.engines.text.rollout_support import rollout_spend
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
@@ -615,7 +612,7 @@ def _superseded_attempt_spend(
     if binding is None:
         raise RouterCompositionError("retried simulation rollout lacks its cell binding")
     try:
-        contract = load_completion_contract(project.artifacts, setup.simulation_completion_input)
+        load_completion_contract(project.artifacts, setup.simulation_completion_input)
     except SimulationConfigurationError as exc:
         raise RouterCompositionError(str(exc)) from exc
     charges = []
@@ -623,15 +620,7 @@ def _superseded_attempt_spend(
         prior, _input = read_rollout(
             project.artifacts, rollout_id_for_binding(binding, attempt=attempt)
         )
-        spend = rollout_spend(
-            prior,
-            unknown_dispatch_fallback_usd=lambda item: unknown_dispatch_worst_case_usd(
-                contract,
-                item.simulation_binding.candidate_alias
-                if item.simulation_binding is not None
-                else None,
-            ),
-        )
+        spend = rollout_spend(prior)
         if spend is None:
             raise RouterCompositionError(
                 "superseded simulation attempt spend cannot be reconciled conservatively"

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -37,7 +36,7 @@ from wmo.common.models import (
     Usage,
 )
 from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
-from wmo.common.routing import FrozenEmbedding, FrozenEmbeddingSet, KnnGuard, RouterFeatureExtractor
+from wmo.common.routing import KnnGuard
 from wmo.common.tasks import load_task_set
 from wmo.optimize.router.composition import (
     ApprovedRouterReview,
@@ -52,6 +51,7 @@ from wmo.optimize.router.composition_test import (
     _resolved,
     _snapshot,
 )
+from wmo.optimize.router.fit.workflow_test import _persist_embeddings
 from wmo.optimize.router.judgment_budget import JudgmentDispatchReceipt
 from wmo.release_revision_test import exact_checkout_revision, verify_release_evidence
 from wmo.runtime.models import CatalogRoleName, ResolvedModel, RuntimeModelCatalog
@@ -153,7 +153,12 @@ class _EvidenceSetupSupplier:
                 envelope=pricing,
                 files={"pricing.json": pricing},
             )
-            _persist_release_embeddings(project, tasks, self.revision)
+        embedding_set_id = _persist_embeddings(
+            project.artifacts,
+            tasks,
+            completed.task_set,
+            code_revision=self.revision,
+        )
         production = EvaluationProtocol(
             protocol_id="w16-production-protocol",
             evidence_source="production",
@@ -179,7 +184,7 @@ class _EvidenceSetupSupplier:
             observed_cells=tuple(observed),
             production_protocol=production,
             simulation_protocol=world,
-            embedding_set_id="embeddings-a",
+            embedding_set_id=embedding_set_id,
             fit_rag_input=completed.fit_rag,
             pricing_snapshot_id="w16-pricing",
             incumbent_alias="candidate-baseline",
@@ -636,32 +641,6 @@ class _EvidenceReviewSupplier:
                 files={"calibration.json": calibration},
             )
         return ApprovedRouterReview(rubric_id="rubric-a", calibration_id="calibration-a")
-
-
-def _persist_release_embeddings(project: ProjectStore, tasks, revision: str) -> None:  # noqa: ANN001
-    """Persist exact local vectors with release-checkout provenance."""
-    extractor = RouterFeatureExtractor()
-    embeddings = FrozenEmbeddingSet(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision=revision,
-        embedding_set_id="embeddings-a",
-        embedder_alias="embedder",
-        embedder=_snapshot("embedder"),
-        embeddings=tuple(
-            FrozenEmbedding(
-                text_sha256=hashlib.sha256(extractor.from_task(task).encode()).hexdigest(),
-                values=(1.0, 0.0),
-            )
-            for task in tasks
-        ),
-    )
-    project.artifacts.write_json(
-        artifact_id=embeddings.embedding_set_id,
-        artifact_type="router-embeddings",
-        envelope=embeddings,
-        files={"embeddings.json": embeddings},
-    )
 
 
 def _dispatch_counts(

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -622,6 +622,8 @@ class _EvidenceReviewSupplier:
                 score_maps=(
                     DimensionScoreMap(
                         dimension_id="dimension-a",
+                        min_score=0,
+                        max_score=5,
                         calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
                     ),
                 ),

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -473,6 +473,8 @@ class _Judge:
                     dimension_id="dimension-a",
                     raw_score=4,
                     calibrated_score=4.0,
+                    min_score=0,
+                    max_score=5,
                     rationale="Deterministic workflow score.",
                 ),
             ),

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -330,7 +330,11 @@ class _SetupSupplier:
             )
         if "pricing-a" not in project.artifacts.list_ids():
             _persist_pricing(project.artifacts)
-            _persist_embeddings(project.artifacts, tasks)
+        embedding_set_id = _persist_embeddings(
+            project.artifacts,
+            tasks,
+            completed.task_set,
+        )
         production = EvaluationProtocol(
             protocol_id="protocol-production",
             evidence_source="production",
@@ -356,7 +360,7 @@ class _SetupSupplier:
             observed_cells=tuple(observed),
             production_protocol=production,
             simulation_protocol=world,
-            embedding_set_id="embeddings-a",
+            embedding_set_id=embedding_set_id,
             fit_rag_input=completed.fit_rag,
             pricing_snapshot_id="pricing-a",
             incumbent_alias="candidate-a",

--- a/wmo/optimize/router/fit/optimizer_test.py
+++ b/wmo/optimize/router/fit/optimizer_test.py
@@ -641,6 +641,8 @@ def _persist_canonical_evaluation(
                         dimension_id="dimension-a",
                         raw_score=5 if score > 0.9 else (4 if score > 0.8 else 3),
                         calibrated_score=score * 5,
+                        min_score=0,
+                        max_score=5,
                         rationale="The response met the expected behavior.",
                     ),
                 ),
@@ -906,6 +908,8 @@ def _persist_calibration(
         score_maps=(
             DimensionScoreMap(
                 dimension_id="dimension-a",
+                min_score=0,
+                max_score=5,
                 calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
             ),
         ),

--- a/wmo/optimize/router/fit/workflow_test.py
+++ b/wmo/optimize/router/fit/workflow_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -29,17 +29,20 @@ from wmo.common.evaluations.evidence import (
 from wmo.common.judging import DimensionJudgment, Judgment
 from wmo.common.models import (
     CandidateTokenPrice,
+    Embedding,
+    EmbeddingClient,
     OperationEconomics,
     PricingSnapshot,
     RoutedCandidateSnapshot,
 )
 from wmo.common.project import ProjectConfig, ProjectStore
 from wmo.common.routing import (
-    FrozenEmbedding,
-    FrozenEmbeddingSet,
     KnnGuard,
     RouterFeatureExtractor,
+    persist_router_embeddings,
+    router_embedding_reservation,
 )
+from wmo.common.tasks import TaskCase
 from wmo.optimize.router.activation import load_project_router
 from wmo.optimize.router.fit.workflow import (
     EvaluationInputs,
@@ -129,7 +132,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
     fit = tuple(_task(f"task-fit-{index:02d}", partition="fit") for index in range(10))
     held_out = tuple(_task(f"task-held-{index:02d}", partition="held_out") for index in range(2))
     tasks = (*fit, *held_out)
-    _persist_task_set(store, "task-set-workflow", tasks)
+    task_set_input = _persist_task_set(store, "task-set-workflow", tasks)
     calibration_input = _persist_calibration(
         store,
         fit_lineages=tuple(task.lineage_group_id for task in fit),
@@ -221,7 +224,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
         evidence_by_task[cell.task_id].model_copy(update={"cell_id": cell.cell_id})
         for cell in plan.cells
     )
-    _persist_embeddings(store, tasks)
+    embedding_set_id = _persist_embeddings(store, tasks, task_set_input)
     protocols = (production_protocol,)
     return project, RouterOptimizationConfig(
         fit=EvaluationInputs(
@@ -244,7 +247,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
                 == "held_out"
             ),
         ),
-        embedding_set_id="embeddings-a",
+        embedding_set_id=embedding_set_id,
         incumbent_alias="candidate-a",
         pricing_snapshot_id="pricing-a",
         guard=KnnGuard(
@@ -283,27 +286,42 @@ def _persist_pricing(store) -> None:  # noqa: ANN001 - focused fixture
     )
 
 
-def _persist_embeddings(store, tasks) -> None:  # noqa: ANN001 - focused fixture
-    """Persist exact local vectors for every request-visible task feature."""
-    extractor = RouterFeatureExtractor()
-    embeddings = FrozenEmbeddingSet(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision="test-revision",
-        embedding_set_id="embeddings-a",
+class _ExactEmbeddingClient:
+    """Return unit vectors without a network or provider client."""
+
+    def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Return one exact local vector for every requested feature."""
+        return tuple(Embedding(values=(1.0, 0.0)) for _ in texts)
+
+
+def _persist_embeddings(
+    store,  # noqa: ANN001 - focused fixture
+    tasks: tuple[TaskCase, ...],
+    task_set_input: ArtifactInput,
+    *,
+    code_revision: str = "test-revision",
+) -> str:
+    """Persist reserved local vectors for every request-visible task feature."""
+    embedder = _snapshot("embedder")
+    texts = tuple(dict.fromkeys(RouterFeatureExtractor().from_task(task) for task in tasks))
+    reservation = router_embedding_reservation(
+        model=embedder,
+        input_usd_per_million_tokens=2,
+        maximum_attempts_per_feature=1,
+        maximum_input_tokens_per_feature=10_000,
+        feature_count=len(texts),
+    )
+    artifact = persist_router_embeddings(
+        store,
+        task_set_input=task_set_input,
+        tasks=tasks,
         embedder_alias="embedder",
-        embedder=_snapshot("embedder"),
-        embeddings=tuple(
-            FrozenEmbedding(
-                text_sha256=hashlib.sha256(extractor.from_task(task).encode()).hexdigest(),
-                values=(1.0, 0.0),
-            )
-            for task in tasks
-        ),
+        embedder=embedder,
+        client=cast(EmbeddingClient, _ExactEmbeddingClient()),
+        reservation=reservation,
+        active_input_usd_per_million_tokens=2,
+        active_maximum_attempts_per_feature=1,
+        created_at=_TIME,
+        code_revision=code_revision,
     )
-    store.write_json(
-        artifact_id=embeddings.embedding_set_id,
-        artifact_type="router-embeddings",
-        envelope=embeddings,
-        files={"embeddings.json": embeddings},
-    )
+    return artifact.embedding_set_id

--- a/wmo/optimize/router/fit/workflow_test.py
+++ b/wmo/optimize/router/fit/workflow_test.py
@@ -169,6 +169,8 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
                     dimension_id="dimension-a",
                     raw_score=4,
                     calibrated_score=4.0,
+                    min_score=0,
+                    max_score=5,
                     rationale="Deterministic completed evidence.",
                 ),
             ),

--- a/wmo/optimize/router/judging/contracts.py
+++ b/wmo/optimize/router/judging/contracts.py
@@ -799,10 +799,10 @@ class ManualJudgeCalibrationAudit(ArtifactEnvelope):
             raise ValueError("manual judge audit must hash its complete canonical input graph")
         if not self.judgments:
             raise ValueError("manual judge audit requires at least one judge probe")
-        if self.schema_version >= 2 and len(self.trace_reviews) != len(self.judgments):
+        if self.schema_version != 2:
+            raise ValueError("manual judge audit requires schema_version=2")
+        if len(self.trace_reviews) != len(self.judgments):
             raise ValueError("manual judge audit requires one human review per judgment")
-        if self.schema_version == 1 and self.trace_reviews:
-            raise ValueError("version-one manual judge audits cannot name trace reviews")
         if len({item.artifact_id for item in self.trace_reviews}) != len(self.trace_reviews):
             raise ValueError("manual judge audit trace reviews must be unique")
         if (self.positional_bias_comparisons is None) != (self.positional_bias_flips is None):

--- a/wmo/optimize/router/judging/service.py
+++ b/wmo/optimize/router/judging/service.py
@@ -495,7 +495,7 @@ def calibrate_manual_judge(
         save_label_draft(store, setup, sample_sha256, supplied_labels, created_at)
         reviewer = reviewer_from_labels(setup, supplied_labels)
     elif supplied_labels:
-        raise ManualJudgeError("supply either a review callback or legacy labels, not both")
+        raise ManualJudgeError("supply either a review callback or explicit labels, not both")
     calls_per_trace = 2 if setup.prompt_template.response_shape == "pairwise" else 1
     expected_calls = (len(plan.traces) - len(completed_reviews)) * (calls_per_trace)
     total_calls = len(plan.traces) * calls_per_trace

--- a/wmo/runtime/router/capability_test.py
+++ b/wmo/runtime/router/capability_test.py
@@ -71,7 +71,7 @@ def _catalog(*, supports_completions: bool) -> RuntimeModelCatalog:
 def _bindings(
     catalog: RuntimeModelCatalog,
 ) -> tuple[tuple[RuntimeCandidateCapability, ...], tuple[RoutedCandidateSnapshot, ...]]:
-    """Build matching runtime and legacy policy candidate bindings."""
+    """Build matching runtime and policy candidate bindings."""
     runtime = []
     policy = []
     for alias in ("candidate-a", "candidate-b"):

--- a/wmo/simulation/engines/text/grounding.py
+++ b/wmo/simulation/engines/text/grounding.py
@@ -246,13 +246,13 @@ def completion_reservations(
     """Resolve and verify exact candidate and world request ceilings.
 
     Args:
-        contract: Frozen automatic-simulation reservations, or ``None`` for v1 callers.
+        contract: Frozen automatic-simulation reservations, or ``None`` when unbudgeted.
         candidate_alias: Evaluation cell candidate alias.
         candidate: Active exact candidate model.
         world_model: Active exact world model.
 
     Returns:
-        Candidate and world request reservations, or two ``None`` values for legacy settings.
+        Candidate and world request reservations, or two ``None`` values when unbudgeted.
 
     Raises:
         SimulationConfigurationError: A reservation is absent or differs from active metadata.
@@ -289,36 +289,6 @@ def completion_reservations(
     return selected, world
 
 
-def unknown_dispatch_worst_case_usd(
-    contract: SimulationCompletionContract | None,
-    candidate_alias: str | None,
-) -> float | None:
-    """Return the persisted retry-inclusive worst case for one ambiguous provider dispatch.
-
-    The failed dispatch is one candidate or one world-model call, but persisted evidence does
-    not always record which, so the returned charge conservatively covers both request
-    ceilings from the frozen completion contract.
-
-    Args:
-        contract: Frozen automatic-simulation reservations, or ``None`` for v1 callers.
-        candidate_alias: Candidate alias bound to the failed cell, or ``None`` when unknown.
-
-    Returns:
-        The combined candidate and world-model retry-inclusive maximum, or ``None`` when the
-        contract or the alias reservation is unavailable.
-    """
-    if contract is None or candidate_alias is None:
-        return None
-    candidates = {item.candidate_alias: item.request for item in contract.candidate_requests}
-    candidate = candidates.get(candidate_alias)
-    if candidate is None:
-        return None
-    return (
-        candidate.estimated_maximum_call_cost_usd
-        + contract.world_model_request.estimated_maximum_call_cost_usd
-    )
-
-
 def episode_reservation_failure(
     settings: WorldModelSettings,
     *,
@@ -336,7 +306,7 @@ def episode_reservation_failure(
 
     Args:
         settings: Frozen retrieval and completion reservations.
-        completion_contract: Frozen completion reservations, or ``None`` for v1 callers.
+        completion_contract: Frozen completion reservations, or ``None`` when unbudgeted.
         remaining_cost_usd: Reconciled cell budget remaining under the durable lease.
         stop_on_overspend: When true, an exhausted remainder blocks the next episode.
 

--- a/wmo/simulation/engines/text/rollout_support.py
+++ b/wmo/simulation/engines/text/rollout_support.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import cast
 
@@ -103,24 +103,17 @@ def normalize_text_tool_failure(episode: AgentEpisode) -> StructuredFailure | No
 
 def known_total_spend(
     rollouts: Sequence[RolloutArtifact],
-    *,
-    unknown_dispatch_fallback_usd: Callable[[RolloutArtifact], float | None] | None = None,
 ) -> float | None:
     """Return total conservative provider spend, or ``None`` if any episode is unpriced.
 
     Args:
         rollouts: Completed text-simulation rollout artifacts to total.
-        unknown_dispatch_fallback_usd: Optional persisted worst-case charge for unknown-spend
-            evidence that predates per-failure reservation persistence.
 
     Returns:
         The known conservative provider spend, or ``None`` when any billed call is not priced
         and has no persisted worst-case reservation.
     """
-    values = tuple(
-        rollout_spend(rollout, unknown_dispatch_fallback_usd=unknown_dispatch_fallback_usd)
-        for rollout in rollouts
-    )
+    values = tuple(rollout_spend(rollout) for rollout in rollouts)
     if any(value is None for value in values):
         return None
     return sum(cast(float, value) for value in values)
@@ -128,8 +121,6 @@ def known_total_spend(
 
 def rollout_spend(
     rollout: RolloutArtifact,
-    *,
-    unknown_dispatch_fallback_usd: Callable[[RolloutArtifact], float | None] | None = None,
 ) -> float | None:
     """Return reconciled provider cost without treating unknown dispatches as free.
 
@@ -139,8 +130,6 @@ def rollout_spend(
 
     Args:
         rollout: Completed text-simulation rollout whose recorded calls are inspected.
-        unknown_dispatch_fallback_usd: Optional persisted worst-case charge for unknown-spend
-            evidence that predates per-failure reservation persistence.
 
     Returns:
         Observed candidate and world-model cost plus conservative retrieval and reservation
@@ -149,8 +138,6 @@ def rollout_spend(
     reserved: float | None = None
     if unknown_spend_failure(rollout.failure):
         reserved = unknown_dispatch_reserved_cost_usd(rollout.failure)
-        if reserved is None and unknown_dispatch_fallback_usd is not None:
-            reserved = unknown_dispatch_fallback_usd(rollout)
         if reserved is None:
             return None
     roles = (

--- a/wmo/simulation/engines/text/simulator.py
+++ b/wmo/simulation/engines/text/simulator.py
@@ -58,7 +58,6 @@ from wmo.simulation.engines.text.grounding import (
     load_completion_contract,
     load_simulation_task_set,
     require_grounding_settings,
-    unknown_dispatch_worst_case_usd,
     verify_fit_retriever,
 )
 from wmo.simulation.engines.text.leases import (
@@ -599,15 +598,7 @@ class WorldModelSimulator:
         for cell_id, binding in bindings.items():
             cell = next(item for item in self._plan.cells if item.cell_id == cell_id)
             rollouts.extend(persisted_cell_attempts(self._store, cell, binding, pins))
-        return known_total_spend(
-            rollouts,
-            unknown_dispatch_fallback_usd=lambda rollout: unknown_dispatch_worst_case_usd(
-                self._completion_contract,
-                rollout.simulation_binding.candidate_alias
-                if rollout.simulation_binding is not None
-                else None,
-            ),
-        )
+        return known_total_spend(rollouts)
 
     def _execute_cell(
         self,

--- a/wmo/simulation/ingest/dataset.py
+++ b/wmo/simulation/ingest/dataset.py
@@ -34,8 +34,9 @@ _TRACES_PATH = "traces.jsonl"
 _ISSUES_PATH = "normalization-issues.json"
 _TRACE_DATASET_PATH = "trace-dataset.json"
 MODEL_IDENTITY_EVIDENCE_PATH = "model-identity-evidence.json"
-_LEGACY_TRACE_DATASET_FILES = frozenset({_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH})
-_TRACE_DATASET_FILES = frozenset((*_LEGACY_TRACE_DATASET_FILES, MODEL_IDENTITY_EVIDENCE_PATH))
+_TRACE_DATASET_FILES = frozenset(
+    {_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH, MODEL_IDENTITY_EVIDENCE_PATH}
+)
 
 
 @dataclass(frozen=True)
@@ -112,26 +113,15 @@ def persist_trace_dataset(
     source, semantic_convention_version = _shared_source(traces)
     traces_payload = canonical_jsonl_bytes(traces)
     issues_payload = _issues_bytes(result.issues)
-    identity_evidence = (
-        complete_model_identity_evidence(traces, result.identity_evidence)
-        if result.include_identity_evidence
-        else None
-    )
-    if identity_evidence is not None:
-        require_model_identity_evidence_matches_traces(traces, identity_evidence)
-    identity_payload = (
-        None if identity_evidence is None else canonical_json_bytes(identity_evidence)
-    )
-    if not result.include_identity_evidence and result.identity_evidence is not None:
-        raise ValueError("identity evidence cannot be supplied when persistence is disabled")
+    identity_evidence = complete_model_identity_evidence(traces, result.identity_evidence)
+    require_model_identity_evidence_matches_traces(traces, identity_evidence)
+    identity_payload = canonical_json_bytes(identity_evidence)
     resolved_dataset_id = dataset_id or current_trace_dataset_id(
         source=source,
         semantic_convention_version=semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
-        identity_evidence_sha256=(
-            None if identity_payload is None else hashlib.sha256(identity_payload).hexdigest()
-        ),
+        identity_evidence_sha256=hashlib.sha256(identity_payload).hexdigest(),
         code_revision=code_revision,
     )
     dataset = TraceDataset(
@@ -152,9 +142,8 @@ def persist_trace_dataset(
         _TRACES_PATH: traces_payload,
         _ISSUES_PATH: issues_payload,
         _TRACE_DATASET_PATH: canonical_json_bytes(dataset),
+        MODEL_IDENTITY_EVIDENCE_PATH: identity_payload,
     }
-    if identity_payload is not None:
-        files[MODEL_IDENTITY_EVIDENCE_PATH] = identity_payload
     existing, manifest = store.write_or_replay(
         artifact_id=dataset.dataset_id,
         artifact_type=_TRACE_DATASET_ARTIFACT_TYPE,
@@ -172,7 +161,7 @@ def current_trace_dataset_id(
     semantic_convention_version: str,
     traces_sha256: str,
     issues_sha256: str,
-    identity_evidence_sha256: str | None = None,
+    identity_evidence_sha256: str,
     code_revision: str,
 ) -> str:
     """Return the current automatic trace-dataset content identity.
@@ -182,23 +171,23 @@ def current_trace_dataset_id(
         semantic_convention_version: Convention used to interpret source model spans.
         traces_sha256: Digest of canonical normalized trace JSONL.
         issues_sha256: Digest of the complete normalization issue report.
-        identity_evidence_sha256: Optional digest of complete model-span provenance. Omission
-            selects the compatible identity form without a provenance component.
+        identity_evidence_sha256: Digest of complete model-span provenance.
         code_revision: Exact producer revision.
 
     Returns:
         Stable current trace-dataset artifact identity.
     """
-    semantic = {
-        "source": source.model_dump(mode="json"),
-        "semantic_convention_version": semantic_convention_version,
-        "traces_sha256": traces_sha256,
-        "issues_sha256": issues_sha256,
-        "code_revision": code_revision,
-    }
-    if identity_evidence_sha256 is not None:
-        semantic["identity_evidence_sha256"] = identity_evidence_sha256
-    return stable_id("trace-dataset", semantic)
+    return stable_id(
+        "trace-dataset",
+        {
+            "source": source.model_dump(mode="json"),
+            "semantic_convention_version": semantic_convention_version,
+            "traces_sha256": traces_sha256,
+            "issues_sha256": issues_sha256,
+            "code_revision": code_revision,
+            "identity_evidence_sha256": identity_evidence_sha256,
+        },
+    )
 
 
 def verify_current_trace_dataset(
@@ -207,7 +196,6 @@ def verify_current_trace_dataset(
 ) -> None:
     """Verify the exact current automatic dataset shape and content identity.
 
-    Generic trace-dataset loading remains compatible with older and explicitly named artifacts.
     Completed build lineage evidence uses this stricter boundary because its parent dataset must be
     reproducible from current canonical source evidence.
 
@@ -226,7 +214,7 @@ def verify_current_trace_dataset(
             f"trace dataset {dataset.dataset_id} must not have artifact inputs"
         )
     paths = {entry.path for entry in stored.manifest.files}
-    if paths not in {_LEGACY_TRACE_DATASET_FILES, _TRACE_DATASET_FILES}:
+    if paths != _TRACE_DATASET_FILES:
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} does not have the exact current-build file set"
         )
@@ -267,7 +255,7 @@ def verify_current_trace_dataset(
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} exclusion count differs from its issue evidence"
         )
-    identity_evidence = read_trace_model_identity_evidence(store, loaded)
+    read_trace_model_identity_evidence(store, loaded)
     for trace in loaded.traces:
         if (
             trace.source.identity != dataset.source
@@ -281,13 +269,9 @@ def verify_current_trace_dataset(
         semantic_convention_version=dataset.semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
-        identity_evidence_sha256=(
-            None
-            if identity_evidence is None
-            else hashlib.sha256(
-                store.read_bytes(dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
-            ).hexdigest()
-        ),
+        identity_evidence_sha256=hashlib.sha256(
+            store.read_bytes(dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
+        ).hexdigest(),
         code_revision=dataset.code_revision,
     )
     if dataset.dataset_id != expected_id:
@@ -300,24 +284,26 @@ def verify_current_trace_dataset(
 def read_trace_model_identity_evidence(
     store: ArtifactStore,
     loaded: LoadedTraceDataset,
-) -> TraceModelIdentityEvidenceSet | None:
-    """Read and verify optional model-span provenance from a loaded trace dataset.
+) -> TraceModelIdentityEvidenceSet:
+    """Read and verify model-span provenance from a loaded trace dataset.
 
     Args:
         store: Project-local immutable artifact store.
         loaded: Digest-verified trace dataset and records.
 
     Returns:
-        Complete current provenance, or ``None`` for a compatible dataset without the payload.
+        Complete current provenance for every model span.
 
     Raises:
-        ArtifactCorruptionError: The payload is malformed, noncanonical, incomplete, extra, or
-            differs from its exact trace span snapshots.
+        ArtifactCorruptionError: The payload is absent, malformed, noncanonical, incomplete, extra,
+            or differs from its exact trace span snapshots.
     """
     stored = store.read(loaded.dataset.dataset_id)
     paths = {entry.path for entry in stored.manifest.files}
     if MODEL_IDENTITY_EVIDENCE_PATH not in paths:
-        return None
+        raise ArtifactCorruptionError(
+            f"trace dataset {loaded.dataset.dataset_id} is missing model identity evidence"
+        )
     payload_bytes = store.read_bytes(
         loaded.dataset.dataset_id,
         MODEL_IDENTITY_EVIDENCE_PATH,

--- a/wmo/simulation/ingest/dataset_test.py
+++ b/wmo/simulation/ingest/dataset_test.py
@@ -176,26 +176,28 @@ def test_direct_model_spans_persist_explicit_unspecified_provenance(tmp_path: Pa
     assert evidence.records[0].connection == "unspecified"
 
 
-def test_strict_loader_preserves_legacy_dataset_without_identity_payload(tmp_path: Path) -> None:
-    """A verified legacy current dataset remains readable with no inferred provenance."""
+def test_current_dataset_without_identity_evidence_is_corrupt(tmp_path: Path) -> None:
+    """Current-build verification refuses a dataset that dropped its provenance payload."""
     trace = _modeled_trace()
     store = _store(tmp_path, "project-a")
     persisted = persist_trace_dataset(
-        TraceNormalizationResult(
-            traces=(trace,),
-            issues=(),
-            include_identity_evidence=False,
-        ),
+        TraceNormalizationResult(traces=(trace,), issues=()),
         store,
         created_at=datetime(2026, 8, 11, tzinfo=UTC),
         code_revision="test-revision",
     )
+    stored = store.read(persisted.dataset.dataset_id)
+    (stored.directory / MODEL_IDENTITY_EVIDENCE_PATH).unlink()
+    files = tuple(
+        entry for entry in stored.manifest.files if entry.path != MODEL_IDENTITY_EVIDENCE_PATH
+    )
+    (stored.directory / "manifest.json").write_bytes(
+        canonical_json_bytes(stored.manifest.model_copy(update={"files": files}))
+    )
     loaded = load_trace_dataset(store, persisted.dataset.dataset_id)
 
-    verify_current_trace_dataset(store, loaded)
-
-    assert read_trace_model_identity_evidence(store, loaded) is None
-    assert MODEL_IDENTITY_EVIDENCE_PATH not in {item.path for item in persisted.manifest.files}
+    with pytest.raises(ArtifactCorruptionError, match="exact current-build file set"):
+        verify_current_trace_dataset(store, loaded)
 
 
 def test_persist_rejects_incomplete_or_extra_supplied_model_identity(tmp_path: Path) -> None:
@@ -420,8 +422,8 @@ def test_persist_trace_dataset_rejects_changed_evidence_under_explicit_id(
         )
 
 
-def test_load_trace_dataset_accepts_pre_revision_identity(tmp_path: Path) -> None:
-    """The loader keeps accepting artifacts whose historical ID omitted producer revision."""
+def test_load_trace_dataset_accepts_an_explicit_dataset_id(tmp_path: Path) -> None:
+    """Generic loading accepts a caller-supplied dataset identity without rehashing it."""
     result = TraceNormalizationResult(traces=(_trace(1),), issues=())
     probe = persist_trace_dataset(
         result,
@@ -430,7 +432,7 @@ def test_load_trace_dataset_accepts_pre_revision_identity(tmp_path: Path) -> Non
         code_revision="test-revision",
     )
     assert probe.dataset.source is not None
-    legacy_id = stable_id(
+    named_id = stable_id(
         "trace-dataset",
         {
             "source": probe.dataset.source.model_dump(mode="json"),
@@ -439,19 +441,19 @@ def test_load_trace_dataset_accepts_pre_revision_identity(tmp_path: Path) -> Non
             "issues_sha256": probe.dataset.issues_sha256,
         },
     )
-    legacy_store = _store(tmp_path / "legacy", "project-a")
-    legacy = persist_trace_dataset(
+    named_store = _store(tmp_path / "named", "project-a")
+    named = persist_trace_dataset(
         result,
-        legacy_store,
+        named_store,
         created_at=datetime(2026, 8, 11, tzinfo=UTC),
         code_revision="test-revision",
-        dataset_id=legacy_id,
+        dataset_id=named_id,
     )
 
-    loaded = load_trace_dataset(legacy_store, legacy_id)
+    loaded = load_trace_dataset(named_store, named_id)
 
-    assert loaded.dataset == legacy.dataset
-    assert loaded.traces == legacy.traces
+    assert loaded.dataset == named.dataset
+    assert loaded.traces == named.traces
 
 
 def test_persist_trace_dataset_rejects_mixed_raw_source_provenance(tmp_path: Path) -> None:

--- a/wmo/simulation/ingest/otel_genai.py
+++ b/wmo/simulation/ingest/otel_genai.py
@@ -138,7 +138,6 @@ def normalize_otel_genai_payloads(
         traces=result.traces,
         issues=(*issues, *result.issues),
         identity_evidence=result.identity_evidence,
-        include_identity_evidence=result.include_identity_evidence,
     )
 
 

--- a/wmo/simulation/ingest/otlp.py
+++ b/wmo/simulation/ingest/otlp.py
@@ -77,14 +77,11 @@ class TraceNormalizationResult:
         issues: Corrupt or incomplete source records that were excluded without repair.
         identity_evidence: Exact model-span provenance from a telemetry-aware normalizer. ``None``
             marks direct or programmatic records whose digest origin is unspecified.
-        include_identity_evidence: Whether persistence materializes the provenance payload. Only
-            exact reconstruction of a verified legacy dataset should disable it.
     """
 
     traces: tuple[Trace, ...]
     issues: tuple[TraceNormalizationIssue, ...]
     identity_evidence: tuple[TraceModelIdentityEvidence, ...] | None = None
-    include_identity_evidence: bool = True
 
     @property
     def invalid_trace_count(self) -> int:

--- a/wmo/simulation/retrieval/build_inputs_test.py
+++ b/wmo/simulation/retrieval/build_inputs_test.py
@@ -720,25 +720,25 @@ def test_binding_loader_rejects_rehashed_extra_task_set_file(tmp_path: Path) -> 
         load_completed_build_rag_lineage_bindings(store, completed)
 
 
-def test_legacy_task_set_loads_but_complete_binding_loader_is_actionable(tmp_path: Path) -> None:
-    """Preserve legacy TaskSet loading while requiring rebuild for refresh bindings.
+def test_named_task_set_loads_but_complete_binding_loader_is_actionable(tmp_path: Path) -> None:
+    """Generic TaskSet loading accepts an explicit ID; refresh bindings still require rebuild.
 
     Args:
         tmp_path: Pytest-owned project root.
     """
     store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
     build = _build(store)
-    legacy = persist_task_set(
+    named = persist_task_set(
         build.mining,
         store,
-        task_set_id="legacy-task-set",
+        task_set_id="named-task-set",
         created_at=_TIME,
-        code_revision="legacy-revision",
+        code_revision="named-revision",
     )
 
-    assert legacy.task_set_id == "legacy-task-set"
+    assert named.task_set_id == "named-task-set"
     with pytest.raises(ArtifactCorruptionError, match="rebuild the project"):
-        load_task_set_lineage_bindings(store, legacy.task_set_id)
+        load_task_set_lineage_bindings(store, named.task_set_id)
 
 
 @pytest.mark.parametrize("replacement_trace_ids", [(), ("trace-terminal", "extra-trace")])

--- a/wmo/simulation/world_model/application.py
+++ b/wmo/simulation/world_model/application.py
@@ -204,7 +204,7 @@ class WorldModel:
     ) -> WorldModelObservation:
         """Predict and append one user turn from an official OpenAI assistant message.
 
-        The persisted artifact is text-only. Any tool call, legacy function call, audio payload,
+        The persisted artifact is text-only. Any tool call, function call, audio payload,
         non-text content, or non-assistant role is rejected before retrieval or provider dispatch.
 
         Args:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

WMO no longer loads or reconstructs older artifact shapes. Current contracts are the only accepted path.

- SFT datasets must persist a `build_spec`. The `legacy_build_spec` training argument is gone.
- Current trace datasets always persist and verify model-identity evidence. The `include_identity_evidence=False` reconstruction path is gone.
- Router embeddings load only the reserved schema. Unreserved payloads fail closed.
- Rubric axes, score maps, and dimension judgments require explicit inclusive ranges.
- Unknown-spend totals use the persisted reservation only. Retry classification no longer infers transport class from exception names.
- Manual judge audits require schema version 2 with one review per judgment.
- Candidate attribution requires persisted identity evidence. Transcript user text comes from captured messages only.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Focused pytest on changed modules, plus composition and fit workflow tests
- W16 public-router evidence test after the reserved-embedding fixture update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e4fbcaa-e6c2-4758-974a-f2fbf2b96bf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e4fbcaa-e6c2-4758-974a-f2fbf2b96bf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

