### PR TITLE
Accept and forward Chat Completions top_p for OpenCode clients

### DIFF
--- a/wmo/common/models/model.py
+++ b/wmo/common/models/model.py
@@ -419,6 +419,7 @@ class ModelRequest(ContractModel):
         tools: Tool schemas available for this turn.
         tool_choice: Optional automatic, disabled, required, or named-tool selection.
         temperature: Optional sampling temperature.
+        top_p: Optional nucleus-sampling probability mass in ``[0, 1]``.
         maximum_output_tokens: Optional upper bound for generated tokens.
     """
 
@@ -426,6 +427,7 @@ class ModelRequest(ContractModel):
     tools: tuple[ToolSchema, ...] = ()
     tool_choice: Literal["auto", "none", "required"] | ToolChoice | None = None
     temperature: float | None = Field(default=None, ge=0, le=2)
+    top_p: float | None = Field(default=None, ge=0, le=1)
     maximum_output_tokens: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="after")

--- a/wmo/runtime/gateway/contracts.py
+++ b/wmo/runtime/gateway/contracts.py
@@ -117,6 +117,7 @@ class GatewayRequest(ContractModel):
     maximum_output_tokens: int | None = Field(default=None, gt=0)
     stop: tuple[str, ...] = ()
     temperature: float | None = Field(default=None, ge=0, le=2)
+    top_p: float | None = Field(default=None, ge=0, le=1)
     stream: bool = False
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)

--- a/wmo/runtime/models/providers/anthropic.py
+++ b/wmo/runtime/models/providers/anthropic.py
@@ -83,6 +83,8 @@ def anthropic_messages_request(model_id: str, request: ModelRequest) -> JsonObje
         payload["tool_choice"] = _anthropic_tool_choice(request.tool_choice)
     if request.temperature is not None:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
     return payload
 
 

--- a/wmo/runtime/models/providers/openai.py
+++ b/wmo/runtime/models/providers/openai.py
@@ -29,6 +29,7 @@ from wmo.runtime.gateway.contracts import GatewayRequest
 from wmo.runtime.models.providers.async_transport import AsyncJsonHttpTransport, RequestDeadline
 from wmo.runtime.models.providers.base import DEFAULT_RETRY_POLICY, DEFAULT_TIMEOUT_SECONDS
 from wmo.runtime.models.providers.errors import (
+    ProviderCapabilityError,
     ProviderRefusalError,
     ProviderRefusalSignal,
     ProviderResponseError,
@@ -58,13 +59,15 @@ def openai_responses_request(
         request: Typed WMO request.
         supports_temperature: Catalog declaration that the model accepts an explicit sampling
             temperature. Reasoning models pin their sampling and reject the parameter, so a
-            ``False`` declaration omits any requested temperature from the wire payload.
+            ``False`` declaration omits any requested temperature from the wire payload and
+            rejects an explicit ``top_p`` before dispatch.
         reasoning_effort: Optional catalog-pinned reasoning-effort level sent verbatim.
 
     Returns:
         Non-streaming Responses API JSON with provider-side storage disabled.
 
     Raises:
+        ProviderCapabilityError: The request sets ``top_p`` on a model that pins sampling.
         ValueError: A message cannot be represented without losing tool linkage.
     """
     instructions: list[str] = []
@@ -102,6 +105,10 @@ def openai_responses_request(
         )
     if request.temperature is not None and supports_temperature:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        if not supports_temperature:
+            raise ProviderCapabilityError(capability="top_p")
+        payload["top_p"] = request.top_p
     if reasoning_effort is not None:
         payload["reasoning"] = {"effort": reasoning_effort}
     if request.maximum_output_tokens is not None:

--- a/wmo/runtime/models/providers/openai_compatible.py
+++ b/wmo/runtime/models/providers/openai_compatible.py
@@ -88,6 +88,8 @@ def openai_compatible_request(model_id: str, request: ModelRequest) -> JsonObjec
         )
     if request.temperature is not None:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
     if request.maximum_output_tokens is not None:
         payload["max_tokens"] = request.maximum_output_tokens
     return payload

