### PR TITLE
gateway: tolerate reasoning content in Anthropic and Gemini native streams

### DIFF
--- a/exp/runtime/models/providers/gemini_streaming.py
+++ b/exp/runtime/models/providers/gemini_streaming.py
@@ -114,9 +114,9 @@ async def _gemini_events(sse: _SseDecoder) -> AsyncIterator[GatewayEvent]:
             )
             for raw_part in parts:
                 part = require_object(raw_part, "Gemini candidate part")
-                text = part.get("text")
-                if isinstance(text, str) and text:
-                    yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=text)
+                if part.get("thought") is True:
+                    # Reasoning parts (thought text and thought signatures) are not
+                    # gateway-visible output, so they carry nothing to surface.
                     continue
                 if part.get("functionCall") is not None:
                     async for event in _tool_events(
@@ -127,9 +127,16 @@ async def _gemini_events(sse: _SseDecoder) -> AsyncIterator[GatewayEvent]:
                         yield event
                     tool_index += 1
                     continue
+                text = part.get("text")
+                if isinstance(text, str):
+                    if text:
+                        yield factory.create(GatewayEventKind.TEXT_DELTA, text_delta=text)
+                    continue
                 if text is not None:
                     raise ProviderResponseError("Gemini text part must be text")
-                raise ProviderResponseError("Gemini stream emitted an unsupported part")
+                # A part with neither visible text nor a function call (for example a
+                # bare thought signature) carries no gateway-visible output; skip it.
+                continue
         finish_reason = candidate.get("finishReason")
         if finish_reason is None:
             continue

--- a/exp/runtime/models/providers/gemini_streaming_test.py
+++ b/exp/runtime/models/providers/gemini_streaming_test.py
@@ -216,6 +216,55 @@ def test_gemini_stream_cancellation_closes_the_active_http_response() -> None:
     asyncio.run(scenario())
 
 
+def test_gemini_stream_skips_reasoning_parts_and_thought_signatures() -> None:
+    """Thought parts and bare thought signatures are skipped, not rejected as malformed."""
+
+    async def scenario() -> None:
+        """Consume a stream that interleaves reasoning parts with visible text."""
+        upstream = _ChunkStream(
+            (
+                _sse(
+                    {
+                        "candidates": [
+                            {"content": {"parts": [{"text": "pondering", "thought": True}]}}
+                        ]
+                    }
+                ),
+                _sse({"candidates": [{"content": {"parts": [{"thoughtSignature": "sig-abc"}]}}]}),
+                _sse({"candidates": [{"content": {"parts": [{"text": ""}]}}]}),
+                _sse({"candidates": [{"content": {"parts": [{"text": "answer"}]}}]}),
+                _sse(
+                    {
+                        "candidates": [{"finishReason": "STOP"}],
+                        "usageMetadata": {"promptTokenCount": 4, "candidatesTokenCount": 2},
+                    }
+                ),
+            )
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            """Return the scripted reasoning-and-text SSE response."""
+            return httpx.Response(200, stream=upstream)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            stream = await _client(http_client).stream(
+                _request(),
+                deadline=RequestDeadline.after(10),
+                idempotency_key="reasoning-operation",
+                retry_policy=RetryPolicy(1, 0, 0),
+            )
+            events = [event async for event in stream]
+
+        assert [event.kind for event in events] == [
+            GatewayEventKind.TEXT_DELTA,
+            GatewayEventKind.USAGE,
+            GatewayEventKind.COMPLETED,
+        ]
+        assert events[0].text_delta == "answer"
+
+    asyncio.run(scenario())
+
+
 def _client(http_client: httpx.AsyncClient) -> GeminiClient:
     """Construct one native Gemini client over the injected async transport."""
     return GeminiClient(

--- a/exp/runtime/models/providers/streaming.py
+++ b/exp/runtime/models/providers/streaming.py
@@ -699,8 +699,8 @@ async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayE
                     GatewayEventKind.REFUSAL_DELTA,
                     text_delta=_optional_string(block.get("refusal"), "Anthropic refusal"),
                 )
-            else:
-                raise ProviderResponseError("Anthropic stream emitted an unsupported content block")
+            # Content blocks that carry no gateway-visible output, such as
+            # extended-thinking blocks, are skipped rather than rejected.
         elif event_type == "content_block_delta":
             index = require_integer(payload.get("index"), "Anthropic content index")
             delta = require_object(payload.get("delta"), "Anthropic content delta")
@@ -724,8 +724,8 @@ async def _anthropic_messages_events(sse: _SseDecoder) -> AsyncIterator[GatewayE
                     GatewayEventKind.REFUSAL_DELTA,
                     text_delta=_optional_string(delta.get("refusal"), "Anthropic refusal delta"),
                 )
-            else:
-                raise ProviderResponseError("Anthropic stream emitted an unsupported content delta")
+            # Deltas for non-visible blocks, such as thinking_delta and
+            # signature_delta on an extended-thinking block, are skipped.
         elif event_type == "content_block_stop":
             index = require_integer(payload.get("index"), "Anthropic content index")
             if index in tools and not tools[index].completed:

--- a/exp/runtime/models/providers/streaming_test.py
+++ b/exp/runtime/models/providers/streaming_test.py
@@ -534,6 +534,107 @@ def test_anthropic_text_stream_emits_text_usage_and_completion() -> None:
     assert committed is True
 
 
+def test_anthropic_stream_skips_extended_thinking_blocks_and_deltas() -> None:
+    """Thinking blocks and their deltas are skipped, not rejected as a malformed stream."""
+    frames = b"".join(
+        (
+            _sse(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 3,
+                            "cache_read_input_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                        }
+                    },
+                },
+                event="message_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                },
+                event="content_block_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "weighing options"},
+                },
+                event="content_block_delta",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "signature_delta", "signature": "sig-xyz"},
+                },
+                event="content_block_delta",
+            ),
+            _sse({"type": "content_block_stop", "index": 0}, event="content_block_stop"),
+            _sse(
+                {
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {"type": "text", "text": ""},
+                },
+                event="content_block_start",
+            ),
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "text_delta", "text": "hi"},
+                },
+                event="content_block_delta",
+            ),
+            _sse({"type": "content_block_stop", "index": 1}, event="content_block_stop"),
+            _sse(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                },
+                event="message_delta",
+            ),
+            _sse({"type": "message_stop"}, event="message_stop"),
+        )
+    )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        """Return the Anthropic extended-thinking fixture."""
+        return httpx.Response(200, stream=_ChunkStream((frames,)))
+
+    async def scenario() -> list[GatewayEvent]:
+        """Consume one native Messages stream that includes an extended-thinking block."""
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+            client = AnthropicClient(
+                model=_snapshot("anthropic"),
+                api_key="fixture-key",
+                base_url="https://anthropic.test/v1",
+                transport=HttpxAsyncJsonTransport(http_client),
+            )
+            stream = await client.stream(
+                _request(GatewayApiSurface.CHAT_COMPLETIONS),
+                deadline=RequestDeadline.after(2),
+                idempotency_key="anthropic-thinking-attempt",
+            )
+            return await _collect(stream)
+
+    events = asyncio.run(scenario())
+
+    assert [event.kind for event in events] == [
+        GatewayEventKind.TEXT_DELTA,
+        GatewayEventKind.USAGE,
+        GatewayEventKind.COMPLETED,
+    ]
+    assert events[0].text_delta == "hi"
+
+
 def test_openai_compatible_stream_emits_refusal_reasoning_usage_and_terminal() -> None:
     """Generic Chat streaming retains refusal semantics and reported reasoning units."""
     frames = b"".join(

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -8,6 +8,7 @@ import pytest
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayNamedToolChoice
+from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.requests import (
     DecodedGatewayRequest,
@@ -93,6 +94,34 @@ def test_chat_decoder_preserves_every_supported_semantic_field() -> None:
     assert request.structured_text is not None and request.structured_text.strict
     assert request.include_usage
     assert request.metadata == {"cohort": "test"}
+
+
+def test_chat_legacy_max_tokens_reaches_native_responses_as_max_output_tokens() -> None:
+    """A Chat request using legacy max_tokens serves a native Responses max_output_tokens.
+
+    Chat clients (playground and agents) commonly send the legacy max_tokens field. On a
+    direct OpenAI deployment the native Responses API rejects max_tokens and wants
+    max_output_tokens, so the canonical request must translate the field and the native
+    payload must never carry max_tokens.
+    """
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 256,
+            "stream": True,
+        }
+    )
+
+    assert decoded.request.maximum_output_tokens == 256
+    payload = openai_responses_stream_payload(
+        "gpt-fixture",
+        decoded.request,
+        supports_temperature=True,
+        reasoning_effort=None,
+    )
+    assert payload["max_output_tokens"] == 256
+    assert "max_tokens" not in payload
 
 
 def test_responses_decoder_preserves_continuation_and_distinct_wire_shapes() -> None:


