### PR TITLE
Add pluggable gateway replay and continuation state

### DIFF
--- a/wmo/runtime/gateway/service.py
+++ b/wmo/runtime/gateway/service.py
@@ -66,6 +66,8 @@ from wmo.runtime.openai_protocol.state import (
     ProtocolNamespace,
     ReplayClaimKind,
     ReplayLease,
+    ResponseContinuationStore,
+    ResponseReplayStore,
     episode_namespace,
     replay_key,
 )
@@ -79,7 +81,7 @@ class GatewayDrainingError(RuntimeError):
 
 
 class GatewayService:
-    """Compose protocol, authority, routing, execution, and bounded process-local state."""
+    """Compose protocol, authority, routing, execution, and injected protocol state."""
 
     def __init__(
         self,
@@ -91,8 +93,8 @@ class GatewayService:
         clock: GatewayClock,
         readiness_probe: Callable[[], Awaitable[ExecutionSnapshot]],
         request_timeout_seconds: float = 120,
-        replay_store: BoundedReplayStore | None = None,
-        continuation_store: BoundedContinuationStore | None = None,
+        replay_store: ResponseReplayStore | None = None,
+        continuation_store: ResponseContinuationStore | None = None,
         wall_clock: Callable[[], float] = time.time,
         terminal_flusher: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
@@ -105,8 +107,8 @@ class GatewayService:
             executor: Async singleton provider executor.
             clock: Shared monotonic and wall clock.
             request_timeout_seconds: One total budget beginning before authorization.
-            replay_store: Optional bounded in-process response replay state.
-            continuation_store: Optional bounded Responses continuation state.
+            replay_store: Optional completed-response ownership and replay state.
+            continuation_store: Optional Responses continuation state.
             wall_clock: Injectable epoch clock for public object timestamps.
             readiness_probe: Credential-free proof that one granted alias can route.
             terminal_flusher: Hook that flushes queued terminal accounting after drain.
@@ -119,8 +121,12 @@ class GatewayService:
         self._executor = executor
         self._clock = clock
         self._request_timeout_seconds = request_timeout_seconds
-        self._replays = replay_store or BoundedReplayStore()
-        self._continuations = continuation_store or BoundedContinuationStore()
+        self._replays: ResponseReplayStore = (
+            replay_store if replay_store is not None else BoundedReplayStore()
+        )
+        self._continuations: ResponseContinuationStore = (
+            continuation_store if continuation_store is not None else BoundedContinuationStore()
+        )
         self._wall_clock = wall_clock
         self._readiness_probe = readiness_probe
         self._terminal_flusher = terminal_flusher or _flush_synchronous_ledger
@@ -603,7 +609,7 @@ class GatewayService:
         events: tuple[GatewayEvent, ...],
         response_id: str | None = None,
     ) -> None:
-        """Retain completed Responses history only in bounded process memory."""
+        """Retain completed Responses history through the injected bounded state contract."""
         terminal = next((event for event in reversed(events) if is_terminal(event)), None)
         if terminal is None or terminal.kind == GatewayEventKind.FAILED:
             return

--- a/wmo/runtime/gateway/tests/data_plane_test.py
+++ b/wmo/runtime/gateway/tests/data_plane_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
@@ -54,8 +55,14 @@ from wmo.runtime.openai_protocol.errors import OpenAIProtocolError
 from wmo.runtime.openai_protocol.requests import decode_chat, decode_responses
 from wmo.runtime.openai_protocol.state import (
     BoundedContinuationStore,
+    BoundedReplayStore,
     ContinuationState,
     ProtocolNamespace,
+    ReplayClaimKind,
+    ReplayKey,
+    ReplayLease,
+    ResponseContinuationStore,
+    ResponseReplayStore,
 )
 
 _DIGEST = "a" * 64
@@ -76,8 +83,14 @@ class _Clock:
 class _ControlStore:
     """Authorize one public alias without retaining the presented key."""
 