--- a/wmo/runtime/models/providers/openai_compatible_test.py
+++ b/wmo/runtime/models/providers/openai_compatible_test.py
@@ -61,11 +61,13 @@ def _snapshot(provider: str = "openai-compatible", model_id: str = "fake-model")
 def _request(
     *,
     tool_choice: ToolChoice | Literal["auto", "none", "required"] | None = None,
+    top_p: float | None = None,
 ) -> ModelRequest:
     """Build a visible transcript containing an earlier tool call and result.
 
     Args:
         tool_choice: Optional tool-choice constraint forwarded to the request.
+        top_p: Optional nucleus-sampling mass forwarded to the request.
 
     Returns:
         A typed request with system, user, assistant tool-call, and tool-result turns.
@@ -97,7 +99,7 @@ def _request(
         ),
         tool_choice=tool_choice,
         temperature=0.2,
-        top_p=1.0,
+        top_p=top_p,
         maximum_output_tokens=128,
     )
 
@@ -105,7 +107,7 @@ def _request(
 def test_openai_compatible_request_keeps_history_tools_and_non_streaming_cap() -> None:
     """Shared conversion keeps every tool turn and emits no streaming request."""
     payload = openai_compatible_request(
-        "fake-model", _request(tool_choice=ToolChoice(name="create_ticket"))
+        "fake-model", _request(tool_choice=ToolChoice(name="create_ticket"), top_p=1.0)
     )
 
     assert payload["stream"] is False

--- a/wmo/runtime/models/providers/openai_compatible_test.py
+++ b/wmo/runtime/models/providers/openai_compatible_test.py
@@ -97,6 +97,7 @@ def _request(
         ),
         tool_choice=tool_choice,
         temperature=0.2,
+        top_p=1.0,
         maximum_output_tokens=128,
     )
 
@@ -109,6 +110,8 @@ def test_openai_compatible_request_keeps_history_tools_and_non_streaming_cap() -
 
     assert payload["stream"] is False
     assert payload["max_tokens"] == 128
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
     assert payload["tool_choice"] == {
         "type": "function",
         "function": {"name": "create_ticket"},
@@ -132,6 +135,17 @@ def test_openai_compatible_request_keeps_history_tools_and_non_streaming_cap() -
             "function": {"name": "create_ticket", "arguments": '{"priority": "normal"}'},
         }
     ]
+
+
+def test_openai_compatible_request_omits_absent_top_p() -> None:
+    """Buffered Chat payloads do not invent a nucleus-sampling value."""
+    payload = openai_compatible_request(
+        "fake-model",
+        ModelRequest(messages=(ModelMessage(role="user", content="hello"),)),
+    )
+
+    assert "top_p" not in payload
+    assert "temperature" not in payload
 
 
 def test_openai_compatible_client_converts_tool_usage_and_resolved_identity() -> None:

--- a/wmo/runtime/models/providers/streaming_requests.py
+++ b/wmo/runtime/models/providers/streaming_requests.py
@@ -30,7 +30,8 @@ def openai_responses_stream_payload(
         Native Responses request with storage disabled and streaming enabled.
 
     Raises:
-        ProviderCapabilityError: The request uses unsupported stop sequences.
+        ProviderCapabilityError: The request uses unsupported stop sequences, or sets
+            ``top_p`` on a model that pins sampling.
         ProviderResponseError: An instruction message has no text.
     """
     if request.stop:
@@ -69,6 +70,10 @@ def openai_responses_stream_payload(
         payload["max_output_tokens"] = request.maximum_output_tokens
     if request.temperature is not None and supports_temperature:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        if not supports_temperature:
+            raise ProviderCapabilityError(capability="top_p")
+        payload["top_p"] = request.top_p
     if reasoning_effort is not None:
         payload["reasoning"] = {"effort": reasoning_effort}
     return payload
@@ -131,6 +136,8 @@ def anthropic_messages_stream_payload(model_id: str, request: GatewayRequest) ->
             payload["tool_choice"] = {"type": mapping[request.tool_choice]}
     if request.temperature is not None:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
     if request.stop:
         payload["stop_sequences"] = list(request.stop)
     return payload

--- a/wmo/runtime/models/providers/streaming_requests.py
+++ b/wmo/runtime/models/providers/streaming_requests.py
@@ -168,6 +168,8 @@ def openai_compatible_stream_payload(model_id: str, request: GatewayRequest) -> 
         payload["max_tokens"] = request.maximum_output_tokens
     if request.temperature is not None:
         payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
     if request.stop:
         payload["stop"] = list(request.stop)
     return payload

--- a/wmo/runtime/models/providers/streaming_requests_test.py
+++ b/wmo/runtime/models/providers/streaming_requests_test.py
@@ -1,11 +1,18 @@
-"""Tests for OpenAI-compatible streaming request payload translation."""
+"""Tests for launch-provider streaming request payload translation."""
+
+import pytest
 
 from wmo.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
     GatewayRequest,
 )
