### PR TITLE
feat(gateway): enforce monthly serving budgets

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -17,11 +17,11 @@ perform no provider request. Only an authorized model request may cross the prov
 
 ## Authority and management
 
-`wmo config gateway` owns explicit local setup. Its provider, identity, key, grant, alias, and pool
-commands produce versioned receipts suitable for interactive or non-interactive callers. There are
-no runtime seeds. A usable installation requires an organization, active identity, active virtual
-key, explicit identity-to-alias grant, active alias revision, immutable catalog snapshot, and a
-resolvable provider credential reference.
+`wmo config gateway` owns explicit local setup. Its provider, identity, key, grant, alias, pool, and
+monthly budget commands produce versioned receipts suitable for interactive or non-interactive
+callers. There are no runtime seeds. A usable installation requires an organization, active
+identity, active virtual key, explicit identity-to-alias grant, active alias revision, immutable
+catalog snapshot, and a resolvable provider credential reference.
 
 Private serving authority lives in `ROOT/gateway/gateway.db`, including identities, keys, grants,
 provider connections and revisions, aliases and revisions, attempts, and usage. SQLite uses WAL
@@ -74,6 +74,22 @@ it. Opted-in refusal deltas are withheld only in a bounded in-memory buffer: a r
 result can advance to the next certified deployment, while mixed semantic output or buffer overflow
 commits and flushes the original route. Provider-internal retry layers are disabled so every
 possible billable dispatch is visible to the gateway ledger.
+
+Before each physical dispatch, the same immediate SQLite transaction reserves the request's
+conservative maximum integer micro-USD cost and inserts its attempt row. Applicable hard limits can
+cover the local team, one identity, one alias pool, and each provider deployment within that pool.
+An exhausted deployment allocation removes only that route from the current certified waterfall.
+If no route can fit the shared team, identity, or total pool allocation, the neutral protocol
+returns HTTP 429 with OpenAI `insufficient_quota` semantics before provider work. Any required
+unknown price makes that route ineligible while a hard limit applies.
+
+Settlement replaces the reservation with observed integer micro-USD usage. A dispatched failure,
+cancellation, or crash without trustworthy usage retains its conservative reservation because it
+may be billable. Retries and fallbacks therefore consume one allocation entry per physical attempt,
+while keyed replay creates no new reservation. A period is the immutable UTC bucket beginning at
+`YYYY-MM-01T00:00:00+00:00`; rollover selects a new bucket and never clears or rewrites an earlier
+month. Management and remaining-allocation reports are CLI surfaces only. There is no budgets
+dashboard.
 
 Each physical attempt records its own provider, model, usage, latency, terminal state, estimated
 cost attribution, and frozen credential-ownership billing source. Later catalog activation and

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -11,7 +11,8 @@ on the exact release checkout.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
   singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
   provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
-  content-free SQLite accounting, and loopback-only health and usage views.
+  content-free SQLite accounting, monthly integer micro-USD enforcement, and loopback-only health
+  and usage views.
 - Both no-argument gateway launch and the retained `wmo run PROJECT [--ghost]` compatibility form
   are installed-wheel surfaces. Gateway startup is provider-idle and requires explicit authority.
 - The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
@@ -21,6 +22,11 @@ on the exact release checkout.
   attempts, provider-authentication fallback, refusal policy, post-commit no-switch, restart and
   replay behavior, revocation, cancellation, WAL mode, and mixed `host_managed`/
   `customer_managed` cost attribution that remains frozen across restart and catalog replacement.
+- Real-SQLite monthly budget evidence covers atomic concurrent reservations, provider-only route
+  exhaustion, shared identity quota errors, billable failure and crash retention, retry and
+  fallback accounting, keyed replay without duplicate spend, explicit schema migration, and UTC
+  month rollover without a reset job. The real loopback waterfall is configured through the
+  interactive-capable CLI and returns OpenAI `insufficient_quota` after shared exhaustion.
 - Deterministic source-level certification additionally covers selection-only project routing,
   authentication-circuit open/skip/recovery, concurrent multi-identity key revocation and alias
   revision activation, and atomic rollback of a failed legacy SQLite migration.
@@ -58,6 +64,9 @@ The machine-readable dated matrix is
 labeled as provider-byte incremental tool-argument streaming.
 
 ## Explicitly excluded
+
+- There is no budgets dashboard. Monthly allocation management and remaining-allocation reporting
+  are explicit interactive or non-interactive CLI operations.
 
 - No paid E2B or Harbor cloud smoke ran. The repository verifies the optional `bounded-close-v1`
   Harbor lifecycle and ledger with injected fakes, but makes no cloud cleanup, provider-quality, or

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ The root surface is deliberately small:
 | `wmo optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
 | `wmo run --root ROOT [--check]` | Validate or start the initialized authenticated multi-alias gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `wmo run PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as no-argument `wmo run`. |
-| `wmo config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
+| `wmo config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, monthly limits, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
 | `wmo config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.wmo/models.toml`. |
 | `wmo config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.wmo/settings.toml`. |
 | `wmo config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.wmo/settings.toml`. |
@@ -69,6 +69,29 @@ value is frozen on each physical attempt before dispatch and remains unchanged a
 replacement and restart. Usage JSON and HTML expose content-free physical-attempt buckets by source;
 they do not partition logical request counts. Legacy schema-v1/v2 attempts migrate explicitly as
 `customer_managed`.
+
+Monthly serving limits are separate from the one-shot `wmo config budget` command ceiling. They use
+integer micro-USD and explicit immutable UTC periods. The local team, an identity, a total alias
+pool, and each provider deployment can have overlapping hard limits:
+
+```console
+wmo config gateway budget set --period 2026-08 --scope identity \
+  --identity TEAM_MEMBER --limit-micro-usd 20000000000 \
+  --root ROOT --non-interactive --json
+wmo config gateway budget set --period 2026-08 --scope deployment \
+  --alias PUBLIC_ALIAS --pool EXACT_POOL --deployment AZURE_DEPLOYMENT \
+  --limit-micro-usd 10000000000 --root ROOT --non-interactive --json
+wmo config gateway budget set --period 2026-08 --scope deployment \
+  --alias PUBLIC_ALIAS --pool EXACT_POOL --deployment BEDROCK_DEPLOYMENT \
+  --limit-micro-usd 10000000000 --root ROOT --non-interactive --json
+wmo config gateway budget remaining --period 2026-08 --root ROOT --json
+```
+
+Omit required values in an interactive terminal to receive prompts. Pass `--non-interactive` to
+fail immediately instead. `--replace` changes a configured limit without deleting the month or its
+spend. Exhausting one deployment continues to the next certified exact-model route. Exhausting all
+applicable shared capacity returns OpenAI `insufficient_quota`. Unknown required pricing fails
+closed under a hard limit. There is no budget reset job and no budgets dashboard.
 
 Official OpenAI SDK clients use the issued virtual key and loopback base URL:
 

--- a/wmo/cli/gateway/app.py
+++ b/wmo/cli/gateway/app.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 
 from wmo.cli.gateway.alias import alias_app