-    def __init__(self, catalog_sha256: str) -> None:
+    def __init__(
+        self,
+        catalog_sha256: str,
+        request_digest: Callable[[GatewayRequest], str] | None = None,
+    ) -> None:
+        """Initialize authority with an optional request-sensitive digest."""
         self._catalog_sha256 = catalog_sha256
+        self._request_digest = request_digest
         self.raw_keys_seen: list[str] = []
 
     def authorize_request(
@@ -100,7 +113,9 @@ class _ControlStore:
             target=DirectTarget(pool_id="pool-one"),
             surface=request.surface,
             catalog_sha256=self._catalog_sha256,
-            canonical_request_sha256=_DIGEST,
+            canonical_request_sha256=(
+                self._request_digest(request) if self._request_digest is not None else _DIGEST
+            ),
             deadline_monotonic=deadline_monotonic,
         )
 
@@ -207,6 +222,31 @@ class _EventStream:
     async def cancel(self) -> None:
         """Record bounded upstream cancellation."""
         self.cancelled = True
+
+
+class _GatedEventStream(_EventStream):
+    """Hold the first provider event until a concurrent gateway claim is waiting."""
+
+    def __init__(
+        self,
+        events: tuple[GatewayEvent, ...],
+        *,
+        started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        """Bind deterministic provider-start and release signals."""
+        super().__init__(events)
+        self._started = started
+        self._release = release
+        self._waiting = True
+
+    async def __anext__(self) -> GatewayEvent:
+        """Wait once before yielding the injected provider sequence."""
+        if self._waiting:
+            self._waiting = False
+            self._started.set()
+            await self._release.wait()
+        return await super().__anext__()
 
 
 class _BlockingStream:
@@ -351,6 +391,56 @@ class _FailOnceContinuationStore(BoundedContinuationStore):
         await super().remember(namespace=namespace, response_id=response_id, state=state)
 
 
+class _SharedProtocolState:
+    """One structural test implementation shared by independent gateway workers."""
+
+    def __init__(self) -> None:
+        """Create finite replay and continuation state without subclass coupling."""
+        self._replays = BoundedReplayStore(capacity=8, byte_cap=65_536, ttl_seconds=60)
+        self._continuations = BoundedContinuationStore(
+            capacity=8,
+            byte_cap=65_536,
+            ttl_seconds=60,
+        )
+        self.join_count = 0
+        self.two_joiners = asyncio.Event()
+
+    async def claim(self, key: ReplayKey) -> ReplayLease:
+        """Delegate one atomic ownership claim to shared bounded state."""
+        lease = await self._replays.claim(key)
+        if lease.kind == ReplayClaimKind.JOIN:
+            self.join_count += 1
+            if self.join_count == 2:
+                self.two_joiners.set()
+        return lease
+
+    async def remember(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        response_id: str,
+        state: ContinuationState,
+    ) -> None:
+        """Retain one continuation for every worker."""
+        await self._continuations.remember(
+            namespace=namespace,
+            response_id=response_id,
+            state=state,
+        )
+
+    async def resolve(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        previous_response_id: str,
+    ) -> ContinuationState:
+        """Resolve one continuation created by any worker."""
+        return await self._continuations.resolve(
+            namespace=namespace,
+            previous_response_id=previous_response_id,
+        )
+
+
 def _catalog() -> tuple[NormalizedGatewayCatalog, ExactModelDeployment]:
     """Build one launch-safe singleton gateway catalog."""
     deployment = ExactModelDeployment(
@@ -385,11 +475,13 @@ def _service(
     provider: _Provider,
     *,
     terminal_flusher: Callable[[], object] | None = None,
-    continuation_store: BoundedContinuationStore | None = None,
+    replay_store: ResponseReplayStore | None = None,
+    continuation_store: ResponseContinuationStore | None = None,
+    request_digest: Callable[[GatewayRequest], str] | None = None,
 ) -> tuple[GatewayService, _ControlStore, _Ledger, ExecutionSnapshot]:
     """Compose the full launch data plane with deterministic injected dependencies."""
     catalog, deployment = _catalog()
-    control = _ControlStore(catalog.identity_sha256())
+    control = _ControlStore(catalog.identity_sha256(), request_digest)
     ledger = _Ledger()
     routes = CatalogRouteResolver({("revision-one", catalog.identity_sha256()): catalog})
     authorization = control.authorize_request(
@@ -431,6 +523,7 @@ def _service(
         ),
         clock=_Clock(),
         readiness_probe=readiness_probe,
+        replay_store=replay_store,
         continuation_store=continuation_store,
         terminal_flusher=flush,
     )
@@ -883,6 +976,113 @@ def test_http_boundary_authenticates_before_json_decode_and_returns_openai_400()
         assert malformed.status_code == 400
         assert malformed.json()["error"]["code"] == "invalid_json"
         assert control.raw_keys_seen == ["caller-secret"]
+
+    asyncio.run(scenario())
+
+
+def test_shared_protocol_state_joins_replays_and_continues_across_gateway_workers() -> None:
+    """Two apps share ownership and continuation state without sharing provider health."""
+
+    async def scenario() -> None:
+        """Drive concurrent, cancelled, conflicting, replayed, and continued HTTP requests."""
+        provider_started = asyncio.Event()
+        release_provider = asyncio.Event()
+        provider = _Provider(
+            lambda: _GatedEventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                ),
+                started=provider_started,
+                release=release_provider,
+            )
+        )
+        shared = _SharedProtocolState()
+        replay_store: ResponseReplayStore = shared
+        continuation_store: ResponseContinuationStore = shared
+
+        def request_digest(request: GatewayRequest) -> str:
+            """Hash canonical test request content for body-conflict detection."""
+            return hashlib.sha256(request.model_dump_json().encode()).hexdigest()
+
+        worker_a, _control_a, _ledger_a, _proof_a = _service(
+            provider,
+            replay_store=replay_store,
+            continuation_store=continuation_store,
+            request_digest=request_digest,
+        )
+        worker_b, _control_b, _ledger_b, _proof_b = _service(
+            provider,
+            replay_store=replay_store,
+            continuation_store=continuation_store,
+            request_digest=request_digest,
+        )
+        transport_a = httpx.ASGITransport(app=create_gateway_app(worker_a))
+        transport_b = httpx.ASGITransport(app=create_gateway_app(worker_b))
+        headers = {
+            "authorization": "Bearer caller-secret",
+            "Idempotency-Key": "shared-operation",
+        }
+        original_body = {"model": "public-model", "input": "first"}
+
+        async with (
+            httpx.AsyncClient(transport=transport_a, base_url="http://worker-a") as client_a,
+            httpx.AsyncClient(transport=transport_b, base_url="http://worker-b") as client_b,
+        ):
+            original = asyncio.create_task(
+                client_a.post("/v1/responses", json=original_body, headers=headers)
+            )
+            await provider_started.wait()
+
+            cancelled_joiner = asyncio.create_task(
+                client_b.post("/v1/responses", json=original_body, headers=headers)
+            )
+            while shared.join_count < 1:
+                await asyncio.sleep(0)
+            cancelled_joiner.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await cancelled_joiner
+
+            surviving_joiner = asyncio.create_task(
+                client_b.post("/v1/responses", json=original_body, headers=headers)
+            )
+            await shared.two_joiners.wait()
+            conflict = await client_b.post(
+                "/v1/responses",
+                json={"model": "public-model", "input": "different"},
+                headers=headers,
+            )
+            assert conflict.status_code == 409
+            assert conflict.json()["error"]["code"] == "idempotency_conflict"
+
+            release_provider.set()
+            original_response, joined_response = await asyncio.gather(original, surviving_joiner)
+            replayed_response = await client_b.post(
+                "/v1/responses",
+                json=original_body,
+                headers=headers,
+            )
+            first_id = original_response.json()["id"]
+            continued = await client_b.post(
+                "/v1/responses",
+                json={
+                    "model": "public-model",
+                    "input": "second",
+                    "previous_response_id": first_id,
+                },
+                headers={"authorization": "Bearer caller-secret"},
+            )
+
+        assert original_response.status_code == 200
+        assert joined_response.content == original_response.content
+        assert replayed_response.content == original_response.content
+        assert continued.status_code == 200
+        assert continued.json()["previous_response_id"] == first_id
+        assert len(provider.streams) == 2
 
     asyncio.run(scenario())
 

