### PR TITLE
Gateway quality pass: error remediation, models detail, CLI core loop, openai-compatible presets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ results, and plans do not live here.
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, and the Bedrock credential chain. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
+| `reference/openai-compatible-recipes.md` | Verified Fireworks and Modal connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -6,6 +6,7 @@ No-argument `exp run` starts an authenticated multi-alias gateway on `127.0.0.1`
 It serves:
 
 - `GET /v1/models`
+- `GET /v1/models/{model_id}`
 - `POST /v1/chat/completions`
 - `POST /v1/responses`
 - `GET /health/live` and `GET /health/ready`
@@ -150,6 +151,14 @@ are accumulated in original order and validated only at the complete-call bounda
 Commit-independent headers are available before streaming begins. Route-dependent headers are
 emitted only after an execution snapshot exists. Stable public IDs do not expose raw key,
 idempotency, request, or provider values.
+
+`GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
+enriched with a `wmo` object carrying the alias revision and catalog digest of the granted
+authority. `GET /v1/models/{model_id}` describes one granted alias with the same object and
+returns the identical `model_not_found` 404 for every other model ID, so the route never confirms
+whether an ungranted alias exists. Quota-exhausted and throttled 429 responses and the draining
+503 advertise a `Retry-After` wait, and monthly quota exhaustion reports its exact UTC
+calendar-month reset boundary in the error message.
 
 OpenAI `3.0.0` `OpenAI` and `AsyncOpenAI` clients are release-certified for Chat Completions and
 Responses in synchronous and asynchronous, streaming and non-streaming forms. Responses

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -154,7 +154,9 @@ idempotency, request, or provider values.
 
 `GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
 enriched with a `wmo` object carrying the alias revision and catalog digest of the granted
-authority. `GET /v1/models/{model_id}` describes one granted alias with the same object and
+authority. Its list envelope carries `wmo.authority_schema_version`, including when `data` is
+empty, so caller-side key validation can distinguish this gateway from a generic OpenAI proxy.
+`GET /v1/models/{model_id}` describes one granted alias with the same object and
 returns the identical `model_not_found` 404 for every other model ID, so the route never confirms
 whether an ungranted alias exists. Quota-exhausted and throttled 429 responses and the draining
 503 advertise a `Retry-After` wait, and monthly quota exhaustion reports its exact UTC

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -1,0 +1,103 @@
+# OpenAI-compatible connection recipes: Fireworks and Modal
+
+The gateway's `openai-compatible` provider family serves every endpoint that speaks the
+OpenAI Chat Completions SSE protocol, selected purely by `base_url`. Fireworks and
+Modal-deployed endpoints are two such services. They are deliberately connection recipes
+rather than new provider names: the provider vocabulary is a frozen contract shared by
+catalog validation, provider setup, the certification matrix, and the CLI, so an endpoint
+that differs from the generic adapter only by its base URL never widens that vocabulary.
+
+Every command and constant below is verified against the current tree by
+`exp/cli/tests/openai_compatible_recipes_test.py`.
+
+## Fireworks AI
+
+Fireworks serves its hosted models at one fixed base URL:
+
+```text
+https://api.fireworks.ai/inference/v1
+```
+
+Authentication uses a bearer key. Keep the key in an environment variable (the catalog
+stores only the variable name, never the value), and use the Fireworks model ID form
+`accounts/fireworks/models/<model-name>`.
+
+```bash
+export FIREWORKS_API_KEY=...   # from https://app.fireworks.ai
+
+exp config gateway init --root ROOT --json
+exp config gateway provider add fireworks \
+  --provider openai-compatible \
+  --base-url https://api.fireworks.ai/inference/v1 \
+  --credential-env FIREWORKS_API_KEY \
+  --root ROOT --non-interactive --json
+```
+
+Then bind one exact model as a direct alias. The capability flags are the template for a
+current Fireworks chat model: most support tools and structured output, and none require
+developer messages. Confirm the flags and the micro-USD-per-million-token prices against
+the Fireworks model page before authoring, because the gateway treats both as frozen
+authority for routing and accounting.
+
+The `--deployment` model segment is the exact provider-side spelling with its slashes;
+`--exact-model` is your stable logical model identity and must use lowercase components
+separated by `.`, `_`, or `-` (for example `llama-v3p1-70b-instruct`).
+
+```bash
+exp config gateway alias create coding \
+  --deployment fireworks:accounts/fireworks/models/llama-v3p1-70b-instruct \
+  --exact-model llama-v3p1-70b-instruct \
+  --supports-tools --supports-structured-output \
+  --input-price 900000 --output-price 900000 \
+  --pricing-source "https://fireworks.ai/pricing" \
+  --root ROOT --non-interactive --json
+
+exp config gateway identity create default --root ROOT --non-interactive --json
+exp config gateway grant add default coding --root ROOT --non-interactive --json
+exp config gateway key issue default --key-id key-one --root ROOT --json
+exp run --root ROOT --check --non-interactive --json
+```
+
+`exp run --check` proves readiness without a paid call; drop `--check` to serve, then use
+the caller loop (`exp config gateway key check`, `models`, and `call`) against the live
+gateway.
+
+## Modal
+
+Modal endpoints are org-deployed web apps (for example a vLLM server deployed with
+`modal deploy`), so there is no default base URL: every deployment has its own hostname
+of the form `https://<workspace>--<app-label>.modal.run`, and the connection fails closed
+at startup until an explicit `base_url` is configured. Point `base_url` at the path that
+serves the OpenAI protocol, typically the `/v1` suffix, and reference whatever bearer
+token the deployment enforces (Modal proxy-auth tokens or an app-defined API key).
+
+```bash
+export MODAL_API_KEY=...       # the token your Modal deployment checks
+
+exp config gateway provider add modal-vllm \
+  --provider openai-compatible \
+  --base-url https://WORKSPACE--APP_LABEL.modal.run/v1 \
+  --credential-env MODAL_API_KEY \
+  --root ROOT --non-interactive --json
+
+exp config gateway alias create local-serve \
+  --deployment modal-vllm:SERVED_MODEL_ID \
+  --exact-model served-model-id \
+  --input-price 0 --output-price 0 \
+  --pricing-source "self-hosted Modal deployment" \
+  --root ROOT --non-interactive --json
+```
+
+`SERVED_MODEL_ID` is the model name the deployment reports in its own `GET /v1/models`;
+self-hosted deployments usually bill through Modal compute rather than per token, so zero
+token prices with an explicit `--pricing-source` keep the accounting honest. If the
+served endpoint reports a different model identity than the one requested, pin it during
+`exp config providers` setup with `served_model_id` instead of authoring a mismatched
+alias.
+
+## Build-time equivalents
+
+The same two connections work for evidence builds and router optimization through
+`exp config providers` by choosing the `openai-compatible` provider with the identical
+`base_url` and credential environment variable; see `reference/providers.md` for that
+flow.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,9 @@ The root surface is deliberately small:
 | `exp run --root ROOT [--check]` | Validate or start the initialized authenticated multi-alias gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `exp run PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as no-argument `exp run`. |
 | `exp config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, monthly limits, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