+from wmo.cli.gateway.budget import budget_app
 from wmo.cli.gateway.key_output import (
     KeyOutputOutcomeUnknownError,
     KeyOutputRecoveryError,
@@ -35,6 +36,7 @@ identity_app = typer.Typer(help="Manage gateway caller identities.", no_args_is_
 key_app = typer.Typer(help="Issue and revoke virtual API keys.", no_args_is_help=True)
 grant_app = typer.Typer(help="Manage deny-by-default identity grants.", no_args_is_help=True)
 gateway_app.add_typer(provider_app, name="provider")
+gateway_app.add_typer(budget_app, name="budget")
 gateway_app.add_typer(identity_app, name="identity")
 gateway_app.add_typer(key_app, name="key")
 gateway_app.add_typer(alias_app, name="alias")

--- a/wmo/cli/gateway/app_test.py
+++ b/wmo/cli/gateway/app_test.py
@@ -37,6 +37,7 @@ from wmo.runtime.gateway.sqlite.store import OperationOutcomeUnknownError, SQLit
 EXPECTED_GATEWAY_COMMANDS = {"init", "status", "usage"}
 EXPECTED_GATEWAY_GROUPS = {
     "alias": {"create", "disable", "list", "update"},
+    "budget": {"list", "remaining", "set"},
     "grant": {"add", "list", "remove"},
     "identity": {"create", "disable", "list", "update"},
     "key": {"issue", "list", "revoke"},

--- a/wmo/cli/gateway/budget.py
+++ b/wmo/cli/gateway/budget.py
@@ -1,0 +1,185 @@
+"""Interactive and agent-friendly monthly gateway budget commands."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+
+from wmo.cli.gateway.receipts import GatewayReceipt, emit_items, emit_receipt
+from wmo.cli.options import ROOT_OPTION, usage_error
+from wmo.runtime.gateway.budgets import (
+    BudgetScope,
+    BudgetScopeKind,
+    SQLiteBudgetStore,
+    current_budget_period,
+)
+from wmo.runtime.gateway.management import GatewayManagement
+
+budget_app = typer.Typer(
+    help="Manage hard integer micro-USD allocations by immutable UTC month.",
+    no_args_is_help=True,
+)
+_JSON_OPTION = typer.Option(False, "--json")
+_NON_INTERACTIVE_OPTION = typer.Option(False, "--non-interactive")
+_SCOPE_OPTION = typer.Option(None, "--scope")
+
+
+@budget_app.command("set")
+def budget_set(
+    period: str | None = typer.Option(None, "--period"),
+    scope_kind: BudgetScopeKind | None = _SCOPE_OPTION,
+    limit_micro_usd: int | None = typer.Option(None, "--limit-micro-usd", min=0),
+    identity_id: str | None = typer.Option(None, "--identity"),
+    alias_id: str | None = typer.Option(None, "--alias"),
+    pool_id: str | None = typer.Option(None, "--pool"),
+    deployment_id: str | None = typer.Option(None, "--deployment"),
+    replace: bool = typer.Option(False, "--replace"),
+    root: Path = ROOT_OPTION,
+    non_interactive: bool = _NON_INTERACTIVE_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Create or explicitly replace one hard monthly allocation."""
+    selected_period = _required_value(
+        period,
+        name="--period",
+        prompt="UTC month (YYYY-MM)",
+        non_interactive=non_interactive,
+    )
+    selected_scope = scope_kind
+    if selected_scope is None:
+        if non_interactive:
+            raise typer.BadParameter("--scope is required with --non-interactive")
+        selected_scope = BudgetScopeKind(typer.prompt("Scope (team, identity, pool, deployment)"))
+    selected_limit = limit_micro_usd
+    if selected_limit is None:
+        if non_interactive:
+            raise typer.BadParameter("--limit-micro-usd is required with --non-interactive")
+        selected_limit = typer.prompt("Limit in integer micro-USD", type=int)
+    scope = _scope(
+        kind=selected_scope,
+        identity_id=identity_id,
+        alias_id=alias_id,
+        pool_id=pool_id,
+        deployment_id=deployment_id,
+        non_interactive=non_interactive,
+    )
+    manager = GatewayManagement(root)
+    with usage_error(ValueError):
+        manager.require_initialized()
+        changed, limit = SQLiteBudgetStore(manager.database_path).set_limit(
+            organization_id=manager.organization_id,
+            period=selected_period,
+            scope=scope,
+            limit_micro_usd=selected_limit,
+            replace=replace,
+        )
+    emit_receipt(
+        GatewayReceipt(
+            operation="budget.set",
+            resource_kind="monthly_budget",
+            resource_id=limit.budget_id,
+            changed=changed,
+            data=limit.model_dump(mode="json"),
+        ),
+        json_output=json_output,
+        human=f"{selected_period} {scope.key()} limit_micro_usd={selected_limit} changed={changed}",
+    )
+
+
+@budget_app.command("list")
+def budget_list(
+    period: str | None = typer.Option(None, "--period"),
+    root: Path = ROOT_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """List configured hard limits for one UTC month."""
+    selected_period = period or current_budget_period(datetime.now(UTC))
+    manager = GatewayManagement(root)
+    with usage_error(ValueError):
+        manager.require_initialized()
+        limits = SQLiteBudgetStore(manager.database_path).limits(
+            organization_id=manager.organization_id,
+            period=selected_period,
+        )
+    emit_items("monthly budgets", limits, json_output=json_output)
+
+
+@budget_app.command("remaining")
+def budget_remaining(
+    period: str | None = typer.Option(None, "--period"),
+    root: Path = ROOT_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Report reserved, settled, and remaining micro-USD for one UTC month."""
+    selected_period = period or current_budget_period(datetime.now(UTC))
+    manager = GatewayManagement(root)
+    with usage_error(ValueError):
+        manager.require_initialized()
+        remaining = SQLiteBudgetStore(manager.database_path).remaining(
+            organization_id=manager.organization_id,
+            period=selected_period,
+        )
+    emit_items("monthly budget remaining", remaining, json_output=json_output)
+
+
+def _scope(
+    *,
+    kind: BudgetScopeKind,
+    identity_id: str | None,
+    alias_id: str | None,
+    pool_id: str | None,
+    deployment_id: str | None,
+    non_interactive: bool,
+) -> BudgetScope:
+    """Resolve required identifiers for one interactive or non-interactive scope."""
+    if kind is BudgetScopeKind.IDENTITY:
+        identity_id = _required_value(
+            identity_id,
+            name="--identity",
+            prompt="Identity ID",
+            non_interactive=non_interactive,
+        )
+    if kind in {BudgetScopeKind.POOL, BudgetScopeKind.DEPLOYMENT}:
+        alias_id = _required_value(
+            alias_id,
+            name="--alias",
+            prompt="Gateway alias ID",
+            non_interactive=non_interactive,
+        )
+        pool_id = _required_value(
+            pool_id,
+            name="--pool",
+            prompt="Exact-model pool ID",
+            non_interactive=non_interactive,
+        )
+    if kind is BudgetScopeKind.DEPLOYMENT:
+        deployment_id = _required_value(
+            deployment_id,
+            name="--deployment",
+            prompt="Provider deployment ID",
+            non_interactive=non_interactive,
+        )
+    return BudgetScope(
+        kind=kind,
+        identity_id=identity_id,
+        alias_id=alias_id,
+        pool_id=pool_id,
+        deployment_id=deployment_id,
+    )
+
+
+def _required_value(
+    value: str | None,
+    *,
+    name: str,
+    prompt: str,
+    non_interactive: bool,
+) -> str:
+    """Return a supplied value, prompt for it, or reject missing automation input."""
+    if value is not None:
+        return value
+    if non_interactive:
+        raise typer.BadParameter(f"{name} is required with --non-interactive")
+    return typer.prompt(prompt)

--- a/wmo/cli/gateway/budget_test.py
+++ b/wmo/cli/gateway/budget_test.py
@@ -1,0 +1,151 @@
+"""Tests for interactive and non-interactive monthly budget management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wmo.cli.app import app
+from wmo.runtime.gateway.contracts import DirectTarget
+from wmo.runtime.gateway.management import GatewayManagement
+
+_DIGEST = "a" * 64
+
+
+def _configured(root: Path) -> GatewayManagement:
+    """Create the authority references required by identity and deployment scopes."""
+    manager = GatewayManagement(root)
+    manager.initialize()
+    store = manager.require_initialized()
+    manager.create_identity(identity_id="identity-one", display_name="Identity")
+    store.register_catalog_snapshot(
+        organization_id=manager.organization_id,
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+    )
+    store.activate_alias_revision(
+        organization_id=manager.organization_id,
+        alias_id="coding",
+        alias_name="coding",
+        revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        snapshot_ref="snapshot-one",
+        catalog_sha256=_DIGEST,
+    )
+    return manager
+
+
+def test_noninteractive_budget_management_reports_integer_remaining(tmp_path: Path) -> None:
+    """Automation can configure overlapping limits and read stable JSON receipts."""
+    _configured(tmp_path)
+    runner = CliRunner()
+    commands = (
+        ["--scope", "team", "--limit-micro-usd", "20000000000"],
+        [
+            "--scope",
+            "identity",
+            "--identity",
+            "identity-one",
+            "--limit-micro-usd",
+            "15000000000",
+        ],
+        [
+            "--scope",
+            "deployment",
+            "--alias",
+            "coding",
+            "--pool",
+            "pool-one",
+            "--deployment",
+            "azure-primary",
+            "--limit-micro-usd",
+            "10000000000",
+        ],
+    )
+    for arguments in commands:
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "budget",
+                "set",
+                "--period",
+                "2026-08",
+                *arguments,
+                "--root",
+                str(tmp_path),
+                "--non-interactive",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        receipt = json.loads(result.stdout)
+        assert receipt["operation"] == "budget.set"
+        assert isinstance(receipt["data"]["limit_micro_usd"], int)
+
+    listed = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "budget",
+            "list",
+            "--period",
+            "2026-08",
+            "--root",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    remaining = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "budget",
+            "remaining",
+            "--period",
+            "2026-08",
+            "--root",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    assert listed.exit_code == 0, listed.output
+    assert remaining.exit_code == 0, remaining.output
+    assert len(json.loads(listed.stdout)["items"]) == 3
+    items = json.loads(remaining.stdout)["items"]
+    assert len(items) == 3
+    assert all(item["remaining_micro_usd"] == item["budget"]["limit_micro_usd"] for item in items)
+    assert "dashboard" not in remaining.stdout.lower()
+
+
+def test_interactive_set_prompts_while_noninteractive_missing_values_fail(tmp_path: Path) -> None:
+    """Human prompts remain available and automation never waits for missing values."""
+    _configured(tmp_path)
+    runner = CliRunner()
+    interactive = runner.invoke(
+        app,
+        ["config", "gateway", "budget", "set", "--root", str(tmp_path)],
+        input="2026-08\nteam\n1000\n",
+    )
+    assert interactive.exit_code == 0, interactive.output
+    assert "2026-08 team limit_micro_usd=1000" in interactive.output
+
+    missing = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "budget",
+            "set",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+        ],
+    )
+    assert missing.exit_code == 2
+    assert "--period is required" in missing.output

--- a/wmo/cli/gateway/budget_test.py
+++ b/wmo/cli/gateway/budget_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import click
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -148,4 +149,5 @@ def test_interactive_set_prompts_while_noninteractive_missing_values_fail(tmp_pa
         ],
     )
     assert missing.exit_code == 2
-    assert "--period is required" in missing.output
+    normalized = " ".join(click.unstyle(missing.output).replace("│", " ").split())
+    assert "--period is required" in normalized

--- a/wmo/release_test.py
+++ b/wmo/release_test.py
@@ -47,14 +47,16 @@ REQUIRED_CORE_REQUIREMENTS = frozenset(
 REQUIRED_WHEEL_MODULES = frozenset(
     {
         "wmo/cli/gateway/app.py",
+        "wmo/cli/gateway/budget.py",
         "wmo/common/judging/calibration.py",
         "wmo/common/judging/labels.py",
         "wmo/common/judging/review.py",
         "wmo/common/models/model.py",
         "wmo/runtime/environments/local.py",
         "wmo/runtime/gateway/lifecycle.py",
+        "wmo/runtime/gateway/budgets.py",
         "wmo/runtime/gateway/ledger.py",
-        "wmo/runtime/gateway/openai/requests.py",
+        "wmo/runtime/openai_protocol/requests.py",
         "wmo/runtime/gateway/provider_certification.py",
         "wmo/runtime/gateway/service.py",
         "wmo/runtime/gateway/usage.py",

--- a/wmo/runtime/gateway/budgets.py
+++ b/wmo/runtime/gateway/budgets.py
@@ -363,15 +363,25 @@ def maximum_attempt_cost_micro_usd(
     if output_tokens is None:
         return None
     prices = deployment.gateway.prices
-    input_rates = [prices.input_micro_usd_per_million_tokens]
-    output_rates = [prices.output_micro_usd_per_million_tokens]
     capabilities = deployment.gateway.capabilities
+    required_rates = [
+        prices.input_micro_usd_per_million_tokens,
+        prices.output_micro_usd_per_million_tokens,
+    ]
     if capabilities.reports_cached_input_tokens:
-        input_rates.append(prices.cached_input_micro_usd_per_million_tokens)
+        required_rates.append(prices.cached_input_micro_usd_per_million_tokens)
     if capabilities.reports_reasoning_tokens:
-        output_rates.append(prices.reasoning_micro_usd_per_million_tokens)
-    if any(rate is None for rate in (*input_rates, *output_rates)):
+        required_rates.append(prices.reasoning_micro_usd_per_million_tokens)
+    if any(rate is None for rate in required_rates):
         return None
+    input_rates = (
+        prices.input_micro_usd_per_million_tokens,
+        prices.cached_input_micro_usd_per_million_tokens,
+    )
+    output_rates = (
+        prices.output_micro_usd_per_million_tokens,
+        prices.reasoning_micro_usd_per_million_tokens,
+    )
     numerator = input_tokens * sum(rate or 0 for rate in input_rates)
     numerator += output_tokens * sum(rate or 0 for rate in output_rates)
     maximum = (numerator + 999_999) // 1_000_000

--- a/wmo/runtime/gateway/budgets.py
+++ b/wmo/runtime/gateway/budgets.py
@@ -1,0 +1,653 @@
+"""UTC-month gateway budget authority and atomic reservation checks."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import Field, model_validator
+
+from wmo.common.core.artifacts import ContractModel, canonical_json_bytes, stable_id
+from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.runtime.gateway.auth import utc_text
+from wmo.runtime.gateway.contracts import GatewayRequest
+from wmo.runtime.gateway.interfaces import GatewayClock
+from wmo.runtime.gateway.sqlite.migrations import connect_database, initialize_database
+from wmo.runtime.gateway.sqlite.store import SystemGatewayClock
+
+MAXIMUM_MICRO_USD = 9_223_372_036_854_775_807
+
+
+class BudgetScopeKind(StrEnum):
+    """Supported hard-limit scopes inside one UTC month."""
+
+    TEAM = "team"
+    IDENTITY = "identity"
+    POOL = "pool"
+    DEPLOYMENT = "deployment"
+
+
+class BudgetScope(ContractModel):
+    """One explicit team, identity, pool, or deployment allocation target."""
+
+    kind: BudgetScopeKind
+    identity_id: str | None = Field(default=None, min_length=1, max_length=256)
+    alias_id: str | None = Field(default=None, min_length=1, max_length=256)
+    pool_id: str | None = Field(default=None, min_length=1, max_length=256)
+    deployment_id: str | None = Field(default=None, min_length=1, max_length=256)
+
+    @model_validator(mode="after")
+    def _require_scope_shape(self) -> BudgetScope:
+        """Require only the identifiers owned by the selected scope."""
+        present = (
+            self.identity_id is not None,
+            self.alias_id is not None,
+            self.pool_id is not None,
+            self.deployment_id is not None,
+        )
+        expected = {
+            BudgetScopeKind.TEAM: (False, False, False, False),
+            BudgetScopeKind.IDENTITY: (True, False, False, False),
+            BudgetScopeKind.POOL: (False, True, True, False),
+            BudgetScopeKind.DEPLOYMENT: (False, True, True, True),
+        }[self.kind]
+        if present != expected:
+            raise ValueError(f"{self.kind.value} budget scope has invalid identifiers")
+        return self
+
+    def key(self) -> str:
+        """Return a concise operator-facing key for this scope."""
+        parts = [self.kind.value]
+        parts.extend(
+            value
+            for value in (self.identity_id, self.alias_id, self.pool_id, self.deployment_id)
+            if value is not None
+        )
+        return ":".join(parts)
+
+    def storage_key(self) -> str:
+        """Return a collision-free content address for SQLite uniqueness."""
+        return stable_id(
+            "gateway-monthly-budget-scope",
+            self.model_dump(mode="json", exclude_none=False),
+        )
+
+
+class MonthlyBudgetLimit(ContractModel):
+    """One hard integer micro-USD allocation for an immutable UTC month bucket."""
+
+    budget_id: str
+    organization_id: str
+    period: str = Field(pattern=r"^\d{4}-(0[1-9]|1[0-2])$")
+    scope: BudgetScope
+    limit_micro_usd: int = Field(ge=0, le=MAXIMUM_MICRO_USD)
+    created_at: datetime
+    updated_at: datetime
+
+
+class MonthlyBudgetRemaining(ContractModel):
+    """Content-free remaining allocation for one configured monthly limit."""
+
+    budget: MonthlyBudgetLimit
+    charged_micro_usd: int = Field(ge=0)
+    reserved_micro_usd: int = Field(ge=0)
+    settled_micro_usd: int = Field(ge=0)
+    remaining_micro_usd: int = Field(ge=0)
+    unknown_cost_attempts: int = Field(ge=0)
+    exhausted: bool
+
+
+class BudgetReservationRejected(ValueError):
+    """One physical route cannot reserve beneath every applicable hard limit."""
+
+    def __init__(self, *, scope_kind: BudgetScopeKind, reason: str) -> None:
+        """Create one content-free route rejection."""
+        self.scope_kind = scope_kind
+        super().__init__(reason)
+
+
+class SQLiteBudgetStore:
+    """Manage and report hard monthly limits in the shared gateway database."""
+
+    def __init__(
+        self,
+        database_path: Path,
+        *,
+        clock: GatewayClock | None = None,
+        busy_timeout_ms: int = 5_000,
+    ) -> None:
+        """Bind one initialized gateway database and injectable UTC clock."""
+        self.database_path = database_path
+        self._clock = SystemGatewayClock() if clock is None else clock
+        self._busy_timeout_ms = busy_timeout_ms
+        initialize_database(database_path, busy_timeout_ms=busy_timeout_ms)
+
+    def set_limit(
+        self,
+        *,
+        organization_id: str,
+        period: str,
+        scope: BudgetScope,
+        limit_micro_usd: int,
+        replace: bool = False,
+    ) -> tuple[bool, MonthlyBudgetLimit]:
+        """Create or explicitly replace one monthly hard limit.
+
+        Args:
+            organization_id: Tenant whose attempts consume the allocation.
+            period: Immutable UTC month in ``YYYY-MM`` form.
+            scope: Exact allocation target.
+            limit_micro_usd: Nonnegative integer hard limit.
+            replace: Whether a different existing limit may be replaced.
+
+        Returns:
+            Change flag and current typed allocation.
+        """
+        if not 0 <= limit_micro_usd <= MAXIMUM_MICRO_USD:
+            raise ValueError("budget limit must fit a nonnegative SQLite integer")
+        period_start = budget_period_start(period)
+        now = utc_text(self._clock.now())
+        budget_id = stable_id(
+            "gateway-monthly-budget",
+            {
+                "organization_id": organization_id,
+                "period_start": period_start,
+                "scope_key": scope.storage_key(),
+            },
+        )
+        with self._transaction() as connection:
+            self._require_scope_authority(
+                connection,
+                organization_id=organization_id,
+                scope=scope,
+            )
+            row = connection.execute(
+                """
+                SELECT limit_micro_usd FROM gateway_monthly_budgets
+                WHERE organization_id = ? AND period_start = ? AND scope_key = ?
+                """,
+                (organization_id, period_start, scope.storage_key()),
+            ).fetchone()
+            if row is not None:
+                if int(row["limit_micro_usd"]) == limit_micro_usd:
+                    return False, self._read_limit(connection, budget_id)
+                if not replace:
+                    raise ValueError("monthly budget exists with another limit; pass --replace")
+                connection.execute(
+                    """
+                    UPDATE gateway_monthly_budgets
+                    SET limit_micro_usd = ?, updated_at = ? WHERE budget_id = ?
+                    """,
+                    (limit_micro_usd, now, budget_id),
+                )
+                return True, self._read_limit(connection, budget_id)
+            connection.execute(
+                """
+                INSERT INTO gateway_monthly_budgets (
+                    budget_id, organization_id, period_start, scope_kind, scope_key,
+                    identity_id, alias_id, pool_id, deployment_id, limit_micro_usd,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    budget_id,
+                    organization_id,
+                    period_start,
+                    scope.kind.value,
+                    scope.storage_key(),
+                    scope.identity_id,
+                    scope.alias_id,
+                    scope.pool_id,
+                    scope.deployment_id,
+                    limit_micro_usd,
+                    now,
+                    now,
+                ),
+            )
+            _backfill_budget(connection, budget_id=budget_id)
+            return True, self._read_limit(connection, budget_id)
+
+    def limits(
+        self,
+        *,
+        organization_id: str,
+        period: str,
+    ) -> tuple[MonthlyBudgetLimit, ...]:
+        """List configured limits for one immutable UTC month."""
+        period_start = budget_period_start(period)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM gateway_monthly_budgets
+                WHERE organization_id = ? AND period_start = ?
+                ORDER BY scope_kind, scope_key
+                """,
+                (organization_id, period_start),
+            ).fetchall()
+        return tuple(_limit_from_row(row) for row in rows)
+
+    def remaining(
+        self,
+        *,
+        organization_id: str,
+        period: str,
+    ) -> tuple[MonthlyBudgetRemaining, ...]:
+        """Read every configured allocation from one consistent SQLite snapshot."""
+        period_start = budget_period_start(period)
+        with self._connect() as connection:
+            connection.execute("BEGIN")
+            try:
+                rows = connection.execute(
+                    """
+                    SELECT * FROM gateway_monthly_budgets
+                    WHERE organization_id = ? AND period_start = ?
+                    ORDER BY scope_kind, scope_key
+                    """,
+                    (organization_id, period_start),
+                ).fetchall()
+                results = tuple(_remaining_from_row(row) for row in rows)
+            finally:
+                connection.rollback()
+        return results
+
+    def _read_limit(
+        self,
+        connection: sqlite3.Connection,
+        budget_id: str,
+    ) -> MonthlyBudgetLimit:
+        """Read one limit by stable ID inside the caller's transaction."""
+        row = connection.execute(
+            "SELECT * FROM gateway_monthly_budgets WHERE budget_id = ?",
+            (budget_id,),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("monthly budget disappeared inside its transaction")
+        return _limit_from_row(row)
+
+    @staticmethod
+    def _require_scope_authority(
+        connection: sqlite3.Connection,
+        *,
+        organization_id: str,
+        scope: BudgetScope,
+    ) -> None:
+        """Require referenced team authority before storing a limit."""
+        organization = connection.execute(
+            "SELECT 1 FROM organizations WHERE organization_id = ? AND active = 1",
+            (organization_id,),
+        ).fetchone()
+        if organization is None:
+            raise ValueError("budget organization is not active")
+        if scope.identity_id is not None:
+            identity = connection.execute(
+                """
+                SELECT 1 FROM identities
+                WHERE organization_id = ? AND identity_id = ? AND active = 1
+                """,
+                (organization_id, scope.identity_id),
+            ).fetchone()
+            if identity is None:
+                raise ValueError("budget identity is not active")
+        if scope.alias_id is not None:
+            alias = connection.execute(
+                """
+                SELECT 1 FROM gateway_aliases
+                WHERE organization_id = ? AND alias_id = ? AND active = 1
+                """,
+                (organization_id, scope.alias_id),
+            ).fetchone()
+            if alias is None:
+                raise ValueError("budget alias is not active")
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open and close one configured connection."""
+        connection = connect_database(self.database_path, busy_timeout_ms=self._busy_timeout_ms)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        """Run one immediate mutation transaction."""
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                yield connection
+            except BaseException:
+                connection.rollback()
+                raise
+            else:
+                connection.commit()
+
+
+def current_budget_period(now: datetime) -> str:
+    """Return the UTC ``YYYY-MM`` bucket containing one aware instant."""
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("budget clock must return a timezone-aware instant")
+    return now.astimezone(UTC).strftime("%Y-%m")
+
+
+def budget_period_start(period: str) -> str:
+    """Normalize one ``YYYY-MM`` value to its immutable UTC bucket start."""
+    try:
+        parsed = datetime.strptime(period, "%Y-%m").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise ValueError("budget period must use YYYY-MM") from exc
+    canonical = parsed.strftime("%Y-%m")
+    if canonical != period:
+        raise ValueError("budget period must use zero-padded YYYY-MM")
+    return f"{period}-01T00:00:00+00:00"
+
+
+def maximum_attempt_cost_micro_usd(
+    request: GatewayRequest,
+    deployment: ExactModelDeployment,
+) -> int | None:
+    """Return a conservative integer micro-USD ceiling for one physical call.
+
+    Canonical UTF-8 bytes conservatively upper-bound input tokens. The caller's output ceiling
+    wins when present, otherwise the frozen deployment limit is required. Optional cache and
+    reasoning dimensions participate only when the deployment declares that it reports them.
+    Unknown required prices produce ``None`` so an applicable hard limit fails closed.
+    """
+    input_tokens = len(canonical_json_bytes(request))
+    output_tokens = request.maximum_output_tokens
+    if output_tokens is None and deployment.capabilities is not None:
+        output_tokens = deployment.capabilities.maximum_output_tokens
+    if output_tokens is None:
+        return None
+    prices = deployment.gateway.prices
+    input_rates = [prices.input_micro_usd_per_million_tokens]
+    output_rates = [prices.output_micro_usd_per_million_tokens]
+    capabilities = deployment.gateway.capabilities
+    if capabilities.reports_cached_input_tokens:
+        input_rates.append(prices.cached_input_micro_usd_per_million_tokens)
+    if capabilities.reports_reasoning_tokens:
+        output_rates.append(prices.reasoning_micro_usd_per_million_tokens)
+    if any(rate is None for rate in (*input_rates, *output_rates)):
+        return None
+    numerator = input_tokens * sum(rate or 0 for rate in input_rates)
+    numerator += output_tokens * sum(rate or 0 for rate in output_rates)
+    return (numerator + 999_999) // 1_000_000
+
+
+def require_attempt_budget(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    identity_id: str,
+    alias_id: str,
+    pool_id: str,
+    deployment_id: str,
+    attempt_id: str,
+    period_start: str,
+    maximum_cost_micro_usd: int | None,
+) -> None:
+    """Atomically require room beneath every limit applicable to one attempt."""
+    rows = connection.execute(
+        """
+        SELECT * FROM gateway_monthly_budgets
+        WHERE organization_id = ? AND period_start = ? AND (
+            scope_kind = 'team'
+            OR (scope_kind = 'identity' AND identity_id = ?)
+            OR (scope_kind = 'pool' AND alias_id = ? AND pool_id = ?)
+            OR (scope_kind = 'deployment' AND alias_id = ? AND pool_id = ?
+                AND deployment_id = ?)
+        )
+        ORDER BY scope_kind, scope_key
+        """,
+        (
+            organization_id,
+            period_start,
+            identity_id,
+            alias_id,
+            pool_id,
+            alias_id,
+            pool_id,
+            deployment_id,
+        ),
+    ).fetchall()
+    if not rows:
+        return
+    for row in rows:
+        scope_kind = BudgetScopeKind(str(row["scope_kind"]))
+        unknown = int(row["unknown_cost_attempts"])
+        charged = int(row["reserved_micro_usd"]) + int(row["settled_micro_usd"])
+        limit = int(row["limit_micro_usd"])
+        if unknown:
+            raise BudgetReservationRejected(
+                scope_kind=scope_kind,
+                reason="monthly hard limit has prior attempts with unknown cost",
+            )
+        if maximum_cost_micro_usd is None:
+            raise BudgetReservationRejected(
+                scope_kind=scope_kind,
+                reason="monthly hard limit requires a known maximum attempt cost",
+            )
+        if maximum_cost_micro_usd > max(0, limit - charged):
+            raise BudgetReservationRejected(
+                scope_kind=scope_kind,
+                reason=f"monthly {scope_kind.value} allocation is exhausted",
+            )
+    assert maximum_cost_micro_usd is not None
+    for row in rows:
+        connection.execute(
+            """
+            UPDATE gateway_monthly_budgets
+            SET reserved_micro_usd = reserved_micro_usd + ?
+            WHERE budget_id = ?
+            """,
+            (maximum_cost_micro_usd, str(row["budget_id"])),
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_attempt_budget_charges (
+                budget_id, attempt_id, reserved_micro_usd
+            ) VALUES (?, ?, ?)
+            """,
+            (str(row["budget_id"]), attempt_id, maximum_cost_micro_usd),
+        )
+
+
+def settle_attempt_budgets(
+    connection: sqlite3.Connection,
+    *,
+    attempt_id: str,
+    settled_micro_usd: int | None,
+) -> None:
+    """Move every applicable attempt charge from reserved or unknown to settled."""
+    rows = connection.execute(
+        """
+        SELECT c.budget_id, c.reserved_micro_usd, c.settled_micro_usd,
+               b.settled_micro_usd AS budget_settled_micro_usd
+        FROM gateway_attempt_budget_charges AS c
+        JOIN gateway_monthly_budgets AS b ON b.budget_id = c.budget_id
+        WHERE c.attempt_id = ?
+        """,
+        (attempt_id,),
+    ).fetchall()
+    for row in rows:
+        if row["settled_micro_usd"] is not None or settled_micro_usd is None:
+            continue
+        budget_id = str(row["budget_id"])
+        if int(row["budget_settled_micro_usd"]) + settled_micro_usd > MAXIMUM_MICRO_USD:
+            raise ValueError("settled monthly gateway cost exceeds SQLite integer capacity")
+        reserved = None if row["reserved_micro_usd"] is None else int(row["reserved_micro_usd"])
+        if reserved is None:
+            update = connection.execute(
+                """
+                UPDATE gateway_monthly_budgets
+                SET unknown_cost_attempts = unknown_cost_attempts - 1,
+                    settled_micro_usd = settled_micro_usd + ?
+                WHERE budget_id = ? AND unknown_cost_attempts > 0
+                """,
+                (settled_micro_usd, budget_id),
+            )
+        else:
+            update = connection.execute(
+                """
+                UPDATE gateway_monthly_budgets
+                SET reserved_micro_usd = reserved_micro_usd - ?,
+                    settled_micro_usd = settled_micro_usd + ?
+                WHERE budget_id = ? AND reserved_micro_usd >= ?
+                """,
+                (
+                    reserved,
+                    settled_micro_usd,
+                    budget_id,
+                    reserved,
+                ),
+            )
+        if update.rowcount != 1:
+            raise RuntimeError("monthly budget counters are inconsistent")
+        charge = connection.execute(
+            """
+            UPDATE gateway_attempt_budget_charges SET settled_micro_usd = ?
+            WHERE budget_id = ? AND attempt_id = ? AND settled_micro_usd IS NULL
+            """,
+            (settled_micro_usd, budget_id, attempt_id),
+        )
+        if charge.rowcount != 1:
+            raise RuntimeError("attempt budget charge is already settled")
+
+
+def _remaining_from_row(row: sqlite3.Row) -> MonthlyBudgetRemaining:
+    """Decode one materialized allocation balance without scanning attempt history."""
+    budget = _limit_from_row(row)
+    reserved = int(row["reserved_micro_usd"])
+    settled = int(row["settled_micro_usd"])
+    charged = reserved + settled
+    unknown = int(row["unknown_cost_attempts"])
+    remaining = 0 if unknown else max(0, budget.limit_micro_usd - charged)
+    return MonthlyBudgetRemaining(
+        budget=budget,
+        charged_micro_usd=charged,
+        reserved_micro_usd=reserved,
+        settled_micro_usd=settled,
+        remaining_micro_usd=remaining,
+        unknown_cost_attempts=unknown,
+        exhausted=unknown > 0 or charged >= budget.limit_micro_usd,
+    )
+
+
+def _backfill_budget(connection: sqlite3.Connection, *, budget_id: str) -> None:
+    """Bind prior attempts to a newly configured limit and materialize exact counters."""
+    row = connection.execute(
+        "SELECT * FROM gateway_monthly_budgets WHERE budget_id = ?",
+        (budget_id,),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("monthly budget disappeared before historical backfill")
+    period_start = str(row["period_start"])
+    predicate, parameters = _attempt_scope_predicate(row, period_start=period_start)
+    attempts = connection.execute(
+        f"""
+        SELECT a.attempt_id, a.budget_reserved_micro_usd,
+               a.budget_settled_micro_usd, a.estimated_cost_micro_usd
+        FROM gateway_attempts AS a
+        JOIN gateway_requests AS r ON r.request_id = a.request_id
+        WHERE {predicate} ORDER BY a.attempt_id
+        """,
+        parameters,
+    )
+    reserved_total = 0
+    settled_total = 0
+    unknown_total = 0
+    for attempt in attempts:
+        settled = _historical_settlement(attempt)
+        reserved = (
+            int(attempt["budget_reserved_micro_usd"])
+            if settled is None and attempt["budget_reserved_micro_usd"] is not None
+            else None
+        )
+        unknown = settled is None and reserved is None
+        reserved_total += reserved or 0
+        settled_total += settled or 0
+        unknown_total += int(unknown)
+        if reserved_total > MAXIMUM_MICRO_USD or settled_total > MAXIMUM_MICRO_USD:
+            raise ValueError("historical monthly gateway cost exceeds SQLite integer capacity")
+        connection.execute(
+            """
+            INSERT INTO gateway_attempt_budget_charges (
+                budget_id, attempt_id, reserved_micro_usd, settled_micro_usd
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (budget_id, str(attempt["attempt_id"]), reserved, settled),
+        )
+    connection.execute(
+        """
+        UPDATE gateway_monthly_budgets
+        SET reserved_micro_usd = ?, settled_micro_usd = ?, unknown_cost_attempts = ?
+        WHERE budget_id = ?
+        """,
+        (reserved_total, settled_total, unknown_total, budget_id),
+    )
+
+
+def _historical_settlement(row: sqlite3.Row) -> int | None:
+    """Return one prior attempt's settled cost while preserving active reservations."""
+    if row["budget_settled_micro_usd"] is not None:
+        return int(row["budget_settled_micro_usd"])
+    if row["budget_reserved_micro_usd"] is not None:
+        return None
+    if row["estimated_cost_micro_usd"] is not None:
+        return int(row["estimated_cost_micro_usd"])
+    return None
+
+
+def _attempt_scope_predicate(
+    row: sqlite3.Row,
+    *,
+    period_start: str,
+) -> tuple[str, tuple[str, ...]]:
+    """Return one fixed SQL predicate and parameters for a stored scope."""
+    base = "a.organization_id = ? AND a.budget_period_start = ?"
+    organization_id = str(row["organization_id"])
+    kind = BudgetScopeKind(str(row["scope_kind"]))
+    if kind is BudgetScopeKind.TEAM:
+        return base, (organization_id, period_start)
+    if kind is BudgetScopeKind.IDENTITY:
+        return f"{base} AND r.identity_id = ?", (
+            organization_id,
+            period_start,
+            str(row["identity_id"]),
+        )
+    if kind is BudgetScopeKind.POOL:
+        return f"{base} AND r.alias_id = ? AND a.pool_id = ?", (
+            organization_id,
+            period_start,
+            str(row["alias_id"]),
+            str(row["pool_id"]),
+        )
+    return f"{base} AND r.alias_id = ? AND a.pool_id = ? AND a.deployment_id = ?", (
+        organization_id,
+        period_start,
+        str(row["alias_id"]),
+        str(row["pool_id"]),
+        str(row["deployment_id"]),
+    )
+
+
+def _limit_from_row(row: sqlite3.Row) -> MonthlyBudgetLimit:
+    """Decode one strict SQLite budget row."""
+    return MonthlyBudgetLimit(
+        budget_id=str(row["budget_id"]),
+        organization_id=str(row["organization_id"]),
+        period=str(row["period_start"])[:7],
+        scope=BudgetScope(
+            kind=BudgetScopeKind(str(row["scope_kind"])),
+            identity_id=(None if row["identity_id"] is None else str(row["identity_id"])),
+            alias_id=None if row["alias_id"] is None else str(row["alias_id"]),
+            pool_id=None if row["pool_id"] is None else str(row["pool_id"]),
+            deployment_id=(None if row["deployment_id"] is None else str(row["deployment_id"])),
+        ),
+        limit_micro_usd=int(row["limit_micro_usd"]),
+        created_at=datetime.fromisoformat(str(row["created_at"])),
+        updated_at=datetime.fromisoformat(str(row["updated_at"])),
+    )

--- a/wmo/runtime/gateway/budgets.py
+++ b/wmo/runtime/gateway/budgets.py
@@ -374,7 +374,8 @@ def maximum_attempt_cost_micro_usd(
         return None
     numerator = input_tokens * sum(rate or 0 for rate in input_rates)
     numerator += output_tokens * sum(rate or 0 for rate in output_rates)
-    return (numerator + 999_999) // 1_000_000
+    maximum = (numerator + 999_999) // 1_000_000
+    return maximum if maximum <= MAXIMUM_MICRO_USD else None
 
 
 def require_attempt_budget(

--- a/wmo/runtime/gateway/budgets_test.py
+++ b/wmo/runtime/gateway/budgets_test.py
@@ -160,6 +160,19 @@ def test_maximum_attempt_cost_is_integer_conservative_and_unknown_prices_fail_cl
 
     assert known is not None and isinstance(known, int) and known > 32
     assert maximum_attempt_cost_micro_usd(request, _deployment(priced=False)) is None
+    unrepresentable = _deployment().model_copy(
+        update={
+            "gateway": _deployment().gateway.model_copy(
+                update={
+                    "prices": GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=10**30,
+                        output_micro_usd_per_million_tokens=10**30,
+                    )
+                }
+            )
+        }
+    )
+    assert maximum_attempt_cost_micro_usd(request, unrepresentable) is None
     assert (
         maximum_attempt_cost_micro_usd(
             request.model_copy(update={"maximum_output_tokens": None}),

--- a/wmo/runtime/gateway/budgets_test.py
+++ b/wmo/runtime/gateway/budgets_test.py
@@ -1,0 +1,428 @@
+"""Tests for monthly hard limits, reservation concurrency, and UTC rollover."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmo.common.models import ModelCapabilities
+from wmo.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
+from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.runtime.gateway.budgets import (
+    BudgetReservationRejected,
+    BudgetScope,
+    BudgetScopeKind,
+    SQLiteBudgetStore,
+    maximum_attempt_cost_micro_usd,
+)
+from wmo.runtime.gateway.contracts import (
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayUsage,
+)
+from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
+from wmo.runtime.gateway.sqlite.store import SQLiteGatewayStore
+
+_CATALOG = "a" * 64
+
+
+class _Clock:
+    """Controllable aware wall and monotonic clock."""
+
+    def __init__(self) -> None:
+        """Start near the end of one UTC month."""
+        self.wall = datetime(2026, 8, 31, 23, 59, tzinfo=UTC)
+        self.monotonic_value = 100.0
+
+    def now(self) -> datetime:
+        """Return controlled wall time."""
+        return self.wall
+
+    def monotonic(self) -> float:
+        """Return controlled monotonic time."""
+        return self.monotonic_value
+
+    def advance(self, duration: timedelta) -> None:
+        """Advance both clocks by one duration."""
+        self.wall += duration
+        self.monotonic_value += duration.total_seconds()
+
+
+def _deployment(*, priced: bool = True, deployment_id: str = "primary") -> ExactModelDeployment:
+    """Return one exact deployment with optional hard-limit pricing."""
+    prices = (
+        GatewayTokenPrices(
+            input_micro_usd_per_million_tokens=1_000_000,
+            output_micro_usd_per_million_tokens=2_000_000,
+        )
+        if priced
+        else GatewayTokenPrices()
+    )
+    return ExactModelDeployment(
+        deployment_id=deployment_id,
+        source_alias=deployment_id,
+        exact_model_id="exact-one",
+        connection=f"connection-{deployment_id}",
+        provider="openai-compatible",
+        provider_model="provider-model",
+        connection_sha256=("b" if deployment_id == "primary" else "c") * 64,
+        capabilities_sha256="d" * 64,
+        capabilities=ModelCapabilities(maximum_output_tokens=16),
+        gateway=GatewayDeploymentMetadata(
+            prices=prices,
+            pricing_source="test",
+        ),
+    )
+
+
+def _request(content: str) -> GatewayRequest:
+    """Build one bounded request whose content is never persisted."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content=content),),
+        maximum_output_tokens=16,
+    )
+
+
+def _authority(
+    tmp_path: Path,
+    clock: _Clock,
+) -> tuple[SQLiteGatewayStore, SQLiteAttemptLedger, SQLiteBudgetStore, str]:
+    """Create real SQLite authority, ledger, budget store, and one granted key."""
+    path = tmp_path / "gateway.db"
+    store = SQLiteGatewayStore(path, clock=clock)
+    ledger = SQLiteAttemptLedger(path, clock=clock)
+    budgets = SQLiteBudgetStore(path, clock=clock)
+    store.create_organization(organization_id="org", slug="org", display_name="Org")
+    store.create_identity(organization_id="org", identity_id="identity", display_name="Identity")
+    store.register_catalog_snapshot(
+        organization_id="org",
+        snapshot_ref="snapshot",
+        catalog_sha256=_CATALOG,
+    )
+    store.activate_alias_revision(
+        organization_id="org",
+        alias_id="coding",
+        alias_name="coding",
+        revision_id="revision",
+        target=DirectTarget(pool_id="pool"),
+        snapshot_ref="snapshot",
+        catalog_sha256=_CATALOG,
+    )
+    store.grant_alias(organization_id="org", identity_id="identity", alias_id="coding")
+    key = store.issue_virtual_key(
+        organization_id="org",
+        identity_id="identity",
+        key_id="key",
+    ).raw_key
+    return store, ledger, budgets, key
+
+
+def _accepted(
+    store: SQLiteGatewayStore,
+    ledger: SQLiteAttemptLedger,
+    clock: _Clock,
+    key: str,
+    content: str,
+) -> tuple[GatewayRequest, ExecutionSnapshot]:
+    """Authorize and durably accept one unique request."""
+    request = _request(content)
+    authorization = store.authorize_request(
+        raw_key=key,
+        alias="coding",
+        request=request,
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    return request, ExecutionSnapshot(
+        authorization=authorization,
+        exact_model_id="exact-one",
+        pool_id="pool",
+        deployment_ids=("primary", "secondary"),
+    )
+
+
+def test_maximum_attempt_cost_is_integer_conservative_and_unknown_prices_fail_closed() -> None:
+    """Reservation pricing uses canonical bytes, output ceiling, and no float money."""
+    request = _request("four bytes")
+    known = maximum_attempt_cost_micro_usd(request, _deployment())
+
+    assert known is not None and isinstance(known, int) and known > 32
+    assert maximum_attempt_cost_micro_usd(request, _deployment(priced=False)) is None
+    assert (
+        maximum_attempt_cost_micro_usd(
+            request.model_copy(update={"maximum_output_tokens": None}),
+            _deployment().model_copy(update={"capabilities": ModelCapabilities()}),
+        )
+        is None
+    )
+
+
+def test_concurrent_identity_reservations_never_exceed_hard_limit(tmp_path: Path) -> None:
+    """BEGIN IMMEDIATE serializes competing reservations before attempt insertion."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.IDENTITY, identity_id="identity"),
+        limit_micro_usd=500,
+    )
+    snapshots = [
+        _accepted(store, ledger, clock, key, f"concurrent-{index}")[1] for index in range(10)
+    ]
+
+    def reserve(index: int) -> str:
+        """Attempt one competing fixed-size reservation."""
+        return ledger.start_attempt(
+            snapshot=snapshots[index],
+            deployment=_deployment(),
+            attempt_ordinal=0,
+            route_depth=0,
+            maximum_cost_micro_usd=100,
+        )
+
+    accepted: list[str] = []
+    rejected = 0
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(reserve, index) for index in range(10)]
+        for future in futures:
+            try:
+                accepted.append(future.result())
+            except BudgetReservationRejected:
+                rejected += 1
+
+    assert len(accepted) == 5
+    assert rejected == 5
+    remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert remaining.reserved_micro_usd == 500
+    assert remaining.remaining_micro_usd == 0
+
+
+def test_settlement_counts_failures_retries_and_rollover_without_reset(tmp_path: Path) -> None:
+    """Every physical attempt settles in its start month and old buckets remain unchanged."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=1_000,
+    )
+    _request_one, snapshot_one = _accepted(store, ledger, clock, key, "failed-attempt")
+    failed = ledger.start_attempt(
+        snapshot=snapshot_one,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=300,
+    )
+    ledger.finish_attempt(
+        attempt_id=failed,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="provider transport failed",
+        ),
+    )
+
+    # A failure without usage can still be billable, so the maximum reservation remains charged.
+    august = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert august.charged_micro_usd == 300
+    clock.advance(timedelta(minutes=2))
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-09",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=1_000,
+    )
+    _request_two, snapshot_two = _accepted(store, ledger, clock, key, "completed-attempt")
+    completed = ledger.start_attempt(
+        snapshot=snapshot_two,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=300,
+    )
+    ledger.finish_attempt(
+        attempt_id=completed,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=0,
+            usage=GatewayUsage(input_tokens=10, output_tokens=5),
+        ),
+        failure=None,
+    )
+
+    assert budgets.remaining(organization_id="org", period="2026-08")[0].charged_micro_usd == 300
+    september = budgets.remaining(organization_id="org", period="2026-09")[0]
+    assert september.reserved_micro_usd == 0
+    assert september.settled_micro_usd == 20
+    assert september.remaining_micro_usd == 980
+
+
+def test_unknown_historical_cost_fails_closed_only_after_limit_exists(tmp_path: Path) -> None:
+    """An unpriced attempt may run without limits but blocks a later hard cap in that month."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    _first_request, first_snapshot = _accepted(store, ledger, clock, key, "unknown-first")
+    attempt = ledger.start_attempt(
+        snapshot=first_snapshot,
+        deployment=_deployment(priced=False),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=None,
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="provider transport failed",
+        ),
+    )
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=1_000,
+    )
+    _second_request, second_snapshot = _accepted(store, ledger, clock, key, "unknown-second")
+
+    with pytest.raises(BudgetReservationRejected, match="prior attempts with unknown cost"):
+        ledger.start_attempt(
+            snapshot=second_snapshot,
+            deployment=_deployment(),
+            attempt_ordinal=0,
+            route_depth=0,
+            maximum_cost_micro_usd=100,
+        )
+    remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert remaining.unknown_cost_attempts == 1
+    assert remaining.remaining_micro_usd == 0
+
+
+def test_limit_created_midflight_adopts_and_settles_existing_reservation(
+    tmp_path: Path,
+) -> None:
+    """A new limit binds an active attempt and later settles it exactly once."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    _request_value, snapshot = _accepted(store, ledger, clock, key, "midflight")
+    attempt = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=300,
+    )
+
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=1_000,
+    )
+    active = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert active.reserved_micro_usd == 300
+    assert active.settled_micro_usd == 0
+
+    terminal = GatewayEvent(
+        kind=GatewayEventKind.COMPLETED,
+        sequence_number=0,
+        usage=GatewayUsage(input_tokens=10, output_tokens=5),
+    )
+    ledger.finish_attempt(attempt_id=attempt, terminal_event=terminal, failure=None)
+    ledger.finish_attempt(attempt_id=attempt, terminal_event=terminal, failure=None)
+
+    settled = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert settled.reserved_micro_usd == 0
+    assert settled.settled_micro_usd == 20
+    assert settled.remaining_micro_usd == 980
+
+
+def test_crash_recovery_retains_reservation_and_idempotent_settlement_charges_once(
+    tmp_path: Path,
+) -> None:
+    """Unknown dispatches keep their maximum while repeated settlement cannot double-charge."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=500,
+    )
+    _request_one, first_snapshot = _accepted(store, ledger, clock, key, "crash")
+    ledger.start_attempt(
+        snapshot=first_snapshot,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=100,
+    )
+    clock.advance(timedelta(seconds=31))
+    assert ledger.reconcile_crashed_requests(cleanup_grace=timedelta(0)) == (0, 1)
+    after_crash = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert after_crash.reserved_micro_usd == 100
+    assert after_crash.remaining_micro_usd == 400
+
+    _request_two, second_snapshot = _accepted(store, ledger, clock, key, "settle-once")
+    settled = ledger.start_attempt(
+        snapshot=second_snapshot,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=200,
+    )
+    terminal = GatewayEvent(
+        kind=GatewayEventKind.COMPLETED,
+        sequence_number=0,
+        usage=GatewayUsage(input_tokens=10, output_tokens=5),
+    )
+    ledger.finish_attempt(attempt_id=settled, terminal_event=terminal, failure=None)
+    ledger.finish_attempt(attempt_id=settled, terminal_event=terminal, failure=None)
+
+    remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert remaining.charged_micro_usd == 120
+    assert remaining.reserved_micro_usd == 100
+    assert remaining.settled_micro_usd == 20
+    assert remaining.remaining_micro_usd == 380
+
+
+def test_migrated_attempts_receive_explicit_period_and_cost_state(tmp_path: Path) -> None:
+    """The current schema stores no floating monetary fields or resettable counters."""
+    clock = _Clock()
+    store, ledger, _budgets, key = _authority(tmp_path, clock)
+    _request_value, snapshot = _accepted(store, ledger, clock, key, "schema")
+    attempt = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=123,
+    )
+    connection = sqlite3.connect(ledger.database_path)
+    try:
+        row = connection.execute(
+            """
+            SELECT budget_period_start, budget_reserved_micro_usd,
+                   budget_settled_micro_usd
+            FROM gateway_attempts WHERE attempt_id = ?
+            """,
+            (attempt,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row == ("2026-08-01T00:00:00+00:00", 123, None)

--- a/wmo/runtime/gateway/budgets_test.py
+++ b/wmo/runtime/gateway/budgets_test.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from wmo.common.core.artifacts import canonical_json_bytes
 from wmo.common.models import ModelCapabilities
 from wmo.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
 from wmo.common.models.gateway_catalog import ExactModelDeployment
@@ -173,6 +174,24 @@ def test_maximum_attempt_cost_is_integer_conservative_and_unknown_prices_fail_cl
         }
     )
     assert maximum_attempt_cost_micro_usd(request, unrepresentable) is None
+    all_prices = _deployment().model_copy(
+        update={
+            "gateway": _deployment().gateway.model_copy(
+                update={
+                    "prices": GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=1_000_000,
+                        cached_input_micro_usd_per_million_tokens=3_000_000,
+                        output_micro_usd_per_million_tokens=2_000_000,
+                        reasoning_micro_usd_per_million_tokens=4_000_000,
+                    )
+                }
+            )
+        }
+    )
+    assert all_prices.gateway.capabilities.reports_cached_input_tokens is False
+    assert all_prices.gateway.capabilities.reports_reasoning_tokens is False
+    all_dimensions = maximum_attempt_cost_micro_usd(request, all_prices)
+    assert all_dimensions is not None and all_dimensions > known
     assert (
         maximum_attempt_cost_micro_usd(
             request.model_copy(update={"maximum_output_tokens": None}),
@@ -220,6 +239,64 @@ def test_concurrent_identity_reservations_never_exceed_hard_limit(tmp_path: Path
     assert rejected == 5
     remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
     assert remaining.reserved_micro_usd == 500
+    assert remaining.remaining_micro_usd == 0
+
+
+def test_configured_optional_prices_are_reserved_even_when_reporting_hints_are_false(
+    tmp_path: Path,
+) -> None:
+    """Provider usage cannot settle cached or reasoning cost above its reservation."""
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(tmp_path, clock)
+    deployment = _deployment().model_copy(
+        update={
+            "gateway": _deployment().gateway.model_copy(
+                update={
+                    "prices": GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=1_000_000,
+                        cached_input_micro_usd_per_million_tokens=3_000_000,
+                        output_micro_usd_per_million_tokens=2_000_000,
+                        reasoning_micro_usd_per_million_tokens=4_000_000,
+                    )
+                }
+            )
+        }
+    )
+    request, snapshot = _accepted(store, ledger, clock, key, "all-price-dimensions")
+    maximum = maximum_attempt_cost_micro_usd(request, deployment)
+    assert maximum is not None
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=maximum,
+    )
+    attempt = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=deployment,
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=maximum,
+    )
+    input_ceiling = len(canonical_json_bytes(request))
+    ledger.finish_attempt(
+        attempt_id=attempt,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=0,
+            usage=GatewayUsage(
+                input_tokens=input_ceiling,
+                cached_input_tokens=input_ceiling,
+                output_tokens=16,
+                reasoning_tokens=16,
+            ),
+        ),
+        failure=None,
+    )
+
+    remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
+    assert remaining.reserved_micro_usd == 0
+    assert remaining.settled_micro_usd == maximum
     assert remaining.remaining_micro_usd == 0
 
 

--- a/wmo/runtime/gateway/contracts.py
+++ b/wmo/runtime/gateway/contracts.py
@@ -241,6 +241,7 @@ class GatewayFailureClass(StrEnum):
     UNSUPPORTED_CAPABILITY = "unsupported_capability"
     AUTHENTICATION = "authentication"
     AUTHORIZATION = "authorization"
+    QUOTA_EXCEEDED = "quota_exceeded"
     THROTTLED = "throttled"
     TRANSPORT = "transport"
     TIMEOUT = "timeout"

--- a/wmo/runtime/gateway/data_plane_test.py
+++ b/wmo/runtime/gateway/data_plane_test.py
@@ -135,9 +135,10 @@ class _Ledger:
         deployment: ExactModelDeployment,
         attempt_ordinal: int,
         route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
     ) -> str:
         """Capture dispatch identity and return a deterministic attempt ID."""
-        del deployment, attempt_ordinal, route_depth
+        del deployment, attempt_ordinal, route_depth, maximum_cost_micro_usd
         self.started.append(snapshot)
         return f"attempt-{len(self.started)}"
 

--- a/wmo/runtime/gateway/execution.py
+++ b/wmo/runtime/gateway/execution.py
@@ -10,6 +10,11 @@ from typing import cast
 
 from wmo.common.core.artifacts import stable_id
 from wmo.common.models.gateway_catalog import ExactModelDeployment
+from wmo.runtime.gateway.budgets import (
+    BudgetReservationRejected,
+    BudgetScopeKind,
+    maximum_attempt_cost_micro_usd,
+)
 from wmo.runtime.gateway.contracts import (
     GatewayEvent,
     GatewayEventKind,
@@ -405,6 +410,23 @@ class GatewayExecutionStream:
                 return None
             except asyncio.CancelledError:
                 raise
+            except _BudgetRouteSkipped as exc:
+                if exc.scope_kind is not BudgetScopeKind.DEPLOYMENT:
+                    failure = _budget_quota_failure()
+                    if finalize_on_exhaustion:
+                        await self._finish_parent(failure)
+                    return failure
+                next_candidate = self._next_budget_candidate(current_candidate)
+                if next_candidate is None:
+                    failure = (
+                        _budget_quota_failure()
+                        if current_candidate == len(self._resolved) - 1
+                        else _all_routes_unavailable()
+                    )
+                    if finalize_on_exhaustion:
+                        await self._finish_parent(failure)
+                    return failure
+                current_candidate = next_candidate
             except _DispatchFailure as exc:
                 failure = exc.failure
                 self._health.failed(self._health_key(current_candidate), failure)
@@ -424,14 +446,18 @@ class GatewayExecutionStream:
         attempt_id: str | None = None
         try:
             self._deadline.attempt_timeout()
-            self._attempt_counts[route_index] += 1
-            self._total_attempts += 1
             attempt_id = self._ledger.start_attempt(
                 snapshot=self._route.snapshot,
                 deployment=binding.deployment,
-                attempt_ordinal=self._total_attempts - 1,
+                attempt_ordinal=self._total_attempts,
                 route_depth=route_index,
+                maximum_cost_micro_usd=maximum_attempt_cost_micro_usd(
+                    self._request,
+                    binding.deployment,
+                ),
             )
+            self._attempt_counts[route_index] += 1
+            self._total_attempts += 1
             self._ledger.record_route_context(
                 attempt_id=attempt_id,
                 route_reason=self._route.route_reason,
@@ -453,6 +479,9 @@ class GatewayExecutionStream:
                 raise asyncio.CancelledError
             current.stream = stream
             current.iterator = stream.__aiter__()
+        except BudgetReservationRejected as exc:
+            self._health.release_probe(binding.health_key)
+            raise _BudgetRouteSkipped(exc.scope_kind) from exc
         except BaseException as exc:
             if attempt_id is None:
                 self._health.release_probe(binding.health_key)
@@ -552,6 +581,13 @@ class GatewayExecutionStream:
                 return route_index
         return None
 
+    def _next_budget_candidate(self, current: int) -> int | None:
+        """Advance past a route whose hard monthly allocation cannot admit this call."""
+        for route_index in range(current + 1, len(self._resolved)):
+            if self._health.claim(self._health_key(route_index)):
+                return route_index
+        return None
+
     def _require_current_index_for_failure(self) -> int:
         """Return the last dispatched route index, including failed opening attempts."""
         if self._current is not None and not self._current.settled:
@@ -639,6 +675,15 @@ class _DispatchFailure(Exception):
         self.attempt_id = attempt_id
         self.failure = failure
         self.cancelled = cancelled
+
+
+class _BudgetRouteSkipped(Exception):
+    """A physical route could not reserve beneath its applicable monthly limits."""
+
+    def __init__(self, scope_kind: BudgetScopeKind) -> None:
+        """Retain only the content-free scope classification for fallback policy."""
+        self.scope_kind = scope_kind
+        super().__init__(scope_kind.value)
 
 
 class GatewayExecutor:
@@ -831,4 +876,12 @@ def _all_routes_unavailable() -> GatewayFailure:
     return GatewayFailure(
         failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
         safe_message="all exact-model deployments are unavailable",
+    )
+
+
+def _budget_quota_failure() -> GatewayFailure:
+    """Return the sanitized quota failure after no route can reserve its maximum cost."""
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+        safe_message="monthly gateway allocation is exhausted",
     )

--- a/wmo/runtime/gateway/interfaces.py
+++ b/wmo/runtime/gateway/interfaces.py
@@ -65,8 +65,9 @@ class AttemptLedger(Protocol):
         deployment: ExactModelDeployment,
         attempt_ordinal: int,
         route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
     ) -> AttemptId:
-        """Persist one accepted attempt before provider dispatch."""
+        """Atomically reserve cost and persist one attempt before provider dispatch."""
         ...
 
     def finish_attempt(

--- a/wmo/runtime/gateway/launch_test.py
+++ b/wmo/runtime/gateway/launch_test.py
@@ -8,6 +8,7 @@ import socket
 import sqlite3
 import threading
 import time
+from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -185,6 +186,8 @@ def test_fresh_root_cli_certifies_lifecycle_and_executes_ordered_waterfall(
     monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret-canary")
     runner = CliRunner()
     base_url = f"http://127.0.0.1:{provider_port}/v1"
+    budget_period = datetime.now(UTC).strftime("%Y-%m")
+    gateway_client: TestClient | None = None
     try:
         commands = (
             ["config", "gateway", "init", "--root", str(tmp_path), "--json"],
@@ -243,6 +246,12 @@ def test_fresh_root_cli_certifies_lifecycle_and_executes_ordered_waterfall(
                     f"{connection_name}:provider-model-{deployment_alias}",
                     "--exact-model",
                     "model-revision-exact",
+                    "--maximum-output-tokens",
+                    "16",
+                    "--input-price",
+                    "1000000",
+                    "--output-price",
+                    "2000000",
                     "--root",
                     str(tmp_path),
                     "--non-interactive",
@@ -329,36 +338,218 @@ def test_fresh_root_cli_certifies_lifecycle_and_executes_ordered_waterfall(
         )
         assert issued.exit_code == 0, issued.output
         raw_key = json.loads(issued.stdout)["data"]["raw_key"]
+        for budget_arguments in (
+            ["--scope", "team"],
+            ["--scope", "identity", "--identity", "default"],
+            ["--scope", "pool", "--alias", "coding", "--pool", "coding"],
+            [
+                "--scope",
+                "deployment",
+                "--alias",
+                "coding",
+                "--pool",
+                "coding",
+                "--deployment",
+                "primary",
+            ],
+            [
+                "--scope",
+                "deployment",
+                "--alias",
+                "coding",
+                "--pool",
+                "coding",
+                "--deployment",
+                "secondary",
+            ],
+        ):
+            configured = runner.invoke(
+                app,
+                [
+                    "config",
+                    "gateway",
+                    "budget",
+                    "set",
+                    "--period",
+                    budget_period,
+                    *budget_arguments,
+                    "--limit-micro-usd",
+                    "1000000",
+                    "--root",
+                    str(tmp_path),
+                    "--non-interactive",
+                    "--json",
+                ],
+            )
+            assert configured.exit_code == 0, configured.output
 
         runtime = load_local_gateway(tmp_path, graceful_timeout_seconds=2)
-        with TestClient(runtime.app) as client:
-            response = client.post(
-                "/v1/chat/completions",
-                headers={"Authorization": f"Bearer {raw_key}"},
-                json={
-                    "model": "coding",
-                    "messages": [{"role": "user", "content": "waterfall-canary"}],
-                },
-            )
+        gateway_client = TestClient(runtime.app)
+        gateway_client.__enter__()
+        first_response = gateway_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": "waterfall-canary"}],
+            },
+        )
 
-        assert response.status_code == 200, response.text
-        assert response.json()["choices"][0]["message"]["content"] == "hello world"
-        assert response.headers["x-gateway-route-depth"] == "1"
+        assert first_response.status_code == 200, first_response.text
+        assert first_response.json()["choices"][0]["message"]["content"] == "hello world"
+        assert first_response.headers["x-gateway-route-depth"] == "1"
         assert _LoopbackProvider.calls == 3
+        remaining_result = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "budget",
+                "remaining",
+                "--period",
+                budget_period,
+                "--root",
+                str(tmp_path),
+                "--json",
+            ],
+        )
+        assert remaining_result.exit_code == 0, remaining_result.output
+        budget_rows = json.loads(remaining_result.stdout)["items"]
+        primary_budget = next(
+            row for row in budget_rows if row["budget"]["scope"].get("deployment_id") == "primary"
+        )
+        assert primary_budget["charged_micro_usd"] > 0
+        exhausted_primary = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "budget",
+                "set",
+                "--period",
+                budget_period,
+                "--scope",
+                "deployment",
+                "--alias",
+                "coding",
+                "--pool",
+                "coding",
+                "--deployment",
+                "primary",
+                "--limit-micro-usd",
+                str(primary_budget["charged_micro_usd"]),
+                "--replace",
+                "--root",
+                str(tmp_path),
+                "--non-interactive",
+                "--json",
+            ],
+        )
+        assert exhausted_primary.exit_code == 0, exhausted_primary.output
+        second_response = gateway_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "messages": [{"role": "user", "content": "budget-fallback-canary"}],
+            },
+        )
+        assert second_response.status_code == 200, second_response.text
+        assert second_response.headers["x-gateway-route-depth"] == "1"
+        assert _LoopbackProvider.calls == 4
+
+        replay_headers = {
+            "Authorization": f"Bearer {raw_key}",
+            "Idempotency-Key": "budget-replay-one",
+        }
+        replay_payload = {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "budget-replay-canary"}],
+        }
+        original = gateway_client.post(
+            "/v1/chat/completions",
+            headers=replay_headers,
+            json=replay_payload,
+        )
+        replay = gateway_client.post(
+            "/v1/chat/completions",
+            headers=replay_headers,
+            json=replay_payload,
+        )
+        assert original.status_code == 200, original.text
+        assert replay.status_code == 200, replay.text
+        assert replay.json() == original.json()
+        assert _LoopbackProvider.calls == 5
+
+        refreshed = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "budget",
+                "remaining",
+                "--period",
+                budget_period,
+                "--root",
+                str(tmp_path),
+                "--json",
+            ],
+        )
+        identity_budget = next(
+            row
+            for row in json.loads(refreshed.stdout)["items"]
+            if row["budget"]["scope"]["kind"] == "identity"
+        )
+        exhausted_identity = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "budget",
+                "set",
+                "--period",
+                budget_period,
+                "--scope",
+                "identity",
+                "--identity",
+                "default",
+                "--limit-micro-usd",
+                str(identity_budget["charged_micro_usd"]),
+                "--replace",
+                "--root",
+                str(tmp_path),
+                "--non-interactive",
+                "--json",
+            ],
+        )
+        assert exhausted_identity.exit_code == 0, exhausted_identity.output
+        quota_response = gateway_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={"model": "coding", "input": "quota-canary"},
+        )
+        assert quota_response.status_code == 429
+        assert quota_response.json()["error"]["code"] == "insufficient_quota"
+        assert quota_response.json()["error"]["type"] == "insufficient_quota"
+        assert _LoopbackProvider.calls == 5
         connection = sqlite3.connect(tmp_path / "gateway" / "gateway.db")
         try:
             attempts = connection.execute(
-                "SELECT deployment_id, attempt_ordinal, route_depth, state "
-                "FROM gateway_attempts ORDER BY attempt_ordinal"
+                "SELECT deployment_id, route_depth, state FROM gateway_attempts "
+                "ORDER BY started_at, attempt_id"
             ).fetchall()
         finally:
             connection.close()
         assert attempts == [
-            ("primary", 0, 0, "failed"),
-            ("primary", 1, 0, "failed"),
-            ("secondary", 2, 1, "completed"),
+            ("primary", 0, "failed"),
+            ("primary", 0, "failed"),
+            ("secondary", 1, "completed"),
+            ("secondary", 1, "completed"),
+            ("secondary", 1, "completed"),
         ]
     finally:
+        if gateway_client is not None:
+            gateway_client.__exit__(None, None, None)
         provider.shutdown()
         provider.server_close()
         provider_thread.join(timeout=5)

--- a/wmo/runtime/gateway/ledger.py
+++ b/wmo/runtime/gateway/ledger.py
@@ -12,6 +12,13 @@ from pathlib import Path
 from wmo.common.core.artifacts import ContractModel
 from wmo.common.models.gateway_catalog import BillingSource, ExactModelDeployment
 from wmo.runtime.gateway.auth import utc_text
+from wmo.runtime.gateway.budgets import (
+    MAXIMUM_MICRO_USD,
+    budget_period_start,
+    current_budget_period,
+    require_attempt_budget,
+    settle_attempt_budgets,
+)
 from wmo.runtime.gateway.contracts import (
     AttemptId,
     AuthorizationSnapshot,
@@ -193,6 +200,7 @@ class SQLiteAttemptLedger:
         deployment: ExactModelDeployment,
         attempt_ordinal: int,
         route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
     ) -> AttemptId:
         """Durably mark a provider dispatch before starting network work.
 
@@ -201,6 +209,7 @@ class SQLiteAttemptLedger:
             deployment: Exact deployment about to receive the request.
             attempt_ordinal: Zero-based physical dispatch position for this request.
             route_depth: Zero-based operational route position.
+            maximum_cost_micro_usd: Conservative charge reserved before dispatch.
 
         Returns:
             Stable new attempt ID.
@@ -209,12 +218,19 @@ class SQLiteAttemptLedger:
             raise GatewayLedgerError("attempt deployment is absent from the execution snapshot")
         if deployment.exact_model_id != snapshot.exact_model_id:
             raise GatewayLedgerError("attempt deployment changes the selected exact model")
+        if maximum_cost_micro_usd is not None and not (
+            0 <= maximum_cost_micro_usd <= MAXIMUM_MICRO_USD
+        ):
+            raise GatewayLedgerError("maximum attempt cost must fit a nonnegative SQLite integer")
         attempt_id = f"attempt-{uuid.uuid4().hex}"
         prices = deployment.gateway.prices
+        now = self._clock.now()
+        period_start = budget_period_start(current_budget_period(now))
         with self._transaction() as connection:
             request = connection.execute(
                 """
-                SELECT organization_id, terminal_state FROM gateway_requests
+                SELECT organization_id, identity_id, alias_id, terminal_state
+                FROM gateway_requests
                 WHERE request_id = ?
                 """,
                 (snapshot.authorization.request_id,),
@@ -233,9 +249,9 @@ class SQLiteAttemptLedger:
                     billing_source,
                     pricing_source, pricing_effective_at,
                     input_rate, cached_input_rate, output_rate, reasoning_rate,
-                    state, started_at
+                    state, started_at, budget_period_start, budget_reserved_micro_usd
                 ) VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, ?
                 )
                 """,
                 (
@@ -260,8 +276,21 @@ class SQLiteAttemptLedger:
                     prices.cached_input_micro_usd_per_million_tokens,
                     prices.output_micro_usd_per_million_tokens,
                     prices.reasoning_micro_usd_per_million_tokens,
-                    utc_text(self._clock.now()),
+                    utc_text(now),
+                    period_start,
+                    maximum_cost_micro_usd,
                 ),
+            )
+            require_attempt_budget(
+                connection,
+                organization_id=snapshot.authorization.organization_id,
+                identity_id=str(request["identity_id"]),
+                alias_id=str(request["alias_id"]),
+                pool_id=snapshot.pool_id,
+                deployment_id=deployment.deployment_id,
+                attempt_id=attempt_id,
+                period_start=period_start,
+                maximum_cost_micro_usd=maximum_cost_micro_usd,
             )
         return attempt_id
 
@@ -314,7 +343,7 @@ class SQLiteAttemptLedger:
             row = connection.execute(
                 """
                 SELECT request_id, state, input_rate, cached_input_rate,
-                       output_rate, reasoning_rate
+                       output_rate, reasoning_rate, budget_reserved_micro_usd
                 FROM gateway_attempts WHERE attempt_id = ?
                 """,
                 (attempt_id,),
@@ -333,17 +362,24 @@ class SQLiteAttemptLedger:
                 output_rate=_optional_int(row["output_rate"]),
                 reasoning_rate=_optional_int(row["reasoning_rate"]),
             )
+            budget_settlement = (
+                cost if cost is not None else _optional_int(row["budget_reserved_micro_usd"])
+            )
+            if budget_settlement is not None and budget_settlement > MAXIMUM_MICRO_USD:
+                raise GatewayLedgerError("attempt cost exceeds SQLite integer capacity")
+            terminal_at = utc_text(self._clock.now())
             connection.execute(
                 """
                 UPDATE gateway_attempts
                 SET state = ?, terminal_at = ?, failure_class = ?,
                     input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
-                    reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?
+                    reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?,
+                    budget_settled_micro_usd = ?
                 WHERE attempt_id = ? AND state = 'dispatched'
                 """,
                 (
                     state,
-                    utc_text(self._clock.now()),
+                    terminal_at,
                     normalized_failure,
                     None if usage is None else usage.input_tokens,
                     None if usage is None else usage.cached_input_tokens,
@@ -351,8 +387,14 @@ class SQLiteAttemptLedger:
                     None if usage is None else usage.reasoning_tokens,
                     "unknown" if usage is None else "observed",
                     cost,
+                    budget_settlement,
                     attempt_id,
                 ),
+            )
+            settle_attempt_budgets(
+                connection,
+                attempt_id=attempt_id,
+                settled_micro_usd=budget_settlement,
             )
             if finalize_request and state in {"completed", "failed", "cancelled", "incomplete"}:
                 connection.execute(
@@ -360,7 +402,7 @@ class SQLiteAttemptLedger:
                     UPDATE gateway_requests SET terminal_state = ?, terminal_at = ?
                     WHERE request_id = ? AND terminal_state IS NULL
                     """,
-                    (state, utc_text(self._clock.now()), str(row["request_id"])),
+                    (state, terminal_at, str(row["request_id"])),
                 )
 
     def finish_request(

--- a/wmo/runtime/gateway/sqlite/migrations.py
+++ b/wmo/runtime/gateway/sqlite/migrations.py
@@ -8,7 +8,7 @@ import stat
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 class GatewaySchemaError(RuntimeError):
@@ -404,6 +404,113 @@ _MIGRATION_6 = (
     """,
 )
 
+_MIGRATION_7 = (
+    """
+    ALTER TABLE gateway_attempts
+    ADD COLUMN budget_period_start TEXT CHECK (
+        budget_period_start IS NULL OR (
+            length(budget_period_start) = 25
+            AND substr(budget_period_start, 8) = '-01T00:00:00+00:00'
+        )
+    )
+    """,
+    """
+    ALTER TABLE gateway_attempts
+    ADD COLUMN budget_reserved_micro_usd INTEGER CHECK (
+        budget_reserved_micro_usd IS NULL OR budget_reserved_micro_usd >= 0
+    )
+    """,
+    """
+    ALTER TABLE gateway_attempts
+    ADD COLUMN budget_settled_micro_usd INTEGER CHECK (
+        budget_settled_micro_usd IS NULL OR budget_settled_micro_usd >= 0
+    )
+    """,
+    """
+    UPDATE gateway_attempts
+    SET budget_period_start = substr(started_at, 1, 7) || '-01T00:00:00+00:00',
+        budget_settled_micro_usd = estimated_cost_micro_usd
+    """,
+    """
+    CREATE TRIGGER gateway_attempts_require_budget_period
+    BEFORE INSERT ON gateway_attempts
+    WHEN NEW.budget_period_start IS NULL
+    BEGIN
+        SELECT RAISE(ABORT, 'gateway attempt requires a UTC budget period');
+    END
+    """,
+    """
+    CREATE TABLE gateway_monthly_budgets (
+        budget_id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        period_start TEXT NOT NULL CHECK (
+            length(period_start) = 25
+            AND substr(period_start, 8) = '-01T00:00:00+00:00'
+        ),
+        scope_kind TEXT NOT NULL CHECK (
+            scope_kind IN ('team', 'identity', 'pool', 'deployment')
+        ),
+        scope_key TEXT NOT NULL,
+        identity_id TEXT,
+        alias_id TEXT,
+        pool_id TEXT,
+        deployment_id TEXT,
+        limit_micro_usd INTEGER NOT NULL CHECK (limit_micro_usd >= 0),
+        reserved_micro_usd INTEGER NOT NULL DEFAULT 0 CHECK (reserved_micro_usd >= 0),
+        settled_micro_usd INTEGER NOT NULL DEFAULT 0 CHECK (settled_micro_usd >= 0),
+        unknown_cost_attempts INTEGER NOT NULL DEFAULT 0 CHECK (unknown_cost_attempts >= 0),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (organization_id, period_start, scope_key),
+        CHECK (
+            (scope_kind = 'team' AND identity_id IS NULL AND alias_id IS NULL
+                AND pool_id IS NULL AND deployment_id IS NULL)
+            OR
+            (scope_kind = 'identity' AND identity_id IS NOT NULL AND alias_id IS NULL
+                AND pool_id IS NULL AND deployment_id IS NULL)
+            OR
+            (scope_kind = 'pool' AND identity_id IS NULL AND alias_id IS NOT NULL
+                AND pool_id IS NOT NULL AND deployment_id IS NULL)
+            OR
+            (scope_kind = 'deployment' AND identity_id IS NULL AND alias_id IS NOT NULL
+                AND pool_id IS NOT NULL AND deployment_id IS NOT NULL)
+        ),
+        FOREIGN KEY (organization_id) REFERENCES organizations (organization_id),
+        FOREIGN KEY (organization_id, identity_id)
+            REFERENCES identities (organization_id, identity_id),
+        FOREIGN KEY (organization_id, alias_id)
+            REFERENCES gateway_aliases (organization_id, alias_id)
+    ) STRICT
+    """,
+    """
+    CREATE TABLE gateway_attempt_budget_charges (
+        budget_id TEXT NOT NULL,
+        attempt_id TEXT NOT NULL,
+        reserved_micro_usd INTEGER CHECK (
+            reserved_micro_usd IS NULL OR reserved_micro_usd >= 0
+        ),
+        settled_micro_usd INTEGER CHECK (
+            settled_micro_usd IS NULL OR settled_micro_usd >= 0
+        ),
+        PRIMARY KEY (budget_id, attempt_id),
+        FOREIGN KEY (budget_id) REFERENCES gateway_monthly_budgets (budget_id),
+        FOREIGN KEY (attempt_id) REFERENCES gateway_attempts (attempt_id)
+    ) STRICT
+    """,
+    """
+    CREATE INDEX gateway_monthly_budgets_period
+    ON gateway_monthly_budgets (organization_id, period_start, scope_kind)
+    """,
+    """
+    CREATE INDEX gateway_attempts_budget_period
+    ON gateway_attempts (organization_id, budget_period_start, pool_id, deployment_id)
+    """,
+    """
+    CREATE INDEX gateway_attempt_budget_charges_attempt
+    ON gateway_attempt_budget_charges (attempt_id)
+    """,
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -411,6 +518,7 @@ _MIGRATIONS = {
     4: _MIGRATION_4,
     5: _MIGRATION_5,
     6: _MIGRATION_6,
+    7: _MIGRATION_7,
 }
 
 
@@ -566,7 +674,9 @@ def _require_schema_objects(connection: sqlite3.Connection) -> None:
         "alias_revisions",
         "catalog_snapshot_refs",
         "gateway_aliases",
+        "gateway_attempt_budget_charges",
         "gateway_attempts",
+        "gateway_monthly_budgets",
         "gateway_requests",
         "identities",
         "identity_alias_grants",

--- a/wmo/runtime/gateway/sqlite/migrations_test.py
+++ b/wmo/runtime/gateway/sqlite/migrations_test.py
@@ -18,6 +18,7 @@ from wmo.runtime.gateway.sqlite.migrations import (
     _MIGRATION_3,
     _MIGRATION_4,
     _MIGRATION_5,
+    _MIGRATION_6,
     SCHEMA_VERSION,
     GatewaySchemaError,
     connect_database,
@@ -43,6 +44,15 @@ def test_initial_database_is_private_wal_with_foreign_keys(tmp_path: Path) -> No
         assert attempt_columns["attempt_ordinal"][3] == 1
         assert attempt_columns["billing_source"][3] == 1
         assert "customer_managed" in str(attempt_columns["billing_source"][4])
+        assert "budget_period_start" in attempt_columns
+        assert "budget_reserved_micro_usd" in attempt_columns
+        assert "budget_settled_micro_usd" in attempt_columns
+        assert (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'gateway_monthly_budgets'"
+            ).fetchone()
+            is not None
+        )
         assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute("PRAGMA busy_timeout").fetchone()[0] == 321
@@ -383,6 +393,97 @@ def test_v6_migration_preserves_billing_and_adds_physical_ordinal(tmp_path: Path
             ).fetchone()
             is not None
         )
+    finally:
+        prior.close()
+
+
+def test_v7_migration_assigns_immutable_period_and_preserves_prior_cost(tmp_path: Path) -> None:
+    """A v6 attempt enters its original UTC month without a destructive reset."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for migration in (
+            _MIGRATION_1,
+            _MIGRATION_2,
+            _MIGRATION_3,
+            _MIGRATION_4,
+            _MIGRATION_5,
+            _MIGRATION_6,
+        ):
+            for statement in migration:
+                connection.execute(statement)
+        connection.execute(
+            """
+            INSERT INTO gateway_requests (
+                request_id, organization_id, identity_id, key_id, alias_id,
+                alias_revision_id, api_surface, canonical_request_sha256,
+                accepted_at, deadline_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "request-one",
+                "org-one",
+                "identity-one",
+                "key-one",
+                "alias-one",
+                "revision-one",
+                "chat_completions",
+                "a" * 64,
+                "2026-08-31T23:59:00+00:00",
+                "2026-09-01T00:01:00+00:00",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_attempts (
+                attempt_id, request_id, organization_id, attempt_ordinal, route_depth,
+                deployment_id, provider, exact_model_id, pool_id, catalog_sha256,
+                billing_source, state, started_at, estimated_cost_micro_usd
+            ) VALUES (?, ?, ?, 0, 0, ?, ?, ?, ?, ?, ?, 'completed', ?, ?)
+            """,
+            (
+                "attempt-one",
+                "request-one",
+                "org-one",
+                "deployment-one",
+                "openai",
+                "exact-one",
+                "pool-one",
+                "b" * 64,
+                "host_managed",
+                "2026-08-31T23:59:30+00:00",
+                17,
+            ),
+        )
+        connection.execute("PRAGMA user_version = 6")
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None
+    current = sqlite3.connect(path)
+    try:
+        row = current.execute(
+            """
+            SELECT budget_period_start, budget_reserved_micro_usd,
+                   budget_settled_micro_usd
+            FROM gateway_attempts WHERE attempt_id = 'attempt-one'
+            """
+        ).fetchone()
+        assert row == ("2026-08-01T00:00:00+00:00", None, 17)
+        assert current.execute("PRAGMA user_version").fetchone() == (7,)
+    finally:
+        current.close()
+    prior = sqlite3.connect(backup)
+    try:
+        columns = {str(row[1]) for row in prior.execute("PRAGMA table_info(gateway_attempts)")}
+        assert "budget_period_start" not in columns
+        assert prior.execute("PRAGMA user_version").fetchone() == (6,)
     finally:
         prior.close()
 

--- a/wmo/runtime/gateway/waterfall_test.py
+++ b/wmo/runtime/gateway/waterfall_test.py
@@ -21,6 +21,7 @@ from wmo.common.models.gateway_catalog import (
     ExactModelPool,
     NormalizedGatewayCatalog,
 )
+from wmo.runtime.gateway.budgets import BudgetReservationRejected, BudgetScopeKind
 from wmo.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
@@ -237,6 +238,74 @@ def test_throttle_window_recovers_without_opening_the_failure_circuit() -> None:
     assert not health.claim(key)
     now[0] += 6
     assert health.claim(key)
+
+
+def test_exhausted_provider_allocation_skips_only_that_certified_route() -> None:
+    """A deployment allocation rejection advances without dispatching or opening health."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    second = _deployment("route-b", connection_sha256="c" * 64)
+    first_provider = _ScriptedProvider([_completed_stream("must not dispatch")])
+    second_provider = _ScriptedProvider([_completed_stream("secondary")])
+    ledger = _WaterfallLedger(rejected_deployments={"route-a"})
+    executor = _executor(
+        (first, second),
+        {first.source_alias: first_provider, second.source_alias: second_provider},
+        ledger,
+    )
+
+    async def scenario() -> tuple[str, int]:
+        """Consume the affordable fallback and return its content and depth."""
+        stream = await executor.start(route=_route((first, second)), request=_request())
+        events = [event async for event in stream]
+        return "".join(event.text_delta or "" for event in events), stream.route_depth
+
+    assert asyncio.run(scenario()) == ("secondary", 1)
+    assert first_provider.idempotency_keys == []
+    assert len(second_provider.idempotency_keys) == 1
+    assert ledger.started == [("route-b", 0, 1)]
+
+
+def test_all_budget_ineligible_routes_return_quota_without_dispatch() -> None:
+    """Shared exhaustion owns the parent terminal and surfaces one quota failure."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    second = _deployment("route-b", connection_sha256="c" * 64)
+    providers = {
+        first.source_alias: _ScriptedProvider([_completed_stream("first")]),
+        second.source_alias: _ScriptedProvider([_completed_stream("second")]),
+    }
+    ledger = _WaterfallLedger(rejected_deployments={"route-a", "route-b"})
+    executor = _executor((first, second), providers, ledger)
+
+    with pytest.raises(GatewayExecutionError) as error:
+        asyncio.run(executor.start(route=_route((first, second)), request=_request()))
+
+    assert error.value.failure.failure_class is GatewayFailureClass.QUOTA_EXCEEDED
+    assert error.value.request_finalized
+    assert all(provider.idempotency_keys == [] for provider in providers.values())
+    assert len(ledger.parent_finishes) == 1
+    assert ledger.parent_finishes[0].failure_class is GatewayFailureClass.QUOTA_EXCEEDED
+
+
+def test_shared_budget_exhaustion_returns_quota_without_probing_later_routes() -> None:
+    """A team, identity, or pool rejection applies to the whole logical waterfall."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    second = _deployment("route-b", connection_sha256="c" * 64)
+    providers = {
+        first.source_alias: _ScriptedProvider([_completed_stream("first")]),
+        second.source_alias: _ScriptedProvider([_completed_stream("second")]),
+    }
+    ledger = _WaterfallLedger(
+        rejected_deployments={"route-a", "route-b"},
+        rejected_scope=BudgetScopeKind.IDENTITY,
+    )
+    executor = _executor((first, second), providers, ledger)
+
+    with pytest.raises(GatewayExecutionError) as error:
+        asyncio.run(executor.start(route=_route((first, second)), request=_request()))
+
+    assert error.value.failure.failure_class is GatewayFailureClass.QUOTA_EXCEEDED
+    assert ledger.budget_checks == ["route-a"]
+    assert all(provider.idempotency_keys == [] for provider in providers.values())
 
 
 def test_same_deployment_retry_reuses_identity_and_records_every_dispatch() -> None:
@@ -904,12 +973,20 @@ class _WaterfallRuntimeCatalog:
 class _WaterfallLedger:
     """Capture physical and parent terminal ownership without request content."""
 
-    def __init__(self) -> None:
-        """Initialize empty ordered accounting records."""
+    def __init__(
+        self,
+        *,
+        rejected_deployments: set[str] | None = None,
+        rejected_scope: BudgetScopeKind = BudgetScopeKind.DEPLOYMENT,
+    ) -> None:
+        """Initialize accounting records and optional predispatch budget rejections."""
         self.started: list[tuple[str, int, int]] = []
         self.finished: list[tuple[str, GatewayFailure | None, bool]] = []
         self.finished_events: list[GatewayEvent | None] = []
         self.parent_finishes: list[GatewayFailure] = []
+        self.rejected_deployments = rejected_deployments or set()
+        self.rejected_scope = rejected_scope
+        self.budget_checks: list[str] = []
 
     def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
         """Accept a parent request when a service-level test requires it."""
@@ -922,9 +999,17 @@ class _WaterfallLedger:
         deployment: ExactModelDeployment,
         attempt_ordinal: int,
         route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
     ) -> str:
         """Record one durable physical dispatch before provider work."""
+        del maximum_cost_micro_usd
         assert deployment.deployment_id in snapshot.deployment_ids
+        self.budget_checks.append(deployment.deployment_id)
+        if deployment.deployment_id in self.rejected_deployments:
+            raise BudgetReservationRejected(
+                scope_kind=self.rejected_scope,
+                reason=f"monthly {self.rejected_scope.value} allocation is exhausted",
+            )
         self.started.append((deployment.deployment_id, attempt_ordinal, route_depth))
         return f"attempt-{len(self.started)}"
 

--- a/wmo/runtime/openai_protocol/errors.py
+++ b/wmo/runtime/openai_protocol/errors.py
@@ -14,7 +14,13 @@ class OpenAIErrorDetail(ContractModel):
     """One public OpenAI error without provider or credential details."""
 
     message: str = Field(min_length=1, max_length=2_048)
-    type: Literal["invalid_request_error", "authentication_error", "permission_error", "api_error"]
+    type: Literal[
+        "invalid_request_error",
+        "authentication_error",
+        "permission_error",
+        "insufficient_quota",
+        "api_error",
+    ]
     param: str | None = Field(default=None, max_length=512)
     code: str = Field(min_length=1, max_length=128)
 
@@ -35,7 +41,11 @@ class OpenAIProtocolError(ValueError):
         code: str,
         message: str,
         error_type: Literal[
-            "invalid_request_error", "authentication_error", "permission_error", "api_error"
+            "invalid_request_error",
+            "authentication_error",
+            "permission_error",
+            "insufficient_quota",
+            "api_error",
         ] = "invalid_request_error",
         param: str | None = None,
     ) -> None:
@@ -122,7 +132,11 @@ def public_failure_error(
             int,
             str,
             Literal[
-                "invalid_request_error", "authentication_error", "permission_error", "api_error"
+                "invalid_request_error",
+                "authentication_error",
+                "permission_error",
+                "insufficient_quota",
+                "api_error",
             ],
         ],
     ] = {
@@ -134,6 +148,7 @@ def public_failure_error(
         ),
         GatewayFailureClass.AUTHENTICATION: (401, "invalid_key", "authentication_error"),
         GatewayFailureClass.AUTHORIZATION: (403, "model_not_granted", "permission_error"),
+        GatewayFailureClass.QUOTA_EXCEEDED: (429, "insufficient_quota", "insufficient_quota"),
         GatewayFailureClass.THROTTLED: (429, "unavailable_route", "api_error"),
         GatewayFailureClass.TIMEOUT: (504, "deadline_exceeded", "api_error"),
         GatewayFailureClass.CANCELLED: (499, "request_cancelled", "api_error"),

--- a/wmo/runtime/openai_protocol/errors_test.py
+++ b/wmo/runtime/openai_protocol/errors_test.py
@@ -1,0 +1,26 @@
+"""Tests for neutral OpenAI-compatible protocol errors."""
+
+from __future__ import annotations
+
+from wmo.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from wmo.runtime.openai_protocol.errors import public_failure_error
+
+
+def test_monthly_quota_failure_uses_openai_insufficient_quota_shape() -> None:
+    """Hard gateway exhaustion returns the standard HTTP and envelope semantics."""
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+            safe_message="monthly gateway allocation is exhausted",
+        )
+    )
+
+    assert error.status_code == 429
+    assert error.json_body() == {
+        "error": {
+            "message": "monthly gateway allocation is exhausted",
+            "type": "insufficient_quota",
+            "param": None,
+            "code": "insufficient_quota",
+        }
+    }


### PR DESCRIPTION
## Summary

- add immutable UTC-month hard limits for team, identity, exact-model pool, and provider deployment scopes, stored and reported only as integer micro-USD
- reserve conservative maximum cost atomically with every physical attempt, then settle to observed usage or retain the reservation for unknown or billable failures
- make exhausted deployment allocations skip only that route while shared exhaustion returns an OpenAI-compatible insufficient_quota response
- add interactive and non-interactive gateway budget CLI management, remaining-allocation receipts, explicit schema-v7 migration, and no reset job or dashboard
- lock concurrency, crash, replay, rollover, migration, archive, and real SQLite plus loopback waterfall behavior

## Evidence

- 109 focused gateway, CLI, migration, protocol, and lifecycle tests
- 1,833 CI-like broad non-live tests, plus 7 Tinker adapter tests
- installed-wheel no-spend release evidence: 1 passed
- rebuilt wheel and sdist archive contract: 1 passed
- full Ruff lint and format checks: green
- full ty check: green

## Stack

- base: agent/gateway-certification-cleanup at dd3f54d95b7d232216720f0576df532d94d8eaff
- head: ac46b9dbaaf7d8adb5e52b8cf43d0ff222e12b1c
- this PR is intentionally ready for review and must not be merged independently of the gateway stack
