### PR TITLE
Keep Unix-only stdlib out of CLI and pytest import paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,10 @@ uv run pytest -q
   (`logging.getLogger(__name__)`), never the `print` builtin — enforced by ruff's `T20` rules.
   The one exception is deliberate user-facing CLI presentation, which goes through a local rich
   `Console` owned by the command module (that is product output, not logging).
+- Library import, CLI import, and pytest collection must not import Unix-only stdlib modules
+  (`fcntl`, `pty`, `termios`, `tty`) at module scope. Load those modules only inside the POSIX
+  helpers that need them. Pseudo-terminal child runners and Darwin file-descriptor probes stay
+  POSIX and skip elsewhere.
 
 ## Writing
 

--- a/exp/cli/judge/trace_viewer.py
+++ b/exp/cli/judge/trace_viewer.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import json
 import sys
-import termios
-import tty
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -558,6 +556,9 @@ def _read_key() -> str:
     Returns:
         Single character, or a normalized name such as ``up`` or ``pgdn``.
     """
+    import termios
+    import tty
+
     descriptor = sys.stdin.fileno()
     saved = termios.tcgetattr(descriptor)
     try:

--- a/exp/cli/shared/picker.py
+++ b/exp/cli/shared/picker.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import os
 import select
 import sys
-import termios
-import tty
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -293,9 +291,11 @@ def uses_keyboard_list(console: Console) -> bool:
         console: Terminal used for the screen.
 
     Returns:
-        True only when both stdout and stdin belong to an interactive terminal.
+        True only on POSIX when both stdout and stdin belong to an interactive terminal.
+        Windows consoles can report a TTY without Unix terminal I/O, so they use the
+        line-based path.
     """
-    return console.is_terminal and _stdin_is_tty()
+    return os.name == "posix" and console.is_terminal and _stdin_is_tty()
 
 
 def interpret_key_bytes(data: bytes) -> PickerEvent:
@@ -436,6 +436,9 @@ def _terminal_key_reader(
     if read_key is not None:
         yield read_key
         return
+    import termios
+    import tty
+
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)
     try:

--- a/exp/cli/shared/picker_test.py
+++ b/exp/cli/shared/picker_test.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 import pytest
 from rich.console import Console
 
+from exp.cli.shared import picker as picker_module
 from exp.cli.shared.picker import (
     PickerAction,
     PickerEvent,
@@ -19,6 +20,7 @@ from exp.cli.shared.picker import (
     select_many_list,
     select_one,
     select_one_list,
+    uses_keyboard_list,
 )
 from exp.conftest import TerminalRun
 
@@ -92,6 +94,14 @@ def _options(count: int) -> tuple[PickerOption, ...]:
         PickerOption(value=f"model-{index}", label=f"model-{index}", detail=f"detail {index}")
         for index in range(1, count + 1)
     )
+
+
+def test_uses_keyboard_list_requires_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-POSIX process stays on the line-based path even when stdin is a TTY."""
+    monkeypatch.setattr(picker_module.os, "name", "nt")
+    monkeypatch.setattr(picker_module, "_stdin_is_tty", lambda: True)
+    console = Console(force_terminal=True, file=io.StringIO())
+    assert uses_keyboard_list(console) is False
 
 
 def test_numbers_and_ranges_toggle_rows_before_an_empty_line_accepts() -> None:

--- a/exp/conftest.py
+++ b/exp/conftest.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
-import pty
 import re
 import select
 import struct
 import subprocess
 import sys
-import termios
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -191,6 +188,10 @@ def _run_terminal_child(
     Returns:
         The transcript, the still-visible screen, and the child exit status.
     """
+    import fcntl
+    import pty
+    import termios
+
     master, slave = pty.openpty()
     fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", size[0], size[1], 0, 0))
     child_environment = dict(os.environ if environment is None else environment)
@@ -270,7 +271,12 @@ def terminal_child() -> Callable[..., TerminalRun]:
 
     Returns:
         The callable used by keyboard picker and installed distribution tests.