--- a/wmo/runtime/openai_protocol/state.py
+++ b/wmo/runtime/openai_protocol/state.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict
 from collections.abc import Callable
 from enum import StrEnum
+from typing import Protocol
 
 from pydantic import Field
 
@@ -59,35 +60,115 @@ class ReplayClaimKind(StrEnum):
 
 
 class _ReplayEntry:
-    """One in-flight or completed response future with bounded retention metadata."""
+    """One in-flight or completed response signal with bounded retention metadata."""
 
-    def __init__(self, future: asyncio.Future[CachedResponse], expires_at: float) -> None:
-        """Create an empty replay entry around one event-loop future."""
-        self.future = future
+    def __init__(self, expires_at: float) -> None:
+        """Create an unpublished replay entry."""
+        self.published = asyncio.Event()
+        self.response: CachedResponse | None = None
         self.expires_at = expires_at
         self.size_bytes = 0
 
 
-class ReplayLease:
-    """One caller's ownership or join handle for a keyed response."""
+class ReplayLease(Protocol):
+    """Ownership-scoped operations for one claimed replay key.
+
+    Implementations must make publication conditional on ownership established by
+    :meth:`ResponseReplayStore.claim`. Cancelling a caller waiting on :meth:`result` must not
+    cancel shared work.
+    """
+
+    @property
+    def kind(self) -> ReplayClaimKind:
+        """Return whether this caller owns, joins, or replays the operation."""
+        ...
+
+    async def result(self) -> CachedResponse:
+        """Join in-flight work or return the already completed exact response."""
+        ...
+
+    async def complete(self, response: CachedResponse) -> None:
+        """Publish one exact successful response from the unique owner."""
+        ...
+
+    async def abandon(self) -> None:
+        """Release this claim only when it still owns unpublished work."""
+        ...
+
+
+class ResponseReplayStore(Protocol):
+    """Atomic completed-response ownership, joining, and replay operations.
+
+    A claim is scoped by the complete :class:`ReplayKey`. Reusing a caller operation within its
+    namespace and surface for another canonical body must fail closed. Implementations must
+    return exactly one owner while work is unpublished, join matching concurrent claims, and
+    replay only a response that its owner successfully published. Cancellation before a claim
+    returns must not strand ownership. A shared implementation must expire ownership left by
+    worker loss within a finite implementation-defined lease so joiners cannot wait forever.
+    """
+
+    async def claim(self, key: ReplayKey) -> ReplayLease:
+        """Claim original work, join an in-flight duplicate, or replay completion."""
+        ...
+
+
+class ResponseContinuationStore(Protocol):
+    """Namespaced state operations required by Responses continuations.
+
+    Implementations must apply their finite retention policy to the complete namespace and public
+    response identity. Missing, expired, evicted, or cross-namespace state must fail closed.
+    """
+
+    async def remember(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        response_id: str,
+        state: ContinuationState,
+    ) -> None:
+        """Retain one completed Responses continuation within implementation bounds."""
+        ...
+
+    async def resolve(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        previous_response_id: str,
+    ) -> ContinuationState:
+        """Resolve an exact namespaced continuation or fail closed."""
+        ...
+
+
+class _BoundedReplayLease:
+    """One local caller's ownership or join handle for a keyed response."""
 
     def __init__(
         self,
         *,
         store: BoundedReplayStore,
         key: ReplayKey,
-        future: asyncio.Future[CachedResponse],
+        entry: _ReplayEntry,
         kind: ReplayClaimKind,
     ) -> None:
         """Bind one replay claim to its store entry."""
         self._store = store
         self._key = key
