### PR TITLE
Certify the installed gateway stack

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Smoke test the wheel
         run: |
           uv venv /tmp/wmo-wheel-smoke
-          uv pip install --python /tmp/wmo-wheel-smoke/bin/python dist/*.whl
+          uv pip install --python /tmp/wmo-wheel-smoke/bin/python dist/*.whl "openai==3.0.0"
           cd /tmp
           /tmp/wmo-wheel-smoke/bin/python - <<'PY'
           import wmo

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,6 +86,18 @@ jobs:
           assert LocalProcessEnvironmentRuntime.__module__ == "wmo.runtime.environments.local"
           PY
           /tmp/wmo-wheel-smoke/bin/wmo --help
+      - name: Installed-wheel no-spend release evidence
+        env:
+          PYTHONNOUSERSITE: "1"
+          TERM: xterm-256color
+          WMO_INSTALLED_RELEASE_EVIDENCE: "1"
+          WMO_RELEASE_REVISION: ${{ steps.source_revision.outputs.sha }}
+          WMO_SOURCE_CHECKOUT: ${{ github.workspace }}
+          WMO_TELEMETRY: "0"
+        run: |
+          cp wmo/release_test.py /tmp/wmo-wheel-smoke/installed_release_evidence.py
+          cd /tmp/wmo-wheel-smoke
+          ./bin/python installed_release_evidence.py
       - uses: actions/upload-artifact@v4
         with:
           name: python-dist

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ results, and plans do not live here.
 |---|---|
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, and the Bedrock credential chain. |
-| `reference/gateway-architecture.md` | Inert gateway foundation contracts, catalog normalization, ownership boundaries, and compatibility locks. |
+| `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -112,9 +112,10 @@ subprocess-bound loopback gateway, a real loopback upstream, and the official SD
 scanner checks database, WAL, backups when present, catalog snapshots, stdout, stderr, logs, usage
 responses, and error bodies for raw content and secret canaries.
 
-`wmo/runtime/gateway/provider_certification.py` is the dated provider capability matrix. It labels
-fixture-backed results separately from credential-gated live results. Azure and OpenRouter inherit
-the compatible streaming fixtures; Gemini and Bedrock have native deterministic fixtures. Live
-provider cells remain explicitly `not_run_requires_credentials` until a separately authorized run
-supplies dated evidence. Deterministic fixtures do not imply hosted-provider availability, billing,
-or account-specific behavior.
+`wmo/runtime/gateway/provider_certification.py` is the dated provider capability matrix. Each cell
+names the official client SDK, public gateway surfaces, provider wire surface, fixture result, and
+credential-gated live status. OpenAI and Anthropic have native fixtures; generic OpenAI-compatible,
+Azure, and OpenRouter share compatible-stream coverage; Gemini and Bedrock have native deterministic
+fixtures. Live provider cells remain explicitly `not_run_requires_credentials` until a separately
+authorized run supplies dated evidence. Deterministic fixtures do not imply hosted-provider
+availability, billing, or account-specific behavior.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -71,10 +71,15 @@ result can advance to the next certified deployment, while mixed semantic output
 commits and flushes the original route. Provider-internal retry layers are disabled so every
 possible billable dispatch is visible to the gateway ledger.
 
-Each physical attempt records its own provider, model, usage, latency, terminal state, and estimated
-cost attribution. The parent request terminalizes once after success, final failure, cancellation,
-disconnect, or crash reconciliation. Unknown prices remain unknown instead of being treated as
-zero or copied across deployments.
+Each physical attempt records its own provider, model, usage, latency, terminal state, estimated
+cost attribution, and frozen credential-ownership billing source. Later catalog activation and
+process restart never rewrite that source. Schema-v1/v2 attempt rows migrate explicitly as
+`customer_managed`; current dispatches persist either `host_managed` or `customer_managed` before
+network work. The public usage report conserves physical attempt, token, cost, unknown-cost, and
+terminal totals across those source buckets without partitioning logical request counts. The parent
+request terminalizes once after success, final failure, cancellation, disconnect, or crash
+reconciliation. Unknown prices remain unknown instead of being treated as zero or copied across
+deployments.
 
 ## OpenAI-compatible protocol
 
@@ -98,9 +103,10 @@ or eviction returns an explicit unavailable error and never reconstructs content
 
 SQLite stores hashes, frozen authority, route identity, state transitions, token counts, latency,
 and estimated cost. It never stores prompts, responses, raw tool arguments, raw virtual keys, or
-provider secrets. `GET /usage` and `GET /usage.json` are two renderings of the same versioned report
-and expose only aggregate and per-identity accounting. Estimated cost is attribution, not a provider
-invoice.
+provider secrets. `GET /usage` and `GET /usage.json` are two renderings of the same schema-v2 report
+and expose only aggregate, per-identity, and physical-attempt `by_billing_source` accounting.
+Source buckets conserve attempt, token, known-cost, unknown-cost, and terminal-state totals but do
+not partition logical request counts. Estimated cost is attribution, not a provider invoice.
 
 The process owns readiness from preflight through bounded drain. New work is rejected after drain
 starts. Admitted tasks, upstream streams, disconnect cleanup, replay ownership, continuation state,

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -66,8 +66,10 @@ Provider execution is always internally streaming. Bounded same-deployment retri
 deployment fallback are allowed only for typed precommit failures. The first outward text, refusal,
 or tool-call semantic event commits the deployment, after which the gateway never switches
 providers. Typed refusal fallback is disabled unless the active alias revision explicitly enables
-it. Provider-internal retry layers are disabled so every possible billable dispatch is visible to
-the gateway ledger.
+it. Opted-in refusal deltas are withheld only in a bounded in-memory buffer: a refusal-only terminal
+result can advance to the next certified deployment, while mixed semantic output or buffer overflow
+commits and flushes the original route. Provider-internal retry layers are disabled so every
+possible billable dispatch is visible to the gateway ledger.
 
 Each physical attempt records its own provider, model, usage, latency, terminal state, and estimated
 cost attribution. The parent request terminalizes once after success, final failure, cancellation,

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -11,9 +11,9 @@ It serves:
 - `GET /health/live` and `GET /health/ready`
 - `GET /usage` and `GET /usage.json`
 
-The separate `wmo run PROJECT` form remains the frozen single-project compatibility server.
-Gateway startup and readiness perform no provider request. Only an authorized model request may
-cross the provider boundary.
+`wmo run PROJECT` is compatibility sugar that activates one project-backed alias and launches this
+same gateway application. It does not create a router HTTP server. Gateway startup and readiness
+perform no provider request. Only an authorized model request may cross the provider boundary.
 
 ## Authority and management
 
@@ -23,7 +23,9 @@ no runtime seeds. A usable installation requires an organization, active identit
 key, explicit identity-to-alias grant, active alias revision, immutable catalog snapshot, and a
 resolvable provider credential reference.
 
-Private authority state lives in `ROOT/gateway/gateway.db`. SQLite uses WAL mode, versioned forward
+Private serving authority lives in `ROOT/gateway/gateway.db`, including identities, keys, grants,
+provider connections and revisions, aliases and revisions, attempts, and usage. SQLite uses WAL
+mode, versioned forward
 migrations, private backups before migration, newer-schema refusal, and serialized initialization.
 Virtual keys are stored only as peppered fingerprints. Key material is delivered once in a JSON
 receipt or to a new mode-`0600` file, and commit ambiguity preserves recoverability. Provider
@@ -38,8 +40,10 @@ changes fail closed.
 
 ## Catalog, aliases, and exact-model pools
 
-`wmo/common/models/catalog.py` is the authored provider and deployment catalog. Gateway snapshots
-under `ROOT/gateway/catalog-snapshots/` are immutable, secret-free views of an exact catalog digest.
+The gateway database owns current provider connection state. Existing model metadata remains the
+authoring input for builds, policies, evaluations, and datasets; it is not consulted as mutable
+serving authority after an alias revision binds exact connection revisions. Gateway snapshots under
+`ROOT/gateway/catalog-snapshots/` are immutable, secret-free artifacts for an exact catalog digest.
 An advertised alias is executable only when readiness holds for the exact tuple of alias name,
 alias revision, and catalog digest used by authorization.
 
@@ -83,8 +87,11 @@ deployments.
 
 ## OpenAI-compatible protocol
 
-Chat Completions and Responses have separate allowlist decoders and field-specific OpenAI error
-responses. Both convert to one canonical gateway request without conflating their wire contracts.
+`wmo/runtime/openai_protocol` is the only OpenAI wire implementation. Chat Completions and
+Responses have separate allowlist decoders and field-specific OpenAI error responses, but both
+convert to one canonical gateway request without conflating their wire contracts. The package also
+owns headers, response assembly, SSE framing, tool-call reconstruction, and official SDK
+compatibility.
 Chat streaming emits valid completion chunks and one `[DONE]`. Responses streaming emits the
 created, in-progress, output, and exactly one terminal lifecycle. Provider tool-argument fragments
 are accumulated in original order and validated only at the complete-call boundary.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -1,98 +1,120 @@
-# Gateway foundation architecture contract
+# Local gateway architecture
 
-## Current scope
+## Supported surface
 
-This reference describes the inert contracts available on main after the gateway foundation
-change. It does not claim that a gateway server, identity store, provider stream, public alias,
-or no-argument `wmo run` mode exists yet.
+No-argument `wmo run` starts an authenticated multi-alias gateway on `127.0.0.1`.
+It serves:
 
-The foundation establishes one vocabulary for later independently reviewed implementations:
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+- `GET /health/live` and `GET /health/ready`
+- `GET /usage` and `GET /usage.json`
 
-- a public gateway alias targets either one exact-model pool or one immutable project activation
-- a project resolver selects one exact logical model, and later operational execution may choose
-  only among deployments certified for that model
-- authentication, grants, persistence, provider execution, and wire encoding depend on injected
-  interfaces instead of importing optimizer owners into runtime
-- tool calls keep their existing parsed argument object and may also retain exact provider JSON
-- provider stream events carry raw tool-argument fragments without requiring each fragment to be
-  valid JSON
+The separate `wmo run PROJECT` form remains the frozen single-project compatibility server.
+Gateway startup and readiness perform no provider request. Only an authorized model request may
+cross the provider boundary.
 
-No root CLI set, endpoint set, release claim, or provider behavior changes in this foundation.
+## Authority and management
 
-## Ownership
+`wmo config gateway` owns explicit local setup. Its provider, identity, key, grant, alias, and pool
+commands produce versioned receipts suitable for interactive or non-interactive callers. There are
+no runtime seeds. A usable installation requires an organization, active identity, active virtual
+key, explicit identity-to-alias grant, active alias revision, immutable catalog snapshot, and a
+resolvable provider credential reference.
 
-`wmo/common/models/catalog.py` remains the sole authored provider and model catalog. A model record
-may carry optional gateway-only protocol capabilities, exact-model certification, and integer
-attribution prices. These fields are deployment metadata. They do not enter
-`ModelCapabilities`, whose existing identity digest remains frozen for compatibility with built
-router artifacts.
+Private authority state lives in `ROOT/gateway/gateway.db`. SQLite uses WAL mode, versioned forward
+migrations, private backups before migration, newer-schema refusal, and serialized initialization.
+Virtual keys are stored only as peppered fingerprints. Key material is delivered once in a JSON
+receipt or to a new mode-`0600` file, and commit ambiguity preserves recoverability. Provider
+configuration stores an environment variable name, never its value. The local pepper is mode
+`0600` and is not exported.
 
-`wmo/common/models/gateway_catalog.py` derives an immutable secret-free deployment view. Existing
-model aliases become separate singleton pools. Runtime gateway contracts and injected interfaces
-live under `wmo/runtime/gateway/`. Runtime continues to be forbidden from importing simulation,
-optimization, or CLI modules by `wmo/repo_import_boundaries_test.py`.
+Every data-plane request is authenticated and authorized before request decoding, routing,
+continuation lookup, or provider work. Authorization freezes organization, identity, API surface,
+alias revision, target, catalog digest, request digest, optional hashed operation identity, and one
+monotonic deadline. Identity disable, key revocation or expiry, grant removal, and alias revision
+changes fail closed.
 
-## Conservative singleton migration
+## Catalog, aliases, and exact-model pools
 
-The derived identity for an existing model includes:
+`wmo/common/models/catalog.py` is the authored provider and deployment catalog. Gateway snapshots
+under `ROOT/gateway/catalog-snapshots/` are immutable, secret-free views of an exact catalog digest.
+An advertised alias is executable only when readiness holds for the exact tuple of alias name,
+alias revision, and catalog digest used by authorization.
 
-1. the normalized secret-free connection identity digest
-2. the exact provider model spelling and optional revision
-3. a digest of the complete authored capability declaration
+An alias targets either:
 
-Capability variants and connections to different compatible endpoints therefore do not collapse
-into one exact model. Separate aliases remain separate singleton pools even when all three inputs
-are identical. Grouping them later requires a deliberate equivalence contract.
+1. a direct exact-model pool, or
+2. one immutable project activation.
 
-Provider `tinker` records and any model carrying SFT provenance are excluded. Sampling handles are
-run-bound training provenance, not general gateway deployments.
+A singleton alias creates a one-deployment pool. `wmo config gateway pool certify` can replace that
+with an ordered pool only when every member has the same exact logical model identity and an
+operator-supplied equivalence certification. The certification records an ID, provenance, evidence
+digest, time, and exact deployment order. Project policy selection still chooses one exact logical
+model; operational fallback can only move among certified deployments for that model.
 
-## Catalog authoring boundary
+## Request, route, and provider attempts
 
-A valid catalog may contain provider connections and zero model records. The role-free connection
-authoring service can create this state for a runtime consumer without inventing optimizer roles.
-The existing `ProviderSetup` service is unchanged and continues to require world-model, judge, and
-embedding roles plus an embedding-capable embedder for build and optimize workflows.
+The content-free ledger accepts the logical request before learned project selection. Selection or
+direct resolution then produces an execution snapshot containing the exact model, pool, and ordered
+deployment IDs. Each physical provider dispatch gets its own durable attempt row immediately before
+network work. Attempt ordinal counts all physical dispatches; route depth identifies the selected
+deployment position.
 
-The catalog stores environment variable names, never credential values. Gateway prices use integer
-micro-USD rates and keep unknown values as `None`. The existing optimizer float pricing and pricing
-snapshot contracts remain unchanged.
+Provider execution is always internally streaming. Bounded same-deployment retries and ordered
+deployment fallback are allowed only for typed precommit failures. The first outward text, refusal,
+or tool-call semantic event commits the deployment, after which the gateway never switches
+providers. Typed refusal fallback is disabled unless the active alias revision explicitly enables
+it. Provider-internal retry layers are disabled so every possible billable dispatch is visible to
+the gateway ledger.
 
-## Raw tool arguments
+Each physical attempt records its own provider, model, usage, latency, terminal state, and estimated
+cost attribution. The parent request terminalizes once after success, final failure, cancellation,
+disconnect, or crash reconciliation. Unknown prices remain unknown instead of being treated as
+zero or copied across deployments.
 
-`ToolCall.arguments` remains the parsed JSON object consumed by environments, judging, simulation,
-and training. `ToolCall.raw_arguments` is optional. When present, it must decode to the same object
-and is used for exact provider-order wire replay. When absent, it is omitted from serialization,
-which keeps legacy payload bytes stable.
+## OpenAI-compatible protocol
 
-Partial provider output uses `GatewayEvent.raw_arguments_delta`. A delta can split at any byte or
-token boundary and is not parsed in isolation. The complete call is validated only at its terminal
-contract boundary.
+Chat Completions and Responses have separate allowlist decoders and field-specific OpenAI error
+responses. Both convert to one canonical gateway request without conflating their wire contracts.
+Chat streaming emits valid completion chunks and one `[DONE]`. Responses streaming emits the
+created, in-progress, output, and exactly one terminal lifecycle. Provider tool-argument fragments
+are accumulated in original order and validated only at the complete-call boundary.
 
-## Request and attempt boundaries
+Commit-independent headers are available before streaming begins. Route-dependent headers are
+emitted only after an execution snapshot exists. Stable public IDs do not expose raw key,
+idempotency, request, or provider values.
 
-Authorization freezes key-derived organization and identity, alias revision, target, API surface,
-request hash, optional hashed caller-operation identity, catalog snapshot, and one monotonic deadline
-before learned selection. Raw idempotency and client request values are not persisted in the
-snapshot. A project target does not yet know its exact model, pool, or deployments at that point.
-Selection and direct-target resolution produce a separate route-bound execution snapshot.
+OpenAI `3.0.0` `OpenAI` and `AsyncOpenAI` clients are release-certified for Chat Completions and
+Responses in synchronous and asynchronous, streaming and non-streaming forms. Responses
+continuation and duplicate replay retain content only in bounded, process-local, tenant and
+alias-revision-scoped stores. Replay is opt-in through an idempotency or client request key. Restart
+or eviction returns an explicit unavailable error and never reconstructs content from SQLite.
 
-The attempt ledger records acceptance before selection. It records a provider attempt only
-immediately before that provider dispatch. This separates requests that fail or crash before any
-upstream work from attempts that may have incurred provider usage.
+## Content-free observability and lifecycle
 
-## Locked repository contracts
+SQLite stores hashes, frozen authority, route identity, state transitions, token counts, latency,
+and estimated cost. It never stores prompts, responses, raw tool arguments, raw virtual keys, or
+provider secrets. `GET /usage` and `GET /usage.json` are two renderings of the same versioned report
+and expose only aggregate and per-identity accounting. Estimated cost is attribution, not a provider
+invoice.
 
-This foundation updates the following tracked locks:
+The process owns readiness from preflight through bounded drain. New work is rejected after drain
+starts. Admitted tasks, upstream streams, disconnect cleanup, replay ownership, continuation state,
+and final ledger settlement are process-owned and bounded. A stuck cancellation cannot prevent the
+terminal flusher from attempting content-free settlement.
 
-- `AGENTS.md` names gateway package ownership and freezes `ModelCapabilities` digest placement.
-- `docs/README.md` indexes this verified reference page.
-- `wmo/common/models/model_test.py` proves legacy tool-call serialization is unchanged.
-- `wmo/common/models/catalog_test.py` proves connections-only catalogs and deployment-local gateway
-  metadata round trip.
-- `wmo/repo_import_boundaries_test.py` already applies to the new runtime package and requires no
-  allowlist widening.
+## Certification boundary
 
-The exact root CLI commands, config subcommands, release scope, dependency list, installed-wheel
-driver, and `wmo run PROJECT` behavior are unchanged. Their executable locks therefore require no
-edit in this foundation.
+Deterministic release evidence uses a built and freshly installed wheel, real SQLite, a real
+subprocess-bound loopback gateway, a real loopback upstream, and the official SDK clients. One
+scanner checks database, WAL, backups when present, catalog snapshots, stdout, stderr, logs, usage
+responses, and error bodies for raw content and secret canaries.
+
+`wmo/runtime/gateway/provider_certification.py` is the dated provider capability matrix. It labels
+fixture-backed results separately from credential-gated live results. Azure and OpenRouter inherit
+the compatible streaming fixtures; Gemini and Bedrock have native deterministic fixtures. Live
+provider cells remain explicitly `not_run_requires_credentials` until a separately authorized run
+supplies dated evidence. Deterministic fixtures do not imply hosted-provider availability, billing,
+or account-specific behavior.

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -19,7 +19,8 @@ on the exact release checkout.
   Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same
   per-identity accounting values. The same lane measures default SDK retries against physical
   attempts, provider-authentication fallback, refusal policy, post-commit no-switch, restart and
-  replay behavior, revocation, cancellation, WAL mode, and cost attribution.
+  replay behavior, revocation, cancellation, WAL mode, and mixed `host_managed`/
+  `customer_managed` cost attribution that remains frozen across restart and catalog replacement.
 - Deterministic source-level certification additionally covers selection-only project routing,
   authentication-circuit open/skip/recovery, concurrent multi-identity key revocation and alias
   revision activation, and atomic rollback of a failed legacy SQLite migration.

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -17,7 +17,12 @@ on the exact release checkout.
 - The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
   upstream, and OpenAI `3.0.0`. It covers `OpenAI` and `AsyncOpenAI` across Chat Completions and
   Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same
-  per-identity accounting values.
+  per-identity accounting values. The same lane measures default SDK retries against physical
+  attempts, provider-authentication fallback, refusal policy, post-commit no-switch, restart and
+  replay behavior, revocation, cancellation, WAL mode, and cost attribution.
+- Deterministic source-level certification additionally covers selection-only project routing,
+  authentication-circuit open/skip/recovery, concurrent multi-identity key revocation and alias
+  revision activation, and atomic rollback of a failed legacy SQLite migration.
 - One content and secret canary scanner covers the gateway database, live WAL, migration backups
   when present, catalog snapshots, stdout, stderr, logs, usage responses, and HTTP error bodies.
 - Public Python exposes provider-free build, explicit router composition, frozen router load and

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -26,8 +26,9 @@ on the exact release checkout.
   revision activation, and atomic rollback of a failed legacy SQLite migration.
 - One content and secret canary scanner covers the gateway database, live WAL, migration backups
   when present, catalog snapshots, stdout, stderr, logs, usage responses, and HTTP error bodies.
-- Public Python exposes provider-free build, explicit router composition, frozen router load and
-  HTTP application, structural text-versus-sandbox comparison, and managed SFT composition.
+- Public Python exposes provider-free build, explicit router composition, frozen selection-only
+  router load through the normal gateway application, structural text-versus-sandbox comparison,
+  and managed SFT composition. No separate router HTTP or SSE implementation is shipped.
 - W16 router evidence uses 100 normalized traces, 50 fit tasks, 20 held-out tasks, 140 planned
   cells, 130 deterministic text simulations, and 140 deterministic judgments under one finite
   simulation and judgment budget. Observed hosted-service spend is exactly $0.00.

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -37,7 +37,9 @@ credentials. `Not run` means exactly that; it is not inferred from fixture cover
 
 | Provider surface | Deterministic evidence in this release | Credential-gated live evidence |
 |---|---|---|
-| OpenAI and generic OpenAI-compatible | Real loopback upstream through the installed gateway; text, tool arguments, usage, cancellation contracts, and all eight official SDK quadrants | Not run against a hosted endpoint |
+| OpenAI | Native Responses fixtures for text, tool arguments, usage, cancellation, and refusal; all eight official SDK quadrants run against the installed local gateway | Not run; requires an OpenAI credential |
+| Anthropic | Native Messages fixtures for text, tool arguments, usage, cancellation, and refusal through both public gateway surfaces | Not run; requires an Anthropic credential |
+| Generic OpenAI-compatible | Real loopback upstream through the installed gateway; text, tool arguments, usage, cancellation, and refusal contracts | Not run; requires a compatible hosted endpoint and credential |
 | Azure OpenAI | Compatible-adapter fixtures for text, tool arguments, usage, cancellation, and refusal | Not run; requires Azure endpoint and credential |
 | OpenRouter | Compatible-adapter fixtures for text, tool arguments, usage, cancellation, and refusal | Not run; requires OpenRouter credential |
 | Gemini | Native fixtures for text, structured complete function arguments, usage, cancellation, and refusal | Not run; requires Gemini credential |

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -9,10 +9,17 @@ on the exact release checkout.
 - Root CLI commands are exactly `build`, `config`, `optimize`, and `run`; optimizer commands are
   exactly `router` and `model`.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
-  singleton direct aliases, frozen-project aliases, Chat Completions, Responses, bounded in-memory
-  continuation and replay, content-free SQLite accounting, and loopback-only health and usage views.
+  singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
+  provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
+  content-free SQLite accounting, and loopback-only health and usage views.
 - Both no-argument gateway launch and the retained `wmo run PROJECT [--ghost]` compatibility form
   are installed-wheel surfaces. Gateway startup is provider-idle and requires explicit authority.
+- The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
+  upstream, and OpenAI `3.0.0`. It covers `OpenAI` and `AsyncOpenAI` across Chat Completions and
+  Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same
+  per-identity accounting values.
+- One content and secret canary scanner covers the gateway database, live WAL, migration backups
+  when present, catalog snapshots, stdout, stderr, logs, usage responses, and HTTP error bodies.
 - Public Python exposes provider-free build, explicit router composition, frozen router load and
   HTTP application, structural text-versus-sandbox comparison, and managed SFT composition.
 - W16 router evidence uses 100 normalized traces, 50 fit tasks, 20 held-out tasks, 140 planned
@@ -22,6 +29,24 @@ on the exact release checkout.
   one malformed sandbox failure in the denominator and claims structural terminal agreement only.
 - Exact-checkout CI supplies the full 40-hex Git revision, recursively verifies every evidence
   artifact and manifest input, and publishes machine-readable JSON plus JUnit evidence.
+
+## Gateway provider evidence matrix
+
+This table separates deterministic protocol evidence from hosted calls that need account
+credentials. `Not run` means exactly that; it is not inferred from fixture coverage.
+
+| Provider surface | Deterministic evidence in this release | Credential-gated live evidence |
+|---|---|---|
+| OpenAI and generic OpenAI-compatible | Real loopback upstream through the installed gateway; text, tool arguments, usage, cancellation contracts, and all eight official SDK quadrants | Not run against a hosted endpoint |
+| Azure OpenAI | Compatible-adapter fixtures for text, tool arguments, usage, cancellation, and refusal | Not run; requires Azure endpoint and credential |
+| OpenRouter | Compatible-adapter fixtures for text, tool arguments, usage, cancellation, and refusal | Not run; requires OpenRouter credential |
+| Gemini | Native fixtures for text, structured complete function arguments, usage, cancellation, and refusal | Not run; requires Gemini credential |
+| Amazon Bedrock | Native EventStream fixtures for text, incremental tool arguments, usage, bounded cancellation, refusal, and single dispatch | Not run; requires an authorized AWS account and region |
+
+The machine-readable dated matrix is
+`wmo/runtime/gateway/provider_certification.py`. Its live cells are
+`not_run_requires_credentials`. Gemini complete structured function arguments are explicitly not
+labeled as provider-byte incremental tool-argument streaming.
 
 ## Explicitly excluded
 
@@ -34,8 +59,9 @@ on the exact release checkout.
   artifact. It makes no trained-model quality-improvement claim.
 - No hosted model, judge, embedding, telemetry, environment, credential, or `.env` path was used by
   release evidence. The deterministic W16 evidence reports exactly $0.00 observed service spend.
-- Deterministic gateway certification uses a real loopback upstream and local SQLite. Live provider
-  behavior remains credential-gated evidence and is not implied by the provider-free release lane.
+- Deterministic gateway certification uses a real loopback upstream and local SQLite. No live
+  provider matrix cell ran, so hosted availability, account limits, billing, and service-specific
+  behavior are not claimed.
 
 These exclusions are product boundaries, not evidence that the corresponding hosted services are
 unsafe or unsupported forever. Any future claim requires separately authorized, finite-budget,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,8 +33,11 @@ provider call, and requires an explicit provider environment reference, exact mo
 grant, and virtual key. `wmo run --non-interactive --json` returns `gateway_not_initialized` plus
 exact next commands on an empty root. `wmo run --check` validates local readiness without binding.
 The gateway writes no prompts, responses, tool arguments, raw keys, or provider secrets to SQLite.
-`GET /usage` and `GET /usage.json` show only per-identity counts, token usage, latency, terminal
-states, and attributed estimated cost. Estimated cost is not provider invoice cost.
+`GET /usage` and `GET /usage.json` expose the same schema-v2 content-free overall and per-identity
+counts, token usage, latency, terminal states, and attributed estimated cost. Their attempt-only
+`by_billing_source` buckets conserve attempts, tokens, known cost, unknown-cost attempts, and
+terminal states across `host_managed` and `customer_managed`; logical request counts are not
+partitioned. Estimated cost is not provider invoice cost.
 
 One-time virtual-key material appears only in the successful key-issue receipt or a newly created
 mode-`0600` output file. Human key issuance on a non-terminal requires `--json` or `--output`.
@@ -57,6 +60,12 @@ pool member must resolve to the same exact model identity. Retryable transport, 
 and malformed precommit failures may advance through the certified order. Refusal fallback requires
 the explicit `--refusal-failover` option and is persisted on that alias revision. No failure can
 switch providers after outward text, refusal, or tool-call output commits the response.
+
+Direct deployments declare `--billing-source host_managed` or `customer_managed`. The selected
+value is frozen on each physical attempt before dispatch and remains unchanged across catalog
+replacement and restart. Usage JSON and HTML expose content-free physical-attempt buckets by source;
+they do not partition logical request counts. Legacy schema-v1/v2 attempts migrate explicitly as
+`customer_managed`.
 
 Official OpenAI SDK clients use the issued virtual key and loopback base URL:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ The root surface is deliberately small:
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run --root ROOT [--check]` | Validate or start the initialized authenticated multi-alias gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
-| `wmo config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
+| `wmo config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
 | `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
 | `wmo config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.wmo/settings.toml`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
@@ -39,6 +39,38 @@ states, and attributed estimated cost. Estimated cost is not provider invoice co
 One-time virtual-key material appears only in the successful key-issue receipt or a newly created
 mode-`0600` output file. Human key issuance on a non-terminal requires `--json` or `--output`.
 Provider configuration accepts an environment variable name, never a raw credential value.
+
+To add ordered failover, first author each deployment as a direct alias with the same
+`--exact-model`. Then certify their equivalence and order with:
+
+```console
+wmo config gateway pool certify PUBLIC_ALIAS \
+  --deployment-alias PRIMARY --deployment-alias SECONDARY \
+  --exact-model EXACT_MODEL --certification-id CERTIFICATION \
+  --provenance PROVENANCE --evidence-sha256 SHA256 \
+  --certified-at TIMESTAMP --expected-catalog-sha256 CATALOG_SHA256 \
+  --revision REVISION --root ROOT --non-interactive --json
+```
+
+`--expected-catalog-sha256` prevents stale authoring from activating a different catalog. Every
+pool member must resolve to the same exact model identity. Retryable transport, availability, rate,
+and malformed precommit failures may advance through the certified order. Refusal fallback requires
+the explicit `--refusal-failover` option and is persisted on that alias revision. No failure can
+switch providers after outward text, refusal, or tool-call output commits the response.
+
+Official OpenAI SDK clients use the issued virtual key and loopback base URL:
+
+```python
+from openai import OpenAI
+
+with OpenAI(api_key=VIRTUAL_KEY, base_url="http://127.0.0.1:8000/v1") as client:
+    response = client.responses.create(model="PUBLIC_ALIAS", input="hello")
+```
+
+Release evidence fixes the SDK at OpenAI `3.0.0` and covers `OpenAI` plus `AsyncOpenAI`, Chat
+Completions plus Responses, and stream plus non-stream calls. Provider protocol fixtures are
+deterministic. Hosted-provider runs require credentials and are reported separately in
+[`release-scope.md`](release-scope.md); fixture success is not presented as a live-provider result.
 
 Build stops at review readiness. `wmo optimize router` creates the bounded fit and held-out
 evaluation chain after candidate and manual judge setup. It never invokes world-model fidelity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ The root surface is deliberately small:
 | `wmo optimize router PROJECT --root ROOT [--yes]` | Complete bounded fit simulation and judgment, lock a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run --root ROOT [--check]` | Validate or start the initialized authenticated multi-alias gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
-| `wmo run PROJECT --root ROOT [--ghost]` | Load a frozen policy and expose it on development-only loopback. | Local OpenAI-compatible endpoint with durable journaling by default or no saved traffic in ghost mode. |
+| `wmo run PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as no-argument `wmo run`. |
 | `wmo config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
 | `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
 | `wmo config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.wmo/settings.toml`. |
@@ -24,11 +24,12 @@ the ceiling. Exact completed replays report a zero-dollar estimate and do not pr
 
 Successful build, router, simulation, and SFT operations preserve anonymous aggregate PostHog
 product telemetry, which may send unless disabled. `run` makes no provider call at startup.
-An HTTP completion or direct `RouterRuntime.complete` call is the explicit online model-call
-boundary. The router remains frozen for the process lifetime. `run --ghost` still permits provider
-calls but disables durable interaction, replay, RAG, and SFT state for that process.
+An authenticated gateway request is the explicit online model-call boundary. Project selectors
+remain frozen for the process lifetime and return only an exact model pool. `--ghost` remains a
+compatibility flag for project-journal behavior; gateway authentication, replay, attempts, and
+usage accounting stay enabled.
 
-No-argument `wmo run` is a separate gateway lifecycle. It binds only `127.0.0.1`, starts with no
+Both `wmo run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
 provider call, and requires an explicit provider environment reference, exact model alias, identity,
 grant, and virtual key. `wmo run --non-interactive --json` returns `gateway_not_initialized` plus
 exact next commands on an empty root. `wmo run --check` validates local readiness without binding.
@@ -41,7 +42,9 @@ partitioned. Estimated cost is not provider invoice cost.
 
 One-time virtual-key material appears only in the successful key-issue receipt or a newly created
 mode-`0600` output file. Human key issuance on a non-terminal requires `--json` or `--output`.
-Provider configuration accepts an environment variable name, never a raw credential value.
+Provider configuration accepts an environment variable name, never a raw credential value. Its
+current revisions live in SQLite; immutable serving snapshots bind exact revisions while build and
+evaluation artifacts remain in the project artifact store.
 
 To add ordered failover, first author each deployment as a direct alias with the same
 `--exact-model`. Then certify their equivalence and order with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ exclude = ["**/*_test.py", "wmo/conftest.py"]
 include = [
     "/wmo",
     "/assets",
+    "/docs/reference/gateway-architecture.md",
+    "/docs/release-scope.md",
+    "/docs/usage.md",
     "/README.md",
     "/pyproject.toml",
     "/conftest.py",

--- a/wmo/cli/gateway/app_test.py
+++ b/wmo/cli/gateway/app_test.py
@@ -57,6 +57,12 @@ def test_gateway_help_tree_is_exact_and_every_node_renders() -> None:
     runner = CliRunner()
     paths = [["config", "gateway"]]
     paths.extend(["config", "gateway", name] for name in EXPECTED_GATEWAY_GROUPS)
+    paths.extend(["config", "gateway", name] for name in EXPECTED_GATEWAY_COMMANDS)
+    paths.extend(
+        ["config", "gateway", group, command]
+        for group, commands in EXPECTED_GATEWAY_GROUPS.items()
+        for command in commands
+    )
     for path in paths:
         result = runner.invoke(app, [*path, "--help"])
         assert result.exit_code == 0, result.output

--- a/wmo/cli/gateway/app_test.py
+++ b/wmo/cli/gateway/app_test.py
@@ -33,6 +33,34 @@ from wmo.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUn
 from wmo.runtime.gateway.sqlite.provider_authority import ProviderConnectionBinding
 from wmo.runtime.gateway.sqlite.store import OperationOutcomeUnknownError, SQLiteGatewayStore
 
+EXPECTED_GATEWAY_COMMANDS = {"init", "status", "usage"}
+EXPECTED_GATEWAY_GROUPS = {
+    "alias": {"create", "disable", "list", "update"},
+    "grant": {"add", "list", "remove"},
+    "identity": {"create", "disable", "list", "update"},
+    "key": {"issue", "list", "revoke"},
+    "pool": {"certify"},
+    "provider": {"add", "disable", "list", "remove", "update"},
+}
+
+
+def test_gateway_help_tree_is_exact_and_every_node_renders() -> None:
+    """Lock every public gateway command and prove its installed help path."""
+    direct = {command.name for command in gateway_cli_app.gateway_app.registered_commands}
+    groups: dict[str | None, set[str | None]] = {}
+    for group in gateway_cli_app.gateway_app.registered_groups:
+        assert group.typer_instance is not None
+        groups[group.name] = {command.name for command in group.typer_instance.registered_commands}
+    assert direct == EXPECTED_GATEWAY_COMMANDS
+    assert groups == EXPECTED_GATEWAY_GROUPS
+
+    runner = CliRunner()
+    paths = [["config", "gateway"]]
+    paths.extend(["config", "gateway", name] for name in EXPECTED_GATEWAY_GROUPS)
+    for path in paths:
+        result = runner.invoke(app, [*path, "--help"])
+        assert result.exit_code == 0, result.output
+
 
 def test_noninteractive_management_story_emits_stable_secret_safe_json(
     tmp_path: Path,

--- a/wmo/cli/gateway/app_test.py
+++ b/wmo/cli/gateway/app_test.py
@@ -17,6 +17,7 @@ from click import unstyle
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
+from wmo.cli.gateway import app as gateway_cli_app
 from wmo.cli.gateway import key_output as gateway_key_output
 from wmo.common.core.artifacts import sha256_json
 from wmo.common.models import (
@@ -170,7 +171,7 @@ def test_noninteractive_management_story_emits_stable_secret_safe_json(
     assert usage.exit_code == 0, usage.output
     assert raw_key not in key_list.stdout
     assert raw_key not in usage.stdout
-    assert json.loads(usage.stdout)["schema_version"] == 1
+    assert json.loads(usage.stdout)["schema_version"] == 2
 
     readiness = runner.invoke(
         app,

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -46,11 +46,15 @@ REQUIRED_CORE_REQUIREMENTS = frozenset(
 )
 REQUIRED_WHEEL_MODULES = frozenset(
     {
+        "wmo/cli/gateway/app.py",
         "wmo/common/judging/calibration.py",
         "wmo/common/judging/labels.py",
         "wmo/common/judging/review.py",
         "wmo/common/models/model.py",
         "wmo/runtime/environments/local.py",
+        "wmo/runtime/gateway/lifecycle.py",
+        "wmo/runtime/gateway/openai/requests.py",
+        "wmo/runtime/gateway/service.py",
         "wmo/runtime/models/registry.py",
         "wmo/runtime/router/application.py",
         "wmo/simulation/comparison.py",
@@ -107,6 +111,35 @@ FORBIDDEN_FLAT_ROUTER_MODULES = frozenset(
     }
 )
 _TEST_RELEASE_REVISION = "1" * 40
+
+
+def _assert_gateway_canaries_absent(
+    root: Path,
+    *,
+    channels: dict[str, bytes | str],
+    canaries: tuple[str, ...],
+) -> None:
+    """Reject raw content or secrets across durable and observable gateway channels.
+
+    Args:
+        root: Gateway root containing SQLite, WAL, backups, and catalog snapshots.
+        channels: Named stdout, stderr, log, or HTTP response bodies.
+        canaries: Raw content and secret values that must never appear.
+
+    Raises:
+        AssertionError: A canary appears in any scanned file or named channel.
+    """
+    encoded = tuple(canary.encode() for canary in canaries)
+    for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
+        payload = path.read_bytes()
+        for index, canary in enumerate(encoded):
+            assert canary not in payload, (
+                f"forbidden gateway canary {index} persisted in {path.relative_to(root)}"
+            )
+    for name, value in sorted(channels.items()):
+        payload = value.encode() if isinstance(value, str) else value
+        for index, canary in enumerate(encoded):
+            assert canary not in payload, f"forbidden gateway canary {index} exposed in {name}"
 
 
 def _normalized_path(member_name: str) -> str:
@@ -395,16 +428,20 @@ def _installed_release_driver() -> None:
     Raises:
         AssertionError: Any package, CLI, API, artifact, replay, or no-spend invariant fails.
     """
+    import asyncio
     import hashlib
     import json
     import math
     import socket
+    import stat
     import threading
     from collections import Counter
     from datetime import UTC, datetime
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-    from openai import OpenAI
+    import httpx
+    import openai
+    from openai import AsyncOpenAI, OpenAI
     from openai.types.responses import FunctionToolParam
 
     import wmo
@@ -517,6 +554,9 @@ def _installed_release_driver() -> None:
                 self.send_error(400)
                 return
             ordinal = state.append(self.path, payload)
+            if payload.get("model") == "gateway-model":
+                self._send_gateway_stream(payload, ordinal=ordinal)
+                return
             if self.path.endswith("/embeddings"):
                 values = payload.get("input", [])
                 texts = [values] if isinstance(values, str) else list(values)
@@ -615,6 +655,70 @@ def _installed_release_driver() -> None:
             body = json.dumps(response).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_gateway_stream(self, payload: dict[str, object], *, ordinal: int) -> None:
+            """Return one deterministic Chat SSE stream for gateway certification.
+
+            Args:
+                payload: Gateway-normalized upstream Chat request.
+                ordinal: Stable provider request ordinal.
+            """
+            assert payload.get("stream") is True
+            assert payload.get("stream_options") == {"include_usage": True}
+            if payload.get("tools"):
+                choices = (
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "role": "assistant",
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": f"call-gateway-{ordinal}",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "lookup_ticket",
+                                                "arguments": '{"ticket":"tool-argument-canary"}',
+                                            },
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ]
+                    },
+                )
+            else:
+                choices = (
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "role": "assistant",
+                                    "content": "gateway-response-canary",
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ]
+                    },
+                )
+            frames = [
+                f"data: {json.dumps(frame, separators=(',', ':'))}\n\n".encode()
+                for frame in choices
+            ]
+            frames.append(
+                b'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n'
+            )
+            frames.append(b"data: [DONE]\n\n")
+            body = b"".join(frames)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -842,44 +946,6 @@ def _installed_release_driver() -> None:
             digest.update(b"\0")
         return digest.hexdigest()
 
-    gateway_root = execution_root / "gateway-empty"
-    empty_gateway = run_cli(
-        "run",
-        "--root",
-        str(gateway_root),
-        "--non-interactive",
-        "--json",
-        expected=2,
-    )
-    empty_payload = json.loads(empty_gateway.stdout)
-    assert empty_payload["error"]["code"] == "gateway_not_initialized"
-    assert not gateway_root.exists()
-    initialized_gateway = run_cli(
-        "config",
-        "gateway",
-        "init",
-        "--root",
-        str(gateway_root),
-        "--non-interactive",
-        "--json",
-    )
-    assert json.loads(initialized_gateway.stdout)["schema_version"] == 1
-
-    def assert_embedded_revision(value: object) -> None:
-        """Require every recursively present code revision to match the installed release.
-
-        Args:
-            value: Decoded artifact JSON value to inspect recursively.
-        """
-        if isinstance(value, dict):
-            for key, item in value.items():
-                if key == "code_revision":
-                    assert item == release_revision
-                assert_embedded_revision(item)
-        elif isinstance(value, list):
-            for item in value:
-                assert_embedded_revision(item)
-
     def unused_loopback_port() -> int:
         """Reserve and release one currently unused loopback TCP port."""
         with socket.socket() as probe:
@@ -907,6 +973,336 @@ def _installed_release_driver() -> None:
             except OSError:
                 time.sleep(0.05)
         raise AssertionError(f"wmo run did not listen on port {port}")
+
+    gateway_root = execution_root / "gateway-empty"
+    empty_gateway = run_cli(
+        "run",
+        "--root",
+        str(gateway_root),
+        "--non-interactive",
+        "--json",
+        expected=2,
+    )
+    empty_payload = json.loads(empty_gateway.stdout)
+    assert empty_payload["error"]["code"] == "gateway_not_initialized"
+    assert not gateway_root.exists()
+    initialized_gateway = run_cli(
+        "config",
+        "gateway",
+        "init",
+        "--root",
+        str(gateway_root),
+        "--non-interactive",
+        "--json",
+    )
+    assert json.loads(initialized_gateway.stdout)["schema_version"] == 1
+
+    provider_secret = "provider-secret-canary-P9"
+    prompt_canary = "prompt-content-canary-P9"
+    response_canary = "gateway-response-canary"
+    tool_argument_canary = "tool-argument-canary"
+    invalid_key_canary = "invalid-virtual-key-canary-P9"
+    child_environment["P9_LOOPBACK_PROVIDER_KEY"] = provider_secret
+    gateway_commands = (
+        (
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "gateway-loopback",
+            "--provider",
+            "openai-compatible",
+            "--credential-env",
+            "P9_LOOPBACK_PROVIDER_KEY",
+            "--base-url",
+            provider_url,
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        ),
+        (
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            "coding",
+            "--deployment",
+            "gateway-loopback:gateway-model",
+            "--exact-model",
+            "gateway-model-revision",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        ),
+        (
+            "config",
+            "gateway",
+            "identity",
+            "create",
+            "default",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        ),
+        (
+            "config",
+            "gateway",
+            "grant",
+            "add",
+            "default",
+            "coding",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        ),
+    )
+    for command in gateway_commands:
+        receipt = run_cli(*command)
+        assert json.loads(receipt.stdout)["schema_version"] == 1
+
+    key_output = execution_root / "gateway-virtual-key.txt"
+    issue_receipt = run_cli(
+        "config",
+        "gateway",
+        "key",
+        "issue",
+        "default",
+        "--key-id",
+        "installed-key",
+        "--output",
+        str(key_output),
+        "--root",
+        str(gateway_root),
+        "--non-interactive",
+        "--json",
+    )
+    raw_key = key_output.read_text(encoding="utf-8").strip()
+    assert raw_key.startswith("wmo_vk_")
+    assert stat.S_IMODE(key_output.stat().st_mode) == 0o600
+    assert raw_key not in issue_receipt.stdout
+
+    gateway_port = unused_loopback_port()
+    gateway_process = subprocess.Popen(
+        [
+            str(executable),
+            "run",
+            "--root",
+            str(gateway_root),
+            "--port",
+            str(gateway_port),
+            "--non-interactive",
+            "--graceful-timeout",
+            "2",
+        ],
+        cwd=execution_root,
+        env=child_environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    gateway_stdout = ""
+    gateway_stderr = ""
+    usage_json_body = ""
+    usage_html_body = ""
+    error_bodies: list[str] = []
+    base_url = f"http://127.0.0.1:{gateway_port}/v1"
+    try:
+        wait_for_loopback(gateway_port, gateway_process)
+        assert openai.__version__ == "3.0.0"
+        with OpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
+            assert [model.id for model in client.models.list().data] == ["coding"]
+            chat = client.chat.completions.create(
+                model="coding",
+                messages=[{"role": "user", "content": prompt_canary}],
+            )
+            assert chat.choices[0].message.content == response_canary
+            chat_chunks = list(
+                client.chat.completions.create(
+                    model="coding",
+                    messages=[{"role": "user", "content": prompt_canary}],
+                    stream=True,
+                )
+            )
+            assert (
+                "".join(
+                    chunk.choices[0].delta.content or "" for chunk in chat_chunks if chunk.choices
+                )
+                == response_canary
+            )
+            response = client.responses.create(model="coding", input=prompt_canary)
+            assert response.output_text == response_canary
+            response_events = list(
+                client.responses.create(model="coding", input=prompt_canary, stream=True)
+            )
+            assert response_events[-1].type == "response.completed"
+            tool_chat = client.chat.completions.create(
+                model="coding",
+                messages=[{"role": "user", "content": prompt_canary}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_ticket",
+                            "description": "Look up one ticket.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"ticket": {"type": "string"}},
+                                "required": ["ticket"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+            )
+            assert tool_chat.choices[0].message.tool_calls
+            tool_call = tool_chat.choices[0].message.tool_calls[0]
+            assert tool_call.type == "function"
+            assert tool_call.function.arguments == ('{"ticket":"tool-argument-canary"}')
+
+        async def exercise_async_gateway() -> None:
+            """Run all async SDK stream and non-stream gateway quadrants."""
+            async with AsyncOpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
+                chat = await client.chat.completions.create(
+                    model="coding",
+                    messages=[{"role": "user", "content": prompt_canary}],
+                )
+                assert chat.choices[0].message.content == response_canary
+                chat_stream = await client.chat.completions.create(
+                    model="coding",
+                    messages=[{"role": "user", "content": prompt_canary}],
+                    stream=True,
+                )
+                chat_chunks = [chunk async for chunk in chat_stream]
+                assert (
+                    "".join(
+                        chunk.choices[0].delta.content or ""
+                        for chunk in chat_chunks
+                        if chunk.choices
+                    )
+                    == response_canary
+                )
+                response = await client.responses.create(model="coding", input=prompt_canary)
+                assert response.output_text == response_canary
+                response_stream = await client.responses.create(
+                    model="coding",
+                    input=prompt_canary,
+                    stream=True,
+                )
+                response_events = [event async for event in response_stream]
+                assert response_events[-1].type == "response.completed"
+
+        asyncio.run(exercise_async_gateway())
+
+        usage_json_response = httpx.get(f"http://127.0.0.1:{gateway_port}/usage.json", timeout=5)
+        usage_html_response = httpx.get(f"http://127.0.0.1:{gateway_port}/usage", timeout=5)
+        usage_json_response.raise_for_status()
+        usage_html_response.raise_for_status()
+        usage_json_body = usage_json_response.text
+        usage_html_body = usage_html_response.text
+        usage_payload = usage_json_response.json()
+        identity_usage = usage_payload["identities"][0]
+        assert usage_payload["totals"]["requests"] == 9
+        expected_cells = (
+            identity_usage["identity_id"],
+            identity_usage["requests"],
+            identity_usage["attempts"],
+            identity_usage["input_tokens"],
+            identity_usage["cached_input_tokens"],
+            identity_usage["output_tokens"],
+            identity_usage["reasoning_tokens"],
+            identity_usage["known_estimated_cost_micro_usd"],
+            identity_usage["unknown_cost_attempts"],
+            identity_usage["total_latency_ms"],
+            ", ".join(
+                f"{item['state']}: {item['attempts']}" for item in identity_usage["terminal_counts"]
+            ),
+        )
+        assert tuple(re.findall(r"<td>(.*?)</td>", usage_html_body)) == tuple(
+            str(value) for value in expected_cells
+        )
+
+        invalid_auth = httpx.get(
+            f"{base_url}/models",
+            headers={"Authorization": f"Bearer {invalid_key_canary}"},
+            timeout=5,
+        )
+        assert invalid_auth.status_code == 401
+        error_bodies.append(invalid_auth.text)
+        invalid_request = httpx.post(
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": prompt_canary}],
+                "n": 2,
+            },
+            timeout=5,
+        )
+        assert invalid_request.status_code == 400
+        error_bodies.append(invalid_request.text)
+        _assert_gateway_canaries_absent(
+            gateway_root,
+            channels={
+                "http_errors": "".join(error_bodies),
+                "usage_html": usage_html_body,
+                "usage_json": usage_json_body,
+            },
+            canaries=(
+                raw_key,
+                provider_secret,
+                prompt_canary,
+                response_canary,
+                tool_argument_canary,
+                invalid_key_canary,
+            ),
+        )
+    finally:
+        gateway_process.send_signal(signal.SIGINT)
+        try:
+            gateway_stdout, gateway_stderr = gateway_process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            gateway_process.kill()
+            gateway_stdout, gateway_stderr = gateway_process.communicate(timeout=5)
+    assert gateway_process.returncode == 0, gateway_stdout + gateway_stderr
+    assert (gateway_root / "gateway" / "gateway.db").is_file()
+    assert tuple((gateway_root / "gateway" / "catalog-snapshots").glob("*.json"))
+    _assert_gateway_canaries_absent(
+        gateway_root,
+        channels={
+            "http_errors": "".join(error_bodies),
+            "stderr": gateway_stderr,
+            "stdout": gateway_stdout,
+            "usage_html": usage_html_body,
+            "usage_json": usage_json_body,
+        },
+        canaries=(
+            raw_key,
+            provider_secret,
+            prompt_canary,
+            response_canary,
+            tool_argument_canary,
+            invalid_key_canary,
+        ),
+    )
+
+    def assert_embedded_revision(value: object) -> None:
+        """Require every recursively present code revision to match the installed release.
+
+        Args:
+            value: Decoded artifact JSON value to inspect recursively.
+        """
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key == "code_revision":
+                    assert item == release_revision
+                assert_embedded_revision(item)
+        elif isinstance(value, list):
+            for item in value:
+                assert_embedded_revision(item)
 
     def run_tty(
         arguments: list[str],
@@ -972,8 +1368,6 @@ def _installed_release_driver() -> None:
         )
         assert "Model setup is required" in build_output
         assert "Candidate aliases" not in build_output
-        assert "\x1b[2K" in build_output
-        assert "\x1b[1A" in build_output
         assert "Complete" in build_output
         support_store = ProjectStore(root, "support-agent")
         support_project = support_store.load_project()
@@ -1551,6 +1945,45 @@ def test_tty_child_exit_survives_terminal_close_races(tmp_path: Path) -> None:
     assert all("COMPLETE" in transcript for transcript in transcripts)
 
 
+def test_gateway_canary_scanner_covers_every_persistent_and_observable_channel(
+    tmp_path: Path,
+) -> None:
+    """Every security-sensitive gateway artifact class reaches one scanner.
+
+    Args:
+        tmp_path: Pytest-owned gateway certification root.
+    """
+    cases = (
+        ("gateway.db", None),
+        ("gateway.db-wal", None),
+        ("gateway.db.backup-v3-test", None),
+        ("catalog-snapshots/snapshot.json", None),
+        (None, "stdout"),
+        (None, "stderr"),
+        (None, "log"),
+        (None, "http_error"),
+        (None, "usage_html"),
+        (None, "usage_json"),
+    )
+    canary = "release-scanner-secret-content-canary"
+    for index, (relative_path, channel) in enumerate(cases):
+        case_root = tmp_path / f"case-{index}"
+        channels: dict[str, bytes | str] = {}
+        if relative_path is not None:
+            path = case_root / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(canary, encoding="utf-8")
+        if channel is not None:
+            channels[channel] = canary
+
+        with pytest.raises(AssertionError, match="forbidden gateway canary 0"):
+            _assert_gateway_canaries_absent(
+                case_root,
+                channels=channels,
+                canaries=(canary,),
+            )
+
+
 def test_installed_wheel_no_spend_release_evidence(tmp_path: Path) -> None:
     """Prove the installed release happy path with deterministic loopback providers.
 
@@ -1581,7 +2014,15 @@ def test_installed_wheel_no_spend_release_evidence(tmp_path: Path) -> None:
     )
     installed_python = virtual_environment / "bin" / "python"
     _run_checked(
-        [uv, "pip", "install", "--python", str(installed_python), str(wheel[0])],
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(installed_python),
+            str(wheel[0]),
+            "openai==3.0.0",
+        ],
         cwd=execution,
         environment=environment,
     )
@@ -1681,11 +2122,15 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
     assert "wmo optimize router" in usage
     assert "wmo optimize model" in usage
     assert "wmo config gateway" in usage
+    assert "wmo config gateway pool certify" in usage
     assert "wmo run --root ROOT" in usage
+    assert "OpenAI `3.0.0`" in usage
     assert "wmo optimize route" not in usage.replace("wmo optimize router", "")
 
     scope = (docs / "release-scope.md").read_text(encoding="utf-8")
     assert "local gateway" in scope
+    assert "Gateway provider evidence matrix" in scope
+    assert "not_run_requires_credentials" in scope
     for exclusion in (
         "No paid E2B or Harbor cloud smoke ran",
         "No real Tinker training ran",
@@ -1693,6 +2138,14 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
         "exactly $0.00 observed service spend",
     ):
         assert exclusion in scope
+
+    architecture = (docs / "reference" / "gateway-architecture.md").read_text(encoding="utf-8")
+    assert "GET /v1/models" in architecture
+    assert "POST /v1/chat/completions" in architecture
+    assert "POST /v1/responses" in architecture
+    assert "provider_certification.py" in architecture
+    assert "inert contracts" not in architecture
+    assert "does not claim that a gateway server" not in architecture
 
     ingest = (docs / "reference" / "ingest.md").read_text(encoding="utf-8")
     assert "PostHogPullRequest" in ingest

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -434,6 +434,7 @@ def _installed_release_driver() -> None:
     import json
     import math
     import socket
+    import sqlite3
     import stat
     import threading
     from collections import Counter
@@ -512,6 +513,18 @@ def _installed_release_driver() -> None:
             with self._lock:
                 return Counter(str(item["path"]) for item in self.requests)
 
+        def count_containing(self, value: str) -> int:
+            """Count requests whose canonical record contains one marker.
+
+            Args:
+                value: Marker expected in a request path or payload.
+
+            Returns:
+                Number of matching physical provider requests.
+            """
+            with self._lock:
+                return sum(value in json.dumps(item, sort_keys=True) for item in self.requests)
+
         def snapshot(self) -> tuple[dict[str, object], ...]:
             """Return a detached ordered copy of recorded provider requests."""
             with self._lock:
@@ -520,7 +533,7 @@ def _installed_release_driver() -> None:
     state = ProviderState()
 
     class ProviderHandler(BaseHTTPRequestHandler):
-        """Minimal OpenAI-compatible handler for deterministic zero-price evidence."""
+        """Minimal multi-protocol handler for deterministic gateway evidence."""
 
         protocol_version = "HTTP/1.0"
 
@@ -555,7 +568,10 @@ def _installed_release_driver() -> None:
                 self.send_error(400)
                 return
             ordinal = state.append(self.path, payload)
-            if payload.get("model") == "gateway-model":
+            if payload.get("model") == "gateway-primary-model":
+                self._send_primary_gateway_stream(payload, ordinal=ordinal)
+                return
+            if payload.get("model") == "gateway-secondary-model":
                 self._send_gateway_stream(payload, ordinal=ordinal)
                 return
             if self.path.endswith("/embeddings"):
@@ -723,6 +739,131 @@ def _installed_release_driver() -> None:
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def _send_primary_gateway_stream(
+            self,
+            payload: dict[str, object],
+            *,
+            ordinal: int,
+        ) -> None:
+            """Return deterministic compatible SSE failures and committed output.
+
+            Args:
+                payload: Gateway-normalized compatible request.
+                ordinal: Stable provider request ordinal.
+            """
+            prompt = json.dumps(payload, sort_keys=True)
+            if "prompt-content-canary-P9" in prompt or "tool-argument-canary" in prompt:
+                body = b'{"error":{"message":"temporary fixture failure"}}'
+                self.send_response(503)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if "refusal-input-canary-P9" in prompt:
+                frames: tuple[dict[str, object], ...] = (
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"refusal": "policy refusal"},
+                                "finish_reason": "content_filter",
+                            }
+                        ],
+                    },
+                )
+                self._send_sse_frames(frames, done=True)
+                return
+            if "postcommit-input-canary-P9" in prompt:
+                frames = cast(
+                    tuple[dict[str, object], ...],
+                    (
+                        {
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": "postcommit-response-canary-P9"},
+                                    "finish_reason": None,
+                                }
+                            ]
+                        },
+                    ),
+                )
+                self._send_sse_frames(frames)
+                return
+            if "cancellation-input-canary-P9" in prompt:
+                first = cast(
+                    tuple[dict[str, object], ...],
+                    (
+                        {
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": "cancellation-response-canary-P9"},
+                                    "finish_reason": None,
+                                }
+                            ]
+                        },
+                    ),
+                )
+                terminal = cast(
+                    tuple[dict[str, object], ...],
+                    (
+                        {
+                            "choices": [],
+                            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+                        },
+                    ),
+                )
+                self._send_sse_frames(
+                    first,
+                    trailing=terminal,
+                    pause_seconds=1.0,
+                    done=True,
+                )
+                return
+            raise AssertionError(f"unexpected primary gateway request {ordinal}")
+
+        def _send_sse_frames(
+            self,
+            frames: tuple[dict[str, object], ...],
+            *,
+            trailing: tuple[dict[str, object], ...] = (),
+            pause_seconds: float = 0,
+            done: bool = False,
+        ) -> None:
+            """Write deterministic SSE frames with an optional cancellation window.
+
+            Args:
+                frames: Frames written and flushed immediately.
+                trailing: Frames written after the optional pause.
+                pause_seconds: Delay before trailing frames.
+                done: Whether to append the compatible terminal sentinel.
+            """
+            first = b"".join(
+                f"data: {json.dumps(frame, separators=(',', ':'))}\n\n".encode() for frame in frames
+            )
+            remainder = b"".join(
+                f"data: {json.dumps(frame, separators=(',', ':'))}\n\n".encode()
+                for frame in trailing
+            )
+            if done:
+                remainder += b"data: [DONE]\n\n"
+            body = first + remainder
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(first)
+            self.wfile.flush()
+            if pause_seconds:
+                time.sleep(pause_seconds)
+            if remainder:
+                try:
+                    self.wfile.write(remainder)
+                except BrokenPipeError:
+                    pass
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), ProviderHandler)
     server.daemon_threads = True