+
+    Raises:
+        pytest.skip.Exception: The host is not POSIX, so a pseudo-terminal is unavailable.
     """
+    if os.name != "posix":
+        pytest.skip("pseudo-terminal child runner requires POSIX")
     return _run_terminal_child
 
 

--- a/exp/runtime/environments/local_test.py
+++ b/exp/runtime/environments/local_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import os
 import subprocess
 import sys
@@ -349,6 +348,8 @@ def _pid_is_running(pid: int) -> bool:
 
 def _open_file_descriptors() -> frozenset[int]:
     """Return low numbered open FDs without allocating a directory-enumeration descriptor."""
+    import fcntl
+
     open_fds: set[int] = set()
     for file_descriptor in range(256):
         try:

--- a/exp/tests/posix_stdlib_import_test.py
+++ b/exp/tests/posix_stdlib_import_test.py
@@ -1,0 +1,119 @@
+"""Package-wide guards against Unix-only stdlib imports at module scope.
+
+``fcntl``, ``pty``, ``termios``, and ``tty`` are absent from Windows CPython. Pytest loads
+``exp/conftest.py`` before collecting any ``exp/`` test, and ``import exp.cli.app`` pulls in the
+picker, so those modules must not be imported until a POSIX helper actually needs them.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+EXP_DIR = REPO_ROOT / "exp"
+POSIX_STDLIB = frozenset({"fcntl", "pty", "termios", "tty"})
+
+
+def _root_module(name: str) -> str:
+    """Return the top-level module name of one import target.
+
+    Args:
+        name: Dotted module path from an ``import`` or ``from`` statement.
+
+    Returns:
+        The first path segment.
+    """
+    return name.split(".", 1)[0]
+
+
+def _posix_names_from_import(node: ast.stmt) -> Iterable[str]:
+    """Yield Unix-only stdlib names imported by one statement.
+
+    Args:
+        node: A statement that may be an import.
+
+    Yields:
+        Root module names that belong to ``POSIX_STDLIB``.
+    """
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            root = _root_module(alias.name)
+            if root in POSIX_STDLIB:
+                yield root
+        return
+    if isinstance(node, ast.ImportFrom) and node.module is not None:
+        root = _root_module(node.module)
+        if root in POSIX_STDLIB:
+            yield root
+
+
+def _walk_module_body(body: list[ast.stmt]) -> Iterable[str]:
+    """Yield Unix-only stdlib names imported outside functions and classes.
+
+    Module-level ``if`` / ``try`` / ``with`` / ``match`` blocks still count: they run at import
+    time. Function and class bodies are skipped so POSIX helpers may import locally.
+
+    Args:
+        body: Statement list from a module or a module-level compound statement.
+
+    Yields:
+        Root module names that belong to ``POSIX_STDLIB``.
+    """
+    for node in body:
+        yield from _posix_names_from_import(node)
+        if isinstance(node, ast.If | ast.For | ast.AsyncFor | ast.While):
+            yield from _walk_module_body(node.body)
+            yield from _walk_module_body(node.orelse)
+        elif isinstance(node, ast.Try):
+            yield from _walk_module_body(node.body)
+            for handler in node.handlers:
+                yield from _walk_module_body(handler.body)
+            yield from _walk_module_body(node.orelse)
+            yield from _walk_module_body(node.finalbody)
+        elif isinstance(node, ast.With | ast.AsyncWith):
+            yield from _walk_module_body(node.body)
+        elif isinstance(node, ast.Match):
+            for case in node.cases:
+                yield from _walk_module_body(case.body)
+
+
+def _module_level_posix_imports(path: Path) -> frozenset[str]:
+    """Return Unix-only stdlib names imported at module scope in one file.
+
+    Args:
+        path: Python source path under ``exp/``.
+
+    Returns:
+        The forbidden names present at import time.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return frozenset(_walk_module_body(tree.body))
+
+
+def test_exp_sources_do_not_import_posix_stdlib_at_module_scope() -> None:
+    """Collection and CLI import must not require Unix-only stdlib modules."""
+    violations: list[str] = []
+    for path in sorted(EXP_DIR.rglob("*.py")):
+        names = _module_level_posix_imports(path)
+        if names:
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            violations.append(f"{relative}: {', '.join(sorted(names))}")
+    assert not violations, "module-level POSIX stdlib imports:\n" + "\n".join(violations)
+
+
+def test_cli_and_conftest_import_when_posix_stdlib_is_missing() -> None:
+    """A fresh interpreter still imports the CLI and suite conftest without Unix stdlib."""
+    script = """
+import sys
+
+for name in ("fcntl", "pty", "termios", "tty"):
+    sys.modules[name] = None
+
+import exp.cli.app
+import exp.conftest
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=120)

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import errno
 import os
-import pty
 import re
 import select
 import shutil
@@ -12,7 +11,6 @@ import signal
 import subprocess
 import sys
 import tarfile
-import termios
 import time
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -22,6 +20,18 @@ from click import unstyle
 
 if os.environ.get("EXP_INSTALLED_RELEASE_EVIDENCE") != "1":
     import pytest
+
+    _POSIX_TTY_ONLY = pytest.mark.skipif(
+        os.name != "posix",
+        reason="pseudo-terminal child runner requires POSIX",
+    )
+else:
+
+    def _keep_for_installed_evidence(function: object) -> object:
+        """Installed-wheel evidence imports this module without pytest."""
+        return function
+
+    _POSIX_TTY_ONLY = _keep_for_installed_evidence
 
 BUILT_DIST_ENV = "EXP_BUILT_DIST_DIR"
 FORBIDDEN_REQUIREMENT = re.compile(
@@ -338,6 +348,9 @@ def _run_tty_child(
             required completion marker.
         OSError: The pseudo-terminal fails for a reason other than normal slave closure.
     """
+    import pty
+    import termios
+
     master, slave = pty.openpty()
     process = subprocess.Popen(
         command,
@@ -2918,6 +2931,7 @@ def _installed_release_driver() -> None:
         assert not server_thread.is_alive()
 
 
+@_POSIX_TTY_ONLY
 def test_tty_child_exit_survives_terminal_close_races(tmp_path: Path) -> None:
     """Treat terminal closure before child reaping as a clean bounded exit.
 


### PR DESCRIPTION
## Summary
- Stop importing `fcntl` / `pty` / `termios` / `tty` at module scope so pytest can collect on Windows and `import wmo.cli.app` works.
- Keep PTY child runners and Darwin FD probes POSIX-only via skip/local import.
- Add an AST and subprocess import gate so the boundary cannot regress.
Fixes #532
## Test plan
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run ty check` (Ubuntu CI; Windows ty still fails on POSIX stubs)
- [ ] `uv run pytest -q wmo/tests/posix_stdlib_import_test.py wmo/cli/shared/picker_test.py wmo/cli/judge/trace_viewer_test.py`
- [ ] `uv run python -c "import wmo.cli.app; import wmo.conftest"`
- [ ] `uv run pytest --collect-only -q wmo`