### PR TITLE
gateway: do not latch accounting-unhealthy on pre-dispatch start_attempt failure

### DIFF
--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -25,6 +25,7 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.interfaces import AttemptLedger, ProviderStream
+from exp.runtime.gateway.ledger import GatewayLedgerError
 from exp.runtime.gateway.routing import GatewayRoute
 from exp.runtime.models import ResolvedModel, RuntimeModelCatalog
 from exp.runtime.models.providers import (
@@ -484,13 +485,14 @@ class GatewayExecutionStream:
             raise _BudgetRouteSkipped(exc.scope_kind) from exc
         except BaseException as exc:
             if attempt_id is None:
+                # A reservation that raised before returning an attempt id wrote nothing
+                # durable, so no terminal accounting is lost and readiness must not latch.
+                # The settlement path terminalizes the accepted request and latches only if
+                # that write is itself lost.
                 self._health.release_probe(binding.health_key)
-                if isinstance(exc, ProviderDeadlineExceeded):
-                    raise GatewayExecutionError(normalized_provider_failure(exc)) from exc
-                if not isinstance(exc, asyncio.CancelledError):
-                    self._accounting_failure()
-                    raise GatewayExecutionError(normalized_provider_failure(exc)) from exc
-                raise
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                raise GatewayExecutionError(_pre_dispatch_failure(exc)) from exc
             failure = normalized_provider_failure(exc)
             raise _DispatchFailure(
                 attempt_id,
@@ -881,6 +883,29 @@ def _all_routes_unavailable() -> GatewayFailure:
         failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
         safe_message="all exact-model deployments are unavailable",
     )
+
+
+def _pre_dispatch_failure(exception: BaseException) -> GatewayFailure:
+    """Classify a failure raised before any attempt row was durably written.
+
+    A reservation that raises before ``start_attempt`` returns an id persists nothing:
+    ledger invariant checks and rolled-back transactions leave no attempt row, so no
+    terminal accounting is lost. A ledger failure surfaces as an honest internal error
+    rather than a provider failure, and every other cause reuses the shared provider
+    taxonomy (for example a deadline maps to a timeout).
+
+    Args:
+        exception: The pre-dispatch cause raised while opening one physical attempt.
+
+    Returns:
+        One sanitized failure for the public boundary and the durable request settlement.
+    """
+    if isinstance(exception, GatewayLedgerError):
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.INTERNAL,
+            safe_message="gateway could not reserve attempt accounting before dispatch",
+        )
+    return normalized_provider_failure(exception)
 
 
 def _budget_quota_failure() -> GatewayFailure:

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -43,6 +43,7 @@ from exp.runtime.gateway.execution import (
     GatewayExecutor,
     _require_deployment_identity,
 )
+from exp.runtime.gateway.ledger import GatewayLedgerError
 from exp.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoute,
@@ -140,6 +141,7 @@ class _Ledger:
         self.routes: list[tuple[str | None, str | None]] = []
         self.finished: list[tuple[GatewayEvent | None, GatewayFailure | None]] = []
         self.fail_finishes = False
+        self.fail_starts = False
 
     def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
         """Capture accepted authority only."""
@@ -156,6 +158,8 @@ class _Ledger:
     ) -> str:
         """Capture dispatch identity and return a deterministic attempt ID."""
         del deployment, attempt_ordinal, route_depth, maximum_cost_micro_usd
+        if self.fail_starts:
+            raise GatewayLedgerError("attempt reservation unavailable")
         self.started.append(snapshot)
         return f"attempt-{len(self.started)}"
 
@@ -859,6 +863,45 @@ def test_terminal_ledger_failure_releases_admission_and_latches_readiness() -> N
             await service.preflight()
 
         ledger.fail_finishes = False