-from wmo.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
+from wmo.runtime.models.providers.errors import ProviderCapabilityError
+from wmo.runtime.models.providers.streaming_requests import (
+    anthropic_messages_stream_payload,
+    openai_compatible_stream_payload,
+    openai_responses_stream_payload,
+)
 
 
 def _chat_request(
@@ -48,6 +55,64 @@ def test_openai_compatible_stream_payload_forwards_top_p_and_usage() -> None:
 def test_openai_compatible_stream_payload_omits_absent_top_p() -> None:
     """An omitted nucleus parameter stays off the wire instead of being invented."""
     payload = openai_compatible_stream_payload("exact-model", _chat_request())
+
+    assert "top_p" not in payload
+    assert "temperature" not in payload
+
+
+def test_openai_responses_stream_payload_forwards_top_p_when_sampling_is_open() -> None:
+    """Native Responses streaming preserves nucleus sampling on models that accept it."""
+    payload = openai_responses_stream_payload(
+        "exact-model",
+        _chat_request(top_p=1.0, temperature=0.2),
+        supports_temperature=True,
+        reasoning_effort=None,
+    )
+
+    assert payload["stream"] is True
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
+
+
+def test_openai_responses_stream_payload_rejects_top_p_when_sampling_is_pinned() -> None:
+    """Pinned-sampling Responses models fail closed instead of dropping caller top_p."""
+    with pytest.raises(ProviderCapabilityError, match="top_p") as captured:
+        openai_responses_stream_payload(
+            "exact-model",
+            _chat_request(top_p=1.0),
+            supports_temperature=False,
+            reasoning_effort="xhigh",
+        )
+    assert captured.value.capability == "top_p"
+
+
+def test_openai_responses_stream_payload_omits_absent_top_p() -> None:
+    """Native Responses streaming does not invent a nucleus-sampling value."""
+    payload = openai_responses_stream_payload(
+        "exact-model",
+        _chat_request(),
+        supports_temperature=True,
+        reasoning_effort=None,
+    )
+
+    assert "top_p" not in payload
+
+
+def test_anthropic_messages_stream_payload_forwards_top_p() -> None:
+    """Native Anthropic streaming preserves nucleus sampling on the Messages wire."""
+    payload = anthropic_messages_stream_payload(
+        "exact-model",
+        _chat_request(top_p=1.0, temperature=0.2),
+    )
+
+    assert payload["stream"] is True
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
+
+
+def test_anthropic_messages_stream_payload_omits_absent_top_p() -> None:
+    """Native Anthropic streaming does not invent a nucleus-sampling value."""
+    payload = anthropic_messages_stream_payload("exact-model", _chat_request())
 
     assert "top_p" not in payload
     assert "temperature" not in payload

--- a/wmo/runtime/models/providers/streaming_requests_test.py
+++ b/wmo/runtime/models/providers/streaming_requests_test.py
@@ -1,0 +1,53 @@
+"""Tests for OpenAI-compatible streaming request payload translation."""
+
+from wmo.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+)
+from wmo.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
+
+
+def _chat_request(
+    *,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> GatewayRequest:
+    """Build one Chat Completions streaming request with optional sampling fields.
+
+    Args:
+        temperature: Optional sampling temperature to include.
+        top_p: Optional nucleus-sampling mass to include.
+
+    Returns:
+        A streaming Chat request carrying the supplied sampling fields.
+    """
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        temperature=temperature,
+        top_p=top_p,
+        stream=True,
+        include_usage=True,
+    )
+
+
+def test_openai_compatible_stream_payload_forwards_top_p_and_usage() -> None:
+    """Streaming Chat payloads preserve nucleus sampling and always request usage."""
+    payload = openai_compatible_stream_payload(
+        "exact-model",
+        _chat_request(top_p=1.0, temperature=0.2),
+    )
+
+    assert payload["stream"] is True
+    assert payload["stream_options"] == {"include_usage": True}
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
+
+
+def test_openai_compatible_stream_payload_omits_absent_top_p() -> None:
+    """An omitted nucleus parameter stays off the wire instead of being invented."""
+    payload = openai_compatible_stream_payload("exact-model", _chat_request())
+
+    assert "top_p" not in payload
+    assert "temperature" not in payload

