### PR TITLE
gateway: surface invoked tool names on per-attempt usage

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -171,14 +171,36 @@ class GatewayRequest(ContractModel):
 
 
 class GatewayUsage(ContractModel):
-    """Normalized token counts and invoked tool names from one provider attempt."""
+    """Normalized token counts and invoked tool names from one provider attempt.
 
-    input_tokens: int = Field(ge=0)
-    output_tokens: int = Field(ge=0)
+    A terminal event may carry only ``tool_names`` when the provider omits token usage. In that
+    case both token totals remain unknown instead of being represented as zero.
+    """
+
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
     cached_input_tokens: int | None = Field(default=None, ge=0)
     reasoning_tokens: int | None = Field(default=None, ge=0)
     tool_names: tuple[str, ...] = ()
     """Invoked tool names in first-use order, names only and never arguments."""
+
+    @model_validator(mode="after")
+    def _require_complete_tokens_or_tool_names(self) -> GatewayUsage:
+        """Require complete token totals unless this is tool-only terminal metadata."""
+        totals = (self.input_tokens, self.output_tokens)
+        if (totals[0] is None) != (totals[1] is None):
+            raise ValueError("input and output token counts must be reported together")
+        if totals[0] is None:
+            if self.cached_input_tokens is not None or self.reasoning_tokens is not None:
+                raise ValueError("token detail counts require input and output totals")
+            if not self.tool_names:
+                raise ValueError("usage requires token totals or invoked tool names")
+        return self
+
+    @property
+    def has_token_counts(self) -> bool:
+        """Return whether both provider token totals are known."""
+        return self.input_tokens is not None and self.output_tokens is not None
 
 
 class GatewayEventKind(StrEnum):
@@ -230,8 +252,9 @@ class GatewayEvent(ContractModel):
                 raise ValueError("tool argument delta requires index and raw fragment")
         elif self.kind == GatewayEventKind.TOOL_CALL_COMPLETED and self.tool_call is None:
             raise ValueError("tool-call completion requires the complete tool call")
-        elif self.kind == GatewayEventKind.USAGE and self.usage is None:
-            raise ValueError("usage event requires normalized usage")
+        elif self.kind == GatewayEventKind.USAGE:
+            if self.usage is None or not self.usage.has_token_counts:
+                raise ValueError("usage event requires complete normalized token usage")
         elif self.kind == GatewayEventKind.FAILED and self.failure is None:
             raise ValueError("failed event requires a normalized failure")
         return self

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -171,12 +171,14 @@ class GatewayRequest(ContractModel):
 
 
 class GatewayUsage(ContractModel):
-    """Normalized token counts from one provider attempt."""
+    """Normalized token counts and invoked tool names from one provider attempt."""
 
     input_tokens: int = Field(ge=0)
     output_tokens: int = Field(ge=0)
     cached_input_tokens: int | None = Field(default=None, ge=0)
     reasoning_tokens: int | None = Field(default=None, ge=0)
+    tool_names: tuple[str, ...] = ()
+    """Invoked tool names in first-use order, names only and never arguments."""
 
 
 class GatewayEventKind(StrEnum):

--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -87,6 +87,7 @@ class _PhysicalAttempt:
     stream: ProviderStream | None = None
     iterator: AsyncIterator[GatewayEvent] | None = None
     latest_usage: GatewayUsage | None = None
+    tool_names: list[str] = field(default_factory=list)
     last_provider_sequence: int = -1
     withheld_refusals: list[GatewayEvent] = field(default_factory=list)
     withheld_refusal_bytes: int = 0
@@ -222,6 +223,9 @@ class GatewayExecutionStream:
             current.last_provider_sequence = event.sequence_number
             if event.usage is not None:
                 current.latest_usage = event.usage
