### PR TITLE
Add embeddable gateway runtime factory

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -35,10 +35,8 @@ runtime = wmo.create_gateway_runtime(
     continuations=continuations,
 )
 
-await runtime.preflight()
 app = runtime.app
-# Serve app with the platform's ASGI worker.
-await runtime.shutdown()
+# Serve app with the platform's ASGI worker, including ASGI lifespan.
 ```
 
 The factory performs no filesystem, SQLite, environment, lock, or server access. A worker may use
@@ -46,6 +44,11 @@ any `SecretResolver` while constructing its provider executor and any `ProjectTa
 while constructing its catalog route resolver. The composed application always mounts the same
 `create_gateway_app` data plane used by the local CLI. The lifecycle exposes explicit preflight,
 readiness, bounded drain, and shutdown operations in addition to its ASGI lifespan.
+
+An ASGI host that drives application lifespan owns preflight and shutdown automatically. A host
+that does not drive lifespan calls `runtime.preflight()` before admission and
+`runtime.shutdown()` during teardown. Shutdown is idempotent across those paths: one runtime starts
+one bounded drain and one terminal flush, then remains permanently not ready.
 
 ## Authority and management
 

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -15,6 +15,38 @@ It serves:
 same gateway application. It does not create a router HTTP server. Gateway startup and readiness
 perform no provider request. Only an authorized model request may cross the provider boundary.
 
+## Embeddable worker composition
+
+Platform workers use the public `create_gateway_runtime` seam. The worker supplies storage,
+provider, secret, project-selection, clock, readiness, and usage implementations, then owns the
+returned lifecycle handle:
+
+```python
+runtime = wmo.create_gateway_runtime(
+    config=wmo.GatewayRuntimeConfig(graceful_timeout_seconds=10),
+    authority=authority,
+    ledger=ledger,
+    routes=routes,
+    executor=executor,
+    clock=clock,
+    readiness=readiness,
+    usage=usage,
+    replay=replay,
+    continuations=continuations,
+)
+
+await runtime.preflight()
+app = runtime.app
+# Serve app with the platform's ASGI worker.
+await runtime.shutdown()
+```
+
+The factory performs no filesystem, SQLite, environment, lock, or server access. A worker may use
+any `SecretResolver` while constructing its provider executor and any `ProjectTargetResolver`
+while constructing its catalog route resolver. The composed application always mounts the same
+`create_gateway_app` data plane used by the local CLI. The lifecycle exposes explicit preflight,
+readiness, bounded drain, and shutdown operations in addition to its ASGI lifespan.
+
 ## Authority and management
 
 `wmo config gateway` owns explicit local setup. Its provider, identity, key, grant, alias, pool, and

--- a/wmo/__init__.py
+++ b/wmo/__init__.py
@@ -96,6 +96,9 @@ if TYPE_CHECKING:
     from wmo.optimize.router.spend import ProviderSpendEntry as ProviderSpendEntry
     from wmo.optimize.router.spend import ProviderSpendLedger as ProviderSpendLedger
     from wmo.optimize.router.spend import ProviderSpendStatus as ProviderSpendStatus
