### PR TITLE
Release experiential 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.3.0"
+version = "0.4.0"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "experiential"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- bump the distribution and lockfile to `0.4.0`

## Validation
- `uv lock --check`
- built wheel and sdist with `uv build --package experiential --no-sources`
- installed-wheel smoke passed, including `exp --help`

After merge, publish `v0.4.0` through the repository’s trusted PyPI workflow.