@@ -904,6 +1045,7 @@ def _installed_release_driver() -> None:
 
     support_trace_ids = write_traces(traces, 10, terminal_last_trace=True)
     write_traces(one_trace, 1)
+    cli_transcripts: list[str] = []
 
     def run_cli(*arguments: str, expected: int = 0) -> subprocess.CompletedProcess[str]:
         """Run the installed CLI without a terminal and validate its exit status.
@@ -928,6 +1070,7 @@ def _installed_release_driver() -> None:
             f"CLI exit {result.returncode}, expected {expected}: {arguments}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
+        cli_transcripts.extend((result.stdout, result.stderr))
         return result
 
     def directory_digest(path: Path) -> str:
@@ -975,6 +1118,56 @@ def _installed_release_driver() -> None:
                 time.sleep(0.05)
         raise AssertionError(f"wmo run did not listen on port {port}")
 
+    def start_gateway(root: Path) -> tuple[subprocess.Popen[str], int, str]:
+        """Start one installed gateway subprocess on an unused loopback port.
+
+        Args:
+            root: Configured gateway root.
+
+        Returns:
+            Process, selected port, and OpenAI-compatible base URL.
+        """
+        port = unused_loopback_port()
+        process = subprocess.Popen(
+            [
+                str(executable),
+                "run",
+                "--root",
+                str(root),
+                "--port",
+                str(port),
+                "--non-interactive",
+                "--graceful-timeout",
+                "2",
+            ],
+            cwd=execution_root,
+            env=child_environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        wait_for_loopback(port, process)
+        return process, port, f"http://127.0.0.1:{port}/v1"
+
+    def stop_gateway(process: subprocess.Popen[str]) -> tuple[str, str]:
+        """Stop one gateway process and return its complete observable output.
+
+        Args:
+            process: Live or already terminated gateway process.
+
+        Returns:
+            Complete stdout and stderr text.
+        """
+        if process.poll() is None:
+            process.send_signal(signal.SIGINT)
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate(timeout=5)
+        assert process.returncode == 0, stdout + stderr
+        return stdout, stderr
+
     gateway_root = execution_root / "gateway-empty"
     empty_gateway = run_cli(
         "run",
@@ -1003,14 +1196,19 @@ def _installed_release_driver() -> None:
     response_canary = "gateway-response-canary"
     tool_argument_canary = "tool-argument-canary"
     invalid_key_canary = "invalid-virtual-key-canary-P9"
+    refusal_input_canary = "refusal-input-canary-P9"
+    postcommit_input_canary = "postcommit-input-canary-P9"
+    postcommit_response_canary = "postcommit-response-canary-P9"
+    cancellation_input_canary = "cancellation-input-canary-P9"
+    cancellation_response_canary = "cancellation-response-canary-P9"
     child_environment["P9_LOOPBACK_PROVIDER_KEY"] = provider_secret
-    gateway_commands = (
+    provider_commands = (
         (
             "config",
             "gateway",
             "provider",
             "add",
-            "gateway-loopback",
+            "gateway-primary",
             "--provider",
             "openai-compatible",
             "--credential-env",
@@ -1025,18 +1223,100 @@ def _installed_release_driver() -> None:
         (
             "config",
             "gateway",
-            "alias",
-            "create",
-            "coding",
-            "--deployment",
-            "gateway-loopback:gateway-model",
-            "--exact-model",
-            "gateway-model-revision",
+            "provider",
+            "add",
+            "gateway-secondary",
+            "--provider",
+            "openai-compatible",
+            "--credential-env",
+            "P9_LOOPBACK_PROVIDER_KEY",
+            "--base-url",
+            provider_url,
             "--root",
             str(gateway_root),
             "--non-interactive",
             "--json",
         ),
+    )
+    for command in provider_commands:
+        receipt = run_cli(*command)
+        assert json.loads(receipt.stdout)["schema_version"] == 1
+
+    catalog_sha256 = ""
+    for alias, deployment in (
+        ("primary", "gateway-primary:gateway-primary-model"),
+        ("secondary", "gateway-secondary:gateway-secondary-model"),
+    ):
+        receipt = run_cli(
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            alias,
+            "--deployment",
+            deployment,
+            "--exact-model",
+            "gateway-model-revision",
+            "--supports-tools",
+            "--supports-structured-output",
+            "--supports-developer-messages",
+            "--supports-strict-tools",
+            "--supports-parallel-tool-calls",
+            "--maximum-output-tokens",
+            "4096",
+            "--input-price",
+            "1000000",
+            "--cached-input-price",
+            "500000",
+            "--output-price",
+            "2000000",
+            "--reasoning-price",
+            "3000000",
+            "--pricing-source",
+            "deterministic loopback fixture",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        )
+        catalog_sha256 = json.loads(receipt.stdout)["data"]["catalog_sha256"]
+
+    for alias, revision, refusal_failover in (("coding", "installed-pool-revision", False),):
+        command = [
+            "config",
+            "gateway",
+            "pool",
+            "certify",
+            alias,
+            "--deployment-alias",
+            "primary",
+            "--deployment-alias",
+            "secondary",
+            "--exact-model",
+            "gateway-model-revision",
+            "--certification-id",
+            f"{alias}-certification",
+            "--provenance",
+            "installed-wheel deterministic loopback",
+            "--evidence-sha256",
+            "a" * 64,
+            "--certified-at",
+            "2026-08-19T00:00:00Z",
+            "--expected-catalog-sha256",
+            catalog_sha256,
+            "--revision",
+            revision,
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        ]
+        if refusal_failover:
+            command.append("--refusal-failover")
+        receipt = run_cli(*command)
+        catalog_sha256 = json.loads(receipt.stdout)["data"]["catalog_sha256"]
+
+    authority_commands = (
         (
             "config",
             "gateway",
@@ -1061,7 +1341,7 @@ def _installed_release_driver() -> None:
             "--json",
         ),
     )
-    for command in gateway_commands:
+    for command in authority_commands:
         receipt = run_cli(*command)
         assert json.loads(receipt.stdout)["schema_version"] == 1
 
@@ -1086,34 +1366,27 @@ def _installed_release_driver() -> None:
     assert stat.S_IMODE(key_output.stat().st_mode) == 0o600
     assert raw_key not in issue_receipt.stdout
 
-    gateway_port = unused_loopback_port()
-    gateway_process = subprocess.Popen(
-        [
-            str(executable),
-            "run",
-            "--root",
-            str(gateway_root),
-            "--port",
-            str(gateway_port),
-            "--non-interactive",
-            "--graceful-timeout",
-            "2",
-        ],
-        cwd=execution_root,
-        env=child_environment,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    gateway_stdout = ""
-    gateway_stderr = ""
+    gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+    gateway_stdout_parts: list[str] = []
+    gateway_stderr_parts: list[str] = []
     usage_json_body = ""
     usage_html_body = ""
     error_bodies: list[str] = []
-    base_url = f"http://127.0.0.1:{gateway_port}/v1"
     try:
-        wait_for_loopback(gateway_port, gateway_process)
         assert openai.__version__ == "3.0.0"
+        default_refusal = httpx.post(
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": refusal_input_canary}],
+            },
+            timeout=10,
+        )
+        default_refusal.raise_for_status()
+        assert default_refusal.json()["choices"][0]["message"]["refusal"] == "policy refusal"
+        assert state.count_containing("gateway-secondary-model") == 0
+
         with OpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
             assert [model.id for model in client.models.list().data] == ["coding"]
             chat = client.chat.completions.create(
@@ -1198,6 +1471,191 @@ def _installed_release_driver() -> None:
 
         asyncio.run(exercise_async_gateway())
 
+        primary_requests = state.count_containing("gateway-primary-model")
+        secondary_requests = state.count_containing("gateway-secondary-model")
+        assert primary_requests >= 2
+        assert secondary_requests == 9
+
+        matrix_stdout, matrix_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(matrix_stdout)
+        gateway_stderr_parts.append(matrix_stderr)
+        gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+
+        postcommit_secondary = state.count_containing("gateway-secondary-model")
+        with httpx.stream(
+            "POST",
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": postcommit_input_canary}],
+                "stream": True,
+            },
+            timeout=10,
+        ) as postcommit:
+            assert postcommit.status_code == 200
+            postcommit_body = "".join(postcommit.iter_text())
+        assert postcommit_response_canary in postcommit_body
+        assert state.count_containing("gateway-secondary-model") == postcommit_secondary
+
+        postcommit_stdout, postcommit_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(postcommit_stdout)
+        gateway_stderr_parts.append(postcommit_stderr)
+        gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+
+        keyed_headers = {
+            "Authorization": f"Bearer {raw_key}",
+            "Idempotency-Key": "installed-restart-operation",
+        }
+        keyed_request = {
+            "model": "coding",
+            "messages": [{"role": "user", "content": prompt_canary}],
+        }
+        keyed_first = httpx.post(
+            f"{base_url}/chat/completions",
+            headers=keyed_headers,
+            json=keyed_request,
+            timeout=10,
+        )
+        keyed_first.raise_for_status()
+        physical_before_replay = len(state.snapshot())
+        keyed_replay = httpx.post(
+            f"{base_url}/chat/completions",
+            headers=keyed_headers,
+            json=keyed_request,
+            timeout=10,
+        )
+        keyed_replay.raise_for_status()
+        assert keyed_replay.content == keyed_first.content
+        assert len(state.snapshot()) == physical_before_replay
+
+        gateway_database = gateway_root / "gateway" / "gateway.db"
+        with sqlite3.connect(gateway_database) as connection:
+            assert connection.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+        assert gateway_database.with_name("gateway.db-wal").exists()
+
+        invalid_request = httpx.post(
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": prompt_canary}],
+                "n": 2,
+            },
+            timeout=5,
+        )
+        assert invalid_request.status_code == 400
+        error_bodies.append(invalid_request.text)
+
+        first_stdout, first_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(first_stdout)
+        gateway_stderr_parts.append(first_stderr)
+        gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+        provider_before_restart_replay = len(state.snapshot())
+        restart_replay = httpx.post(
+            f"{base_url}/chat/completions",
+            headers=keyed_headers,
+            json=keyed_request,
+            timeout=10,
+        )
+        assert restart_replay.status_code == 409
+        assert restart_replay.json()["error"]["code"] == "idempotency_replay_unavailable"
+        assert len(state.snapshot()) == provider_before_restart_replay
+        error_bodies.append(restart_replay.text)
+
+        cancellation_secondary = state.count_containing("gateway-secondary-model")
+        with httpx.stream(
+            "POST",
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": cancellation_input_canary}],
+                "stream": True,
+            },
+            timeout=10,
+        ) as cancellation:
+            assert cancellation.status_code == 200
+            for line in cancellation.iter_lines():
+                if cancellation_response_canary in line:
+                    break
+            else:
+                raise AssertionError("gateway cancellation stream produced no semantic output")
+        assert state.count_containing("gateway-secondary-model") == cancellation_secondary
+
+        second_stdout, second_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(second_stdout)
+        gateway_stderr_parts.append(second_stderr)
+        opted_policy = run_cli(
+            "config",
+            "gateway",
+            "pool",
+            "certify",
+            "coding",
+            "--deployment-alias",
+            "primary",
+            "--deployment-alias",
+            "secondary",
+            "--exact-model",
+            "gateway-model-revision",
+            "--certification-id",
+            "coding-refusal-certification",
+            "--provenance",
+            "installed-wheel deterministic loopback refusal policy",
+            "--evidence-sha256",
+            "b" * 64,
+            "--certified-at",
+            "2026-08-19T00:00:01Z",
+            "--expected-catalog-sha256",
+            catalog_sha256,
+            "--revision",
+            "installed-refusal-revision",
+            "--replace",
+            "--refusal-failover",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        )
+        opted_catalog_sha256 = json.loads(opted_policy.stdout)["data"]["catalog_sha256"]
+        assert opted_catalog_sha256 != catalog_sha256
+        gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+        opted_secondary = state.count_containing("gateway-secondary-model")
+        opted_refusal = httpx.post(
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": refusal_input_canary}],
+            },
+            timeout=10,
+        )
+        opted_refusal.raise_for_status()
+        assert opted_refusal.json()["choices"][0]["message"]["refusal"] == "policy refusal"
+        assert state.count_containing("gateway-secondary-model") == opted_secondary
+
+        revoked = run_cli(
+            "config",
+            "gateway",
+            "key",
+            "revoke",
+            "installed-key",
+            "--root",
+            str(gateway_root),
+            "--non-interactive",
+            "--json",
+        )
+        assert json.loads(revoked.stdout)["changed"] is True
+        provider_before_revoke = len(state.snapshot())
+        revoked_auth = httpx.get(
+            f"{base_url}/models",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            timeout=5,
+        )
+        assert revoked_auth.status_code == 401
+        assert len(state.snapshot()) == provider_before_revoke
+        error_bodies.append(revoked_auth.text)
+
         usage_json_response = httpx.get(f"http://127.0.0.1:{gateway_port}/usage.json", timeout=5)
         usage_html_response = httpx.get(f"http://127.0.0.1:{gateway_port}/usage", timeout=5)
         usage_json_response.raise_for_status()
@@ -1206,7 +1664,15 @@ def _installed_release_driver() -> None:
         usage_html_body = usage_html_response.text
         usage_payload = usage_json_response.json()
         identity_usage = usage_payload["identities"][0]
-        assert usage_payload["totals"]["requests"] == 9
+        assert usage_payload["totals"]["requests"] >= 14
+        assert usage_payload["totals"]["attempts"] > usage_payload["totals"]["requests"]
+        assert usage_payload["totals"]["known_estimated_cost_micro_usd"] > 0
+        terminal_counts = {
+            item["state"]: item["attempts"] for item in usage_payload["totals"]["terminal_counts"]
+        }
+        assert terminal_counts["completed"] >= 10
+        assert terminal_counts["failed"] >= 2
+        assert terminal_counts["cancelled"] >= 1
         expected_cells = (
             identity_usage["identity_id"],
             identity_usage["requests"],
@@ -1233,21 +1699,10 @@ def _installed_release_driver() -> None:
         )
         assert invalid_auth.status_code == 401
         error_bodies.append(invalid_auth.text)
-        invalid_request = httpx.post(
-            f"{base_url}/chat/completions",
-            headers={"Authorization": f"Bearer {raw_key}"},
-            json={
-                "model": "coding",
-                "messages": [{"role": "user", "content": prompt_canary}],
-                "n": 2,
-            },
-            timeout=5,
-        )
-        assert invalid_request.status_code == 400
-        error_bodies.append(invalid_request.text)
         _assert_gateway_canaries_absent(
             gateway_root,
             channels={
+                "cli": "".join(cli_transcripts),
                 "http_errors": "".join(error_bodies),
                 "usage_html": usage_html_body,
                 "usage_json": usage_json_body,
@@ -1259,21 +1714,25 @@ def _installed_release_driver() -> None:
                 response_canary,
                 tool_argument_canary,
                 invalid_key_canary,
+                refusal_input_canary,
+                postcommit_input_canary,
+                postcommit_response_canary,
+                cancellation_input_canary,
+                cancellation_response_canary,
             ),
         )
     finally:
-        gateway_process.send_signal(signal.SIGINT)
-        try:
-            gateway_stdout, gateway_stderr = gateway_process.communicate(timeout=10)
-        except subprocess.TimeoutExpired:
-            gateway_process.kill()
-            gateway_stdout, gateway_stderr = gateway_process.communicate(timeout=5)
-    assert gateway_process.returncode == 0, gateway_stdout + gateway_stderr
+        gateway_stdout, gateway_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(gateway_stdout)
+        gateway_stderr_parts.append(gateway_stderr)
+    gateway_stdout = "".join(gateway_stdout_parts)
+    gateway_stderr = "".join(gateway_stderr_parts)
     assert (gateway_root / "gateway" / "gateway.db").is_file()
     assert tuple((gateway_root / "gateway" / "catalog-snapshots").glob("*.json"))
     _assert_gateway_canaries_absent(
         gateway_root,
         channels={
+            "cli": "".join(cli_transcripts),
             "http_errors": "".join(error_bodies),
             "stderr": gateway_stderr,
             "stdout": gateway_stdout,
@@ -1287,6 +1746,11 @@ def _installed_release_driver() -> None:
             response_canary,
             tool_argument_canary,
             invalid_key_canary,
+            refusal_input_canary,
+            postcommit_input_canary,
+            postcommit_response_canary,
+            cancellation_input_canary,
+            cancellation_response_canary,
         ),
     )
 

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -2633,9 +2633,21 @@ def _installed_release_driver() -> None:
         try:
             wait_for_loopback(router_port, router_process)
             assert state.snapshot() == provider_calls_before_run
+            compatibility_key_directory = root / "gateway" / "compatibility-keys"
+            compatibility_key_files = tuple(compatibility_key_directory.glob("*.txt"))
+            assert len(compatibility_key_files) == 1
+            compatibility_key_file = compatibility_key_files[0]
+            compatibility_key = compatibility_key_file.read_text(encoding="utf-8").strip()
+            assert compatibility_key.startswith("wmo_vk_")
+            assert stat.S_IMODE(compatibility_key_file.stat().st_mode) == 0o600
+            assert not key_output_marker_path(compatibility_key_file).exists()
+            assert (
+                tuple(compatibility_key_directory.glob(f".{compatibility_key_file.name}.*.reserve"))
+                == ()
+            )
             client = OpenAI(
                 base_url=f"http://127.0.0.1:{router_port}/v1",
-                api_key="unused-loopback-client-key",
+                api_key=compatibility_key,
             )
             chat = client.chat.completions.create(
                 model="support-agent",

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -458,11 +458,6 @@ def _installed_release_driver() -> None:
     from openai.types.responses import FunctionToolParam
 
     import wmo
-    from wmo.cli.gateway.catalog import (
-        upsert_certified_pool,
-        upsert_connection,
-        upsert_singleton_deployment,
-    )
     from wmo.cli.gateway.key_output import key_output_marker_path
     from wmo.common.models import (
         BillingSource,
@@ -497,6 +492,11 @@ def _installed_release_driver() -> None:
     from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
     from wmo.optimize.router.judging.contracts import ManualJudgeTraceReviewArtifact
     from wmo.optimize.router.judging.service import prepare_manual_judge_calibration
+    from wmo.runtime.gateway.catalog_authority import (
+        upsert_certified_pool,
+        upsert_connection,
+        upsert_singleton_deployment,
+    )
     from wmo.runtime.gateway.lifecycle import load_local_gateway
     from wmo.runtime.gateway.management import GatewayManagement
     from wmo.runtime.models import (

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -771,6 +771,12 @@ def _installed_release_driver() -> None:
             if payload.get("model") in {"gateway-secondary-model", "project-secondary-model"}:
                 self._send_gateway_stream(payload, ordinal=ordinal)
                 return
+            if payload.get("stream") is True and payload.get("model") in {
+                "core-model",
+                "candidate-b-model",
+            }:
+                self._send_gateway_stream(payload, ordinal=ordinal)
+                return
             if self.path.endswith("/embeddings"):
                 values = payload.get("input", [])
                 texts = [values] if isinstance(values, str) else list(values)
@@ -915,11 +921,13 @@ def _installed_release_driver() -> None:
                     },
                 )
             else:
-                content = (
-                    project_response_canary
-                    if project_prompt_canary in json.dumps(payload, sort_keys=True)
-                    else response_canary
-                )
+                serialized = json.dumps(payload, sort_keys=True)
+                if project_prompt_canary in serialized:
+                    content = project_response_canary
+                elif "Duplicate routed example" in serialized:
+                    content = "Duplicate routed target"
+                else:
+                    content = response_canary
                 choices = (
                     {
                         "choices": [

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -685,6 +685,10 @@ def _installed_release_driver() -> None:
             """
             assert payload.get("stream") is True
             assert payload.get("stream_options") == {"include_usage": True}