+    from wmo.runtime.gateway.composition import GatewayRuntime as GatewayRuntime
+    from wmo.runtime.gateway.composition import GatewayRuntimeConfig as GatewayRuntimeConfig
+    from wmo.runtime.gateway.composition import create_gateway_runtime as create_gateway_runtime
     from wmo.runtime.models import RuntimeModelCatalog as RuntimeModelCatalog
     from wmo.runtime.router.economics import (
         BillingSourceEconomics as BillingSourceEconomics,
@@ -153,6 +156,9 @@ _EXPORT_MODULES = {
     "ResolvedDiscoveredModel": "wmo.common.models",
     "resolve_discovered_model": "wmo.common.models",
     "RuntimeModelCatalog": "wmo.runtime.models",
+    "GatewayRuntime": "wmo.runtime.gateway.composition",
+    "GatewayRuntimeConfig": "wmo.runtime.gateway.composition",
+    "create_gateway_runtime": "wmo.runtime.gateway.composition",
     "ExportedProjectBundle": "wmo.common.project",
     "export_project_bundle": "wmo.common.project",
     "restore_project_bundle": "wmo.common.project",

--- a/wmo/runtime/gateway/__init__.py
+++ b/wmo/runtime/gateway/__init__.py
@@ -1,5 +1,10 @@
 """Provider-neutral contracts for the local identity-aware model gateway."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from wmo.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     CompatibilityDisposition,
@@ -30,6 +35,17 @@ from wmo.runtime.gateway.interfaces import (
     SecretResolver,
 )
 
+if TYPE_CHECKING:
+    from wmo.runtime.gateway.composition import GatewayRuntime as GatewayRuntime
+    from wmo.runtime.gateway.composition import GatewayRuntimeConfig as GatewayRuntimeConfig
+    from wmo.runtime.gateway.composition import create_gateway_runtime as create_gateway_runtime
+
+_LAZY_EXPORT_MODULES = {
+    "GatewayRuntime": "wmo.runtime.gateway.composition",
+    "GatewayRuntimeConfig": "wmo.runtime.gateway.composition",
+    "create_gateway_runtime": "wmo.runtime.gateway.composition",
+}
+
 __all__ = [
     "AttemptLedger",
     "AuthorizationSnapshot",
@@ -47,6 +63,8 @@ __all__ = [
     "GatewayFailureClass",
     "GatewayMessage",
     "GatewayRequest",
+    "GatewayRuntime",
+    "GatewayRuntimeConfig",
     "GatewayTarget",
     "GatewayToolDefinition",
     "GatewayUsage",
@@ -56,4 +74,20 @@ __all__ = [
     "ProviderStream",
     "SecretResolver",
     "StructuredTextFormat",
+    "create_gateway_runtime",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve one composition export without widening gateway import dependencies."""
+    module_name = _LAZY_EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return eager contracts plus supported lazy composition exports."""
+    return sorted(set(globals()) | set(__all__))

--- a/wmo/runtime/gateway/composition.py
+++ b/wmo/runtime/gateway/composition.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from enum import StrEnum
 
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -22,6 +24,15 @@ from wmo.runtime.openai_protocol.state import BoundedContinuationStore, BoundedR
 GatewayReadinessProbe = Callable[[], Awaitable[ExecutionSnapshot]]
 GatewayUsageSupplier = Callable[[], GatewayUsageReport]
 GatewayTerminalFlusher = Callable[[], Awaitable[None]]
+
+
+class _GatewayLifecyclePhase(StrEnum):
+    """Process-local admission and shutdown phases for one owned runtime."""
+
+    STARTING = "starting"
+    READY = "ready"
+    DRAINING = "draining"
+    STOPPED = "stopped"
 
 
 @dataclass(frozen=True)
@@ -46,7 +57,12 @@ class GatewayRuntimeConfig:
 class GatewayLifecycleState:
     """Track whether an owned application accepts readiness traffic."""
 
-    ready: bool = False
+    phase: _GatewayLifecyclePhase = _GatewayLifecyclePhase.STARTING
+
+    @property
+    def ready(self) -> bool:
+        """Return whether the runtime most recently passed preflight and still admits work."""
+        return self.phase is _GatewayLifecyclePhase.READY
 
 
 @dataclass
@@ -57,32 +73,60 @@ class GatewayRuntime:
     state: GatewayLifecycleState
     config: GatewayRuntimeConfig
     app: FastAPI = field(init=False)
+    _drain_task: asyncio.Task[bool] | None = field(default=None, init=False, repr=False)
 
     async def preflight(self) -> ExecutionSnapshot:
         """Prove one route ready and expose readiness only after proof succeeds."""
-        proof = await self.service.preflight()
-        self.state.ready = True
+        try:
+            proof = await self.service.preflight()
+        except Exception:
+            if self.state.phase is _GatewayLifecyclePhase.READY:
+                self.state.phase = _GatewayLifecyclePhase.STARTING
+            raise
+        if self.state.phase not in {
+            _GatewayLifecyclePhase.DRAINING,
+            _GatewayLifecyclePhase.STOPPED,
+        }:
+            self.state.phase = _GatewayLifecyclePhase.READY
         return proof
 
     async def readiness(self) -> bool:
-        """Return current readiness after rechecking process-local service health."""
-        if not self.state.ready:
+        """Re-probe recoverably unless this runtime has begun fail-closed shutdown."""
+        if self.state.phase in {
+            _GatewayLifecyclePhase.DRAINING,
+            _GatewayLifecyclePhase.STOPPED,
+        }:
             return False
         try:
-            await self.service.preflight()
+            await self.preflight()
         except Exception:  # noqa: BLE001 - readiness converts all failures to not-ready.
-            self.state.ready = False
-        return self.state.ready
+            return False
+        return self.state.phase is _GatewayLifecyclePhase.READY
 
     async def drain(self, *, timeout_seconds: float | None = None) -> bool:
-        """Stop admission and drain owned work within an explicit finite bound."""
+        """Stop admission once and drain owned work within an explicit finite bound."""
         bound = self.config.graceful_timeout_seconds if timeout_seconds is None else timeout_seconds
-        self.state.ready = False
-        return await self.service.drain(timeout_seconds=bound)
+        if not math.isfinite(bound) or bound <= 0:
+            raise ValueError("timeout_seconds must be finite and positive")
+        task = self._drain_task
+        if task is None:
+            self.state.phase = _GatewayLifecyclePhase.DRAINING
+            task = asyncio.create_task(self._drain_once(bound))
+            self._drain_task = task
+        if task.done():
+            return task.result()
+        return await asyncio.shield(task)
 
     async def shutdown(self) -> bool:
         """Drain this worker using its configured graceful shutdown bound."""
         return await self.drain()
+
+    async def _drain_once(self, timeout_seconds: float) -> bool:
+        """Run the sole service drain and permanently close lifecycle admission."""
+        try:
+            return await self.service.drain(timeout_seconds=timeout_seconds)
+        finally:
+            self.state.phase = _GatewayLifecyclePhase.STOPPED
 
 
 def create_gateway_runtime(

--- a/wmo/runtime/gateway/composition.py
+++ b/wmo/runtime/gateway/composition.py
@@ -1,0 +1,191 @@
+"""Embeddable gateway application composition and owned worker lifecycle."""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from wmo.runtime.gateway.contracts import ExecutionSnapshot
+from wmo.runtime.gateway.execution import GatewayExecutor
+from wmo.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayControlStore
+from wmo.runtime.gateway.routing import CatalogRouteResolver
+from wmo.runtime.gateway.service import GatewayService, create_gateway_app
+from wmo.runtime.gateway.usage import GatewayUsageReport, usage_html
+from wmo.runtime.openai_protocol.state import BoundedContinuationStore, BoundedReplayStore
+
+GatewayReadinessProbe = Callable[[], Awaitable[ExecutionSnapshot]]
+GatewayUsageSupplier = Callable[[], GatewayUsageReport]
+GatewayTerminalFlusher = Callable[[], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class GatewayRuntimeConfig:
+    """Finite worker-owned gateway timing and application metadata."""
+
+    graceful_timeout_seconds: float
+    request_timeout_seconds: float = 120
+    title: str = "WMO gateway"
+
+    def __post_init__(self) -> None:
+        """Reject timing bounds that cannot provide a finite worker lifecycle."""
+        if not math.isfinite(self.graceful_timeout_seconds) or self.graceful_timeout_seconds <= 0:
+            raise ValueError("graceful_timeout_seconds must be finite and positive")
+        if not math.isfinite(self.request_timeout_seconds) or self.request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be finite and positive")
+        if not self.title:
+            raise ValueError("title must not be empty")
+
+
+@dataclass
+class GatewayLifecycleState:
+    """Track whether an owned application accepts readiness traffic."""
+
+    ready: bool = False
+
+
+@dataclass
+class GatewayRuntime:
+    """Own one injected gateway service, ASGI application, and bounded lifecycle."""
+
+    service: GatewayService
+    state: GatewayLifecycleState
+    config: GatewayRuntimeConfig
+    app: FastAPI = field(init=False)
+
+    async def preflight(self) -> ExecutionSnapshot:
+        """Prove one route ready and expose readiness only after proof succeeds."""
+        proof = await self.service.preflight()
+        self.state.ready = True
+        return proof
+
+    async def readiness(self) -> bool:
+        """Return current readiness after rechecking process-local service health."""
+        if not self.state.ready:
+            return False
+        try:
+            await self.service.preflight()
+        except Exception:  # noqa: BLE001 - readiness converts all failures to not-ready.
+            self.state.ready = False
+        return self.state.ready
+
+    async def drain(self, *, timeout_seconds: float | None = None) -> bool:
+        """Stop admission and drain owned work within an explicit finite bound."""
+        bound = self.config.graceful_timeout_seconds if timeout_seconds is None else timeout_seconds
+        self.state.ready = False
+        return await self.service.drain(timeout_seconds=bound)
+
+    async def shutdown(self) -> bool:
+        """Drain this worker using its configured graceful shutdown bound."""
+        return await self.drain()
+
+
+def create_gateway_runtime(
+    *,
+    config: GatewayRuntimeConfig,
+    authority: GatewayControlStore,
+    ledger: AttemptLedger,
+    routes: CatalogRouteResolver,
+    executor: GatewayExecutor,
+    clock: GatewayClock,
+    readiness: GatewayReadinessProbe,
+    usage: GatewayUsageSupplier,
+    replay: BoundedReplayStore | None = None,
+    continuations: BoundedContinuationStore | None = None,
+    wall_clock: Callable[[], float] | None = None,
+    terminal_flusher: GatewayTerminalFlusher | None = None,
+) -> GatewayRuntime:
+    """Compose one hosted-safe gateway runtime entirely from injected dependencies.
+
+    Callers own provider construction, secret resolution, catalog snapshots, project selection,
+    authority, accounting, and durable flushing. This factory performs no filesystem, environment,
+    database, process, or server access.
+
+    Args:
+        config: Finite request and shutdown bounds plus application metadata.
+        authority: Injected key, grant, alias, and revision authority.
+        ledger: Injected content-free request and attempt accounting.
+        routes: Injected direct and project route resolver.
+        executor: Injected bounded provider executor.
+        clock: Injected authority and deadline clock.
+        readiness: Credential-free proof for one granted executable route.
+        usage: Content-free usage report supplier for the public usage routes.
+        replay: Optional bounded Chat and Responses replay state.
+        continuations: Optional bounded Responses continuation state.
+        wall_clock: Optional epoch clock for public OpenAI object timestamps.
+        terminal_flusher: Optional bounded durable-accounting flush hook.
+
+    Returns:
+        An explicit owned lifecycle handle containing the composed FastAPI application.
+    """
+    service = GatewayService(
+        control_store=authority,
+        ledger=ledger,
+        routes=routes,
+        executor=executor,
+        clock=clock,
+        readiness_probe=readiness,
+        request_timeout_seconds=config.request_timeout_seconds,
+        replay_store=replay,
+        continuation_store=continuations,
+        wall_clock=wall_clock or time.time,
+        terminal_flusher=terminal_flusher,
+    )
+    state = GatewayLifecycleState()
+    runtime = GatewayRuntime(
+        service=service,
+        state=state,
+        config=config,
+    )
+    runtime.app = _create_managed_app(runtime, usage=usage)
+    return runtime
+
+
+def _create_managed_app(
+    runtime: GatewayRuntime,
+    *,
+    usage: GatewayUsageSupplier,
+) -> FastAPI:
+    """Wrap the single OpenAI data plane with worker health and usage routes."""
+
+    @asynccontextmanager
+    async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
+        """Own readiness and bounded shutdown for one ASGI application lifetime."""
+        await runtime.preflight()
+        try:
+            yield
+        finally:
+            await runtime.shutdown()
+
+    application = FastAPI(title=runtime.config.title, lifespan=lifespan)
+
+    @application.get("/health/live")
+    async def health_live() -> JSONResponse:
+        """Return liveness after an ASGI listener can reach this worker."""
+        return JSONResponse({"status": "live"})
+
+    @application.get("/health/ready")
+    async def health_ready() -> JSONResponse:
+        """Return readiness only while service preflight remains healthy."""
+        ready = await runtime.readiness()
+        status = 200 if ready else 503
+        return JSONResponse({"status": "ready" if ready else "not_ready"}, status_code=status)
+
+    @application.get("/usage.json")
+    async def usage_json() -> JSONResponse:
+        """Return versioned content-free usage from the injected supplier."""
+        report = usage()
+        return JSONResponse(report.model_dump(mode="json"))
+
+    @application.get("/usage")
+    async def usage_page() -> HTMLResponse:
+        """Return the minimal content-free usage page."""
+        return HTMLResponse(usage_html(usage()))
+
+    application.mount("/", create_gateway_app(runtime.service))
+    return application

--- a/wmo/runtime/gateway/composition_test.py
+++ b/wmo/runtime/gateway/composition_test.py
@@ -1,0 +1,212 @@
+"""End-to-end parity tests for hosted and local gateway composition."""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+from http.server import ThreadingHTTPServer
+from inspect import Parameter, signature
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import JsonValue
+
+from wmo.runtime.gateway.composition import GatewayRuntimeConfig, create_gateway_runtime
+from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
+from wmo.runtime.gateway.lifecycle import load_local_gateway
+from wmo.runtime.gateway.tests.launch_test import _configure_gateway, _LoopbackProvider
+from wmo.runtime.gateway.usage import read_usage_report
+
+_DYNAMIC_FIELDS = frozenset({"completed_at", "created", "created_at", "id", "request_id"})
+
+
+def test_public_factory_is_injected_and_worker_owned() -> None:
+    """The public call site contains no local storage, lock, server, or environment input."""
+    parameters = signature(create_gateway_runtime).parameters
+
+    assert tuple(parameters) == (
+        "config",
+        "authority",
+        "ledger",
+        "routes",
+        "executor",
+        "clock",
+        "readiness",
+        "usage",
+        "replay",
+        "continuations",
+        "wall_clock",
+        "terminal_flusher",
+    )
+    assert all(item.kind is Parameter.KEYWORD_ONLY for item in parameters.values())
+    with pytest.raises(ValueError, match="finite and positive"):
+        GatewayRuntimeConfig(graceful_timeout_seconds=float("inf"))
+
+
+def test_injected_runtime_matches_local_http_surface_end_to_end(tmp_path: Path) -> None:
+    """Injected worker dependencies preserve every managed local gateway route shape."""
+    _LoopbackProvider.calls = 0
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), _LoopbackProvider)
+    provider_thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    provider_thread.start()
+    manager, raw_key = _configure_gateway(
+        tmp_path,
+        base_url=f"http://127.0.0.1:{provider.server_port}/v1",
+    )
+    local = load_local_gateway(
+        tmp_path,
+        graceful_timeout_seconds=1,
+        environment={"LOOPBACK_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    service = local.service
+    ledger = cast(SQLiteAttemptLedger, service._ledger)  # noqa: SLF001 - parity seam evidence
+    injected = create_gateway_runtime(
+        config=GatewayRuntimeConfig(
+            graceful_timeout_seconds=1,
+            title="WMO local gateway",
+        ),
+        authority=service._control,  # noqa: SLF001 - parity seam evidence
+        ledger=ledger,
+        routes=service._routes,  # noqa: SLF001 - parity seam evidence
+        executor=service._executor,  # noqa: SLF001 - parity seam evidence
+        clock=service._clock,  # noqa: SLF001 - parity seam evidence
+        readiness=service._readiness_probe,  # noqa: SLF001 - parity seam evidence
+        usage=lambda: read_usage_report(ledger, organization_id=manager.organization_id),
+    )
+
+    try:
+        with TestClient(local.app) as local_client, TestClient(injected.app) as injected_client:
+            local_results = _exercise_surface(local_client, raw_key=raw_key)
+            injected_results = _exercise_surface(injected_client, raw_key=raw_key)
+        assert local.state.ready is False
+        assert injected.state.ready is False
+    finally:
+        provider.shutdown()
+        provider.server_close()
+        provider_thread.join(timeout=2)
+
+    assert local_results == injected_results
+    assert _LoopbackProvider.calls == 8
+    assert not provider_thread.is_alive()
+
+
+def _exercise_surface(client: TestClient, *, raw_key: str) -> dict[str, JsonValue]:
+    """Exercise every managed route with completed, streaming, and error traffic."""
+    authorization = {"Authorization": f"Bearer {raw_key}"}
+    live = client.get("/health/live")
+    ready = client.get("/health/ready")
+    models = client.get("/v1/models", headers=authorization)
+    malformed = client.post(
+        "/v1/chat/completions",
+        headers={**authorization, "Content-Type": "application/json"},
+        content="{",
+    )
+    chat = client.post(
+        "/v1/chat/completions",
+        headers=authorization,
+        json={
+            "model": "coding",
+            "messages": [{"role": "user", "content": "chat-completed-canary"}],
+        },
+    )
+    responses = client.post(
+        "/v1/responses",
+        headers=authorization,
+        json={"model": "coding", "input": "responses-completed-canary"},
+    )
+    chat_stream = client.post(
+        "/v1/chat/completions",
+        headers=authorization,
+        json={
+            "model": "coding",
+            "messages": [{"role": "user", "content": "chat-stream-canary"}],
+            "stream": True,
+        },
+    )
+    responses_stream = client.post(
+        "/v1/responses",
+        headers=authorization,
+        json={"model": "coding", "input": "responses-stream-canary", "stream": True},
+    )
+    usage_json = client.get("/usage.json")
+    usage_page = client.get("/usage")
+
+    assert all(
+        response.status_code == 200
+        for response in (
+            live,
+            ready,
+            usage_json,
+            usage_page,
+            models,
+            chat,
+            responses,
+            chat_stream,
+            responses_stream,
+        )
+    )
+    assert malformed.status_code == 400
+    return {
+        "health_live": live.json(),
+        "health_ready": ready.json(),
+        "usage_json": _without_usage_counts(usage_json.json()),
+        "usage_page_shape": _usage_page_shape(usage_page.text),
+        "models": models.json(),
+        "malformed": malformed.json(),
+        "chat": _stable_json(chat.json()),
+        "responses": _stable_json(responses.json()),
+        "chat_stream": _stable_sse(chat_stream.text),
+        "responses_stream": _stable_sse(responses_stream.text),
+    }
+
+
+def _stable_json(value: JsonValue) -> JsonValue:
+    """Replace public request timestamps and opaque IDs while preserving response shape."""
+    if isinstance(value, dict):
+        return {
+            key: (
+                "<dynamic>" if key in _DYNAMIC_FIELDS or key.endswith("_id") else _stable_json(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_stable_json(item) for item in value]
+    return value
+
+
+def _stable_sse(body: str) -> list[JsonValue]:
+    """Decode public SSE data frames and normalize only opaque identity fields."""
+    frames: list[JsonValue] = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = line.removeprefix("data: ")
+        if payload == "[DONE]":
+            frames.append(payload)
+        else:
+            frames.append(_stable_json(cast(JsonValue, json.loads(payload))))
+    return frames
+
+
+def _without_usage_counts(value: JsonValue) -> JsonValue:
+    """Keep the usage schema while ignoring counts changed by the first client run."""
+    if isinstance(value, dict):
+        return {
+            key: (
+                0
+                if isinstance(item, (int, float))
+                else _without_usage_counts(cast(JsonValue, item))
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_without_usage_counts(item) for item in value]
+    return value
+
+
+def _usage_page_shape(body: str) -> str:
+    """Return stable HTML structure without request-dependent numeric text."""
+    return re.sub(r"\d+(?:\.\d+)?", "0", body)

--- a/wmo/runtime/gateway/composition_test.py
+++ b/wmo/runtime/gateway/composition_test.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import threading
+from collections.abc import Awaitable, Callable
 from http.server import ThreadingHTTPServer
 from inspect import Parameter, signature
 from pathlib import Path
@@ -14,9 +16,16 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import JsonValue
 
-from wmo.runtime.gateway.composition import GatewayRuntimeConfig, create_gateway_runtime
+from wmo.runtime.gateway.composition import (
+    GatewayRuntime,
+    GatewayRuntimeConfig,
+    GatewayTerminalFlusher,
+    create_gateway_runtime,
+)
+from wmo.runtime.gateway.contracts import ExecutionSnapshot
 from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
-from wmo.runtime.gateway.lifecycle import load_local_gateway
+from wmo.runtime.gateway.lifecycle import LocalGatewayRuntime, load_local_gateway
+from wmo.runtime.gateway.management import GatewayManagement
 from wmo.runtime.gateway.tests.launch_test import _configure_gateway, _LoopbackProvider
 from wmo.runtime.gateway.usage import read_usage_report
 
@@ -44,6 +53,109 @@ def test_public_factory_is_injected_and_worker_owned() -> None:
     assert all(item.kind is Parameter.KEYWORD_ONLY for item in parameters.values())
     with pytest.raises(ValueError, match="finite and positive"):
         GatewayRuntimeConfig(graceful_timeout_seconds=float("inf"))
+
+
+def test_readiness_recovers_after_one_transient_reprobe_failure(tmp_path: Path) -> None:
+    """A transient readiness failure returns 503 once, then re-probes to recovery."""
+    manager, _raw_key = _configure_gateway(
+        tmp_path,
+        base_url="http://127.0.0.1:9/v1",
+    )
+    local = load_local_gateway(
+        tmp_path,
+        graceful_timeout_seconds=1,
+        environment={"LOOPBACK_PROVIDER_KEY": "provider-secret-canary"},
+    )
+
+    async def original_proof() -> ExecutionSnapshot:
+        """Resolve the local credential-free proof on a dedicated loop."""
+        return await local.service._readiness_probe()  # noqa: SLF001 - injected probe fixture
+
+    proof = asyncio.run(original_proof())
+    calls = 0
+
+    async def fail_once() -> ExecutionSnapshot:
+        """Fail the first post-startup re-probe, then return healthy proof."""
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("transient readiness failure")
+        return proof
+
+    runtime = _compose_from_local(local, manager, readiness=fail_once)
+
+    with TestClient(runtime.app) as client:
+        failed = client.get("/health/ready")
+        recovered = client.get("/health/ready")
+
+        assert failed.status_code == 503
+        assert failed.json() == {"status": "not_ready"}
+        assert recovered.status_code == 200
+        assert recovered.json() == {"status": "ready"}
+        assert runtime.state.ready
+    assert calls == 3
+    assert not runtime.state.ready
+
+
+@pytest.mark.parametrize(
+    "timeout_seconds",
+    (float("nan"), float("inf"), float("-inf"), 0.0, -1.0),
+    ids=("nan", "positive-infinity", "negative-infinity", "zero", "negative"),
+)
+def test_drain_rejects_every_invalid_timeout_override(
+    tmp_path: Path,
+    timeout_seconds: float,
+) -> None:
+    """Every per-call drain override must preserve the finite positive bound."""
+    manager, _raw_key = _configure_gateway(
+        tmp_path,
+        base_url="http://127.0.0.1:9/v1",
+    )
+    local = load_local_gateway(
+        tmp_path,
+        graceful_timeout_seconds=1,
+        environment={"LOOPBACK_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    runtime = _compose_from_local(local, manager)
+
+    asyncio.run(runtime.preflight())
+    assert runtime.state.ready
+    with pytest.raises(ValueError, match="timeout_seconds must be finite and positive"):
+        asyncio.run(runtime.drain(timeout_seconds=timeout_seconds))
+    assert runtime.state.ready
+
+
+def test_explicit_shutdown_and_lifespan_teardown_flush_once(tmp_path: Path) -> None:
+    """One lifecycle owner makes explicit and ASGI shutdown idempotent."""
+    manager, _raw_key = _configure_gateway(
+        tmp_path,
+        base_url="http://127.0.0.1:9/v1",
+    )
+    local = load_local_gateway(
+        tmp_path,
+        graceful_timeout_seconds=1,
+        environment={"LOOPBACK_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    flushes: list[bool] = []
+
+    async def flush() -> None:
+        """Record one terminal accounting flush."""
+        flushes.append(True)
+
+    runtime = _compose_from_local(local, manager, terminal_flusher=flush)
+
+    async def scenario() -> None:
+        """Mix explicit shutdown with automatic lifespan teardown on one loop."""
+        async with runtime.app.router.lifespan_context(runtime.app):
+            assert runtime.state.ready
+            assert await runtime.shutdown()
+            assert not runtime.state.ready
+            assert not await runtime.readiness()
+        assert await runtime.shutdown()
+
+    asyncio.run(scenario())
+
+    assert flushes == [True]
 
 
 def test_injected_runtime_matches_local_http_surface_end_to_end(tmp_path: Path) -> None:
@@ -91,6 +203,29 @@ def test_injected_runtime_matches_local_http_surface_end_to_end(tmp_path: Path) 
     assert local_results == injected_results
     assert _LoopbackProvider.calls == 8
     assert not provider_thread.is_alive()
+
+
+def _compose_from_local(
+    local: LocalGatewayRuntime,
+    manager: GatewayManagement,
+    *,
+    readiness: Callable[[], Awaitable[ExecutionSnapshot]] | None = None,
+    terminal_flusher: GatewayTerminalFlusher | None = None,
+) -> GatewayRuntime:
+    """Recompose local dependencies through the fully injected hosted seam."""
+    service = local.service
+    ledger = cast(SQLiteAttemptLedger, service._ledger)  # noqa: SLF001 - parity seam evidence
+    return create_gateway_runtime(
+        config=GatewayRuntimeConfig(graceful_timeout_seconds=1),
+        authority=service._control,  # noqa: SLF001 - parity seam evidence
+        ledger=ledger,
+        routes=service._routes,  # noqa: SLF001 - parity seam evidence
+        executor=service._executor,  # noqa: SLF001 - parity seam evidence
+        clock=service._clock,  # noqa: SLF001 - parity seam evidence
+        readiness=readiness or service._readiness_probe,  # noqa: SLF001
+        usage=lambda: read_usage_report(ledger, organization_id=manager.organization_id),
+        terminal_flusher=terminal_flusher,
+    )
 
 
 def _exercise_surface(client: TestClient, *, raw_key: str) -> dict[str, JsonValue]:

--- a/wmo/runtime/gateway/lifecycle.py
+++ b/wmo/runtime/gateway/lifecycle.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import time
-from collections.abc import AsyncIterator, Iterator, Mapping
-from contextlib import asynccontextmanager, contextmanager
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
 from typing import Protocol, cast
 
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, JSONResponse
 from filelock import FileLock, Timeout
 
 from wmo.common.core.artifacts import sha256_json
@@ -19,6 +18,12 @@ from wmo.common.models import (
     ModelCatalog,
     NormalizedGatewayCatalog,
     normalize_gateway_catalog,
+)
+from wmo.runtime.gateway.composition import (
+    GatewayLifecycleState,
+    GatewayRuntime,
+    GatewayRuntimeConfig,
+    create_gateway_runtime,
 )
 from wmo.runtime.gateway.contracts import (
     AuthorizationSnapshot,
@@ -37,9 +42,9 @@ from wmo.runtime.gateway.routing import (
     GatewayRoutingError,
     RouterProjectTargetResolver,
 )
-from wmo.runtime.gateway.service import GatewayService, create_gateway_app
+from wmo.runtime.gateway.service import GatewayService
 from wmo.runtime.gateway.sqlite.store import SQLiteGatewayStore, SystemGatewayClock
-from wmo.runtime.gateway.usage import read_usage_report, usage_html
+from wmo.runtime.gateway.usage import read_usage_report
 from wmo.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from wmo.runtime.models.credentials import ModelCredentialError
 from wmo.runtime.router.errors import RouterApplicationError
@@ -65,22 +70,44 @@ class ProjectLoader(Protocol):
         ...
 
 
-@dataclass
-class GatewayLifecycleState:
-    """Mutable process-local health state exposed only through loopback routes."""
-
-    ready: bool = False
-
-
 @dataclass(frozen=True)
 class LocalGatewayRuntime:
     """Fully composed local service and its loopback application."""
 
-    app: FastAPI
-    service: GatewayService
-    state: GatewayLifecycleState
+    runtime: GatewayRuntime
     reconciled_expired_requests: int
     reconciled_unknown_attempts: int
+
+    @property
+    def app(self) -> FastAPI:
+        """Return the shared managed FastAPI application."""
+        return self.runtime.app
+
+    @property
+    def service(self) -> GatewayService:
+        """Return the shared injected gateway service."""
+        return self.runtime.service
+
+    @property
+    def state(self) -> GatewayLifecycleState:
+        """Return the shared process-local readiness state."""
+        return self.runtime.state
+
+    async def preflight(self) -> ExecutionSnapshot:
+        """Preflight the shared gateway composition seam."""
+        return await self.runtime.preflight()
+
+    async def readiness(self) -> bool:
+        """Return current shared runtime readiness."""
+        return await self.runtime.readiness()
+
+    async def drain(self, *, timeout_seconds: float | None = None) -> bool:
+        """Drain the shared runtime within the selected bound."""
+        return await self.runtime.drain(timeout_seconds=timeout_seconds)
+
+    async def shutdown(self) -> bool:
+        """Shut down the shared runtime within its local bound."""
+        return await self.runtime.shutdown()
 
 
 @dataclass(frozen=True)
@@ -277,79 +304,24 @@ def load_local_gateway(
         )
         for item in readiness
     )
-    service = GatewayService(
-        control_store=_ReadyControlStore(store=store, authorities=ready_authorities),
+    runtime = create_gateway_runtime(
+        config=GatewayRuntimeConfig(
+            graceful_timeout_seconds=graceful_timeout_seconds,
+            title="WMO local gateway",
+        ),
+        authority=_ReadyControlStore(store=store, authorities=ready_authorities),
         ledger=ledger,
         routes=routes,
         executor=executor,
         clock=SystemGatewayClock(),
-        readiness_probe=readiness_probe,
-    )
-    state = GatewayLifecycleState()
-    app = _create_managed_app(
-        service,
-        ledger=ledger,
-        organization_id=manager.organization_id,
-        state=state,
-        graceful_timeout_seconds=graceful_timeout_seconds,
+        readiness=readiness_probe,
+        usage=lambda: read_usage_report(ledger, organization_id=manager.organization_id),
     )
     return LocalGatewayRuntime(
-        app=app,
-        service=service,
-        state=state,
+        runtime=runtime,
         reconciled_expired_requests=expired,
         reconciled_unknown_attempts=unknown,
     )
-
-
-def _create_managed_app(
-    service: GatewayService,
-    *,
-    ledger: SQLiteAttemptLedger,
-    organization_id: str,
-    state: GatewayLifecycleState,
-    graceful_timeout_seconds: float,
-) -> FastAPI:
-    """Wrap the authenticated data plane with loopback health and usage routes."""
-
-    @asynccontextmanager
-    async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
-        """Own readiness and bounded drain for the ASGI server lifetime."""
-        await service.preflight()
-        state.ready = True
-        try:
-            yield
-        finally:
-            state.ready = False
-            await service.drain(timeout_seconds=graceful_timeout_seconds)
-
-    application = FastAPI(title="WMO local gateway", lifespan=lifespan)
-
-    @application.get("/health/live")
-    async def health_live() -> JSONResponse:
-        """Return liveness after the loopback listener can reach this process."""
-        return JSONResponse({"status": "live"})
-
-    @application.get("/health/ready")
-    async def health_ready() -> JSONResponse:
-        """Return readiness only while the service accepts new requests."""
-        status = 200 if state.ready else 503
-        return JSONResponse({"status": "ready" if state.ready else "not_ready"}, status_code=status)
-
-    @application.get("/usage.json")
-    async def usage_json() -> JSONResponse:
-        """Return versioned content-free usage on loopback."""
-        report = read_usage_report(ledger, organization_id=organization_id)
-        return JSONResponse(report.model_dump(mode="json"))
-
-    @application.get("/usage")
-    async def usage_page() -> HTMLResponse:
-        """Return the minimal content-free loopback usage page."""
-        report = read_usage_report(ledger, organization_id=organization_id)
-        return HTMLResponse(usage_html(report))
-
-    application.mount("/", create_gateway_app(service))
-    return application
 
 
 def _granted_active_aliases(manager: GatewayManagement) -> tuple[GatewayAliasView, ...]:

--- a/wmo/tests/api_test.py
+++ b/wmo/tests/api_test.py
@@ -61,6 +61,11 @@ from wmo.optimize.router.hosted import (
     run_hosted_router_workflow,
 )
 from wmo.optimize.router.spend import ProviderSpendEntry, ProviderSpendLedger
+from wmo.runtime.gateway.composition import (
+    GatewayRuntime,
+    GatewayRuntimeConfig,
+    create_gateway_runtime,
+)
 from wmo.runtime.models import RuntimeModelCatalog
 from wmo.runtime.router.economics import (
     BillingSourceEconomics,
@@ -149,6 +154,14 @@ def test_public_api_matches_quickstart() -> None:
     assert wmo.ResolvedDiscoveredModel is ResolvedDiscoveredModel
     assert wmo.resolve_discovered_model is resolve_discovered_model
     assert wmo.RuntimeModelCatalog is RuntimeModelCatalog
+    assert wmo.GatewayRuntime is GatewayRuntime
+    assert wmo.GatewayRuntimeConfig is GatewayRuntimeConfig
+    assert wmo.create_gateway_runtime is create_gateway_runtime
+    assert {
+        "GatewayRuntime",
+        "GatewayRuntimeConfig",
+        "create_gateway_runtime",
+    }.issubset(wmo.__all__)
     assert "ledger" in signature(FileHostedAttemptAuthorityStore.commit_stage).parameters
     assert wmo.ProviderSpendLedger is ProviderSpendLedger
     assert wmo.ProviderSpendEntry is ProviderSpendEntry

--- a/wmo/tests/release_test.py
+++ b/wmo/tests/release_test.py
@@ -53,6 +53,7 @@ REQUIRED_WHEEL_MODULES = frozenset(
         "wmo/common/judging/review.py",
         "wmo/common/models/model.py",
         "wmo/runtime/environments/local.py",
+        "wmo/runtime/gateway/composition.py",
         "wmo/runtime/gateway/lifecycle.py",
         "wmo/runtime/gateway/budgets.py",
         "wmo/runtime/gateway/ledger.py",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add a public `create_gateway_runtime` composition seam with injected authority, accounting, routing, execution, clocks, readiness, usage, replay, continuation, and flush dependencies
- return an owned runtime handle with the shared FastAPI application plus recoverable readiness and one idempotent, bounded shutdown lifecycle
- route `load_local_gateway` through the same seam while preserving SQLite, filesystem, CLI, and OpenAI protocol behavior
- document the hosted worker call site and its ASGI versus manual lifecycle ownership
- add in-process parity and lifecycle coverage for models, Chat Completions, Responses, health, usage, streaming, OpenAI errors, transient readiness recovery, invalid drain bounds, and single terminal flushing

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q wmo/runtime/gateway wmo/cli/run/app_test.py wmo/runtime/router/application_test.py wmo/tests/api_test.py` (132 passed)
- `uv run pytest -q` on the initial change (1835 passed, 12 skipped, 13 unrelated failures: 11 terminal-rendering tests depend on unavailable terminal control behavior, one live CLI pipeline waits for unauthenticated `/v1/models` to return 200, and one release-evidence test intentionally rejects a dirty checkout)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5fab5d6-180b-46b6-bb30-829e89908365?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5fab5d6-180b-46b6-bb30-829e89908365&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