+| `exp config gateway call ALIAS PROMPT [--json]` | Send one chat completion to a live gateway as a caller, streaming text to stdout. | One HTTP request against the running gateway; no local state. |
+| `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
+| `exp config gateway key check [--json]` | Validate one raw virtual key against a live gateway and print its granted aliases without storing the key. | One HTTP request against the running gateway; no local state. |
 | `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.exp/models.toml`. |
 | `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.exp/settings.toml`. |
 | `exp config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.exp/settings.toml`. |

--- a/exp/cli/gateway/app.py
+++ b/exp/cli/gateway/app.py
@@ -12,6 +12,7 @@ from rich.console import Console
 
 from exp.cli.gateway.alias import alias_app
 from exp.cli.gateway.budget import budget_app
+from exp.cli.gateway.caller import caller_call, caller_key_check, caller_models
 from exp.cli.gateway.key_output import (
     KeyOutputOutcomeUnknownError,
     KeyOutputRecoveryError,
@@ -42,6 +43,9 @@ gateway_app.add_typer(key_app, name="key")
 gateway_app.add_typer(alias_app, name="alias")
 gateway_app.add_typer(pool_app, name="pool")
 gateway_app.add_typer(grant_app, name="grant")
+gateway_app.command("call")(caller_call)
+gateway_app.command("models")(caller_models)
+key_app.command("check")(caller_key_check)
 
 _console = Console()
 _JSON_OPTION = typer.Option(False, "--json", help="Write one versioned JSON document to stdout.")

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -34,13 +34,16 @@ from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUn
 from exp.runtime.gateway.sqlite.provider_authority import ProviderConnectionBinding
 from exp.runtime.gateway.sqlite.store import OperationOutcomeUnknownError, SQLiteGatewayStore
 
-EXPECTED_GATEWAY_COMMANDS = {"init", "status", "usage"}
+# call, models, and key check are the deliberate caller-side additions for the agent
+# core loop against a live gateway: one-shot completion, caller-view discovery, and
+# raw-key validation. They widen the locked gateway tree on purpose; see caller.py.
+EXPECTED_GATEWAY_COMMANDS = {"call", "init", "models", "status", "usage"}
 EXPECTED_GATEWAY_GROUPS = {
     "alias": {"create", "disable", "list", "update"},
     "budget": {"list", "remaining", "set"},
     "grant": {"add", "list", "remove"},
     "identity": {"create", "disable", "list", "update"},
-    "key": {"issue", "list", "revoke"},
+    "key": {"check", "issue", "list", "revoke"},
     "pool": {"certify"},
     "provider": {"add", "disable", "list", "remove", "update"},
 }

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -1,0 +1,381 @@
+"""Caller-side commands that drive one live authenticated gateway over HTTP.
+
+These commands cover the agent core loop against a running ``exp run`` gateway: discover
+the aliases a virtual key can use, validate a key, and make one chat completion. They are
+pure HTTP callers: spend authority stays entirely with the gateway's key grants and
+monthly budgets, no provider client or provider credential is ever constructed, and the
+presented virtual key is used for the one request and never stored or echoed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import httpx
+import typer
+
+from exp.common.core.artifacts import JsonObject
+
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:8000/v1"
+
+_URL_OPTION = typer.Option(
+    DEFAULT_GATEWAY_URL,
+    "--url",
+    envvar=["EXP_GATEWAY_URL", "OPENAI_BASE_URL"],
+    help="Base URL of a live gateway, normally ending in /v1.",
+)
+_KEY_OPTION = typer.Option(
+    None,
+    "--key",
+    envvar=["EXP_GATEWAY_KEY", "OPENAI_API_KEY"],
+    help="Virtual gateway key; read from the environment when omitted.",
+)
+_TIMEOUT_OPTION = typer.Option(
+    120.0,
+    "--timeout",
+    min=0.1,
+    help="Total HTTP timeout in seconds for the gateway request.",
+)
+_JSON_OPTION = typer.Option(False, "--json", help="Write the raw gateway JSON to stdout.")
+
+
+def caller_call(
+    alias: str = typer.Argument(..., help="Granted public model alias to call."),
+    prompt: str = typer.Argument(..., help="One user message sent to the alias."),
+    url: str = _URL_OPTION,
+    key: str | None = _KEY_OPTION,
+    timeout: float = _TIMEOUT_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Send one chat completion to a live gateway and stream the text to stdout.
+
+    Args:
+        alias: Granted public model alias to call.
+        prompt: One user message sent to the alias.
+        url: Live gateway base URL.
+        key: Virtual gateway key, defaulting to the documented environment variables.
+        timeout: Total HTTP timeout in seconds.
+        json_output: Whether to make one non-streaming call and print the raw envelope.
+    """
+    raw_key = _require_key(key)
+    body: JsonObject = {
+        "model": alias,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": not json_output,
+    }
+    with _gateway_client(url, timeout=timeout) as client:
+        if json_output:
+            response = _gateway_request(
+                client, "POST", "/chat/completions", raw_key=raw_key, url=url, body=body
+            )
+            _require_success(response)
+            typer.echo(response.text)
+            return
+        _stream_completion(client, raw_key=raw_key, url=url, body=body)
+
+
+def caller_models(
+    url: str = _URL_OPTION,
+    key: str | None = _KEY_OPTION,
+    timeout: float = _TIMEOUT_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """List the model aliases a live gateway grants to the presented key.
+
+    This is the caller view served by ``GET /v1/models``, distinct from the operator-side
+    ``exp config gateway alias list`` which reads local authority state directly.
+
+    Args:
+        url: Live gateway base URL.
+        key: Virtual gateway key, defaulting to the documented environment variables.
+        timeout: Total HTTP timeout in seconds.
+        json_output: Whether to print the raw OpenAI-shaped list envelope.
+    """
+    raw_key = _require_key(key)
+    with _gateway_client(url, timeout=timeout) as client:
+        response = _gateway_request(client, "GET", "/models", raw_key=raw_key, url=url)
+    _require_success(response)
+    if json_output:
+        typer.echo(response.text)
+        return
+    for model in _listed_models(response):
+        identity = str(model.get("id", ""))
+        authority = model.get("wmo")
+        if isinstance(authority, dict) and "alias_revision_id" in authority:
+            typer.echo(f"{identity} (revision {authority['alias_revision_id']})")
+        else:
+            typer.echo(identity)
+
+
+def caller_key_check(
+    url: str = _URL_OPTION,
+    key: str | None = _KEY_OPTION,
+    timeout: float = _TIMEOUT_OPTION,
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Validate one raw virtual key against a live gateway without storing it.
+
+    The key is sent once as the Bearer credential of ``GET /v1/models``; a valid key
+    prints its granted aliases and an invalid key exits nonzero with the gateway's
+    remediation message. The raw key never appears in stdout, stderr, or any file.
+
+    Args:
+        url: Live gateway base URL.
+        key: Virtual gateway key, defaulting to the documented environment variables.
+        timeout: Total HTTP timeout in seconds.
+        json_output: Whether to print one versioned key-check JSON document.
+    """
+    raw_key = _require_key(key)
+    with _gateway_client(url, timeout=timeout) as client:
+        response = _gateway_request(client, "GET", "/models", raw_key=raw_key, url=url)
+    if response.status_code == 200:
+        aliases = [str(model.get("id", "")) for model in _listed_models(response)]
+        if json_output:
+            typer.echo(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "operation": "key.check",
+                        "valid": True,
+                        "granted_aliases": aliases,
+                    },
+                    separators=(",", ":"),
+                )
+            )
+            return
+        if aliases:
+            typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
+        else:
+            typer.echo("key valid; no aliases granted (add one with 'exp config gateway grant')")
+        return
+    code, message = _error_detail(response)
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "operation": "key.check",
+                    "valid": False,
+                    "error_code": code,
+                    "message": message,
+                },
+                separators=(",", ":"),
+            )
+        )
+    else:
+        typer.echo(f"key invalid ({code}): {message}", err=True)
+    raise typer.Exit(code=1)
+
+
+def _stream_completion(
+    client: httpx.Client,
+    *,
+    raw_key: str,
+    url: str,
+    body: JsonObject,
+) -> None:
+    """Stream one chat completion, echoing text deltas as the gateway sends them.
+
+    Args:
+        client: Open gateway HTTP client.
+        raw_key: Presented virtual key.
+        url: Gateway base URL, used only in connection diagnostics.
+        body: Complete Chat Completions request payload with ``stream`` enabled.
+    """
+    try:
+        with client.stream(
+            "POST",
+            "/chat/completions",
+            json=body,
+            headers=_authorization(raw_key),
+        ) as response:
+            if response.status_code != 200:
+                response.read()
+                _require_success(response)
+            emitted = False
+            for line in response.iter_lines():
+                delta = _stream_text_delta(line)
+                if delta:
+                    typer.echo(delta, nl=False)
+                    emitted = True
+            if emitted:
+                typer.echo("")
+    except httpx.HTTPError:
+        raise _unreachable_gateway(url) from None
+
+
+def _stream_text_delta(line: str) -> str:
+    """Return the visible text carried by one Chat Completions SSE line.
+
+    Args:
+        line: One raw server-sent-event line.
+
+    Returns:
+        Text delta content, or an empty string for control frames and other events.
+    """
+    if not line.startswith("data: "):
+        return ""
+    payload = line[len("data: ") :].strip()
+    if not payload or payload == "[DONE]":
+        return ""
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(chunk, dict):
+        return ""
+    choices = chunk.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return ""
+    delta = choices[0].get("delta")
+    if not isinstance(delta, dict):
+        return ""
+    content = delta.get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _gateway_client(url: str, *, timeout: float) -> httpx.Client:
+    """Return the HTTP client used for one live-gateway command invocation.
+
+    Args:
+        url: Gateway base URL, normally ending in ``/v1``.
+        timeout: Total HTTP timeout in seconds.
+
+    Returns:
+        Configured client whose base URL prefixes every relative request path.
+    """
+    return httpx.Client(base_url=url.rstrip("/"), timeout=timeout)
+
+
+def _gateway_request(
+    client: httpx.Client,
+    method: str,
+    path: str,
+    *,
+    raw_key: str,
+    url: str,
+    body: JsonObject | None = None,
+) -> httpx.Response:
+    """Perform one authenticated gateway request with actionable connection errors.
+
+    Args:
+        client: Open gateway HTTP client.
+        method: HTTP method.
+        path: Path relative to the gateway base URL.
+        raw_key: Presented virtual key.
+        url: Gateway base URL, used only in connection diagnostics.
+        body: Optional JSON request payload.
+
+    Returns:
+        The gateway HTTP response, whatever its status code.
+
+    Raises:
+        typer.BadParameter: No gateway answered at the configured URL.
+    """
+    try:
+        return client.request(method, path, json=body, headers=_authorization(raw_key))
+    except httpx.HTTPError:
+        raise _unreachable_gateway(url) from None
+
+
+def _require_success(response: httpx.Response) -> None:
+    """Exit with the gateway's own remediation message for a non-200 response.
+
+    Args:
+        response: Completed gateway HTTP response.
+
+    Raises:
+        typer.Exit: The gateway answered with an error envelope.
+    """
+    if response.status_code == 200:
+        return
+    code, message = _error_detail(response)
+    retry_after = response.headers.get("Retry-After")
+    suffix = f" (Retry-After: {retry_after}s)" if retry_after else ""
+    typer.echo(f"gateway error {code}: {message}{suffix}", err=True)
+    raise typer.Exit(code=1)
+
+
+def _error_detail(response: httpx.Response) -> tuple[str, str]:
+    """Extract the stable code and display-safe message from one error response.
+
+    Args:
+        response: Completed non-200 gateway HTTP response.
+
+    Returns:
+        Machine-readable code and human-readable message, with HTTP-level fallbacks.
+    """
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return (f"http_{response.status_code}", "The gateway returned a non-JSON error response.")
+    if isinstance(payload, dict) and isinstance(payload.get("error"), dict):
+        error = cast(JsonObject, payload["error"])
+        return (str(error.get("code", "unknown")), str(error.get("message", "")))
+    return (f"http_{response.status_code}", "The gateway returned an unrecognized error shape.")
+
+
+def _listed_models(response: httpx.Response) -> list[JsonObject]:
+    """Return the model objects of one ``GET /v1/models`` response.
+
+    Args:
+        response: Successful models-list response.
+
+    Returns:
+        Model objects in gateway order; malformed entries are dropped.
+    """
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return []
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        return []
+    return [cast(JsonObject, item) for item in payload["data"] if isinstance(item, dict)]
+
+
+def _authorization(raw_key: str) -> dict[str, str]:
+    """Return the Bearer header for one presented virtual key.
+
+    Args:
+        raw_key: Presented virtual key.
+
+    Returns:
+        Header map used for exactly one request.
+    """
+    return {"Authorization": f"Bearer {raw_key}"}
+
+
+def _require_key(key: str | None) -> str:
+    """Return the presented key or fail with the exact way to provide one.
+
+    Args:
+        key: Optional key from the ``--key`` option or its environment variables.
+
+    Returns:
+        Non-empty raw virtual key.
+
+    Raises:
+        typer.BadParameter: No key was provided.
+    """
+    if key is not None and key.strip():
+        return key.strip()
+    raise typer.BadParameter(
+        "a virtual gateway key is required; pass --key, set EXP_GATEWAY_KEY or "
+        "OPENAI_API_KEY, or issue one with 'exp config gateway key issue'"
+    )
+
+
+def _unreachable_gateway(url: str) -> typer.BadParameter:
+    """Build the actionable error for a gateway that did not answer.
+
+    Args:
+        url: Gateway base URL that failed to respond.
+
+    Returns:
+        Usage error naming the URL and the exact way to start or select a gateway.
+    """
+    return typer.BadParameter(
+        f"no gateway answered at {url}; start one with 'exp run' or point "
+        "--url (or EXP_GATEWAY_URL) at a live gateway"
+    )

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -146,7 +146,12 @@ def caller_key_check(
                     )
                 )
                 return
-            typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
+            if aliases:
+                typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
+            else:
+                typer.echo(
+                    "key valid; no aliases granted (add one with 'exp config gateway grant')"
+                )
             return
         code = "invalid_gateway_response"
         message = "HTTP 200 did not contain the EXP gateway model-authority response shape."
@@ -402,8 +407,8 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
         response: Successful response from the caller's ``GET /v1/models`` request.
 
     Returns:
-        Validated non-empty model objects, or ``None`` when the response is not the EXP
-        gateway authority shape. An empty list has no authority evidence and fails closed.
+        Validated model objects, including an empty list when the authority marker is present,
+        or ``None`` when the response is not the EXP gateway authority shape.
     """
     try:
         payload = response.json()
@@ -411,8 +416,14 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
         return None
     if not isinstance(payload, dict) or payload.get("object") != "list":
         return None
+    authority_marker = payload.get("wmo")
+    if (
+        not isinstance(authority_marker, dict)
+        or authority_marker.get("authority_schema_version") != 1
+    ):
+        return None
     data = payload.get("data")
-    if not isinstance(data, list) or not data:
+    if not isinstance(data, list):
         return None
     models: list[JsonObject] = []
     for item in data:

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -146,12 +146,7 @@ def caller_key_check(
                     )
                 )
                 return
-            if aliases:
-                typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
-            else:
-                typer.echo(
-                    "key valid; no aliases granted (add one with 'exp config gateway grant')"
-                )
+            typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
             return
         code = "invalid_gateway_response"
         message = "HTTP 200 did not contain the EXP gateway model-authority response shape."
@@ -407,8 +402,8 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
         response: Successful response from the caller's ``GET /v1/models`` request.
 
     Returns:
-        Validated model objects, including an empty list for a valid key with no grants,
-        or ``None`` when the response is not the EXP gateway authority shape.
+        Validated non-empty model objects, or ``None`` when the response is not the EXP
+        gateway authority shape. An empty list has no authority evidence and fails closed.
     """
     try:
         payload = response.json()
@@ -417,7 +412,7 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
     if not isinstance(payload, dict) or payload.get("object") != "list":
         return None
     data = payload.get("data")
-    if not isinstance(data, list):
+    if not isinstance(data, list) or not data:
         return None
     models: list[JsonObject] = []
     for item in data:

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -130,26 +130,33 @@ def caller_key_check(
     with _gateway_client(url, timeout=timeout) as client:
         response = _gateway_request(client, "GET", "/models", raw_key=raw_key, url=url)
     if response.status_code == 200:
-        aliases = [str(model.get("id", "")) for model in _listed_models(response)]
-        if json_output:
-            typer.echo(
-                json.dumps(
-                    {
-                        "schema_version": 1,
-                        "operation": "key.check",
-                        "valid": True,
-                        "granted_aliases": aliases,
-                    },
-                    separators=(",", ":"),
+        models = _listed_authority_models(response)
+        if models is not None:
+            aliases = [str(model["id"]) for model in models]
+            if json_output:
+                typer.echo(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "operation": "key.check",
+                            "valid": True,
+                            "granted_aliases": aliases,
+                        },
+                        separators=(",", ":"),
+                    )
                 )
-            )
+                return
+            if aliases:
+                typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
+            else:
+                typer.echo(
+                    "key valid; no aliases granted (add one with 'exp config gateway grant')"
+                )
             return
-        if aliases:
-            typer.echo(f"key valid; granted aliases: {', '.join(aliases)}")
-        else:
-            typer.echo("key valid; no aliases granted (add one with 'exp config gateway grant')")
-        return
-    code, message = _error_detail(response)
+        code = "invalid_gateway_response"
+        message = "HTTP 200 did not contain the EXP gateway model-authority response shape."
+    else:
+        code, message = _error_detail(response)
     if json_output:
         typer.echo(
             json.dumps(
@@ -195,6 +202,13 @@ def _stream_completion(
                 _require_success(response)
             emitted = False
             for line in response.iter_lines():
+                stream_error = _stream_error_detail(line)
+                if stream_error is not None:
+                    if emitted:
+                        typer.echo("")
+                    code, message = stream_error
+                    typer.echo(f"gateway error {code}: {message}", err=True)
+                    raise typer.Exit(code=1)
                 delta = _stream_text_delta(line)
                 if delta:
                     typer.echo(delta, nl=False)
@@ -203,6 +217,22 @@ def _stream_completion(
                 typer.echo("")
     except httpx.HTTPError:
         raise _unreachable_gateway(url) from None
+
+
+def _stream_error_detail(line: str) -> tuple[str, str] | None:
+    """Return the code and message from one terminal streamed error envelope.
+
+    Args:
+        line: One raw server-sent-event line.
+
+    Returns:
+        Stream error details, or ``None`` when the line is not a gateway error.
+    """
+    chunk = _stream_payload(line)
+    if chunk is None or not isinstance(chunk.get("error"), dict):
+        return None
+    error = cast(JsonObject, chunk["error"])
+    return str(error.get("code", "unknown")), str(error.get("message", ""))
 
 
 def _stream_text_delta(line: str) -> str:
@@ -214,16 +244,8 @@ def _stream_text_delta(line: str) -> str:
     Returns:
         Text delta content, or an empty string for control frames and other events.
     """
-    if not line.startswith("data: "):
-        return ""
-    payload = line[len("data: ") :].strip()
-    if not payload or payload == "[DONE]":
-        return ""
-    try:
-        chunk = json.loads(payload)
-    except json.JSONDecodeError:
-        return ""
-    if not isinstance(chunk, dict):
+    chunk = _stream_payload(line)
+    if chunk is None:
         return ""
     choices = chunk.get("choices")
     if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
@@ -233,6 +255,27 @@ def _stream_text_delta(line: str) -> str:
         return ""
     content = delta.get("content")
     return content if isinstance(content, str) else ""
+
+
+def _stream_payload(line: str) -> JsonObject | None:
+    """Decode one JSON server-sent-event data line into an object.
+
+    Args:
+        line: One raw server-sent-event line.
+
+    Returns:
+        JSON object payload, or ``None`` for control, malformed, and non-data lines.
+    """
+    if not line.startswith("data: "):
+        return None
+    payload = line[len("data: ") :].strip()
+    if not payload or payload == "[DONE]":
+        return None
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    return cast(JsonObject, chunk) if isinstance(chunk, dict) else None
 
 
 def _gateway_client(url: str, *, timeout: float) -> httpx.Client:
@@ -332,6 +375,60 @@ def _listed_models(response: httpx.Response) -> list[JsonObject]:
     if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
         return []
     return [cast(JsonObject, item) for item in payload["data"] if isinstance(item, dict)]
+
+
+def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | None:
+    """Return a validated EXP gateway model-authority list.
+
+    Args:
+        response: Successful response from the caller's ``GET /v1/models`` request.
+
+    Returns:
+        Validated model objects, including an empty list for a valid key with no grants,
+        or ``None`` when the response is not the EXP gateway authority shape.
+    """
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("object") != "list":
+        return None
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return None
+    models: list[JsonObject] = []
+    for item in data:
+        if not isinstance(item, dict):
+            return None
+        model = cast(JsonObject, item)
+        if not _is_authority_model(model):
+            return None
+        models.append(model)
+    return models
+
+
+def _is_authority_model(model: JsonObject) -> bool:
+    """Check the stable wire fields that identify an EXP authority model object.
+
+    Args:
+        model: One decoded model object from a models-list response.
+
+    Returns:
+        ``True`` only when the object carries the gateway authority metadata.
+    """
+    if (
+        model.get("object") != "model"
+        or model.get("created") != 0
+        or model.get("owned_by") != "wmo"
+    ):
+        return False
+    model_id = model.get("id")
+    authority = model.get("wmo")
+    if not isinstance(model_id, str) or not model_id or not isinstance(authority, dict):
+        return False
+    revision = authority.get("alias_revision_id")
+    digest = authority.get("catalog_sha256")
+    return isinstance(revision, str) and bool(revision) and isinstance(digest, str) and bool(digest)
 
 
 def _authorization(raw_key: str) -> dict[str, str]:

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -201,7 +201,11 @@ def _stream_completion(
                 response.read()
                 _require_success(response)
             emitted = False
+            saw_done = False
             for line in response.iter_lines():
+                if _stream_done(line):
+                    saw_done = True
+                    break
                 stream_error = _stream_error_detail(line)
                 if stream_error is not None:
                     if emitted:
@@ -215,8 +219,27 @@ def _stream_completion(
                     emitted = True
             if emitted:
                 typer.echo("")
+            if not saw_done:
+                typer.echo(
+                    "gateway error incomplete_stream: The gateway stream ended before the "
+                    "[DONE] terminal marker.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
     except httpx.HTTPError:
         raise _unreachable_gateway(url) from None
+
+
+def _stream_done(line: str) -> bool:
+    """Return whether one SSE line carries the protocol terminal marker.
+
+    Args:
+        line: One raw server-sent-event line.
+
+    Returns:
+        ``True`` only for the exact OpenAI-compatible ``[DONE]`` data frame.
+    """
+    return line.startswith("data: ") and line[len("data: ") :].strip() == "[DONE]"
 
 
 def _stream_error_detail(line: str) -> tuple[str, str] | None:

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -86,6 +86,36 @@ def test_call_streams_text_deltas_to_stdout(monkeypatch: pytest.MonkeyPatch) -> 
     assert result.output == "Hello world\n"
 
 
+def test_call_surfaces_a_terminal_stream_error_after_http_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A streamed gateway error does not get hidden by the final done frame."""
+    frames = (
+        'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'
+        'data: {"error":{"code":"insufficient_quota","message":"quota is exhausted"}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve a successful stream that terminates with a gateway error."""
+        del request
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=frames.encode(),
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "call", "coding", "hello", "--key", _RAW_KEY],
+    )
+
+    assert result.exit_code == 1
+    assert "partial" in result.output
+    assert "gateway error insufficient_quota: quota is exhausted" in result.output
+
+
 def test_call_json_prints_the_raw_completion_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -226,6 +256,7 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
                     {
                         "id": "coding",
                         "object": "model",
+                        "created": 0,
                         "owned_by": "wmo",
                         "wmo": {
                             "alias_revision_id": "revision-one",
@@ -254,6 +285,41 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
     }
     assert _RAW_KEY not in human.output
     assert _RAW_KEY not in raw.output
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    (
+        {"object": "list"},
+        {"object": "list", "data": [{"id": "generic-model", "object": "model"}]},
+    ),
+)
+def test_key_check_rejects_http_200_without_gateway_authority_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    envelope: dict[str, object],
+) -> None:
+    """An unrelated HTTP 200 model list cannot validate a gateway key."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve a malformed or generic OpenAI model-list response."""
+        del request
+        return httpx.Response(200, json=envelope)
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "key", "check", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {
+        "schema_version": 1,
+        "operation": "key.check",
+        "valid": False,
+        "error_code": "invalid_gateway_response",
+        "message": "HTTP 200 did not contain the EXP gateway model-authority response shape.",
+    }
+    assert _RAW_KEY not in result.output
 
 
 def test_key_check_rejects_an_invalid_key_with_the_gateway_remediation(

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -255,6 +255,7 @@ def test_models_prints_the_caller_view_with_granted_revisions(
                 "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
             }
         ],
+        "wmo": {"authority_schema_version": 1},
     }
 
     def respond(request: httpx.Request) -> httpx.Response:
@@ -298,6 +299,7 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
                         },
                     }
                 ],
+                "wmo": {"authority_schema_version": 1},
             },
         )
 
@@ -355,6 +357,43 @@ def test_key_check_rejects_http_200_without_gateway_authority_shape(
         "message": "HTTP 200 did not contain the EXP gateway model-authority response shape.",
     }
     assert _RAW_KEY not in result.output
+
+
+def test_key_check_accepts_a_gateway_authority_envelope_with_no_grants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marked empty gateway list proves authentication without inventing grants."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve the gateway's authenticated no-grants envelope."""
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [],
+                "wmo": {"authority_schema_version": 1},
+            },
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    human = CliRunner().invoke(app, ["config", "gateway", "key", "check", "--key", _RAW_KEY])
+    raw = CliRunner().invoke(
+        app,
+        ["config", "gateway", "key", "check", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert human.exit_code == 0, human.output
+    assert human.output == (
+        "key valid; no aliases granted (add one with 'exp config gateway grant')\n"
+    )
+    assert raw.exit_code == 0, raw.output
+    assert json.loads(raw.stdout) == {
+        "schema_version": 1,
+        "operation": "key.check",
+        "valid": True,
+        "granted_aliases": [],
+    }
 
 
 def test_key_check_rejects_an_invalid_key_with_the_gateway_remediation(

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -325,6 +325,7 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
     "envelope",
     (
         {"object": "list"},
+        {"object": "list", "data": []},
         {"object": "list", "data": [{"id": "generic-model", "object": "model"}]},
     ),
 )

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -116,6 +116,39 @@ def test_call_surfaces_a_terminal_stream_error_after_http_200(
     assert "gateway error insufficient_quota: quota is exhausted" in result.output
 
 
+@pytest.mark.parametrize(
+    "frames",
+    (
+        'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"partial"}}]}\n\ndata: not-json\n\n',
+    ),
+)
+def test_call_rejects_a_stream_without_the_done_terminal_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    frames: str,
+) -> None:
+    """A clean or malformed premature EOF cannot be reported as success."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve a stream that closes without a valid terminal frame."""
+        del request
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=frames.encode(),
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "call", "coding", "hello", "--key", _RAW_KEY],
+    )
+
+    assert result.exit_code == 1
+    assert "gateway error incomplete_stream" in result.output
+    assert "[DONE] terminal marker" in result.output
+
+
 def test_call_json_prints_the_raw_completion_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 
 import httpx
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from exp.cli.app import app
@@ -212,7 +213,7 @@ def test_missing_key_names_the_exact_ways_to_provide_one() -> None:
     result = CliRunner().invoke(app, ["config", "gateway", "call", "coding", "hello"])
 
     assert result.exit_code == 2
-    normalized = " ".join(result.output.replace("│", " ").split())
+    normalized = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "pass --key" in normalized
     assert "EXP_GATEWAY_KEY" in normalized
     assert "exp config gateway key issue" in normalized
@@ -234,7 +235,7 @@ def test_unreachable_gateway_is_a_usage_error_naming_the_url(
     )
 
     assert result.exit_code == 2
-    normalized = " ".join(result.output.replace("│", " ").split())
+    normalized = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "no gateway answered at http://127.0.0.1:9/v1" in normalized
     assert "exp run" in normalized
 

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -1,0 +1,299 @@
+"""Command-level tests for the caller-side live-gateway core loop."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from exp.cli.app import app
+from exp.cli.gateway import caller
+
+_RAW_KEY = "wmo_vk_caller-secret-canary"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_gateway_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep developer-machine gateway and OpenAI variables out of every test."""
+    for variable in ("EXP_GATEWAY_URL", "OPENAI_BASE_URL", "EXP_GATEWAY_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(variable, raising=False)
+
+
+def _mock_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> list[httpx.Request]:
+    """Route caller HTTP traffic through one in-memory gateway handler.
+
+    Args:
+        monkeypatch: Scoped patch context.
+        handler: Callable answering every request the caller sends.
+
+    Returns:
+        Live list receiving each request the caller sends.
+    """
+    seen: list[httpx.Request] = []
+
+    def build(url: str, *, timeout: float) -> httpx.Client:
+        """Return a mock-backed client that records every outgoing request."""
+        del timeout
+
+        def record(request: httpx.Request) -> httpx.Response:
+            """Capture the request before delegating to the test handler."""
+            seen.append(request)
+            return handler(request)
+
+        return httpx.Client(base_url=url.rstrip("/"), transport=httpx.MockTransport(record))
+
+    monkeypatch.setattr(caller, "_gateway_client", build)
+    return seen
+
+
+def test_call_streams_text_deltas_to_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default call streams SSE deltas and prints only the visible text."""
+    chunks = (
+        {"choices": [{"delta": {"role": "assistant"}}]},
+        {"choices": [{"delta": {"content": "Hello"}}]},
+        {"choices": [{"delta": {"content": " world"}}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+    )
+    frames = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve one streaming completion for the expected authenticated request."""
+        assert request.url.path == "/v1/chat/completions"
+        assert request.headers["Authorization"] == f"Bearer {_RAW_KEY}"
+        payload = json.loads(request.content)
+        assert payload["model"] == "coding"
+        assert payload["stream"] is True
+        assert payload["messages"] == [{"role": "user", "content": "say hello"}]
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=frames.encode(),
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "call", "coding", "say hello", "--key", _RAW_KEY],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "Hello world\n"
+
+
+def test_call_json_prints_the_raw_completion_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The --json form makes one non-streaming call and passes the envelope through."""
+    envelope = {
+        "id": "chatcmpl-one",
+        "object": "chat.completion",
+        "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+    }
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve one completed envelope and require streaming to be disabled."""
+        assert json.loads(request.content)["stream"] is False
+        return httpx.Response(200, json=envelope)
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "call", "coding", "say hello", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == envelope
+
+
+def test_call_surfaces_gateway_error_code_message_and_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gateway error exits nonzero with its code, remediation text, and wait."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve one quota-exhausted error envelope."""
+        del request
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "60"},
+            json={
+                "error": {
+                    "message": "monthly gateway allocation is exhausted.",
+                    "type": "insufficient_quota",
+                    "param": None,
+                    "code": "insufficient_quota",
+                }
+            },
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "call", "coding", "say hello", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert "gateway error insufficient_quota" in result.output
+    assert "monthly gateway allocation is exhausted." in result.output
+    assert "(Retry-After: 60s)" in result.output
+
+
+def test_missing_key_names_the_exact_ways_to_provide_one() -> None:
+    """A missing key is a usage error with every supported source spelled out."""
+    result = CliRunner().invoke(app, ["config", "gateway", "call", "coding", "hello"])
+
+    assert result.exit_code == 2
+    normalized = " ".join(result.output.replace("│", " ").split())
+    assert "pass --key" in normalized
+    assert "EXP_GATEWAY_KEY" in normalized
+    assert "exp config gateway key issue" in normalized
+
+
+def test_unreachable_gateway_is_a_usage_error_naming_the_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection failure names the URL and how to start or select a gateway."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Refuse the connection like an unbound loopback port."""
+        raise httpx.ConnectError("connection refused", request=request)
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "models", "--key", _RAW_KEY, "--url", "http://127.0.0.1:9/v1"],
+    )
+
+    assert result.exit_code == 2
+    normalized = " ".join(result.output.replace("│", " ").split())
+    assert "no gateway answered at http://127.0.0.1:9/v1" in normalized
+    assert "exp run" in normalized
+
+
+def test_models_prints_the_caller_view_with_granted_revisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The live caller view lists each granted alias with its active revision."""
+    envelope = {
+        "object": "list",
+        "data": [
+            {
+                "id": "coding",
+                "object": "model",
+                "created": 0,
+                "owned_by": "wmo",
+                "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+            }
+        ],
+    }
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve the enriched discovery list for the authenticated caller."""
+        assert request.url.path == "/v1/models"
+        assert request.headers["Authorization"] == f"Bearer {_RAW_KEY}"
+        return httpx.Response(200, json=envelope)
+
+    seen = _mock_gateway(monkeypatch, respond)
+    human = CliRunner().invoke(app, ["config", "gateway", "models", "--key", _RAW_KEY])
+    raw = CliRunner().invoke(app, ["config", "gateway", "models", "--key", _RAW_KEY, "--json"])
+
+    assert human.exit_code == 0, human.output
+    assert human.output == "coding (revision revision-one)\n"
+    assert raw.exit_code == 0, raw.output
+    assert json.loads(raw.stdout) == envelope
+    assert len(seen) == 2
+
+
+def test_key_check_reports_granted_aliases_without_echoing_the_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid key prints its grants and never appears in any output."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve one granted alias for the presented key."""
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "coding",
+                        "object": "model",
+                        "owned_by": "wmo",
+                        "wmo": {
+                            "alias_revision_id": "revision-one",
+                            "catalog_sha256": "a" * 64,
+                        },
+                    }
+                ],
+            },
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    human = CliRunner().invoke(app, ["config", "gateway", "key", "check", "--key", _RAW_KEY])
+    raw = CliRunner().invoke(
+        app,
+        ["config", "gateway", "key", "check", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert human.exit_code == 0, human.output
+    assert human.output == "key valid; granted aliases: coding\n"
+    assert raw.exit_code == 0, raw.output
+    assert json.loads(raw.stdout) == {
+        "schema_version": 1,
+        "operation": "key.check",
+        "valid": True,
+        "granted_aliases": ["coding"],
+    }
+    assert _RAW_KEY not in human.output
+    assert _RAW_KEY not in raw.output
+
+
+def test_key_check_rejects_an_invalid_key_with_the_gateway_remediation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An invalid key exits nonzero and relays the gateway's own next action."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        """Serve the gateway's sanitized invalid-key envelope."""
+        del request
+        return httpx.Response(
+            401,
+            json={
+                "error": {
+                    "message": (
+                        "The gateway key is invalid, expired, or revoked. Ask the gateway "
+                        "operator to issue a new virtual key."
+                    ),
+                    "type": "authentication_error",
+                    "param": None,
+                    "code": "invalid_key",
+                }
+            },
+        )
+
+    _mock_gateway(monkeypatch, respond)
+    result = CliRunner().invoke(
+        app,
+        ["config", "gateway", "key", "check", "--key", _RAW_KEY, "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {
+        "schema_version": 1,
+        "operation": "key.check",
+        "valid": False,
+        "error_code": "invalid_key",
+        "message": (
+            "The gateway key is invalid, expired, or revoked. Ask the gateway operator "
+            "to issue a new virtual key."
+        ),
+    }
+    assert _RAW_KEY not in result.output

--- a/exp/cli/tests/openai_compatible_recipes_test.py
+++ b/exp/cli/tests/openai_compatible_recipes_test.py
@@ -1,0 +1,211 @@
+"""Verification of the documented Fireworks and Modal openai-compatible recipes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from exp.cli.app import app
+
+FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1"
+_RECIPES_DOC = Path(__file__).parents[3] / "docs" / "reference" / "openai-compatible-recipes.md"
+
+
+def _author_connection_and_alias(
+    root: Path,
+    *,
+    connection: str,
+    base_url: str | None,
+    credential_env: str,
+    model: str,
+    exact_model: str,
+    alias: str,
+    capability_flags: tuple[str, ...] = (),
+) -> None:
+    """Author one openai-compatible connection, alias, identity, and grant.
+
+    Args:
+        root: Temporary EXP root receiving gateway state.
+        connection: Provider connection name.
+        base_url: Optional endpoint base URL exactly as the recipe documents it.
+        credential_env: Credential environment variable name.
+        model: Provider-side model ID for the deployment.
+        exact_model: Stable operator-asserted logical model identity.
+        alias: Public gateway alias to create and grant.
+        capability_flags: Extra alias-create capability and price flags.
+    """
+    runner = CliRunner()
+    base_url_arguments = [] if base_url is None else ["--base-url", base_url]
+    commands = (
+        ["config", "gateway", "init", "--root", str(root), "--json"],
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            connection,
+            "--provider",
+            "openai-compatible",
+            *base_url_arguments,
+            "--credential-env",
+            credential_env,
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            alias,
+            "--deployment",
+            f"{connection}:{model}",
+            "--exact-model",
+            exact_model,
+            *capability_flags,
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "identity",
+            "create",
+            "default",
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "grant",
+            "add",
+            "default",
+            alias,
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    for command in commands:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0, result.output
+
+
+def test_fireworks_recipe_reaches_gateway_readiness_without_a_provider_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented Fireworks recipe authors a servable alias as written."""
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fireworks-secret-canary")
+    _author_connection_and_alias(
+        tmp_path,
+        connection="fireworks",
+        base_url=FIREWORKS_BASE_URL,
+        credential_env="FIREWORKS_API_KEY",
+        model="accounts/fireworks/models/recipe-model",
+        exact_model="recipe-model",
+        alias="coding",
+        capability_flags=(
+            "--supports-tools",
+            "--supports-structured-output",
+            "--input-price",
+            "900000",
+            "--output-price",
+            "900000",
+            "--pricing-source",
+            "https://fireworks.ai/pricing",
+        ),
+    )
+
+    readiness = CliRunner().invoke(
+        app,
+        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+    )
+
+    assert readiness.exit_code == 0, readiness.output
+    assert json.loads(readiness.stdout)["status"] == "ready"
+    assert "fireworks-secret-canary" not in readiness.stdout
+
+
+def test_modal_recipe_fails_closed_without_its_deployment_base_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Modal connection is unavailable until its explicit base_url is configured."""
+    monkeypatch.setenv("MODAL_API_KEY", "modal-secret-canary")
+    _author_connection_and_alias(
+        tmp_path,
+        connection="modal-vllm",
+        base_url=None,
+        credential_env="MODAL_API_KEY",
+        model="recipe-served-model",
+        exact_model="recipe-served-model",
+        alias="local-serve",
+    )
+
+    readiness = CliRunner().invoke(
+        app,
+        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+    )
+
+    assert readiness.exit_code == 2
+    assert "local-serve" in readiness.output
+
+
+def test_modal_recipe_reaches_readiness_with_its_deployment_base_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented Modal recipe is servable once base_url names the deployment."""
+    monkeypatch.setenv("MODAL_API_KEY", "modal-secret-canary")
+    _author_connection_and_alias(
+        tmp_path,
+        connection="modal-vllm",
+        base_url="https://workspace--app-label.modal.run/v1",
+        credential_env="MODAL_API_KEY",
+        model="recipe-served-model",
+        exact_model="recipe-served-model",
+        alias="local-serve",
+        capability_flags=(
+            "--input-price",
+            "0",
+            "--output-price",
+            "0",
+            "--pricing-source",
+            "self-hosted Modal deployment",
+        ),
+    )
+
+    readiness = CliRunner().invoke(
+        app,
+        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+    )
+
+    assert readiness.exit_code == 0, readiness.output
+    assert json.loads(readiness.stdout)["status"] == "ready"
+
+
+def test_recipes_doc_pins_the_verified_constants_and_is_indexed() -> None:
+    """The published recipe doc and this verification stay in exact agreement."""
+    doc = _RECIPES_DOC.read_text(encoding="utf-8")
+    index = (_RECIPES_DOC.parents[1] / "README.md").read_text(encoding="utf-8")
+
+    assert FIREWORKS_BASE_URL in doc
+    assert "FIREWORKS_API_KEY" in doc
+    assert "accounts/fireworks/models/" in doc
+    assert ".modal.run" in doc
+    assert "exp config gateway provider add" in doc
+    assert "--provider openai-compatible" in doc.replace(" \\\n  ", " ")
+    assert "exp/cli/tests/openai_compatible_recipes_test.py" in doc
+    assert "`reference/openai-compatible-recipes.md`" in index

--- a/exp/runtime/gateway/discovery.py
+++ b/exp/runtime/gateway/discovery.py
@@ -8,6 +8,9 @@ from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 AliasAuthority = tuple[str, str, str]
 """Granted alias name, active revision, and catalog digest."""
 
+MODEL_AUTHORITY_SCHEMA_VERSION = 1
+"""Version of the gateway-specific model-list authority envelope."""
+
 
 def public_model_object(authority: AliasAuthority) -> JsonObject:
     """Build one OpenAI model object enriched with the granted alias authority.
@@ -29,6 +32,22 @@ def public_model_object(authority: AliasAuthority) -> JsonObject:
         "created": 0,
         "owned_by": "wmo",
         "wmo": {"alias_revision_id": revision, "catalog_sha256": digest},
+    }
+
+
+def public_model_list(authorities: tuple[AliasAuthority, ...]) -> JsonObject:
+    """Build a caller model list with an authority marker even when it is empty.
+
+    Args:
+        authorities: Granted alias, revision, and catalog digest triples.
+
+    Returns:
+        OpenAI-compatible model-list envelope with the gateway authority marker.
+    """
+    return {
+        "object": "list",
+        "data": [public_model_object(authority) for authority in authorities],
+        "wmo": {"authority_schema_version": MODEL_AUTHORITY_SCHEMA_VERSION},
     }
 
 

--- a/exp/runtime/gateway/discovery.py
+++ b/exp/runtime/gateway/discovery.py
@@ -1,0 +1,63 @@
+"""Caller-facing model discovery objects for the gateway HTTP boundary."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+AliasAuthority = tuple[str, str, str]
+"""Granted alias name, active revision, and catalog digest."""
+
+
+def public_model_object(authority: AliasAuthority) -> JsonObject:
+    """Build one OpenAI model object enriched with the granted alias authority.
+
+    The four OpenAI keys keep their exact meaning for official clients; the ``wmo``
+    object carries only authority metadata the gateway already exposes to callers
+    through response headers and grants, never provider or credential detail.
+
+    Args:
+        authority: Granted alias, active revision, and catalog digest triple.
+
+    Returns:
+        JSON-compatible public model object.
+    """
+    alias, revision, digest = authority
+    return {
+        "id": alias,
+        "object": "model",
+        "created": 0,
+        "owned_by": "wmo",
+        "wmo": {"alias_revision_id": revision, "catalog_sha256": digest},
+    }
+
+
+def require_granted_authority(
+    authorities: tuple[AliasAuthority, ...],
+    model_id: str,
+) -> AliasAuthority:
+    """Return one granted alias authority without confirming ungranted aliases.
+
+    Args:
+        authorities: Every authority granted to the presented key.
+        model_id: Public model alias requested by the caller.
+
+    Returns:
+        The matching granted authority.
+
+    Raises:
+        OpenAIProtocolError: The alias is unknown or not granted to this key; both
+            cases raise the identical 404 so the route is not an existence oracle.
+    """
+    for authority in authorities:
+        if authority[0] == model_id:
+            return authority
+    raise OpenAIProtocolError(
+        status_code=404,
+        code="model_not_found",
+        message=(
+            "The requested model does not exist or is not granted to this key. "
+            "GET /v1/models lists the model aliases available to this key."
+        ),
+        param="model",
+    )

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -1,0 +1,43 @@
+"""Tests for caller-facing model discovery objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.gateway.discovery import public_model_object, require_granted_authority
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+_AUTHORITY = ("coding", "revision-one", "a" * 64)
+
+
+def test_public_model_object_keeps_the_openai_keys_and_adds_authority() -> None:
+    """The enriched object stays a valid OpenAI model for official clients."""
+    assert public_model_object(_AUTHORITY) == {
+        "id": "coding",
+        "object": "model",
+        "created": 0,
+        "owned_by": "wmo",
+        "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+    }
+
+
+def test_require_granted_authority_returns_the_exact_granted_triple() -> None:
+    """A granted alias resolves to its own frozen authority."""
+    assert require_granted_authority((_AUTHORITY,), "coding") == _AUTHORITY
+
+
+def test_unknown_and_ungranted_aliases_raise_the_identical_404() -> None:
+    """The 404 never distinguishes an unknown alias from an ungranted one."""
+    with pytest.raises(OpenAIProtocolError) as ungranted:
+        require_granted_authority((_AUTHORITY,), "other-model")
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        require_granted_authority((), "coding")
+
+    assert ungranted.value.status_code == 404
+    assert ungranted.value.detail == unknown.value.detail
+    assert ungranted.value.detail.code == "model_not_found"
+    assert "other-model" not in ungranted.value.detail.message
+    assert (
+        "GET /v1/models lists the model aliases available to this key."
+        in ungranted.value.detail.message
+    )

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from exp.runtime.gateway.discovery import public_model_object, require_granted_authority
+from exp.runtime.gateway.discovery import (
+    public_model_list,
+    public_model_object,
+    require_granted_authority,
+)
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 _AUTHORITY = ("coding", "revision-one", "a" * 64)
@@ -18,6 +22,15 @@ def test_public_model_object_keeps_the_openai_keys_and_adds_authority() -> None:
         "created": 0,
         "owned_by": "wmo",
         "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+    }
+
+
+def test_public_model_list_marks_even_an_empty_authority_envelope() -> None:
+    """The caller can identify an authenticated gateway with no granted aliases."""
+    assert public_model_list(()) == {
+        "object": "list",
+        "data": [],
+        "wmo": {"authority_schema_version": 1},
     }
 
 

--- a/exp/runtime/gateway/interfaces.py
+++ b/exp/runtime/gateway/interfaces.py
@@ -42,6 +42,10 @@ class GatewayControlStore(Protocol):
         """Return active aliases explicitly granted to the key-derived identity."""
         ...
 
+    def granted_alias_authorities(self, *, raw_key: str) -> tuple[tuple[str, str, str], ...]:
+        """Return granted alias, active revision, and catalog digest triples."""
+        ...
+
 
 class SecretResolver(Protocol):
     """Late-bound resolver for opaque provider credential references."""

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -119,7 +119,13 @@ class _ReadyControlStore:
     def granted_aliases(self, *, raw_key: str) -> tuple[str, ...]:
         """Return granted aliases that were ready in this process snapshot."""
         return tuple(
-            alias
+            alias for alias, _revision, _digest in self.granted_alias_authorities(raw_key=raw_key)
+        )
+
+    def granted_alias_authorities(self, *, raw_key: str) -> tuple[tuple[str, str, str], ...]:
+        """Return granted authority triples that were ready in this process snapshot."""
+        return tuple(
+            (alias, revision, digest)
             for alias, revision, digest in self.store.granted_alias_authorities(raw_key=raw_key)
             if (alias, revision, digest) in self.authorities
         )

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -244,6 +244,21 @@ def test_local_gateway_preflights_real_state_and_serves_health_and_usage(
         )
         assert models.status_code == 200
         assert [item["id"] for item in models.json()["data"]] == ["coding"]
+        detail = client.get(
+            "/v1/models/coding",
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert detail.status_code == 200
+        assert detail.json() == models.json()["data"][0]
+        assert detail.json()["object"] == "model"
+        assert detail.json()["wmo"]["alias_revision_id"]
+        assert detail.json()["wmo"]["catalog_sha256"]
+        missing = client.get(
+            "/v1/models/ungranted",
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert missing.status_code == 404
+        assert missing.json()["error"]["code"] == "model_not_found"
         usage = client.get("/usage.json")
         page = client.get("/usage")
 

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -26,6 +26,7 @@ from exp.runtime.gateway.contracts import (
     GatewayFailureClass,
     GatewayRequest,
 )
+from exp.runtime.gateway.discovery import public_model_object, require_granted_authority
 from exp.runtime.gateway.execution import (
     GatewayExecutionError,
     GatewayExecutionStream,
@@ -237,6 +238,17 @@ class GatewayService:
     def models(self, *, raw_key: str) -> tuple[str, ...]:
         """Return only aliases granted to one authenticated key-derived identity."""
         return self._control.granted_aliases(raw_key=raw_key)
+
+    def model_authorities(self, *, raw_key: str) -> tuple[tuple[str, str, str], ...]:
+        """Return granted alias, revision, and catalog digest triples for one key."""
+        return self._control.granted_alias_authorities(raw_key=raw_key)
+
+    def model_authority(self, *, raw_key: str, model_id: str) -> tuple[str, str, str]:
+        """Return one granted alias authority or raise the shared no-oracle 404."""
+        return require_granted_authority(
+            self._control.granted_alias_authorities(raw_key=raw_key),
+            model_id,
+        )
 
     def authenticate(self, *, raw_key: str) -> None:
         """Authenticate a key before the HTTP boundary performs full protocol decoding."""
@@ -639,16 +651,26 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         """List only aliases granted to the presented virtual key."""
         try:
             raw_key = _bearer_key(authorization)
-            aliases = service.models(raw_key=raw_key)
+            authorities = service.model_authorities(raw_key=raw_key)
             return JSONResponse(
                 {
                     "object": "list",
-                    "data": [
-                        {"id": alias, "object": "model", "created": 0, "owned_by": "exp"}
-                        for alias in aliases
-                    ],
+                    "data": [public_model_object(authority) for authority in authorities],
                 }
             )
+        except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
+            return _exception_response(exc)
+
+    @app.get("/v1/models/{model_id}")
+    async def model_detail(
+        model_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> Response:
+        """Describe one granted alias, answering 404 for every other model ID."""
+        try:
+            raw_key = _bearer_key(authorization)
+            authority = service.model_authority(raw_key=raw_key, model_id=model_id)
+            return JSONResponse(public_model_object(authority))
         except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
             return _exception_response(exc)
 

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -26,7 +26,11 @@ from exp.runtime.gateway.contracts import (
     GatewayFailureClass,
     GatewayRequest,
 )
-from exp.runtime.gateway.discovery import public_model_object, require_granted_authority
+from exp.runtime.gateway.discovery import (
+    public_model_list,
+    public_model_object,
+    require_granted_authority,
+)
 from exp.runtime.gateway.execution import (
     GatewayExecutionError,
     GatewayExecutionStream,
@@ -652,12 +656,7 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         try:
             raw_key = _bearer_key(authorization)
             authorities = service.model_authorities(raw_key=raw_key)
-            return JSONResponse(
-                {
-                    "object": "list",
-                    "data": [public_model_object(authority) for authority in authorities],
-                }
-            )
+            return JSONResponse(public_model_list(authorities))
         except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
             return _exception_response(exc)
 

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -74,6 +74,7 @@ from exp.runtime.openai_protocol.state import (
 from exp.runtime.openai_protocol.streaming import stable_public_id
 
 _STREAM_REPLAY_CAPTURE_BYTES = 64 * 1024 * 1024
+_DRAINING_RETRY_AFTER_SECONDS = 10
 
 
 class GatewayDrainingError(RuntimeError):
@@ -497,7 +498,10 @@ class GatewayService:
                         raise OpenAIProtocolError(
                             status_code=500,
                             code="idempotency_replay_unavailable",
-                            message="The completed stream exceeds the bounded replay cache.",
+                            message=(
+                                "The completed stream exceeds the bounded replay cache. "
+                                "Resend without an Idempotency-Key or request less output."
+                            ),
                             error_type="api_error",
                         )
             for data in terminal_frames:
@@ -704,13 +708,13 @@ async def _dispatch(
             raise OpenAIProtocolError(
                 status_code=400,
                 code="invalid_json",
-                message="Request body must contain valid JSON.",
+                message="Request body must contain valid JSON. Re-encode the payload and resend.",
             ) from exc
         if not isinstance(payload, dict):
             raise OpenAIProtocolError(
                 status_code=400,
                 code="invalid_request",
-                message="Request body must be a JSON object.",
+                message="Request body must be a JSON object. Re-encode the payload and resend.",
             )
         decoded = decoder(
             cast(JsonObject, payload),
@@ -731,7 +735,10 @@ def _bearer_key(value: str | None) -> str:
         raise OpenAIProtocolError(
             status_code=401,
             code="invalid_key",
-            message="A valid gateway Bearer key is required.",
+            message=(
+                "A valid gateway Bearer key is required. Send the virtual key as "
+                "'Authorization: Bearer <key>'."
+            ),
             error_type="authentication_error",
         )
     return value[7:].strip()
@@ -746,14 +753,20 @@ def _exception_response(exception: BaseException) -> Response:
         error = OpenAIProtocolError(
             status_code=401,
             code="invalid_key",
-            message="The gateway key is invalid, expired, or revoked.",
+            message=(
+                "The gateway key is invalid, expired, or revoked. Ask the gateway operator "
+                "to issue a new virtual key."
+            ),
             error_type="authentication_error",
         )
     elif isinstance(exception, AliasNotGrantedError):
         error = OpenAIProtocolError(
             status_code=403,
             code="model_not_granted",
-            message="The requested model alias is not granted to this identity.",
+            message=(
+                "The requested model alias is not granted to this identity. "
+                "GET /v1/models lists the model aliases available to this key."
+            ),
             error_type="permission_error",
             param="model",
         )
@@ -761,14 +774,20 @@ def _exception_response(exception: BaseException) -> Response:
         error = OpenAIProtocolError(
             status_code=409,
             code="idempotency_conflict",
-            message="The caller operation was reused with different request content.",
+            message=(
+                "The caller operation was reused with different request content. "
+                "Send a new Idempotency-Key for each distinct request."
+            ),
             param="Idempotency-Key",
         )
     elif isinstance(exception, IdempotencyReplayUnavailableError):
         error = OpenAIProtocolError(
             status_code=409,
             code="idempotency_replay_unavailable",
-            message="The completed keyed result is unavailable after restart.",
+            message=(
+                "The completed keyed result is unavailable after restart. "
+                "Resend the request with a new Idempotency-Key."
+            ),
             error_type="api_error",
             param="Idempotency-Key",
         )
@@ -778,7 +797,10 @@ def _exception_response(exception: BaseException) -> Response:
         error = public_failure_error(
             GatewayFailure(
                 failure_class=GatewayFailureClass.TIMEOUT,
-                safe_message="Gateway request deadline exceeded.",
+                safe_message=(
+                    "Gateway request deadline exceeded. Retry with a shorter prompt "
+                    "or a smaller max_tokens value."
+                ),
             )
         )
     elif isinstance(exception, (GatewayRoutingError, GatewayStoreError)):
@@ -790,9 +812,13 @@ def _exception_response(exception: BaseException) -> Response:
                 else "invalid_request"
             ),
             message=(
-                "The authorized model route is unavailable."
+                "The authorized model route is unavailable. Retry after a short delay; "
+                "if this persists, ask the gateway operator to check the alias deployments."
                 if isinstance(exception, GatewayRoutingError)
-                else "The gateway request is invalid."
+                else (
+                    "The gateway request is invalid. Verify the model alias and request "
+                    "fields, then resend."
+                )
             ),
             error_type=(
                 "api_error"
@@ -804,31 +830,44 @@ def _exception_response(exception: BaseException) -> Response:
         error = OpenAIProtocolError(
             status_code=502,
             code="provider_output_too_large",
-            message="Provider output exceeded the gateway response limit.",
+            message=(
+                "Provider output exceeded the gateway response limit. "
+                "Request less output, for example with a lower max_tokens value."
+            ),
             error_type="api_error",
         )
     elif isinstance(exception, asyncio.CancelledError):
         error = OpenAIProtocolError(
             status_code=499,
             code="request_cancelled",
-            message="The gateway request was cancelled.",
+            message=(
+                "The gateway request was cancelled. Resend the request if cancellation "
+                "was not intended."
+            ),
             error_type="api_error",
         )
     elif isinstance(exception, GatewayDrainingError):
         error = OpenAIProtocolError(
             status_code=503,
             code="gateway_draining",
-            message="The gateway is draining and is not accepting new requests.",
+            message=(
+                "The gateway is draining and is not accepting new requests. "
+                "Retry after the delay in the Retry-After header."
+            ),
             error_type="api_error",
+            retry_after_seconds=_DRAINING_RETRY_AFTER_SECONDS,
         )
     else:
         error = OpenAIProtocolError(
             status_code=500,
             code="internal_error",
-            message="The gateway request failed.",
+            message=(
+                "The gateway request failed. Retry the request; if this persists, "
+                "ask the gateway operator to inspect the server logs."
+            ),
             error_type="api_error",
         )
-    return JSONResponse(error.json_body(), status_code=error.status_code)
+    return JSONResponse(error.json_body(), status_code=error.status_code, headers=error.headers())
 
 
 def _protocol_namespace(authorization: AuthorizationSnapshot) -> ProtocolNamespace:

--- a/exp/runtime/gateway/service_test.py
+++ b/exp/runtime/gateway/service_test.py
@@ -1,0 +1,100 @@
+"""Tests for sanitized HTTP boundary error responses of the gateway service."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import Response
+
+from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.runtime.gateway.execution import GatewayExecutionError
+from exp.runtime.gateway.service import GatewayDrainingError, _exception_response
+from exp.runtime.gateway.sqlite.store import AliasNotGrantedError, InvalidVirtualKeyError
+
+
+def _decoded_error(response: Response) -> dict[str, str | None]:
+    """Return the OpenAI error object carried by one boundary response.
+
+    Args:
+        response: Boundary JSON response under test.
+
+    Returns:
+        Decoded ``error`` object.
+    """
+    body = json.loads(bytes(response.body))
+    return body["error"]
+
+
+def test_ungranted_alias_points_the_caller_at_the_models_route() -> None:
+    """A denied alias states the failure and the exact discovery request."""
+    response = _exception_response(AliasNotGrantedError("alias is not granted"))
+
+    error = _decoded_error(response)
+    assert response.status_code == 403
+    assert error["code"] == "model_not_granted"
+    assert error["message"] is not None
+    assert "GET /v1/models lists the model aliases available to this key." in error["message"]
+    assert "Retry-After" not in response.headers
+
+
+def test_draining_gateway_advertises_a_retry_after_wait() -> None:
+    """Draining is a temporary condition and says exactly how to proceed."""
+    response = _exception_response(GatewayDrainingError("gateway is draining"))
+
+    error = _decoded_error(response)
+    assert response.status_code == 503
+    assert error["code"] == "gateway_draining"
+    assert response.headers["Retry-After"] == "10"
+    assert error["message"] is not None
+    assert "Retry after the delay in the Retry-After header." in error["message"]
+
+
+def test_throttled_execution_failure_carries_a_retry_after_header() -> None:
+    """A provider 429 surfaces its frozen code plus a bounded advertised wait."""
+    response = _exception_response(
+        GatewayExecutionError(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.THROTTLED,
+                safe_message=(
+                    "provider throttled the request; retry after the delay in the "
+                    "Retry-After header"
+                ),
+            )
+        )
+    )
+
+    error = _decoded_error(response)
+    assert response.status_code == 429
+    assert error["code"] == "unavailable_route"
+    assert response.headers["Retry-After"] == "5"
+
+
+def test_quota_exhaustion_reports_the_utc_reset_boundary() -> None:
+    """Monthly exhaustion includes the reset time and a Retry-After wait."""
+    response = _exception_response(
+        GatewayExecutionError(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+                safe_message="monthly gateway allocation is exhausted",
+            )
+        )
+    )
+
+    error = _decoded_error(response)
+    assert response.status_code == 429
+    assert error["code"] == "insufficient_quota"
+    assert error["message"] is not None
+    assert "The allocation resets at " in error["message"]
+    assert int(response.headers["Retry-After"]) >= 1
+
+
+def test_invalid_key_states_the_recovery_path_without_key_material() -> None:
+    """An invalid key failure explains issuance without echoing any credential."""
+    response = _exception_response(InvalidVirtualKeyError("wmo_vk_canary rejected"))
+
+    error = _decoded_error(response)
+    assert response.status_code == 401
+    assert error["code"] == "invalid_key"
+    assert error["message"] is not None
+    assert "issue a new virtual key" in error["message"]
+    assert "wmo_vk_canary" not in json.dumps(_decoded_error(response))

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -131,6 +131,11 @@ class _ControlStore:
         self.raw_keys_seen.append(raw_key)
         return ("public-model",)
 
+    def granted_alias_authorities(self, *, raw_key: str) -> tuple[tuple[str, str, str], ...]:
+        """Return the only granted alias with its frozen revision and digest."""
+        self.raw_keys_seen.append(raw_key)
+        return (("public-model", "revision-one", self._catalog_sha256),)
+
 
 class _Ledger:
     """Capture content-free request and attempt accounting calls."""
@@ -1372,5 +1377,45 @@ def test_cancelling_terminal_delivery_preserves_completed_keyed_replay() -> None
         assert replay.status_code == 200
         assert b"response.completed" in replay.body
         assert len(provider.streams) == 1
+
+    asyncio.run(scenario())
+
+
+def test_model_discovery_is_enriched_and_detail_is_not_an_existence_oracle() -> None:
+    """Discovery lists granted authority metadata; every other model ID is one 404."""
+
+    async def scenario() -> None:
+        """Exercise the models list and detail routes on a dedicated event loop."""
+        provider = _Provider(lambda: _EventStream(()))
+        service, _control, _ledger, _proof = _service(provider)
+        digest = _catalog()[0].identity_sha256()
+        expected = {
+            "id": "public-model",
+            "object": "model",
+            "created": 0,
+            "owned_by": "wmo",
+            "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
+        }
+        transport = httpx.ASGITransport(app=create_gateway_app(service))
+        async with httpx.AsyncClient(transport=transport, base_url="http://gateway") as client:
+            headers = {"authorization": "Bearer caller-secret"}
+            listed = await client.get("/v1/models", headers=headers)
+            granted = await client.get("/v1/models/public-model", headers=headers)
+            ungranted = await client.get("/v1/models/other-model", headers=headers)
+            unauthenticated = await client.get("/v1/models/public-model")
+
+        assert listed.status_code == 200
+        assert listed.json() == {"object": "list", "data": [expected]}
+        assert granted.status_code == 200
+        assert granted.json() == expected
+        assert ungranted.status_code == 404
+        error = ungranted.json()["error"]
+        assert error["code"] == "model_not_found"
+        assert error["param"] == "model"
+        assert "does not exist or is not granted" in error["message"]
+        assert "GET /v1/models lists the model aliases available to this key." in error["message"]
+        assert "other-model" not in error["message"]
+        assert unauthenticated.status_code == 401
+        assert len(provider.streams) == 0
 
     asyncio.run(scenario())

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -1405,7 +1405,11 @@ def test_model_discovery_is_enriched_and_detail_is_not_an_existence_oracle() -> 
             unauthenticated = await client.get("/v1/models/public-model")
 
         assert listed.status_code == 200
-        assert listed.json() == {"object": "list", "data": [expected]}
+        assert listed.json() == {
+            "object": "list",
+            "data": [expected],
+            "wmo": {"authority_schema_version": 1},
+        }
         assert granted.status_code == 200
         assert granted.json() == expected
         assert ungranted.status_code == 404

--- a/exp/runtime/models/providers/errors.py
+++ b/exp/runtime/models/providers/errors.py
@@ -77,24 +77,33 @@ def normalized_provider_failure(exception: BaseException) -> GatewayFailure:
     if isinstance(exception, asyncio.CancelledError):
         return GatewayFailure(
             failure_class=GatewayFailureClass.CANCELLED,
-            safe_message="provider request was cancelled",
+            safe_message=(
+                "provider request was cancelled; resend the request if cancellation "
+                "was not intended"
+            ),
         )
     if isinstance(exception, ProviderDeadlineExceeded):
         return GatewayFailure(
             failure_class=GatewayFailureClass.TIMEOUT,
-            safe_message="provider request deadline exceeded",
+            safe_message=(
+                "provider request deadline exceeded; retry with a shorter prompt "
+                "or a smaller max_tokens value"
+            ),
             failover_eligible=True,
         )
     if isinstance(exception, ProviderRefusalError):
         return GatewayFailure(
             failure_class=GatewayFailureClass.REFUSAL,
-            safe_message="provider refused the request",
+            safe_message="provider refused the request; revise the request content and retry",
             safe_details={"signal": exception.signal.value},
         )
     if isinstance(exception, ProviderCapabilityError):
         return GatewayFailure(
             failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
-            safe_message="provider deployment cannot preserve the requested capability",
+            safe_message=(
+                "provider deployment cannot preserve the requested capability; remove the "
+                "unsupported field or request a different model alias"
+            ),
             safe_details={"capability": exception.capability},
         )
     if isinstance(exception, ProviderTransportError):
@@ -102,12 +111,12 @@ def normalized_provider_failure(exception: BaseException) -> GatewayFailure:
     if isinstance(exception, ProviderResponseError):
         return GatewayFailure(
             failure_class=GatewayFailureClass.MALFORMED_RESPONSE,
-            safe_message="provider returned a malformed response",
+            safe_message="provider returned a malformed response; retry the request",
             failover_eligible=True,
         )
     return GatewayFailure(
         failure_class=GatewayFailureClass.INTERNAL,
-        safe_message="provider execution failed",
+        safe_message="provider execution failed; retry the request",
     )
 
 
@@ -126,28 +135,36 @@ def _transport_failure(status_code: int | None) -> GatewayFailure:
     if status_code in {401, 403}:
         return GatewayFailure(
             failure_class=GatewayFailureClass.PROVIDER_AUTHENTICATION,
-            safe_message="provider authentication failed",
+            safe_message=(
+                "provider authentication failed; ask the gateway operator to verify "
+                "the provider connection credential"
+            ),
             failover_eligible=True,
             safe_details=details,
         )
     if status_code == 404:
         return GatewayFailure(
             failure_class=GatewayFailureClass.PROVIDER_NOT_FOUND,
-            safe_message="provider deployment was not found",
+            safe_message=(
+                "provider deployment was not found; ask the gateway operator to verify "
+                "the deployment model ID in the catalog"
+            ),
             failover_eligible=True,
             safe_details=details,
         )
     if status_code == 429:
         return GatewayFailure(
             failure_class=GatewayFailureClass.THROTTLED,
-            safe_message="provider throttled the request",
+            safe_message=(
+                "provider throttled the request; retry after the delay in the Retry-After header"
+            ),
             failover_eligible=True,
             safe_details=details,
         )
     if status_code == 408:
         return GatewayFailure(
             failure_class=GatewayFailureClass.TIMEOUT,
-            safe_message="provider request timed out",
+            safe_message="provider request timed out; retry the request",
             retryable_same_deployment=True,
             failover_eligible=True,
             safe_details=details,
@@ -155,7 +172,7 @@ def _transport_failure(status_code: int | None) -> GatewayFailure:
     if status_code is not None and status_code >= 500:
         return GatewayFailure(
             failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
-            safe_message="provider service failed",
+            safe_message="provider service failed; retry after a short delay",
             retryable_same_deployment=True,
             failover_eligible=True,
             safe_details=details,
@@ -163,12 +180,15 @@ def _transport_failure(status_code: int | None) -> GatewayFailure:
     if status_code is not None:
         return GatewayFailure(
             failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
-            safe_message="provider rejected the request",
+            safe_message=(
+                "provider rejected the request; verify the request fields against "
+                "the model alias capabilities"
+            ),
             safe_details=details,
         )
     return GatewayFailure(
         failure_class=GatewayFailureClass.TRANSPORT,
-        safe_message="provider transport failed",
+        safe_message="provider transport failed; retry the request",
         retryable_same_deployment=True,
         failover_eligible=True,
     )

--- a/exp/runtime/models/providers/errors_test.py
+++ b/exp/runtime/models/providers/errors_test.py
@@ -90,6 +90,66 @@ def test_refusal_and_capability_failures_keep_only_safe_signals() -> None:
     assert capability.safe_details == {"capability": "strict_tools"}
 
 
+@pytest.mark.parametrize(
+    ("exception", "safe_message"),
+    [
+        (
+            ProviderTransportError("raw auth canary", status_code=401),
+            "provider authentication failed; ask the gateway operator to verify "
+            "the provider connection credential",
+        ),
+        (
+            ProviderTransportError("raw missing canary", status_code=404),
+            "provider deployment was not found; ask the gateway operator to verify "
+            "the deployment model ID in the catalog",
+        ),
+        (
+            ProviderTransportError("raw throttle canary", status_code=429),
+            "provider throttled the request; retry after the delay in the Retry-After header",
+        ),
+        (
+            ProviderTransportError("raw slow canary", status_code=408),
+            "provider request timed out; retry the request",
+        ),
+        (
+            ProviderTransportError("raw server canary", status_code=503),
+            "provider service failed; retry after a short delay",
+        ),
+        (
+            ProviderTransportError("raw reject canary", status_code=422),
+            "provider rejected the request; verify the request fields against "
+            "the model alias capabilities",
+        ),
+        (
+            ProviderTransportError("raw body canary"),
+            "provider transport failed; retry the request",
+        ),
+        (
+            ProviderDeadlineExceeded("raw deadline canary"),
+            "provider request deadline exceeded; retry with a shorter prompt "
+            "or a smaller max_tokens value",
+        ),
+        (
+            ProviderResponseError("raw response canary"),
+            "provider returned a malformed response; retry the request",
+        ),
+        (
+            RuntimeError("raw internal canary"),
+            "provider execution failed; retry the request",
+        ),
+    ],
+)
+def test_safe_messages_state_the_failure_and_the_next_action(
+    exception: BaseException,
+    safe_message: str,
+) -> None:
+    """Every public message says what failed and exactly what to do next."""
+    failure = normalized_provider_failure(exception)
+
+    assert failure.safe_message == safe_message
+    assert "canary" not in failure.model_dump_json()
+
+
 def test_cancellation_has_a_dedicated_nonretryable_failure() -> None:
     """Client disconnect cancellation must not be retried or made failover eligible."""
     failure = normalized_provider_failure(asyncio.CancelledError())

--- a/exp/runtime/openai_protocol/errors.py
+++ b/exp/runtime/openai_protocol/errors.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import math
+from datetime import UTC, datetime
 from typing import Literal
 
 from pydantic import Field
 
 from exp.common.core.artifacts import ContractModel, JsonObject
 from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+
+THROTTLED_RETRY_AFTER_SECONDS = 5
 
 
 class OpenAIErrorDetail(ContractModel):
@@ -48,6 +52,7 @@ class OpenAIProtocolError(ValueError):
             "api_error",
         ] = "invalid_request_error",
         param: str | None = None,
+        retry_after_seconds: int | None = None,
     ) -> None:
         """Create one sanitized public protocol failure.
 
@@ -57,9 +62,13 @@ class OpenAIProtocolError(ValueError):
             message: Display-safe explanation and remediation.
             error_type: OpenAI error category.
             param: Exact public request field responsible for the error.
+            retry_after_seconds: Optional positive wait advertised as ``Retry-After``.
         """
+        if retry_after_seconds is not None and retry_after_seconds <= 0:
+            raise ValueError("retry_after_seconds must be positive")
         super().__init__(message)
         self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
         self.detail = OpenAIErrorDetail(
             message=message,
             type=error_type,
@@ -74,6 +83,12 @@ class OpenAIProtocolError(ValueError):
     def json_body(self) -> JsonObject:
         """Return a JSON-compatible body suitable for an HTTP response."""
         return self.envelope().model_dump(mode="json")
+
+    def headers(self) -> dict[str, str]:
+        """Return transport headers implied by this error, such as ``Retry-After``."""
+        if self.retry_after_seconds is None:
+            return {}
+        return {"Retry-After": str(self.retry_after_seconds)}
 
 
 def invalid_field(param: str, message: str | None = None) -> OpenAIProtocolError:
@@ -109,19 +124,30 @@ def unsupported_field(param: str, *, capability: bool = False) -> OpenAIProtocol
     return OpenAIProtocolError(
         status_code=400,
         code=code,
-        message=f"The {noun} '{param}' is not supported by this gateway profile.",
+        message=(
+            f"The {noun} '{param}' is not supported by this gateway profile. "
+            "Remove the field and resend the request."
+        ),
         param=param,
     )
 
 
 def public_failure_error(
-    failure: GatewayFailure, *, param: str | None = None
+    failure: GatewayFailure,
+    *,
+    param: str | None = None,
+    now: datetime | None = None,
 ) -> OpenAIProtocolError:
     """Map one sanitized gateway failure to a stable public error.
+
+    Quota exhaustion and provider throttling advertise a ``Retry-After`` wait. Gateway
+    budgets are hard UTC-calendar-month allocations, so an exhausted quota reports the
+    exact next month boundary as its reset time.
 
     Args:
         failure: Provider-neutral failure already stripped of sensitive details.
         param: Optional request field responsible for the failure.
+        now: Injectable current UTC time used only to compute the quota reset boundary.
 
     Returns:
         OpenAI-shaped protocol error with no raw provider data.
@@ -157,10 +183,39 @@ def public_failure_error(
         failure.failure_class,
         (502, "all_routes_failed", "api_error"),
     )
+    message = failure.safe_message
+    retry_after_seconds: int | None = None
+    if failure.failure_class is GatewayFailureClass.THROTTLED:
+        retry_after_seconds = THROTTLED_RETRY_AFTER_SECONDS
+    elif failure.failure_class is GatewayFailureClass.QUOTA_EXCEEDED:
+        moment = now if now is not None else datetime.now(UTC)
+        reset = _next_utc_month_start(moment)
+        retry_after_seconds = max(1, math.ceil((reset - moment).total_seconds()))
+        boundary = reset.isoformat().replace("+00:00", "Z")
+        message = (
+            f"{message}. The allocation resets at {boundary}; retry after that time "
+            "or ask the gateway operator to raise the monthly budget."
+        )
     return OpenAIProtocolError(
         status_code=status,
         code=code,
-        message=failure.safe_message,
+        message=message,
         error_type=error_type,
         param=param,
+        retry_after_seconds=retry_after_seconds,
     )
+
+
+def _next_utc_month_start(moment: datetime) -> datetime:
+    """Return the start of the UTC calendar month strictly after ``moment``.
+
+    Args:
+        moment: Timezone-aware current time.
+
+    Returns:
+        Midnight UTC on the first day of the following month.
+    """
+    anchored = moment.astimezone(UTC)
+    if anchored.month == 12:
+        return datetime(anchored.year + 1, 1, 1, tzinfo=UTC)
+    return datetime(anchored.year, anchored.month + 1, 1, tzinfo=UTC)

--- a/exp/runtime/openai_protocol/errors_test.py
+++ b/exp/runtime/openai_protocol/errors_test.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
+import pytest
+
 from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
-from exp.runtime.openai_protocol.errors import public_failure_error
+from exp.runtime.openai_protocol.errors import (
+    THROTTLED_RETRY_AFTER_SECONDS,
+    OpenAIProtocolError,
+    public_failure_error,
+)
 
 
 def test_monthly_quota_failure_uses_openai_insufficient_quota_shape() -> None:
@@ -12,15 +20,75 @@ def test_monthly_quota_failure_uses_openai_insufficient_quota_shape() -> None:
         GatewayFailure(
             failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
             safe_message="monthly gateway allocation is exhausted",
-        )
+        ),
+        now=datetime(2026, 8, 19, 12, 0, tzinfo=UTC),
     )
 
     assert error.status_code == 429
     assert error.json_body() == {
         "error": {
-            "message": "monthly gateway allocation is exhausted",
+            "message": (
+                "monthly gateway allocation is exhausted. The allocation resets at "
+                "2026-09-01T00:00:00Z; retry after that time or ask the gateway "
+                "operator to raise the monthly budget."
+            ),
             "type": "insufficient_quota",
             "param": None,
             "code": "insufficient_quota",
         }
     }
+
+
+def test_quota_retry_after_counts_down_to_the_next_utc_month_boundary() -> None:
+    """The advertised wait is the exact seconds until the UTC month rolls over."""
+    now = datetime(2026, 12, 31, 23, 59, 0, tzinfo=UTC)
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+            safe_message="monthly gateway allocation is exhausted",
+        ),
+        now=now,
+    )
+
+    assert error.retry_after_seconds == 60
+    assert error.headers() == {"Retry-After": "60"}
+    assert "2027-01-01T00:00:00Z" in error.detail.message
+
+
+def test_throttled_failure_advertises_a_default_retry_after() -> None:
+    """Provider throttling keeps its frozen code and adds a short bounded wait."""
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.THROTTLED,
+            safe_message="provider throttled the request",
+        )
+    )
+
+    assert error.status_code == 429
+    assert error.detail.code == "unavailable_route"
+    assert error.retry_after_seconds == THROTTLED_RETRY_AFTER_SECONDS
+    assert error.headers() == {"Retry-After": str(THROTTLED_RETRY_AFTER_SECONDS)}
+
+
+def test_non_retryable_failures_carry_no_retry_after_header() -> None:
+    """Only quota and throttling errors advertise a wait."""
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.AUTHENTICATION,
+            safe_message="the key is not valid",
+        )
+    )
+
+    assert error.retry_after_seconds is None
+    assert error.headers() == {}
+
+
+def test_retry_after_must_be_positive() -> None:
+    """A non-positive advertised wait is a programming error, not a response."""
+    with pytest.raises(ValueError, match="retry_after_seconds must be positive"):
+        OpenAIProtocolError(
+            status_code=429,
+            code="insufficient_quota",
+            message="quota exhausted",
+            retry_after_seconds=0,
+        )

--- a/exp/runtime/openai_protocol/state.py
+++ b/exp/runtime/openai_protocol/state.py
@@ -418,7 +418,11 @@ class BoundedContinuationStore:
             raise OpenAIProtocolError(
                 status_code=400,
                 code="continuation_unavailable",
-                message="The response is too large for bounded local continuation.",
+                message=(
+                    "The response is too large for bounded local continuation. "
+                    "Resend the full conversation history in this request instead of "
+                    "previous_response_id."
+                ),
                 param="previous_response_id",
             )
         key = (namespace, response_id)
@@ -457,7 +461,10 @@ class BoundedContinuationStore:
                 raise OpenAIProtocolError(
                     status_code=400,
                     code="continuation_unavailable",
-                    message="previous_response_id is unavailable or expired in this namespace.",
+                    message=(
+                        "previous_response_id is unavailable or expired in this namespace. "
+                        "Resend the full conversation history in this request."
+                    ),
                     param="previous_response_id",
                 )
             self._entries.move_to_end(key)

--- a/exp/runtime/openai_protocol/state_test.py
+++ b/exp/runtime/openai_protocol/state_test.py
@@ -248,7 +248,10 @@ def test_continuation_is_bounded_namespaced_and_restart_unavailable() -> None:
         await store.remember(namespace=_namespace(), response_id="resp_one", state=state)
         assert await store.resolve(namespace=_namespace(), previous_response_id="resp_one") == state
 
-        with pytest.raises(OpenAIProtocolError, match="unavailable or expired"):
+        with pytest.raises(
+            OpenAIProtocolError,
+            match="unavailable or expired.*Resend the full conversation history",
+        ):
             await store.resolve(
                 namespace=_namespace(identity="identity-two"),
                 previous_response_id="resp_one",


### PR DESCRIPTION
Four small, pure additions to the gateway for the launch quality pass. Zero contract changes: every frozen error code, the OpenAI wire shapes, the provider vocabulary, and the catalog fields are untouched. Each addition is one commit with tests, and the whole-repo gate (`ruff check`, `ruff format --check`, `ty check`, `pytest -q`) is green at the head.

**Merge freeze: do not merge.** Silen approves personally, and this is Kion's repo, so it awaits his review as module owner too.

## 1. Error remediation + Retry-After (48e6f6b8)

Error messages are part of the interface (AGENTS rule 9); codes are the frozen contract, text is not. Every public gateway error now states what failed, why, and the exact next action:

- `model_not_granted` (403) now ends with "GET /v1/models lists the model aliases available to this key."
- `continuation_unavailable` (400) now ends with "Resend the full conversation history in this request."
- Throttled and quota-exhausted 429s and the draining 503 advertise a `Retry-After` header (5s for provider throttling, 10s for draining). Monthly quota exhaustion computes the exact next UTC calendar-month boundary (budgets are UTC-month buckets) for both the header and the message.
- Provider `safe_messages`, protocol templates, and every `_exception_response` branch got the same what/why/next-action pass.

The sanitization invariant is preserved: no provider content and no internal identifiers appear in any message; new tests pin the exact strings and assert canary absence. Tests that pinned old strings were updated deliberately in the same commit.

## 2. GET /v1/models enrichment + GET /v1/models/{id} (cfb2ef34)

- List entries keep the strict OpenAI shape (`id`, `object`, `created`, `owned_by`) and add one `wmo` object with `alias_revision_id` and `catalog_sha256`, both already returned by the store's existing `granted_alias_authorities` contract (the revision is already public via the `x-gateway-alias-revision` header). No new catalog fields.
- New detail route `GET /v1/models/{model_id}` returns the same object for a granted alias and the identical `model_not_found` 404 for unknown and ungranted aliases alike, so it is not an existence oracle (the requested ID is never echoed in the message).
- `GatewayControlStore` gains `granted_alias_authorities` as a pure protocol addition; the ready-filtered lifecycle store implements it with the same startup-readiness filtering as `granted_aliases`.
- The discovery objects live in a new focused `wmo/runtime/gateway/discovery.py` because `service.py` would otherwise cross the 999-line cap.

## 3. CLI core-loop parity (c86fa31f)

New caller-side commands under `wmo config gateway ...` (module `wmo/cli/gateway/caller.py`), covering the agent core loop against a LIVE gateway:

- `wmo config gateway call ALIAS "prompt" [--url] [--key] [--json]`: one chat completion over HTTP, SSE text streamed to stdout, `--json` for the raw non-streaming envelope.
- `wmo config gateway key check`: validates a raw key via `GET /v1/models`, prints granted aliases; the key is used for one request and never stored or echoed.
- `wmo config gateway models [--json]`: the caller view of `GET /v1/models` (distinct from the operator-side `alias list`).

`--url`/`--key` default from `WMO_GATEWAY_URL`/`OPENAI_BASE_URL` and `WMO_GATEWAY_KEY`/`OPENAI_API_KEY`, matching the exports `wmo run` prints. **CLI lock tests updated deliberately**: the gateway help-tree lock widens by exactly `call`, `models`, and `key check`, with the justification comment beside the lock. The root command set and the locked `config`/`optimize` group sets are unchanged.

On spend consent: these commands construct no provider client and hold no provider credential; spend is governed by the gateway's own key grants and monthly budget ceilings (the same authority that exempts long-lived serving), so one-shot `require_spend_consent` is not applied. Flagging this interpretation explicitly for review.

Verified end to end against a real `wmo run` gateway backed by a loopback OpenAI-compatible SSE stub: streaming call, `--json` envelope, valid/invalid key check, caller models view, detail route, no-oracle 404, and the new remediation messages were all observed live.

## 4. Fireworks + Modal: documented connection recipes, not new provider names (c95a12c0)

**This one deliberately took the packet's fallback.** Adding `fireworks`/`modal` to `_HTTP_PROVIDERS` is a provider-vocabulary contract change, not a pure addition: the name would have to ripple through `_SUPPORTED_PROVIDERS` (registry), `SETUP_PROVIDERS` (setup contract), the `ProviderCertificationMatrix` validator (which requires an exact provider set and dated certification cells per capability), `_FIXED_ORIGIN_PROVIDERS` (catalog), the provider picker, and two CLI help strings. That belongs to the module owner.

Instead: `docs/reference/openai-compatible-recipes.md` gives verified copy-paste recipes through the existing `openai-compatible` family: Fireworks with its fixed base URL (`https://api.fireworks.ai/inference/v1`) and capability/price template, and Modal with the documented requirement for an explicit org-deployed `base_url` (`https://<workspace>--<app-label>.modal.run/v1`). `wmo/cli/tests/openai_compatible_recipes_test.py` drives the exact documented commands to `wmo run --check` readiness and proves the Modal connection fails closed without its base URL, keeping doc and behavior pinned together.

## Out of scope (untouched, per packet)

Multimodal/PDF input, top_p/seed/reasoning passthrough, cache-sticky deployment selection, waterfall spill policy, and GatewayUsage/price fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coexistence with PR #530 (top_p passthrough)

No file overlap: #530 edits the request manifest/decoders and provider request shaping (`manifest.py`, `requests.py`, `model_adapter.py`, `streaming_requests.py`, provider clients); this PR edits the error/state/service/discovery and CLI surfaces. The one shared seam is the `unsupported_field` template in `openai_protocol/errors.py`: this PR appends a remediation sentence after the original text, so tests matching the existing prefix (including any #530 adds or removes for `top_p`) are unaffected. Whichever PR merges second just reruns the whole-repo gate. top_p/seed/reasoning passthrough itself remains untouched here, per the out-of-scope list.