--- a/wmo/runtime/models/providers/tests/native_test.py
+++ b/wmo/runtime/models/providers/tests/native_test.py
@@ -19,12 +19,17 @@ from wmo.runtime.models.providers.anthropic import (
     anthropic_messages_response,
 )
 from wmo.runtime.models.providers.errors import (
+    ProviderCapabilityError,
     ProviderRefusalError,
     ProviderRefusalSignal,
     ProviderRetryableResponseError,
 )
 from wmo.runtime.models.providers.gemini import GeminiClient, gemini_generate_response
-from wmo.runtime.models.providers.openai import OpenAIClient, openai_responses_response
+from wmo.runtime.models.providers.openai import (
+    OpenAIClient,
+    openai_responses_request,
+    openai_responses_response,
+)
 from wmo.runtime.models.providers.openai_compatible import OpenRouterClient
 from wmo.runtime.models.providers.openai_compatible_test import _request, _snapshot
 from wmo.runtime.models.providers.tinker_sampling import (
@@ -187,7 +192,38 @@ def test_openai_reasoning_model_declarations_shape_the_wire_payload() -> None:
 
     payload = transport.requests[0][2]
     assert "temperature" not in payload
+    assert "top_p" not in payload
     assert payload["reasoning"] == {"effort": "xhigh"}
+
+
+def test_openai_responses_forwards_top_p_on_sampling_models() -> None:
+    """Direct OpenAI Responses keeps caller nucleus sampling on the native wire."""
+    payload = openai_responses_request(
+        "gpt-5.4",
+        _request(top_p=1.0),
+        supports_temperature=True,
+    )
+
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
+
+
+def test_openai_reasoning_model_rejects_top_p_before_dispatch() -> None:
+    """Pinned-sampling OpenAI models reject top_p instead of silently ignoring it."""
+    transport = ScriptedJsonTransport([])
+    client = OpenAIClient(
+        model=_snapshot("openai", "gpt-5.6-luna"),
+        api_key="fixture-openai-key",
+        base_url="https://openai.fixture/v1",
+        transport=transport,
+        supports_temperature=False,
+        reasoning_effort="xhigh",
+    )
+
+    with pytest.raises(ProviderCapabilityError, match="top_p") as captured:
+        client.complete(_request(top_p=1.0))
+    assert captured.value.capability == "top_p"
+    assert transport.requests == []
 
 
 def test_openai_embeddings_use_the_shared_normalized_response_contract() -> None:
@@ -297,6 +333,8 @@ def test_anthropic_uses_native_tool_blocks_and_normalizes_cache_usage() -> None:
     assert url == "https://anthropic.fixture/v1/messages"
     assert headers["x-api-key"] == "fixture-anthropic-key"
     assert payload["tool_choice"] == {"type": "any"}
+    assert payload["temperature"] == 0.2
+    assert "top_p" not in payload
     messages = payload["messages"]
     assert isinstance(messages, list)
     assert messages[1]["content"][0] == {
@@ -319,6 +357,14 @@ def test_anthropic_tool_none_keeps_history_schemas_and_uses_native_none() -> Non
         }
     ]
     assert payload["tool_choice"] == {"type": "none"}
+
+
+def test_anthropic_messages_forwards_top_p() -> None:
+    """Native Anthropic Messages keeps caller nucleus sampling on the wire."""
+    payload = anthropic_messages_request("claude-fixture", _request(top_p=1.0))
+
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 1.0
 
 
 def test_gemini_uses_native_function_calls_usage_identity_and_embeddings() -> None:

--- a/wmo/runtime/openai_protocol/manifest.py
+++ b/wmo/runtime/openai_protocol/manifest.py
@@ -32,6 +32,7 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "max_completion_tokens",
                 "stop",
                 "temperature",
+                "top_p",
                 "stream",
                 "stream_options",
             )