+            if event.kind == GatewayEventKind.TOOL_CALL_COMPLETED and event.tool_call is not None:
+                if event.tool_call.name not in current.tool_names:
+                    current.tool_names.append(event.tool_call.name)
             if (
                 event.kind == GatewayEventKind.REFUSAL_DELTA
                 and self._refusal_failover
@@ -249,7 +253,9 @@ class GatewayExecutionStream:
                 if self._committed:
                     return self._outward(event)
                 continue
-            terminal = _with_latest_usage(event, current.latest_usage)
+            terminal = _stamp_tool_names(
+                _with_latest_usage(event, current.latest_usage), current.tool_names
+            )
             withheld_non_refusal_failure = False
             typed_refusal = (
                 terminal.kind == GatewayEventKind.FAILED
@@ -371,11 +377,14 @@ class GatewayExecutionStream:
             if self._settled or current.settled:
                 return
             owns_cancel = True
-            terminal = GatewayEvent(
-                kind=GatewayEventKind.FAILED,
-                sequence_number=current.last_provider_sequence + 1,
-                failure=failure,
-                usage=current.latest_usage,
+            terminal = _stamp_tool_names(
+                GatewayEvent(
+                    kind=GatewayEventKind.FAILED,
+                    sequence_number=current.last_provider_sequence + 1,
+                    failure=failure,
+                    usage=current.latest_usage,
+                ),
+                current.tool_names,
             )
             try:
                 self._ledger.finish_attempt(
@@ -873,6 +882,23 @@ def _with_latest_usage(
     if latest_usage is None or event.usage is not None:
         return event
     return event.model_copy(update={"usage": latest_usage})
+
+
+def _stamp_tool_names(event: GatewayEvent, tool_names: list[str]) -> GatewayEvent:
+    """Stamp invoked tool names onto a terminal event's usage.
+
+    Args:
+        event: Terminal event whose usage should carry the invoked tool names.
+        tool_names: Deduplicated invoked tool names in first-use order.
+
+    Returns:
+        The event unchanged when it has no usage or no tool was invoked, otherwise a copy
+        whose usage lists the invoked tool names.
+    """
+    if event.usage is None or not tool_names:
+        return event
+    usage = event.usage.model_copy(update={"tool_names": tuple(tool_names)})
+    return event.model_copy(update={"usage": usage})
 
 
 def _all_routes_unavailable() -> GatewayFailure:

--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -885,19 +885,23 @@ def _with_latest_usage(
 
 
 def _stamp_tool_names(event: GatewayEvent, tool_names: list[str]) -> GatewayEvent:
-    """Stamp invoked tool names onto a terminal event's usage.
+    """Stamp invoked tool names onto a terminal event without inventing token counts.
 
     Args:
         event: Terminal event whose usage should carry the invoked tool names.
         tool_names: Deduplicated invoked tool names in first-use order.
 
     Returns:
-        The event unchanged when it has no usage or no tool was invoked, otherwise a copy
-        whose usage lists the invoked tool names.
+        The event unchanged when no tool was invoked, otherwise a copy whose usage lists the
+        invoked tool names. When token usage is absent, the copied usage contains only the names.
     """
-    if event.usage is None or not tool_names:
+    if not tool_names:
         return event
-    usage = event.usage.model_copy(update={"tool_names": tuple(tool_names)})
+    usage = (
+        GatewayUsage(tool_names=tuple(tool_names))
+        if event.usage is None
+        else event.usage.model_copy(update={"tool_names": tuple(tool_names)})
+    )
     return event.model_copy(update={"usage": usage})
 
 

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -787,8 +787,10 @@ def _estimated_cost(
     reasoning_rate: int | None,
 ) -> int | None:
     """Compute attributed integer micro-USD or preserve unknown pricing."""
-    if usage is None:
+    if usage is None or not usage.has_token_counts:
         return None
+    assert usage.input_tokens is not None
+    assert usage.output_tokens is not None
     dimensions = (
         (usage.input_tokens, input_rate),
         (usage.cached_input_tokens or 0, cached_input_rate),

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -15,7 +15,13 @@ import httpx
 import pytest
 from fastapi.responses import StreamingResponse
 
-from exp.common.models import BillingSource, ModelCapabilities, ModelClient, ModelSnapshot
+from exp.common.models import (
+    BillingSource,
+    ModelCapabilities,
+    ModelClient,
+    ModelSnapshot,
+    ToolCall,
+)
 from exp.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
 from exp.common.models.gateway_catalog import (
     ExactModelDeployment,
@@ -577,6 +583,118 @@ def test_direct_request_routes_streams_and_accounts_before_public_completion() -
         assert ledger.routes == [("direct", None)]
         assert ledger.finished[0][0] is not None
         assert ledger.finished[0][0].kind is GatewayEventKind.COMPLETED
+
+    asyncio.run(scenario())
+
+
+def test_terminal_usage_carries_deduplicated_invoked_tool_names() -> None:
+    """Settled terminal usage lists the invoked tool names in first-use order, deduplicated."""
+
+    async def scenario() -> None:
+        """Drive a request whose stream invokes two tools, one of them twice by name."""
+
+        def _tool_events(
+            index: int, call_id: str, name: str, base: int
+        ) -> tuple[GatewayEvent, ...]:
+            """Build one well-formed start, arguments, and completion tool triple."""
+            return (
+                GatewayEvent(
+                    kind=GatewayEventKind.TOOL_CALL_STARTED,
+                    sequence_number=base,
+                    tool_call_index=index,
+                    tool_call_id=call_id,
+                    tool_name=name,
+                ),
+                GatewayEvent(
+                    kind=GatewayEventKind.TOOL_ARGUMENTS_DELTA,
+                    sequence_number=base + 1,
+                    tool_call_index=index,
+                    raw_arguments_delta="{}",
+                ),
+                GatewayEvent(
+                    kind=GatewayEventKind.TOOL_CALL_COMPLETED,
+                    sequence_number=base + 2,
+                    tool_call=ToolCall(
+                        call_id=call_id, name=name, arguments={}, raw_arguments="{}"
+                    ),
+                ),
+            )
+
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    *_tool_events(0, "call-a", "search", 0),
+                    *_tool_events(1, "call-b", "lookup", 3),
+                    *_tool_events(2, "call-c", "search", 6),
+                    GatewayEvent(
+                        kind=GatewayEventKind.USAGE,
+                        sequence_number=9,
+                        usage=GatewayUsage(input_tokens=3, output_tokens=1),
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=10),
+                )
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+
+        await service.preflight()
+        response = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+        terminal = ledger.finished[0][0]
+        assert terminal is not None
+        assert terminal.usage is not None
+        assert terminal.usage.tool_names == ("search", "lookup")
+
+    asyncio.run(scenario())
+
+
+def test_terminal_usage_tool_names_default_empty_without_tool_calls() -> None:
+    """A stream that invokes no tool settles terminal usage with an empty tool-name tuple."""
+
+    async def scenario() -> None:
+        """Drive one text-only request and confirm no tool names are recorded."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hello",
+                    ),
+                    GatewayEvent(
+                        kind=GatewayEventKind.COMPLETED,
+                        sequence_number=1,
+                        usage=GatewayUsage(input_tokens=3, output_tokens=1),
+                    ),
+                )
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+
+        await service.preflight()
+        await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            ),
+        )
+
+        terminal = ledger.finished[0][0]
+        assert terminal is not None
+        assert terminal.usage is not None
+        assert terminal.usage.tool_names == ()
 
     asyncio.run(scenario())
 

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -699,6 +699,114 @@ def test_terminal_usage_tool_names_default_empty_without_tool_calls() -> None:
     asyncio.run(scenario())
 
 
+def test_terminal_tool_names_survive_when_provider_omits_usage() -> None:
+    """A usage-less completed attempt retains invoked names without fabricating token counts."""
+
+    async def scenario() -> None:
+        """Drive one tool completion directly into a terminal event without usage."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TOOL_CALL_COMPLETED,
+                        sequence_number=0,
+                        tool_call=ToolCall(
+                            call_id="call-a", name="search", arguments={}, raw_arguments="{}"
+                        ),
+                    ),
+                    GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+                )
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+
+        await service.preflight()
+        response = await service.complete(
+            raw_key="caller-secret",
+            decoded=decode_chat(
+                {
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            ),
+        )
+
+        body = json.loads(cast(bytes, response.body))
+        terminal = ledger.finished[0][0]
+        assert response.status_code == 200
+        assert body["usage"] is None
+        assert terminal is not None
+        assert terminal.usage == GatewayUsage(tool_names=("search",))
+        assert terminal.usage is not None
+        assert terminal.usage.input_tokens is None
+        assert terminal.usage.output_tokens is None
+
+    asyncio.run(scenario())
+
+
+def test_abort_preserves_tool_names_when_provider_omits_usage() -> None:
+    """An aborted attempt retains invoked names even when no usage event arrived."""
+
+    async def scenario() -> None:
+        """Abort after a completed tool call and inspect the durable terminal event."""
+        catalog, _deployment = _catalog()
+        ledger = _Ledger()
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TOOL_CALL_COMPLETED,
+                        sequence_number=0,
+                        tool_call=ToolCall(
+                            call_id="call-a", name="search", arguments={}, raw_arguments="{}"
+                        ),
+                    ),
+                )
+            )
+        )
+        request = GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="abort"),),
+        )
+        authorization = _ControlStore(catalog.identity_sha256()).authorize_request(
+            raw_key="caller-secret",
+            alias="public-model",
+            request=request,
+            deadline_monotonic=time.monotonic() + 30,
+        )
+        route = await CatalogRouteResolver(
+            {("revision-one", catalog.identity_sha256()): catalog}
+        ).resolve(
+            authorization=authorization,
+            request=request,
+            episode_namespace=("org", "identity", "revision-one", "episode"),
+        )
+        executor = GatewayExecutor(
+            {
+                ("revision-one", catalog.identity_sha256()): cast(
+                    RuntimeModelCatalog, _RuntimeCatalog(provider)
+                )
+            },
+            ledger,
+        )
+        stream = await executor.start(route=route, request=request)
+        event = await stream.__anext__()
+        assert event.kind is GatewayEventKind.TOOL_CALL_COMPLETED
+
+        await stream.abort(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.CANCELLED,
+                safe_message="provider request was cancelled",
+            )
+        )
+
+        terminal = ledger.finished[0][0]
+        assert terminal is not None
+        assert terminal.usage == GatewayUsage(tool_names=("search",))
+
+    asyncio.run(scenario())
+
+
 def test_project_route_uses_selection_only_and_preserves_fallback_context() -> None:
     """Project targets resolve to one singleton deployment through the selection-only seam."""
 

--- a/exp/runtime/openai_protocol/response.py
+++ b/exp/runtime/openai_protocol/response.py
@@ -126,7 +126,14 @@ def completed_body(
         ]
         or None,
     }
-    usage = next((event.usage for event in reversed(events) if event.usage is not None), None)
+    usage = next(
+        (
+            event.usage
+            for event in reversed(events)
+            if event.usage is not None and event.usage.has_token_counts
+        ),
+        None,
+    )
     return {
         "id": stable_public_id("chatcmpl", request_id),
         "object": "chat.completion",
@@ -152,8 +159,10 @@ def completed_body(
 
 def chat_usage(usage: GatewayUsage | None) -> JsonObject | None:
     """Encode normalized usage in the Chat completion shape."""
-    if usage is None:
+    if usage is None or not usage.has_token_counts:
         return None
+    assert usage.input_tokens is not None
+    assert usage.output_tokens is not None
     details: JsonObject = {}
     if usage.cached_input_tokens is not None:
         details["cached_tokens"] = usage.cached_input_tokens

--- a/exp/runtime/openai_protocol/streaming.py
+++ b/exp/runtime/openai_protocol/streaming.py
@@ -75,7 +75,7 @@ class ChatSseEncoder:
             OpenAIProtocolError: Event order, tool identity, or terminal state is invalid.
         """
         self._require_event(event)
-        if event.usage is not None:
+        if event.usage is not None and event.usage.has_token_counts:
             self._usage = event.usage
         if event.kind == GatewayEventKind.TEXT_DELTA:
             return (self._chunk(delta={"content": event.text_delta}),)
@@ -281,7 +281,7 @@ class ResponsesSseEncoder:
     def feed(self, event: GatewayEvent) -> tuple[str, ...]:
         """Encode one ordered normalized event into Responses lifecycle frames."""
         self._require_event(event)
-        if event.usage is not None:
+        if event.usage is not None and event.usage.has_token_counts:
             self._usage = event.usage
         if event.kind == GatewayEventKind.TEXT_DELTA:
             return self._content_delta("text", _required_text(event.text_delta))
@@ -695,6 +695,10 @@ def _chat_data(payload: JsonObject) -> str:
 
 def _chat_usage(usage: GatewayUsage) -> JsonObject:
     """Map normalized usage to the official Chat token accounting shape."""
+    if not usage.has_token_counts:
+        raise ValueError("Chat usage encoding requires complete token usage")
+    assert usage.input_tokens is not None
+    assert usage.output_tokens is not None
     return {
         "prompt_tokens": usage.input_tokens,
         "completion_tokens": usage.output_tokens,
@@ -706,8 +710,10 @@ def _chat_usage(usage: GatewayUsage) -> JsonObject:
 
 def _responses_usage(usage: GatewayUsage | None) -> JsonObject | None:
     """Map normalized usage to the official Responses accounting shape."""
-    if usage is None:
+    if usage is None or not usage.has_token_counts:
         return None
+    assert usage.input_tokens is not None
+    assert usage.output_tokens is not None
     return {
         "input_tokens": usage.input_tokens,
         "input_tokens_details": {"cached_tokens": usage.cached_input_tokens or 0},


### PR DESCRIPTION
**Draft for Kion's review as module owner. Do not merge.** Third first-party/gateway fast-follow in the same pin-bump change set as #538 (anthropic/gemini reasoning-parse) and #534 (accounting latch). Non-launch-blocking: the platform half is already built and merged and stays defensive-NULL / honest empty state until this lands and the pin bumps.

## Goal

Let the gateway surface the tool NAMES a model actually invoked on the per-attempt usage the platform settles, so the "Tools called" telemetry lights up. Names only, never arguments (the platform ledger is content-free by contract).

## Change

- `contracts.py`: `GatewayUsage` gains `tool_names: tuple[str, ...] = ()` (first-use order, names only, documented). Default `()` keeps every existing construction and the platform's non-bumped path byte-identical.
- `execution.py`: `GatewayExecutionStream` accumulates invoked names per physical attempt. As each `TOOL_CALL_COMPLETED` passes, its `tool_call.name` is appended to that attempt's list, deduplicated in first-use order (right where `latest_usage` is already tracked). A single `_stamp_tool_names` helper stamps the accumulated names onto the terminal event's usage on both the settled-success path and the `abort` path, mirroring how token counts flow from attempt to event. Semantics are INVOKED tools (what the model called), not `request.tools` (offered).

Per-attempt is correct: the platform copies the winning (last) attempt's `tool_names` onto the event, the same way `input`/`output_tokens` flow attempt -> event.

## Platform activation (not here; happens at the pin bump)

The one-liner is already staged on the platform side (`explabs/gateway/ledger.py` `finish_attempt`, gw/int-p4-worker / #472): the marked `None,` becomes `None if usage is None else list(usage.tool_names)`. `list(...)` on the `tuple` field works directly. Storage/read/display already merged (schema #456, reads #463, FE #490).

## Tests

Colocated in `exp/runtime/gateway/tests/data_plane_test.py`:
- a stream invoking two tools (one repeated by name) settles terminal usage with `("search", "lookup")` (deduplicated, first-use order), driven through the full service with a separate USAGE event then COMPLETED (the real provider ordering).
- a tool-free stream settles with `()`.

Whole-repo gate green: `ruff check` + `ruff format`, `ty check`, `pytest` over gateway + providers + openai_protocol (349 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)