### PR TITLE
Restore GenAI prompt text on calibration transcripts

### DIFF
--- a/wmo/cli/judge_transcript.py
+++ b/wmo/cli/judge_transcript.py
@@ -160,12 +160,16 @@ def user_input(attributes: dict[str, JsonValue]) -> str | None:
         attributes: Canonical normalized span attributes.
 
     Returns:
-        Latest user content when captured, otherwise ``None``.
+        Latest user content from captured messages, or the current GenAI prompt attribute.
     """
-    return _last_role_message(
+    text = _last_role_message(
         _decoded_json_value(attributes.get("gen_ai.input.messages")),
         frozenset({"user", "human"}),
     )
+    if text is not None:
+        return text
+    prompt = attributes.get("gen_ai.prompt")
+    return prompt.strip() if isinstance(prompt, str) and prompt.strip() else None
 
 
 def _last_role_message(value: JsonValue, roles: frozenset[str]) -> str | None:

--- a/wmo/cli/judge_transcript_test.py
+++ b/wmo/cli/judge_transcript_test.py
@@ -1,1 +1,43 @@
 """Tests for readable calibration transcript rendering."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from wmo.cli.judge_transcript import span_evidence_text, user_input
+from wmo.common.traces import TraceSpan
+
+_TIME = datetime(2026, 8, 19, tzinfo=UTC)
+
+
+def test_user_input_reads_current_prompt_attribute_when_messages_are_absent() -> None:
+    """Normalized GenAI spans still record the request on gen_ai.prompt."""
+    assert user_input({"gen_ai.prompt": "delete the file"}) == "delete the file"
+
+
+def test_user_input_prefers_captured_messages_over_prompt() -> None:
+    """Structured input messages are the primary request text when both exist."""
+    assert (
+        user_input(
+            {
+                "gen_ai.prompt": "older prompt text",
+                "gen_ai.input.messages": [
+                    {"role": "user", "content": "latest user message"},
+                ],
+            }
+        )
+        == "latest user message"
+    )
+
+
+def test_span_evidence_includes_prompt_only_user_text() -> None:
+    """Cited span evidence keeps the recorded request when messages were never captured."""
+    span = TraceSpan(
+        span_id="span-1",
+        name="chat",
+        started_at=_TIME,
+        ended_at=_TIME,
+        attributes={"gen_ai.prompt": "Run two commands"},
+    )
+
+    assert span_evidence_text(span) == "User message: Run two commands"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review of the merged legacy-shim removal found one real regression.

`wmo build` and environment-capture still record the user request on `gen_ai.prompt` when `gen_ai.input.messages` is absent. That is current GenAI source grammar, not an old WMO artifact loader. After #510, judge transcripts, cited span evidence, and the trace viewer dropped that text.

This restores prompt-attribute extraction when messages are missing, and prefers captured messages when both exist.

The rest of the merged removal was reviewed against current writers: SFT `build_spec`, required identity evidence, reserved embeddings, required rubric ranges, persisted unknown-spend reservations, and `retryable` on current dispatch failures. Those paths already persist the current contract.

## Testing

- `uv run pytest -q wmo/cli/judge_transcript_test.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e4fbcaa-e6c2-4758-974a-f2fbf2b96bf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e4fbcaa-e6c2-4758-974a-f2fbf2b96bf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