### PR DESCRIPTION
**Draft for Kion's review as module owner. Do not merge.** This is a targeted fix for a first-party direct-serving bug the platform team found on the live gateway. Non-blocking (first-party currently serves via its OpenRouter fallback rung), but this is the fix that lets the platform route first-party onto direct provider keys.

## The bug

The gateway streams natively to first-party providers and normalizes their SSE. Both native stream parsers reject any content shape they do not recognize by raising `ProviderResponseError`, which `normalized_provider_failure` classifies as `malformed_response` (`failover_eligible`). Current frontier models emit reasoning content that is not gateway-visible output, so a clean provider `200` was surfaced as `malformed_response` and the model fell through to its fallback rung.

- **Anthropic** (`_anthropic_messages_events` in `streaming.py`): a `content_block_start` whose block type was not `text`/`tool_use`/`refusal` raised "unsupported content block", and a `content_block_delta` whose delta type was not `text_delta`/`input_json_delta`/`refusal_delta` raised "unsupported content delta". Extended-thinking responses send a `thinking` block with `thinking_delta` and `signature_delta` deltas, which tripped both.
- **Gemini** (`_gemini_events` in `gemini_streaming.py`): a part carrying neither non-empty `text` nor a `functionCall` raised "unsupported part", and an empty-string text part raised "text part must be text". Gemini 2.5 emits `thought` parts and bare `thoughtSignature` parts, which tripped this.