@@ -67,7 +68,6 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "service_tier",
                 "store",
                 "top_logprobs",
-                "top_p",
                 "user",
                 "verbosity",
                 "web_search_options",

--- a/wmo/runtime/openai_protocol/manifest_test.py
+++ b/wmo/runtime/openai_protocol/manifest_test.py
@@ -35,6 +35,8 @@ def test_manifests_classify_explicit_exclusions() -> None:
     assert chat["audio"] == CompatibilityDisposition.UNSUPPORTED
     assert chat["n"] == CompatibilityDisposition.UNSUPPORTED
     assert chat["logprobs"] == CompatibilityDisposition.UNSUPPORTED
+    assert chat["top_p"] == CompatibilityDisposition.SUPPORTED
     assert responses["background"] == CompatibilityDisposition.UNSUPPORTED
     assert responses["conversation"] == CompatibilityDisposition.UNSUPPORTED
     assert responses["include"] == CompatibilityDisposition.UNSUPPORTED
+    assert responses["top_p"] == CompatibilityDisposition.UNSUPPORTED

--- a/wmo/runtime/openai_protocol/model_adapter.py
+++ b/wmo/runtime/openai_protocol/model_adapter.py
@@ -63,6 +63,7 @@ def model_request(request: GatewayRequest) -> ModelRequest:
         tools=tools,
         tool_choice=choice,
         temperature=request.temperature,
+        top_p=request.top_p,
         maximum_output_tokens=request.maximum_output_tokens,
     )
 

--- a/wmo/runtime/openai_protocol/model_adapter_test.py
+++ b/wmo/runtime/openai_protocol/model_adapter_test.py
@@ -43,6 +43,7 @@ def test_model_request_preserves_messages_tools_and_limits() -> None:
         ),
         tool_choice=GatewayNamedToolChoice(name="lookup"),
         temperature=0.25,
+        top_p=1.0,
         maximum_output_tokens=128,
     )
 
@@ -53,6 +54,8 @@ def test_model_request_preserves_messages_tools_and_limits() -> None:
     assert adapted.messages[1].assistant_action.tool_calls[0].arguments == {"q": 1}
     assert isinstance(adapted.tool_choice, ToolChoice)
     assert adapted.tool_choice.name == "lookup"
+    assert adapted.temperature == 0.25
+    assert adapted.top_p == 1.0
     assert adapted.maximum_output_tokens == 128
 
 

--- a/wmo/runtime/openai_protocol/requests.py
+++ b/wmo/runtime/openai_protocol/requests.py
@@ -160,6 +160,7 @@ class _ChatRequest(_WireModel):
     max_completion_tokens: int | None = Field(default=None, gt=0)
     stop: str | tuple[str, ...] | None = None
     temperature: float | None = Field(default=None, ge=0, le=2)
+    top_p: float | None = Field(default=None, ge=0, le=1)
     response_format: _ChatResponseFormat | None = None
     stream: bool = False
     stream_options: _ChatStreamOptions | None = None