-        self._future = future
+        self._entry = entry
         self.kind = kind
 
     async def result(self) -> CachedResponse:
         """Join in-flight work or return the already completed exact response."""
-        return await asyncio.shield(self._future)
+        await asyncio.shield(self._entry.published.wait())
+        response = self._entry.response
+        if response is None:
+            raise OpenAIProtocolError(
+                status_code=409,
+                code="idempotency_replay_unavailable",
+                message="The original keyed request ended before publishing a replayable result.",
+                error_type="api_error",
+                param="Idempotency-Key",
+            )
+        return response
 
     async def complete(self, response: CachedResponse) -> None:
         """Publish one exact response from the unique owner.
@@ -105,12 +186,12 @@ class ReplayLease:
                 message="Only the original keyed request may publish its result.",
                 param="Idempotency-Key",
             )
-        await self._store._complete(self._key, self._future, response)
+        await self._store._complete(self._key, self._entry, response)
 
     async def abandon(self) -> None:
         """Remove failed owner work so no joiner receives invented response content."""
         if self.kind == ReplayClaimKind.OWNER:
-            await self._store._abandon(self._key, self._future)
+            await self._store._abandon(self._key, self._entry)
 
 
 class BoundedReplayStore:
@@ -169,29 +250,30 @@ class BoundedReplayStore:
             entry = self._entries.get(key)
             if entry is not None:
                 self._entries.move_to_end(key)
-                kind = ReplayClaimKind.REPLAY if entry.future.done() else ReplayClaimKind.JOIN
-                return ReplayLease(store=self, key=key, future=entry.future, kind=kind)
+                kind = (
+                    ReplayClaimKind.REPLAY if entry.response is not None else ReplayClaimKind.JOIN
+                )
+                return _BoundedReplayLease(store=self, key=key, entry=entry, kind=kind)
             self._make_capacity()
-            future = asyncio.get_running_loop().create_future()
-            entry = _ReplayEntry(future, self._clock() + self._ttl_seconds)
+            entry = _ReplayEntry(self._clock() + self._ttl_seconds)
             self._entries[key] = entry
             self._evict_completed()
-            return ReplayLease(
+            return _BoundedReplayLease(
                 store=self,
                 key=key,
-                future=future,
+                entry=entry,
                 kind=ReplayClaimKind.OWNER,
             )
 
     async def _complete(
         self,
         key: ReplayKey,
-        future: asyncio.Future[CachedResponse],
+        claimed_entry: _ReplayEntry,
         response: CachedResponse,
     ) -> None:
         """Atomically publish an owner result and apply retention bounds."""
         if response.size_bytes > self._byte_cap:
-            await self._abandon(key, future)
+            await self._abandon(key, claimed_entry)
             raise OpenAIProtocolError(
                 status_code=500,
                 code="idempotency_replay_unavailable",
@@ -200,7 +282,7 @@ class BoundedReplayStore:
             )
         async with self._lock:
             entry = self._entries.get(key)
-            if entry is None or entry.future is not future or future.done():
+            if entry is None or entry is not claimed_entry or entry.published.is_set():
                 raise OpenAIProtocolError(
                     status_code=409,
                     code="idempotency_conflict",
@@ -210,22 +292,23 @@ class BoundedReplayStore:
             entry.size_bytes = response.size_bytes
             entry.expires_at = self._clock() + self._ttl_seconds
             self._response_bytes += entry.size_bytes
-            future.set_result(response)
+            entry.response = response
+            entry.published.set()
             self._entries.move_to_end(key)
             self._evict_completed()
 
-    async def _abandon(self, key: ReplayKey, future: asyncio.Future[CachedResponse]) -> None:
+    async def _abandon(self, key: ReplayKey, claimed_entry: _ReplayEntry) -> None:
         """Remove matching in-flight work without erasing a published result."""
         async with self._lock:
             entry = self._entries.get(key)
-            if entry is not None and entry.future is future and not future.done():
+            if entry is not None and entry is claimed_entry and not entry.published.is_set():
                 self._entries.pop(key)
-                future.cancel()
+                entry.published.set()
 
     def _expire(self, now: float) -> None:
         """Drop completed expired entries without evicting active work."""
         for key, entry in tuple(self._entries.items()):
-            if entry.future.done() and entry.expires_at <= now:
+            if entry.response is not None and entry.expires_at <= now:
                 self._entries.pop(key)
                 self._response_bytes -= entry.size_bytes
 
@@ -233,7 +316,11 @@ class BoundedReplayStore:
         """Evict oldest completed entries until count and byte bounds hold."""
         while len(self._entries) > self._capacity or self._response_bytes > self._byte_cap:
             completed = next(
-                ((key, entry) for key, entry in self._entries.items() if entry.future.done()),
+                (
+                    (key, entry)
+                    for key, entry in self._entries.items()
+                    if entry.response is not None
+                ),
                 None,
             )
             if completed is None:
@@ -246,7 +333,11 @@ class BoundedReplayStore:
         """Evict completed work or reject when every bounded slot is in flight."""
         while len(self._entries) >= self._capacity:
             completed = next(
-                ((key, entry) for key, entry in self._entries.items() if entry.future.done()),
+                (
+                    (key, entry)
+                    for key, entry in self._entries.items()
+                    if entry.response is not None
+                ),
                 None,
             )
             if completed is None:

--- a/wmo/runtime/openai_protocol/state_test.py
+++ b/wmo/runtime/openai_protocol/state_test.py
@@ -131,6 +131,99 @@ def test_replay_capacity_rejects_new_work_without_evicting_inflight_owners() -> 
     asyncio.run(scenario())
 
 
+def test_cancelled_replay_joiner_does_not_cancel_shared_ownership() -> None:
+    """Cancelling one waiter preserves owner publication and later exact replay."""
+
+    async def scenario() -> None:
+        """Cancel a join, publish through the owner, and replay the result."""
+        store = BoundedReplayStore(capacity=2, byte_cap=1_024, ttl_seconds=60)
+        key = replay_key(
+            namespace=_namespace(),
+            surface=GatewayApiSurface.RESPONSES,
+            caller_operation="operation-one",
+            canonical_request_sha256=_REQUEST_DIGEST,
+        )
+        assert key is not None
+        owner = await store.claim(key)
+        joiner = await store.claim(key)
+        waiting = asyncio.create_task(joiner.result())
+        await asyncio.sleep(0)
+        waiting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiting
+
+        response = CachedResponse(
+            status_code=200,
+            media_type="application/json",
+            body=b'{"id":"response-one"}',
+        )
+        await owner.complete(response)
+        replay = await store.claim(key)
+        assert replay.kind == ReplayClaimKind.REPLAY
+        assert await replay.result() == response
+
+    asyncio.run(scenario())
+
+
+def test_abandoned_replay_owner_wakes_joiners_with_unavailable_error() -> None:
+    """Owner cancellation releases joiners through a defined fail-closed result."""
+
+    async def scenario() -> None:
+        """Abandon one owner and prove its joiner can fail without cancellation."""
+        store = BoundedReplayStore(capacity=2, byte_cap=1_024, ttl_seconds=60)
+        key = replay_key(
+            namespace=_namespace(),
+            surface=GatewayApiSurface.RESPONSES,
+            caller_operation="operation-one",
+            canonical_request_sha256=_REQUEST_DIGEST,
+        )
+        assert key is not None
+        owner = await store.claim(key)
+        joiner = await store.claim(key)
+        waiting = asyncio.create_task(joiner.result())
+        await asyncio.sleep(0)
+        await owner.abandon()
+
+        with pytest.raises(OpenAIProtocolError) as captured:
+            await waiting
+        assert captured.value.detail.code == "idempotency_replay_unavailable"
+        replacement = await store.claim(key)
+        assert replacement.kind == ReplayClaimKind.OWNER
+        await replacement.abandon()
+
+    asyncio.run(scenario())
+
+
+def test_replay_rejects_unretainable_response_and_releases_ownership() -> None:
+    """An oversized result fails closed and leaves no false completed replay."""
+
+    async def scenario() -> None:
+        """Reject one publication, then prove the operation can be owned again."""
+        store = BoundedReplayStore(capacity=1, byte_cap=8, ttl_seconds=60)
+        key = replay_key(
+            namespace=_namespace(),
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            caller_operation="operation-one",
+            canonical_request_sha256=_REQUEST_DIGEST,
+        )
+        assert key is not None
+        owner = await store.claim(key)
+        with pytest.raises(OpenAIProtocolError) as captured:
+            await owner.complete(
+                CachedResponse(
+                    status_code=200,
+                    media_type="application/json",
+                    body=b"response exceeds the bound",
+                )
+            )
+        assert captured.value.detail.code == "idempotency_replay_unavailable"
+        replacement = await store.claim(key)
+        assert replacement.kind == ReplayClaimKind.OWNER
+        await replacement.abandon()
+
+    asyncio.run(scenario())
+
+
 def test_continuation_is_bounded_namespaced_and_restart_unavailable() -> None:
     """Responses history obeys identity, alias revision, capacity, TTL, and restart boundaries."""
 
@@ -160,12 +253,15 @@ def test_continuation_is_bounded_namespaced_and_restart_unavailable() -> None:
                 namespace=_namespace(identity="identity-two"),
                 previous_response_id="resp_one",
             )
+        await store.remember(namespace=_namespace(), response_id="resp_two", state=state)
+        with pytest.raises(OpenAIProtocolError, match="unavailable or expired"):
+            await store.resolve(namespace=_namespace(), previous_response_id="resp_one")
         restarted = BoundedContinuationStore()
         with pytest.raises(OpenAIProtocolError, match="unavailable or expired"):
             await restarted.resolve(namespace=_namespace(), previous_response_id="resp_one")
 
         now[0] = 111.0
         with pytest.raises(OpenAIProtocolError, match="unavailable or expired"):
-            await store.resolve(namespace=_namespace(), previous_response_id="resp_one")
+            await store.resolve(namespace=_namespace(), previous_response_id="resp_two")
 
     asyncio.run(scenario())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- define narrow async replay lease, replay store, and Responses continuation store protocols
- keep bounded in-memory stores as local defaults while allowing shared structural implementations
- preserve namespaced conflict detection, bounded retention, fail-closed publication ordering, and cancellation isolation
- add deterministic two-worker FastAPI coverage for joining, replay, body conflicts, cancellation, and cross-worker continuation

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q wmo/runtime/openai_protocol/state_test.py wmo/runtime/gateway/tests/data_plane_test.py wmo/runtime/gateway/tests/launch_test.py wmo/runtime/openai_protocol/tests/sdk_harness_test.py` (31 passed)
- `uv run pytest -q` (1837 passed, 12 skipped, 13 unrelated failures: terminal rendering assumptions, a loopback live-pipeline timeout, and a clean-checkout release evidence guard)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c360b10-205b-429e-86ae-59bbdfd8ac55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c360b10-205b-429e-86ae-59bbdfd8ac55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