## The fix

Both parsers now skip reasoning content instead of rejecting it, matching how robust clients accumulate only visible output:

- Anthropic: unrecognized `content_block_start` / `content_block_delta` are skipped; `text`, `tool_use`, and `refusal` are unchanged. A skipped thinking block registers no tool accumulator, so its `content_block_stop` is already a no-op.
- Gemini: a part flagged `thought`, and any part with neither visible text nor a `functionCall` (for example a bare `thoughtSignature`), is skipped; empty text parts are skipped. A non-string `text` value is still a malformed response.

## Tests

Colocated regression tests (whole-repo gate green: `ruff check`, `ruff format`, `ty check`, `pytest` over `exp/runtime/models/providers/` and `exp/runtime/gateway/`, 292 passed):

- `test_anthropic_stream_skips_extended_thinking_blocks_and_deltas`: a stream with a `thinking` block plus `thinking_delta` and `signature_delta`, then visible text, yields exactly `TEXT_DELTA`, `USAGE`, `COMPLETED`.
- `test_gemini_stream_skips_reasoning_parts_and_thought_signatures`: a stream interleaving a `thought` part, a bare `thoughtSignature`, and an empty text part with visible text yields exactly `TEXT_DELTA`, `USAGE`, `COMPLETED`.

## Note on the third symptom (OpenAI `provider_authentication`)

The platform also saw `provider=openai` direct return `provider_authentication`. That is a genuine upstream 401/403 (`stream_attempts.py` raises `ProviderTransportError(status_code)` which `_transport_failure` maps to `PROVIDER_AUTHENTICATION`). The OpenAI adapter authenticates correctly (`Authorization: Bearer <key>`, key read from the connection's `api_key_env`, posting to `/v1/responses`). No adapter change is warranted; this is being flagged to the platform side as a house-connection credential/wiring question (the value bound to the OpenAI connection's `api_key_env`, or that key's Responses-API access), not a WMO bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)