@@ -285,6 +286,7 @@ def decode_chat(
             maximum_output_tokens=maximum,
             stop=stop,
             temperature=request.temperature,
+            top_p=request.top_p,
             stream=request.stream,
             include_usage=(
                 request.stream_options is not None and request.stream_options.include_usage

--- a/wmo/runtime/openai_protocol/requests_test.py
+++ b/wmo/runtime/openai_protocol/requests_test.py
@@ -56,6 +56,7 @@ def test_chat_decoder_preserves_every_supported_semantic_field() -> None:
             "max_completion_tokens": 123,
             "stop": ["END", "STOP"],
             "temperature": 0.2,
+            "top_p": 1,
             "response_format": {
                 "type": "json_schema",
                 "json_schema": {
@@ -87,6 +88,8 @@ def test_chat_decoder_preserves_every_supported_semantic_field() -> None:
     assert request.tool_choice.name == "weather"
     assert request.maximum_output_tokens == 123
     assert request.stop == ("END", "STOP")
+    assert request.temperature == 0.2
+    assert request.top_p == 1.0
     assert request.structured_text is not None and request.structured_text.strict
     assert request.include_usage
     assert request.metadata == {"cohort": "test"}
@@ -211,6 +214,45 @@ def test_invalid_tool_arguments_and_conflicting_operation_headers_are_specific()
         )
     assert operation.value.detail.code == "idempotency_conflict"
     assert operation.value.detail.param == "Idempotency-Key"
+
+
+def test_chat_decoder_accepts_opencode_nucleus_and_usage_stream_shape() -> None:
+    """OpenCode Chat Completions send top_p=1 with streamed usage and must decode losslessly."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hello"}],
+            "top_p": 1,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    )
+
+    assert decoded.request.top_p == 1.0
+    assert decoded.request.stream
+    assert decoded.request.include_usage
+
+
+def test_chat_decoder_rejects_out_of_range_top_p() -> None:
+    """Nucleus sampling stays inside the official [0, 1] interval."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hello"}],
+                "top_p": 1.5,
+            }
+        )
+    assert captured.value.detail.code == "invalid_parameter"
+    assert captured.value.detail.param == "top_p"
+
+
+def test_responses_decoder_still_rejects_top_p() -> None:
+    """Responses keeps top_p excluded so Chat support does not widen that surface."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_responses({"model": "coding", "input": "hello", "top_p": 1})
+    assert captured.value.detail.code == "unsupported_parameter"
+    assert captured.value.detail.param == "top_p"
 
 
 def test_empty_responses_input_is_a_public_protocol_error() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

OpenCode 1.18.x (`@ai-sdk/openai-compatible`) sends Chat Completions requests with `top_p=1`, `stream=true`, and `stream_options.include_usage=true`. The gateway rejected `top_p` as an unsupported parameter during protocol decode, before any provider call.

Reproduced against `HEAD` with that exact payload:

```
status_code= 400
code= unsupported_parameter
param= top_p
message= The parameter 'top_p' is not supported by this gateway profile.
```

`stream` and `stream_options.include_usage` were already accepted. The only inbound blocker was `top_p`.

## Fix

- Add typed `top_p` (`0..1`, optional) on `GatewayRequest` and `ModelRequest`.
- Decode it on Chat Completions and advertise `top_p` as supported on the Chat compatibility manifest.
- Forward it on OpenAI-compatible, native OpenAI Responses, and Anthropic Messages builders (buffered and streaming).
- Reject `top_p` before dispatch when an OpenAI model pins sampling (`supports_temperature=False`), instead of silently dropping the caller value.
- Omit `top_p` from upstream payloads when the caller did not send it.

The public Responses API still classifies inbound `top_p` as unsupported. No other sampling or convenience parameters were added.

## Greptile follow-up

Greptile scored 4/5 because Chat accepted `top_p` before deployment selection, while native OpenAI Responses and Anthropic builders omitted it. Those provider paths now preserve the value. Pinned-sampling OpenAI models fail closed with `ProviderCapabilityError(capability="top_p")` and make no HTTP request.

## Evidence

After the inbound fix, the OpenCode-shaped payload decodes losslessly:

```
alias= coding
surface= chat_completions
top_p= 1.0
stream= True
include_usage= True
```

Provider builders now preserve it on the paths Greptile named:

- OpenAI Responses streaming and buffered payloads include `top_p` when sampling is open.
- Anthropic Messages streaming and buffered payloads include `top_p`.
- Pinned-sampling OpenAI Responses reject `top_p` before dispatch (`transport.requests == []`).
- `decode_responses(..., top_p=1)` still returns `unsupported_parameter`.

Focused tests after the follow-up: 69 passed, including:

- `requests_test.py`: OpenCode decode, out-of-range `top_p`, Responses inbound rejection
- `model_adapter_test.py`: canonical conversion
- `manifest_test.py`: Chat supported, Responses unsupported
- `openai_compatible_test.py`: buffered forwarding and omit-when-absent
- `streaming_requests_test.py`: OpenAI-compatible, Responses, and Anthropic streaming forwarding, plus pinned-sampling rejection
- `tests/native_test.py`: OpenAI Responses and Anthropic deployment-path forwarding, plus reject-before-dispatch

Also ran `uv run ruff check .`, `uv run ruff format --check .`, and `uv run ty check` over the whole project. All passed. Related streaming and SDK harness suites remain green (33 passed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cacbe0d-d580-4456-b991-414af5e94c29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cacbe0d-d580-4456-b991-414af5e94c29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

