### PR TITLE
Add immutable project activation gateway seam

### DIFF
--- a/wmo/cli/gateway/compatibility.py
+++ b/wmo/cli/gateway/compatibility.py
@@ -11,8 +11,9 @@ from wmo.cli.gateway.key_output import (
     recover_key_output,
     settle_key_output,
 )
-from wmo.optimize.router.activation import load_project_router
+from wmo.optimize.router.activation import verify_automatic_router_policy
 from wmo.runtime.gateway.management import GatewayManagement
+from wmo.runtime.gateway.project_activation import LocalArtifactProjectActivationRepository
 from wmo.runtime.gateway.project_alias import prepare_project_gateway_alias
 
 
@@ -48,7 +49,10 @@ def prepare_project_gateway(
         project,
         root,
         policy_id=policy_id,
-        project_loader=load_project_router,
+        project_repository=LocalArtifactProjectActivationRepository(
+            root,
+            verifier=verify_automatic_router_policy,
+        ),
     )
     manager = GatewayManagement(root)
     key_file = manager.state_dir / "compatibility-keys" / f"{alias.identity_id}.txt"

--- a/wmo/cli/run/app.py
+++ b/wmo/cli/run/app.py
@@ -101,12 +101,13 @@ def _run_gateway(
 
     from wmo.cli.gateway.compatibility import prepare_project_gateway
     from wmo.cli.gateway.setup import interactive_gateway_setup
-    from wmo.optimize.router.activation import load_project_router
+    from wmo.optimize.router.activation import verify_automatic_router_policy
     from wmo.runtime.gateway.lifecycle import (
         gateway_instance_lock,
         load_local_gateway,
     )
     from wmo.runtime.gateway.management import GatewayManagement
+    from wmo.runtime.gateway.project_activation import LocalArtifactProjectActivationRepository
 
     setup = None
     manager = GatewayManagement(root)
@@ -122,10 +123,14 @@ def _run_gateway(
 
     with usage_error(ValueError):
         with gateway_instance_lock(root, port=port):
+            project_repository = LocalArtifactProjectActivationRepository(
+                root,
+                verifier=verify_automatic_router_policy,
+            )
             runtime = load_local_gateway(
                 root,
                 graceful_timeout_seconds=graceful_timeout,
-                project_loader=load_project_router,
+                project_repository=project_repository,
                 only_aliases=(None if compatibility is None else frozenset({compatibility.alias})),
             )
             asyncio.run(runtime.service.preflight())

--- a/wmo/cli/run/app_test.py
+++ b/wmo/cli/run/app_test.py
@@ -59,7 +59,7 @@ def test_project_form_launches_the_normal_gateway_on_loopback(
         root: Path,
         *,
         graceful_timeout_seconds: float,
-        project_loader: object,
+        project_repository: object,
         only_aliases: frozenset[str] | None,
     ) -> object:
         """Capture the one shared lifecycle composition.
@@ -67,13 +67,13 @@ def test_project_form_launches_the_normal_gateway_on_loopback(
         Args:
             root: Gateway and artifact root.
             graceful_timeout_seconds: Requested shutdown drain bound.
-            project_loader: Injected selection-only project loader.
+            project_repository: Injected immutable project activation repository.
             only_aliases: Optional compatibility alias filter.
 
         Returns:
             Gateway runtime fixture passed to the normal server.
         """
-        del graceful_timeout_seconds, project_loader
+        del graceful_timeout_seconds, project_repository
         loaded.append((root, only_aliases))
         return SimpleNamespace(
             app=application,

--- a/wmo/runtime/gateway/composition.py
+++ b/wmo/runtime/gateway/composition.py
@@ -19,7 +19,7 @@ from wmo.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayC
 from wmo.runtime.gateway.routing import CatalogRouteResolver
 from wmo.runtime.gateway.service import GatewayService, create_gateway_app
 from wmo.runtime.gateway.usage import GatewayUsageReport, usage_html
-from wmo.runtime.openai_protocol.state import BoundedContinuationStore, BoundedReplayStore
+from wmo.runtime.openai_protocol.state import ResponseContinuationStore, ResponseReplayStore
 
 GatewayReadinessProbe = Callable[[], Awaitable[ExecutionSnapshot]]
 GatewayUsageSupplier = Callable[[], GatewayUsageReport]
@@ -139,8 +139,8 @@ def create_gateway_runtime(
     clock: GatewayClock,
     readiness: GatewayReadinessProbe,
     usage: GatewayUsageSupplier,
-    replay: BoundedReplayStore | None = None,
-    continuations: BoundedContinuationStore | None = None,
+    replay: ResponseReplayStore | None = None,
+    continuations: ResponseContinuationStore | None = None,
     wall_clock: Callable[[], float] | None = None,
     terminal_flusher: GatewayTerminalFlusher | None = None,
 ) -> GatewayRuntime:

--- a/wmo/runtime/gateway/lifecycle.py
+++ b/wmo/runtime/gateway/lifecycle.py
@@ -48,6 +48,7 @@ from wmo.runtime.gateway.sqlite.store import SQLiteGatewayStore, SystemGatewayCl
 from wmo.runtime.gateway.usage import read_usage_report
 from wmo.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from wmo.runtime.models.credentials import ModelCredentialError
+from wmo.runtime.openai_protocol.state import ResponseContinuationStore, ResponseReplayStore
 from wmo.runtime.router.errors import RouterApplicationError
 from wmo.runtime.router.runtime import DecisionSink, RouterRuntime
 
@@ -176,6 +177,8 @@ def load_local_gateway(
     environment: Mapping[str, str] | None = None,
     project_repository: ProjectActivationRepository | None = None,
     decision_sink: DecisionSink | None = None,
+    replay: ResponseReplayStore | None = None,
+    continuations: ResponseContinuationStore | None = None,
     only_aliases: frozenset[str] | None = None,
 ) -> LocalGatewayRuntime:
     """Load all granted active aliases and compose the loopback application.
@@ -186,6 +189,8 @@ def load_local_gateway(
         environment: Optional provider credential mapping used by tests.
         project_repository: Repository for verified immutable project activations.
         decision_sink: Optional aggregate-safe recorder for served project selections.
+        replay: Optional shared Chat and Responses replay state.
+        continuations: Optional shared Responses continuation state.
         only_aliases: Optional exact public aliases to expose from the shared application.
 
     Returns:
@@ -313,6 +318,8 @@ def load_local_gateway(
         clock=SystemGatewayClock(),
         readiness=readiness_probe,
         usage=lambda: read_usage_report(ledger, organization_id=manager.organization_id),
+        replay=replay,
+        continuations=continuations,
     )
     return LocalGatewayRuntime(
         runtime=runtime,

--- a/wmo/runtime/gateway/lifecycle.py
+++ b/wmo/runtime/gateway/lifecycle.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import Protocol, cast
+from typing import cast
 
 from fastapi import FastAPI
 from filelock import FileLock, Timeout
@@ -37,6 +37,7 @@ from wmo.runtime.gateway.execution import GatewayExecutor
 from wmo.runtime.gateway.interfaces import ProjectTargetResolver
 from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
 from wmo.runtime.gateway.management import GatewayAliasView, GatewayManagement
+from wmo.runtime.gateway.project_activation import ProjectActivationRepository
 from wmo.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoutingError,
@@ -53,21 +54,6 @@ from wmo.runtime.router.runtime import RouterRuntime
 
 class GatewayLifecycleError(ValueError):
     """Local gateway configuration cannot form one ready execution snapshot."""
-
-
-class ProjectLoader(Protocol):
-    """Load one exact frozen project policy without executing provider work."""
-
-    def __call__(
-        self,
-        project: str,
-        root: Path,
-        *,
-        policy_id: str,
-        runtime_catalog: RuntimeModelCatalog,
-    ) -> RouterRuntime:
-        """Return one verified selection-only project runtime."""
-        ...
 
 
 @dataclass(frozen=True)
@@ -188,7 +174,7 @@ def load_local_gateway(
     *,
     graceful_timeout_seconds: float,
     environment: Mapping[str, str] | None = None,
-    project_loader: ProjectLoader | None = None,
+    project_repository: ProjectActivationRepository | None = None,
     only_aliases: frozenset[str] | None = None,
 ) -> LocalGatewayRuntime:
     """Load all granted active aliases and compose the loopback application.
@@ -197,7 +183,7 @@ def load_local_gateway(
         root: Initialized WMO root.
         graceful_timeout_seconds: Shutdown drain bound.
         environment: Optional provider credential mapping used by tests.
-        project_loader: CLI-injected verified project activation loader.
+        project_repository: Repository for verified immutable project activations.
         only_aliases: Optional exact public aliases to expose from the shared application.
 
     Returns:
@@ -245,19 +231,19 @@ def load_local_gateway(
             continue
         if alias.target_kind != "project":
             raise GatewayLifecycleError(f"alias {alias.alias_name!r} has an unknown target kind")
-        if project_loader is None:
+        if project_repository is None:
             raise GatewayLifecycleError(
-                f"project alias {alias.alias_name!r} requires a project activation loader"
+                f"project alias {alias.alias_name!r} requires a project activation repository"
             )
         project_ref = _required(alias.project_ref, "project reference", alias)
         activation_ref = _required(alias.activation_ref, "activation reference", alias)
         try:
-            runtime = project_loader(
+            activation = project_repository.load(
                 project_ref,
-                root,
-                policy_id=activation_ref,
+                activation_ref,
                 runtime_catalog=runtime_catalog,
             )
+            runtime = RouterRuntime.from_activation(activation, runtime_catalog)
             proof = _project_readiness(
                 manager,
                 alias,

--- a/wmo/runtime/gateway/lifecycle.py
+++ b/wmo/runtime/gateway/lifecycle.py
@@ -37,7 +37,12 @@ from wmo.runtime.gateway.execution import GatewayExecutor
 from wmo.runtime.gateway.interfaces import ProjectTargetResolver
 from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
 from wmo.runtime.gateway.management import GatewayAliasView, GatewayManagement
-from wmo.runtime.gateway.project_activation import ProjectActivation, ProjectActivationRepository
+from wmo.runtime.gateway.project_activation import (
+    ProjectActivation,
+    ProjectActivationError,
+    ProjectActivationRepository,
+    require_project_activation_authority,
+)
 from wmo.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoutingError,
@@ -536,13 +541,11 @@ def _require_activation_authority(
     activation_ref: str,
 ) -> None:
     """Require repository output to match the exact authorized project target."""
-    if activation.project_ref != project_ref:
-        raise GatewayLifecycleError(
-            f"project activation repository returned project reference "
-            f"{activation.project_ref!r}, expected {project_ref!r}"
+    try:
+        require_project_activation_authority(
+            activation,
+            project_ref=project_ref,
+            activation_ref=activation_ref,
         )
-    if activation.activation_ref != activation_ref:
-        raise GatewayLifecycleError(
-            f"project activation repository returned activation reference "
-            f"{activation.activation_ref!r}, expected {activation_ref!r}"
-        )
+    except ProjectActivationError as exc:
+        raise GatewayLifecycleError(str(exc)) from exc

--- a/wmo/runtime/gateway/lifecycle.py
+++ b/wmo/runtime/gateway/lifecycle.py
@@ -37,7 +37,7 @@ from wmo.runtime.gateway.execution import GatewayExecutor
 from wmo.runtime.gateway.interfaces import ProjectTargetResolver
 from wmo.runtime.gateway.ledger import SQLiteAttemptLedger
 from wmo.runtime.gateway.management import GatewayAliasView, GatewayManagement
-from wmo.runtime.gateway.project_activation import ProjectActivationRepository
+from wmo.runtime.gateway.project_activation import ProjectActivation, ProjectActivationRepository
 from wmo.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoutingError,
@@ -49,7 +49,7 @@ from wmo.runtime.gateway.usage import read_usage_report
 from wmo.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from wmo.runtime.models.credentials import ModelCredentialError
 from wmo.runtime.router.errors import RouterApplicationError
-from wmo.runtime.router.runtime import RouterRuntime
+from wmo.runtime.router.runtime import DecisionSink, RouterRuntime
 
 
 class GatewayLifecycleError(ValueError):
@@ -175,6 +175,7 @@ def load_local_gateway(
     graceful_timeout_seconds: float,
     environment: Mapping[str, str] | None = None,
     project_repository: ProjectActivationRepository | None = None,
+    decision_sink: DecisionSink | None = None,
     only_aliases: frozenset[str] | None = None,
 ) -> LocalGatewayRuntime:
     """Load all granted active aliases and compose the loopback application.
@@ -184,6 +185,7 @@ def load_local_gateway(
         graceful_timeout_seconds: Shutdown drain bound.
         environment: Optional provider credential mapping used by tests.
         project_repository: Repository for verified immutable project activations.
+        decision_sink: Optional aggregate-safe recorder for served project selections.
         only_aliases: Optional exact public aliases to expose from the shared application.
 
     Returns:
@@ -243,7 +245,16 @@ def load_local_gateway(
                 activation_ref,
                 runtime_catalog=runtime_catalog,
             )
-            runtime = RouterRuntime.from_activation(activation, runtime_catalog)
+            _require_activation_authority(
+                activation,
+                project_ref=project_ref,
+                activation_ref=activation_ref,
+            )
+            runtime = RouterRuntime.from_activation(
+                activation,
+                runtime_catalog,
+                decision_sink=decision_sink,
+            )
             proof = _project_readiness(
                 manager,
                 alias,
@@ -509,3 +520,22 @@ def _required(value: str | None, name: str, alias: GatewayAliasView) -> str:
     if value is None:
         raise GatewayLifecycleError(f"alias {alias.alias_name!r} is missing {name}")
     return value
+
+
+def _require_activation_authority(
+    activation: ProjectActivation,
+    *,
+    project_ref: str,
+    activation_ref: str,
+) -> None:
+    """Require repository output to match the exact authorized project target."""
+    if activation.project_ref != project_ref:
+        raise GatewayLifecycleError(
+            f"project activation repository returned project reference "
+            f"{activation.project_ref!r}, expected {project_ref!r}"
+        )
+    if activation.activation_ref != activation_ref:
+        raise GatewayLifecycleError(
+            f"project activation repository returned activation reference "
+            f"{activation.activation_ref!r}, expected {activation_ref!r}"
+        )

--- a/wmo/runtime/gateway/lifecycle_test.py
+++ b/wmo/runtime/gateway/lifecycle_test.py
@@ -15,11 +15,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from wmo.common.models import (
+    BillingSource,
+    CandidateTokenPrice,
     ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayEquivalenceCertification,
     GatewayTokenPrices,
     ModelCapabilities,
+    ModelRecord,
+    PricingSnapshot,
+    RoutedCandidateSnapshot,
+    load_model_catalog,
+    write_model_catalog,
 )
 from wmo.runtime.gateway.catalog_authority import (
     upsert_certified_pool,
@@ -32,6 +39,7 @@ from wmo.runtime.gateway.lifecycle import (
     load_local_gateway,
 )
 from wmo.runtime.gateway.management import GatewayManagement
+from wmo.runtime.gateway.project_activation import ProjectActivation
 from wmo.runtime.models import RuntimeModelCatalog
 from wmo.runtime.router.runtime import RouterRuntime
 
@@ -44,6 +52,104 @@ class _ReadinessProjectRuntime:
         self.policy = SimpleNamespace(
             candidates=tuple(SimpleNamespace(alias=alias) for alias in aliases)
         )
+
+
+class _ReadinessProjectRepository:
+    """Return one caller-supplied activation object without filesystem access."""
+
+    def __init__(self, activation: ProjectActivation) -> None:
+        """Store one immutable activation for exact-reference lookup."""
+        self.activation = activation
+
+    def load(
+        self,
+        project_ref: str,
+        activation_ref: str | None,
+        *,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> ProjectActivation:
+        """Return the supplied activation after checking requested identifiers."""
+        del runtime_catalog
+        assert project_ref == "project-one"
+        assert activation_ref == "activation-one"
+        return self.activation
+
+
+def _repository_for_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime: RouterRuntime,
+) -> _ReadinessProjectRepository:
+    """Adapt an existing selection runtime to the activation repository seam."""
+
+    def from_activation(
+        cls: type[RouterRuntime],
+        activation: ProjectActivation,
+        catalog: RuntimeModelCatalog,
+    ) -> RouterRuntime:
+        """Return the runtime represented by this test's opaque activation."""
+        del cls, catalog
+        return cast(RouterRuntime, activation)
+
+    monkeypatch.setattr(RouterRuntime, "from_activation", classmethod(from_activation))
+    return _ReadinessProjectRepository(cast(ProjectActivation, runtime))
+
+
+def _project_activation(
+    root: Path,
+    *,
+    candidate_aliases: tuple[str, ...],
+    environment: dict[str, str],
+) -> ProjectActivation:
+    """Build immutable learned-selection material matching one gateway catalog."""
+    from wmo.runtime.router.runtime_test import _fixture
+
+    policy, manifest, bank, _snapshots, _client = _fixture()
+    catalog = RuntimeModelCatalog(load_model_catalog(root / "models.toml"), environment=environment)
+    snapshots = {alias: catalog.snapshot(alias)[0] for alias in (*candidate_aliases, "embedder")}
+    candidates = tuple(
+        RoutedCandidateSnapshot(alias=alias, model=snapshots[alias]) for alias in candidate_aliases
+    )
+    policy = policy.model_copy(
+        update={
+            "policy_id": "activation-one",
+            "baseline_alias": (
+                "baseline" if "baseline" in candidate_aliases else candidate_aliases[-1]
+            ),
+            "candidates": candidates,
+            "embedder_alias": "embedder",
+            "embedder": snapshots["embedder"],
+        }
+    )
+    manifest = manifest.model_copy(
+        update={
+            "candidate_aliases": candidate_aliases,
+            "embedder_alias": "embedder",
+            "embedder": snapshots["embedder"],
+        }
+    )
+    pricing = PricingSnapshot(
+        schema_version=1,
+        created_at=policy.created_at,
+        code_revision="test",
+        pricing_snapshot_id=policy.pricing_snapshot_id,
+        candidate_prices=tuple(
+            CandidateTokenPrice(
+                candidate_alias=alias,
+                input_usd_per_million_tokens=1,
+                output_usd_per_million_tokens=2,
+            )
+            for alias in candidate_aliases
+        ),
+    )
+    return ProjectActivation(
+        project_ref="project-one",
+        activation_ref="activation-one",
+        policy=policy,
+        bank_manifest=manifest,
+        bank=bank,
+        pricing=pricing,
+        pricing_sha256=policy.pricing_snapshot_sha256,
+    )
 
 
 def test_local_gateway_preflights_real_state_and_serves_health_and_usage(
@@ -229,22 +335,15 @@ def test_live_alias_revision_drift_is_removed_from_discovery_and_dispatch(
 
 def test_project_certified_pool_preflight_resolves_all_siblings_and_reloads(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Project startup accepts one candidate inside an available certified pool."""
     manager, raw_key = _configured_project_pool(tmp_path)
 
-    def load_project(
-        project: str,
-        root: Path,
-        *,
-        policy_id: str,
-        runtime_catalog: RuntimeModelCatalog,
-    ) -> RouterRuntime:
-        """Return a selection-only runtime naming the pool's primary deployment."""
-        del root, runtime_catalog
-        assert project == "project-one"
-        assert policy_id == "activation-one"
-        return cast(RouterRuntime, _ReadinessProjectRuntime("primary"))
+    repository = _repository_for_runtime(
+        monkeypatch,
+        cast(RouterRuntime, _ReadinessProjectRuntime("primary")),
+    )
 
     for _reload in range(2):
         runtime = load_local_gateway(
@@ -254,7 +353,7 @@ def test_project_certified_pool_preflight_resolves_all_siblings_and_reloads(
                 "PRIMARY_PROVIDER_KEY": "primary-available",
                 "SECONDARY_PROVIDER_KEY": "secondary-available",
             },
-            project_loader=load_project,
+            project_repository=repository,
         )
         with TestClient(runtime.app) as client:
             models = client.get(
@@ -269,9 +368,8 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
     tmp_path: Path,
 ) -> None:
     """Real lifecycle uses RouterRuntime selection only, then owns provider fallback."""
-    from wmo.runtime.router.runtime_test import _runtime
-
     dispatched: list[str] = []
+    provider_requests: list[str] = []
 
     class ProjectProviderHandler(BaseHTTPRequestHandler):
         """Serve one precommit failure followed by deterministic Chat SSE."""
@@ -287,6 +385,21 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
             length = int(self.headers.get("Content-Length", "0"))
             payload = json.loads(self.rfile.read(length))
             model = str(payload["model"])
+            provider_requests.append(self.path)
+            if self.path.endswith("/embeddings"):
+                body = json.dumps(
+                    {
+                        "data": [{"embedding": [1.0, 0.0], "index": 0}],
+                        "model": model,
+                        "usage": {"prompt_tokens": 3, "total_tokens": 3},
+                    }
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
             dispatched.append(model)
             if model == "cheap-model":
                 body = b'{"error":{"message":"temporary project route failure"}}'
@@ -321,21 +434,6 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
             deployment_aliases=("cheap", "baseline"),
             base_url=base_url,
         )
-        project_runtime, project_client = _runtime()
-
-        def load_project(
-            project: str,
-            root: Path,
-            *,
-            policy_id: str,
-            runtime_catalog: RuntimeModelCatalog,
-        ) -> RouterRuntime:
-            """Inject one real frozen runtime without completing through it."""
-            del root, runtime_catalog
-            assert project == "project-one"
-            assert policy_id == "activation-one"
-            return project_runtime
-
         runtime = load_local_gateway(
             tmp_path,
             graceful_timeout_seconds=1,
@@ -343,9 +441,20 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
                 "CHEAP_PROVIDER_KEY": "available",
                 "BASELINE_PROVIDER_KEY": "available",
             },
-            project_loader=load_project,
+            project_repository=_ReadinessProjectRepository(
+                _project_activation(
+                    tmp_path,
+                    candidate_aliases=("baseline", "cheap"),
+                    environment={
+                        "CHEAP_PROVIDER_KEY": "available",
+                        "BASELINE_PROVIDER_KEY": "available",
+                    },
+                )
+            ),
         )
+        assert provider_requests == []
         with TestClient(runtime.app) as client:
+            assert provider_requests == []
             response = client.post(
                 "/v1/chat/completions",
                 headers={"Authorization": f"Bearer {raw_key}"},
@@ -356,10 +465,8 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
             )
         assert response.status_code == 200
         assert response.json()["choices"][0]["message"]["content"] == ("project-response-canary")
+        assert provider_requests[0].endswith("/embeddings")
         assert dispatched == ["cheap-model", "cheap-model", "baseline-model"]
-        assert project_client.embed_calls == 1
-        assert project_client.complete_calls == 0
-        assert project_runtime.records_decisions is False
         with sqlite3.connect(manager.database_path) as connection:
             attempts = connection.execute(
                 """
@@ -390,27 +497,20 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
 
 def test_project_certified_pool_is_unavailable_when_any_sibling_cannot_resolve(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Project startup fails closed before dispatch when a pool sibling lacks credentials."""
     _manager, _raw_key = _configured_project_pool(tmp_path)
-
-    def load_project(
-        project: str,
-        root: Path,
-        *,
-        policy_id: str,
-        runtime_catalog: RuntimeModelCatalog,
-    ) -> RouterRuntime:
-        """Return the same frozen candidate without touching provider clients."""
-        del project, root, policy_id, runtime_catalog
-        return cast(RouterRuntime, _ReadinessProjectRuntime("primary"))
 
     with pytest.raises(GatewayLifecycleError, match="no granted active alias is locally available"):
         load_local_gateway(
             tmp_path,
             graceful_timeout_seconds=1,
             environment={"PRIMARY_PROVIDER_KEY": "primary-available"},
-            project_loader=load_project,
+            project_repository=_repository_for_runtime(
+                monkeypatch,
+                cast(RouterRuntime, _ReadinessProjectRuntime("primary")),
+            ),
         )
 
 
@@ -477,6 +577,16 @@ def _configured_project_pool(
             ),
             replace=False,
         )
+    authored = load_model_catalog(root / "models.toml")
+    primary_connection = f"{deployment_aliases[0]}-provider"
+    models = dict(authored.models)
+    models["embedder"] = ModelRecord(
+        connection=primary_connection,
+        model="embedder-model",
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        capabilities=ModelCapabilities(supports_embeddings=True),
+    )
+    write_model_catalog(root / "models.toml", authored.model_copy(update={"models": models}))
     normalized = None
     for deployment_alias in deployment_aliases:
         normalized, _snapshot, _changed = upsert_singleton_deployment(

--- a/wmo/runtime/gateway/lifecycle_test.py
+++ b/wmo/runtime/gateway/lifecycle_test.py
@@ -43,6 +43,14 @@ from wmo.runtime.gateway.lifecycle import (
 from wmo.runtime.gateway.management import GatewayManagement
 from wmo.runtime.gateway.project_activation import ProjectActivation
 from wmo.runtime.models import RuntimeModelCatalog
+from wmo.runtime.openai_protocol.state import (
+    BoundedContinuationStore,
+    BoundedReplayStore,
+    ContinuationState,
+    ProtocolNamespace,
+    ReplayKey,
+    ReplayLease,
+)
 from wmo.runtime.router.runtime import RouterRuntime
 
 
@@ -77,6 +85,54 @@ class _ReadinessProjectRepository:
         assert project_ref == "project-one"
         assert activation_ref == "activation-one"
         return self.activation
+
+
+class _ObjectReplayStore:
+    """Object-backed replay adapter injected through gateway composition."""
+
+    def __init__(self) -> None:
+        """Create one adapter around the bounded local replay implementation."""
+        self._store = BoundedReplayStore()
+        self.claim_calls = 0
+
+    async def claim(self, key: ReplayKey) -> ReplayLease:
+        """Record and delegate one replay ownership claim."""
+        self.claim_calls += 1
+        return await self._store.claim(key)
+
+
+class _ObjectContinuationStore:
+    """Object-backed continuation adapter injected through gateway composition."""
+
+    def __init__(self) -> None:
+        """Create one adapter around the bounded local continuation implementation."""
+        self._store = BoundedContinuationStore()
+
+    async def remember(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        response_id: str,
+        state: ContinuationState,
+    ) -> None:
+        """Delegate one namespaced continuation publication."""
+        await self._store.remember(
+            namespace=namespace,
+            response_id=response_id,
+            state=state,
+        )
+
+    async def resolve(
+        self,
+        *,
+        namespace: ProtocolNamespace,
+        previous_response_id: str,
+    ) -> ContinuationState:
+        """Delegate one namespaced continuation lookup."""
+        return await self._store.resolve(
+            namespace=namespace,
+            previous_response_id=previous_response_id,
+        )
 
 
 def _repository_for_runtime(
@@ -370,13 +426,15 @@ def test_project_certified_pool_preflight_resolves_all_siblings_and_reloads(
     assert manager.aliases()[0].target_kind == "project"
 
 
-def test_real_project_selection_dispatches_frozen_pool_without_router_completion(
+def test_object_project_activation_uses_factory_and_injected_protocol_state(
     tmp_path: Path,
 ) -> None:
-    """Real lifecycle uses RouterRuntime selection only, then owns provider fallback."""
+    """Object activation uses the shared factory with injectable protocol state."""
     dispatched: list[str] = []
     provider_requests: list[str] = []
     recorded: list[RoutingDecision] = []
+    replay = _ObjectReplayStore()
+    continuations = _ObjectContinuationStore()
 
     class ProjectProviderHandler(BaseHTTPRequestHandler):
         """Serve one precommit failure followed by deterministic Chat SSE."""
@@ -459,15 +517,22 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
                 )
             ),
             decision_sink=recorded.append,
+            replay=replay,
+            continuations=continuations,
         )
         assert provider_requests == []
         assert recorded == []
+        assert runtime.service._replays is replay  # noqa: SLF001 - composition seam evidence
+        assert runtime.service._continuations is continuations  # noqa: SLF001
         with TestClient(runtime.app) as client:
             assert provider_requests == []
             assert recorded == []
             response = client.post(
                 "/v1/chat/completions",
-                headers={"Authorization": f"Bearer {raw_key}"},
+                headers={
+                    "Authorization": f"Bearer {raw_key}",
+                    "Idempotency-Key": "object-project-selection",
+                },
                 json={
                     "model": "coding",
                     "messages": [{"role": "user", "content": "project-prompt-canary"}],
@@ -477,6 +542,7 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
         assert response.json()["choices"][0]["message"]["content"] == ("project-response-canary")
         assert provider_requests[0].endswith("/embeddings")
         assert dispatched == ["cheap-model", "cheap-model", "baseline-model"]
+        assert replay.claim_calls == 1
         assert len(recorded) == 1
         assert recorded[0].selected_alias == "cheap"
         with sqlite3.connect(manager.database_path) as connection:

--- a/wmo/runtime/gateway/lifecycle_test.py
+++ b/wmo/runtime/gateway/lifecycle_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from dataclasses import replace
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -28,6 +29,7 @@ from wmo.common.models import (
     load_model_catalog,
     write_model_catalog,
 )
+from wmo.common.routing import RoutingDecision
 from wmo.runtime.gateway.catalog_authority import (
     upsert_certified_pool,
     upsert_connection,
@@ -49,6 +51,8 @@ class _ReadinessProjectRuntime:
 
     def __init__(self, *aliases: str) -> None:
         """Build one minimal policy view from ordered candidate aliases."""
+        self.project_ref = "project-one"
+        self.activation_ref = "activation-one"
         self.policy = SimpleNamespace(
             candidates=tuple(SimpleNamespace(alias=alias) for alias in aliases)
         )
@@ -85,9 +89,11 @@ def _repository_for_runtime(
         cls: type[RouterRuntime],
         activation: ProjectActivation,
         catalog: RuntimeModelCatalog,
+        *,
+        decision_sink: object | None = None,
     ) -> RouterRuntime:
         """Return the runtime represented by this test's opaque activation."""
-        del cls, catalog
+        del cls, catalog, decision_sink
         return cast(RouterRuntime, activation)
 
     monkeypatch.setattr(RouterRuntime, "from_activation", classmethod(from_activation))
@@ -370,6 +376,7 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
     """Real lifecycle uses RouterRuntime selection only, then owns provider fallback."""
     dispatched: list[str] = []
     provider_requests: list[str] = []
+    recorded: list[RoutingDecision] = []
 
     class ProjectProviderHandler(BaseHTTPRequestHandler):
         """Serve one precommit failure followed by deterministic Chat SSE."""
@@ -451,10 +458,13 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
                     },
                 )
             ),
+            decision_sink=recorded.append,
         )
         assert provider_requests == []
+        assert recorded == []
         with TestClient(runtime.app) as client:
             assert provider_requests == []
+            assert recorded == []
             response = client.post(
                 "/v1/chat/completions",
                 headers={"Authorization": f"Bearer {raw_key}"},
@@ -467,6 +477,8 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
         assert response.json()["choices"][0]["message"]["content"] == ("project-response-canary")
         assert provider_requests[0].endswith("/embeddings")
         assert dispatched == ["cheap-model", "cheap-model", "baseline-model"]
+        assert len(recorded) == 1
+        assert recorded[0].selected_alias == "cheap"
         with sqlite3.connect(manager.database_path) as connection:
             attempts = connection.execute(
                 """
@@ -489,6 +501,74 @@ def test_real_project_selection_dispatches_frozen_pool_without_router_completion
             durable += wal.read_bytes()
         assert b"project-prompt-canary" not in durable
         assert b"project-response-canary" not in durable
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.mark.parametrize("mismatch", ["project", "activation"])
+def test_project_activation_authority_mismatch_fails_before_selection_or_provider_work(
+    tmp_path: Path,
+    mismatch: str,
+) -> None:
+    """Repository authority drift cannot bind, mutate decisions, or contact a provider."""
+    provider_requests: list[str] = []
+    recorded: list[RoutingDecision] = []
+
+    class ProviderHandler(BaseHTTPRequestHandler):
+        """Record any provider call that escapes authority validation."""
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            """Suppress nondeterministic loopback server logs."""
+            del format, args
+
+        def do_POST(self) -> None:
+            """Record an unexpected provider request and reject it."""
+            provider_requests.append(self.path)
+            self.send_response(500)
+            self.end_headers()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ProviderHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}/v1"
+        _manager, _raw_key = _configured_project_pool(
+            tmp_path,
+            deployment_aliases=("cheap", "baseline"),
+            base_url=base_url,
+        )
+        environment = {
+            "CHEAP_PROVIDER_KEY": "available",
+            "BASELINE_PROVIDER_KEY": "available",
+        }
+        activation = _project_activation(
+            tmp_path,
+            candidate_aliases=("baseline", "cheap"),
+            environment=environment,
+        )
+        if mismatch == "project":
+            activation = replace(activation, project_ref="other-project")
+        else:
+            policy = activation.policy.model_copy(update={"policy_id": "other-activation"})
+            activation = replace(
+                activation,
+                activation_ref="other-activation",
+                policy=policy,
+            )
+
+        with pytest.raises(GatewayLifecycleError, match=f"returned {mismatch} reference"):
+            load_local_gateway(
+                tmp_path,
+                graceful_timeout_seconds=1,
+                environment=environment,
+                project_repository=_ReadinessProjectRepository(activation),
+                decision_sink=recorded.append,
+            )
+
+        assert provider_requests == []
+        assert recorded == []
     finally:
         server.shutdown()
         server.server_close()

--- a/wmo/runtime/gateway/project_activation.py
+++ b/wmo/runtime/gateway/project_activation.py
@@ -1,0 +1,291 @@
+"""Immutable project activation contracts and the local artifact-store adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from wmo.common.core.artifacts import (
+    ArtifactId,
+    Sha256,
+    envelope_matches_manifest,
+    sha256_json,
+)
+from wmo.common.evaluations import load_evaluation_dataset
+from wmo.common.evaluations.evidence import read_evaluation_plan
+from wmo.common.models import PricingSnapshot, load_pricing_snapshot
+from wmo.common.project import (
+    ArtifactCorruptionError,
+    ArtifactStore,
+    ArtifactStoreError,
+    ProjectStore,
+    ProjectStoreError,
+    artifact_input,
+)
+from wmo.common.routing import KnnRouterPolicy
+from wmo.common.routing.bank import KnnBankManifest, KnnEvidenceBank, bank_bytes, load_knn_bank
+from wmo.common.tasks import load_task_set
+from wmo.runtime.models import RuntimeModelCatalog
+
+ProjectActivationVerifier = Callable[
+    [ArtifactStore, KnnRouterPolicy, RuntimeModelCatalog],
+    None,
+]
+
+
+class ProjectActivationError(ValueError):
+    """A project activation cannot be verified from its immutable material."""
+
+
+@dataclass(frozen=True, eq=False)
+class ProjectActivation:
+    """Verified immutable material for one learned exact-model selector."""
+
+    project_ref: str
+    activation_ref: ArtifactId
+    policy: KnnRouterPolicy
+    bank_manifest: KnnBankManifest
+    bank: KnnEvidenceBank
+    pricing: PricingSnapshot
+    pricing_sha256: Sha256
+
+    def __post_init__(self) -> None:
+        """Reject identifiers that differ from the frozen selection material."""
+        if not self.project_ref.strip():
+            raise ValueError("project activation requires a non-empty project reference")
+        if self.activation_ref != self.policy.policy_id:
+            raise ValueError("project activation reference differs from its frozen policy")
+        if self.pricing.pricing_snapshot_id != self.policy.pricing_snapshot_id:
+            raise ValueError("project activation pricing differs from its frozen policy")
+        if self.pricing_sha256 != self.policy.pricing_snapshot_sha256:
+            raise ValueError("project activation pricing digest differs from its frozen policy")
+
+    @property
+    def candidate_aliases(self) -> tuple[str, ...]:
+        """Return ordered logical aliases eligible for learned selection."""
+        return tuple(candidate.alias for candidate in self.policy.candidates)
+
+    def __eq__(self, other: object) -> bool:
+        """Return content equality without applying array equality elementwise."""
+        if not isinstance(other, ProjectActivation):
+            return NotImplemented
+        return (
+            self.project_ref,
+            self.activation_ref,
+            self.policy,
+            self.bank_manifest,
+            bank_bytes(self.bank),
+            self.pricing,
+            self.pricing_sha256,
+        ) == (
+            other.project_ref,
+            other.activation_ref,
+            other.policy,
+            other.bank_manifest,
+            bank_bytes(other.bank),
+            other.pricing,
+            other.pricing_sha256,
+        )
+
+
+class ProjectActivationRepository(Protocol):
+    """Load verified immutable project activations without provider execution."""
+
+    def load(
+        self,
+        project_ref: str,
+        activation_ref: ArtifactId | None,
+        *,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> ProjectActivation:
+        """Return one exact activation with no filesystem or credential references."""
+        ...
+
+
+@dataclass(frozen=True)
+class LocalArtifactProjectActivationRepository:
+    """Load project activations from WMO's local immutable artifact store."""
+
+    root: Path
+    verifier: ProjectActivationVerifier | None = None
+
+    def load(
+        self,
+        project_ref: str,
+        activation_ref: ArtifactId | None,
+        *,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> ProjectActivation:
+        """Load and verify one local project activation without issuing model requests."""
+        project = ProjectStore(self.root, project_ref)
+        try:
+            project.load_project()
+            resolved_ref = activation_ref or _only_policy(project.artifacts)
+            activation = load_project_activation(
+                project.artifacts,
+                project_ref=project_ref,
+                activation_ref=resolved_ref,
+            )
+            _verify_policy_inputs(
+                project.artifacts,
+                activation.policy,
+                runtime_catalog,
+                verifier=self.verifier,
+            )
+            return activation
+        except ProjectActivationError:
+            raise
+        except (ArtifactStoreError, OSError, ProjectStoreError, ValueError) as exc:
+            raise ProjectActivationError(str(exc)) from exc
+
+
+def load_project_activation(
+    store: ArtifactStore,
+    *,
+    project_ref: str,
+    activation_ref: ArtifactId,
+) -> ProjectActivation:
+    """Load and cross-check one complete immutable project selection bundle."""
+    try:
+        stored = store.read(activation_ref)
+        if stored.manifest.artifact_type != "router-policy":
+            raise ValueError(f"artifact {activation_ref} is not a router policy")
+        policy = KnnRouterPolicy.model_validate_json(
+            store.read_bytes(activation_ref, "policy.json")
+        )
+        if policy.policy_id != activation_ref:
+            raise ValueError("router policy ID differs from its artifact")
+        if not envelope_matches_manifest(policy, stored.manifest):
+            raise ValueError("router policy payload differs from its artifact manifest")
+        manifest, bank = load_knn_bank(
+            store,
+            policy.bank_artifact_id,
+            expected_sha256=policy.bank_sha256,
+        )
+        pricing, pricing_sha256 = load_pricing_snapshot(store, policy.pricing_snapshot_id)
+        _verify_selection_bundle(
+            store,
+            policy=policy,
+            manifest=manifest,
+            bank=bank,
+            pricing=pricing,
+            pricing_sha256=pricing_sha256,
+        )
+        return ProjectActivation(
+            project_ref=project_ref,
+            activation_ref=activation_ref,
+            policy=policy,
+            bank_manifest=manifest,
+            bank=bank,
+            pricing=pricing,
+            pricing_sha256=pricing_sha256,
+        )
+    except (ArtifactCorruptionError, ValueError) as exc:
+        raise ProjectActivationError(f"router policy {activation_ref} is invalid") from exc
+
+
+def _only_policy(store: ArtifactStore) -> ArtifactId:
+    """Resolve the only completed router policy in one project artifact store."""
+    policies = tuple(
+        artifact_id
+        for artifact_id in store.list_ids()
+        if store.read(artifact_id).manifest.artifact_type == "router-policy"
+    )
+    if not policies:
+        raise ProjectActivationError("project has no frozen router policy; run wmo optimize router")
+    if len(policies) > 1:
+        raise ProjectActivationError(
+            "project has multiple frozen router policies; pass --policy with one of: "
+            + ", ".join(policies)
+        )
+    return policies[0]
+
+
+def _verify_selection_bundle(
+    store: ArtifactStore,
+    *,
+    policy: KnnRouterPolicy,
+    manifest: KnnBankManifest,
+    bank: KnnEvidenceBank,
+    pricing: PricingSnapshot,
+    pricing_sha256: Sha256,
+) -> None:
+    """Verify the canonical fit-only dependency chain for one activation."""
+    pricing_input = artifact_input(store.read(policy.pricing_snapshot_id).manifest)
+    bank_input = artifact_input(store.read(policy.bank_artifact_id).manifest)
+    evaluation = load_evaluation_dataset(store, policy.fit_evaluation_id)
+    evaluation_input = artifact_input(store.read(policy.fit_evaluation_id).manifest)
+    plan, plan_input = read_evaluation_plan(store, policy.evaluation_plan_id)
+    load_task_set(store, policy.task_set_id)
+    task_input = artifact_input(store.read(policy.task_set_id).manifest)
+    expected_policy_inputs = tuple(
+        sorted((evaluation_input, bank_input), key=lambda item: item.artifact_id)
+    )
+    expected_bank_inputs = tuple(
+        sorted(
+            (evaluation_input, plan_input, task_input, pricing_input),
+            key=lambda item: item.artifact_id,
+        )
+    )
+    protocol_scope_sha256 = sha256_json(
+        [item.model_dump(mode="json") for item in evaluation.manifest.protocols]
+    )
+    if policy.inputs != expected_policy_inputs:
+        raise ValueError("router policy inputs differ from the canonical fit lock")
+    if manifest.inputs != expected_bank_inputs:
+        raise ValueError("router bank inputs differ from the canonical fit evidence")
+    checks = (
+        (evaluation.manifest.evaluation_plan_id, policy.evaluation_plan_id),
+        (evaluation.manifest.evaluation_plan_sha256, policy.evaluation_plan_sha256),
+        (evaluation.manifest.task_set_id, policy.task_set_id),
+        (evaluation.manifest.candidate_snapshots, policy.candidates),
+        (protocol_scope_sha256, policy.evaluation_protocols_sha256),
+        (plan_input.sha256, policy.evaluation_plan_sha256),
+        (task_input.sha256, policy.task_set_sha256),
+        (evaluation.manifest.fit_task_ids, manifest.task_ids),
+        (evaluation.manifest.held_out_task_ids, ()),
+        (plan.task_set_id, policy.task_set_id),
+        (plan.candidate_snapshots, policy.candidates),
+        (plan.pricing_snapshot_id, policy.pricing_snapshot_id),
+        (plan.pricing_snapshot_sha256, policy.pricing_snapshot_sha256),
+        (pricing.pricing_snapshot_id, policy.pricing_snapshot_id),
+        (pricing_sha256, policy.pricing_snapshot_sha256),
+        (manifest.candidate_aliases, bank.candidate_aliases),
+    )
+    if any(actual != expected for actual, expected in checks):
+        raise ValueError("router fit evidence differs from the frozen policy scope")
+    required_evaluation_inputs = {plan_input, task_input, pricing_input}
+    if not required_evaluation_inputs.issubset(evaluation.manifest.inputs):
+        raise ValueError("router evaluation omits a frozen scope input")
+    if task_input not in plan.inputs or pricing_input not in plan.inputs:
+        raise ValueError("router evaluation plan omits task or pricing scope")
+
+
+def _verify_policy_inputs(
+    store: ArtifactStore,
+    policy: KnnRouterPolicy,
+    runtime_catalog: RuntimeModelCatalog,
+    *,
+    verifier: ProjectActivationVerifier | None,
+) -> None:
+    """Require an owner verifier when a plan contains automatic artifacts."""
+    automatic_types = frozenset({"router-execution-contract", "router-runtime-capabilities"})
+    plan, _plan_input = read_evaluation_plan(store, policy.evaluation_plan_id)
+    automatic_inputs = []
+    for item in plan.inputs:
+        stored = store.read(item.artifact_id)
+        if artifact_input(stored.manifest) != item:
+            raise ProjectActivationError(
+                f"router plan input {item.artifact_id!r} differs from its manifest"
+            )
+        if stored.manifest.artifact_type in automatic_types:
+            automatic_inputs.append(item)
+    if verifier is not None:
+        verifier(store, policy, runtime_catalog)
+        return
+    if automatic_inputs:
+        raise ProjectActivationError(
+            "automatic router policy requires optimizer-owned activation verification"
+        )

--- a/wmo/runtime/gateway/project_activation.py
+++ b/wmo/runtime/gateway/project_activation.py
@@ -104,6 +104,25 @@ class ProjectActivationRepository(Protocol):
         ...
 
 
+def require_project_activation_authority(
+    activation: ProjectActivation,
+    *,
+    project_ref: str,
+    activation_ref: ArtifactId | None,
+) -> None:
+    """Require repository output to match the exact requested project authority."""
+    if activation.project_ref != project_ref:
+        raise ProjectActivationError(
+            f"project activation repository returned project reference "
+            f"{activation.project_ref!r}, expected {project_ref!r}"
+        )
+    if activation_ref is not None and activation.activation_ref != activation_ref:
+        raise ProjectActivationError(
+            f"project activation repository returned activation reference "
+            f"{activation.activation_ref!r}, expected {activation_ref!r}"
+        )
+
+
 @dataclass(frozen=True)
 class LocalArtifactProjectActivationRepository:
     """Load project activations from WMO's local immutable artifact store."""

--- a/wmo/runtime/gateway/project_activation_test.py
+++ b/wmo/runtime/gateway/project_activation_test.py
@@ -1,0 +1,94 @@
+"""Tests for immutable project activations and local artifact loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmo.common.models import ModelMessage, ModelRequest
+from wmo.common.project import ProjectConfig, ProjectStore
+from wmo.runtime.gateway.project_activation import (
+    LocalArtifactProjectActivationRepository,
+    ProjectActivation,
+    load_project_activation,
+)
+from wmo.runtime.models import RuntimeModelCatalog
+from wmo.runtime.router.runtime import RouterRuntime
+from wmo.runtime.router.runtime_test import _persist_runtime_fixture
+
+
+class _StaticActivationRepository:
+    """Return one caller-owned activation without consulting local project state."""
+
+    def __init__(self, activation: ProjectActivation) -> None:
+        """Store the exact immutable activation returned by this repository."""
+        self.activation = activation
+        self.loads = 0
+
+    def load(
+        self,
+        project_ref: str,
+        activation_ref: str | None,
+        *,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> ProjectActivation:
+        """Return the activation after checking its requested authority."""
+        del runtime_catalog
+        assert project_ref == self.activation.project_ref
+        assert activation_ref == self.activation.activation_ref
+        self.loads += 1
+        return self.activation
+
+
+def test_caller_supplied_activation_selects_without_a_local_project_directory(
+    tmp_path: Path,
+) -> None:
+    """A stable activation can be loaded and used after its project directory is absent."""
+    store, policy, catalog, client = _persist_runtime_fixture(tmp_path)
+    activation = load_project_activation(
+        store,
+        project_ref="platform-project",
+        activation_ref=policy.policy_id,
+    )
+    repository = _StaticActivationRepository(activation)
+
+    supplied = repository.load(
+        "platform-project",
+        policy.policy_id,
+        runtime_catalog=catalog,
+    )
+    runtime = RouterRuntime.from_activation(supplied, catalog)
+
+    assert repository.loads == 1
+    assert not (tmp_path / "projects" / "platform-project").exists()
+    assert client.embed_calls == 0
+    decision = runtime.select(
+        ModelRequest(messages=(ModelMessage(role="user", content="route this"),)),
+        episode_id="episode-one",
+    )
+    assert decision.selected_alias == "cheap"
+    assert client.embed_calls == 1
+    assert client.complete_calls == 0
+
+
+def test_local_artifact_repository_returns_the_same_immutable_activation(
+    tmp_path: Path,
+) -> None:
+    """The default local adapter preserves the direct activation contract exactly."""
+    store, policy, catalog, client = _persist_runtime_fixture(tmp_path)
+    ProjectStore(tmp_path, "project-a").initialize(ProjectConfig(project_id="project-a"))
+    direct = load_project_activation(
+        store,
+        project_ref="project-a",
+        activation_ref=policy.policy_id,
+    )
+
+    local = LocalArtifactProjectActivationRepository(tmp_path).load(
+        "project-a",
+        policy.policy_id,
+        runtime_catalog=catalog,
+    )
+
+    assert local == direct
+    assert local.candidate_aliases == ("baseline", "cheap")
+    assert client.embed_calls == 0
+    assert client.complete_calls == 0

--- a/wmo/runtime/gateway/project_alias.py
+++ b/wmo/runtime/gateway/project_alias.py
@@ -15,7 +15,10 @@ from wmo.common.models import (
 )
 from wmo.runtime.gateway.catalog_authority import snapshot_current_catalog
 from wmo.runtime.gateway.management import GatewayManagement
-from wmo.runtime.gateway.project_activation import ProjectActivationRepository
+from wmo.runtime.gateway.project_activation import (
+    ProjectActivationRepository,
+    require_project_activation_authority,
+)
 from wmo.runtime.models import RuntimeModelCatalog
 
 
@@ -52,10 +55,6 @@ def prepare_project_gateway_alias(
     Returns:
         Exact alias, identity, and policy authority for the shared gateway.
     """
-    manager = GatewayManagement(root)
-    if not manager.initialized:
-        manager.initialize()
-    manager.migrate_legacy_provider_connections()
     catalog_for_activation = runtime_catalog or RuntimeModelCatalog(
         load_model_catalog(root / "models.toml"),
         environment=environment,
@@ -65,6 +64,15 @@ def prepare_project_gateway_alias(
         policy_id,
         runtime_catalog=catalog_for_activation,
     )
+    require_project_activation_authority(
+        activation,
+        project_ref=project,
+        activation_ref=policy_id,
+    )
+    manager = GatewayManagement(root)
+    if not manager.initialized:
+        manager.initialize()
+    manager.migrate_legacy_provider_connections()
     metadata_changed = _migrate_legacy_project_gateway_metadata(
         root,
         aliases=activation.candidate_aliases,

--- a/wmo/runtime/gateway/project_alias.py
+++ b/wmo/runtime/gateway/project_alias.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
 
-from wmo.common.core.artifacts import ArtifactId, sha256_json, stable_id
+from wmo.common.core.artifacts import sha256_json, stable_id
 from wmo.common.models import (
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
@@ -16,24 +15,8 @@ from wmo.common.models import (
 )
 from wmo.runtime.gateway.catalog_authority import snapshot_current_catalog
 from wmo.runtime.gateway.management import GatewayManagement
+from wmo.runtime.gateway.project_activation import ProjectActivationRepository
 from wmo.runtime.models import RuntimeModelCatalog
-from wmo.runtime.router.runtime import RouterRuntime
-
-
-class ProjectAliasLoader(Protocol):
-    """Load one exact frozen project runtime without provider execution."""
-
-    def __call__(
-        self,
-        project: str,
-        root: Path,
-        *,
-        policy_id: ArtifactId | None = None,
-        environment: Mapping[str, str] | None = None,
-        runtime_catalog: RuntimeModelCatalog | None = None,
-    ) -> RouterRuntime:
-        """Return one verified selection-only router runtime."""
-        ...
 
 
 @dataclass(frozen=True)
@@ -52,7 +35,7 @@ def prepare_project_gateway_alias(
     root: Path,
     *,
     policy_id: str | None,
-    project_loader: ProjectAliasLoader,
+    project_repository: ProjectActivationRepository,
     environment: Mapping[str, str] | None = None,
     runtime_catalog: RuntimeModelCatalog | None = None,
 ) -> ProjectGatewayAlias:
@@ -62,7 +45,7 @@ def prepare_project_gateway_alias(
         project: Existing immutable project name and public compatibility alias.
         root: WMO artifact and gateway root.
         policy_id: Optional exact frozen router policy.
-        project_loader: Verified selection-only runtime loader.
+        project_repository: Verified immutable project activation repository.
         environment: Optional provider environment used by compatibility clients.
         runtime_catalog: Optional preconstructed catalog used by deterministic callers.
 
@@ -73,16 +56,18 @@ def prepare_project_gateway_alias(
     if not manager.initialized:
         manager.initialize()
     manager.migrate_legacy_provider_connections()
-    runtime = project_loader(
-        project,
-        root,
-        policy_id=policy_id,
+    catalog_for_activation = runtime_catalog or RuntimeModelCatalog(
+        load_model_catalog(root / "models.toml"),
         environment=environment,
-        runtime_catalog=runtime_catalog,
+    )
+    activation = project_repository.load(
+        project,
+        policy_id,
+        runtime_catalog=catalog_for_activation,
     )
     metadata_changed = _migrate_legacy_project_gateway_metadata(
         root,
-        aliases=tuple(candidate.alias for candidate in runtime.policy.candidates),
+        aliases=activation.candidate_aliases,
     )
     serving_connections = {
         item.connection_id: item.config for item in manager.provider_connections()
@@ -94,7 +79,7 @@ def prepare_project_gateway_alias(
     deployment_aliases = {item.source_alias for item in normalized.deployments}
     missing = sorted(
         candidate.alias
-        for candidate in runtime.policy.candidates
+        for candidate in activation.policy.candidates
         if candidate.alias not in deployment_aliases
     )
     if missing:
@@ -107,7 +92,7 @@ def prepare_project_gateway_alias(
         "project-gateway-alias-revision",
         {
             "project": project,
-            "policy_id": runtime.policy.policy_id,
+            "policy_id": activation.activation_ref,
             "catalog_sha256": catalog_sha256,
         },
     )
@@ -116,7 +101,7 @@ def prepare_project_gateway_alias(
         alias_name=project,
         revision_id=revision_id,
         project_ref=project,
-        activation_ref=runtime.policy.policy_id,
+        activation_ref=activation.activation_ref,
         snapshot_ref=f"catalog-snapshots/{snapshot.name}",
         catalog_sha256=catalog_sha256,
         provider_connections=manager.provider_bindings(catalog),
@@ -135,7 +120,7 @@ def prepare_project_gateway_alias(
         alias=project,
         alias_revision_id=revision_id,
         identity_id=identity_id,
-        policy_id=runtime.policy.policy_id,
+        policy_id=activation.activation_ref,
         changed=metadata_changed or alias_changed or identity_changed or grant_changed,
     )
 

--- a/wmo/runtime/gateway/project_alias_test.py
+++ b/wmo/runtime/gateway/project_alias_test.py
@@ -1,18 +1,77 @@
 """Tests for project-backed gateway alias compatibility migrations."""
 
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from wmo.common.models import (
     BillingSource,
+    CandidateTokenPrice,
     ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
     ModelCatalog,
     ModelRecord,
+    PricingSnapshot,
     load_model_catalog,
     write_model_catalog,
 )
-from wmo.runtime.gateway.project_alias import _migrate_legacy_project_gateway_metadata
+from wmo.runtime.gateway.project_activation import ProjectActivation, ProjectActivationError
+from wmo.runtime.gateway.project_alias import (
+    _migrate_legacy_project_gateway_metadata,
+    prepare_project_gateway_alias,
+)
+from wmo.runtime.models import RuntimeModelCatalog
+from wmo.runtime.router.runtime_test import _fixture
+
+
+class _MismatchedRepository:
+    """Return one activation without enforcing the requested lookup authority."""
+
+    def __init__(self, activation: ProjectActivation) -> None:
+        """Store one deliberately mismatched activation."""
+        self.activation = activation
+
+    def load(
+        self,
+        project_ref: str,
+        activation_ref: str | None,
+        *,
+        runtime_catalog: RuntimeModelCatalog,
+    ) -> ProjectActivation:
+        """Return the stored activation while ignoring requested references."""
+        del project_ref, activation_ref, runtime_catalog
+        return self.activation
+
+
+def _activation(*, project_ref: str, activation_ref: str) -> ProjectActivation:
+    """Build one internally consistent activation with selected external references."""
+    policy, manifest, bank, _snapshots, _client = _fixture()
+    policy = policy.model_copy(update={"policy_id": activation_ref})
+    pricing = PricingSnapshot(
+        schema_version=1,
+        created_at=policy.created_at,
+        code_revision="test",
+        pricing_snapshot_id=policy.pricing_snapshot_id,
+        candidate_prices=tuple(
+            CandidateTokenPrice(
+                candidate_alias=alias,
+                input_usd_per_million_tokens=1,
+                output_usd_per_million_tokens=2,
+            )
+            for alias in bank.candidate_aliases
+        ),
+    )
+    return ProjectActivation(
+        project_ref=project_ref,
+        activation_ref=activation_ref,
+        policy=policy,
+        bank_manifest=manifest,
+        bank=bank,
+        pricing=pricing,
+        pricing_sha256=policy.pricing_snapshot_sha256,
+    )
 
 
 def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path: Path) -> None:
@@ -56,3 +115,28 @@ def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path
         )
         is False
     )
+
+
+@pytest.mark.parametrize("mismatch", ["project", "activation"])
+def test_alias_preparation_rejects_wrong_authority_before_persisting(
+    tmp_path: Path,
+    mismatch: str,
+) -> None:
+    """Wrong repository authority cannot initialize or mutate gateway state."""
+    project_ref = "other-project" if mismatch == "project" else "project-one"
+    activation_ref = "other-activation" if mismatch == "activation" else "activation-one"
+    repository = _MismatchedRepository(
+        _activation(project_ref=project_ref, activation_ref=activation_ref)
+    )
+
+    with pytest.raises(ProjectActivationError, match=f"returned {mismatch} reference"):
+        prepare_project_gateway_alias(
+            "project-one",
+            tmp_path,
+            policy_id="activation-one",
+            project_repository=repository,
+            runtime_catalog=cast(RuntimeModelCatalog, object()),
+        )
+
+    assert not (tmp_path / "gateway").exists()
+    assert not (tmp_path / "models.toml").exists()

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from uuid import uuid4
 
@@ -11,28 +11,19 @@ from fastapi.testclient import TestClient
 from openai import OpenAI
 
 from wmo.common.core.artifacts import ArtifactId
-from wmo.common.evaluations.evidence import read_evaluation_plan
 from wmo.common.models import load_model_catalog
-from wmo.common.project import (
-    ArtifactStore,
-    ArtifactStoreError,
-    ProjectStore,
-    ProjectStoreError,
-    artifact_input,
-)
-from wmo.common.routing import KnnRouterPolicy
 from wmo.runtime.gateway.lifecycle import load_local_gateway
 from wmo.runtime.gateway.management import GatewayManagement
+from wmo.runtime.gateway.project_activation import (
+    LocalArtifactProjectActivationRepository,
+    ProjectActivationVerifier,
+)
 from wmo.runtime.gateway.project_alias import prepare_project_gateway_alias
 from wmo.runtime.models import RuntimeModelCatalog
 from wmo.runtime.router.errors import RouterApplicationError
 from wmo.runtime.router.runtime import DecisionSink, RouterRuntime
 
-RouterPolicyVerifier = Callable[[ArtifactStore, KnnRouterPolicy, RuntimeModelCatalog], None]
-
-_AUTOMATIC_POLICY_INPUT_TYPES = frozenset(
-    {"router-execution-contract", "router-runtime-capabilities"}
-)
+RouterPolicyVerifier = ProjectActivationVerifier
 
 
 class _RevokingGatewayClient(TestClient):
@@ -79,33 +70,30 @@ def load_project_router(
     Raises:
         RouterApplicationError: Project, policy, catalog, or frozen identity is invalid.
     """
-    project_store = ProjectStore(root, project)
     try:
-        project_store.load_project()
-        resolved_policy_id = policy_id or _only_policy(project_store.artifacts)
-        policy = _load_policy(project_store.artifacts, resolved_policy_id)
         catalog = runtime_catalog
         if catalog is None:
             catalog = RuntimeModelCatalog(
-                load_model_catalog(project_store.model_catalog_path),
+                load_model_catalog(root / "models.toml"),
                 environment=environment,
             )
-        _verify_policy_activation(
-            project_store.artifacts,
-            policy,
-            catalog,
-            policy_verifier=policy_verifier,
+        repository = LocalArtifactProjectActivationRepository(
+            root,
+            verifier=policy_verifier,
         )
-        return RouterRuntime.load(
-            project_store.artifacts,
-            resolved_policy_id,
+        activation = repository.load(
+            project,
+            policy_id,
+            runtime_catalog=catalog,
+        )
+        return RouterRuntime.from_activation(
+            activation,
             catalog,
-            pricing_snapshot_id=policy.pricing_snapshot_id,
             decision_sink=decision_sink,
         )
     except RouterApplicationError:
         raise
-    except (ArtifactStoreError, OSError, ProjectStoreError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         raise RouterApplicationError(str(exc)) from exc
 
 
@@ -142,30 +130,16 @@ def load_router(
         raise RouterApplicationError("ghost mode cannot use a routing decision sink")
     del ghost
 
-    def project_loader(
-        project: str,
-        root: Path,
-        *,
-        policy_id: ArtifactId | None = None,
-        environment: Mapping[str, str] | None = None,
-        runtime_catalog: RuntimeModelCatalog | None = None,
-    ) -> RouterRuntime:
-        """Load the caller-selected immutable policy for gateway selection only."""
-        return load_project_router(
-            project,
-            root,
-            policy_id=policy_id,
-            environment=environment,
-            runtime_catalog=runtime_catalog,
-            decision_sink=decision_sink,
-            policy_verifier=policy_verifier,
-        )
+    repository = LocalArtifactProjectActivationRepository(
+        root,
+        verifier=policy_verifier,
+    )
 
     alias = prepare_project_gateway_alias(
         project,
         root,
         policy_id=policy_id,
-        project_loader=project_loader,
+        project_repository=repository,
         environment=environment,
         runtime_catalog=runtime_catalog,
     )
@@ -177,7 +151,7 @@ def load_router(
             root,
             graceful_timeout_seconds=10,
             environment=environment,
-            project_loader=project_loader,
+            project_repository=repository,
             only_aliases=frozenset({alias.alias}),
         )
     except BaseException:
@@ -193,72 +167,3 @@ def load_router(
         base_url="http://wmo.local/v1",
         http_client=transport,
     )
-
-
-def _only_policy(store: ArtifactStore) -> ArtifactId:
-    """Resolve the only completed router policy, failing on absent or ambiguous state."""
-    policies = tuple(
-        artifact_id
-        for artifact_id in store.list_ids()
-        if store.read(artifact_id).manifest.artifact_type == "router-policy"
-    )
-    if not policies:
-        raise RouterApplicationError("project has no frozen router policy; run wmo optimize router")
-    if len(policies) > 1:
-        raise RouterApplicationError(
-            "project has multiple frozen router policies; pass --policy with one of: "
-            + ", ".join(policies)
-        )
-    return policies[0]
-
-
-def _load_policy(store: ArtifactStore, policy_id: ArtifactId) -> KnnRouterPolicy:
-    """Load one manifest-verified policy envelope for runtime activation."""
-    stored = store.read(policy_id)
-    if stored.manifest.artifact_type != "router-policy":
-        raise RouterApplicationError(f"artifact {policy_id} is not a frozen router policy")
-    policy = KnnRouterPolicy.model_validate_json(store.read_bytes(policy_id, "policy.json"))
-    if policy.policy_id != policy_id:
-        raise RouterApplicationError("router policy identity differs from its artifact")
-    return policy
-
-
-def _verify_policy_activation(
-    store: ArtifactStore,
-    policy: KnnRouterPolicy,
-    catalog: RuntimeModelCatalog,
-    *,
-    policy_verifier: RouterPolicyVerifier | None,
-) -> None:
-    """Require optimizer verification whenever a plan contains automatic artifacts.
-
-    Runtime owns provider activation but does not depend on offline optimization. Automatic plans
-    therefore require their optimizer owner to inject the complete artifact verifier. Plans with
-    no automatic inputs retain the provider-free runtime loading path.
-
-    Args:
-        store: Project-local immutable artifact store.
-        policy: Selected frozen router policy.
-        catalog: Current credential-free catalog resolver.
-        policy_verifier: Optional optimizer-owned automatic artifact verifier.
-
-    Raises:
-        RouterApplicationError: Plan inputs drift or automatic verification is unavailable.
-    """
-    plan, _plan_input = read_evaluation_plan(store, policy.evaluation_plan_id)
-    automatic_inputs = []
-    for item in plan.inputs:
-        stored = store.read(item.artifact_id)
-        if artifact_input(stored.manifest) != item:
-            raise RouterApplicationError(
-                f"router plan input {item.artifact_id!r} differs from its manifest"
-            )
-        if stored.manifest.artifact_type in _AUTOMATIC_POLICY_INPUT_TYPES:
-            automatic_inputs.append(item)
-    if policy_verifier is not None:
-        policy_verifier(store, policy, catalog)
-        return
-    if automatic_inputs:
-        raise RouterApplicationError(
-            "automatic router policy requires optimizer-owned activation verification"
-        )

--- a/wmo/runtime/router/application.py
+++ b/wmo/runtime/router/application.py
@@ -152,6 +152,7 @@ def load_router(
             graceful_timeout_seconds=10,
             environment=environment,
             project_repository=repository,
+            decision_sink=decision_sink,
             only_aliases=frozenset({alias.alias}),
         )
     except BaseException:

--- a/wmo/runtime/router/application_test.py
+++ b/wmo/runtime/router/application_test.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import FastAPI
 from openai import OpenAI
 
+from wmo.common.routing import RoutingDecision
 from wmo.runtime.gateway.project_alias import ProjectGatewayAlias
 from wmo.runtime.router.application import RouterApplicationError, load_router
 
@@ -26,9 +27,12 @@ def test_load_router_uses_the_normal_gateway_application_and_revokes_its_key(
         return {"object": "list", "data": []}
 
     prepared: list[tuple[str, Path, str | None]] = []
-    loaded: list[tuple[Path, frozenset[str] | None]] = []
+    loaded: list[tuple[Path, object, frozenset[str] | None]] = []
     issued: list[tuple[str, str]] = []
     revoked: list[str] = []
+
+    def decision_sink(_decision: RoutingDecision) -> None:
+        """Accept one served project selection."""
 
     class Management:
         """Capture the virtual-key lifecycle owned by the compatibility client."""
@@ -73,11 +77,12 @@ def test_load_router_uses_the_normal_gateway_application_and_revokes_its_key(
         graceful_timeout_seconds: float,
         environment: object,
         project_repository: object,
+        decision_sink: object,
         only_aliases: frozenset[str] | None,
     ) -> object:
         """Return the same gateway application used by the CLI launch path."""
         del graceful_timeout_seconds, environment, project_repository
-        loaded.append((root, only_aliases))
+        loaded.append((root, decision_sink, only_aliases))
         return SimpleNamespace(app=application)
 
     monkeypatch.setattr("wmo.runtime.router.application.GatewayManagement", Management)
@@ -87,13 +92,18 @@ def test_load_router_uses_the_normal_gateway_application_and_revokes_its_key(
     )
     monkeypatch.setattr("wmo.runtime.router.application.load_local_gateway", load_gateway)
 
-    client = load_router("support", root=tmp_path, policy_id="policy-a")
+    client = load_router(
+        "support",
+        root=tmp_path,
+        policy_id="policy-a",
+        decision_sink=decision_sink,
+    )
     assert isinstance(client, OpenAI)
     assert client.models.list().data == []
     client.close()
 
     assert prepared == [("support", tmp_path, "policy-a")]
-    assert loaded == [(tmp_path, frozenset({"support"}))]
+    assert loaded == [(tmp_path, decision_sink, frozenset({"support"}))]
     assert issued[0][0] == "project-identity"
     assert revoked == [issued[0][1]]
 

--- a/wmo/runtime/router/application_test.py
+++ b/wmo/runtime/router/application_test.py
@@ -52,12 +52,12 @@ def test_load_router_uses_the_normal_gateway_application_and_revokes_its_key(
         root: Path,
         *,
         policy_id: str | None,
-        project_loader: object,
+        project_repository: object,
         environment: object,
         runtime_catalog: object,
     ) -> ProjectGatewayAlias:
         """Return one already activated project-backed alias."""
-        del environment, project_loader, runtime_catalog
+        del environment, project_repository, runtime_catalog
         prepared.append((project, root, policy_id))
         return ProjectGatewayAlias(
             alias=project,
@@ -72,11 +72,11 @@ def test_load_router_uses_the_normal_gateway_application_and_revokes_its_key(
         *,
         graceful_timeout_seconds: float,
         environment: object,
-        project_loader: object,
+        project_repository: object,
         only_aliases: frozenset[str] | None,
     ) -> object:
         """Return the same gateway application used by the CLI launch path."""
-        del graceful_timeout_seconds, environment, project_loader
+        del graceful_timeout_seconds, environment, project_repository
         loaded.append((root, only_aliases))
         return SimpleNamespace(app=application)
 

--- a/wmo/runtime/router/runtime.py
+++ b/wmo/runtime/router/runtime.py
@@ -15,8 +15,6 @@ from wmo.common.core.artifacts import (
     ArtifactId,
     ContractModel,
     Sha256,
-    envelope_matches_manifest,
-    sha256_json,
 )
 from wmo.common.models import (
     CandidateTokenPrice,
@@ -26,14 +24,15 @@ from wmo.common.models import (
     ModelResponse,
     OperationEconomics,
 )
-from wmo.common.project import ArtifactCorruptionError, ArtifactStore
+from wmo.common.project import ArtifactStore
 from wmo.common.routing import (
     KnnRouterPolicy,
     RouterFeatureExtractor,
     RoutingDecision,
 )
-from wmo.common.routing.bank import KnnBankManifest, KnnEvidenceBank, bank_bytes, load_knn_bank
+from wmo.common.routing.bank import KnnBankManifest, KnnEvidenceBank, bank_bytes
 from wmo.common.routing.decision import policy_content_sha256, select_from_bank
+from wmo.runtime.gateway.project_activation import ProjectActivation, load_project_activation
 from wmo.runtime.models import ResolvedModel, RuntimeModelCatalog
 from wmo.runtime.router.economics import (
     BillingSourceEconomics,
@@ -208,88 +207,51 @@ class RouterRuntime:
         Raises:
             RouterRuntimeIntegrityError: Any artifact or runtime identity is invalid.
         """
-        from wmo.common.models import load_pricing_snapshot
-        from wmo.common.project import artifact_input
-
         try:
-            from wmo.common.evaluations import load_evaluation_dataset
-            from wmo.common.evaluations.evidence import read_evaluation_plan
-            from wmo.common.tasks import load_task_set
-
-            pricing, pricing_sha256 = load_pricing_snapshot(store, pricing_snapshot_id)
-            pricing_input = artifact_input(store.read(pricing_snapshot_id).manifest)
-            stored = store.read(policy_id)
-            if stored.manifest.artifact_type != "router-policy":
-                raise ValueError(f"artifact {policy_id} is not a router policy")
-            policy = KnnRouterPolicy.model_validate_json(store.read_bytes(policy_id, "policy.json"))
-            if policy.policy_id != policy_id:
-                raise ValueError("router policy ID differs from its artifact")
-            if not envelope_matches_manifest(policy, stored.manifest):
-                raise ValueError("router policy payload differs from its artifact manifest")
-            manifest, bank = load_knn_bank(
-                store, policy.bank_artifact_id, expected_sha256=policy.bank_sha256
+            activation = load_project_activation(
+                store,
+                project_ref=store.project_directory.name,
+                activation_ref=policy_id,
             )
-            bank_input = artifact_input(store.read(policy.bank_artifact_id).manifest)
-            evaluation = load_evaluation_dataset(store, policy.fit_evaluation_id)
-            evaluation_input = artifact_input(store.read(policy.fit_evaluation_id).manifest)
-            plan, plan_input = read_evaluation_plan(store, policy.evaluation_plan_id)
-            load_task_set(store, policy.task_set_id)
-            task_input = artifact_input(store.read(policy.task_set_id).manifest)
-            expected_policy_inputs = tuple(
-                sorted((evaluation_input, bank_input), key=lambda item: item.artifact_id)
-            )
-            expected_bank_inputs = tuple(
-                sorted(
-                    (evaluation_input, plan_input, task_input, pricing_input),
-                    key=lambda item: item.artifact_id,
-                )
-            )
-            protocol_scope_sha256 = sha256_json(
-                [item.model_dump(mode="json") for item in evaluation.manifest.protocols]
-            )
-            if policy.inputs != expected_policy_inputs:
-                raise ValueError("router policy inputs differ from the canonical fit lock")
-            if manifest.inputs != expected_bank_inputs:
-                raise ValueError("router bank inputs differ from the canonical fit evidence")
-            evaluation_checks = (
-                (evaluation.manifest.evaluation_plan_id, policy.evaluation_plan_id),
-                (evaluation.manifest.evaluation_plan_sha256, policy.evaluation_plan_sha256),
-                (evaluation.manifest.task_set_id, policy.task_set_id),
-                (evaluation.manifest.candidate_snapshots, policy.candidates),
-                (protocol_scope_sha256, policy.evaluation_protocols_sha256),
-                (plan_input.sha256, policy.evaluation_plan_sha256),
-                (task_input.sha256, policy.task_set_sha256),
-                (evaluation.manifest.fit_task_ids, manifest.task_ids),
-                (evaluation.manifest.held_out_task_ids, ()),
-                (plan.task_set_id, policy.task_set_id),
-                (plan.candidate_snapshots, policy.candidates),
-                (plan.pricing_snapshot_id, policy.pricing_snapshot_id),
-                (plan.pricing_snapshot_sha256, policy.pricing_snapshot_sha256),
-            )
-            if any(actual != expected for actual, expected in evaluation_checks):
-                raise ValueError("router fit evidence differs from the frozen policy scope")
-            required_evaluation_inputs = {
-                plan_input,
-                task_input,
-                pricing_input,
-            }
-            if not required_evaluation_inputs.issubset(evaluation.manifest.inputs):
-                raise ValueError("router evaluation omits a frozen scope input")
-            if task_input not in plan.inputs or pricing_input not in plan.inputs:
-                raise ValueError("router evaluation plan omits task or pricing scope")
-        except (ArtifactCorruptionError, ValueError) as exc:
+        except ValueError as exc:
             raise RouterRuntimeIntegrityError(f"router policy {policy_id} is invalid") from exc
-        return cls(
-            policy,
-            manifest,
-            bank,
+        if pricing_snapshot_id != activation.pricing.pricing_snapshot_id:
+            raise RouterRuntimeIntegrityError(f"router policy {policy_id} is invalid")
+        return cls.from_activation(
+            activation,
             catalog,
-            pricing_snapshot_id=pricing_snapshot_id,
-            pricing_snapshot_sha256=pricing_sha256,
+            decision_sink=decision_sink,
+        )
+
+    @classmethod
+    def from_activation(
+        cls,
+        activation: ProjectActivation,
+        catalog: RuntimeModelCatalog,
+        *,
+        decision_sink: DecisionSink | None = None,
+    ) -> RouterRuntime:
+        """Bind immutable selection material to runtime-owned model resolution.
+
+        Args:
+            activation: Verified project identifiers, policy, bank, and pricing material.
+            catalog: Active catalog used to resolve the embedder and verify candidate pins.
+            decision_sink: Optional aggregate-safe routing-decision recorder.
+
+        Returns:
+            Selection runtime with no candidate provider request issued during activation.
+        """
+        return cls(
+            activation.policy,
+            activation.bank_manifest,
+            activation.bank,
+            catalog,
+            pricing_snapshot_id=activation.pricing.pricing_snapshot_id,
+            pricing_snapshot_sha256=activation.pricing_sha256,
             pricing_candidate_aliases=tuple(
-                item.candidate_alias for item in pricing.candidate_prices
+                item.candidate_alias for item in activation.pricing.candidate_prices
             ),
-            pricing_candidate_prices=pricing.candidate_prices,
+            pricing_candidate_prices=activation.pricing.candidate_prices,
             decision_sink=decision_sink,
         )
 

--- a/wmo/tests/release_test.py
+++ b/wmo/tests/release_test.py
@@ -466,16 +466,21 @@ def _installed_release_driver() -> None:
     from wmo.cli.gateway.key_output import key_output_marker_path
     from wmo.common.models import (
         BillingSource,
+        CandidateTokenPrice,
         ConnectionConfig,
         Embedding,
         GatewayDeploymentCapabilities,
         GatewayEquivalenceCertification,
         GatewayTokenPrices,
         ModelCapabilities,
+        ModelRecord,
         ModelRequest,
         ModelResponse,
         ModelSnapshot,
+        PricingSnapshot,
         RoutedCandidateSnapshot,
+        load_model_catalog,
+        write_model_catalog,
     )
     from wmo.common.project import ProjectStore, artifact_input
     from wmo.common.routing import KnnGuard, KnnRouterPolicy
@@ -495,6 +500,7 @@ def _installed_release_driver() -> None:
     )
     from wmo.runtime.gateway.lifecycle import load_local_gateway
     from wmo.runtime.gateway.management import GatewayManagement
+    from wmo.runtime.gateway.project_activation import ProjectActivation
     from wmo.runtime.models import (
         CatalogRoleName,
         ResolvedModel,
@@ -2191,6 +2197,18 @@ def _installed_release_driver() -> None:
             ),
             replace=False,
         )
+    authored_project_catalog = load_model_catalog(project_root / "models.toml")
+    authored_models = dict(authored_project_catalog.models)
+    authored_models["embedder"] = ModelRecord(
+        connection="project-cheap",
+        model="project-embedder-model",
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        capabilities=ModelCapabilities(supports_embeddings=True),
+    )
+    write_model_catalog(
+        project_root / "models.toml",
+        authored_project_catalog.model_copy(update={"models": authored_models}),
+    )
     project_catalog = None
     for alias, provider_model, billing_source in (
         ("cheap", "project-primary-model", BillingSource.HOST_MANAGED),
@@ -2244,19 +2262,64 @@ def _installed_release_driver() -> None:
         key_id="project-key",
     ).raw_key
     learned_runtime, learned_client = installed_project_runtime()
+    activation_catalog = RuntimeModelCatalog(
+        load_model_catalog(project_root / "models.toml"),
+        environment={"P9_LOOPBACK_PROVIDER_KEY": provider_secret},
+    )
+    activation_snapshots = {
+        alias: activation_catalog.snapshot(alias)[0] for alias in ("baseline", "cheap", "embedder")
+    }
+    activation_candidates = tuple(
+        RoutedCandidateSnapshot(alias=alias, model=activation_snapshots[alias])
+        for alias in ("baseline", "cheap")
+    )
+    activation_policy = learned_runtime.policy.model_copy(
+        update={
+            "candidates": activation_candidates,
+            "embedder": activation_snapshots["embedder"],
+        }
+    )
+    activation_manifest = learned_runtime.manifest.model_copy(
+        update={"embedder": activation_snapshots["embedder"]}
+    )
+    installed_activation = ProjectActivation(
+        project_ref="installed-project",
+        activation_ref="installed-project-policy",
+        policy=activation_policy,
+        bank_manifest=activation_manifest,
+        bank=learned_runtime.bank,
+        pricing=PricingSnapshot(
+            schema_version=1,
+            created_at=activation_policy.created_at,
+            code_revision=release_revision,
+            pricing_snapshot_id=activation_policy.pricing_snapshot_id,
+            candidate_prices=tuple(
+                CandidateTokenPrice(
+                    candidate_alias=alias,
+                    input_usd_per_million_tokens=1,
+                    output_usd_per_million_tokens=2,
+                )
+                for alias in ("baseline", "cheap")
+            ),
+        ),
+        pricing_sha256=activation_policy.pricing_snapshot_sha256,
+    )
 
-    def load_installed_project(
-        project: str,
-        root: Path,
-        *,
-        policy_id: str,
-        runtime_catalog: RuntimeModelCatalog,
-    ) -> RouterRuntime:
-        """Inject one real installed selection runtime without project completion."""
-        del root, runtime_catalog
-        assert project == "installed-project"
-        assert policy_id == "installed-project-policy"
-        return learned_runtime
+    class InstalledActivationRepository:
+        """Return one installed immutable activation without local project state."""
+
+        def load(
+            self,
+            project_ref: str,
+            activation_ref: str | None,
+            *,
+            runtime_catalog: RuntimeModelCatalog,
+        ) -> ProjectActivation:
+            """Return the exact caller-owned activation without provider work."""
+            del runtime_catalog
+            assert project_ref == "installed-project"
+            assert activation_ref == "installed-project-policy"
+            return installed_activation
 
     project_provider_before_load = state.snapshot()
     project_primary_before = state.count_containing("project-primary-model")
@@ -2265,7 +2328,7 @@ def _installed_release_driver() -> None:
         project_root,
         graceful_timeout_seconds=2,
         environment={"P9_LOOPBACK_PROVIDER_KEY": provider_secret},
-        project_loader=load_installed_project,
+        project_repository=InstalledActivationRepository(),
     )
     assert state.snapshot() == project_provider_before_load
     project_port = unused_loopback_port()
@@ -2302,7 +2365,7 @@ def _installed_release_driver() -> None:
     assert not project_thread.is_alive()
     assert state.count_containing("project-primary-model") == project_primary_before + 2
     assert state.count_containing("project-secondary-model") == project_secondary_before + 1
-    assert learned_client.embed_calls == 1
+    assert learned_client.embed_calls == 0
     assert learned_client.complete_calls == 0
     assert learned_runtime.records_decisions is False
     assert not (project_root / "projects").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add a stable immutable `ProjectActivation` contract and narrow repository protocol for caller-supplied learned selection material
- add the local artifact-store repository used by `wmo run PROJECT`, preserving bundle verification, automatic policy verification, exact candidate checks, and conservative fallback
- validate returned project and explicit policy authority before any alias-preparation persistence and again before lifecycle runtime construction
- preserve caller-supplied decision recording through the served runtime
- compose local and object-backed project activations through the single `create_gateway_runtime` factory merged in #523
- retain #525's replay and continuation protocols, custom state injection, and bounded local defaults
- keep gateway ownership of authentication, authorization, certified pool resolution, provider execution, failover, streaming, budgets, attempts, and usage

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- focused lifecycle, project activation, router, CLI, gateway composition, and protocol state coverage: 290 passed
- combined alias authority, composition, activation, router application, and state integration coverage: 31 passed
- exact authority regressions: project and policy mismatch variants persist no gateway or model state, make no provider call, and record no decision

## Behavioral evidence

The object-backed integration test loads a caller-supplied activation through the normal local gateway lifecycle, reaches the shared #523 factory, injects structural #525 replay and continuation adapters, performs keyed learned selection, hands the exact model to the certified provider pool, records one decision, and leaves provider work entirely under gateway ownership.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-158ca20c-4bc4-4e43-8c64-0cf259188aad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-158ca20c-4bc4-4e43-8c64-0cf259188aad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