+            prompt = json.dumps(payload, sort_keys=True)
+            if "sdk-retry-input-canary-P9" in prompt:
+                self._send_retryable_failure()
+                return
             if payload.get("tools"):
                 choices = (
                     {
@@ -753,9 +757,16 @@ def _installed_release_driver() -> None:
                 ordinal: Stable provider request ordinal.
             """
             prompt = json.dumps(payload, sort_keys=True)
-            if "prompt-content-canary-P9" in prompt or "tool-argument-canary" in prompt:
-                body = b'{"error":{"message":"temporary fixture failure"}}'
-                self.send_response(503)
+            if (
+                "prompt-content-canary-P9" in prompt
+                or "tool-argument-canary" in prompt
+                or "sdk-retry-input-canary-P9" in prompt
+            ):
+                self._send_retryable_failure()
+                return
+            if "provider-auth-input-canary-P9" in prompt:
+                body = b'{"error":{"message":"fixture credential rejected"}}'
+                self.send_response(401)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
@@ -864,6 +875,15 @@ def _installed_release_driver() -> None:
                     self.wfile.write(remainder)
                 except BrokenPipeError:
                     pass
+
+        def _send_retryable_failure(self) -> None:
+            """Return one content-free retryable provider failure."""
+            body = b'{"error":{"message":"temporary fixture failure"}}'
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), ProviderHandler)
     server.daemon_threads = True
@@ -1197,6 +1217,8 @@ def _installed_release_driver() -> None:
     tool_argument_canary = "tool-argument-canary"
     invalid_key_canary = "invalid-virtual-key-canary-P9"
     refusal_input_canary = "refusal-input-canary-P9"
+    auth_input_canary = "provider-auth-input-canary-P9"
+    sdk_retry_input_canary = "sdk-retry-input-canary-P9"
     postcommit_input_canary = "postcommit-input-canary-P9"
     postcommit_response_canary = "postcommit-response-canary-P9"
     cancellation_input_canary = "cancellation-input-canary-P9"
@@ -1387,6 +1409,20 @@ def _installed_release_driver() -> None:
         assert default_refusal.json()["choices"][0]["message"]["refusal"] == "policy refusal"
         assert state.count_containing("gateway-secondary-model") == 0
 
+        auth_secondary = state.count_containing("gateway-secondary-model")
+        auth_fallback = httpx.post(
+            f"{base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": auth_input_canary}],
+            },
+            timeout=10,
+        )
+        auth_fallback.raise_for_status()
+        assert auth_fallback.json()["choices"][0]["message"]["content"] == response_canary
+        assert state.count_containing("gateway-secondary-model") == auth_secondary + 1
+
         with OpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
             assert [model.id for model in client.models.list().data] == ["coding"]
             chat = client.chat.completions.create(
@@ -1474,11 +1510,43 @@ def _installed_release_driver() -> None:
         primary_requests = state.count_containing("gateway-primary-model")
         secondary_requests = state.count_containing("gateway-secondary-model")
         assert primary_requests >= 2
-        assert secondary_requests == 9
+        assert secondary_requests == 10
 
         matrix_stdout, matrix_stderr = stop_gateway(gateway_process)
         gateway_stdout_parts.append(matrix_stdout)
         gateway_stderr_parts.append(matrix_stderr)
+        gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+
+        usage_before_retry = httpx.get(
+            f"http://127.0.0.1:{gateway_port}/usage.json",
+            timeout=5,
+        ).json()["totals"]
+        provider_before_retry = state.count_containing(sdk_retry_input_canary)
+        try:
+            with OpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
+                client.chat.completions.create(
+                    model="coding",
+                    messages=[{"role": "user", "content": sdk_retry_input_canary}],
+                )
+        except openai.APIStatusError as exc:
+            assert exc.status_code in {502, 503}
+            error_bodies.append(exc.response.text)
+        else:
+            raise AssertionError("default SDK retry scenario unexpectedly succeeded")
+        usage_after_retry = httpx.get(
+            f"http://127.0.0.1:{gateway_port}/usage.json",
+            timeout=5,
+        ).json()["totals"]
+        provider_retry_calls = (
+            state.count_containing(sdk_retry_input_canary) - provider_before_retry
+        )
+        assert usage_after_retry["requests"] - usage_before_retry["requests"] == 3
+        assert usage_after_retry["attempts"] - usage_before_retry["attempts"] == 4
+        assert provider_retry_calls == 4
+
+        retry_stdout, retry_stderr = stop_gateway(gateway_process)
+        gateway_stdout_parts.append(retry_stdout)
+        gateway_stderr_parts.append(retry_stderr)
         gateway_process, gateway_port, base_url = start_gateway(gateway_root)
 
         postcommit_secondary = state.count_containing("gateway-secondary-model")
@@ -1631,8 +1699,8 @@ def _installed_release_driver() -> None:
             timeout=10,
         )
         opted_refusal.raise_for_status()
-        assert opted_refusal.json()["choices"][0]["message"]["refusal"] == "policy refusal"
-        assert state.count_containing("gateway-secondary-model") == opted_secondary
+        assert opted_refusal.json()["choices"][0]["message"]["content"] == response_canary
+        assert state.count_containing("gateway-secondary-model") == opted_secondary + 1
 
         revoked = run_cli(
             "config",
@@ -1715,6 +1783,8 @@ def _installed_release_driver() -> None:
                 tool_argument_canary,
                 invalid_key_canary,
                 refusal_input_canary,
+                auth_input_canary,
+                sdk_retry_input_canary,
                 postcommit_input_canary,
                 postcommit_response_canary,
                 cancellation_input_canary,
@@ -1747,6 +1817,8 @@ def _installed_release_driver() -> None:
             tool_argument_canary,
             invalid_key_canary,
             refusal_input_canary,
+            auth_input_canary,
+            sdk_retry_input_canary,
             postcommit_input_canary,
             postcommit_response_canary,
             cancellation_input_canary,
@@ -2447,6 +2519,16 @@ def test_gateway_canary_scanner_covers_every_persistent_and_observable_channel(
                 channels=channels,
                 canaries=(canary,),
             )
+
+
+def test_package_workflow_installs_the_exact_certified_openai_sdk() -> None:
+    """The archive smoke lane constrains the SDK version claimed by certification."""
+    repository = Path(__file__).resolve().parent.parent
+    workflow = (repository / ".github" / "workflows" / "python-package.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'dist/*.whl "openai==3.0.0"' in workflow
 
 
 def test_installed_wheel_no_spend_release_evidence(tmp_path: Path) -> None:

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -54,6 +54,7 @@ REQUIRED_WHEEL_MODULES = frozenset(
         "wmo/runtime/environments/local.py",
         "wmo/runtime/gateway/lifecycle.py",
         "wmo/runtime/gateway/openai/requests.py",
+        "wmo/runtime/gateway/provider_certification.py",
         "wmo/runtime/gateway/service.py",
         "wmo/runtime/models/registry.py",
         "wmo/runtime/router/application.py",

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -53,9 +53,11 @@ REQUIRED_WHEEL_MODULES = frozenset(
         "wmo/common/models/model.py",
         "wmo/runtime/environments/local.py",
         "wmo/runtime/gateway/lifecycle.py",
+        "wmo/runtime/gateway/ledger.py",
         "wmo/runtime/gateway/openai/requests.py",
         "wmo/runtime/gateway/provider_certification.py",
         "wmo/runtime/gateway/service.py",
+        "wmo/runtime/gateway/usage.py",
         "wmo/runtime/models/registry.py",
         "wmo/runtime/router/application.py",
         "wmo/simulation/comparison.py",
@@ -74,6 +76,9 @@ REQUIRED_SDIST_MEMBERS = frozenset(
     {
         "README.md",
         "assets/wmo-workflow.png",
+        "docs/reference/gateway-architecture.md",
+        "docs/release-scope.md",
+        "docs/usage.md",
         "pyproject.toml",
         "wmo/optimize/router/automatic/service.py",
         "wmo/optimize/router/composition.py",
@@ -224,6 +229,9 @@ def _tracked_sdist_members() -> frozenset[str]:
             ".gitignore",
             "README.md",
             "assets",
+            "docs/reference/gateway-architecture.md",
+            "docs/release-scope.md",
+            "docs/usage.md",
             "pyproject.toml",
             "conftest.py",
             "wmo",
@@ -438,22 +446,48 @@ def _installed_release_driver() -> None:
     import stat
     import threading
     from collections import Counter
+    from collections.abc import Sequence
     from datetime import UTC, datetime
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
     import httpx
+    import numpy as np
     import openai
+    import uvicorn
     from openai import AsyncOpenAI, OpenAI
     from openai.types.responses import FunctionToolParam
 
     import wmo
+    from wmo.cli.gateway.catalog import (
+        upsert_certified_pool,
+        upsert_connection,
+        upsert_singleton_deployment,
+    )
+    from wmo.cli.gateway.key_output import key_output_marker_path
     from wmo.common.models import (
+        BillingSource,
         ConnectionConfig,
+        Embedding,
         EmbeddingCostReservation,
+        GatewayDeploymentCapabilities,
+        GatewayEquivalenceCertification,
+        GatewayTokenPrices,
         ModelCapabilities,
+        ModelRequest,
+        ModelResponse,
+        ModelSnapshot,
+        RoutedCandidateSnapshot,
         load_model_catalog,
     )
     from wmo.common.project import ProjectStore, artifact_input
+    from wmo.common.routing import KnnGuard, KnnRouterPolicy
+    from wmo.common.routing.bank import (
+        CandidateEvidenceCount,
+        KnnBankManifest,
+        KnnEvidenceBank,
+        bank_bytes,
+    )
+    from wmo.common.routing.features import ROUTER_FEATURE_SCHEMA_SHA256
     from wmo.optimize.model.sft import (
         RuntimeInteractionExampleSource,
         load_sft_model_optimization_config,
@@ -463,8 +497,16 @@ def _installed_release_driver() -> None:
     from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
     from wmo.optimize.router.judging.contracts import ManualJudgeTraceReviewArtifact
     from wmo.optimize.router.judging.service import prepare_manual_judge_calibration
-    from wmo.runtime.models import CapabilityRequirement, RuntimeModelCatalog
+    from wmo.runtime.gateway.lifecycle import load_local_gateway
+    from wmo.runtime.gateway.management import GatewayManagement
+    from wmo.runtime.models import (
+        CapabilityRequirement,
+        CatalogRoleName,
+        ResolvedModel,
+        RuntimeModelCatalog,
+    )
     from wmo.runtime.router import (
+        RouterRuntime,
         RuntimeAcceptedEvent,
         RuntimeCompletedEvent,
         RuntimeInteractionJournal,
@@ -530,6 +572,161 @@ def _installed_release_driver() -> None:
             with self._lock:
                 return tuple(dict(item) for item in self.requests)
 
+    class InstalledProjectClient:
+        """Deterministic selection client that forbids router-owned completion."""
+
+        def __init__(self) -> None:
+            """Initialize selection and completion counters."""
+            self.embed_calls = 0
+            self.complete_calls = 0
+
+        def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
+            """Return one stable feature embedding for learned selection."""
+            assert len(texts) == 1
+            self.embed_calls += 1
+            return (Embedding(values=(1.0, 0.0)),)
+
+        def complete(self, request: ModelRequest) -> ModelResponse:
+            """Reject completion because the gateway owns physical provider work."""
+            del request
+            self.complete_calls += 1
+            raise AssertionError("project router completion must remain unused")
+
+    class InstalledProjectCatalog:
+        """Resolve frozen selection-only models without provider network work."""
+
+        def __init__(
+            self,
+            snapshots: dict[str, ModelSnapshot],
+            client: InstalledProjectClient,
+        ) -> None:
+            """Bind exact snapshots and the deterministic selection client."""
+            self._snapshots = snapshots
+            self._client = client
+
+        def resolve(
+            self,
+            alias: str,
+            *,
+            role: CatalogRoleName | None = None,
+        ) -> ResolvedModel:
+            """Return one candidate or embedder binding by frozen alias."""
+            del role
+            snapshot = self._snapshots[alias]
+            capabilities = ModelCapabilities(
+                supports_embeddings=alias == "embedder",
+            )
+            return ResolvedModel(
+                alias=alias,
+                snapshot=snapshot,
+                capabilities=capabilities,
+                client=self._client,
+                embedding_client=(self._client if capabilities.supports_embeddings else None),
+            )
+
+    def installed_project_runtime() -> tuple[RouterRuntime, InstalledProjectClient]:
+        """Build one real packaged RouterRuntime for installed selection-only evidence."""
+        digest = "a" * 64
+        created_at = datetime(2026, 8, 19, tzinfo=UTC)
+        snapshots: dict[str, ModelSnapshot] = {}
+        for alias in ("baseline", "cheap", "embedder"):
+            capabilities = ModelCapabilities(supports_embeddings=alias == "embedder")
+            snapshots[alias] = ModelSnapshot(
+                provider="installed-fixture",
+                model_id=alias,
+                revision="fixture",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities_sha256=capabilities.identity_sha256(),
+                connection_sha256="b" * 64,
+            )
+        bank = KnnEvidenceBank(
+            task_ids=tuple(f"task-{index}" for index in range(8)),
+            candidate_aliases=("baseline", "cheap"),
+            embeddings=np.asarray(((1.0, 0.0),) * 8, dtype=np.float32),
+            scores=np.asarray(((0.4, 1.0),) * 8, dtype=np.float32),
+            candidate_costs=np.asarray(((0.5, 0.1),) * 8, dtype=np.float64),
+            score_counts=np.ones((8, 2), dtype=np.int32),
+            cost_counts=np.ones((8, 2), dtype=np.int32),
+            workload_weights=np.ones(8, dtype=np.float64),
+            novelty_floor=0.5,
+        )
+        bank_sha256 = hashlib.sha256(bank_bytes(bank)).hexdigest()
+        manifest = KnnBankManifest(
+            schema_version=1,
+            created_at=created_at,
+            code_revision=release_revision,
+            bank_artifact_id="installed-project-bank",
+            fit_evaluation_id="installed-project-fit",
+            evaluation_plan_id="installed-project-plan",
+            evaluation_plan_sha256=digest,
+            task_set_id="installed-project-tasks",
+            task_set_sha256=digest,
+            task_ids=bank.task_ids,
+            candidate_aliases=bank.candidate_aliases,
+            evaluation_protocols_sha256=digest,
+            embedder_alias="embedder",
+            embedder=snapshots["embedder"],
+            feature_extractor_id="request-visible-v2",
+            feature_schema_sha256=ROUTER_FEATURE_SCHEMA_SHA256,
+            pricing_snapshot_id="installed-project-pricing",
+            pricing_snapshot_sha256=digest,
+            bank_sha256=bank_sha256,
+            embedding_dimension=2,
+            novelty_floor=0.5,
+            evidence_counts=tuple(
+                CandidateEvidenceCount(
+                    candidate_alias=alias,
+                    scored_task_count=8,
+                    costed_task_count=8,
+                )
+                for alias in bank.candidate_aliases
+            ),
+        )
+        policy = KnnRouterPolicy(
+            schema_version=1,
+            created_at=created_at,
+            code_revision=release_revision,
+            policy_id="installed-project-policy",
+            baseline_alias="baseline",
+            candidates=tuple(
+                RoutedCandidateSnapshot(alias=alias, model=snapshots[alias])
+                for alias in bank.candidate_aliases
+            ),
+            embedder_alias="embedder",
+            embedder=snapshots["embedder"],
+            feature_extractor_id=manifest.feature_extractor_id,
+            feature_schema_sha256=manifest.feature_schema_sha256,
+            pricing_snapshot_id=manifest.pricing_snapshot_id,
+            pricing_snapshot_sha256=manifest.pricing_snapshot_sha256,
+            bank_artifact_id=manifest.bank_artifact_id,
+            bank_sha256=bank_sha256,
+            guard=KnnGuard(
+                maximum_neighbors=8,
+                minimum_paired_observations=8,
+                relative_similarity_threshold=0.95,
+                uncertainty_multiplier=0.5,
+                quality_tolerance=0,
+            ),
+            fit_evaluation_id=manifest.fit_evaluation_id,
+            evaluation_plan_id=manifest.evaluation_plan_id,
+            evaluation_plan_sha256=manifest.evaluation_plan_sha256,
+            task_set_id=manifest.task_set_id,
+            task_set_sha256=manifest.task_set_sha256,
+            evaluation_protocols_sha256=manifest.evaluation_protocols_sha256,
+            judgment_status="provisional",
+        )
+        client = InstalledProjectClient()
+        runtime = RouterRuntime(
+            policy,
+            manifest,
+            bank,
+            cast(RuntimeModelCatalog, InstalledProjectCatalog(snapshots, client)),
+            pricing_snapshot_id=manifest.pricing_snapshot_id,
+            pricing_snapshot_sha256=manifest.pricing_snapshot_sha256,
+            pricing_candidate_aliases=manifest.candidate_aliases,
+        )
+        return runtime, client
+
     state = ProviderState()
 
     class ProviderHandler(BaseHTTPRequestHandler):
@@ -568,10 +765,10 @@ def _installed_release_driver() -> None:
                 self.send_error(400)
                 return
             ordinal = state.append(self.path, payload)
-            if payload.get("model") == "gateway-primary-model":
+            if payload.get("model") in {"gateway-primary-model", "project-primary-model"}:
                 self._send_primary_gateway_stream(payload, ordinal=ordinal)
                 return
-            if payload.get("model") == "gateway-secondary-model":
+            if payload.get("model") in {"gateway-secondary-model", "project-secondary-model"}:
                 self._send_gateway_stream(payload, ordinal=ordinal)
                 return
             if self.path.endswith("/embeddings"):
@@ -704,7 +901,10 @@ def _installed_release_driver() -> None:
                                             "type": "function",
                                             "function": {
                                                 "name": "lookup_ticket",
-                                                "arguments": '{"ticket":"tool-argument-canary"}',
+                                                "arguments": json.dumps(
+                                                    {"ticket": tool_argument_canary},
+                                                    separators=(",", ":"),
+                                                ),
                                             },
                                         }
                                     ],
@@ -715,6 +915,11 @@ def _installed_release_driver() -> None:
                     },
                 )
             else:
+                content = (
+                    project_response_canary
+                    if project_prompt_canary in json.dumps(payload, sort_keys=True)
+                    else response_canary
+                )
                 choices = (
                     {
                         "choices": [
@@ -722,7 +927,7 @@ def _installed_release_driver() -> None:
                                 "index": 0,
                                 "delta": {
                                     "role": "assistant",
-                                    "content": "gateway-response-canary",
+                                    "content": content,
                                 },
                                 "finish_reason": "stop",
                             }
@@ -764,6 +969,9 @@ def _installed_release_driver() -> None:
             ):
                 self._send_retryable_failure()
                 return
+            if "project-prompt-canary-P9" in prompt:
+                self._send_retryable_failure()
+                return
             if "provider-auth-input-canary-P9" in prompt:
                 body = b'{"error":{"message":"fixture credential rejected"}}'
                 self.send_response(401)
@@ -794,7 +1002,7 @@ def _installed_release_driver() -> None:
                             "choices": [
                                 {
                                     "index": 0,
-                                    "delta": {"content": "postcommit-response-canary-P9"},
+                                    "delta": {"content": postcommit_response_canary},
                                     "finish_reason": None,
                                 }
                             ]
@@ -811,7 +1019,7 @@ def _installed_release_driver() -> None:
                             "choices": [
                                 {
                                     "index": 0,
-                                    "delta": {"content": "cancellation-response-canary-P9"},
+                                    "delta": {"content": cancellation_response_canary},
                                     "finish_reason": None,
                                 }
                             ]
@@ -1110,6 +1318,45 @@ def _installed_release_driver() -> None:
             digest.update(b"\0")
         return digest.hexdigest()
 
+    def gateway_attempt_rows(database: Path) -> tuple[dict[str, object], ...]:
+        """Read stable content-free attempt evidence from the installed database.
+
+        Args:
+            database: Gateway SQLite path.
+
+        Returns:
+            Attempt rows ordered by durable creation identity.
+        """
+        with sqlite3.connect(database) as connection:
+            connection.row_factory = sqlite3.Row
+            rows = connection.execute(
+                """
+                SELECT attempt_id, request_id, attempt_ordinal, route_depth,
+                       deployment_id, billing_source, state, failure_class,
+                       input_tokens, cached_input_tokens, output_tokens,
+                       reasoning_tokens, estimated_cost_micro_usd
+                FROM gateway_attempts
+                ORDER BY started_at, request_id, attempt_ordinal, attempt_id
+                """
+            ).fetchall()
+        return tuple(dict(row) for row in rows)
+
+    def frozen_billing_evidence(
+        rows: tuple[dict[str, object], ...],
+    ) -> dict[str, tuple[object, object]]:
+        """Index immutable billing source and cost by physical attempt.
+
+        Args:
+            rows: Content-free attempt rows.
+
+        Returns:
+            Billing source and attributed cost keyed by attempt ID.
+        """
+        return {
+            str(row["attempt_id"]): (row["billing_source"], row["estimated_cost_micro_usd"])
+            for row in rows
+        }
+
     def unused_loopback_port() -> int:
         """Reserve and release one currently unused loopback TCP port."""
         with socket.socket() as probe:
@@ -1189,6 +1436,7 @@ def _installed_release_driver() -> None:
         return stdout, stderr
 
     gateway_root = execution_root / "gateway-empty"
+    gateway_database = gateway_root / "gateway" / "gateway.db"
     empty_gateway = run_cli(
         "run",
         "--root",
@@ -1211,18 +1459,21 @@ def _installed_release_driver() -> None:
     )
     assert json.loads(initialized_gateway.stdout)["schema_version"] == 1
 
-    provider_secret = "provider-secret-canary-P9"
-    prompt_canary = "prompt-content-canary-P9"
-    response_canary = "gateway-response-canary"
-    tool_argument_canary = "tool-argument-canary"
-    invalid_key_canary = "invalid-virtual-key-canary-P9"
-    refusal_input_canary = "refusal-input-canary-P9"
-    auth_input_canary = "provider-auth-input-canary-P9"
-    sdk_retry_input_canary = "sdk-retry-input-canary-P9"
-    postcommit_input_canary = "postcommit-input-canary-P9"
-    postcommit_response_canary = "postcommit-response-canary-P9"
-    cancellation_input_canary = "cancellation-input-canary-P9"
-    cancellation_response_canary = "cancellation-response-canary-P9"
+    canary_suffix = hashlib.sha256(str(execution_root).encode()).hexdigest()[:16]
+    provider_secret = f"provider-secret-canary-P9-{canary_suffix}"
+    prompt_canary = f"prompt-content-canary-P9-{canary_suffix}"
+    response_canary = f"gateway-response-canary-{canary_suffix}"
+    tool_argument_canary = f"tool-argument-canary-{canary_suffix}"
+    invalid_key_canary = f"invalid-virtual-key-canary-P9-{canary_suffix}"
+    refusal_input_canary = f"refusal-input-canary-P9-{canary_suffix}"
+    auth_input_canary = f"provider-auth-input-canary-P9-{canary_suffix}"
+    sdk_retry_input_canary = f"sdk-retry-input-canary-P9-{canary_suffix}"
+    postcommit_input_canary = f"postcommit-input-canary-P9-{canary_suffix}"
+    postcommit_response_canary = f"postcommit-response-canary-P9-{canary_suffix}"
+    cancellation_input_canary = f"cancellation-input-canary-P9-{canary_suffix}"
+    cancellation_response_canary = f"cancellation-response-canary-P9-{canary_suffix}"
+    project_prompt_canary = f"project-prompt-canary-P9-{canary_suffix}"
+    project_response_canary = f"project-response-canary-P9-{canary_suffix}"
     child_environment["P9_LOOPBACK_PROVIDER_KEY"] = provider_secret
     provider_commands = (
         (
@@ -1265,9 +1516,9 @@ def _installed_release_driver() -> None:
         assert json.loads(receipt.stdout)["schema_version"] == 1
 
     catalog_sha256 = ""
-    for alias, deployment in (
-        ("primary", "gateway-primary:gateway-primary-model"),
-        ("secondary", "gateway-secondary:gateway-secondary-model"),
+    for alias, deployment, billing_source in (
+        ("primary", "gateway-primary:gateway-primary-model", "host_managed"),
+        ("secondary", "gateway-secondary:gateway-secondary-model", "customer_managed"),
     ):
         receipt = run_cli(
             "config",
@@ -1296,6 +1547,8 @@ def _installed_release_driver() -> None:
             "3000000",
             "--pricing-source",
             "deterministic loopback fixture",
+            "--billing-source",
+            billing_source,
             "--root",
             str(gateway_root),
             "--non-interactive",
@@ -1367,7 +1620,10 @@ def _installed_release_driver() -> None:
         receipt = run_cli(*command)
         assert json.loads(receipt.stdout)["schema_version"] == 1
 
-    key_output = execution_root / "gateway-virtual-key.txt"
+    key_output_directory = execution_root / "gateway-key-output"
+    key_output_directory.mkdir(mode=0o700)
+    assert stat.S_IMODE(key_output_directory.stat().st_mode) == 0o700
+    key_output = key_output_directory / "key.txt"
     issue_receipt = run_cli(
         "config",
         "gateway",
@@ -1387,6 +1643,21 @@ def _installed_release_driver() -> None:
     assert raw_key.startswith("wmo_vk_")
     assert stat.S_IMODE(key_output.stat().st_mode) == 0o600
     assert raw_key not in issue_receipt.stdout
+
+    def assert_key_and_canaries_confined() -> None:
+        """Require one authorized key output and no duplicate secret or content artifact."""
+        assert not key_output_marker_path(key_output).exists()
+        assert tuple(key_output.parent.glob(f".{key_output.name}.*.reserve")) == ()
+        forbidden = raw_key.encode()
+        entries = tuple(key_output_directory.iterdir())
+        assert entries == (key_output,)
+        assert all(
+            forbidden not in path.read_bytes()
+            for path in entries
+            if path != key_output and path.is_file() and not path.is_symlink()
+        )
+
+    assert_key_and_canaries_confined()
 
     gateway_process, gateway_port, base_url = start_gateway(gateway_root)
     gateway_stdout_parts: list[str] = []
@@ -1409,6 +1680,9 @@ def _installed_release_driver() -> None:
         assert default_refusal.json()["choices"][0]["message"]["refusal"] == "policy refusal"
         assert state.count_containing("gateway-secondary-model") == 0
 
+        auth_attempt_ids = {
+            str(row["attempt_id"]) for row in gateway_attempt_rows(gateway_database)
+        }
         auth_secondary = state.count_containing("gateway-secondary-model")
         auth_fallback = httpx.post(
             f"{base_url}/chat/completions",
@@ -1422,6 +1696,25 @@ def _installed_release_driver() -> None:
         auth_fallback.raise_for_status()
         assert auth_fallback.json()["choices"][0]["message"]["content"] == response_canary
         assert state.count_containing("gateway-secondary-model") == auth_secondary + 1
+        auth_attempts = tuple(
+            row
+            for row in gateway_attempt_rows(gateway_database)
+            if str(row["attempt_id"]) not in auth_attempt_ids
+        )
+        assert len(auth_attempts) == 2
+        assert len({row["request_id"] for row in auth_attempts}) == 1
+        assert [row["attempt_ordinal"] for row in auth_attempts] == [0, 1]
+        assert [row["route_depth"] for row in auth_attempts] == [0, 1]
+        assert [row["billing_source"] for row in auth_attempts] == [
+            "host_managed",
+            "customer_managed",
+        ]
+        assert [row["state"] for row in auth_attempts] == ["failed", "completed"]
+        assert auth_attempts[0]["failure_class"] == "provider_authentication"
+        assert auth_attempts[0]["estimated_cost_micro_usd"] is None
+        assert auth_attempts[1]["input_tokens"] == 3
+        assert auth_attempts[1]["output_tokens"] == 2
+        assert auth_attempts[1]["estimated_cost_micro_usd"] == 7
 
         with OpenAI(api_key=raw_key, base_url=base_url, timeout=10) as client:
             assert [model.id for model in client.models.list().data] == ["coding"]
@@ -1471,7 +1764,9 @@ def _installed_release_driver() -> None:
             assert tool_chat.choices[0].message.tool_calls
             tool_call = tool_chat.choices[0].message.tool_calls[0]
             assert tool_call.type == "function"
-            assert tool_call.function.arguments == ('{"ticket":"tool-argument-canary"}')
+            assert tool_call.function.arguments == json.dumps(
+                {"ticket": tool_argument_canary}, separators=(",", ":")
+            )
 
         async def exercise_async_gateway() -> None:
             """Run all async SDK stream and non-stream gateway quadrants."""
@@ -1515,7 +1810,11 @@ def _installed_release_driver() -> None:
         matrix_stdout, matrix_stderr = stop_gateway(gateway_process)
         gateway_stdout_parts.append(matrix_stdout)
         gateway_stderr_parts.append(matrix_stderr)
+        frozen_before_restart = frozen_billing_evidence(gateway_attempt_rows(gateway_database))
         gateway_process, gateway_port, base_url = start_gateway(gateway_root)
+        assert frozen_billing_evidence(gateway_attempt_rows(gateway_database)) == (
+            frozen_before_restart
+        )
 
         usage_before_retry = httpx.get(
             f"http://127.0.0.1:{gateway_port}/usage.json",
@@ -1597,7 +1896,6 @@ def _installed_release_driver() -> None:
         assert keyed_replay.content == keyed_first.content
         assert len(state.snapshot()) == physical_before_replay
 
-        gateway_database = gateway_root / "gateway" / "gateway.db"
         with sqlite3.connect(gateway_database) as connection:
             assert connection.execute("PRAGMA journal_mode").fetchone() == ("wal",)
         assert gateway_database.with_name("gateway.db-wal").exists()
@@ -1620,6 +1918,7 @@ def _installed_release_driver() -> None:
         gateway_stderr_parts.append(first_stderr)
         gateway_process, gateway_port, base_url = start_gateway(gateway_root)
         provider_before_restart_replay = len(state.snapshot())
+        attempts_before_restart_replay = gateway_attempt_rows(gateway_database)
         restart_replay = httpx.post(
             f"{base_url}/chat/completions",
             headers=keyed_headers,
@@ -1629,6 +1928,7 @@ def _installed_release_driver() -> None:
         assert restart_replay.status_code == 409
         assert restart_replay.json()["error"]["code"] == "idempotency_replay_unavailable"
         assert len(state.snapshot()) == provider_before_restart_replay
+        assert gateway_attempt_rows(gateway_database) == attempts_before_restart_replay
         error_bodies.append(restart_replay.text)
 
         cancellation_secondary = state.count_containing("gateway-secondary-model")
@@ -1687,6 +1987,11 @@ def _installed_release_driver() -> None:
         )
         opted_catalog_sha256 = json.loads(opted_policy.stdout)["data"]["catalog_sha256"]
         assert opted_catalog_sha256 != catalog_sha256
+        billing_after_pool_replace = frozen_billing_evidence(gateway_attempt_rows(gateway_database))
+        assert {
+            attempt_id: billing_after_pool_replace[attempt_id]
+            for attempt_id in frozen_before_restart
+        } == frozen_before_restart
         gateway_process, gateway_port, base_url = start_gateway(gateway_root)
         opted_secondary = state.count_containing("gateway-secondary-model")
         opted_refusal = httpx.post(
@@ -1731,6 +2036,7 @@ def _installed_release_driver() -> None:
         usage_json_body = usage_json_response.text
         usage_html_body = usage_html_response.text
         usage_payload = usage_json_response.json()
+        assert usage_payload["schema_version"] == 2
         identity_usage = usage_payload["identities"][0]
         assert usage_payload["totals"]["requests"] >= 14
         assert usage_payload["totals"]["attempts"] > usage_payload["totals"]["requests"]
@@ -1741,6 +2047,71 @@ def _installed_release_driver() -> None:
         assert terminal_counts["completed"] >= 10
         assert terminal_counts["failed"] >= 2
         assert terminal_counts["cancelled"] >= 1
+        attempt_rows = gateway_attempt_rows(gateway_database)
+        billing_sources = {str(row["billing_source"]) for row in attempt_rows}
+        assert billing_sources == {"customer_managed", "host_managed"}
+        assert (
+            sum(cast(int | None, row["input_tokens"]) or 0 for row in attempt_rows)
+            == (usage_payload["totals"]["input_tokens"])
+        )
+        assert (
+            sum(cast(int | None, row["cached_input_tokens"]) or 0 for row in attempt_rows)
+            == (usage_payload["totals"]["cached_input_tokens"])
+        )
+        assert (
+            sum(cast(int | None, row["output_tokens"]) or 0 for row in attempt_rows)
+            == (usage_payload["totals"]["output_tokens"])
+        )
+        assert (
+            sum(cast(int | None, row["reasoning_tokens"]) or 0 for row in attempt_rows)
+            == (usage_payload["totals"]["reasoning_tokens"])
+        )
+        assert (
+            sum(cast(int | None, row["estimated_cost_micro_usd"]) or 0 for row in attempt_rows)
+            == (usage_payload["totals"]["known_estimated_cost_micro_usd"])
+        )
+        assert (
+            sum(row["estimated_cost_micro_usd"] is None for row in attempt_rows)
+            == (usage_payload["totals"]["unknown_cost_attempts"])
+        )
+        source_buckets = usage_payload["by_billing_source"]
+        assert [bucket["billing_source"] for bucket in source_buckets] == [
+            "customer_managed",
+            "host_managed",
+        ]
+        for bucket in source_buckets:
+            billing_source = bucket["billing_source"]
+            source_rows = tuple(
+                row for row in attempt_rows if row["billing_source"] == billing_source
+            )
+            assert source_rows
+            assert all(row["state"] != "dispatched" for row in source_rows)
+            assert bucket["attempts"] == len(source_rows)
+            assert bucket["input_tokens"] == sum(
+                cast(int | None, row["input_tokens"]) or 0 for row in source_rows
+            )
+            assert bucket["cached_input_tokens"] == sum(
+                cast(int | None, row["cached_input_tokens"]) or 0 for row in source_rows
+            )
+            assert bucket["output_tokens"] == sum(
+                cast(int | None, row["output_tokens"]) or 0 for row in source_rows
+            )
+            assert bucket["reasoning_tokens"] == sum(
+                cast(int | None, row["reasoning_tokens"]) or 0 for row in source_rows
+            )
+            assert bucket["known_estimated_cost_micro_usd"] == sum(
+                cast(int | None, row["estimated_cost_micro_usd"]) or 0 for row in source_rows
+            )
+            assert bucket["unknown_cost_attempts"] == sum(
+                row["estimated_cost_micro_usd"] is None for row in source_rows
+            )
+            expected_source_terminals = {
+                state: sum(row["state"] == state for row in source_rows)
+                for state in sorted({str(row["state"]) for row in source_rows})
+            }
+            assert {
+                item["state"]: item["attempts"] for item in bucket["terminal_counts"]
+            } == expected_source_terminals
         expected_cells = (
             identity_usage["identity_id"],
             identity_usage["requests"],
@@ -1756,8 +2127,25 @@ def _installed_release_driver() -> None:
                 f"{item['state']}: {item['attempts']}" for item in identity_usage["terminal_counts"]
             ),
         )
+        expected_source_cells = tuple(
+            value
+            for bucket in source_buckets
+            for value in (
+                bucket["billing_source"],
+                bucket["attempts"],
+                bucket["input_tokens"],
+                bucket["cached_input_tokens"],
+                bucket["output_tokens"],
+                bucket["reasoning_tokens"],
+                bucket["known_estimated_cost_micro_usd"],
+                bucket["unknown_cost_attempts"],
+                ", ".join(
+                    f"{item['state']}: {item['attempts']}" for item in bucket["terminal_counts"]
+                ),
+            )
+        )
         assert tuple(re.findall(r"<td>(.*?)</td>", usage_html_body)) == tuple(
-            str(value) for value in expected_cells
+            str(value) for value in (*expected_cells, *expected_source_cells)
         )
 
         invalid_auth = httpx.get(
@@ -1795,6 +2183,158 @@ def _installed_release_driver() -> None:
         gateway_stdout, gateway_stderr = stop_gateway(gateway_process)
         gateway_stdout_parts.append(gateway_stdout)
         gateway_stderr_parts.append(gateway_stderr)
+
+    project_root = execution_root / "gateway-project"
+    project_manager = GatewayManagement(project_root)
+    project_manager.initialize()
+    for alias in ("cheap", "baseline"):
+        upsert_connection(
+            project_root,
+            name=f"project-{alias}",
+            connection=ConnectionConfig(
+                provider="openai-compatible",
+                base_url=provider_url,
+                api_key_env="P9_LOOPBACK_PROVIDER_KEY",
+            ),
+            replace=False,
+        )
+    project_catalog = None
+    for alias, provider_model, billing_source in (
+        ("cheap", "project-primary-model", BillingSource.HOST_MANAGED),
+        ("baseline", "project-secondary-model", BillingSource.CUSTOMER_MANAGED),
+    ):
+        project_catalog, _snapshot, _changed = upsert_singleton_deployment(
+            project_root,
+            deployment_alias=alias,
+            connection_name=f"project-{alias}",
+            provider_model=provider_model,
+            exact_model_id="project-exact-model",
+            revision=None,
+            capabilities=ModelCapabilities(),
+            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=1_000_000,
+                output_micro_usd_per_million_tokens=2_000_000,
+            ),
+            pricing_source="installed project fixture",
+            billing_source=billing_source,
+            replace=False,
+        )
+    assert project_catalog is not None
+    project_catalog, project_snapshot, _changed = upsert_certified_pool(
+        project_root,
+        pool_id="project-pool",
+        exact_model_id="project-exact-model",
+        deployment_aliases=("cheap", "baseline"),
+        certification=GatewayEquivalenceCertification(
+            certification_id="installed-project-certification",
+            provenance="installed deterministic exact-model fixture",
+            evidence_sha256="c" * 64,
+            certified_at=datetime(2026, 8, 19, tzinfo=UTC),
+        ),
+        expected_catalog_sha256=project_catalog.identity_sha256(),
+        replace=False,
+    )
+    project_manager.activate_project_alias(
+        alias_id="project-coding",
+        alias_name="project-coding",
+        revision_id="installed-project-revision",
+        project_ref="installed-project",
+        activation_ref="installed-project-policy",
+        snapshot_ref=f"catalog-snapshots/{project_snapshot.name}",
+        catalog_sha256=project_catalog.identity_sha256(),
+    )
+    project_manager.create_identity(identity_id="project-identity", display_name="Project")
+    project_manager.add_grant(identity_id="project-identity", alias_id="project-coding")
+    project_key = project_manager.issue_key(
+        identity_id="project-identity",
+        key_id="project-key",
+    ).raw_key
+    learned_runtime, learned_client = installed_project_runtime()
+
+    def load_installed_project(
+        project: str,
+        root: Path,
+        *,
+        policy_id: str,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> RouterRuntime:
+        """Inject one real installed selection runtime without project completion."""
+        del root, runtime_catalog
+        assert project == "installed-project"
+        assert policy_id == "installed-project-policy"
+        return learned_runtime
+
+    project_provider_before_load = state.snapshot()
+    project_primary_before = state.count_containing("project-primary-model")
+    project_secondary_before = state.count_containing("project-secondary-model")
+    installed_project_gateway = load_local_gateway(
+        project_root,
+        graceful_timeout_seconds=2,
+        environment={"P9_LOOPBACK_PROVIDER_KEY": provider_secret},
+        project_loader=load_installed_project,
+    )
+    assert state.snapshot() == project_provider_before_load
+    project_port = unused_loopback_port()
+    project_server = uvicorn.Server(
+        uvicorn.Config(
+            installed_project_gateway.app,
+            host="127.0.0.1",
+            port=project_port,
+            log_level="critical",
+            access_log=False,
+        )
+    )
+    project_thread = threading.Thread(target=project_server.run, daemon=True)
+    project_thread.start()
+    project_deadline = time.monotonic() + 20
+    while not project_server.started and time.monotonic() < project_deadline:
+        time.sleep(0.01)
+    assert project_server.started
+    assert state.snapshot() == project_provider_before_load
+    try:
+        with OpenAI(
+            api_key=project_key,
+            base_url=f"http://127.0.0.1:{project_port}/v1",
+            timeout=10,
+        ) as client:
+            project_response = client.chat.completions.create(
+                model="project-coding",
+                messages=[{"role": "user", "content": project_prompt_canary}],
+            )
+        assert project_response.choices[0].message.content == project_response_canary
+    finally:
+        project_server.should_exit = True
+        project_thread.join(timeout=10)
+    assert not project_thread.is_alive()
+    assert state.count_containing("project-primary-model") == project_primary_before + 2
+    assert state.count_containing("project-secondary-model") == project_secondary_before + 1
+    assert learned_client.embed_calls == 1
+    assert learned_client.complete_calls == 0
+    assert learned_runtime.records_decisions is False
+    assert not (project_root / "projects").exists()
+    with sqlite3.connect(project_manager.database_path) as connection:
+        project_attempts = connection.execute(
+            """
+            SELECT attempt_ordinal, route_depth, exact_model_id, billing_source, state
+            FROM gateway_attempts ORDER BY attempt_ordinal
+            """
+        ).fetchall()
+    assert project_attempts == [
+        (0, 0, "project-exact-model", "host_managed", "failed"),
+        (1, 0, "project-exact-model", "host_managed", "failed"),
+        (2, 1, "project-exact-model", "customer_managed", "completed"),
+    ]
+    _assert_gateway_canaries_absent(
+        project_root,
+        channels={},
+        canaries=(
+            project_key,
+            provider_secret,
+            project_prompt_canary,
+            project_response_canary,
+        ),
+    )
     gateway_stdout = "".join(gateway_stdout_parts)
     gateway_stderr = "".join(gateway_stderr_parts)
     assert (gateway_root / "gateway" / "gateway.db").is_file()
@@ -2434,6 +2974,7 @@ def _installed_release_driver() -> None:
                 for input_item in manifest.inputs:
                     input_manifest = project_store.artifacts.read(input_item.artifact_id).manifest
                     assert artifact_input(input_manifest) == input_item
+        assert_key_and_canaries_confined()
     finally:
         server.shutdown()
         server.server_close()
@@ -2672,6 +3213,8 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
     assert "wmo config gateway pool certify" in usage
     assert "wmo run --root ROOT" in usage
     assert "OpenAI `3.0.0`" in usage
+    assert "schema-v2" in usage
+    assert "by_billing_source" in usage
     assert "wmo optimize route" not in usage.replace("wmo optimize router", "")
 
     scope = (docs / "release-scope.md").read_text(encoding="utf-8")
@@ -2691,6 +3234,8 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
     assert "POST /v1/chat/completions" in architecture
     assert "POST /v1/responses" in architecture
     assert "provider_certification.py" in architecture
+    assert "schema-v2" in architecture
+    assert "by_billing_source" in architecture
     assert "inert contracts" not in architecture
     assert "does not claim that a gateway server" not in architecture
 

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -463,7 +463,6 @@ def _installed_release_driver() -> None:
         BillingSource,
         ConnectionConfig,
         Embedding,
-        EmbeddingCostReservation,
         GatewayDeploymentCapabilities,
         GatewayEquivalenceCertification,
         GatewayTokenPrices,
@@ -472,7 +471,6 @@ def _installed_release_driver() -> None:
         ModelResponse,
         ModelSnapshot,
         RoutedCandidateSnapshot,
-        load_model_catalog,
     )
     from wmo.common.project import ProjectStore, artifact_input
     from wmo.common.routing import KnnGuard, KnnRouterPolicy
@@ -483,13 +481,6 @@ def _installed_release_driver() -> None:
         bank_bytes,
     )
     from wmo.common.routing.features import ROUTER_FEATURE_SCHEMA_SHA256
-    from wmo.optimize.model.sft import (
-        RuntimeInteractionExampleSource,
-        load_sft_model_optimization_config,
-        load_verified_sft_dataset,
-        prepare_runtime_sft_model_optimization,
-    )
-    from wmo.optimize.model.sft.selection import load_latest_sft_model_optimization
     from wmo.optimize.router.judging.contracts import ManualJudgeTraceReviewArtifact
     from wmo.optimize.router.judging.service import prepare_manual_judge_calibration
     from wmo.runtime.gateway.catalog_authority import (
@@ -500,22 +491,11 @@ def _installed_release_driver() -> None:
     from wmo.runtime.gateway.lifecycle import load_local_gateway
     from wmo.runtime.gateway.management import GatewayManagement
     from wmo.runtime.models import (
-        CapabilityRequirement,
         CatalogRoleName,
         ResolvedModel,
         RuntimeModelCatalog,
     )
-    from wmo.runtime.router import (
-        RouterRuntime,
-        RuntimeAcceptedEvent,
-        RuntimeCompletedEvent,
-        RuntimeInteractionJournal,
-    )
-    from wmo.simulation.retrieval import (
-        RAGEmbedderBinding,
-        load_completed_build_rag_lineage_bindings,
-        refresh_runtime_trace_rag,
-    )
+    from wmo.runtime.router import RouterRuntime, RuntimeInteractionJournal
 
     release_revision = os.environ["WMO_RELEASE_REVISION"]
     assert re.fullmatch(r"[0-9a-f]{40}", release_revision), release_revision
@@ -2725,6 +2705,7 @@ def _installed_release_driver() -> None:
                 messages=[{"role": "user", "content": "Durable keyed request"}],
                 extra_headers={"Idempotency-Key": "p17-durable-request"},
             )
+            assert keyed_chat.id
             client.close()
         finally:
             router_process.terminate()
@@ -2736,17 +2717,33 @@ def _installed_release_driver() -> None:
         journal = RuntimeInteractionJournal(support_store.paths)
         events_before_public_replay = journal.read_events()
         provider_before_public_replay = state.snapshot()
+        gateway_database = root / "gateway" / "gateway.db"
+        artifacts_before_public_replay = directory_digest(support_store.paths.artifacts_directory)
+        project_before_public_replay = support_store.paths.project_toml.read_bytes()
+        with sqlite3.connect(gateway_database) as connection:
+            gateway_requests_before_public_replay = connection.execute(
+                "SELECT COUNT(*) FROM gateway_requests"
+            ).fetchone()[0]
+            gateway_attempts_before_public_replay = connection.execute(
+                "SELECT COUNT(*) FROM gateway_attempts"
+            ).fetchone()[0]
         with wmo.load_router(
             "support-agent",
             root=root,
             environment={"AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder"},
         ) as loaded_router:
-            replayed_chat = loaded_router.chat.completions.create(
-                model="support-agent",
-                messages=[{"role": "user", "content": "Durable keyed request"}],
-                extra_headers={"Idempotency-Key": "p17-durable-request"},
-            )
-            assert replayed_chat.id == keyed_chat.id
+            try:
+                loaded_router.chat.completions.create(
+                    model="support-agent",
+                    messages=[{"role": "user", "content": "Durable keyed request"}],
+                    extra_headers={"Idempotency-Key": "p17-durable-request"},
+                )
+            except openai.ConflictError as error:
+                assert error.status_code == 409
+                assert "idempotency_replay_unavailable" in str(error)
+            else:
+                raise AssertionError("restarted project gateway replay must fail closed")
+            assert state.snapshot() == provider_before_public_replay
             public_response = loaded_router.responses.create(
                 model="support-agent",
                 input="Programmatic router response",
@@ -2762,212 +2759,21 @@ def _installed_release_driver() -> None:
             )
             assert duplicate_first.choices[0].message.content == "Duplicate routed target"
             assert duplicate_second.choices[0].message.content == "Duplicate routed target"
-        events = journal.read_events()
+        assert journal.read_events() == events_before_public_replay
         assert state.snapshot() != provider_before_public_replay
-        accepted = tuple(event for event in events if isinstance(event, RuntimeAcceptedEvent))
-        completed = tuple(event for event in events if isinstance(event, RuntimeCompletedEvent))
-        prior_completed = tuple(
-            event
-            for event in events_before_public_replay
-            if isinstance(event, RuntimeCompletedEvent)
+        assert support_store.paths.project_toml.read_bytes() == project_before_public_replay
+        assert directory_digest(support_store.paths.artifacts_directory) == (
+            artifacts_before_public_replay
         )
-        assert len(completed) == len(prior_completed) + 3
-        assert len({event.interaction_id for event in completed}) == len(completed)
-        assert accepted[1].identity.lineage_id == accepted[2].identity.lineage_id
-        assert accepted[1].acceptance.selected_alias == accepted[2].acceptance.selected_alias
-        current_project = support_store.load_project()
-        assert current_project.build is not None
-        assert current_project.models is not None
-        completed_build = current_project.build
-        completed_build_digests = {
-            pointer.artifact_id: directory_digest(
-                support_store.paths.artifacts_directory / pointer.artifact_id
-            )
-            for pointer in (
-                completed_build.trace_dataset,
-                completed_build.task_set,
-                completed_build.serving_rag,
-                completed_build.fit_rag,
-                completed_build.world_model,
-            )
-        }
-        imported_bindings = load_completed_build_rag_lineage_bindings(
-            support_store.artifacts,
-            completed_build,
-        )
-        assert {binding.trace_id for binding in imported_bindings} == set(support_trace_ids)
-        catalog = load_model_catalog(root / "models.toml")
-        resolved_embedder = RuntimeModelCatalog(
-            catalog,
-            environment={"AZURE_OPENAI_API_KEY": "deterministic-loopback-placeholder"},
-        ).preflight(
-            current_project.models.embedder,
-            CapabilityRequirement(requires_embeddings=True),
-        )
-        assert resolved_embedder.embedding_client is not None
-        embedding_price = resolved_embedder.capabilities.input_cost_per_million_tokens_usd
-        assert embedding_price == 0
-        embedding_binding = RAGEmbedderBinding(
-            client=resolved_embedder.embedding_client,
-            snapshot=resolved_embedder.snapshot,
-            maximum_attempts=3,
-            input_usd_per_million_tokens=embedding_price,
-        )
-        embedding_reservation = EmbeddingCostReservation(
-            model=resolved_embedder.snapshot,
-            input_usd_per_million_tokens=embedding_price,
-            maximum_attempts=embedding_binding.maximum_attempts,
-            maximum_input_tokens=1_000_000,
-        )
-        refresh_time = datetime.now(UTC)
-        provider_before_refresh = state.snapshot()
-        refresh = refresh_runtime_trace_rag(
-            journal,
-            support_store.artifacts,
-            (completed_build.trace_dataset,),
-            imported_bindings,
-            embedder=embedding_binding,
-            embedding_reservation=embedding_reservation,
-            maximum_embedding_cost_usd=0,
-            created_at=refresh_time,
-            code_revision=release_revision,
-        )
-        provider_after_refresh = state.snapshot()
-        assert len(provider_after_refresh) > len(provider_before_refresh)
-        assert all(
-            request["path"] == provider_embeddings_path
-            for request in provider_after_refresh[len(provider_before_refresh) :]
-        )
-        assert refresh.snapshot_export.snapshot.completed_target_count == len(completed)
-        assert refresh.retrieval.index.rag_id not in {
-            completed_build.serving_rag.artifact_id,
-            completed_build.fit_rag.artifact_id,
-        }
-        assert refresh.dataset.dataset.dataset_id != completed_build.trace_dataset.artifact_id
-        response_acceptances = tuple(
-            event
-            for event in accepted
-            if event.identity.lineage_id == accepted[1].identity.lineage_id
-        )
-        assert len(response_acceptances) == 2
-        observed_response = response_acceptances[0]
-        terminal_response = response_acceptances[1]
-        tool_transitions = tuple(
-            transition
-            for transition in refresh.retrieval.transitions
-            if transition.trace_id == observed_response.interaction_id
-            and transition.action.kind == "tool_call"
-            and transition.observation.kind == "tool_result"
-        )
-        assert len(tool_transitions) == 1
-        assert tool_transitions[0].action.tool_name == "lookup_ticket"
-        assert tool_transitions[0].observation.content == "Ticket 42 is ready for reset."
-        assert terminal_response.interaction_id not in {
-            transition.trace_id for transition in refresh.retrieval.transitions
-        }
-        refresh_payload = json.dumps(
-            [trace.model_dump(mode="json") for trace in refresh.dataset.traces],
-            sort_keys=True,
-        )
-        assert "P17 generated world observation" not in refresh_payload
-        assert support_store.load_project().build == completed_build
-        assert {
-            artifact_id: directory_digest(support_store.paths.artifacts_directory / artifact_id)
-            for artifact_id in completed_build_digests
-        } == completed_build_digests
-        replayed_refresh = refresh_runtime_trace_rag(
-            journal,
-            support_store.artifacts,
-            (completed_build.trace_dataset,),
-            imported_bindings,
-            embedder=embedding_binding,
-            embedding_reservation=embedding_reservation,
-            maximum_embedding_cost_usd=0,
-            created_at=refresh_time,
-            code_revision=release_revision,
-        )
-        assert replayed_refresh.refresh.refresh_id == refresh.refresh.refresh_id
-        assert replayed_refresh.retrieval.index.rag_id == refresh.retrieval.index.rag_id
-        assert state.snapshot() == provider_after_refresh
-        provider_before_model_optimization = state.snapshot()
-        budget_result = run_cli("config", "budget", "1", "--root", str(root))
-        assert "maximum command cost: $1.00" in budget_result.stdout
-        training_price = 750_000 / (len(completed) * 4_096)
-        model_optimization_output = run_tty(
-            [
-                "optimize",
-                "model",
-                "support-agent",
-                "--root",
-                str(root),
-                "--tinker-connection",
-                "tinker-local",
-                "--tinker-api-key-env",
-                "P17_MISSING_TINKER_KEY",
-                "--base-model-alias",
-                "tinker-base",
-                "--base-model",
-                "fake-base-model",
-                "--maximum-cost-usd",
-                "1",
-                "--training-usd-per-million-tokens",
-                str(training_price),
-            ],
-            [
-                ("Use Tinker connection 'tinker-local'", "y"),
-                ("Authorize wmo optimize model support-agent to spend up to", "n"),
-            ],
-            completion_marker="Managed Tinker SFT was not started.",
-        )
-        assert "Managed Tinker SFT was not started." in model_optimization_output
-        assert state.snapshot() == provider_before_model_optimization
-        assert "P17_MISSING_TINKER_KEY" not in child_environment
-        latest = load_latest_sft_model_optimization(support_store)
-        assert latest is not None
-        config = load_sft_model_optimization_config(
-            support_store,
-            latest.config.artifact_id,
-        )
-        dataset = load_verified_sft_dataset(support_store, latest.dataset.artifact_id)
-        assert config.dataset == latest.dataset
-        assert dataset.build_spec is not None
-        assert dataset.build_spec.held_out_fraction == 0
-        assert dataset.rows
-        assert all(row.partition == "train" for row in dataset.rows)
-        runtime_rows = tuple(
-            row
-            for row in dataset.rows
-            if isinstance(row.example.source, RuntimeInteractionExampleSource)
-        )
-        assert len(runtime_rows) == len(completed)
-        assert {
-            cast(RuntimeInteractionExampleSource, row.example.source).interaction_id
-            for row in runtime_rows
-        } == {event.interaction_id for event in completed}
-        duplicate_rows = tuple(
-            row for row in runtime_rows if row.example.target.content == "Duplicate routed target"
-        )
-        assert len(duplicate_rows) == 2
-        assert len({row.example.example_id for row in duplicate_rows}) == 2
-        assert len({row.fingerprint for row in duplicate_rows}) == 1
-        duplicate_groups = {row.example.leakage_group_id for row in duplicate_rows}
-        assert len(duplicate_groups) == 2
-        assert any(
-            duplicate_groups.issubset(set(partition.leakage_group_ids))
-            for partition in dataset.partitions
-        )
-        assert any(row.example.target.tool_calls for row in runtime_rows)
-        assert "P17 generated world observation" not in json.dumps(
-            [row.model_dump(mode="json") for row in dataset.rows],
-            sort_keys=True,
-        )
-        replayed_preparation = prepare_runtime_sft_model_optimization(
-            support_store,
-            created_at=dataset.dataset.created_at,
-            code_revision=release_revision,
-        )
-        assert replayed_preparation.created is False
-        assert replayed_preparation.dataset.dataset.dataset_id == dataset.dataset.dataset_id
+        with sqlite3.connect(gateway_database) as connection:
+            gateway_requests_after_public_replay = connection.execute(
+                "SELECT COUNT(*) FROM gateway_requests"
+            ).fetchone()[0]
+            gateway_attempts_after_public_replay = connection.execute(
+                "SELECT COUNT(*) FROM gateway_attempts"
+            ).fetchone()[0]
+        assert gateway_requests_after_public_replay == gateway_requests_before_public_replay + 3
+        assert gateway_attempts_after_public_replay == gateway_attempts_before_public_replay + 3
         one_result = run_cli(
             "build",
             "one-trace",

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -221,14 +221,15 @@ class GatewayExecutionStream:
                 and self._refusal_failover
                 and not self._committed
             ):
-                current.withheld_refusals.append(event)
-                current.withheld_refusal_bytes += len((event.text_delta or "").encode("utf-8"))
+                event_bytes = len((event.text_delta or "").encode("utf-8"))
                 if (
-                    current.withheld_refusal_bytes > _MAX_WITHHELD_REFUSAL_BYTES
-                    or len(current.withheld_refusals) > _MAX_WITHHELD_REFUSAL_EVENTS
+                    current.withheld_refusal_bytes + event_bytes > _MAX_WITHHELD_REFUSAL_BYTES
+                    or len(current.withheld_refusals) + 1 > _MAX_WITHHELD_REFUSAL_EVENTS
                 ):
-                    self._commit_withheld_refusal(current)
+                    self._commit_withheld_refusal(current, event)
                     return self._outward(self._pending_outward.popleft())
+                current.withheld_refusals.append(event)
+                current.withheld_refusal_bytes += event_bytes
                 continue
             if current.withheld_refusals and event.kind in _SEMANTIC_EVENTS:
                 self._commit_withheld_refusal(current, event)

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -242,6 +242,7 @@ class GatewayExecutionStream:
                     return self._outward(event)
                 continue
             terminal = _with_latest_usage(event, current.latest_usage)
+            withheld_non_refusal_failure = False
             typed_refusal = (
                 terminal.kind == GatewayEventKind.FAILED
                 and terminal.failure is not None
@@ -264,19 +265,7 @@ class GatewayExecutionStream:
                     usage=terminal.usage,
                 )
             elif current.withheld_refusals:
-                failure = terminal.failure or GatewayFailure(
-                    failure_class=GatewayFailureClass.INTERNAL,
-                    safe_message="provider execution failed",
-                )
-                self._health.failed(self._health_key(current.route_index), failure)
-                await self._finish_current(
-                    terminal=terminal,
-                    failure=failure,
-                    finalize_request=True,
-                )
-                self._settle()
-                self._commit_withheld_refusal(current, terminal)
-                return self._outward(self._pending_outward.popleft())
+                withheld_non_refusal_failure = True
             if terminal.kind != GatewayEventKind.FAILED:
                 self._health.succeeded(self._health_key(current.route_index))
                 await self._finish_current(terminal=terminal, failure=None, finalize_request=True)
@@ -295,7 +284,13 @@ class GatewayExecutionStream:
                     finalize_request=True,
                 )
                 self._settle()
+                if withheld_non_refusal_failure:
+                    self._commit_withheld_refusal(current, terminal)
+                    return self._outward(self._pending_outward.popleft())
                 return self._outward(terminal)
+            if withheld_non_refusal_failure:
+                current.withheld_refusals.clear()
+                current.withheld_refusal_bytes = 0
             await self._finish_current(
                 terminal=terminal,
                 failure=failure,

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -85,6 +85,7 @@ class _PhysicalAttempt:
     last_provider_sequence: int = -1
     withheld_refusals: list[GatewayEvent] = field(default_factory=list)
     withheld_refusal_bytes: int = 0
+    visible_refusal: bool = False
     settled: bool = False
 
 
@@ -235,6 +236,8 @@ class GatewayExecutionStream:
                 self._commit_withheld_refusal(current, event)
                 return self._outward(self._pending_outward.popleft())
             if event.kind in _SEMANTIC_EVENTS:
+                if event.kind == GatewayEventKind.REFUSAL_DELTA:
+                    current.visible_refusal = True
                 self._committed = True
                 return self._outward(event)
             if event.kind not in _TERMINAL_EVENTS:
@@ -287,6 +290,14 @@ class GatewayExecutionStream:
                 if withheld_non_refusal_failure:
                     self._commit_withheld_refusal(current, terminal)
                     return self._outward(self._pending_outward.popleft())
+                if typed_refusal and current.visible_refusal:
+                    return self._outward(
+                        GatewayEvent(
+                            kind=GatewayEventKind.COMPLETED,
+                            sequence_number=terminal.sequence_number,
+                            usage=terminal.usage,
+                        )
+                    )
                 return self._outward(terminal)
             if withheld_non_refusal_failure:
                 current.withheld_refusals.clear()
@@ -572,6 +583,7 @@ class GatewayExecutionStream:
             *following: Semantic or terminal events that arrived after the refusal.
         """
         self._committed = True
+        current.visible_refusal = True
         self._pending_outward.extend(current.withheld_refusals)
         self._pending_outward.extend(following)
         current.withheld_refusals.clear()

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from collections.abc import AsyncIterator, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import cast
 
 from wmo.common.core.artifacts import stable_id
@@ -48,6 +49,8 @@ _TERMINAL_EVENTS = {
     GatewayEventKind.INCOMPLETE,
     GatewayEventKind.FAILED,
 }
+_MAX_WITHHELD_REFUSAL_BYTES = 65_536
+_MAX_WITHHELD_REFUSAL_EVENTS = 256
 
 
 class GatewayExecutionError(RuntimeError):
@@ -80,6 +83,8 @@ class _PhysicalAttempt:
     iterator: AsyncIterator[GatewayEvent] | None = None
     latest_usage: GatewayUsage | None = None
     last_provider_sequence: int = -1
+    withheld_refusals: list[GatewayEvent] = field(default_factory=list)
+    withheld_refusal_bytes: int = 0
     settled: bool = False
 
 
@@ -134,6 +139,7 @@ class GatewayExecutionStream:
         self._settled = False
         self._parent_finalized = False
         self._next_sequence = 0
+        self._pending_outward: deque[GatewayEvent] = deque()
         self._settlement_lock = asyncio.Lock()
 
     @property
@@ -167,6 +173,8 @@ class GatewayExecutionStream:
 
     async def __anext__(self) -> GatewayEvent:
         """Yield one logical event, advancing routes only before semantic commitment."""
+        if self._pending_outward:
+            return self._outward(self._pending_outward.popleft())
         if self._settled:
             raise StopAsyncIteration
         while True:
@@ -208,6 +216,23 @@ class GatewayExecutionStream:
             current.last_provider_sequence = event.sequence_number
             if event.usage is not None:
                 current.latest_usage = event.usage
+            if (
+                event.kind == GatewayEventKind.REFUSAL_DELTA
+                and self._refusal_failover
+                and not self._committed
+            ):
+                current.withheld_refusals.append(event)
+                current.withheld_refusal_bytes += len((event.text_delta or "").encode("utf-8"))
+                if (
+                    current.withheld_refusal_bytes > _MAX_WITHHELD_REFUSAL_BYTES
+                    or len(current.withheld_refusals) > _MAX_WITHHELD_REFUSAL_EVENTS
+                ):
+                    self._commit_withheld_refusal(current)
+                    return self._outward(self._pending_outward.popleft())
+                continue
+            if current.withheld_refusals and event.kind in _SEMANTIC_EVENTS:
+                self._commit_withheld_refusal(current, event)
+                return self._outward(self._pending_outward.popleft())
             if event.kind in _SEMANTIC_EVENTS:
                 self._committed = True
                 return self._outward(event)
@@ -216,6 +241,41 @@ class GatewayExecutionStream:
                     return self._outward(event)
                 continue
             terminal = _with_latest_usage(event, current.latest_usage)
+            typed_refusal = (
+                terminal.kind == GatewayEventKind.FAILED
+                and terminal.failure is not None
+                and terminal.failure.failure_class == GatewayFailureClass.REFUSAL
+            )
+            if current.withheld_refusals and typed_refusal:
+                current.withheld_refusals.clear()
+                current.withheld_refusal_bytes = 0
+            elif current.withheld_refusals and terminal.kind != GatewayEventKind.FAILED:
+                current.withheld_refusals.clear()
+                current.withheld_refusal_bytes = 0
+                terminal = GatewayEvent(
+                    kind=GatewayEventKind.FAILED,
+                    sequence_number=terminal.sequence_number,
+                    failure=GatewayFailure(
+                        failure_class=GatewayFailureClass.REFUSAL,
+                        safe_message="provider refused the request",
+                        safe_details={"signal": "provider_refusal"},
+                    ),
+                    usage=terminal.usage,
+                )
+            elif current.withheld_refusals:
+                failure = terminal.failure or GatewayFailure(
+                    failure_class=GatewayFailureClass.INTERNAL,
+                    safe_message="provider execution failed",
+                )
+                self._health.failed(self._health_key(current.route_index), failure)
+                await self._finish_current(
+                    terminal=terminal,
+                    failure=failure,
+                    finalize_request=True,
+                )
+                self._settle()
+                self._commit_withheld_refusal(current, terminal)
+                return self._outward(self._pending_outward.popleft())
             if terminal.kind != GatewayEventKind.FAILED:
                 self._health.succeeded(self._health_key(current.route_index))
                 await self._finish_current(terminal=terminal, failure=None, finalize_request=True)
@@ -503,6 +563,23 @@ class GatewayExecutionStream:
         outward = event.model_copy(update={"sequence_number": self._next_sequence})
         self._next_sequence += 1
         return outward
+
+    def _commit_withheld_refusal(
+        self,
+        current: _PhysicalAttempt,
+        *following: GatewayEvent,
+    ) -> None:
+        """Flush bounded refusal output and permanently freeze the active route.
+
+        Args:
+            current: Physical attempt holding in-memory refusal deltas.
+            *following: Semantic or terminal events that arrived after the refusal.
+        """
+        self._committed = True
+        self._pending_outward.extend(current.withheld_refusals)
+        self._pending_outward.extend(following)
+        current.withheld_refusals.clear()
+        current.withheld_refusal_bytes = 0
 
     def _require_current(self) -> _PhysicalAttempt:
         """Return the active or terminal attempt after successful stream opening."""

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from wmo.common.core.artifacts import ContractModel
-from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.common.models.gateway_catalog import BillingSource, ExactModelDeployment
 from wmo.runtime.gateway.auth import utc_text
 from wmo.runtime.gateway.contracts import (
     AttemptId,
@@ -62,6 +62,27 @@ class IdentityUsage(ContractModel):
     total_latency_ms: int
     average_latency_ms: float | None
     terminal_counts: tuple[UsageTerminalCount, ...]
+
+
+class BillingSourceUsage(ContractModel):
+    """Content-free physical-attempt totals for one credential ownership source."""
+
+    billing_source: BillingSource
+    attempts: int
+    input_tokens: int
+    cached_input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int
+    known_estimated_cost_micro_usd: int
+    unknown_cost_attempts: int
+    terminal_counts: tuple[UsageTerminalCount, ...]
+
+
+class LedgerUsageSnapshot(ContractModel):
+    """One SQLite read snapshot containing identity and billing-source aggregates."""
+
+    identities: tuple[IdentityUsage, ...]
+    by_billing_source: tuple[BillingSourceUsage, ...]
 
 
 class SQLiteAttemptLedger:
@@ -461,58 +482,129 @@ class SQLiteAttemptLedger:
         Returns:
             Stable identity usage rows without prompts or outputs.
         """
+        return self.usage_snapshot(
+            organization_id=organization_id,
+            identity_id=identity_id,
+        ).identities
+
+    def usage_by_billing_source(
+        self,
+        *,
+        organization_id: str,
+        identity_id: str | None = None,
+    ) -> tuple[BillingSourceUsage, ...]:
+        """Aggregate physical attempts by their frozen credential ownership source.
+
+        Args:
+            organization_id: Tenant boundary.
+            identity_id: Optional identity filter applied through the parent request.
+
+        Returns:
+            Deterministic source buckets without partitioning logical request counts.
+        """
+        return self.usage_snapshot(
+            organization_id=organization_id,
+            identity_id=identity_id,
+        ).by_billing_source
+
+    def usage_snapshot(
+        self,
+        *,
+        organization_id: str,
+        identity_id: str | None = None,
+    ) -> LedgerUsageSnapshot:
+        """Read identity and source aggregates from one explicit SQLite snapshot.
+
+        Args:
+            organization_id: Tenant boundary.
+            identity_id: Optional exact identity filter.
+
+        Returns:
+            Internally conserving usage aggregates from one WAL read transaction.
+        """
         parameters: tuple[str, ...]
         predicate = "i.organization_id = ?"
+        source_predicate = "r.organization_id = ?"
         if identity_id is None:
             parameters = (organization_id,)
         else:
             predicate += " AND i.identity_id = ?"
+            source_predicate += " AND r.identity_id = ?"
             parameters = (organization_id, identity_id)
         with self._connect() as connection:
-            rows = connection.execute(
-                f"""
-                SELECT i.identity_id,
-                       COUNT(DISTINCT r.request_id) AS requests,
-                       COUNT(a.attempt_id) AS attempts,
-                       COALESCE(SUM(a.input_tokens), 0) AS input_tokens,
-                       COALESCE(SUM(a.cached_input_tokens), 0) AS cached_input_tokens,
-                       COALESCE(SUM(a.output_tokens), 0) AS output_tokens,
-                       COALESCE(SUM(a.reasoning_tokens), 0) AS reasoning_tokens,
-                       COALESCE(SUM(a.estimated_cost_micro_usd), 0) AS known_cost,
-                       COALESCE(SUM(CASE
-                           WHEN a.attempt_id IS NOT NULL
-                            AND a.estimated_cost_micro_usd IS NULL THEN 1 ELSE 0 END), 0
-                       ) AS unknown_cost_attempts,
-                       COALESCE(SUM(CASE WHEN a.terminal_at IS NOT NULL THEN
-                           ROUND((julianday(a.terminal_at) - julianday(a.started_at)) * 86400000)
-                           ELSE 0 END), 0) AS total_latency_ms,
-                       AVG(CASE WHEN a.terminal_at IS NOT NULL THEN
-                           (julianday(a.terminal_at) - julianday(a.started_at)) * 86400000
-                           ELSE NULL END) AS average_latency_ms
-                FROM identities AS i
-                LEFT JOIN gateway_requests AS r
-                  ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
-                LEFT JOIN gateway_attempts AS a ON a.request_id = r.request_id
-                WHERE {predicate}
-                GROUP BY i.identity_id ORDER BY i.identity_id
-                """,
-                parameters,
-            ).fetchall()
-            terminal_rows = connection.execute(
-                f"""
-                SELECT i.identity_id, a.state, COUNT(*) AS attempts
-                FROM identities AS i
-                JOIN gateway_requests AS r
-                  ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
-                JOIN gateway_attempts AS a ON a.request_id = r.request_id
-                WHERE {predicate} AND a.state != 'dispatched'
-                GROUP BY i.identity_id, a.state ORDER BY i.identity_id, a.state
-                """,
-                parameters,
-            ).fetchall()
-        terminal_by_identity: dict[str, list[UsageTerminalCount]] = {}
+            connection.execute("BEGIN")
+            try:
+                identities = self._identity_usage_rows(
+                    connection,
+                    organization_id=organization_id,
+                    predicate=predicate,
+                    parameters=parameters,
+                )
+                by_billing_source = self._billing_source_usage_rows(
+                    connection,
+                    predicate=source_predicate,
+                    parameters=parameters,
+                )
+            finally:
+                connection.rollback()
+        return LedgerUsageSnapshot(
+            identities=identities,
+            by_billing_source=by_billing_source,
+        )
+
+    def _identity_usage_rows(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        organization_id: str,
+        predicate: str,
+        parameters: tuple[str, ...],
+    ) -> tuple[IdentityUsage, ...]:
+        """Read bounded identity aggregates inside the caller's SQLite snapshot."""
+        rows = connection.execute(
+            f"""
+            SELECT i.identity_id,
+                   COUNT(DISTINCT r.request_id) AS requests,
+                   COUNT(a.attempt_id) AS attempts,
+                   COALESCE(SUM(a.input_tokens), 0) AS input_tokens,
+                   COALESCE(SUM(a.cached_input_tokens), 0) AS cached_input_tokens,
+                   COALESCE(SUM(a.output_tokens), 0) AS output_tokens,
+                   COALESCE(SUM(a.reasoning_tokens), 0) AS reasoning_tokens,
+                   COALESCE(SUM(a.estimated_cost_micro_usd), 0) AS known_cost,
+                   COALESCE(SUM(CASE
+                       WHEN a.attempt_id IS NOT NULL
+                        AND a.estimated_cost_micro_usd IS NULL THEN 1 ELSE 0 END), 0
+                   ) AS unknown_cost_attempts,
+                   COALESCE(SUM(CASE WHEN a.terminal_at IS NOT NULL THEN
+                       ROUND((julianday(a.terminal_at) - julianday(a.started_at)) * 86400000)
+                       ELSE 0 END), 0) AS total_latency_ms,
+                   AVG(CASE WHEN a.terminal_at IS NOT NULL THEN
+                       (julianday(a.terminal_at) - julianday(a.started_at)) * 86400000
+                       ELSE NULL END) AS average_latency_ms
+            FROM identities AS i
+            LEFT JOIN gateway_requests AS r
+              ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
+            LEFT JOIN gateway_attempts AS a ON a.request_id = r.request_id
+            WHERE {predicate}
+            GROUP BY i.identity_id ORDER BY i.identity_id
+            """,
+            parameters,
+        ).fetchall()
+        terminal_rows = connection.execute(
+            f"""
+            SELECT i.identity_id, a.state, COUNT(*) AS attempts
+            FROM identities AS i
+            JOIN gateway_requests AS r
+              ON r.organization_id = i.organization_id AND r.identity_id = i.identity_id
+            JOIN gateway_attempts AS a ON a.request_id = r.request_id
+            WHERE {predicate} AND a.state != 'dispatched'
+            GROUP BY i.identity_id, a.state ORDER BY i.identity_id, a.state
+            """,
+            parameters,
+        ).fetchall()
+        terminals: dict[str, list[UsageTerminalCount]] = {}
         for row in terminal_rows:
-            terminal_by_identity.setdefault(str(row["identity_id"]), []).append(
+            terminals.setdefault(str(row["identity_id"]), []).append(
                 UsageTerminalCount(state=str(row["state"]), attempts=int(row["attempts"]))
             )
         return tuple(
@@ -531,7 +623,64 @@ class SQLiteAttemptLedger:
                 average_latency_ms=(
                     None if row["average_latency_ms"] is None else float(row["average_latency_ms"])
                 ),
-                terminal_counts=tuple(terminal_by_identity.get(str(row["identity_id"]), [])),
+                terminal_counts=tuple(terminals.get(str(row["identity_id"]), ())),
+            )
+            for row in rows
+        )
+
+    def _billing_source_usage_rows(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        predicate: str,
+        parameters: tuple[str, ...],
+    ) -> tuple[BillingSourceUsage, ...]:
+        """Read bounded source aggregates inside the caller's SQLite snapshot."""
+        rows = connection.execute(
+            f"""
+            SELECT a.billing_source,
+                   COUNT(a.attempt_id) AS attempts,
+                   COALESCE(SUM(a.input_tokens), 0) AS input_tokens,
+                   COALESCE(SUM(a.cached_input_tokens), 0) AS cached_input_tokens,
+                   COALESCE(SUM(a.output_tokens), 0) AS output_tokens,
+                   COALESCE(SUM(a.reasoning_tokens), 0) AS reasoning_tokens,
+                   COALESCE(SUM(a.estimated_cost_micro_usd), 0) AS known_cost,
+                   COALESCE(SUM(CASE
+                       WHEN a.estimated_cost_micro_usd IS NULL THEN 1 ELSE 0 END), 0
+                   ) AS unknown_cost_attempts
+            FROM gateway_attempts AS a
+            JOIN gateway_requests AS r ON r.request_id = a.request_id
+            WHERE {predicate}
+            GROUP BY a.billing_source ORDER BY a.billing_source
+            """,
+            parameters,
+        ).fetchall()
+        terminal_rows = connection.execute(
+            f"""
+            SELECT a.billing_source, a.state, COUNT(*) AS attempts
+            FROM gateway_attempts AS a
+            JOIN gateway_requests AS r ON r.request_id = a.request_id
+            WHERE {predicate} AND a.state != 'dispatched'
+            GROUP BY a.billing_source, a.state ORDER BY a.billing_source, a.state
+            """,
+            parameters,
+        ).fetchall()
+        terminals: dict[str, list[UsageTerminalCount]] = {}
+        for row in terminal_rows:
+            terminals.setdefault(str(row["billing_source"]), []).append(
+                UsageTerminalCount(state=str(row["state"]), attempts=int(row["attempts"]))
+            )
+        return tuple(
+            BillingSourceUsage(
+                billing_source=BillingSource(str(row["billing_source"])),
+                attempts=int(row["attempts"]),
+                input_tokens=int(row["input_tokens"]),
+                cached_input_tokens=int(row["cached_input_tokens"]),
+                output_tokens=int(row["output_tokens"]),
+                reasoning_tokens=int(row["reasoning_tokens"]),
+                known_estimated_cost_micro_usd=int(row["known_cost"]),
+                unknown_cost_attempts=int(row["unknown_cost_attempts"]),
+                terminal_counts=tuple(terminals.get(str(row["billing_source"]), ())),
             )
             for row in rows
         )

--- a/wmo/runtime/gateway/ledger_test.py
+++ b/wmo/runtime/gateway/ledger_test.py
@@ -251,6 +251,162 @@ def test_attempt_retains_dispatch_billing_source_after_catalog_change(tmp_path: 
     assert row == (BillingSource.HOST_MANAGED.value, "completed")
 
 
+def test_usage_billing_source_buckets_conserve_physical_attempt_totals(tmp_path: Path) -> None:
+    """Source buckets conserve attempts, usage, cost, unknowns, and terminal states."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+
+    host_authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("host-attempt"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=host_authorization)
+    host_attempt = ledger.start_attempt(
+        snapshot=_execution(host_authorization),
+        deployment=_deployment(billing_source=BillingSource.HOST_MANAGED),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    ledger.finish_attempt(
+        attempt_id=host_attempt,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=3, output_tokens=2),
+        ),
+        failure=None,
+    )
+
+    customer_authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("customer-attempt"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=customer_authorization)
+    customer_attempt = ledger.start_attempt(
+        snapshot=_execution(customer_authorization),
+        deployment=_deployment(
+            priced=False,
+            billing_source=BillingSource.CUSTOMER_MANAGED,
+        ),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    ledger.finish_attempt(
+        attempt_id=customer_attempt,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="provider unavailable",
+        ),
+    )
+
+    buckets = ledger.usage_by_billing_source(organization_id="org-one")
+
+    assert [bucket.billing_source for bucket in buckets] == [
+        BillingSource.CUSTOMER_MANAGED,
+        BillingSource.HOST_MANAGED,
+    ]
+    customer, host = buckets
+    assert customer.attempts == 1
+    assert customer.unknown_cost_attempts == 1
+    assert [(item.state, item.attempts) for item in customer.terminal_counts] == [("failed", 1)]
+    assert host.attempts == 1
+    assert host.input_tokens == 3
+    assert host.output_tokens == 2
+    assert host.known_estimated_cost_micro_usd == 14
+    assert host.unknown_cost_attempts == 0
+    assert [(item.state, item.attempts) for item in host.terminal_counts] == [("completed", 1)]
+
+
+def test_usage_snapshot_conserves_source_totals_during_concurrent_wal_settlement(
+    tmp_path: Path,
+) -> None:
+    """Concurrent settlement cannot split identity and source report snapshots."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    attempts: list[str] = []
+    for index in range(24):
+        authorization = store.authorize_request(
+            raw_key=raw_key,
+            alias="coding",
+            request=_request(f"concurrent-usage-{index}"),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
+        ledger.accept_request(authorization=authorization)
+        attempts.append(
+            ledger.start_attempt(
+                snapshot=_execution(authorization),
+                deployment=_deployment(
+                    billing_source=(
+                        BillingSource.HOST_MANAGED
+                        if index % 2 == 0
+                        else BillingSource.CUSTOMER_MANAGED
+                    )
+                ),
+                attempt_ordinal=0,
+                route_depth=0,
+            )
+        )
+
+    def settle_attempts() -> None:
+        """Settle every dispatched attempt while readers hold independent WAL snapshots."""
+        for attempt_id in attempts:
+            ledger.finish_attempt(
+                attempt_id=attempt_id,
+                terminal_event=GatewayEvent(
+                    kind=GatewayEventKind.COMPLETED,
+                    sequence_number=1,
+                    usage=GatewayUsage(input_tokens=3, output_tokens=2),
+                ),
+                failure=None,
+            )
+            time.sleep(0.001)
+
+    def assert_conservation() -> None:
+        """Require every metric and terminal state to reconcile inside one read."""
+        snapshot = ledger.usage_snapshot(organization_id="org-one")
+        identity = snapshot.identities[0]
+        sources = snapshot.by_billing_source
+        assert identity.attempts == sum(item.attempts for item in sources)
+        for field_name in (
+            "input_tokens",
+            "cached_input_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "known_estimated_cost_micro_usd",
+            "unknown_cost_attempts",
+        ):
+            assert getattr(identity, field_name) == sum(
+                getattr(item, field_name) for item in sources
+            )
+        identity_terminals = {item.state: item.attempts for item in identity.terminal_counts}
+        source_terminals: dict[str, int] = {}
+        for source in sources:
+            for item in source.terminal_counts:
+                source_terminals[item.state] = source_terminals.get(item.state, 0) + item.attempts
+        assert identity_terminals == source_terminals
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        settlement = executor.submit(settle_attempts)
+        for _index in range(100):
+            assert_conservation()
+            if settlement.done():
+                break
+        settlement.result(timeout=5)
+
+    final = ledger.usage_snapshot(organization_id="org-one")
+    assert sum(item.attempts for item in final.identities[0].terminal_counts) == len(attempts)
+    assert sum(
+        terminal.attempts
+        for source in final.by_billing_source
+        for terminal in source.terminal_counts
+    ) == len(attempts)
+
+
 def test_unknown_prices_remain_unknown_instead_of_zero(tmp_path: Path) -> None:
     """Observed token usage with absent rates increments unknown-cost accounting."""
     clock = FakeLedgerClock()

--- a/wmo/runtime/gateway/lifecycle_test.py
+++ b/wmo/runtime/gateway/lifecycle_test.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
+import threading
 from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -69,7 +72,7 @@ def test_local_gateway_preflights_real_state_and_serves_health_and_usage(
 
     assert runtime.state.ready is False
     assert usage.status_code == 200
-    assert usage.json()["schema_version"] == 1
+    assert usage.json()["schema_version"] == 2
     assert usage.json()["identities"][0]["identity_id"] == "default"
     assert page.status_code == 200
     assert "provider-secret-canary" not in page.text
@@ -262,6 +265,129 @@ def test_project_certified_pool_preflight_resolves_all_siblings_and_reloads(
     assert manager.aliases()[0].target_kind == "project"
 
 
+def test_real_project_selection_dispatches_frozen_pool_without_router_completion(
+    tmp_path: Path,
+) -> None:
+    """Real lifecycle uses RouterRuntime selection only, then owns provider fallback."""
+    from wmo.runtime.router.runtime_test import _runtime
+
+    dispatched: list[str] = []
+
+    class ProjectProviderHandler(BaseHTTPRequestHandler):
+        """Serve one precommit failure followed by deterministic Chat SSE."""
+
+        protocol_version = "HTTP/1.0"
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            """Suppress nondeterministic loopback server logs."""
+            del format, args
+
+        def do_POST(self) -> None:
+            """Record exact model dispatch and return failure or successful stream."""
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            model = str(payload["model"])
+            dispatched.append(model)
+            if model == "cheap-model":
+                body = b'{"error":{"message":"temporary project route failure"}}'
+                self.send_response(503)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            assert model == "baseline-model"
+            body = b"".join(
+                (
+                    b'data: {"choices":[{"index":0,"delta":{"content":'
+                    b'"project-response-canary"},"finish_reason":"stop"}]}\n\n',
+                    b'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n',
+                    b"data: [DONE]\n\n",
+                )
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ProjectProviderHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}/v1"
+        manager, raw_key = _configured_project_pool(
+            tmp_path,
+            deployment_aliases=("cheap", "baseline"),
+            base_url=base_url,
+        )
+        project_runtime, project_client = _runtime()
+
+        def load_project(
+            project: str,
+            root: Path,
+            *,
+            policy_id: str,
+            runtime_catalog: RuntimeModelCatalog,
+        ) -> RouterRuntime:
+            """Inject one real frozen runtime without completing through it."""
+            del root, runtime_catalog
+            assert project == "project-one"
+            assert policy_id == "activation-one"
+            return project_runtime
+
+        runtime = load_local_gateway(
+            tmp_path,
+            graceful_timeout_seconds=1,
+            environment={
+                "CHEAP_PROVIDER_KEY": "available",
+                "BASELINE_PROVIDER_KEY": "available",
+            },
+            project_loader=load_project,
+        )
+        with TestClient(runtime.app) as client:
+            response = client.post(
+                "/v1/chat/completions",
+                headers={"Authorization": f"Bearer {raw_key}"},
+                json={
+                    "model": "coding",
+                    "messages": [{"role": "user", "content": "project-prompt-canary"}],
+                },
+            )
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == ("project-response-canary")
+        assert dispatched == ["cheap-model", "cheap-model", "baseline-model"]
+        assert project_client.embed_calls == 1
+        assert project_client.complete_calls == 0
+        assert project_runtime.records_decisions is False
+        with sqlite3.connect(manager.database_path) as connection:
+            attempts = connection.execute(
+                """
+                SELECT attempt_ordinal, route_depth, exact_model_id, state
+                FROM gateway_attempts ORDER BY attempt_ordinal
+                """
+            ).fetchall()
+            retained_content = connection.execute(
+                "SELECT SUM(content_retained) FROM gateway_attempts"
+            ).fetchone()[0]
+        assert attempts == [
+            (0, 0, "model-revision-exact", "failed"),
+            (1, 0, "model-revision-exact", "failed"),
+            (2, 1, "model-revision-exact", "completed"),
+        ]
+        assert retained_content == 0
+        durable = manager.database_path.read_bytes()
+        wal = manager.database_path.with_name("gateway.db-wal")
+        if wal.exists():
+            durable += wal.read_bytes()
+        assert b"project-prompt-canary" not in durable
+        assert b"project-response-canary" not in durable
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_project_certified_pool_is_unavailable_when_any_sibling_cannot_resolve(
     tmp_path: Path,
 ) -> None:
@@ -329,33 +455,34 @@ def _configured_gateway(root: Path) -> tuple[GatewayManagement, str]:
     return manager, issued.raw_key
 
 
-def _configured_project_pool(root: Path) -> tuple[GatewayManagement, str]:
+def _configured_project_pool(
+    root: Path,
+    *,
+    deployment_aliases: tuple[str, str] = ("primary", "secondary"),
+    base_url: str = "http://127.0.0.1:9/v1",
+) -> tuple[GatewayManagement, str]:
     """Create one project alias whose candidate belongs to a certified ordered pool."""
     manager = GatewayManagement(root)
     manager.initialize()
-    for name, credential_env in (
-        ("primary-provider", "PRIMARY_PROVIDER_KEY"),
-        ("secondary-provider", "SECONDARY_PROVIDER_KEY"),
-    ):
+    for deployment_alias in deployment_aliases:
+        name = f"{deployment_alias}-provider"
+        credential_env = f"{deployment_alias.upper()}_PROVIDER_KEY"
         upsert_connection(
             root,
             name=name,
             connection=ConnectionConfig(
                 provider="openai-compatible",
-                base_url="http://127.0.0.1:9/v1",
+                base_url=base_url,
                 api_key_env=credential_env,
             ),
             replace=False,
         )
     normalized = None
-    for deployment_alias, connection_name in (
-        ("primary", "primary-provider"),
-        ("secondary", "secondary-provider"),
-    ):
+    for deployment_alias in deployment_aliases:
         normalized, _snapshot, _changed = upsert_singleton_deployment(
             root,
             deployment_alias=deployment_alias,
-            connection_name=connection_name,
+            connection_name=f"{deployment_alias}-provider",
             provider_model=f"{deployment_alias}-model",
             exact_model_id="model-revision-exact",
             revision=None,
@@ -370,7 +497,7 @@ def _configured_project_pool(root: Path) -> tuple[GatewayManagement, str]:
         root,
         pool_id="certified-pool",
         exact_model_id="model-revision-exact",
-        deployment_aliases=("primary", "secondary"),
+        deployment_aliases=deployment_aliases,
         certification=GatewayEquivalenceCertification(
             certification_id="certification-one",
             provenance="operator-reviewed deployment manifests",

--- a/wmo/runtime/gateway/provider_certification.py
+++ b/wmo/runtime/gateway/provider_certification.py
@@ -1,4 +1,4 @@
-"""Dated, secret-free certification matrix for later gateway provider adapters."""
+"""Dated, secret-free certification matrix for launch gateway provider adapters."""
 
 from __future__ import annotations
 
@@ -34,6 +34,9 @@ class ProviderCertificationCell(ContractModel):
     """One dated provider-capability result with reviewable local evidence."""
 
     provider: str = Field(min_length=1, max_length=64)
+    provider_api_surface: str = Field(min_length=1, max_length=128)
+    client_sdk: str = Field(min_length=1, max_length=64)
+    gateway_api_surfaces: tuple[str, ...] = Field(min_length=1)
     capability: ProviderCapability
     result: ProviderCertificationResult
     evaluated_at: datetime
@@ -57,7 +60,15 @@ class ProviderCertificationMatrix(ContractModel):
         Raises:
             ValueError: A provider-capability pair repeats or is absent.
         """
-        providers = {"azure", "bedrock", "gemini", "openrouter"}
+        providers = {
+            "anthropic",
+            "azure",
+            "bedrock",
+            "gemini",
+            "openai",
+            "openai-compatible",
+            "openrouter",
+        }
         expected = {
             (provider, capability) for provider in providers for capability in ProviderCapability
         }
@@ -74,8 +85,28 @@ class ProviderCertificationMatrix(ContractModel):
 
 
 _EVALUATED_AT = datetime(2026, 8, 18, tzinfo=UTC)
+_CLIENT_SDK = "openai==3.0.0"
+_GATEWAY_API_SURFACES = ("chat.completions", "responses")
+_PROVIDER_API_SURFACES = {
+    "anthropic": "messages SSE",
+    "azure": "chat.completions SSE",
+    "bedrock": "ConverseStream EventStream",
+    "gemini": "streamGenerateContent SSE",
+    "openai": "responses SSE",
+    "openai-compatible": "chat.completions SSE",
+    "openrouter": "chat.completions SSE",
+}
 _GEMINI_EVIDENCE = ("wmo/runtime/models/providers/gemini_streaming_test.py",)
 _BEDROCK_EVIDENCE = ("wmo/runtime/models/providers/bedrock_streaming_test.py",)
+_OPENAI_EVIDENCE = (
+    "wmo/runtime/models/providers/native_test.py",
+    "wmo/runtime/models/providers/streaming_test.py",
+)
+_ANTHROPIC_EVIDENCE = _OPENAI_EVIDENCE
+_OPENAI_COMPATIBLE_EVIDENCE = (
+    "wmo/runtime/models/providers/openai_compatible_test.py",
+    "wmo/runtime/models/providers/streaming_test.py",
+)
 _COMPATIBLE_EVIDENCE = (
     "wmo/runtime/models/providers/later_provider_streaming_test.py",
     "wmo/runtime/models/providers/streaming_test.py",
@@ -104,6 +135,9 @@ def _cell(
     """
     return ProviderCertificationCell(
         provider=provider,
+        provider_api_surface=_PROVIDER_API_SURFACES[provider],
+        client_sdk=_CLIENT_SDK,
+        gateway_api_surfaces=_GATEWAY_API_SURFACES,
         capability=capability,
         result=result,
         evaluated_at=_EVALUATED_AT,
@@ -192,10 +226,41 @@ def _compatible_provider_cells(provider: str) -> tuple[ProviderCertificationCell
     return tuple(cells)
 
 
+def _launch_provider_cells(
+    provider: str,
+    evidence: tuple[str, ...],
+) -> tuple[ProviderCertificationCell, ...]:
+    """Return direct launch-provider fixture results plus the unrun live cell.
+
+    Args:
+        provider: OpenAI, Anthropic, or generic OpenAI-compatible identifier.
+        evidence: Deterministic provider-specific fixture paths.
+
+    Returns:
+        Complete capability cells for the launch adapter.
+    """
+    cells: list[ProviderCertificationCell] = []
+    for capability in ProviderCapability:
+        if capability is ProviderCapability.CREDENTIAL_GATED_LIVE:
+            result = ProviderCertificationResult.NOT_RUN_REQUIRES_CREDENTIALS
+            limitation = "No provider credential was available in the deterministic lane."
+        else:
+            result = ProviderCertificationResult.PROVIDER_FIXTURE_PASS
+            limitation = None
+        cells.append(_cell(provider, capability, result, evidence, limitation=limitation))
+    return tuple(cells)
+
+
 PROVIDER_CERTIFICATION_MATRIX = ProviderCertificationMatrix(
     cells=tuple(
         sorted(
             (
+                *_launch_provider_cells("openai", _OPENAI_EVIDENCE),
+                *_launch_provider_cells("anthropic", _ANTHROPIC_EVIDENCE),
+                *_launch_provider_cells(
+                    "openai-compatible",
+                    _OPENAI_COMPATIBLE_EVIDENCE,
+                ),
                 *_native_provider_cells("gemini", _GEMINI_EVIDENCE),
                 *_native_provider_cells("bedrock", _BEDROCK_EVIDENCE),
                 *_compatible_provider_cells("azure"),

--- a/wmo/runtime/gateway/provider_certification.py
+++ b/wmo/runtime/gateway/provider_certification.py
@@ -84,7 +84,7 @@ class ProviderCertificationMatrix(ContractModel):
         return sha256_json(self)
 
 
-_EVALUATED_AT = datetime(2026, 8, 18, tzinfo=UTC)
+_EVALUATED_AT = datetime(2026, 8, 19, tzinfo=UTC)
 _CLIENT_SDK = "openai==3.0.0"
 _GATEWAY_API_SURFACES = ("chat.completions", "responses")
 _PROVIDER_API_SURFACES = {
@@ -102,7 +102,12 @@ _OPENAI_EVIDENCE = (
     "wmo/runtime/models/providers/native_test.py",
     "wmo/runtime/models/providers/streaming_test.py",
 )
-_ANTHROPIC_EVIDENCE = _OPENAI_EVIDENCE
+_ANTHROPIC_EVIDENCE = (
+    "wmo/runtime/models/providers/native_test.py",
+    "wmo/runtime/models/providers/streaming_test.py",
+    "wmo/runtime/models/providers/streaming_test.py::"
+    "test_anthropic_text_stream_emits_text_usage_and_completion",
+)
 _OPENAI_COMPATIBLE_EVIDENCE = (
     "wmo/runtime/models/providers/openai_compatible_test.py",
     "wmo/runtime/models/providers/streaming_test.py",

--- a/wmo/runtime/gateway/provider_certification_test.py
+++ b/wmo/runtime/gateway/provider_certification_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from wmo.common.core.artifacts import assert_secret_free
 from wmo.runtime.gateway.provider_certification import (
     PROVIDER_CERTIFICATION_MATRIX,
@@ -26,6 +28,7 @@ def test_provider_matrix_is_complete_deterministic_and_secret_free() -> None:
         "openrouter",
     }
     assert {cell.client_sdk for cell in matrix.cells} == {"openai==3.0.0"}
+    assert {cell.evaluated_at for cell in matrix.cells} == {datetime(2026, 8, 19, tzinfo=UTC)}
     assert {cell.gateway_api_surfaces for cell in matrix.cells} == {
         ("chat.completions", "responses")
     }
@@ -70,3 +73,15 @@ def test_gemini_raw_argument_limit_is_explicit_while_bedrock_is_certified() -> N
         cells[("bedrock", ProviderCapability.TOOL_ARGUMENT_STREAM)].result
         is ProviderCertificationResult.PROVIDER_FIXTURE_PASS
     )
+
+
+def test_anthropic_text_stream_cell_names_exact_native_fixture() -> None:
+    """Anthropic text certification is bound to native text lifecycle evidence."""
+    cells = {(cell.provider, cell.capability): cell for cell in PROVIDER_CERTIFICATION_MATRIX.cells}
+    cell = cells[("anthropic", ProviderCapability.TEXT_STREAM)]
+
+    assert cell.result is ProviderCertificationResult.PROVIDER_FIXTURE_PASS
+    assert (
+        "wmo/runtime/models/providers/streaming_test.py::"
+        "test_anthropic_text_stream_emits_text_usage_and_completion"
+    ) in cell.evidence

--- a/wmo/runtime/gateway/provider_certification_test.py
+++ b/wmo/runtime/gateway/provider_certification_test.py
@@ -1,4 +1,4 @@
-"""Tests for the honest later-provider certification artifact."""
+"""Tests for the honest launch-provider certification artifact."""
 
 from __future__ import annotations
 
@@ -12,10 +12,24 @@ from wmo.runtime.gateway.provider_certification import (
 
 
 def test_provider_matrix_is_complete_deterministic_and_secret_free() -> None:
-    """Every later-provider cell is labeled and the artifact round-trips exactly."""
+    """Every launch-provider cell is labeled and the artifact round-trips exactly."""
     matrix = PROVIDER_CERTIFICATION_MATRIX
 
-    assert len(matrix.cells) == 4 * len(ProviderCapability)
+    assert len(matrix.cells) == 7 * len(ProviderCapability)
+    assert {cell.provider for cell in matrix.cells} == {
+        "anthropic",
+        "azure",
+        "bedrock",
+        "gemini",
+        "openai",
+        "openai-compatible",
+        "openrouter",
+    }
+    assert {cell.client_sdk for cell in matrix.cells} == {"openai==3.0.0"}
+    assert {cell.gateway_api_surfaces for cell in matrix.cells} == {
+        ("chat.completions", "responses")
+    }
+    assert all(cell.provider_api_surface for cell in matrix.cells)
     assert matrix.identity_sha256() == PROVIDER_CERTIFICATION_MATRIX.identity_sha256()
     assert ProviderCertificationMatrix.model_validate_json(matrix.model_dump_json()) == matrix
     assert_secret_free(matrix.model_dump(mode="json"))
@@ -30,9 +44,12 @@ def test_provider_matrix_does_not_claim_unperformed_live_credentials() -> None:
     )
 
     assert {cell.provider for cell in live_cells} == {
+        "anthropic",
         "azure",
         "bedrock",
         "gemini",
+        "openai",
+        "openai-compatible",
         "openrouter",
     }
     assert all(

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from wmo.runtime.gateway.sqlite import migrations
 from wmo.runtime.gateway.sqlite.migrations import (
     _MIGRATION_1,
     _MIGRATION_2,
@@ -384,6 +385,53 @@ def test_v6_migration_preserves_billing_and_adds_physical_ordinal(tmp_path: Path
         )
     finally:
         prior.close()
+
+
+def test_failed_legacy_migration_rolls_back_the_live_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed forward migration leaves the legacy database intact and recoverable."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for migration in (_MIGRATION_1, _MIGRATION_2, _MIGRATION_3):
+            for statement in migration:
+                connection.execute(statement)
+        connection.execute("PRAGMA user_version = 3")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+    monkeypatch.setitem(
+        migrations._MIGRATIONS,
+        4,
+        (
+            "ALTER TABLE gateway_attempts RENAME TO gateway_attempts_v3",
+            "INVALID MIGRATION STATEMENT",
+        ),
+    )
+
+    with pytest.raises(GatewaySchemaError, match="migration failed"):
+        initialize_database(path)
+
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone() == (3,)
+        tables = {
+            str(row[0])
+            for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+    finally:
+        connection.close()
+    assert "gateway_attempts" in tables
+    assert "gateway_attempts_v3" not in tables
+    backups = tuple(tmp_path.glob("gateway.db.backup-v3-*"))
+    assert len(backups) == 1
+    with sqlite3.connect(backups[0]) as backup:
+        assert backup.execute("PRAGMA user_version").fetchone() == (3,)
 
 
 def test_concurrent_initializers_choose_migration_plan_under_exclusive_lock(

--- a/wmo/runtime/gateway/sqlite/store_test.py
+++ b/wmo/runtime/gateway/sqlite/store_test.py
@@ -224,6 +224,74 @@ def test_authorization_serializes_with_concurrent_key_revocation(
         )
 
 
+def test_concurrent_multi_identity_revoke_and_revision_activation_are_serialized(
+    tmp_path: Path,
+) -> None:
+    """WAL preserves a concurrent revocation while another identity activates a revision."""
+    store, clock, revoked_raw_key = _configured_store(tmp_path)
+    store.create_identity(
+        organization_id="org-one",
+        identity_id="identity-two",
+        display_name="Identity Two",
+    )
+    store.grant_alias(
+        organization_id="org-one",
+        identity_id="identity-two",
+        alias_id="alias-coding",
+    )
+    surviving_raw_key = store.issue_virtual_key(
+        organization_id="org-one",
+        identity_id="identity-two",
+        key_id="key-two",
+    ).raw_key
+    second_store = SQLiteGatewayStore(
+        tmp_path / "gateway.db",
+        clock=clock,
+        busy_timeout_ms=10_000,
+    )
+    barrier = threading.Barrier(2)
+
+    def revoke() -> bool:
+        """Revoke the first identity's key at the shared concurrency boundary."""
+        barrier.wait(timeout=5)
+        return store.revoke_virtual_key(organization_id="org-one", key_id="key-one")
+
+    def activate() -> None:
+        """Activate a new immutable revision at the shared concurrency boundary."""
+        barrier.wait(timeout=5)
+        second_store.activate_alias_revision(
+            organization_id="org-one",
+            alias_id="alias-coding",
+            alias_name="coding",
+            revision_id="revision-two",
+            target=DirectTarget(pool_id="pool-coding"),
+            snapshot_ref="snapshot-one",
+            catalog_sha256=_DIGEST,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        revoked = executor.submit(revoke)
+        activated = executor.submit(activate)
+        assert revoked.result(timeout=15)
+        assert activated.result(timeout=15) is None
+
+    with pytest.raises(InvalidVirtualKeyError, match="invalid"):
+        store.authorize_request(
+            raw_key=revoked_raw_key,
+            alias="coding",
+            request=_request(),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
+    snapshot = second_store.authorize_request(
+        raw_key=surviving_raw_key,
+        alias="coding",
+        request=_request(),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    assert snapshot.identity_id == "identity-two"
+    assert snapshot.alias_revision_id == "revision-two"
+
+
 def test_expiry_identity_disable_and_pepper_rotation_fail_closed(tmp_path: Path) -> None:
     """Expiry and identity state deny old keys while pepper rotation preserves fingerprints."""
     clock = FakeClock()

--- a/wmo/runtime/gateway/usage.py
+++ b/wmo/runtime/gateway/usage.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 from html import escape
+from typing import Literal
 
 from pydantic import Field
 
 from wmo.common.core.artifacts import ContractModel
-from wmo.runtime.gateway.ledger import IdentityUsage, SQLiteAttemptLedger, UsageTerminalCount
+from wmo.runtime.gateway.ledger import (
+    BillingSourceUsage,
+    IdentityUsage,
+    SQLiteAttemptLedger,
+    UsageTerminalCount,
+)
 
 
 class GatewayUsageTotals(ContractModel):
@@ -28,10 +34,11 @@ class GatewayUsageTotals(ContractModel):
 class GatewayUsageReport(ContractModel):
     """Versioned aggregate and per-identity attributed usage report."""
 
-    schema_version: int = Field(default=1, frozen=True)
+    schema_version: Literal[2] = 2
     organization_id: str
     totals: GatewayUsageTotals
     identities: tuple[IdentityUsage, ...]
+    by_billing_source: tuple[BillingSourceUsage, ...]
     cost_description: str = "attributed estimated cost, not provider invoice cost"
 
 
@@ -51,7 +58,12 @@ def read_usage_report(
     Returns:
         Versioned aggregate and per-identity usage.
     """
-    identities = ledger.usage(organization_id=organization_id, identity_id=identity_id)
+    snapshot = ledger.usage_snapshot(
+        organization_id=organization_id,
+        identity_id=identity_id,
+    )
+    identities = snapshot.identities
+    by_billing_source = snapshot.by_billing_source
     terminal: dict[str, int] = {}
     for identity in identities:
         for count in identity.terminal_counts:
@@ -77,6 +89,7 @@ def read_usage_report(
         organization_id=organization_id,
         totals=totals,
         identities=identities,
+        by_billing_source=by_billing_source,
     )
 
 
@@ -105,6 +118,20 @@ def usage_html(report: GatewayUsageReport) -> str:
         "</tr>"
         for item in report.identities
     )
+    source_rows = "".join(
+        "<tr>"
+        f"<td>{escape(item.billing_source.value)}</td>"
+        f"<td>{item.attempts}</td>"
+        f"<td>{item.input_tokens}</td>"
+        f"<td>{item.cached_input_tokens}</td>"
+        f"<td>{item.output_tokens}</td>"
+        f"<td>{item.reasoning_tokens}</td>"
+        f"<td>{item.known_estimated_cost_micro_usd}</td>"
+        f"<td>{item.unknown_cost_attempts}</td>"
+        f"<td>{escape(_source_terminal_summary(item))}</td>"
+        "</tr>"
+        for item in report.by_billing_source
+    )
     totals = report.totals
     return (
         "<!doctype html><html><head><meta charset='utf-8'>"
@@ -124,12 +151,25 @@ def usage_html(report: GatewayUsageReport) -> str:
         "<th>Reasoning tokens</th><th>Known micro-USD</th>"
         "<th>Unknown-cost attempts</th><th>Total latency ms</th>"
         "<th>Terminal states</th></tr></thead>"
-        f"<tbody>{rows}</tbody></table></body></html>"
+        f"<tbody>{rows}</tbody></table>"
+        "<h2>Attempts by billing source</h2>"
+        "<table><thead><tr><th>Billing source</th><th>Attempts</th>"
+        "<th>Input tokens</th><th>Cached input</th><th>Output tokens</th>"
+        "<th>Reasoning tokens</th><th>Known micro-USD</th>"
+        "<th>Unknown-cost attempts</th><th>Terminal states</th></tr></thead>"
+        f"<tbody>{source_rows}</tbody></table></body></html>"
     )
 
 
 def _terminal_summary(usage: IdentityUsage) -> str:
     """Return stable terminal-state counts for one HTML table cell."""
+    if not usage.terminal_counts:
+        return "none"
+    return ", ".join(f"{count.state}: {count.attempts}" for count in usage.terminal_counts)
+
+
+def _source_terminal_summary(usage: BillingSourceUsage) -> str:
+    """Return stable terminal-state counts for one billing-source table cell."""
     if not usage.terminal_counts:
         return "none"
     return ", ".join(f"{count.state}: {count.attempts}" for count in usage.terminal_counts)

--- a/wmo/runtime/gateway/waterfall_test.py
+++ b/wmo/runtime/gateway/waterfall_test.py
@@ -412,8 +412,12 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
                             usage=GatewayUsage(input_tokens=5, output_tokens=2),
                         ),
                         GatewayEvent(
-                            kind=GatewayEventKind.COMPLETED,
+                            kind=GatewayEventKind.FAILED,
                             sequence_number=2,
+                            failure=GatewayFailure(
+                                failure_class=GatewayFailureClass.REFUSAL,
+                                safe_message="provider refused the request",
+                            ),
                         ),
                     )
                 )
@@ -453,7 +457,11 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
     ]
     assert all(event.kind is not GatewayEventKind.REFUSAL_DELTA for event in opted_events)
     assert opted_fallbacks == 1
-    assert default_ledger.finished[0][1] is None
+    default_failure = default_ledger.finished[0][1]
+    assert default_failure is not None
+    assert default_failure.failure_class is GatewayFailureClass.REFUSAL
+    assert default_ledger.finished_events[0] is not None
+    assert default_ledger.finished_events[0].kind is GatewayEventKind.FAILED
     opted_failure = opted_ledger.finished[0][1]
     assert opted_failure is not None
     assert opted_failure.failure_class is GatewayFailureClass.REFUSAL

--- a/wmo/runtime/gateway/waterfall_test.py
+++ b/wmo/runtime/gateway/waterfall_test.py
@@ -462,6 +462,69 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
     assert opted_ledger.finished_events[0].usage == GatewayUsage(input_tokens=5, output_tokens=2)
 
 
+def test_buffered_refusal_followed_by_retryable_failure_advances_without_exposure() -> None:
+    """An opted-in uncommitted refusal does not block another safe failure class."""
+
+    async def scenario() -> None:
+        """Fail the refusing primary before commitment and complete on the secondary."""
+        first = _deployment("route-a", connection_sha256="b" * 64)
+        second = _deployment("route-b", connection_sha256="c" * 64)
+        failure = GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="provider transport failed",
+            failover_eligible=True,
+        )
+        first_provider = _ScriptedProvider(
+            [
+                _WaterfallStream(
+                    (
+                        GatewayEvent(
+                            kind=GatewayEventKind.REFUSAL_DELTA,
+                            sequence_number=0,
+                            text_delta="private refusal detail",
+                        ),
+                        GatewayEvent(
+                            kind=GatewayEventKind.FAILED,
+                            sequence_number=1,
+                            failure=failure,
+                        ),
+                    )
+                )
+            ]
+        )
+        second_provider = _ScriptedProvider([_completed_stream("safe fallback")])
+        ledger = _WaterfallLedger()
+        executor = _executor(
+            (first, second),
+            {
+                first.source_alias: first_provider,
+                second.source_alias: second_provider,
+            },
+            ledger,
+            maximum_same_deployment_attempts=1,
+        )
+
+        stream = await executor.start(
+            route=_route((first, second), refusal_failover=True),
+            request=_request(),
+        )
+        events = [event async for event in stream]
+
+        assert [event.kind for event in events] == [
+            GatewayEventKind.TEXT_DELTA,
+            GatewayEventKind.COMPLETED,
+        ]
+        assert events[0].text_delta == "safe fallback"
+        assert all(event.text_delta != "private refusal detail" for event in events)
+        assert len(second_provider.idempotency_keys) == 1
+        assert ledger.finished[0][1] == failure
+        assert ledger.finished[0][2] is False
+        assert ledger.finished[1][1] is None
+        assert ledger.finished[1][2] is True
+
+    asyncio.run(scenario())
+
+
 @pytest.mark.parametrize(
     "refusals",
     [

--- a/wmo/runtime/gateway/waterfall_test.py
+++ b/wmo/runtime/gateway/waterfall_test.py
@@ -33,6 +33,7 @@ from wmo.runtime.gateway.contracts import (
     GatewayMessage,
     GatewayRequest,
     GatewayTarget,
+    GatewayUsage,
     ProjectSelection,
     ProjectTarget,
 )
@@ -165,6 +166,52 @@ def test_circuit_identity_is_catalog_and_connection_scoped() -> None:
     health.succeeded(second)
     now[0] += 11
     assert health.claim(first)
+
+
+def test_provider_auth_failover_opens_skips_and_recovers_the_primary() -> None:
+    """Provider authentication failover opens one circuit and later probes recovery."""
+    now = [100.0]
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    second = _deployment("route-b", connection_sha256="c" * 64)
+    first_provider = _ScriptedProvider(
+        [
+            ProviderTransportError("provider rejected credentials", status_code=401),
+            _completed_stream("primary recovered"),
+        ]
+    )
+    second_provider = _ScriptedProvider(
+        [_completed_stream("fallback one"), _completed_stream("fallback two")]
+    )
+    health = DeploymentHealthRegistry(
+        failure_threshold=1,
+        open_seconds=10,
+        throttle_seconds=5,
+        clock=lambda: now[0],
+    )
+    executor = _executor(
+        (first, second),
+        {
+            first.source_alias: first_provider,
+            second.source_alias: second_provider,
+        },
+        _WaterfallLedger(),
+        maximum_same_deployment_attempts=1,
+        health=health,
+    )
+
+    async def consume() -> str:
+        """Run one logical request and return its sole text delta."""
+        stream = await executor.start(route=_route((first, second)), request=_request())
+        events = [event async for event in stream]
+        return "".join(event.text_delta or "" for event in events)
+
+    assert asyncio.run(consume()) == "fallback one"
+    assert asyncio.run(consume()) == "fallback two"
+    assert len(first_provider.idempotency_keys) == 1
+    now[0] += 11
+    assert asyncio.run(consume()) == "primary recovered"
+    assert len(first_provider.idempotency_keys) == 2
+    assert len(second_provider.idempotency_keys) == 2
 
 
 def test_throttle_window_recovers_without_opening_the_failure_circuit() -> None:
@@ -344,25 +391,29 @@ def test_first_semantic_event_freezes_route_even_when_provider_later_fails() -> 
 
 
 def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> None:
-    """A typed precommit refusal advances only for an explicitly allowed alias revision."""
+    """A provider refusal stream advances only for an explicitly allowed alias revision."""
 
-    async def scenario(*, opted_in: bool) -> tuple[list[GatewayEvent], int]:
+    async def scenario(*, opted_in: bool) -> tuple[list[GatewayEvent], int, _WaterfallLedger]:
         """Run one refusal with or without the injected revision policy."""
         first = _deployment("route-a", connection_sha256="b" * 64)
         second = _deployment("route-b", connection_sha256="c" * 64)
-        refusal = GatewayFailure(
-            failure_class=GatewayFailureClass.REFUSAL,
-            safe_message="provider refused the request",
-            safe_details={"signal": "safety"},
-        )
         first_provider = _ScriptedProvider(
             [
                 _WaterfallStream(
                     (
                         GatewayEvent(
-                            kind=GatewayEventKind.FAILED,
+                            kind=GatewayEventKind.REFUSAL_DELTA,
                             sequence_number=0,
-                            failure=refusal,
+                            text_delta="provider refusal body",
+                        ),
+                        GatewayEvent(
+                            kind=GatewayEventKind.USAGE,
+                            sequence_number=1,
+                            usage=GatewayUsage(input_tokens=5, output_tokens=2),
+                        ),
+                        GatewayEvent(
+                            kind=GatewayEventKind.COMPLETED,
+                            sequence_number=2,
                         ),
                     )
                 )
@@ -385,12 +436,16 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
             request=_request(),
         )
         events = [event async for event in stream]
-        return events, len(second_provider.idempotency_keys)
+        return events, len(second_provider.idempotency_keys), ledger
 
-    default_events, default_fallbacks = asyncio.run(scenario(opted_in=False))
-    opted_events, opted_fallbacks = asyncio.run(scenario(opted_in=True))
+    default_events, default_fallbacks, default_ledger = asyncio.run(scenario(opted_in=False))
+    opted_events, opted_fallbacks, opted_ledger = asyncio.run(scenario(opted_in=True))
 
-    assert [event.kind for event in default_events] == [GatewayEventKind.FAILED]
+    assert [event.kind for event in default_events] == [
+        GatewayEventKind.REFUSAL_DELTA,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
     assert default_fallbacks == 0
     assert [event.kind for event in opted_events] == [
         GatewayEventKind.TEXT_DELTA,
@@ -398,6 +453,80 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
     ]
     assert all(event.kind is not GatewayEventKind.REFUSAL_DELTA for event in opted_events)
     assert opted_fallbacks == 1
+    assert default_ledger.finished[0][1] is None
+    opted_failure = opted_ledger.finished[0][1]
+    assert opted_failure is not None
+    assert opted_failure.failure_class is GatewayFailureClass.REFUSAL
+    assert opted_ledger.finished[0][2] is False
+    assert opted_ledger.finished_events[0] is not None
+    assert opted_ledger.finished_events[0].usage == GatewayUsage(input_tokens=5, output_tokens=2)
+
+
+@pytest.mark.parametrize(
+    "first_events",
+    [
+        (
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=0,
+                text_delta="r" * 70_000,
+            ),
+            GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+        ),
+        (
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=0,
+                text_delta="refused",
+            ),
+            GatewayEvent(
+                kind=GatewayEventKind.TEXT_DELTA,
+                sequence_number=1,
+                text_delta="mixed output",
+            ),
+            GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=2),
+        ),
+        tuple(
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=index,
+                text_delta="",
+            )
+            for index in range(257)
+        )
+        + (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=257),),
+    ],
+)
+def test_refusal_buffer_overflow_or_mixed_output_commits_without_failover(
+    first_events: tuple[GatewayEvent, ...],
+) -> None:
+    """A bounded refusal buffer flushes safely before semantic output can switch routes."""
+
+    async def scenario() -> tuple[list[GatewayEvent], int]:
+        """Consume one overflow or mixed-semantic provider stream."""
+        first = _deployment("route-a", connection_sha256="b" * 64)
+        second = _deployment("route-b", connection_sha256="c" * 64)
+        first_provider = _ScriptedProvider([_WaterfallStream(first_events)])
+        second_provider = _ScriptedProvider([_completed_stream("must not run")])
+        executor = _executor(
+            (first, second),
+            {
+                first.source_alias: first_provider,
+                second.source_alias: second_provider,
+            },
+            _WaterfallLedger(),
+            maximum_same_deployment_attempts=1,
+        )
+        stream = await executor.start(
+            route=_route((first, second), refusal_failover=True),
+            request=_request(),
+        )
+        return [event async for event in stream], len(second_provider.idempotency_keys)
+
+    events, fallback_count = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [event.kind for event in first_events]
+    assert fallback_count == 0
 
 
 def test_deadline_between_attempts_finalizes_parent_and_releases_claims(
@@ -629,6 +758,7 @@ class _WaterfallLedger:
         """Initialize empty ordered accounting records."""
         self.started: list[tuple[str, int, int]] = []
         self.finished: list[tuple[str, GatewayFailure | None, bool]] = []
+        self.finished_events: list[GatewayEvent | None] = []
         self.parent_finishes: list[GatewayFailure] = []
 
     def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
@@ -667,7 +797,7 @@ class _WaterfallLedger:
         finalize_request: bool = True,
     ) -> None:
         """Record physical settlement and whether it owns parent terminalization."""
-        del terminal_event
+        self.finished_events.append(terminal_event)
         self.finished.append((attempt_id, failure, finalize_request))
 
     def finish_request(

--- a/wmo/runtime/gateway/waterfall_test.py
+++ b/wmo/runtime/gateway/waterfall_test.py
@@ -463,6 +463,67 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
 
 
 @pytest.mark.parametrize(
+    "refusals",
+    [
+        ("r" * 65_536,),
+        ("a" * 32_768, "b" * 32_768),
+        tuple("" for _index in range(256)),
+    ],
+)
+def test_refusal_buffer_accepts_exact_byte_and_event_bounds(
+    refusals: tuple[str, ...],
+) -> None:
+    """Exact refusal bounds remain precommit and can advance without exposure."""
+
+    async def scenario() -> tuple[list[GatewayEvent], int]:
+        """Complete one exactly bounded refusal-only route and its fallback."""
+        first = _deployment("route-a", connection_sha256="b" * 64)
+        second = _deployment("route-b", connection_sha256="c" * 64)
+        first_events = tuple(
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=index,
+                text_delta=text,
+            )
+            for index, text in enumerate(refusals)
+        ) + (
+            GatewayEvent(
+                kind=GatewayEventKind.USAGE,
+                sequence_number=len(refusals),
+                usage=GatewayUsage(input_tokens=5, output_tokens=2),
+            ),
+            GatewayEvent(
+                kind=GatewayEventKind.COMPLETED,
+                sequence_number=len(refusals) + 1,
+            ),
+        )
+        second_provider = _ScriptedProvider([_completed_stream("bounded fallback")])
+        executor = _executor(
+            (first, second),
+            {
+                first.source_alias: _ScriptedProvider([_WaterfallStream(first_events)]),
+                second.source_alias: second_provider,
+            },
+            _WaterfallLedger(),
+            maximum_same_deployment_attempts=1,
+        )
+        stream = await executor.start(
+            route=_route((first, second), refusal_failover=True),
+            request=_request(),
+        )
+        return [event async for event in stream], len(second_provider.idempotency_keys)
+
+    events, fallback_count = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[0].text_delta == "bounded fallback"
+    assert fallback_count == 1
+
+
+@pytest.mark.parametrize(
     "first_events",
     [
         (
@@ -472,6 +533,19 @@ def test_refusal_failover_requires_opt_in_and_withholds_the_failed_route() -> No
                 text_delta="r" * 70_000,
             ),
             GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+        ),
+        (
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=0,
+                text_delta="a" * 32_768,
+            ),
+            GatewayEvent(
+                kind=GatewayEventKind.REFUSAL_DELTA,
+                sequence_number=1,
+                text_delta="b" * 32_769,
+            ),
+            GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=2),
         ),
         (
             GatewayEvent(
@@ -526,6 +600,11 @@ def test_refusal_buffer_overflow_or_mixed_output_commits_without_failover(
     events, fallback_count = asyncio.run(scenario())
 
     assert [event.kind for event in events] == [event.kind for event in first_events]
+    assert [
+        event.text_delta for event in events if event.kind is GatewayEventKind.REFUSAL_DELTA
+    ] == [
+        event.text_delta for event in first_events if event.kind is GatewayEventKind.REFUSAL_DELTA
+    ]
     assert fallback_count == 0
 
 

--- a/wmo/runtime/models/providers/streaming_test.py
+++ b/wmo/runtime/models/providers/streaming_test.py
@@ -453,6 +453,87 @@ def test_anthropic_stream_normalizes_cache_usage_and_tool_fragments() -> None:
     assert events[4].usage.cached_input_tokens == 3
 
 
+def test_anthropic_text_stream_emits_text_usage_and_completion() -> None:
+    """Native Messages text streaming commits and emits one complete lifecycle."""
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 3,
+                            "cache_read_input_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                        }
+                    },
+                },
+                event="message_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+                event="content_block_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "hello"},
+                },
+                event="content_block_delta",
+            ),
+            _sse({"type": "content_block_stop", "index": 0}, event="content_block_stop"),
+            _sse(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                },
+                event="message_delta",
+            ),
+            _sse({"type": "message_stop"}, event="message_stop"),
+        )
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        """Require native streaming and return the Anthropic text fixture."""
+        assert json.loads(request.content)["stream"] is True
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> tuple[list[GatewayEvent], bool]:
+        """Consume one native Messages text stream and its commitment state."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = AnthropicClient(
+                model=_snapshot("anthropic"),
+                api_key="fixture-key",
+                base_url="https://anthropic.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(2),
+                idempotency_key="anthropic-text-attempt",
+            )
+            return await _collect(stream), stream.committed
+
+    events, committed = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[0].text_delta == "hello"
+    assert events[1].usage is not None
+    assert events[1].usage.input_tokens == 3
+    assert events[1].usage.output_tokens == 2
+    assert committed is True
+
+
 def test_openai_compatible_stream_emits_refusal_reasoning_usage_and_terminal() -> None:
     """Generic Chat streaming retains refusal semantics and reported reasoning units."""
     frames = b"".join(


### PR DESCRIPTION
## Summary

- prove installed `wmo run` and `wmo run PROJECT` use the same gateway application, endpoint, authentication, SQLite authority, neutral OpenAI protocol, provider execution, and accounting path
- exercise real loopback Chat Completions and Responses through the official OpenAI SDK, including streaming, tool calls, continuation lineage, restart replay behavior, and project sticky selection
- verify project-backed serving records attempts in the gateway database while leaving the project artifact store and router journal unchanged
- lock provider certification, mixed billing-source attribution, refusal and waterfall boundaries, CLI help, archive contents, and secret/content canaries

## Validation

- full Ruff, format, and type checks
- focused unified serving suite: 309 passed
- full non-live suite: 1851 passed, 2 skipped, 1 deselected
- installed-wheel end-to-end evidence: 1 passed
- final release/API/startup lane after the packaging correction: 19 passed, 1 skipped

## Stack

- base: `agent/gateway-exact-model-waterfall` at `52a023cc`
- head: `dd3f54d9`

This PR is ready for review and must not be merged independently of its stack.