+        response = await asyncio.wait_for(
+            service.complete(raw_key="caller-secret", decoded=decoded),
+            timeout=0.5,
+        )
+        assert response.status_code == 200
+
+    asyncio.run(scenario())
+
+
+def test_pre_dispatch_start_failure_keeps_readiness_and_serves_other_requests() -> None:
+    """A lost pre-dispatch reservation fails one request without latching readiness."""
+
+    async def scenario() -> None:
+        """Fail one reservation before dispatch, then prove readiness and a later request."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=0),)
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+        service._executor._permits = asyncio.Semaphore(1)  # noqa: SLF001 - admission regression
+        ledger.fail_starts = True
+        decoded = decode_chat(
+            {
+                "model": "public-model",
+                "messages": [{"role": "user", "content": "account"}],
+            }
+        )
+
+        with pytest.raises(GatewayExecutionError) as raised:
+            await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert raised.value.failure.failure_class == GatewayFailureClass.INTERNAL
+        assert not raised.value.request_finalized
+        assert ledger.started == []
+        assert ledger.finished == [(None, raised.value.failure)]
+
+        await service.preflight()
+
+        ledger.fail_starts = False
         response = await asyncio.wait_for(
             service.complete(raw_key="caller-secret", decoded=decoded),
             timeout=0.5,

--- a/exp/runtime/gateway/tests/waterfall_test.py
+++ b/exp/runtime/gateway/tests/waterfall_test.py
@@ -40,6 +40,7 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.execution import GatewayExecutionError, GatewayExecutor
 from exp.runtime.gateway.health import DeploymentHealthRegistry
+from exp.runtime.gateway.ledger import GatewayLedgerError
 from exp.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute
 from exp.runtime.models import ResolvedModel, RuntimeModelCatalog
 from exp.runtime.models.providers import ProviderDeadlineExceeded, RequestDeadline
@@ -399,6 +400,37 @@ def test_all_opening_failures_settle_the_last_attempt_as_parent_owner() -> None:
         assert raised.value.request_finalized
         assert [entry[2] for entry in ledger.finished] == [False, True]
         assert ledger.parent_finishes == []
+
+    asyncio.run(scenario())
+
+
+def test_pre_dispatch_start_failure_does_not_latch_and_still_serves() -> None:
+    """A lost pre-dispatch reservation surfaces one internal failure without latching."""
+
+    async def scenario() -> None:
+        """Fail one reservation before dispatch, then reserve and serve a later request."""
+        first = _deployment("route-a", connection_sha256="b" * 64)
+        ledger = _WaterfallLedger()
+        ledger.fail_starts = True
+        provider = _ScriptedProvider([_completed_stream("served")])
+        executor = _executor((first,), {first.source_alias: provider}, ledger)
+
+        with pytest.raises(GatewayExecutionError) as raised:
+            await executor.start(route=_route((first,)), request=_request())
+        assert raised.value.failure.failure_class == GatewayFailureClass.INTERNAL
+        assert not raised.value.request_finalized
+        assert ledger.started == []
+        assert ledger.finished == []
+        assert ledger.parent_finishes == []
+
+        executor.require_healthy()
+
+        ledger.fail_starts = False
+        stream = await executor.start(route=_route((first,)), request=_request())
+        events = [event async for event in stream]
+        assert events[-1].kind == GatewayEventKind.COMPLETED
+        assert len(ledger.started) == 1
+        executor.require_healthy()
 
     asyncio.run(scenario())
 
@@ -987,6 +1019,7 @@ class _WaterfallLedger:
         self.rejected_deployments = rejected_deployments or set()
         self.rejected_scope = rejected_scope
         self.budget_checks: list[str] = []
+        self.fail_starts = False
 
     def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
         """Accept a parent request when a service-level test requires it."""
@@ -1005,6 +1038,8 @@ class _WaterfallLedger:
         del maximum_cost_micro_usd
         assert deployment.deployment_id in snapshot.deployment_ids
         self.budget_checks.append(deployment.deployment_id)
+        if self.fail_starts:
+            raise GatewayLedgerError("attempt reservation unavailable")
         if deployment.deployment_id in self.rejected_deployments:
             raise BudgetReservationRejected(
                 scope_kind=self.rejected_scope,


### PR DESCRIPTION
## The bug (P0)

A pre-dispatch reservation failure permanently latches the whole worker accounting-unhealthy, taking `/v1` readiness down for every org until restart.

In `wmo/runtime/gateway/execution.py`, `GatewayExecutionStream._dispatch` opens one physical attempt as: `deadline.attempt_timeout()` then `ledger.start_attempt(...)` (which returns the attempt id) then `provider.stream(...)`. When `start_attempt` raises before returning an id, `attempt_id` is still `None`, and the `except` handler (previously) called `self._accounting_failure()` (which is `GatewayExecutor.mark_accounting_unhealthy`) before raising.

`mark_accounting_unhealthy` sets `_accounting_healthy = False` with no reset path. `GatewayExecutor.require_healthy` then raises forever, and `GatewayService.preflight` calls it on every readiness probe. So one failed pre-dispatch reservation poisons readiness for every org until the process restarts.

The latch is only correct for lost terminal accounting writes (`finish_attempt` / `finish_request`), which is why it stays wired into the settlement paths (`_finish_open_failure`, `_finish_current`, `_finish_parent`, `abort`, and the service-level `_finish_request_quietly`). A `start_attempt` that fails at `attempt_id is None` has written nothing durable: `GatewayLedgerError` invariant checks raise before any write, and any failure inside the transaction rolls back. Nothing is lost, so nothing should latch.

## The fix

In the `attempt_id is None` branch of `_dispatch`:

- Drop the `self._accounting_failure()` call.
- Re-raise `asyncio.CancelledError` unchanged, otherwise raise `GatewayExecutionError(_pre_dispatch_failure(exc))` (non-latching). This mirrors the existing typed non-latching escape for `BudgetReservationRejected` a few lines above.
- The old `ProviderDeadlineExceeded` special-case is folded in: it already routed through `normalized_provider_failure` (deadline maps to `TIMEOUT`), and `_pre_dispatch_failure` preserves that.

Behavior after the fix: a pre-dispatch `start_attempt` failure raises a `GatewayExecutionError` up to `GatewayService.complete`, which terminalizes the accepted request via `_finish_request_quietly`. That path latches only if the actual `finish_request` terminal write is lost, which is a genuine lost-terminal case. Readiness stays healthy and other orgs keep serving.

### Typed error

I did not add a new public `PreDispatchLedgerError`. Instead I reused the existing typed `GatewayLedgerError` via a small module helper `_pre_dispatch_failure(exception)` that returns a clean `INTERNAL` failure (`"gateway could not reserve attempt accounting before dispatch"`) for ledger errors, and falls back to `normalized_provider_failure` for everything else. This keeps the public surface minimal while still giving callers an honest, correctly-classified failure instead of a mislabeled "provider execution failed". If you would prefer a dedicated typed exception, that is an easy follow-up. Flagging the helper here for your review per AGENTS.md rule 9/14.

## Tests

- `wmo/runtime/gateway/tests/waterfall_test.py::test_pre_dispatch_start_failure_does_not_latch_and_still_serves` (executor level): a `start_attempt` failure raises `GatewayExecutionError` with an `INTERNAL` failure, `require_healthy()` stays healthy, no attempt/parent writes happen, and a subsequent request reserves and serves.
- `wmo/runtime/gateway/tests/data_plane_test.py::test_pre_dispatch_start_failure_keeps_readiness_and_serves_other_requests` (service level): the inverse of the existing `test_terminal_ledger_failure_releases_admission_and_latches_readiness`. A pre-dispatch failure fails one request, the request is terminalized (`finish_request` recorded), `preflight()` does not raise, and a later request returns 200.

Both test doubles gained a `fail_starts` flag that raises `GatewayLedgerError` from `start_attempt`. The existing terminal-latch test still passes unchanged.

## Whole-repo gate

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 601 files already formatted
- `uv run ty check` — All checks passed
- `uv run pytest -q` — green. (`execution.py` is 916 lines, under the 999 cap. No em dashes in the diff. Tests colocated.)

## Platform impact

This is the upstream real fix for the amplifier that the platform currently shields with `worker.py`'s `DispatchLatchShield` (launch stopgap). Once WMO is repinned past this change, that stopgap can be removed: WMO no longer latches worker-health on a pre-dispatch reservation failure, and surfaces a clean typed failure. Does not block the platform launch.

Draft for @Kion review. Not merging; WMO is yours to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)