### PR TITLE
Remove legacy artifact fallbacks and compatibility shims

### DIFF
--- a/wmo/cli/tests/terminal_tasks_live_pipeline_test.py
+++ b/wmo/cli/tests/terminal_tasks_live_pipeline_test.py
@@ -237,7 +237,7 @@ def _calibrate_judge(runner: CliRunner, root: Path) -> None:
     labels = [
         argument
         for trace in plan.traces
-        for argument in ("--label", f"{trace.trace_id}:task-success=4")
+        for argument in ("--label", f"{trace.trace_id}:task-success=1")
     ]
     result = runner.invoke(
         app,

--- a/wmo/common/evaluations/build_test.py
+++ b/wmo/common/evaluations/build_test.py
@@ -827,6 +827,8 @@ def _persist_calibration(
         score_maps=(
             DimensionScoreMap(
                 dimension_id="dimension-a",
+                min_score=0,
+                max_score=5,
                 calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
             ),
         ),

--- a/wmo/common/judging/rubric.py
+++ b/wmo/common/judging/rubric.py
@@ -33,8 +33,8 @@ class RubricDimension(ContractModel):
     dimension_id: ArtifactId
     name: str = Field(min_length=1, max_length=256)
     description: str = Field(min_length=1)
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
+    max_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
     anchors: tuple[ScoreAnchor, ...]
 
     @model_validator(mode="after")
@@ -238,8 +238,8 @@ class DimensionScoreMap(ContractModel):
     """A monotonic mapping from raw judge scores to expected human scores."""
 
     dimension_id: ArtifactId
-    min_score: int = Field(default=0, ge=0, le=_MAX_AXIS_SCORE)
-    max_score: int = Field(default=5, ge=0, le=_MAX_AXIS_SCORE)
+    min_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
+    max_score: int = Field(ge=0, le=_MAX_AXIS_SCORE)
     calibrated_scores: tuple[float, ...]
 
     @model_validator(mode="after")

--- a/wmo/common/judging/rubric_test.py
+++ b/wmo/common/judging/rubric_test.py
@@ -104,22 +104,18 @@ def test_rubric_rejects_empty_axes_duplicate_ids_and_invalid_ranges() -> None:
         )
 
 
-def test_legacy_zero_to_five_payload_loads_without_range_fields() -> None:
-    """Pre-range rubric cards keep their 0-5 meaning when min_score and max_score are absent."""
-    axis = RubricDimension.model_validate(
-        {
-            "dimension_id": "task-success",
-            "name": "Task success",
-            "description": "Whether the customer received a correct outcome.",
-            "anchors": [
-                {"score": score, "description": f"Score {score} outcome."} for score in range(6)
-            ],
-        }
-    )
-
-    assert axis.min_score == 0
-    assert axis.max_score == 5
-    assert axis.permitted_scores() == (0, 1, 2, 3, 4, 5)
+def test_rubric_axis_requires_explicit_range_fields() -> None:
+    """A rubric axis cannot infer an inclusive range from missing min_score or max_score."""
+    payload = {
+        "dimension_id": "task-success",
+        "name": "Task success",
+        "description": "Whether the customer received a correct outcome.",
+        "anchors": [
+            {"score": score, "description": f"Score {score} outcome."} for score in range(6)
+        ],
+    }
+    with pytest.raises(ValidationError, match="min_score"):
+        RubricDimension.model_validate(payload)
 
 
 def test_rubric_rejects_axes_that_do_not_share_one_range() -> None:

--- a/wmo/common/models/model_test.py
+++ b/wmo/common/models/model_test.py
@@ -109,7 +109,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
 
 def test_completion_support_preserves_provider_identity_for_existing_traces() -> None:
     """Completion eligibility is frozen separately without orphaning old trace snapshots."""
-    legacy_payload = {
+    identity_payload = {
         "supports_tools": False,
         "supports_embeddings": False,
         "context_window_tokens": None,
@@ -119,7 +119,7 @@ def test_completion_support_preserves_provider_identity_for_existing_traces() ->
     supported = ModelCapabilities(supports_completions=True)
     unsupported = ModelCapabilities(supports_completions=False)
 
-    assert unknown.identity_sha256() == sha256_json(legacy_payload)
+    assert unknown.identity_sha256() == sha256_json(identity_payload)
     assert supported.identity_sha256() == unsupported.identity_sha256()
     assert supported.identity_sha256() == unknown.identity_sha256()
     pinned_sampling = ModelCapabilities(supports_temperature=False, reasoning_effort="xhigh")
@@ -131,8 +131,8 @@ def test_completion_support_preserves_provider_identity_for_existing_traces() ->
         )
 
 
-def test_legacy_routed_candidate_payload_reserializes_byte_for_byte() -> None:
-    """Automatic capability freezing cannot add fields to the v1 candidate contract."""
+def test_routed_candidate_payload_reserializes_byte_for_byte() -> None:
+    """Automatic capability freezing cannot add fields to the candidate contract."""
     payload = {
         "alias": "candidate-a",
         "model": {

--- a/wmo/common/rollouts/dispatch_failures.py
+++ b/wmo/common/rollouts/dispatch_failures.py
@@ -18,17 +18,6 @@ UNKNOWN_DISPATCH_RESERVED_COST_KEY = "unknown_dispatch_reserved_cost_usd"
 
 _DISPATCH_FAILURE_PHASE = "candidate_or_world_model"
 
-_TRANSPORT_EXCEPTION_TYPES = frozenset(
-    {
-        "ProviderTransportError",
-        "TimeoutError",
-        "ConnectionError",
-        "ConnectionResetError",
-        "OSError",
-    }
-)
-"""Exception types treated as transport-class for evidence persisted without a retry flag."""
-
 
 def unknown_spend_failure(failure: StructuredFailure | None) -> bool:
     """Return whether a persisted failure left its dispatched provider spend unknown.
@@ -57,7 +46,7 @@ def unknown_dispatch_reserved_cost_usd(failure: StructuredFailure | None) -> flo
 
     Returns:
         The nonnegative finite reserved amount persisted with the failure, or ``None`` when
-        the evidence predates reservation persistence or the value is unusable.
+        the value is absent or unusable.
     """
     if failure is None:
         return None
@@ -73,11 +62,9 @@ def unknown_dispatch_reserved_cost_usd(failure: StructuredFailure | None) -> flo
 def retryable_dispatch_failure(failure: StructuredFailure | None) -> bool:
     """Return whether a persisted provider dispatch failure is transport-retryable.
 
-    Only candidate or world-model dispatch failures qualify. Evidence that carries an
-    explicit ``retry_classification`` detail is trusted exactly as classified. Evidence
-    persisted before retry classification existed falls back to the transport-class
-    exception types, so a legacy transient transport failure stays resumable. Budget,
-    validation, and stale-lease failures never qualify.
+    Only candidate or world-model dispatch failures qualify. The persisted ``retryable``
+    flag is the sole resume signal. Budget, validation, and stale-lease failures never
+    qualify.
 
     Args:
         failure: Structured failure retained by a rollout artifact, or ``None``.
@@ -91,8 +78,4 @@ def retryable_dispatch_failure(failure: StructuredFailure | None) -> bool:
         return False
     if failure.details.get("phase") != _DISPATCH_FAILURE_PHASE:
         return False
-    if failure.retryable:
-        return True
-    if "retry_classification" in failure.details:
-        return False
-    return failure.exception_type in _TRANSPORT_EXCEPTION_TYPES
+    return failure.retryable

--- a/wmo/common/rollouts/dispatch_failures_test.py
+++ b/wmo/common/rollouts/dispatch_failures_test.py
@@ -98,7 +98,7 @@ def test_retryable_dispatch_failure_requires_provider_dispatch_transport_class()
     """Only transport-class provider dispatch failures qualify for resume re-execution."""
     assert retryable_dispatch_failure(None) is False
     assert retryable_dispatch_failure(_failure(retryable=True)) is True
-    assert retryable_dispatch_failure(_failure()) is True
+    assert retryable_dispatch_failure(_failure()) is False
     assert (
         retryable_dispatch_failure(
             _failure(

--- a/wmo/common/routing/embeddings.py
+++ b/wmo/common/routing/embeddings.py
@@ -193,18 +193,18 @@ class FrozenEmbeddingClient(EmbeddingClient):
 
 def load_frozen_embedding_set(
     store: ArtifactStore, artifact_id: ArtifactId
-) -> FrozenEmbeddingSet | ReservedFrozenEmbeddingSet:
-    """Load one manifest-verified completed router embedding artifact.
+) -> ReservedFrozenEmbeddingSet:
+    """Load one manifest-verified reserved router embedding artifact.
 
     Args:
         store: Project-local immutable artifact store.
         artifact_id: Router-embedding artifact identity.
 
     Returns:
-        Parsed frozen embedding set.
+        Parsed reserved frozen embedding set.
 
     Raises:
-        ValueError: The artifact type, payload, or bound identity is invalid.
+        ValueError: The artifact type, payload, schema, or bound identity is invalid.
     """
     stored = store.read(artifact_id)
     if stored.manifest.artifact_type != "router-embeddings":
@@ -216,32 +216,26 @@ def load_frozen_embedding_set(
         raise ValueError("router embedding payload is not valid JSON") from exc
     if not isinstance(raw, dict):
         raise ValueError("router embedding payload must be a JSON object")
-    schema_version = raw.get("schema_version")
-    value: FrozenEmbeddingSet | ReservedFrozenEmbeddingSet = (
-        ReservedFrozenEmbeddingSet.model_validate_json(payload)
-        if schema_version == 2
-        else FrozenEmbeddingSet.model_validate_json(payload)
-    )
-    if value.schema_version not in {1, 2}:
+    if raw.get("schema_version") != 2:
         raise ValueError("router embedding set schema version is unsupported")
+    value = ReservedFrozenEmbeddingSet.model_validate_json(payload)
     if value.embedding_set_id != artifact_id:
         raise ValueError("router embedding set identity differs from its artifact")
     if not envelope_matches_manifest(value, stored.manifest):
         raise ValueError("router embedding payload differs from its artifact manifest")
     for item in value.embeddings:
         Embedding(values=item.values)
-    if isinstance(value, ReservedFrozenEmbeddingSet):
-        if len(value.inputs) != 1:
-            raise ValueError("router embedding set needs one exact task-set input")
-        expected_id = _router_embedding_set_id(
-            task_set_input=value.inputs[0],
-            embedder_alias=value.embedder_alias,
-            embedder=value.embedder,
-            reservation=value.reservation,
-            feature_digests=tuple(item.text_sha256 for item in value.embeddings),
-        )
-        if expected_id != artifact_id:
-            raise ValueError("router embedding set content identity is invalid")
+    if len(value.inputs) != 1:
+        raise ValueError("router embedding set needs one exact task-set input")
+    expected_id = _router_embedding_set_id(
+        task_set_input=value.inputs[0],
+        embedder_alias=value.embedder_alias,
+        embedder=value.embedder,
+        reservation=value.reservation,
+        feature_digests=tuple(item.text_sha256 for item in value.embeddings),
+    )
+    if expected_id != artifact_id:
+        raise ValueError("router embedding set content identity is invalid")
     return value
 
 
@@ -390,8 +384,7 @@ def persist_router_embeddings(
     if destination.exists():
         existing = load_frozen_embedding_set(store, embedding_set_id)
         if (
-            not isinstance(existing, ReservedFrozenEmbeddingSet)
-            or existing.inputs != (task_set_input,)
+            existing.inputs != (task_set_input,)
             or existing.embedder_alias != embedder_alias
             or existing.embedder != embedder
             or existing.reservation != reservation

--- a/wmo/common/routing/embeddings_test.py
+++ b/wmo/common/routing/embeddings_test.py
@@ -239,29 +239,28 @@ def test_router_embedding_rejects_symlinked_coordination_ancestor_before_dispatc
     assert tuple(sorted(path.name for path in external.iterdir())) == before
 
 
-def test_legacy_frozen_embedding_payload_reserializes_without_v2_fields() -> None:
-    """Loading a v1 embedding set preserves its exact serialized field set."""
-    payload = {
-        "schema_version": 1,
-        "created_at": "2026-08-12T00:00:00Z",
-        "inputs": [],
-        "code_revision": "legacy",
-        "source": None,
-        "embedding_set_id": "legacy-embeddings",
-        "embedder_alias": "embedder",
-        "embedder": {
-            "provider": "fixture",
-            "model_id": "embedder",
-            "revision": None,
-            "capabilities_sha256": _DIGEST,
-            "connection_sha256": _DIGEST,
-        },
-        "embeddings": [{"text_sha256": _DIGEST, "values": [1.0, 0.0]}],
-    }
+def test_router_embedding_loader_rejects_schema_version_one(tmp_path: Path) -> None:
+    """Persisted router embeddings must use the reserved schema, not the prior envelope."""
+    project, _task, model = _project_task_model(tmp_path)
+    payload = FrozenEmbeddingSet(
+        schema_version=1,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        inputs=(_artifact_input(),),
+        code_revision="test",
+        embedding_set_id="schema-v1-embeddings",
+        embedder_alias="embedder",
+        embedder=model,
+        embeddings=(FrozenEmbedding(text_sha256=_DIGEST, values=(1.0, 0.0)),),
+    )
+    project.artifacts.write_json(
+        artifact_id=payload.embedding_set_id,
+        artifact_type="router-embeddings",
+        envelope=payload,
+        files={"embeddings.json": payload},
+    )
 
-    restored = FrozenEmbeddingSet.model_validate(payload)
-
-    assert restored.model_dump(mode="json") == payload
+    with pytest.raises(ValueError, match="schema version is unsupported"):
+        load_frozen_embedding_set(project.artifacts, payload.embedding_set_id)
 
 
 def test_router_embedding_under_reservation_fails_before_dispatch(tmp_path: Path) -> None:
@@ -446,8 +445,15 @@ def test_router_embedding_loader_rejects_manifest_envelope_drift(tmp_path: Path)
         tmp_path: Temporary initialized project root.
     """
     project, _task, model = _project_task_model(tmp_path)
-    payload = FrozenEmbeddingSet(
-        schema_version=1,
+    reservation = router_embedding_reservation(
+        model=model,
+        input_usd_per_million_tokens=2,
+        maximum_attempts_per_feature=2,
+        maximum_input_tokens_per_feature=10_000,
+        feature_count=1,
+    )
+    payload = ReservedFrozenEmbeddingSet(
+        schema_version=2,
         created_at=datetime(2026, 8, 12, tzinfo=UTC),
         inputs=(_artifact_input(),),
         code_revision="payload",
@@ -455,6 +461,8 @@ def test_router_embedding_loader_rejects_manifest_envelope_drift(tmp_path: Path)
         embedder_alias="embedder",
         embedder=model,
         embeddings=(FrozenEmbedding(text_sha256=_DIGEST, values=(1.0, 0.0)),),
+        embedding_dimension=2,
+        reservation=reservation,
     )
     envelope = payload.model_copy(update={"code_revision": "manifest"})
     project.artifacts.write_json(

--- a/wmo/optimize/model/sft/builder.py
+++ b/wmo/optimize/model/sft/builder.py
@@ -291,8 +291,6 @@ def write_sft_dataset(store: ProjectStore, artifact: SFTDatasetArtifact) -> SFTD
     Raises:
         SFTBuildError: Existing data conflicts or serialized rows violate dataset invariants.
     """
-    if artifact.build_spec is None:
-        raise SFTBuildError("new SFT datasets must persist their deterministic build spec")
     _validate_artifact_rows(artifact)
     files = {
         "dataset.json": artifact.metadata().model_dump(mode="json", exclude_none=False),
@@ -373,40 +371,22 @@ def load_sft_dataset(
 def load_verified_sft_dataset(
     store: ProjectStore,
     dataset_id: ArtifactId,
-    *,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> SFTDatasetArtifact:
     """Reload and rebuild one accepted dataset from its persisted W12 evidence chain.
 
     Args:
         store: Project-local store owning the dataset and every transitive source artifact.
         dataset_id: Stable ID of the previously persisted W12 dataset.
-        legacy_build_spec: Exact original W12 build settings when loading metadata that predates
-            persisted build specifications.
 
     Returns:
         The canonical dataset only when its stored bytes equal a fresh deterministic rebuild.
 
     Raises:
         SFTBuildError: Any dataset, source, evidence, input, partition, build, or fingerprint
-            invariant cannot be reproduced from the immutable project store. Legacy metadata
-            additionally requires its original build settings before it can be verified.
+            invariant cannot be reproduced from the immutable project store.
     """
     loaded = load_sft_dataset(store, dataset_id)
     build_spec = loaded.build_spec
-    if build_spec is None:
-        if legacy_build_spec is None:
-            raise SFTBuildError(
-                f"frozen SFT dataset {dataset_id} predates persisted build specs; "
-                "provide legacy_build_spec with its original W12 settings"
-            )
-        build_spec = legacy_build_spec
-        loaded = loaded.model_copy(update={"build_spec": build_spec})
-    elif legacy_build_spec is not None:
-        raise SFTBuildError(
-            f"frozen SFT dataset {dataset_id} already persists its build spec; "
-            "legacy_build_spec is only valid for legacy metadata"
-        )
     production_sources = tuple(
         ProductionSFTSource(acceptance_evidence_id=source.acceptance_evidence.artifact_id)
         for source in loaded.sources

--- a/wmo/optimize/model/sft/contracts.py
+++ b/wmo/optimize/model/sft/contracts.py
@@ -480,7 +480,7 @@ class SFTInspectionReport(ContractModel):
 class SFTDatasetMetadata(ContractModel):
     """All non-row frozen manifest data persisted beside canonical SFT JSONL examples."""
 
-    build_spec: SFTBuildSpec | None = None
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]
@@ -491,7 +491,7 @@ class SFTDatasetMetadata(ContractModel):
 class SFTDatasetArtifact(ContractModel):
     """Materialized dataset rows plus the immutable metadata required to reload and inspect them."""
 
-    build_spec: SFTBuildSpec | None = None
+    build_spec: SFTBuildSpec
     dataset: SFTDataset
     sources: tuple[SFTSourceReference, ...]
     partitions: tuple[SFTPartition, ...]

--- a/wmo/optimize/model/sft/run_manifest.py
+++ b/wmo/optimize/model/sft/run_manifest.py
@@ -30,7 +30,7 @@ from wmo.common.project import (
     artifact_input,
 )
 from wmo.optimize.model.sft.builder import SFTBuildError, load_verified_sft_dataset
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
 from wmo.optimize.model.sft.rendering import partitioned_rows_sha256
 from wmo.optimize.model.sft.training_contracts import (
     TinkerSFTError,
@@ -430,15 +430,12 @@ def load_tinker_sft_run(
 def verified_training_inputs(
     store: ProjectStore,
     dataset_id: ArtifactId,
-    *,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> tuple[SFTDatasetArtifact, ArtifactInput]:
     """Load one recursively verified W12 dataset and its exact manifest input.
 
     Args:
         store: Project store owning the immutable dataset.
         dataset_id: Persisted W12 dataset identity.
-        legacy_build_spec: Explicit settings required only for a legacy dataset.
 
     Returns:
         The verified dataset and exact manifest input used by W13.
@@ -447,11 +444,7 @@ def verified_training_inputs(
         TinkerSFTError: The W12 artifact graph cannot be verified for training.
     """
     try:
-        dataset = load_verified_sft_dataset(
-            store,
-            dataset_id,
-            legacy_build_spec=legacy_build_spec,
-        )
+        dataset = load_verified_sft_dataset(store, dataset_id)
         dataset_input = artifact_input(store.artifacts.read(dataset_id).manifest)
     except (ArtifactCorruptionError, SFTBuildError) as exc:
         raise TinkerSFTError(f"W12 dataset {dataset_id} is not safe for training: {exc}") from exc

--- a/wmo/optimize/model/sft/training.py
+++ b/wmo/optimize/model/sft/training.py
@@ -19,7 +19,7 @@ from wmo.common.core.artifacts import (
 from wmo.common.core.locks import file_write_lock
 from wmo.common.models import NumericMeasurement
 from wmo.common.project import ProjectStore
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact
 from wmo.optimize.model.sft.provider_resources import validate_provider_resource_id
 from wmo.optimize.model.sft.run_manifest import (
     _read_model,
@@ -84,7 +84,6 @@ class TinkerSFTOptimizer:
         output_dir: Path,
         created_at: datetime,
         code_revision: str,
-        legacy_build_spec: SFTBuildSpec | None = None,
     ) -> TinkerSFTResult:
         """Train from one persisted dataset without changing catalog, router, or serving state."""
         return train_tinker_sft(
@@ -95,7 +94,6 @@ class TinkerSFTOptimizer:
             backend=self._backend,
             created_at=created_at,
             code_revision=code_revision,
-            legacy_build_spec=legacy_build_spec,
         )
 
 
@@ -108,7 +106,6 @@ def train_tinker_sft(
     backend: TrainerBackend,
     created_at: datetime,
     code_revision: str,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Train a managed LoRA from frozen W12 examples with append-only local provenance.
 
@@ -120,8 +117,6 @@ def train_tinker_sft(
         backend: Concrete Tinker SDK adapter or a deterministic injected fake.
         created_at: Time recorded when this output directory is first initialized.
         code_revision: Exact revision recorded when this output directory is first initialized.
-        legacy_build_spec: Original W12 build settings for a dataset that predates persisted
-            build specifications. The runner rebuilds and verifies the legacy evidence chain.
 
     Returns:
         Completed model-handle and result artifacts containing only training and checkpoint facts.
@@ -129,11 +124,7 @@ def train_tinker_sft(
     Raises:
         TinkerSFTError: Dataset, budget, or append-only resume state is unsafe to continue.
     """
-    dataset, dataset_input = verified_training_inputs(
-        store,
-        dataset_id,
-        legacy_build_spec=legacy_build_spec,
-    )
+    dataset, dataset_input = verified_training_inputs(store, dataset_id)
     validate_run_inputs(dataset, created_at=created_at, code_revision=code_revision)
     manifest_path = output_dir / _MANIFEST_FILE
     with file_write_lock(manifest_path, what="the Tinker SFT run"):

--- a/wmo/optimize/model/sft/training_test.py
+++ b/wmo/optimize/model/sft/training_test.py
@@ -24,7 +24,7 @@ from wmo.optimize.model.sft.builder_test import (
 from wmo.optimize.model.sft.builder_test import (
     _write_production_source,
 )
-from wmo.optimize.model.sft.contracts import SFTBuildSpec, SFTDatasetArtifact, SFTExample
+from wmo.optimize.model.sft.contracts import SFTDatasetArtifact, SFTExample
 from wmo.optimize.model.sft.rendering import (
     canonical_partitioned_rows_jsonl,
     partitioned_rows_sha256,
@@ -229,28 +229,6 @@ def _persisted_dataset(tmp_path: Path) -> _PersistedDataset:
     return _PersistedDataset(store=store, artifact=artifact)
 
 
-def _legacy_w12_dataset(tmp_path: Path) -> _PersistedDataset:
-    """Persist the exact W12 metadata shape that predates the build-spec field."""
-    store = _fixture_store(tmp_path / "project")
-    sources = (
-        _write_production_source(store, "train-source-a"),
-        _write_production_source(store, "train-source-b"),
-    )
-    artifact = _build_fixture_dataset(store, production=sources)
-    metadata = artifact.metadata().model_dump(mode="json", exclude_none=False)
-    metadata.pop("build_spec")
-    store.artifacts.write(
-        artifact_id=artifact.dataset.dataset_id,
-        artifact_type="sft-dataset",
-        envelope=artifact.dataset,
-        files={
-            "dataset.json": canonical_json_bytes(metadata),
-            "examples.jsonl": canonical_partitioned_rows_jsonl(artifact.rows),
-        },
-    )
-    return _PersistedDataset(store=store, artifact=artifact)
-
-
 def _spec(**overrides: int | float | str | None) -> TinkerSFTSpec:
     """Return one small deterministic training specification."""
     fields: dict[str, int | float | str | None] = {
@@ -274,7 +252,6 @@ def _run(
     backend: _FakeBackend,
     *,
     spec: TinkerSFTSpec | None = None,
-    legacy_build_spec: SFTBuildSpec | None = None,
 ) -> TinkerSFTResult:
     """Run the public operation with immutable test provenance."""
     return train_tinker_sft(
@@ -285,7 +262,6 @@ def _run(
         backend=backend,
         created_at=_TIME,
         code_revision="w13-test",
-        legacy_build_spec=legacy_build_spec,
     )
 
 
@@ -331,47 +307,32 @@ def test_fake_backend_consumes_only_train_rows_and_writes_terminal_provenance(
     assert "quality" not in json.dumps(terminal)
 
 
-def test_legacy_w12_dataset_requires_and_verifies_its_original_build_spec(
-    tmp_path: Path,
-) -> None:
-    """Legacy W12 metadata trains only after its original build settings reproduce it."""
-    fixture = _legacy_w12_dataset(tmp_path)
-    missing_backend = _FakeBackend()
-
-    with pytest.raises(TinkerSFTError, match="legacy_build_spec"):
-        _run(fixture, tmp_path / "missing-spec", missing_backend)
-
-    assert missing_backend.open_resume_paths == []
-    assert fixture.artifact.build_spec is not None
-    backend = _FakeBackend()
-
-    result = _run(
-        fixture,
-        tmp_path / "migrated-run",
-        backend,
-        legacy_build_spec=fixture.artifact.build_spec,
+def test_dataset_without_persisted_build_spec_is_rejected(tmp_path: Path) -> None:
+    """Training refuses W12 metadata that omits the required build specification."""
+    store = _fixture_store(tmp_path / "project")
+    sources = (
+        _write_production_source(store, "train-source-a"),
+        _write_production_source(store, "train-source-b"),
     )
-
-    assert result.dataset_id == fixture.artifact.dataset.dataset_id
-    assert backend.open_resume_paths == [None]
-
-
-def test_legacy_w12_dataset_rejects_a_nonmatching_migration_build_spec(
-    tmp_path: Path,
-) -> None:
-    """A caller-supplied legacy spec cannot rewrite the frozen W12 evidence chain."""
-    fixture = _legacy_w12_dataset(tmp_path)
+    artifact = _build_fixture_dataset(store, production=sources)
+    metadata = artifact.metadata().model_dump(mode="json", exclude_none=False)
+    metadata.pop("build_spec")
+    store.artifacts.write(
+        artifact_id=artifact.dataset.dataset_id,
+        artifact_type="sft-dataset",
+        envelope=artifact.dataset,
+        files={
+            "dataset.json": canonical_json_bytes(metadata),
+            "examples.jsonl": canonical_partitioned_rows_jsonl(artifact.rows),
+        },
+    )
     backend = _FakeBackend()
 
-    with pytest.raises(TinkerSFTError, match="does not equal its canonical evidence rebuild"):
+    with pytest.raises(TinkerSFTError, match="invalid data files"):
         _run(
-            fixture,
-            tmp_path / "wrong-spec",
+            _PersistedDataset(store=store, artifact=artifact),
+            tmp_path / "missing-spec",
             backend,
-            legacy_build_spec=SFTBuildSpec(
-                held_out_fraction=0.2,
-                representative_sample_count=2,
-            ),
         )
 
     assert backend.open_resume_paths == []

--- a/wmo/optimize/router/automatic/artifacts.py
+++ b/wmo/optimize/router/automatic/artifacts.py
@@ -306,7 +306,7 @@ def _candidate_bindings(
 def _runtime_capability_bindings(
     preflight: AutomaticRouterPreflight,
 ) -> tuple[RuntimeCandidateCapability, ...]:
-    """Build runtime-owned candidate bindings without extending the legacy policy.
+    """Build runtime-owned candidate bindings without extending the frozen policy.
 
     Args:
         preflight: Verified catalog and selected candidate identities.

--- a/wmo/optimize/router/automatic/attribution_test.py
+++ b/wmo/optimize/router/automatic/attribution_test.py
@@ -115,8 +115,8 @@ def test_unique_inferred_mapping_omits_ambiguous_aliases_and_revision_drift() ->
     )
 
 
-def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> None:
-    """Direct and legacy records never receive provider/model-only inference."""
+def test_unspecified_and_missing_identity_require_full_snapshot_equality() -> None:
+    """Direct and unspecified records never receive provider/model-only inference."""
     recorded = _model("openai", "gpt-test", None, "a", "b")
     trace = _trace((recorded,))
     candidates = _candidates(recorded, _model("anthropic", "other", None, "c", "d"))
@@ -127,7 +127,7 @@ def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> Non
         _evidence(trace, capabilities="unspecified", connection="unspecified"),
         candidates,
     )[0]
-    legacy = resolve_router_observed_attributions(
+    missing = resolve_router_observed_attributions(
         (_task(trace),),
         (trace,),
         None,
@@ -135,7 +135,7 @@ def test_unspecified_and_legacy_identity_require_full_snapshot_equality() -> Non
     )[0]
 
     assert unspecified.match_kind == "strict_snapshot"
-    assert legacy.match_kind == "strict_snapshot"
+    assert missing.match_kind == "strict_snapshot"
 
     changed = recorded.model_copy(update={"connection_sha256": "e" * 64})
     assert (

--- a/wmo/optimize/router/automatic/execution_contract.py
+++ b/wmo/optimize/router/automatic/execution_contract.py
@@ -21,7 +21,6 @@ from wmo.common.core.artifacts import (
 from wmo.common.models import CompletionCostReservation, ModelSnapshot
 from wmo.common.project import ArtifactStore, artifact_input
 from wmo.common.routing import (
-    ReservedFrozenEmbeddingSet,
     RouterEmbeddingReservation,
     load_frozen_embedding_set,
 )
@@ -304,8 +303,7 @@ def load_router_execution_contract(
         raise ValueError("router execution contract differs from its manifest")
     embedding_set = load_frozen_embedding_set(store, value.router_embedding_input.artifact_id)
     if (
-        not isinstance(embedding_set, ReservedFrozenEmbeddingSet)
-        or artifact_input(store.read(value.router_embedding_input.artifact_id).manifest)
+        artifact_input(store.read(value.router_embedding_input.artifact_id).manifest)
         != value.router_embedding_input
         or embedding_set.reservation != value.router_embedding_reservation
     ):

--- a/wmo/optimize/router/automatic/service.py
+++ b/wmo/optimize/router/automatic/service.py
@@ -185,7 +185,6 @@ def optimize_project_router(
                 if preflight.trace_identity_evidence is None
                 else preflight.trace_identity_evidence.records
             ),
-            include_identity_evidence=preflight.trace_identity_evidence is not None,
         ),
         services=services,
         budget=RouterCompositionBudget(

--- a/wmo/optimize/router/composition.py
+++ b/wmo/optimize/router/composition.py
@@ -76,11 +76,6 @@ from wmo.runtime.models import RuntimeModelCatalog
 from wmo.runtime.router import RouterRuntime
 from wmo.simulation.build import ProjectBuild
 from wmo.simulation.engines.text.bindings import rollout_id_for_binding
-from wmo.simulation.engines.text.errors import SimulationConfigurationError
-from wmo.simulation.engines.text.grounding import (
-    load_completion_contract,
-    unknown_dispatch_worst_case_usd,
-)
 from wmo.simulation.engines.text.resume import reexecutable_dispatch_failure
 from wmo.simulation.engines.text.rollout_support import rollout_spend
 from wmo.simulation.ingest.otlp import TraceNormalizationResult
@@ -151,7 +146,7 @@ class RouterEvaluationSetup(ContractModel):
     incumbent_alias: ArtifactId | None = None
     judgment_status: Literal["provisional", "human_calibrated"]
     world_model_settings: WorldModelSettings
-    simulation_completion_input: ArtifactInput | None = None
+    simulation_completion_input: ArtifactInput
     agent_id: str = Field(min_length=1, max_length=256)
     seed: int
     maximum_steps: int = Field(gt=0)
@@ -614,24 +609,12 @@ def _superseded_attempt_spend(
     binding = rollout.simulation_binding
     if binding is None:
         raise RouterCompositionError("retried simulation rollout lacks its cell binding")
-    try:
-        contract = load_completion_contract(project.artifacts, setup.simulation_completion_input)
-    except SimulationConfigurationError as exc:
-        raise RouterCompositionError(str(exc)) from exc
     charges = []
     for attempt in range(rollout.retry_attempt):
         prior, _input = read_rollout(
             project.artifacts, rollout_id_for_binding(binding, attempt=attempt)
         )
-        spend = rollout_spend(
-            prior,
-            unknown_dispatch_fallback_usd=lambda item: unknown_dispatch_worst_case_usd(
-                contract,
-                item.simulation_binding.candidate_alias
-                if item.simulation_binding is not None
-                else None,
-            ),
-        )
+        spend = rollout_spend(prior)
         if spend is None:
             raise RouterCompositionError(
                 "superseded simulation attempt spend cannot be reconciled conservatively"

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -214,6 +214,7 @@ class _EvidenceSetupSupplier:
                 project.artifacts,
                 candidate_aliases=("candidate-baseline", "candidate-economy"),
                 snapshot=_snapshot,
+                code_revision=self.revision,
             ),
             agent_id="agent-a",
             seed=16,
@@ -225,8 +226,13 @@ class _EvidenceSetupSupplier:
 class _EvidenceSimulatorFactory:
     """Bind the actual text simulator to deterministic local model-client fakes."""
 
-    def __init__(self) -> None:
-        """Initialize deterministic candidate clients and a call counter."""
+    def __init__(self, revision: str) -> None:
+        """Initialize deterministic candidate clients and a call counter.
+
+        Args:
+            revision: Exact checkout revision bound to persisted reservations.
+        """
+        self.revision = revision
         self.calls = 0
         self.candidates = {
             "candidate-baseline": _ScriptedClient(
@@ -304,6 +310,7 @@ class _EvidenceSimulatorFactory:
                 project.artifacts,
                 candidate_aliases=("candidate-baseline", "candidate-economy"),
                 snapshot=_snapshot,
+                code_revision=self.revision,
             ),
             clock=lambda: _TIME,
             monotonic=lambda: 1.0,
@@ -436,7 +443,7 @@ def test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native(
         issues=(),
     )
     completed_build = _bind_completed_build(project, normalized, revision=revision)
-    simulator = _EvidenceSimulatorFactory()
+    simulator = _EvidenceSimulatorFactory(revision)
     judge = _EvidenceJudge(revision)
     runtime_catalog = _RuntimeCatalog()
     services = RouterWorkflowServices(

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -235,6 +235,7 @@ class _EvidenceSimulatorFactory:
                         "Resolved by baseline.",
                         snapshot=_snapshot("candidate-baseline"),
                         cost=0.0,
+                        usage=Usage(input_tokens=0, output_tokens=0),
                     )
                 ]
                 * 100
@@ -245,6 +246,7 @@ class _EvidenceSimulatorFactory:
                         "Resolved by economy.",
                         snapshot=_snapshot("candidate-economy"),
                         cost=0.0,
+                        usage=Usage(input_tokens=0, output_tokens=0),
                     )
                 ]
                 * 100
@@ -256,6 +258,7 @@ class _EvidenceSimulatorFactory:
                     '{"message":"Done.","terminal":true}',
                     snapshot=_snapshot("world-model-a"),
                     cost=0.0,
+                    usage=Usage(input_tokens=0, output_tokens=0),
                 )
             ]
             * 200

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -37,7 +36,7 @@ from wmo.common.models import (
     Usage,
 )
 from wmo.common.project import ProjectConfig, ProjectStore, artifact_input
-from wmo.common.routing import FrozenEmbedding, FrozenEmbeddingSet, KnnGuard, RouterFeatureExtractor
+from wmo.common.routing import KnnGuard
 from wmo.common.tasks import load_task_set
 from wmo.optimize.router.composition import (
     ApprovedRouterReview,
@@ -52,6 +51,7 @@ from wmo.optimize.router.composition_test import (
     _resolved,
     _snapshot,
 )
+from wmo.optimize.router.fit.workflow_test import _persist_embeddings
 from wmo.optimize.router.judgment_budget import JudgmentDispatchReceipt
 from wmo.release_revision_test import exact_checkout_revision, verify_release_evidence
 from wmo.runtime.models import CatalogRoleName, ResolvedModel, RuntimeModelCatalog
@@ -154,7 +154,14 @@ class _EvidenceSetupSupplier:
                 envelope=pricing,
                 files={"pricing.json": pricing},
             )
-            _persist_release_embeddings(project, tasks, self.revision)
+        embedding_set_id = _persist_embeddings(
+            project.artifacts,
+            tasks,
+            task_set_input=build.review.task_set,
+            embedder=_snapshot("embedder"),
+            created_at=_TIME,
+            code_revision=self.revision,
+        )
         production = EvaluationProtocol(
             protocol_id="w16-production-protocol",
             evidence_source="production",
@@ -180,7 +187,7 @@ class _EvidenceSetupSupplier:
             observed_cells=tuple(observed),
             production_protocol=production,
             simulation_protocol=world,
-            embedding_set_id="embeddings-a",
+            embedding_set_id=embedding_set_id,
             fit_rag_input=completed.fit_rag,
             pricing_snapshot_id="w16-pricing",
             incumbent_alias="candidate-baseline",
@@ -206,6 +213,7 @@ class _EvidenceSetupSupplier:
             simulation_completion_input=_persist_completion_contract(
                 project.artifacts,
                 candidate_aliases=("candidate-baseline", "candidate-economy"),
+                snapshot=_snapshot,
             ),
             agent_id="agent-a",
             seed=16,
@@ -292,6 +300,7 @@ class _EvidenceSimulatorFactory:
             completion_contract_input=_persist_completion_contract(
                 project.artifacts,
                 candidate_aliases=("candidate-baseline", "candidate-economy"),
+                snapshot=_snapshot,
             ),
             clock=lambda: _TIME,
             monotonic=lambda: 1.0,
@@ -645,32 +654,6 @@ class _EvidenceReviewSupplier:
                 files={"calibration.json": calibration},
             )
         return ApprovedRouterReview(rubric_id="rubric-a", calibration_id="calibration-a")
-
-
-def _persist_release_embeddings(project: ProjectStore, tasks, revision: str) -> None:  # noqa: ANN001
-    """Persist exact local vectors with release-checkout provenance."""
-    extractor = RouterFeatureExtractor()
-    embeddings = FrozenEmbeddingSet(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision=revision,
-        embedding_set_id="embeddings-a",
-        embedder_alias="embedder",
-        embedder=_snapshot("embedder"),
-        embeddings=tuple(
-            FrozenEmbedding(
-                text_sha256=hashlib.sha256(extractor.from_task(task).encode()).hexdigest(),
-                values=(1.0, 0.0),
-            )
-            for task in tasks
-        ),
-    )
-    project.artifacts.write_json(
-        artifact_id=embeddings.embedding_set_id,
-        artifact_type="router-embeddings",
-        envelope=embeddings,
-        files={"embeddings.json": embeddings},
-    )
 
 
 def _dispatch_counts(

--- a/wmo/optimize/router/composition_evidence_test.py
+++ b/wmo/optimize/router/composition_evidence_test.py
@@ -59,6 +59,7 @@ from wmo.runtime.router.application import create_project_router_app
 from wmo.simulation.engines.text.simulator import WorldModelSimulator
 from wmo.simulation.engines.text.simulator_test import (
     _OneTurnAgent,
+    _persist_completion_contract,
     _response,
     _ScriptedClient,
 )
@@ -202,6 +203,10 @@ class _EvidenceSetupSupplier:
                     maximum_input_tokens=10_000,
                 ),
             ),
+            simulation_completion_input=_persist_completion_contract(
+                project.artifacts,
+                candidate_aliases=("candidate-baseline", "candidate-economy"),
+            ),
             agent_id="agent-a",
             seed=16,
             maximum_steps=2,
@@ -284,6 +289,10 @@ class _EvidenceSimulatorFactory:
                 )
             },
             agent_factory=_OneTurnAgent,
+            completion_contract_input=_persist_completion_contract(
+                project.artifacts,
+                candidate_aliases=("candidate-baseline", "candidate-economy"),
+            ),
             clock=lambda: _TIME,
             monotonic=lambda: 1.0,
         )
@@ -622,6 +631,8 @@ class _EvidenceReviewSupplier:
                 score_maps=(
                     DimensionScoreMap(
                         dimension_id="dimension-a",
+                        min_score=0,
+                        max_score=5,
                         calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
                     ),
                 ),

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -76,6 +76,7 @@ from wmo.simulation.engines.text import simulator as text_simulator_module
 from wmo.simulation.engines.text.simulator import WorldModelSimulator
 from wmo.simulation.engines.text.simulator_test import (
     _OneTurnAgent,
+    _persist_completion_contract,
     _response,
     _ScriptedClient,
 )
@@ -379,6 +380,7 @@ class _SetupSupplier:
                     maximum_input_tokens=10_000,
                 ),
             ),
+            simulation_completion_input=_persist_completion_contract(project.artifacts),
             agent_id="agent-a",
             seed=7,
             maximum_steps=2,
@@ -542,6 +544,7 @@ class _SimulatorFactory:
                 )
             },
             agent_factory=_OneTurnAgent,
+            completion_contract_input=_persist_completion_contract(project.artifacts),
             clock=lambda: _TIME,
             monotonic=lambda: 1.0,
         )
@@ -933,7 +936,7 @@ def test_failed_rollouts_skip_judging_and_rerun_replays_after_partial_failure(
     def failing_admission(
         settings: WorldModelSettings,
         *,
-        completion_contract: SimulationCompletionContract | None,
+        completion_contract: SimulationCompletionContract,
         remaining_cost_usd: float,
         stop_on_overspend: bool = True,
     ) -> StructuredFailure | None:

--- a/wmo/optimize/router/composition_test.py
+++ b/wmo/optimize/router/composition_test.py
@@ -165,7 +165,15 @@ def _capabilities(alias: str) -> ModelCapabilities:
     """Return the exact frozen capabilities used by each focused model."""
     if alias == "embedder":
         return ModelCapabilities(supports_embeddings=True)
-    return ModelCapabilities(context_window_tokens=100_000, maximum_output_tokens=16_000)
+    return ModelCapabilities(
+        supports_completions=True,
+        context_window_tokens=100_000,
+        maximum_output_tokens=16_000,
+        input_cost_per_million_tokens_usd=1,
+        output_cost_per_million_tokens_usd=2,
+        cached_input_cost_per_million_tokens_usd=0.5,
+        cache_write_cost_per_million_tokens_usd=1.5,
+    )
 
 
 def _snapshot(alias: str) -> ModelSnapshot:
@@ -331,7 +339,12 @@ class _SetupSupplier:
             )
         if "pricing-a" not in project.artifacts.list_ids():
             _persist_pricing(project.artifacts)
-            _persist_embeddings(project.artifacts, tasks)
+        embedding_set_id = _persist_embeddings(
+            project.artifacts,
+            tasks,
+            task_set_input=build.review.task_set,
+            embedder=_snapshot("embedder"),
+        )
         production = EvaluationProtocol(
             protocol_id="protocol-production",
             evidence_source="production",
@@ -357,7 +370,7 @@ class _SetupSupplier:
             observed_cells=tuple(observed),
             production_protocol=production,
             simulation_protocol=world,
-            embedding_set_id="embeddings-a",
+            embedding_set_id=embedding_set_id,
             fit_rag_input=completed.fit_rag,
             pricing_snapshot_id="pricing-a",
             incumbent_alias="candidate-a",
@@ -380,7 +393,10 @@ class _SetupSupplier:
                     maximum_input_tokens=10_000,
                 ),
             ),
-            simulation_completion_input=_persist_completion_contract(project.artifacts),
+            simulation_completion_input=_persist_completion_contract(
+                project.artifacts,
+                snapshot=_snapshot,
+            ),
             agent_id="agent-a",
             seed=7,
             maximum_steps=2,
@@ -544,7 +560,10 @@ class _SimulatorFactory:
                 )
             },
             agent_factory=_OneTurnAgent,
-            completion_contract_input=_persist_completion_contract(project.artifacts),
+            completion_contract_input=_persist_completion_contract(
+                project.artifacts,
+                snapshot=_snapshot,
+            ),
             clock=lambda: _TIME,
             monotonic=lambda: 1.0,
         )

--- a/wmo/optimize/router/evaluation/simulation_spec.py
+++ b/wmo/optimize/router/evaluation/simulation_spec.py
@@ -62,16 +62,14 @@ def build_router_simulation_spec(
         "stop_on_overspend": stop_on_overspend,
         "code_revision": code_revision,
     }
-    if setup.simulation_completion_input is not None:
-        binding["simulation_completion"] = setup.simulation_completion_input.model_dump(mode="json")
+    binding["simulation_completion"] = setup.simulation_completion_input.model_dump(mode="json")
     spec_inputs = [
         plan_input,
         task_input,
         setup.fit_rag_input,
         setup.world_model_settings.grounded_world_model_input,
+        setup.simulation_completion_input,
     ]
-    if setup.simulation_completion_input is not None:
-        spec_inputs.append(setup.simulation_completion_input)
     return SimulationSpec(
         schema_version=1,
         created_at=created_at,

--- a/wmo/optimize/router/evaluation/simulation_spec_test.py
+++ b/wmo/optimize/router/evaluation/simulation_spec_test.py
@@ -93,6 +93,9 @@ def _plan_and_setup() -> tuple[EvaluationPlan, EvaluationCell, RouterEvaluationS
             grounded_world_model_input=ArtifactInput(artifact_id="world-model-a", sha256=_DIGEST),
             prompt_version="text-world-model-v1",
         ),
+        simulation_completion_input=ArtifactInput(
+            artifact_id="completion-contract-a", sha256=_DIGEST
+        ),
         agent_id="agent-a",
         seed=7,
         maximum_steps=2,

--- a/wmo/optimize/router/evaluation/spend.py
+++ b/wmo/optimize/router/evaluation/spend.py
@@ -90,17 +90,12 @@ def _unknown_dispatch_charge(rollout: RolloutArtifact) -> float:
         rollout: Failed evidence whose dispatched spend is permanently ambiguous.
 
     Returns:
-        The reservation persisted with the failure, or the durable sandbox episode ceiling
-        for environment dispatches that predate per-failure reservation persistence.
+        The reservation persisted with the failure.
 
     Raises:
         RouterCompositionError: No durable worst-case reservation was persisted.
     """
     reserved = unknown_dispatch_reserved_cost_usd(rollout.failure)
-    if reserved is None and rollout.evidence_source == "sandbox":
-        binding = rollout.sandbox_binding
-        if binding is not None:
-            reserved = binding.environment_maximum_episode_cost_usd
     if reserved is None:
         raise RouterCompositionError(
             "simulation rollout has unknown dispatched spend and no persisted reservation"

--- a/wmo/optimize/router/fit/optimizer_test.py
+++ b/wmo/optimize/router/fit/optimizer_test.py
@@ -906,6 +906,8 @@ def _persist_calibration(
         score_maps=(
             DimensionScoreMap(
                 dimension_id="dimension-a",
+                min_score=0,
+                max_score=5,
                 calibrated_scores=(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
             ),
         ),

--- a/wmo/optimize/router/fit/workflow_test.py
+++ b/wmo/optimize/router/fit/workflow_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -29,17 +29,20 @@ from wmo.common.evaluations.evidence import (
 from wmo.common.judging import DimensionJudgment, Judgment
 from wmo.common.models import (
     CandidateTokenPrice,
+    Embedding,
+    ModelSnapshot,
     OperationEconomics,
     PricingSnapshot,
     RoutedCandidateSnapshot,
 )
-from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.common.project import ArtifactStore, ProjectConfig, ProjectStore
 from wmo.common.routing import (
-    FrozenEmbedding,
-    FrozenEmbeddingSet,
     KnnGuard,
     RouterFeatureExtractor,
+    persist_router_embeddings,
+    router_embedding_reservation,
 )
+from wmo.common.tasks import TaskCase
 from wmo.optimize.router.activation import load_project_router
 from wmo.optimize.router.fit.workflow import (
     EvaluationInputs,
@@ -129,7 +132,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
     fit = tuple(_task(f"task-fit-{index:02d}", partition="fit") for index in range(10))
     held_out = tuple(_task(f"task-held-{index:02d}", partition="held_out") for index in range(2))
     tasks = (*fit, *held_out)
-    _persist_task_set(store, "task-set-workflow", tasks)
+    task_set_input = _persist_task_set(store, "task-set-workflow", tasks)
     calibration_input = _persist_calibration(
         store,
         fit_lineages=tuple(task.lineage_group_id for task in fit),
@@ -219,7 +222,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
         evidence_by_task[cell.task_id].model_copy(update={"cell_id": cell.cell_id})
         for cell in plan.cells
     )
-    _persist_embeddings(store, tasks)
+    embedding_set_id = _persist_embeddings(store, tasks, task_set_input=task_set_input)
     protocols = (production_protocol,)
     return project, RouterOptimizationConfig(
         fit=EvaluationInputs(
@@ -242,7 +245,7 @@ def _workflow_fixture(root: Path) -> tuple[ProjectStore, RouterOptimizationConfi
                 == "held_out"
             ),
         ),
-        embedding_set_id="embeddings-a",
+        embedding_set_id=embedding_set_id,
         incumbent_alias="candidate-a",
         pricing_snapshot_id="pricing-a",
         guard=KnnGuard(
@@ -281,27 +284,56 @@ def _persist_pricing(store) -> None:  # noqa: ANN001 - focused fixture
     )
 
 
-def _persist_embeddings(store, tasks) -> None:  # noqa: ANN001 - focused fixture
-    """Persist exact local vectors for every request-visible task feature."""
-    extractor = RouterFeatureExtractor()
-    embeddings = FrozenEmbeddingSet(
-        schema_version=1,
-        created_at=_TIME,
-        code_revision="test-revision",
-        embedding_set_id="embeddings-a",
+class _UnitEmbeddingClient:
+    """Return a fixed unit vector for every requested feature text."""
+
+    def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+        """Return one deterministic unit vector per input text."""
+        return tuple(Embedding(values=(1.0, 0.0)) for _ in texts)
+
+
+def _persist_embeddings(
+    store: ArtifactStore,
+    tasks: Sequence[TaskCase],
+    *,
+    task_set_input: ArtifactInput,
+    embedder: ModelSnapshot | None = None,
+    created_at: datetime = _TIME,
+    code_revision: str = "test-revision",
+) -> str:
+    """Persist reserved local vectors for every request-visible task feature.
+
+    Args:
+        store: Project-local artifact store.
+        tasks: Fit and held-out tasks whose request-visible features are embedded.
+        task_set_input: Exact task-set pointer bound into the reserved artifact.
+        embedder: Exact embedder identity, or the shared workflow-test snapshot.
+        created_at: Artifact completion time.
+        code_revision: Exact producer revision.
+
+    Returns:
+        Content-addressed reserved embedding-set identity.
+    """
+    model = embedder or _snapshot("embedder")
+    texts = tuple(dict.fromkeys(RouterFeatureExtractor().from_task(task) for task in tasks))
+    reservation = router_embedding_reservation(
+        model=model,
+        input_usd_per_million_tokens=0.0,
+        maximum_attempts_per_feature=1,
+        maximum_input_tokens_per_feature=10_000,
+        feature_count=len(texts),
+    )
+    artifact = persist_router_embeddings(
+        store,
+        task_set_input=task_set_input,
+        tasks=tasks,
         embedder_alias="embedder",
-        embedder=_snapshot("embedder"),
-        embeddings=tuple(
-            FrozenEmbedding(
-                text_sha256=hashlib.sha256(extractor.from_task(task).encode()).hexdigest(),
-                values=(1.0, 0.0),
-            )
-            for task in tasks
-        ),
+        embedder=model,
+        client=_UnitEmbeddingClient(),
+        reservation=reservation,
+        active_input_usd_per_million_tokens=0.0,
+        active_maximum_attempts_per_feature=1,
+        created_at=created_at,
+        code_revision=code_revision,
     )
-    store.write_json(
-        artifact_id=embeddings.embedding_set_id,
-        artifact_type="router-embeddings",
-        envelope=embeddings,
-        files={"embeddings.json": embeddings},
-    )
+    return artifact.embedding_set_id

--- a/wmo/optimize/router/judging/contracts.py
+++ b/wmo/optimize/router/judging/contracts.py
@@ -752,6 +752,7 @@ def judge_feedback_schema(
 class ManualJudgeCalibrationAudit(ArtifactEnvelope):
     """Immutable reviewed calibration evidence before the approval decision."""
 
+    schema_version: Literal[2] = 2
     audit_id: ArtifactId
     setup: ArtifactInput
     human_labels: ArtifactInput
@@ -799,10 +800,8 @@ class ManualJudgeCalibrationAudit(ArtifactEnvelope):
             raise ValueError("manual judge audit must hash its complete canonical input graph")
         if not self.judgments:
             raise ValueError("manual judge audit requires at least one judge probe")
-        if self.schema_version >= 2 and len(self.trace_reviews) != len(self.judgments):
+        if len(self.trace_reviews) != len(self.judgments):
             raise ValueError("manual judge audit requires one human review per judgment")
-        if self.schema_version == 1 and self.trace_reviews:
-            raise ValueError("version-one manual judge audits cannot name trace reviews")
         if len({item.artifact_id for item in self.trace_reviews}) != len(self.trace_reviews):
             raise ValueError("manual judge audit trace reviews must be unique")
         if (self.positional_bias_comparisons is None) != (self.positional_bias_flips is None):

--- a/wmo/optimize/router/judging/service.py
+++ b/wmo/optimize/router/judging/service.py
@@ -495,7 +495,7 @@ def calibrate_manual_judge(
         save_label_draft(store, setup, sample_sha256, supplied_labels, created_at)
         reviewer = reviewer_from_labels(setup, supplied_labels)
     elif supplied_labels:
-        raise ManualJudgeError("supply either a review callback or legacy labels, not both")
+        raise ManualJudgeError("supply either a review callback or supplied labels, not both")
     calls_per_trace = 2 if setup.prompt_template.response_shape == "pairwise" else 1
     expected_calls = (len(plan.traces) - len(completed_reviews)) * (calls_per_trace)
     total_calls = len(plan.traces) * calls_per_trace

--- a/wmo/runtime/router/capability_test.py
+++ b/wmo/runtime/router/capability_test.py
@@ -71,7 +71,7 @@ def _catalog(*, supports_completions: bool) -> RuntimeModelCatalog:
 def _bindings(
     catalog: RuntimeModelCatalog,
 ) -> tuple[tuple[RuntimeCandidateCapability, ...], tuple[RoutedCandidateSnapshot, ...]]:
-    """Build matching runtime and legacy policy candidate bindings."""
+    """Build matching runtime and frozen policy candidate bindings."""
     runtime = []
     policy = []
     for alias in ("candidate-a", "candidate-b"):

--- a/wmo/simulation/comparison_evidence_test.py
+++ b/wmo/simulation/comparison_evidence_test.py
@@ -61,6 +61,7 @@ from wmo.simulation.engines.text.simulator_test import (
     _FitRetriever,
     _grounded_world_model,
     _grounded_world_model_input,
+    _persist_completion_contract,
     _response,
     _ScriptedClient,
     _snapshot,
@@ -145,6 +146,7 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
     )
     text_plan, text_plan_input = _persist_plan(store, tasks, task_input, "text", revision)
     sandbox_plan, sandbox_plan_input = _persist_plan(store, tasks, task_input, "sandbox", revision)
+    completion_input = _persist_completion_contract(store)
     text_spec = _spec(
         text_plan,
         text_plan_input,
@@ -153,6 +155,7 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
         revision,
         fit_rag_input=fit_rag_input,
         grounded_world_model_input=grounded_world_model_input,
+        completion_contract_input=completion_input,
     )
     sandbox_spec = _spec(
         sandbox_plan,
@@ -207,6 +210,7 @@ def test_w16_actual_text_and_local_process_comparison_preserves_failure_denomina
             )
         },
         agent_factory=_TextComparisonAgent,
+        completion_contract_input=completion_input,
         clock=lambda: _EVIDENCE_AT,
         monotonic=lambda: 1.0,
     )
@@ -469,6 +473,7 @@ def _spec(
     *,
     fit_rag_input: ArtifactInput | None = None,
     grounded_world_model_input: ArtifactInput | None = None,
+    completion_contract_input: ArtifactInput | None = None,
 ) -> SimulationSpec:
     """Return one executable specification without pre-persisting outputs.
 
@@ -480,19 +485,23 @@ def _spec(
         revision: Exact source revision bound to created artifacts.
         fit_rag_input: Exact persisted fit-only RAG pointer for world-model mode.
         grounded_world_model_input: Exact persisted grounded runtime pointer.
+        completion_contract_input: Exact completion reservation for world-model mode.
 
     Returns:
         Finite specification bound to the selected plan and task set.
     """
     rag_input = fit_rag_input or _fit_rag_input()
     grounded_input = grounded_world_model_input or _grounded_world_model_input()
+    extras = (rag_input, grounded_input)
+    if mode is SimulationMode.WORLD_MODEL and completion_contract_input is not None:
+        extras = (*extras, completion_contract_input)
     return SimulationSpec(
         schema_version=1,
         created_at=_EVIDENCE_AT,
         inputs=_inputs(
             plan_input,
             task_input,
-            *((rag_input, grounded_input) if mode is SimulationMode.WORLD_MODEL else ()),
+            *(extras if mode is SimulationMode.WORLD_MODEL else ()),
         ),
         code_revision=revision,
         simulation_id=f"w16-{mode.value}-simulation",

--- a/wmo/simulation/engines/text/grounding.py
+++ b/wmo/simulation/engines/text/grounding.py
@@ -10,9 +10,6 @@ from wmo.common.core.artifacts import (
 )
 from wmo.common.models import (
     CompletionCostReservation,
-    EmbeddingCostReservation,
-    NumericMeasurement,
-    OperationEconomics,
     verify_completion_reservation,
 )
 from wmo.common.project import ArtifactCorruptionError, ArtifactStore, artifact_input
@@ -29,22 +26,20 @@ from wmo.simulation.specs import (
 
 
 def load_completion_contract(
-    store: ArtifactStore, contract_input: ArtifactInput | None
-) -> SimulationCompletionContract | None:
-    """Load the exact optional completion reservation artifact.
+    store: ArtifactStore, contract_input: ArtifactInput
+) -> SimulationCompletionContract:
+    """Load the exact completion reservation artifact.
 
     Args:
         store: Project-local immutable artifact store.
         contract_input: Expected immutable contract manifest.
 
     Returns:
-        Verified completion contract, or ``None`` for v1 simulation callers.
+        Verified completion contract.
 
     Raises:
         SimulationConfigurationError: The artifact is missing, corrupt, or hash-mismatched.
     """
-    if contract_input is None:
-        return None
     try:
         contract, persisted_input = load_simulation_completion_contract(
             store, contract_input.artifact_id
@@ -174,91 +169,27 @@ def require_grounding_settings(
     return settings
 
 
-def maximum_query_reservation(
-    reservation: EmbeddingCostReservation,
-) -> OperationEconomics:
-    """Return the retry-inclusive maximum spend reserved for one retrieval query.
-
-    Args:
-        reservation: Persisted price, retry ceiling, and maximum query-token count.
-
-    Returns:
-        Estimated economics for the largest allowed query and every allowed retry.
-    """
-    cost = (
-        reservation.maximum_input_tokens
-        * reservation.maximum_attempts
-        * reservation.input_usd_per_million_tokens
-        / 1_000_000
-    )
-    return OperationEconomics(cost_usd=NumericMeasurement(value=cost, provenance="estimated"))
-
-
-def query_reservation_failure(
-    reservation: EmbeddingCostReservation,
-    remaining_cost_usd: float,
-    *,
-    stop_on_overspend: bool = True,
-) -> StructuredFailure | None:
-    """Reject retrieval dispatch only when stop mode finds the remainder exhausted.
-
-    The worst-case query reservation is a planning value and never gates dispatch on its own:
-    an episode with real budget remaining always admits its next query. By default the
-    authorized run also admits queries after the remainder is exhausted; stop mode returns a
-    structured budget failure instead.
-
-    Args:
-        reservation: Persisted worst-case query-embedding reservation.
-        remaining_cost_usd: Reconciled provider budget available to the cell.
-        stop_on_overspend: When true, an exhausted remainder blocks the next query.
-
-    Returns:
-        Structured budget failure when stop mode finds no reconciled spend remaining,
-        otherwise ``None``.
-
-    Raises:
-        SimulationConfigurationError: The reservation unexpectedly has no estimated cost.
-    """
-    economics = maximum_query_reservation(reservation)
-    cost = economics.cost_usd
-    if cost is None:  # pragma: no cover - maximum_query_reservation always prices the call
-        raise SimulationConfigurationError("query-embedding reservation has unknown cost")
-    if remaining_cost_usd > 0 or not stop_on_overspend:
-        return None
-    return StructuredFailure(
-        code=FailureCode.BUDGET,
-        message="reconciled provider spend has exhausted the remaining retrieval ceiling",
-        attribution=FailureAttribution.MODEL,
-        details={
-            "phase": "query_embedding_reservation",
-            "remaining_cost_usd": remaining_cost_usd,
-        },
-    )
-
-
 def completion_reservations(
-    contract: SimulationCompletionContract | None,
+    contract: SimulationCompletionContract,
     *,
     candidate_alias: str,
     candidate: ResolvedModel,
     world_model: ResolvedModel,
-) -> tuple[CompletionCostReservation | None, CompletionCostReservation | None]:
+) -> tuple[CompletionCostReservation, CompletionCostReservation]:
     """Resolve and verify exact candidate and world request ceilings.
 
     Args:
-        contract: Frozen automatic-simulation reservations, or ``None`` for v1 callers.
+        contract: Frozen automatic-simulation reservations.
         candidate_alias: Evaluation cell candidate alias.
         candidate: Active exact candidate model.
         world_model: Active exact world model.
 
     Returns:
-        Candidate and world request reservations, or two ``None`` values for legacy settings.
+        Candidate and world request reservations.
 
     Raises:
         SimulationConfigurationError: A reservation is absent or differs from active metadata.
     """
-    if contract is None:
-        return None, None
     if contract.world_model_alias != world_model.alias:
         raise SimulationConfigurationError(
             "completion reservation contract selects a different world-model alias"
@@ -290,7 +221,7 @@ def completion_reservations(
 
 
 def unknown_dispatch_worst_case_usd(
-    contract: SimulationCompletionContract | None,
+    contract: SimulationCompletionContract,
     candidate_alias: str | None,
 ) -> float | None:
     """Return the persisted retry-inclusive worst case for one ambiguous provider dispatch.
@@ -300,14 +231,14 @@ def unknown_dispatch_worst_case_usd(
     ceilings from the frozen completion contract.
 
     Args:
-        contract: Frozen automatic-simulation reservations, or ``None`` for v1 callers.
+        contract: Frozen automatic-simulation reservations.
         candidate_alias: Candidate alias bound to the failed cell, or ``None`` when unknown.
 
     Returns:
         The combined candidate and world-model retry-inclusive maximum, or ``None`` when the
-        contract or the alias reservation is unavailable.
+        alias reservation is unavailable.
     """
-    if contract is None or candidate_alias is None:
+    if candidate_alias is None:
         return None
     candidates = {item.candidate_alias: item.request for item in contract.candidate_requests}
     candidate = candidates.get(candidate_alias)
@@ -322,7 +253,7 @@ def unknown_dispatch_worst_case_usd(
 def episode_reservation_failure(
     settings: WorldModelSettings,
     *,
-    completion_contract: SimulationCompletionContract | None,
+    completion_contract: SimulationCompletionContract,
     remaining_cost_usd: float,
     stop_on_overspend: bool = True,
 ) -> StructuredFailure | None:
@@ -336,7 +267,7 @@ def episode_reservation_failure(
 
     Args:
         settings: Frozen retrieval and completion reservations.
-        completion_contract: Frozen completion reservations, or ``None`` for v1 callers.
+        completion_contract: Frozen completion reservations.
         remaining_cost_usd: Reconciled cell budget remaining under the durable lease.
         stop_on_overspend: When true, an exhausted remainder blocks the next episode.
 
@@ -349,10 +280,6 @@ def episode_reservation_failure(
     query = settings.query_embedding
     if query is None:  # pragma: no cover - grounding settings require it
         raise SimulationConfigurationError("query-embedding reservation is missing")
-    if completion_contract is None:
-        return query_reservation_failure(
-            query, remaining_cost_usd, stop_on_overspend=stop_on_overspend
-        )
     if remaining_cost_usd > 0 or not stop_on_overspend:
         return None
     return StructuredFailure(

--- a/wmo/simulation/engines/text/rollout_support.py
+++ b/wmo/simulation/engines/text/rollout_support.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import cast
 
@@ -103,24 +103,17 @@ def normalize_text_tool_failure(episode: AgentEpisode) -> StructuredFailure | No
 
 def known_total_spend(
     rollouts: Sequence[RolloutArtifact],
-    *,
-    unknown_dispatch_fallback_usd: Callable[[RolloutArtifact], float | None] | None = None,
 ) -> float | None:
     """Return total conservative provider spend, or ``None`` if any episode is unpriced.
 
     Args:
         rollouts: Completed text-simulation rollout artifacts to total.
-        unknown_dispatch_fallback_usd: Optional persisted worst-case charge for unknown-spend
-            evidence that predates per-failure reservation persistence.
 
     Returns:
         The known conservative provider spend, or ``None`` when any billed call is not priced
         and has no persisted worst-case reservation.
     """
-    values = tuple(
-        rollout_spend(rollout, unknown_dispatch_fallback_usd=unknown_dispatch_fallback_usd)
-        for rollout in rollouts
-    )
+    values = tuple(rollout_spend(rollout) for rollout in rollouts)
     if any(value is None for value in values):
         return None
     return sum(cast(float, value) for value in values)
@@ -128,8 +121,6 @@ def known_total_spend(
 
 def rollout_spend(
     rollout: RolloutArtifact,
-    *,
-    unknown_dispatch_fallback_usd: Callable[[RolloutArtifact], float | None] | None = None,
 ) -> float | None:
     """Return reconciled provider cost without treating unknown dispatches as free.
 
@@ -139,8 +130,6 @@ def rollout_spend(
 
     Args:
         rollout: Completed text-simulation rollout whose recorded calls are inspected.
-        unknown_dispatch_fallback_usd: Optional persisted worst-case charge for unknown-spend
-            evidence that predates per-failure reservation persistence.
 
     Returns:
         Observed candidate and world-model cost plus conservative retrieval and reservation
@@ -149,8 +138,6 @@ def rollout_spend(
     reserved: float | None = None
     if unknown_spend_failure(rollout.failure):
         reserved = unknown_dispatch_reserved_cost_usd(rollout.failure)
-        if reserved is None and unknown_dispatch_fallback_usd is not None:
-            reserved = unknown_dispatch_fallback_usd(rollout)
         if reserved is None:
             return None
     roles = (

--- a/wmo/simulation/engines/text/simulator.py
+++ b/wmo/simulation/engines/text/simulator.py
@@ -58,7 +58,6 @@ from wmo.simulation.engines.text.grounding import (
     load_completion_contract,
     load_simulation_task_set,
     require_grounding_settings,
-    unknown_dispatch_worst_case_usd,
     verify_fit_retriever,
 )
 from wmo.simulation.engines.text.leases import (
@@ -122,7 +121,7 @@ class WorldModelSimulator:
         world_models: Independently resolved world-model providers keyed by local alias.
         grounded_world_models: Artifact-bound fit-only executors keyed by world-model alias.
         agent_factory: Creates an isolated customer-agent runtime for each episode worker.
-        completion_contract_input: Optional exact automatic-simulation reservation artifact.
+        completion_contract_input: Exact automatic-simulation reservation artifact.
         redacted_field_names: Project-configured labels removed before evidence persists.
         clock: Time source for artifact and span timestamps.
         monotonic: Monotonic time source for orchestration latency measurements.
@@ -143,7 +142,7 @@ class WorldModelSimulator:
         world_models: Mapping[str, ResolvedModel],
         grounded_world_models: Mapping[str, GroundedWorldModel],
         agent_factory: Callable[[], AgentRuntime],
-        completion_contract_input: ArtifactInput | None = None,
+        completion_contract_input: ArtifactInput,
         redacted_field_names: tuple[str, ...] = (),
         clock: Callable[[], datetime] | None = None,
         monotonic: Callable[[], float] = time.monotonic,
@@ -163,7 +162,7 @@ class WorldModelSimulator:
             world_models: Remote world-model aliases resolved through the canonical runtime package.
             grounded_world_models: Persisted fit-bound executors for those world models.
             agent_factory: Per-episode customer-agent construction seam.
-            completion_contract_input: Optional exact completion reservation manifest.
+            completion_contract_input: Exact completion reservation manifest.
             redacted_field_names: Local field labels removed before artifact persistence.
             clock: Time source, injectable for deterministic tests.
             monotonic: Duration source, injectable for deterministic tests.
@@ -304,10 +303,7 @@ class WorldModelSimulator:
             raise SimulationConfigurationError(
                 "simulation spec inputs must include the exact task-set manifest reference"
             )
-        if (
-            self._completion_contract_input is not None
-            and self._completion_contract_input not in spec.inputs
-        ):
+        if self._completion_contract_input not in spec.inputs:
             raise SimulationConfigurationError(
                 "simulation spec inputs omit the exact completion reservation contract"
             )
@@ -599,15 +595,7 @@ class WorldModelSimulator:
         for cell_id, binding in bindings.items():
             cell = next(item for item in self._plan.cells if item.cell_id == cell_id)
             rollouts.extend(persisted_cell_attempts(self._store, cell, binding, pins))
-        return known_total_spend(
-            rollouts,
-            unknown_dispatch_fallback_usd=lambda rollout: unknown_dispatch_worst_case_usd(
-                self._completion_contract,
-                rollout.simulation_binding.candidate_alias
-                if rollout.simulation_binding is not None
-                else None,
-            ),
-        )
+        return known_total_spend(rollouts)
 
     def _execute_cell(
         self,
@@ -701,11 +689,7 @@ class WorldModelSimulator:
             query_embedding=settings.query_embedding,
             candidate_request=candidate_request,
             world_model_request=world_request,
-            completion_maximum_attempts=(
-                self._completion_contract.maximum_attempts
-                if self._completion_contract is not None
-                else 1
-            ),
+            completion_maximum_attempts=self._completion_contract.maximum_attempts,
             maximum_cost_usd=maximum_cell_cost_usd,
             stop_on_overspend=spec.stop_on_overspend,
             maximum_steps=spec.maximum_steps,

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -507,6 +507,7 @@ def _persist_completion_contract(
     snapshot: Callable[[str], ModelSnapshot] | None = None,
     candidate_maximum_input_tokens: int = 80_000,
     candidate_maximum_output_tokens: int = 16_000,
+    code_revision: str = "test-revision",
 ) -> ArtifactInput:
     """Persist the complete candidate and world reservation fixture.
 
@@ -516,6 +517,7 @@ def _persist_completion_contract(
         snapshot: Exact model-identity factory, or the shared simulator-test snapshot.
         candidate_maximum_input_tokens: Hard candidate input admission ceiling.
         candidate_maximum_output_tokens: Candidate provider output ceiling.
+        code_revision: Exact producer revision bound to the contract artifact.
 
     Returns:
         Exact completion-contract manifest input.
@@ -543,7 +545,7 @@ def _persist_completion_contract(
         ),
         maximum_attempts=1,
         created_at=_TIME,
-        code_revision="test-revision",
+        code_revision=code_revision,
     )
     return contract_input
 

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -293,12 +293,25 @@ def _response(
     snapshot: ModelSnapshot,
     cost: float | None = 0.10,
     finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+    usage: Usage | None = None,
 ) -> ModelResponse:
+    """Build one scripted completion with explicit observed economics.
+
+    Args:
+        content: Visible assistant text.
+        snapshot: Exact served model identity.
+        cost: Observed provider spend, or ``None`` when spend is unknown.
+        finish_reason: Provider stop reason recorded on the response.
+        usage: Observed token counts, or the shared 8-input 4-output fixture.
+
+    Returns:
+        Provider-neutral completion used by scripted simulator clients.
+    """
     return ModelResponse(
         output=AssistantAction(content=content),
         model=snapshot,
         economics=OperationEconomics(
-            usage=Usage(input_tokens=8, output_tokens=4),
+            usage=usage or Usage(input_tokens=8, output_tokens=4),
             cost_usd=(
                 NumericMeasurement(value=cost, provenance="observed") if cost is not None else None
             ),

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -460,6 +460,7 @@ def _query_embedding(
 def _completion_reservation(
     alias: str,
     *,
+    model: ModelSnapshot | None = None,
     maximum_input_tokens: int = 80_000,
     maximum_output_tokens: int = 16_000,
 ) -> CompletionCostReservation:
@@ -467,6 +468,7 @@ def _completion_reservation(
 
     Args:
         alias: Exact candidate or world-model alias.
+        model: Exact model identity, or the shared simulator-test snapshot.
         maximum_input_tokens: Hard per-request input admission ceiling.
         maximum_output_tokens: Provider output ceiling.
 
@@ -474,7 +476,7 @@ def _completion_reservation(
         Conservative completion request reservation.
     """
     return completion_cost_reservation(
-        model=_snapshot(alias),
+        model=model or _snapshot(alias),
         input_usd_per_million_tokens=1,
         output_usd_per_million_tokens=2,
         cached_input_usd_per_million_tokens=0.5,
@@ -489,6 +491,7 @@ def _persist_completion_contract(
     store: ArtifactStore,
     *,
     candidate_aliases: tuple[str, ...] = ("candidate-a", "candidate-b"),
+    snapshot: Callable[[str], ModelSnapshot] | None = None,
     candidate_maximum_input_tokens: int = 80_000,
     candidate_maximum_output_tokens: int = 16_000,
 ) -> ArtifactInput:
@@ -497,12 +500,14 @@ def _persist_completion_contract(
     Args:
         store: Project-local artifact store.
         candidate_aliases: Candidate aliases that need request reservations.
+        snapshot: Exact model-identity factory, or the shared simulator-test snapshot.
         candidate_maximum_input_tokens: Hard candidate input admission ceiling.
         candidate_maximum_output_tokens: Candidate provider output ceiling.
 
     Returns:
         Exact completion-contract manifest input.
     """
+    model_for = snapshot or _snapshot
     _contract, contract_input = persist_simulation_completion_contract(
         store,
         inputs=(),
@@ -511,6 +516,7 @@ def _persist_completion_contract(
                 candidate_alias=alias,
                 request=_completion_reservation(
                     alias,
+                    model=model_for(alias),
                     maximum_input_tokens=candidate_maximum_input_tokens,
                     maximum_output_tokens=candidate_maximum_output_tokens,
                 ),
@@ -518,7 +524,10 @@ def _persist_completion_contract(
             for alias in candidate_aliases
         ),
         world_model_alias="world-model-a",
-        world_model_request=_completion_reservation("world-model-a"),
+        world_model_request=_completion_reservation(
+            "world-model-a",
+            model=model_for("world-model-a"),
+        ),
         maximum_attempts=1,
         created_at=_TIME,
         code_revision="test-revision",

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -457,14 +457,21 @@ def _query_embedding(
     )
 
 
-def _completion_reservation(alias: str) -> CompletionCostReservation:
+def _completion_reservation(
+    alias: str,
+    *,
+    maximum_input_tokens: int = 80_000,
+    maximum_output_tokens: int = 16_000,
+) -> CompletionCostReservation:
     """Build a complete one-attempt request reservation for one fixture model.
 
     Args:
         alias: Exact candidate or world-model alias.
+        maximum_input_tokens: Hard per-request input admission ceiling.
+        maximum_output_tokens: Provider output ceiling.
 
     Returns:
-        Conservative full-context completion request reservation.
+        Conservative completion request reservation.
     """
     return completion_cost_reservation(
         model=_snapshot(alias),
@@ -473,8 +480,8 @@ def _completion_reservation(alias: str) -> CompletionCostReservation:
         cached_input_usd_per_million_tokens=0.5,
         cache_write_usd_per_million_tokens=1.5,
         maximum_attempts=1,
-        maximum_input_tokens=80_000,
-        maximum_output_tokens=16_000,
+        maximum_input_tokens=maximum_input_tokens,
+        maximum_output_tokens=maximum_output_tokens,
     )
 
 
@@ -482,12 +489,16 @@ def _persist_completion_contract(
     store: ArtifactStore,
     *,
     candidate_aliases: tuple[str, ...] = ("candidate-a", "candidate-b"),
+    candidate_maximum_input_tokens: int = 80_000,
+    candidate_maximum_output_tokens: int = 16_000,
 ) -> ArtifactInput:
     """Persist the complete candidate and world reservation fixture.
 
     Args:
         store: Project-local artifact store.
         candidate_aliases: Candidate aliases that need request reservations.
+        candidate_maximum_input_tokens: Hard candidate input admission ceiling.
+        candidate_maximum_output_tokens: Candidate provider output ceiling.
 
     Returns:
         Exact completion-contract manifest input.
@@ -498,7 +509,11 @@ def _persist_completion_contract(
         candidate_requests=tuple(
             CandidateCompletionReservation(
                 candidate_alias=alias,
-                request=_completion_reservation(alias),
+                request=_completion_reservation(
+                    alias,
+                    maximum_input_tokens=candidate_maximum_input_tokens,
+                    maximum_output_tokens=candidate_maximum_output_tokens,
+                ),
             )
             for alias in candidate_aliases
         ),
@@ -679,14 +694,14 @@ def test_text_simulation_persists_separate_economics_and_resumes_without_duplica
     tasks = {"task-a": _task("task-a")}
     task_set_input = _persist_task_set(store, tasks)
     candidate_client = _ScriptedClient(
-        [_response("I can help.", snapshot=_snapshot("candidate-a"), cost=0.2)]
+        [_response("I can help.", snapshot=_snapshot("candidate-a"), cost=0.05)]
     )
     world_client = _ScriptedClient(
         [
             _response(
                 '{"message":"Thanks.","terminal":true}',
                 snapshot=_snapshot("world-model-a"),
-                cost=0.8,
+                cost=0.10,
             )
         ]
     )
@@ -708,12 +723,12 @@ def test_text_simulation_persists_separate_economics_and_resumes_without_duplica
     resumed = simulator.run(spec.model_copy(update={"created_at": _TIME + timedelta(hours=1)}))
 
     assert rollout.candidate_economics.cost_usd == NumericMeasurement(
-        value=0.2,
+        value=0.05,
         provenance="observed",
     )
     assert rollout.world_model_economics is not None
     assert rollout.world_model_economics.cost_usd == NumericMeasurement(
-        value=0.8,
+        value=0.10,
         provenance="observed",
     )
     assert rollout.retrieval_economics is not None
@@ -782,14 +797,14 @@ def test_persisted_rollout_redacts_generated_secrets_and_records_audit_count(
     plan_input = _persist_plan(store, plan)
     task_set_input = _persist_task_set(store, {"task-a": _task("task-a")})
     candidate_client = _ScriptedClient(
-        [_response(f"export KEY={secret}", snapshot=_snapshot("candidate-a"), cost=0.2)]
+        [_response(f"export KEY={secret}", snapshot=_snapshot("candidate-a"), cost=0.05)]
     )
     world_client = _ScriptedClient(
         [
             _response(
                 '{"message":"Done.","terminal":true}',
                 snapshot=_snapshot("world-model-a"),
-                cost=0.8,
+                cost=0.10,
             )
         ]
     )
@@ -857,14 +872,14 @@ def test_persisted_fit_rag_grounds_active_simulation_and_replay_has_zero_dispatc
     fit_rag_input = artifact_input(persisted.manifest)
     retriever = load_fit_rag_retriever(store, fit_rag_input, embedder=embedding)
     candidate_client = _ScriptedClient(
-        [_response("I can help.", snapshot=_snapshot("candidate-a"), cost=0.2)]
+        [_response("I can help.", snapshot=_snapshot("candidate-a"), cost=0.05)]
     )
     world_client = _ScriptedClient(
         [
             _response(
                 '{"message":"Thanks.","terminal":true}',
                 snapshot=_snapshot("world-model-a"),
-                cost=0.8,
+                cost=0.10,
             )
         ]
     )
@@ -1129,6 +1144,11 @@ def test_text_simulation_records_tool_tasks_and_context_overflow_as_failed_cells
     task_set_input = _persist_task_set(store, tasks)
     candidate_client = _ScriptedClient([])
     world_client = _ScriptedClient([])
+    completion_input = _persist_completion_contract(
+        store,
+        candidate_maximum_input_tokens=1_000,
+        candidate_maximum_output_tokens=1_000,
+    )
     simulator = _simulator(
         store,
         plan,
@@ -1137,8 +1157,15 @@ def test_text_simulation_records_tool_tasks_and_context_overflow_as_failed_cells
         candidate_client,
         world_client,
         candidate_context_window=16_000,
+        completion_contract_input=completion_input,
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a", "cell-b"), store)
+    spec = _spec(
+        plan_input,
+        task_set_input,
+        ("cell-a", "cell-b"),
+        store,
+        completion_contract_input=completion_input,
+    )
 
     artifact_set = simulator.run(spec)
     tool_rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
@@ -1195,7 +1222,7 @@ def test_text_simulation_observes_length_stop_and_stops_spend_admission(tmp_path
             _response(
                 "unfinished",
                 snapshot=_snapshot("candidate-a"),
-                cost=0.6,
+                cost=0.10,
                 finish_reason=ModelFinishReason.LENGTH,
             )
         ]
@@ -1214,7 +1241,7 @@ def test_text_simulation_observes_length_stop_and_stops_spend_admission(tmp_path
         task_set_input,
         ("cell-a", "cell-b"),
         store,
-        maximum_cost_usd=0.5,
+        maximum_cost_usd=0.08,
         stop_on_overspend=True,
     )
 
@@ -1245,7 +1272,11 @@ def test_text_simulation_does_not_treat_unpriced_provider_calls_as_zero_spend(
     tasks = {"task-a": _task("task-a"), "task-b": _task("task-b")}
     task_set_input = _persist_task_set(store, tasks)
     candidate_client = _ScriptedClient(
-        [_response("I can help.", snapshot=_snapshot("candidate-a"), cost=None)]
+        [
+            _response("I can help.", snapshot=_snapshot("candidate-a"), cost=None).model_copy(
+                update={"economics": OperationEconomics()}
+            )
+        ]
     )
     world_client = _ScriptedClient(
         [
@@ -1269,7 +1300,7 @@ def test_text_simulation_does_not_treat_unpriced_provider_calls_as_zero_spend(
         task_set_input,
         ("cell-a", "cell-b"),
         store,
-        maximum_cost_usd=1.0,
+        maximum_cost_usd=0.01,
         stop_on_overspend=True,
     )
 
@@ -1618,6 +1649,7 @@ def test_finite_budget_provider_timeout_poisons_later_paid_admission(tmp_path: P
         candidate_client,
         world_client,
     )
+    call_reservation = _completion_reservation("candidate-a").estimated_maximum_call_cost_usd
 
     artifact_set = simulator.run(
         _spec(
@@ -1640,7 +1672,7 @@ def test_finite_budget_provider_timeout_poisons_later_paid_admission(tmp_path: P
     assert first.candidate_economics.cost_usd is None
     assert second.stop_reason == StopReason.MAXIMUM_COST
     assert second.failure is not None
-    assert second.failure.details["observed_spend_usd"] is None
+    assert second.failure.details["observed_spend_usd"] == pytest.approx(call_reservation)
 
 
 def test_stale_transition_blocks_paid_admission_until_unknown_spend_rollout_persists(

--- a/wmo/simulation/engines/text/simulator_test.py
+++ b/wmo/simulation/engines/text/simulator_test.py
@@ -478,11 +478,16 @@ def _completion_reservation(alias: str) -> CompletionCostReservation:
     )
 
 
-def _persist_completion_contract(store: ArtifactStore) -> ArtifactInput:
+def _persist_completion_contract(
+    store: ArtifactStore,
+    *,
+    candidate_aliases: tuple[str, ...] = ("candidate-a", "candidate-b"),
+) -> ArtifactInput:
     """Persist the complete candidate and world reservation fixture.
 
     Args:
         store: Project-local artifact store.
+        candidate_aliases: Candidate aliases that need request reservations.
 
     Returns:
         Exact completion-contract manifest input.
@@ -490,15 +495,12 @@ def _persist_completion_contract(store: ArtifactStore) -> ArtifactInput:
     _contract, contract_input = persist_simulation_completion_contract(
         store,
         inputs=(),
-        candidate_requests=(
+        candidate_requests=tuple(
             CandidateCompletionReservation(
-                candidate_alias="candidate-a",
-                request=_completion_reservation("candidate-a"),
-            ),
-            CandidateCompletionReservation(
-                candidate_alias="candidate-b",
-                request=_completion_reservation("candidate-b"),
-            ),
+                candidate_alias=alias,
+                request=_completion_reservation(alias),
+            )
+            for alias in candidate_aliases
         ),
         world_model_alias="world-model-a",
         world_model_request=_completion_reservation("world-model-a"),
@@ -546,6 +548,7 @@ def _spec(
     plan_input: ArtifactInput,
     task_set_input: ArtifactInput,
     cells: tuple[str, ...],
+    store: ArtifactStore,
     *,
     fit_rag_input: ArtifactInput | None = None,
     completion_contract_input: ArtifactInput | None = None,
@@ -558,9 +561,10 @@ def _spec(
         plan_input: Exact persisted evaluation-plan pointer.
         task_set_input: Exact persisted task-set pointer.
         cells: Ordered evaluation-cell identities selected for execution.
+        store: Project-local artifact store used to persist the reservation contract.
         fit_rag_input: Optional explicit fit-only RAG pointer.
         query_embedding: Optional explicit query-embedding reservation.
-        completion_contract_input: Optional exact completion reservation artifact.
+        completion_contract_input: Exact completion reservation artifact, or a persisted default.
         **updates: Additional specification fields overriding fixture defaults.
 
     Returns:
@@ -568,9 +572,8 @@ def _spec(
     """
     rag_input = fit_rag_input or _fit_rag_input()
     grounded_input = _grounded_world_model_input()
-    inputs = [plan_input, task_set_input, rag_input, grounded_input]
-    if completion_contract_input is not None:
-        inputs.append(completion_contract_input)
+    contract_input = completion_contract_input or _persist_completion_contract(store)
+    inputs = [plan_input, task_set_input, rag_input, grounded_input, contract_input]
     values: dict[str, object] = {
         "schema_version": 1,
         "created_at": _TIME,
@@ -627,7 +630,7 @@ def _simulator(
         agent_factory: Factory creating one isolated agent runtime per episode.
         fit_retriever: Optional exact read-only fit retriever.
         fit_rag_input: Optional explicit fit-only RAG pointer.
-        completion_contract_input: Optional exact completion reservation artifact.
+        completion_contract_input: Exact completion reservation artifact, or a persisted default.
 
     Returns:
         Fully bound text-world-model simulator.
@@ -635,6 +638,7 @@ def _simulator(
     retriever = fit_retriever or _FitRetriever(_fit_rag_input())
     rag_input = fit_rag_input or retriever.rag_input
     typed_retriever = cast(TraceRAGRetriever, retriever)
+    contract_input = completion_contract_input or _persist_completion_contract(store)
     return WorldModelSimulator(
         store=store,
         evaluation_plan=plan,
@@ -654,7 +658,7 @@ def _simulator(
             "world-model-a": _grounded_world_model(world_client, typed_retriever)
         },
         agent_factory=agent_factory,
-        completion_contract_input=completion_contract_input,
+        completion_contract_input=contract_input,
         clock=lambda: _TIME,
         monotonic=lambda: 1.0,
     )
@@ -696,7 +700,7 @@ def test_text_simulation_persists_separate_economics_and_resumes_without_duplica
         world_client,
         fit_retriever=retriever,
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a",))
+    spec = _spec(plan_input, task_set_input, ("cell-a",), store)
 
     artifact_set = simulator.run(spec)
     rollout_id = artifact_set.artifact_ids[0]
@@ -798,7 +802,7 @@ def test_persisted_rollout_redacts_generated_secrets_and_records_audit_count(
         world_client,
         fit_retriever=_FitRetriever(_fit_rag_input()),
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a",))
+    spec = _spec(plan_input, task_set_input, ("cell-a",), store)
 
     artifact_set = simulator.run(spec)
     rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
@@ -879,6 +883,7 @@ def test_persisted_fit_rag_grounds_active_simulation_and_replay_has_zero_dispatc
         plan_input,
         task_set_input,
         ("cell-a",),
+        store,
         fit_rag_input=fit_rag_input,
         query_embedding=reservation,
     )
@@ -957,6 +962,7 @@ def test_worst_case_query_reservation_never_blocks_an_episode_with_spend_remaini
             plan_input,
             task_set_input,
             ("cell-a",),
+            store,
             world_model=settings,
             maximum_cost_usd=0.1,
         )
@@ -1030,6 +1036,7 @@ def test_expensive_episode_estimate_dispatches_until_actual_spend_reaches_the_ce
             plan_input,
             task_set_input,
             ("cell-a",),
+            store,
             world_model=settings,
             completion_contract_input=completion_input,
             maximum_cost_usd=0.1,
@@ -1096,7 +1103,7 @@ def test_query_embedding_catalog_drift_blocks_every_dispatch(
     artifacts_before = store.list_ids()
 
     with pytest.raises(SimulationConfigurationError, match=message):
-        simulator.run(_spec(plan_input, task_set_input, ("cell-a",), world_model=settings))
+        simulator.run(_spec(plan_input, task_set_input, ("cell-a",), store, world_model=settings))
 
     assert store.list_ids() == artifacts_before
     assert candidate_client.requests == []
@@ -1131,7 +1138,7 @@ def test_text_simulation_records_tool_tasks_and_context_overflow_as_failed_cells
         world_client,
         candidate_context_window=16_000,
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a", "cell-b"))
+    spec = _spec(plan_input, task_set_input, ("cell-a", "cell-b"), store)
 
     artifact_set = simulator.run(spec)
     tool_rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
@@ -1166,7 +1173,7 @@ def test_text_simulation_normalizes_agent_tool_attempts_to_unsupported_cells(
         agent_factory=_ToolAttemptAgent,
     )
 
-    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",)))
+    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",), store))
     rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
 
     assert rollout.failure is not None
@@ -1206,6 +1213,7 @@ def test_text_simulation_observes_length_stop_and_stops_spend_admission(tmp_path
         plan_input,
         task_set_input,
         ("cell-a", "cell-b"),
+        store,
         maximum_cost_usd=0.5,
         stop_on_overspend=True,
     )
@@ -1260,6 +1268,7 @@ def test_text_simulation_does_not_treat_unpriced_provider_calls_as_zero_spend(
         plan_input,
         task_set_input,
         ("cell-a", "cell-b"),
+        store,
         maximum_cost_usd=1.0,
         stop_on_overspend=True,
     )
@@ -1329,6 +1338,7 @@ def test_invalid_production_usage_charges_reservation_and_admits_later_paid_cell
         plan_input,
         task_set_input,
         ("cell-a", "cell-b"),
+        store,
         completion_contract_input=completion_input,
         maximum_cost_usd=1.0,
     )
@@ -1389,6 +1399,7 @@ def test_resume_reexecutes_retryable_transport_failure_as_new_immutable_attempt(
         plan_input,
         task_set_input,
         ("cell-a",),
+        store,
         completion_contract_input=completion_input,
         maximum_cost_usd=1.0,
     )
@@ -1444,6 +1455,7 @@ def test_persistent_transport_failure_stops_at_the_attempt_cap_and_replays(
         plan_input,
         task_set_input,
         ("cell-a",),
+        store,
         completion_contract_input=completion_input,
         maximum_cost_usd=10.0,
     )
@@ -1507,6 +1519,7 @@ def test_retrieval_dispatch_failure_persists_a_zero_incremental_reservation(
         plan_input,
         task_set_input,
         ("cell-a",),
+        store,
         completion_contract_input=completion_input,
         maximum_cost_usd=10.0,
     )
@@ -1560,6 +1573,7 @@ def test_prior_attempt_reservation_charges_the_ceiling_before_retry(tmp_path: Pa
         plan_input,
         task_set_input,
         ("cell-a",),
+        store,
         completion_contract_input=completion_input,
         maximum_cost_usd=0.4 * call_reservation,
         stop_on_overspend=True,
@@ -1610,6 +1624,7 @@ def test_finite_budget_provider_timeout_poisons_later_paid_admission(tmp_path: P
             plan_input,
             task_set_input,
             ("cell-a", "cell-b"),
+            store,
             maximum_cost_usd=0.01,
             stop_on_overspend=True,
         )
@@ -1662,6 +1677,7 @@ def test_stale_transition_blocks_paid_admission_until_unknown_spend_rollout_pers
         plan_input,
         task_set_input,
         ("cell-a", "cell-b"),
+        store,
         maximum_cost_usd=1.0,
         stop_on_overspend=True,
     )
@@ -1783,6 +1799,7 @@ def test_text_simulation_serializes_finite_cost_admission(tmp_path: Path) -> Non
         plan_input,
         task_set_input,
         tuple(cell.cell_id for cell in cells),
+        store,
         maximum_concurrency=2,
     )
 
@@ -1829,7 +1846,7 @@ def test_text_simulation_continues_after_agent_completion_until_world_terminal(
         world_client,
     )
 
-    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",)))
+    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",), store))
     rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
 
     assert rollout.stop_reason == StopReason.COMPLETED
@@ -1880,7 +1897,7 @@ def test_text_simulation_turn_exhaustion_is_a_judgeable_outcome_without_failure(
         world_client,
     )
 
-    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",)))
+    artifact_set = simulator.run(_spec(plan_input, task_set_input, ("cell-a",), store))
     rollout = simulator._load_rollout(artifact_set.artifact_ids[0])
 
     assert rollout.stop_reason == StopReason.MAXIMUM_STEPS
@@ -1907,7 +1924,7 @@ def test_text_simulation_cross_runner_claim_prevents_duplicate_paid_calls(tmp_pa
             )
         ]
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a",))
+    spec = _spec(plan_input, task_set_input, ("cell-a",), store)
     first = _simulator(store, plan, plan_input, task_set_input, candidate_client, world_client)
     second = _simulator(store, plan, plan_input, task_set_input, candidate_client, world_client)
 
@@ -1938,7 +1955,7 @@ def test_text_simulation_live_hung_claim_times_out_without_calls_or_result_artif
         candidate_client,
         world_client,
     )
-    spec = _spec(plan_input, task_set_input, ("cell-a",), maximum_cost_usd=1.0)
+    spec = _spec(plan_input, task_set_input, ("cell-a",), store, maximum_cost_usd=1.0)
     cells, world_model, grounded_world_model = simulator._validate_spec_and_bindings(spec)
     canonical_spec, spec_input = persist_canonical_specification(store, spec)
     resolution, resolution_input, bindings = simulator._persist_resolution(
@@ -2008,6 +2025,7 @@ def test_two_finite_budget_runners_complete_each_cell_exactly_once(tmp_path: Pat
         plan_input,
         task_set_input,
         ("cell-a", "cell-b"),
+        store,
         maximum_cost_usd=0.5,
     )
     runners = (

--- a/wmo/simulation/ingest/dataset.py
+++ b/wmo/simulation/ingest/dataset.py
@@ -34,8 +34,9 @@ _TRACES_PATH = "traces.jsonl"
 _ISSUES_PATH = "normalization-issues.json"
 _TRACE_DATASET_PATH = "trace-dataset.json"
 MODEL_IDENTITY_EVIDENCE_PATH = "model-identity-evidence.json"
-_LEGACY_TRACE_DATASET_FILES = frozenset({_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH})
-_TRACE_DATASET_FILES = frozenset((*_LEGACY_TRACE_DATASET_FILES, MODEL_IDENTITY_EVIDENCE_PATH))
+_TRACE_DATASET_FILES = frozenset(
+    {_ISSUES_PATH, _TRACE_DATASET_PATH, _TRACES_PATH, MODEL_IDENTITY_EVIDENCE_PATH}
+)
 
 
 @dataclass(frozen=True)
@@ -112,26 +113,15 @@ def persist_trace_dataset(
     source, semantic_convention_version = _shared_source(traces)
     traces_payload = canonical_jsonl_bytes(traces)
     issues_payload = _issues_bytes(result.issues)
-    identity_evidence = (
-        complete_model_identity_evidence(traces, result.identity_evidence)
-        if result.include_identity_evidence
-        else None
-    )
-    if identity_evidence is not None:
-        require_model_identity_evidence_matches_traces(traces, identity_evidence)
-    identity_payload = (
-        None if identity_evidence is None else canonical_json_bytes(identity_evidence)
-    )
-    if not result.include_identity_evidence and result.identity_evidence is not None:
-        raise ValueError("identity evidence cannot be supplied when persistence is disabled")
+    identity_evidence = complete_model_identity_evidence(traces, result.identity_evidence)
+    require_model_identity_evidence_matches_traces(traces, identity_evidence)
+    identity_payload = canonical_json_bytes(identity_evidence)
     resolved_dataset_id = dataset_id or current_trace_dataset_id(
         source=source,
         semantic_convention_version=semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
-        identity_evidence_sha256=(
-            None if identity_payload is None else hashlib.sha256(identity_payload).hexdigest()
-        ),
+        identity_evidence_sha256=hashlib.sha256(identity_payload).hexdigest(),
         code_revision=code_revision,
     )
     dataset = TraceDataset(
@@ -152,9 +142,8 @@ def persist_trace_dataset(
         _TRACES_PATH: traces_payload,
         _ISSUES_PATH: issues_payload,
         _TRACE_DATASET_PATH: canonical_json_bytes(dataset),
+        MODEL_IDENTITY_EVIDENCE_PATH: identity_payload,
     }
-    if identity_payload is not None:
-        files[MODEL_IDENTITY_EVIDENCE_PATH] = identity_payload
     existing, manifest = store.write_or_replay(
         artifact_id=dataset.dataset_id,
         artifact_type=_TRACE_DATASET_ARTIFACT_TYPE,
@@ -172,7 +161,7 @@ def current_trace_dataset_id(
     semantic_convention_version: str,
     traces_sha256: str,
     issues_sha256: str,
-    identity_evidence_sha256: str | None = None,
+    identity_evidence_sha256: str,
     code_revision: str,
 ) -> str:
     """Return the current automatic trace-dataset content identity.
@@ -182,23 +171,23 @@ def current_trace_dataset_id(
         semantic_convention_version: Convention used to interpret source model spans.
         traces_sha256: Digest of canonical normalized trace JSONL.
         issues_sha256: Digest of the complete normalization issue report.
-        identity_evidence_sha256: Optional digest of complete model-span provenance. Omission
-            selects the compatible identity form without a provenance component.
+        identity_evidence_sha256: Digest of complete model-span provenance.
         code_revision: Exact producer revision.
 
     Returns:
         Stable current trace-dataset artifact identity.
     """
-    semantic = {
-        "source": source.model_dump(mode="json"),
-        "semantic_convention_version": semantic_convention_version,
-        "traces_sha256": traces_sha256,
-        "issues_sha256": issues_sha256,
-        "code_revision": code_revision,
-    }
-    if identity_evidence_sha256 is not None:
-        semantic["identity_evidence_sha256"] = identity_evidence_sha256
-    return stable_id("trace-dataset", semantic)
+    return stable_id(
+        "trace-dataset",
+        {
+            "source": source.model_dump(mode="json"),
+            "semantic_convention_version": semantic_convention_version,
+            "traces_sha256": traces_sha256,
+            "issues_sha256": issues_sha256,
+            "code_revision": code_revision,
+            "identity_evidence_sha256": identity_evidence_sha256,
+        },
+    )
 
 
 def verify_current_trace_dataset(
@@ -207,7 +196,6 @@ def verify_current_trace_dataset(
 ) -> None:
     """Verify the exact current automatic dataset shape and content identity.
 
-    Generic trace-dataset loading remains compatible with older and explicitly named artifacts.
     Completed build lineage evidence uses this stricter boundary because its parent dataset must be
     reproducible from current canonical source evidence.
 
@@ -226,7 +214,7 @@ def verify_current_trace_dataset(
             f"trace dataset {dataset.dataset_id} must not have artifact inputs"
         )
     paths = {entry.path for entry in stored.manifest.files}
-    if paths not in {_LEGACY_TRACE_DATASET_FILES, _TRACE_DATASET_FILES}:
+    if paths != _TRACE_DATASET_FILES:
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} does not have the exact current-build file set"
         )
@@ -267,7 +255,7 @@ def verify_current_trace_dataset(
         raise ArtifactCorruptionError(
             f"trace dataset {dataset.dataset_id} exclusion count differs from its issue evidence"
         )
-    identity_evidence = read_trace_model_identity_evidence(store, loaded)
+    read_trace_model_identity_evidence(store, loaded)
     for trace in loaded.traces:
         if (
             trace.source.identity != dataset.source
@@ -281,13 +269,9 @@ def verify_current_trace_dataset(
         semantic_convention_version=dataset.semantic_convention_version,
         traces_sha256=hashlib.sha256(traces_payload).hexdigest(),
         issues_sha256=hashlib.sha256(issues_payload).hexdigest(),
-        identity_evidence_sha256=(
-            None
-            if identity_evidence is None
-            else hashlib.sha256(
-                store.read_bytes(dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
-            ).hexdigest()
-        ),
+        identity_evidence_sha256=hashlib.sha256(
+            store.read_bytes(dataset.dataset_id, MODEL_IDENTITY_EVIDENCE_PATH)
+        ).hexdigest(),
         code_revision=dataset.code_revision,
     )
     if dataset.dataset_id != expected_id:
@@ -300,24 +284,26 @@ def verify_current_trace_dataset(
 def read_trace_model_identity_evidence(
     store: ArtifactStore,
     loaded: LoadedTraceDataset,
-) -> TraceModelIdentityEvidenceSet | None:
-    """Read and verify optional model-span provenance from a loaded trace dataset.
+) -> TraceModelIdentityEvidenceSet:
+    """Read and verify model-span provenance from a loaded trace dataset.
 
     Args:
         store: Project-local immutable artifact store.
         loaded: Digest-verified trace dataset and records.
 
     Returns:
-        Complete current provenance, or ``None`` for a compatible dataset without the payload.
+        Complete current provenance for every model span in the dataset.
 
     Raises:
-        ArtifactCorruptionError: The payload is malformed, noncanonical, incomplete, extra, or
-            differs from its exact trace span snapshots.
+        ArtifactCorruptionError: The payload is absent, malformed, noncanonical, incomplete,
+            extra, or differs from its exact trace span snapshots.
     """
     stored = store.read(loaded.dataset.dataset_id)
     paths = {entry.path for entry in stored.manifest.files}
     if MODEL_IDENTITY_EVIDENCE_PATH not in paths:
-        return None
+        raise ArtifactCorruptionError(
+            f"trace dataset {loaded.dataset.dataset_id} is missing model identity evidence"
+        )
     payload_bytes = store.read_bytes(
         loaded.dataset.dataset_id,
         MODEL_IDENTITY_EVIDENCE_PATH,

--- a/wmo/simulation/ingest/dataset_test.py
+++ b/wmo/simulation/ingest/dataset_test.py
@@ -176,26 +176,32 @@ def test_direct_model_spans_persist_explicit_unspecified_provenance(tmp_path: Pa
     assert evidence.records[0].connection == "unspecified"
 
 
-def test_strict_loader_preserves_legacy_dataset_without_identity_payload(tmp_path: Path) -> None:
-    """A verified legacy current dataset remains readable with no inferred provenance."""
-    trace = _modeled_trace()
+def test_current_dataset_identity_includes_revision_and_identity_evidence(
+    tmp_path: Path,
+) -> None:
+    """Current content-addressed IDs include producer revision and identity evidence."""
     store = _store(tmp_path, "project-a")
     persisted = persist_trace_dataset(
-        TraceNormalizationResult(
-            traces=(trace,),
-            issues=(),
-            include_identity_evidence=False,
-        ),
+        TraceNormalizationResult(traces=(_modeled_trace(),), issues=()),
         store,
         created_at=datetime(2026, 8, 11, tzinfo=UTC),
         code_revision="test-revision",
     )
+    assert persisted.dataset.source is not None
+    historical_id = stable_id(
+        "trace-dataset",
+        {
+            "source": persisted.dataset.source.model_dump(mode="json"),
+            "semantic_convention_version": persisted.dataset.semantic_convention_version,
+            "traces_sha256": persisted.dataset.traces_sha256,
+            "issues_sha256": persisted.dataset.issues_sha256,
+        },
+    )
     loaded = load_trace_dataset(store, persisted.dataset.dataset_id)
 
+    assert persisted.dataset.dataset_id != historical_id
     verify_current_trace_dataset(store, loaded)
-
-    assert read_trace_model_identity_evidence(store, loaded) is None
-    assert MODEL_IDENTITY_EVIDENCE_PATH not in {item.path for item in persisted.manifest.files}
+    assert read_trace_model_identity_evidence(store, loaded).records
 
 
 def test_persist_rejects_incomplete_or_extra_supplied_model_identity(tmp_path: Path) -> None:
@@ -418,40 +424,6 @@ def test_persist_trace_dataset_rejects_changed_evidence_under_explicit_id(
             code_revision="test-revision",
             dataset_id="trace-dataset-explicit",
         )
-
-
-def test_load_trace_dataset_accepts_pre_revision_identity(tmp_path: Path) -> None:
-    """The loader keeps accepting artifacts whose historical ID omitted producer revision."""
-    result = TraceNormalizationResult(traces=(_trace(1),), issues=())
-    probe = persist_trace_dataset(
-        result,
-        _store(tmp_path / "probe", "project-a"),
-        created_at=datetime(2026, 8, 11, tzinfo=UTC),
-        code_revision="test-revision",
-    )
-    assert probe.dataset.source is not None
-    legacy_id = stable_id(
-        "trace-dataset",
-        {
-            "source": probe.dataset.source.model_dump(mode="json"),
-            "semantic_convention_version": probe.dataset.semantic_convention_version,
-            "traces_sha256": probe.dataset.traces_sha256,
-            "issues_sha256": probe.dataset.issues_sha256,
-        },
-    )
-    legacy_store = _store(tmp_path / "legacy", "project-a")
-    legacy = persist_trace_dataset(
-        result,
-        legacy_store,
-        created_at=datetime(2026, 8, 11, tzinfo=UTC),
-        code_revision="test-revision",
-        dataset_id=legacy_id,
-    )
-
-    loaded = load_trace_dataset(legacy_store, legacy_id)
-
-    assert loaded.dataset == legacy.dataset
-    assert loaded.traces == legacy.traces
 
 
 def test_persist_trace_dataset_rejects_mixed_raw_source_provenance(tmp_path: Path) -> None:

--- a/wmo/simulation/ingest/otel_genai.py
+++ b/wmo/simulation/ingest/otel_genai.py
@@ -138,7 +138,6 @@ def normalize_otel_genai_payloads(
         traces=result.traces,
         issues=(*issues, *result.issues),
         identity_evidence=result.identity_evidence,
-        include_identity_evidence=result.include_identity_evidence,
     )
 
 

--- a/wmo/simulation/ingest/otlp.py
+++ b/wmo/simulation/ingest/otlp.py
@@ -77,14 +77,11 @@ class TraceNormalizationResult:
         issues: Corrupt or incomplete source records that were excluded without repair.
         identity_evidence: Exact model-span provenance from a telemetry-aware normalizer. ``None``
             marks direct or programmatic records whose digest origin is unspecified.
-        include_identity_evidence: Whether persistence materializes the provenance payload. Only
-            exact reconstruction of a verified legacy dataset should disable it.
     """
 
     traces: tuple[Trace, ...]
     issues: tuple[TraceNormalizationIssue, ...]
     identity_evidence: tuple[TraceModelIdentityEvidence, ...] | None = None
-    include_identity_evidence: bool = True
 
     @property
     def invalid_trace_count(self) -> int:

--- a/wmo/simulation/retrieval/build_inputs_test.py
+++ b/wmo/simulation/retrieval/build_inputs_test.py
@@ -720,25 +720,25 @@ def test_binding_loader_rejects_rehashed_extra_task_set_file(tmp_path: Path) -> 
         load_completed_build_rag_lineage_bindings(store, completed)
 
 
-def test_legacy_task_set_loads_but_complete_binding_loader_is_actionable(tmp_path: Path) -> None:
-    """Preserve legacy TaskSet loading while requiring rebuild for refresh bindings.
+def test_task_set_without_lineage_bindings_cannot_refresh(tmp_path: Path) -> None:
+    """A task set without complete lineage bindings cannot refresh runtime retrieval.
 
     Args:
         tmp_path: Pytest-owned project root.
     """
     store = ArtifactStore(ProjectPaths(root=tmp_path, project_id="support"))
     build = _build(store)
-    legacy = persist_task_set(
+    task_set = persist_task_set(
         build.mining,
         store,
-        task_set_id="legacy-task-set",
+        task_set_id="incomplete-task-set",
         created_at=_TIME,
-        code_revision="legacy-revision",
+        code_revision="test-revision",
     )
 
-    assert legacy.task_set_id == "legacy-task-set"
+    assert task_set.task_set_id == "incomplete-task-set"
     with pytest.raises(ArtifactCorruptionError, match="rebuild the project"):
-        load_task_set_lineage_bindings(store, legacy.task_set_id)
+        load_task_set_lineage_bindings(store, task_set.task_set_id)
 
 
 @pytest.mark.parametrize("replacement_trace_ids", [(), ("trace-terminal", "extra-trace")])

--- a/wmo/simulation/world_model/application.py
+++ b/wmo/simulation/world_model/application.py
@@ -204,7 +204,7 @@ class WorldModel:
     ) -> WorldModelObservation:
         """Predict and append one user turn from an official OpenAI assistant message.
 
-        The persisted artifact is text-only. Any tool call, legacy function call, audio payload,
+        The persisted artifact is text-only. Any tool call, function call, audio payload,
         non-text content, or non-assistant role is rejected before retrieval or provider dispatch.
 
         Args:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
WMO does not support legacy artifact shapes or migration shims. This change requires the current contracts and rejects older payloads instead of reconstructing them.

## What changed

- SFT datasets must persist a `build_spec`. The `legacy_build_spec` training path is gone.
- Trace datasets always persist model-identity evidence and include it in the content-addressed ID.
- Router embeddings load only reserved schema version 2.
- Dispatch resume trusts the persisted `retryable` flag only.
- Unknown-spend charges use the reservation stored on the failure, not a reconstructed fallback.
- Text simulation always binds a completion reservation contract.
- Rubric axes and score maps require explicit `min_score` and `max_score`.
- Manual judge audits require schema version 2 with one review per judgment.

Current product fallbacks stay in place: runtime embedding and capability fallback, OpenAI-compatible providers, and Rich `legacy_windows` in CLI tests.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q --tb=line -k "not live"` excluding `picker_test.py`, `picker_view_test.py`, and `release_test.py`: 1446 passed, 11 skipped

Those excluded modules failed on this host before and after the change (terminal redraw codes and `\x1b[2K` / cursor-restore assertions). This branch does not edit them.

[pytest_full_except_terminal_flakes.log](https://cursor.com/agents/bc-44d7e779-312c-4761-9316-006afd44620b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpytest_full_except_terminal_flakes.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44d7e779-312c-4761-9316-006afd44620b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44d7e779-312c-4761-9316-006afd44620b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

