### PR TITLE
Use builder provider selector in first-run gateway setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Experiential is an open source gateway and router for agent workflows:
 
 ## Getting Started
 
-Start a local OpenAI-compatible gateway. On first run, the setup wizard asks for a provider,
-model, and public alias, then prints a one-time virtual key:
+Start a local OpenAI-compatible gateway. On first run, the setup wizard lets you select multiple
+providers, collects a model and public alias for each, then prints a one-time virtual key:
 
 ```bash
 pip install experiential

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Experiential is an open source gateway and router for agent workflows:
 
 ## Getting Started
 
-Start a local OpenAI-compatible gateway. On first run, the setup wizard lets you select multiple
-providers, collects a model and public alias for each, then prints a one-time virtual key:
+Start a local OpenAI-compatible gateway. On first run, the setup wizard uses the provider selector,
+persists the selected provider connections, then collects one initial model and public alias before
+printing a one-time virtual key:
 
 ```bash
 pip install experiential

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,8 +33,9 @@ compatibility flag for project-journal behavior; gateway authentication, replay,
 usage accounting stay enabled.
 
 Both `exp run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
-provider call, and requires an explicit provider environment reference, exact model alias, identity,
-grant, and virtual key. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
+provider call, and requires explicit provider environment references, exact model aliases, identity,
+grants, and a virtual key. Interactive first-run setup can configure multiple providers and aliases
+in one session. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
 exact next commands on an empty root. `exp run --check` validates local readiness without binding.
 The gateway writes no prompts, responses, tool arguments, raw keys, or provider secrets to SQLite.
 `GET /usage` and `GET /usage.json` expose the same schema-v2 content-free overall and per-identity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,7 @@ The root surface is deliberately small:
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |
 | `exp optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `exp optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
-| `exp run --root ROOT [--check]` | Validate or start the initialized authenticated multi-alias gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
+| `exp run --root ROOT [--check]` | Validate or start the initialized authenticated gateway on loopback. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `exp run PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as no-argument `exp run`. |
 | `exp config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, monthly limits, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
 | `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.exp/models.toml`. |
@@ -33,9 +33,10 @@ compatibility flag for project-journal behavior; gateway authentication, replay,
 usage accounting stay enabled.
 
 Both `exp run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
-provider call, and requires explicit provider environment references, exact model aliases, identity,
-grants, and a virtual key. Interactive first-run setup can configure multiple providers and aliases
-in one session. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
+provider call, and requires an explicit provider environment reference, exact model alias, identity,
+grant, and a virtual key. Interactive first-run setup can persist multiple provider connections and
+creates one initial gateway alias; additional deployments and certified pools remain explicit
+gateway configuration. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
 exact next commands on an empty root. `exp run --check` validates local readiness without binding.
 The gateway writes no prompts, responses, tool arguments, raw keys, or provider secrets to SQLite.
 `GET /usage` and `GET /usage.json` expose the same schema-v2 content-free overall and per-identity

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -88,11 +88,14 @@ def interactive_gateway_setup(
     if manager.initialized:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     console = console or Console(theme=EXP_THEME)
-    selection = select_providers(
-        SetupSession(),
-        console=console,
-        environment={},
-    )
+    try:
+        selection = select_providers(
+            SetupSession(),
+            console=console,
+            environment={},
+        )
+    except (EOFError, KeyboardInterrupt, SetupCancelled):
+        raise typer.Abort from None
     if selection is None:
         raise typer.Abort()
     providers, _manual_models = selection

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -1,4 +1,4 @@
-"""TTY-only first-run setup for an explicit multi-alias local gateway."""
+"""TTY-only first-run setup for an explicit singleton local gateway."""
 
 from __future__ import annotations
 
@@ -15,7 +15,6 @@ from exp.cli.providers.provider_picker import (
     select_providers,
 )
 from exp.common.models import (
-    ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayTokenPrices,
     ModelCapabilities,
@@ -33,29 +32,18 @@ class InteractiveSetupResult:
     """Explicit resources created by one accepted first-run summary."""
 
     identity_id: str
-    aliases: tuple[str, ...]
+    alias: str
     raw_key: str
 
 
-@dataclass(frozen=True)
-class _GatewayDeploymentSetup:
-    """One provider-backed public alias collected during gateway setup."""
-
-    connection_id: str
-    connection: ConnectionConfig
-    provider_model: str
-    exact_model_id: str
-    alias: str
-
-
 def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
-    """Collect and create a minimal gateway backed by every selected provider.
+    """Collect and create one minimal provider-backed singleton gateway.
 
     Args:
         root: Empty EXP root selected by the operator.
 
     Returns:
-        Created identity, aliases, and one-time key material.
+        Created identity, alias, and one-time key material.
 
     Raises:
         typer.Abort: The operator rejects the displayed mutation summary.
@@ -77,74 +65,63 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
     connections = collect_provider_connections(providers, console=console)
     if not connections:
         raise typer.Abort()
-    deployments = tuple(
-        _GatewayDeploymentSetup(
-            connection_id=provider,
-            connection=connection,
-            provider_model=typer.prompt(f"{provider} exact provider model ID"),
-            exact_model_id=typer.prompt(f"{provider} exact logical model identity"),
-            alias=typer.prompt(f"{provider} public model alias"),
-        )
-        for provider, connection in connections
-    )
-    aliases = tuple(item.alias for item in deployments)
-    if len(set(aliases)) != len(aliases):
-        raise ValueError("gateway public model aliases must be unique")
+    provider_name, _provider_connection = connections[0]
+    provider_model = typer.prompt("Exact provider model ID")
+    exact_model_id = typer.prompt("Exact logical model identity")
+    alias = typer.prompt("Public model alias")
     identity_id = typer.prompt("Default identity", default="default")
     typer.echo("\nPlanned local mutations:")
-    for item in deployments:
-        credential_reference = item.connection.api_key_env or "AWS credential chain"
+    for connection_id, connection in connections:
+        credential_reference = connection.api_key_env or "AWS credential chain"
         typer.echo(
-            f"  provider: {item.connection_id} ({item.connection.provider}, "
+            f"  provider connection: {connection_id} ({connection.provider}, "
             f"credential env {credential_reference})"
         )
-        typer.echo(f"  alias: {item.alias} -> {item.provider_model} ({item.exact_model_id})")
-    typer.echo(f"  identity and grants: {identity_id} -> {', '.join(aliases)}")
+    typer.echo(f"  singleton: {alias} -> {provider_model} ({exact_model_id})")
+    typer.echo(f"  identity and grant: {identity_id} -> {alias}")
     typer.echo("  issue one virtual key and reveal it once")
     if not typer.confirm("Create this gateway configuration?"):
         raise typer.Abort()
 
     manager.initialize()
-    for provider, connection in connections:
-        manager.upsert_provider_connection(connection_id=provider, config=connection)
+    for connection_id, connection in connections:
+        manager.upsert_provider_connection(connection_id=connection_id, config=connection)
     serving_connections = {
         item.connection_id: item.config for item in manager.provider_connections()
     }
-    for item in deployments:
-        normalized, snapshot, _changed = upsert_singleton_deployment(
-            root,
-            deployment_alias=item.alias,
-            connection_name=item.connection_id,
-            provider_model=item.provider_model,
-            exact_model_id=item.exact_model_id,
-            revision=None,
-            capabilities=ModelCapabilities(),
-            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
-            prices=GatewayTokenPrices(),
-            pricing_source=None,
-            replace=False,
-            serving_connections=serving_connections,
-        )
-        authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
-        revision_id = f"revision-{uuid.uuid4().hex}"
-        manager.activate_direct_alias(
-            alias_id=item.alias,
-            alias_name=item.alias,
-            revision_id=revision_id,
-            pool_id=item.alias,
-            snapshot_ref=f"catalog-snapshots/{snapshot.name}",
-            catalog_sha256=normalized.identity_sha256(),
-            provider_connections=manager.provider_bindings(authored),
-        )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        root,
+        deployment_alias=alias,
+        connection_name=provider_name,
+        provider_model=provider_model,
+        exact_model_id=exact_model_id,
+        revision=None,
+        capabilities=ModelCapabilities(),
+        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+        prices=GatewayTokenPrices(),
+        pricing_source=None,
+        replace=False,
+        serving_connections=serving_connections,
+    )
+    authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
+    revision_id = f"revision-{uuid.uuid4().hex}"
+    manager.activate_direct_alias(
+        alias_id=alias,
+        alias_name=alias,
+        revision_id=revision_id,
+        pool_id=alias,
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+        provider_connections=manager.provider_bindings(authored),
+    )
     manager.create_identity(identity_id=identity_id, display_name=identity_id)
-    for item in deployments:
-        manager.add_grant(identity_id=identity_id, alias_id=item.alias)
+    manager.add_grant(identity_id=identity_id, alias_id=alias)
     issued = manager.issue_key(
         identity_id=identity_id,
         key_id=f"key-{uuid.uuid4().hex}",
     )
     return InteractiveSetupResult(
         identity_id=identity_id,
-        aliases=aliases,
+        alias=alias,
         raw_key=issued.raw_key,
     )

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -3,23 +3,32 @@
 from __future__ import annotations
 
 import uuid
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.table import Table
+from rich.text import Text
 
 from exp.cli.providers.provider_picker import (
+    SetupCancelled,
     SetupSession,
+    ask_text,
     collect_provider_connections,
     select_providers,
 )
+from exp.cli.shared.progress import progress_display
+from exp.cli.shared.theme import EXP_THEME
 from exp.common.models import (
     GatewayDeploymentCapabilities,
     GatewayTokenPrices,
     ModelCapabilities,
     ModelCatalog,
+    derive_model_alias,
 )
+from exp.common.progress import report
 from exp.runtime.gateway.catalog_authority import (
     authored_snapshot_path,
     upsert_singleton_deployment,
@@ -36,24 +45,49 @@ class InteractiveSetupResult:
     raw_key: str
 
 
-def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
+@dataclass(frozen=True)
+class _GatewaySetupValues:
+    """Values shown on the first-run gateway defaults screen."""
+
+    provider_model: str
+    exact_model_id: str
+    alias: str
+    identity_id: str
+
+
+_DEFAULT_GATEWAY_MODELS = {
+    "openai": "gpt-5.6-luna",
+    "anthropic": "claude-sonnet-4-5",
+    "gemini": "gemini-3.6-flash",
+    "openrouter": "openai/gpt-5.4",
+    "openai-compatible": "gpt-5.4",
+    "azure": "gpt-5-deployment",
+    "bedrock": "anthropic.claude-sonnet-4-5",
+}
+
+
+def interactive_gateway_setup(
+    root: Path,
+    *,
+    console: Console | None = None,
+) -> InteractiveSetupResult:
     """Collect and create one minimal provider-backed singleton gateway.
 
     Args:
         root: Empty EXP root selected by the operator.
+        console: Optional terminal override used by tests and embedding callers.
 
     Returns:
         Created identity, alias, and one-time key material.
 
     Raises:
-        typer.Abort: The operator rejects the displayed mutation summary.
+        typer.Abort: The operator cancels setup or reaches end of input.
         ValueError: Existing state or incomplete metadata prevents safe setup.
     """
     manager = GatewayManagement(root)
     if manager.initialized:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
-    typer.echo(f"Gateway state will be stored under {root / 'gateway'}.")
-    console = Console()
+    console = console or Console(theme=EXP_THEME)
     selection = select_providers(
         SetupSession(),
         console=console,
@@ -66,62 +100,142 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
     if not connections:
         raise typer.Abort()
     provider_name, _provider_connection = connections[0]
-    provider_model = typer.prompt("Exact provider model ID")
-    exact_model_id = typer.prompt("Exact logical model identity")
-    alias = typer.prompt("Public model alias")
-    identity_id = typer.prompt("Default identity", default="default")
-    typer.echo("\nPlanned local mutations:")
-    for connection_id, connection in connections:
-        credential_reference = connection.api_key_env or "AWS credential chain"
-        typer.echo(
-            f"  provider connection: {connection_id} ({connection.provider}, "
-            f"credential env {credential_reference})"
-        )
-    typer.echo(f"  singleton: {alias} -> {provider_model} ({exact_model_id})")
-    typer.echo(f"  identity and grant: {identity_id} -> {alias}")
-    typer.echo("  issue one virtual key and reveal it once")
-    if not typer.confirm("Create this gateway configuration?"):
-        raise typer.Abort()
+    values = _collect_gateway_values(provider_name, console=console)
 
-    manager.initialize()
-    for connection_id, connection in connections:
-        manager.upsert_provider_connection(connection_id=connection_id, config=connection)
-    serving_connections = {
-        item.connection_id: item.config for item in manager.provider_connections()
-    }
-    normalized, snapshot, _changed = upsert_singleton_deployment(
-        root,
-        deployment_alias=alias,
-        connection_name=provider_name,
-        provider_model=provider_model,
-        exact_model_id=exact_model_id,
-        revision=None,
-        capabilities=ModelCapabilities(),
-        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
-        prices=GatewayTokenPrices(),
-        pricing_source=None,
-        replace=False,
-        serving_connections=serving_connections,
+    total_steps = len(connections) + 6
+    completed_steps = 0
+
+    progress_context = (
+        progress_display(console, single_line=True) if console.is_interactive else nullcontext(None)
     )
-    authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
-    revision_id = f"revision-{uuid.uuid4().hex}"
-    manager.activate_direct_alias(
-        alias_id=alias,
-        alias_name=alias,
-        revision_id=revision_id,
-        pool_id=alias,
-        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
-        catalog_sha256=normalized.identity_sha256(),
-        provider_connections=manager.provider_bindings(authored),
-    )
-    manager.create_identity(identity_id=identity_id, display_name=identity_id)
-    manager.add_grant(identity_id=identity_id, alias_id=alias)
-    issued = manager.issue_key(
-        identity_id=identity_id,
-        key_id=f"key-{uuid.uuid4().hex}",
-    )
+    with progress_context as progress:
+
+        def advance(detail: str) -> None:
+            """Advance the gateway setup progress bar after one completed mutation."""
+            nonlocal completed_steps
+            completed_steps += 1
+            report(
+                progress,
+                "gateway setup",
+                completed=completed_steps,
+                total=total_steps,
+                detail=detail,
+            )
+
+        manager.initialize()
+        advance("initialize")
+        for connection_id, connection in connections:
+            manager.upsert_provider_connection(connection_id=connection_id, config=connection)
+            advance(f"connect {connection_id}")
+        serving_connections = {
+            item.connection_id: item.config for item in manager.provider_connections()
+        }
+        normalized, snapshot, _changed = upsert_singleton_deployment(
+            root,
+            deployment_alias=values.alias,
+            connection_name=provider_name,
+            provider_model=values.provider_model,
+            exact_model_id=values.exact_model_id,
+            revision=None,
+            capabilities=ModelCapabilities(),
+            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+            prices=GatewayTokenPrices(),
+            pricing_source=None,
+            replace=False,
+            serving_connections=serving_connections,
+        )
+        advance("write catalog")
+        authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
+        revision_id = f"revision-{uuid.uuid4().hex}"
+        manager.activate_direct_alias(
+            alias_id=values.alias,
+            alias_name=values.alias,
+            revision_id=revision_id,
+            pool_id=values.alias,
+            snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+            catalog_sha256=normalized.identity_sha256(),
+            provider_connections=manager.provider_bindings(authored),
+        )
+        advance("activate alias")
+        manager.create_identity(identity_id=values.identity_id, display_name=values.identity_id)
+        advance("create identity")
+        manager.add_grant(identity_id=values.identity_id, alias_id=values.alias)
+        advance("grant alias")
+        issued = manager.issue_key(
+            identity_id=values.identity_id,
+            key_id=f"key-{uuid.uuid4().hex}",
+        )
+        advance("issue key")
+    console.print("[green]✓ Gateway configured[/green]")
     return InteractiveSetupResult(
-        identity_id=identity_id,
-        alias=alias,
+        identity_id=values.identity_id,
+        alias=values.alias,
         raw_key=issued.raw_key,
+    )
+
+
+def _collect_gateway_values(provider: str, *, console: Console) -> _GatewaySetupValues:
+    """Show gateway defaults and collect edits only when the operator requests them.
+
+    Args:
+        provider: First selected provider that receives the initial singleton alias.
+        console: Terminal used for the defaults screen and optional field edits.
+
+    Returns:
+        Gateway values accepted from the defaults screen or edited by the operator.
+
+    Raises:
+        typer.Abort: The operator reaches end of input or interrupts the screen.
+    """
+    defaults = _gateway_defaults(provider)
+    table = Table.grid(padding=(0, 2))
+    table.add_column(style="dim")
+    table.add_column(style="green")
+    for label, value in (
+        ("Provider model", defaults.provider_model),
+        ("Exact model ID", defaults.exact_model_id),
+        ("Alias", defaults.alias),
+        ("Identity ID", defaults.identity_id),
+    ):
+        table.add_row(label, Text(value, style="green"))
+    console.print(table)
+    try:
+        answer = console.input(
+            "[dim]Press Enter to accept all defaults, or type edit to change them.[/dim] "
+        ).strip()
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise typer.Abort from exc
+    if not answer:
+        return defaults
+
+    try:
+        return _GatewaySetupValues(
+            provider_model=ask_text(
+                "Provider model", console=console, default=defaults.provider_model
+            ),
+            exact_model_id=ask_text(
+                "Exact model ID", console=console, default=defaults.exact_model_id
+            ),
+            alias=ask_text("Alias", console=console, default=defaults.alias),
+            identity_id=ask_text("Identity ID", console=console, default=defaults.identity_id),
+        )
+    except SetupCancelled as exc:
+        raise typer.Abort from exc
+
+
+def _gateway_defaults(provider: str) -> _GatewaySetupValues:
+    """Return the concise first-run defaults for one provider-backed singleton.
+
+    Args:
+        provider: Supported provider receiving the initial singleton alias.
+
+    Returns:
+        Provider model, logical identity, alias, and caller identity defaults.
+    """
+    provider_model = _DEFAULT_GATEWAY_MODELS[provider]
+    return _GatewaySetupValues(
+        provider_model=provider_model,
+        exact_model_id=provider_model,
+        alias=derive_model_alias(provider, provider_model, frozenset()),
+        identity_id="default",
     )

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -1,4 +1,4 @@
-"""TTY-only first-run setup for an explicit singleton local gateway."""
+"""TTY-only first-run setup for an explicit multi-alias local gateway."""
 
 from __future__ import annotations
 
@@ -9,8 +9,13 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from exp.cli.providers.provider_picker import collect_provider_connection, select_single_provider
+from exp.cli.providers.provider_picker import (
+    SetupSession,
+    collect_provider_connections,
+    select_providers,
+)
 from exp.common.models import (
+    ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayTokenPrices,
     ModelCapabilities,
@@ -28,18 +33,29 @@ class InteractiveSetupResult:
     """Explicit resources created by one accepted first-run summary."""
 
     identity_id: str
-    alias: str
+    aliases: tuple[str, ...]
     raw_key: str
 
 
+@dataclass(frozen=True)
+class _GatewayDeploymentSetup:
+    """One provider-backed public alias collected during gateway setup."""
+
+    connection_id: str
+    connection: ConnectionConfig
+    provider_model: str
+    exact_model_id: str
+    alias: str
+
+
 def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
-    """Collect and create one minimal provider-backed singleton gateway.
+    """Collect and create a minimal gateway backed by every selected provider.
 
     Args:
         root: Empty EXP root selected by the operator.
 
     Returns:
-        Created identity, alias, and one-time key material.
+        Created identity, aliases, and one-time key material.
 
     Raises:
         typer.Abort: The operator rejects the displayed mutation summary.
@@ -50,67 +66,85 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     typer.echo(f"Gateway state will be stored under {root / 'gateway'}.")
     console = Console()
-    provider = select_single_provider(console=console, environment={})
-    if provider is None:
+    selection = select_providers(
+        SetupSession(),
+        console=console,
+        environment={},
+    )
+    if selection is None:
         raise typer.Abort()
-    connection = collect_provider_connection(provider, console=console)
-    if connection is None:
+    providers, _manual_models = selection
+    connections = collect_provider_connections(providers, console=console)
+    if not connections:
         raise typer.Abort()
-    provider_name = provider
-    provider_model = typer.prompt("Exact provider model ID")
-    exact_model_id = typer.prompt("Exact logical model identity")
-    alias = typer.prompt("Public model alias")
+    deployments = tuple(
+        _GatewayDeploymentSetup(
+            connection_id=provider,
+            connection=connection,
+            provider_model=typer.prompt(f"{provider} exact provider model ID"),
+            exact_model_id=typer.prompt(f"{provider} exact logical model identity"),
+            alias=typer.prompt(f"{provider} public model alias"),
+        )
+        for provider, connection in connections
+    )
+    aliases = tuple(item.alias for item in deployments)
+    if len(set(aliases)) != len(aliases):
+        raise ValueError("gateway public model aliases must be unique")
     identity_id = typer.prompt("Default identity", default="default")
     typer.echo("\nPlanned local mutations:")
-    credential_reference = connection.api_key_env or "AWS credential chain"
-    typer.echo(f"  provider: {provider_name} ({provider}, credential env {credential_reference})")
-    typer.echo(f"  singleton: {alias} -> {provider_model} ({exact_model_id})")
-    typer.echo(f"  identity and grant: {identity_id} -> {alias}")
+    for item in deployments:
+        credential_reference = item.connection.api_key_env or "AWS credential chain"
+        typer.echo(
+            f"  provider: {item.connection_id} ({item.connection.provider}, "
+            f"credential env {credential_reference})"
+        )
+        typer.echo(f"  alias: {item.alias} -> {item.provider_model} ({item.exact_model_id})")
+    typer.echo(f"  identity and grants: {identity_id} -> {', '.join(aliases)}")
     typer.echo("  issue one virtual key and reveal it once")
     if not typer.confirm("Create this gateway configuration?"):
         raise typer.Abort()
 
     manager.initialize()
-    _changed, _authority = manager.upsert_provider_connection(
-        connection_id=provider_name,
-        config=connection,
-    )
+    for provider, connection in connections:
+        manager.upsert_provider_connection(connection_id=provider, config=connection)
     serving_connections = {
         item.connection_id: item.config for item in manager.provider_connections()
     }
-    normalized, snapshot, _changed = upsert_singleton_deployment(
-        root,
-        deployment_alias=alias,
-        connection_name=provider_name,
-        provider_model=provider_model,
-        exact_model_id=exact_model_id,
-        revision=None,
-        capabilities=ModelCapabilities(),
-        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
-        prices=GatewayTokenPrices(),
-        pricing_source=None,
-        replace=False,
-        serving_connections=serving_connections,
-    )
-    authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
-    revision_id = f"revision-{uuid.uuid4().hex}"
-    manager.activate_direct_alias(
-        alias_id=alias,
-        alias_name=alias,
-        revision_id=revision_id,
-        pool_id=alias,
-        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
-        catalog_sha256=normalized.identity_sha256(),
-        provider_connections=manager.provider_bindings(authored),
-    )
+    for item in deployments:
+        normalized, snapshot, _changed = upsert_singleton_deployment(
+            root,
+            deployment_alias=item.alias,
+            connection_name=item.connection_id,
+            provider_model=item.provider_model,
+            exact_model_id=item.exact_model_id,
+            revision=None,
+            capabilities=ModelCapabilities(),
+            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+            prices=GatewayTokenPrices(),
+            pricing_source=None,
+            replace=False,
+            serving_connections=serving_connections,
+        )
+        authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
+        revision_id = f"revision-{uuid.uuid4().hex}"
+        manager.activate_direct_alias(
+            alias_id=item.alias,
+            alias_name=item.alias,
+            revision_id=revision_id,
+            pool_id=item.alias,
+            snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+            catalog_sha256=normalized.identity_sha256(),
+            provider_connections=manager.provider_bindings(authored),
+        )
     manager.create_identity(identity_id=identity_id, display_name=identity_id)
-    manager.add_grant(identity_id=identity_id, alias_id=alias)
+    for item in deployments:
+        manager.add_grant(identity_id=identity_id, alias_id=item.alias)
     issued = manager.issue_key(
         identity_id=identity_id,
         key_id=f"key-{uuid.uuid4().hex}",
     )
     return InteractiveSetupResult(
         identity_id=identity_id,
-        alias=alias,
+        aliases=aliases,
         raw_key=issued.raw_key,
     )

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -105,7 +105,10 @@ def _collect_provider_connection(provider: str) -> ConnectionConfig:
             return ConnectionConfig(
                 provider=provider,
                 base_url=typer.prompt("OpenAI-compatible base URL"),
-                api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
+                api_key_env=typer.prompt(
+                    "Credential environment variable name",
+                    default=_CANONICAL_CREDENTIAL_ENV[provider],
+                ),
             )
         return ConnectionConfig(
             provider=provider,

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -25,12 +25,13 @@ from exp.runtime.gateway.management import GatewayManagement
 
 _GATEWAY_PROVIDER_OPTIONS = tuple(
     PickerOption(value=provider, label=provider)
-    for provider in ("openai", "anthropic", "azure", "bedrock")
+    for provider in ("openai", "anthropic", "azure", "bedrock", "openai-compatible")
 )
 _CANONICAL_CREDENTIAL_ENV = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "azure": "AZURE_OPENAI_API_KEY",
+    "openai-compatible": "OPENAI_COMPATIBLE_API_KEY",
 }
 
 
@@ -99,6 +100,12 @@ def _collect_provider_connection(provider: str) -> ConnectionConfig:
                 base_url=base_url,
                 api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
                 api_version=api_version,
+            )
+        if provider == "openai-compatible":
+            return ConnectionConfig(
+                provider=provider,
+                base_url=typer.prompt("OpenAI-compatible base URL"),
+                api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
             )
         return ConnectionConfig(
             provider=provider,

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -96,7 +96,10 @@ def interactive_gateway_setup(
     if selection is None:
         raise typer.Abort()
     providers, _manual_models = selection
-    connections = collect_provider_connections(providers, console=console)
+    try:
+        connections = collect_provider_connections(providers, console=console)
+    except SetupCancelled:
+        raise typer.Abort from None
     if not connections:
         raise typer.Abort()
     provider_name, _provider_connection = connections[0]

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -9,9 +9,8 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from exp.cli.shared.picker import PickerAction, PickerKeyReader, PickerOption, choose_one
+from exp.cli.providers.provider_picker import collect_provider_connection, select_single_provider
 from exp.common.models import (
-    ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayTokenPrices,
     ModelCapabilities,
@@ -23,17 +22,6 @@ from exp.runtime.gateway.catalog_authority import (
 )
 from exp.runtime.gateway.management import GatewayManagement
 
-_GATEWAY_PROVIDER_OPTIONS = tuple(
-    PickerOption(value=provider, label=provider)
-    for provider in ("openai", "anthropic", "azure", "bedrock", "openai-compatible")
-)
-_CANONICAL_CREDENTIAL_ENV = {
-    "openai": "OPENAI_API_KEY",
-    "anthropic": "ANTHROPIC_API_KEY",
-    "azure": "AZURE_OPENAI_API_KEY",
-    "openai-compatible": "OPENAI_COMPATIBLE_API_KEY",
-}
-
 
 @dataclass(frozen=True)
 class InteractiveSetupResult:
@@ -42,85 +30,6 @@ class InteractiveSetupResult:
     identity_id: str
     alias: str
     raw_key: str
-
-
-def select_gateway_provider(
-    *,
-    console: Console,
-    read_key: PickerKeyReader | None = None,
-) -> str:
-    """Select the first-run gateway provider with the builder wizard's picker.
-
-    Args:
-        console: Interactive terminal used to render the provider selector.
-        read_key: Optional keyboard source used by tests instead of the controlling terminal.
-
-    Returns:
-        One of the supported first-run provider kinds.
-
-    Raises:
-        typer.Abort: The operator cancels the selector.
-    """
-    while True:
-        result = choose_one(
-            console,
-            title="Provider",
-            options=_GATEWAY_PROVIDER_OPTIONS,
-            default="openai",
-            read_key=read_key,
-        )
-        if result.action is PickerAction.CANCEL:
-            raise typer.Abort()
-        if result.action is PickerAction.BACK:
-            console.print("[yellow]This is the first screen.[/yellow]")
-            continue
-        if not result.values:
-            raise ValueError("provider selector returned no provider")
-        return result.values[0]
-
-
-def _collect_provider_connection(provider: str) -> ConnectionConfig:
-    """Collect the provider-specific fields required by the gateway catalog.
-
-    Args:
-        provider: Provider selected in the first-run selector.
-
-    Returns:
-        Secret-free connection metadata using the provider's canonical credential reference.
-
-    Raises:
-        ValueError: The provider is not one of the first-run selector choices.
-    """
-    if provider in _CANONICAL_CREDENTIAL_ENV:
-        if provider == "azure":
-            base_url = typer.prompt("Azure base URL")
-            api_version = typer.prompt("Azure OpenAI API version", default="v1")
-            return ConnectionConfig(
-                provider=provider,
-                base_url=base_url,
-                api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
-                api_version=api_version,
-            )
-        if provider == "openai-compatible":
-            return ConnectionConfig(
-                provider=provider,
-                base_url=typer.prompt("OpenAI-compatible base URL"),
-                api_key_env=typer.prompt(
-                    "Credential environment variable name",
-                    default=_CANONICAL_CREDENTIAL_ENV[provider],
-                ),
-            )
-        return ConnectionConfig(
-            provider=provider,
-            api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
-        )
-    if provider == "bedrock":
-        region = typer.prompt(
-            "AWS region (empty uses AWS_REGION or the AWS configuration)",
-            default="",
-        )
-        return ConnectionConfig(provider=provider, region=region or None)
-    raise ValueError(f"unsupported first-run provider {provider!r}")
 
 
 def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
@@ -140,8 +49,13 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
     if manager.initialized:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     typer.echo(f"Gateway state will be stored under {root / 'gateway'}.")
-    provider = select_gateway_provider(console=Console())
-    connection = _collect_provider_connection(provider)
+    console = Console()
+    provider = select_single_provider(console=console, environment={})
+    if provider is None:
+        raise typer.Abort()
+    connection = collect_provider_connection(provider, console=console)
+    if connection is None:
+        raise typer.Abort()
     provider_name = provider
     provider_model = typer.prompt("Exact provider model ID")
     exact_model_id = typer.prompt("Exact logical model identity")

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import typer
+from rich.console import Console
 
+from exp.cli.shared.picker import PickerAction, PickerKeyReader, PickerOption, choose_one
 from exp.common.models import (
     ConnectionConfig,
     GatewayDeploymentCapabilities,
@@ -21,6 +23,16 @@ from exp.runtime.gateway.catalog_authority import (
 )
 from exp.runtime.gateway.management import GatewayManagement
 
+_GATEWAY_PROVIDER_OPTIONS = tuple(
+    PickerOption(value=provider, label=provider)
+    for provider in ("openai", "anthropic", "azure", "bedrock")
+)
+_CANONICAL_CREDENTIAL_ENV = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "azure": "AZURE_OPENAI_API_KEY",
+}
+
 
 @dataclass(frozen=True)
 class InteractiveSetupResult:
@@ -29,6 +41,76 @@ class InteractiveSetupResult:
     identity_id: str
     alias: str
     raw_key: str
+
+
+def select_gateway_provider(
+    *,
+    console: Console,
+    read_key: PickerKeyReader | None = None,
+) -> str:
+    """Select the first-run gateway provider with the builder wizard's picker.
+
+    Args:
+        console: Interactive terminal used to render the provider selector.
+        read_key: Optional keyboard source used by tests instead of the controlling terminal.
+
+    Returns:
+        One of the supported first-run provider kinds.
+
+    Raises:
+        typer.Abort: The operator cancels the selector.
+    """
+    while True:
+        result = choose_one(
+            console,
+            title="Provider",
+            options=_GATEWAY_PROVIDER_OPTIONS,
+            default="openai",
+            read_key=read_key,
+        )
+        if result.action is PickerAction.CANCEL:
+            raise typer.Abort()
+        if result.action is PickerAction.BACK:
+            console.print("[yellow]This is the first screen.[/yellow]")
+            continue
+        if not result.values:
+            raise ValueError("provider selector returned no provider")
+        return result.values[0]
+
+
+def _collect_provider_connection(provider: str) -> ConnectionConfig:
+    """Collect the provider-specific fields required by the gateway catalog.
+
+    Args:
+        provider: Provider selected in the first-run selector.
+
+    Returns:
+        Secret-free connection metadata using the provider's canonical credential reference.
+
+    Raises:
+        ValueError: The provider is not one of the first-run selector choices.
+    """
+    if provider in _CANONICAL_CREDENTIAL_ENV:
+        if provider == "azure":
+            base_url = typer.prompt("Azure base URL")
+            api_version = typer.prompt("Azure OpenAI API version", default="v1")
+            return ConnectionConfig(
+                provider=provider,
+                base_url=base_url,
+                api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
+                api_version=api_version,
+            )
+        return ConnectionConfig(
+            provider=provider,
+            api_key_env=_CANONICAL_CREDENTIAL_ENV[provider],
+        )
+    if provider == "bedrock":
+        region = typer.prompt(
+            "AWS region (empty uses AWS_REGION or the AWS configuration)",
+            default="",
+        )
+        return ConnectionConfig(provider=provider, region=region or None)
+    raise ValueError(f"unsupported first-run provider {provider!r}")
 
 
 def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
@@ -48,16 +130,16 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
     if manager.initialized:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     typer.echo(f"Gateway state will be stored under {root / 'gateway'}.")
-    provider_name = typer.prompt("Provider connection name")
-    provider = typer.prompt("Provider adapter (openai, anthropic, openai-compatible)")
-    credential_env = typer.prompt("Credential environment variable name")
-    base_url = typer.prompt("Base URL (leave empty for provider default)", default="")
+    provider = select_gateway_provider(console=Console())
+    connection = _collect_provider_connection(provider)
+    provider_name = provider
     provider_model = typer.prompt("Exact provider model ID")
     exact_model_id = typer.prompt("Exact logical model identity")
     alias = typer.prompt("Public model alias")
     identity_id = typer.prompt("Default identity", default="default")
     typer.echo("\nPlanned local mutations:")
-    typer.echo(f"  provider: {provider_name} ({provider}, credential env {credential_env})")
+    credential_reference = connection.api_key_env or "AWS credential chain"
+    typer.echo(f"  provider: {provider_name} ({provider}, credential env {credential_reference})")
     typer.echo(f"  singleton: {alias} -> {provider_model} ({exact_model_id})")
     typer.echo(f"  identity and grant: {identity_id} -> {alias}")
     typer.echo("  issue one virtual key and reveal it once")
@@ -67,11 +149,7 @@ def interactive_gateway_setup(root: Path) -> InteractiveSetupResult:
     manager.initialize()
     _changed, _authority = manager.upsert_provider_connection(
         connection_id=provider_name,
-        config=ConnectionConfig(
-            provider=provider,
-            base_url=base_url or None,
-            api_key_env=credential_env,
-        ),
+        config=connection,
     )
     serving_connections = {
         item.connection_id: item.config for item in manager.provider_connections()

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -82,11 +82,11 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
     assert "bedrock" in console.output
 
 
-def test_gateway_setup_creates_one_alias_for_each_selected_provider(
+def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First-run gateway setup persists every selected provider instead of discarding extras."""
+    """First-run setup persists selected connections without inventing public aliases."""
     connections = (
         ("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),
         ("anthropic", ConnectionConfig(provider="anthropic", api_key_env="ANTHROPIC_API_KEY")),
@@ -104,9 +104,6 @@ def test_gateway_setup_creates_one_alias_for_each_selected_provider(
             "gpt-5",
             "logical-openai",
             "openai-alias",
-            "claude-sonnet",
-            "logical-anthropic",
-            "anthropic-alias",
             "default",
         )
     )
@@ -115,16 +112,13 @@ def test_gateway_setup_creates_one_alias_for_each_selected_provider(
 
     result = setup.interactive_gateway_setup(tmp_path)
 
-    assert result.aliases == ("openai-alias", "anthropic-alias")
+    assert result.alias == "openai-alias"
     manager = setup.GatewayManagement(tmp_path)
     assert {item.connection_id for item in manager.provider_connections()} == {
         "openai",
         "anthropic",
     }
-    assert {item.alias_id for item in manager.aliases()} == {
-        "openai-alias",
-        "anthropic-alias",
-    }
+    assert {item.alias_id for item in manager.aliases()} == {"openai-alias"}
 
 
 @pytest.mark.parametrize(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -12,19 +12,25 @@ from exp.common.models import ConnectionConfig
 
 @pytest.mark.parametrize(
     ("answer", "provider"),
-    (("1", "openai"), ("2", "anthropic"), ("3", "azure"), ("4", "bedrock")),
+    (
+        ("1", "openai"),
+        ("2", "anthropic"),
+        ("3", "azure"),
+        ("4", "bedrock"),
+        ("5", "openai-compatible"),
+    ),
 )
-def test_gateway_provider_selector_exposes_the_four_first_run_providers(
+def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
     answer: str,
     provider: str,
 ) -> None:
-    """The line fallback presents and accepts each supported first-run provider."""
+    """The line fallback presents the four primary providers and the legacy compatible path."""
     console = ScriptedConsole(f"{answer}\n")
 
     selected = setup.select_gateway_provider(console=console)
 
     assert selected == provider
-    for expected in ("openai", "anthropic", "azure", "bedrock"):
+    for expected in ("openai", "anthropic", "azure", "bedrock", "openai-compatible"):
         assert expected in console.output
 
 
@@ -74,6 +80,25 @@ def test_azure_provider_connection_collects_required_endpoint_fields(
         base_url="https://resource.openai.azure.com",
         api_key_env="AZURE_OPENAI_API_KEY",
         api_version="v1",
+    )
+
+
+def test_openai_compatible_provider_connection_collects_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI-compatible setup retains its explicit endpoint and canonical credential reference."""
+    monkeypatch.setattr(
+        setup.typer,
+        "prompt",
+        lambda _text, **_kwargs: "https://gateway.example.test/v1",
+    )
+
+    connection = setup._collect_provider_connection("openai-compatible")  # noqa: SLF001
+
+    assert connection == ConnectionConfig(
+        provider="openai-compatible",
+        base_url="https://gateway.example.test/v1",
+        api_key_env="OPENAI_COMPATIBLE_API_KEY",
     )
 
 

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import typer
 
 from exp.cli.gateway import setup
 from exp.cli.providers import provider_picker
@@ -141,6 +142,27 @@ def test_gateway_setup_can_edit_the_displayed_defaults(
     assert "Exact model ID" in console.output
     assert "Alias" in console.output
     assert "Identity ID" in console.output
+
+
+def test_gateway_setup_aborts_when_connection_prompt_is_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-run setup converts shared provider prompt cancellation into a clean abort."""
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+
+    def _cancel(*_args: object, **_kwargs: object) -> None:
+        """Raise the shared picker cancellation sentinel."""
+        raise provider_picker.SetupCancelled
+
+    monkeypatch.setattr(setup, "collect_provider_connections", _cancel)
+
+    with pytest.raises(typer.Abort):
+        setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole(""))
 
 
 @pytest.mark.parametrize(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import pytest
 
 from exp.cli.gateway import setup
+from exp.cli.providers import provider_picker
 from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.models import ConnectionConfig
+
+
+def test_gateway_setup_uses_the_shared_provider_setup_seams() -> None:
+    """Gateway first-run setup does not maintain a second provider picker implementation."""
+    assert setup.select_single_provider is provider_picker.select_single_provider
+    assert setup.collect_provider_connection is provider_picker.collect_provider_connection
 
 
 @pytest.mark.parametrize(
@@ -15,9 +22,9 @@ from exp.common.models import ConnectionConfig
     (
         ("1", "openai"),
         ("2", "anthropic"),
-        ("3", "azure"),
-        ("4", "bedrock"),
         ("5", "openai-compatible"),
+        ("6", "azure"),
+        ("7", "bedrock"),
     ),
 )
 def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
@@ -25,9 +32,9 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
     provider: str,
 ) -> None:
     """The line fallback presents the four primary providers and the legacy compatible path."""
-    console = ScriptedConsole(f"{answer}\n")
+    console = ScriptedConsole(f"{answer}\n\n")
 
-    selected = setup.select_gateway_provider(console=console)
+    selected = provider_picker.select_single_provider(console=console, environment={})
 
     assert selected == provider
     for expected in ("openai", "anthropic", "azure", "bedrock", "openai-compatible"):
@@ -36,13 +43,25 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
 
 def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
     """The gateway selector accepts the same Up, Down, and Enter interaction as the builder."""
-    keys = iter((PickerKey.DOWN, PickerKey.DOWN, PickerKey.ENTER))
+    keys = iter(
+        (
+            *(PickerKey.DOWN for _ in range(5)),
+            PickerKey.ENTER,
+            PickerKey.DOWN,
+            PickerKey.DOWN,
+            PickerKey.ENTER,
+        )
+    )
     console = ScriptedConsole("")
 
-    selected = setup.select_gateway_provider(console=console, read_key=lambda: next(keys))
+    selected = provider_picker.select_single_provider(
+        console=console,
+        environment={},
+        read_key=lambda: next(keys),
+    )
 
     assert selected == "azure"
-    assert "Provider" in console.output
+    assert "Providers" in console.output
     assert "openai" in console.output
     assert "bedrock" in console.output
 
@@ -56,7 +75,7 @@ def test_native_provider_connection_uses_its_canonical_credential_env(
     credential_env: str,
 ) -> None:
     """Native providers use the same canonical credential references as builder setup."""
-    connection = setup._collect_provider_connection(provider)  # noqa: SLF001
+    connection = provider_picker.collect_provider_connection(provider, console=ScriptedConsole(""))
 
     assert connection == ConnectionConfig(provider=provider, api_key_env=credential_env)
 
@@ -71,9 +90,9 @@ def test_azure_provider_connection_collects_required_endpoint_fields(
         """Return the next scripted Azure connection field."""
         return next(answers)
 
-    monkeypatch.setattr(setup.typer, "prompt", _prompt)
+    monkeypatch.setattr(provider_picker, "ask_text", _prompt)
 
-    connection = setup._collect_provider_connection("azure")  # noqa: SLF001
+    connection = provider_picker.collect_provider_connection("azure", console=ScriptedConsole(""))
 
     assert connection == ConnectionConfig(
         provider="azure",
@@ -89,13 +108,11 @@ def test_openai_compatible_provider_connection_collects_endpoint(
     """OpenAI-compatible setup retains its endpoint and credential-variable override."""
     answers = iter(("https://gateway.example.test/v1", "COMPATIBLE_API_KEY"))
 
-    monkeypatch.setattr(
-        setup.typer,
-        "prompt",
-        lambda _text, **_kwargs: next(answers),
-    )
+    monkeypatch.setattr(provider_picker, "ask_text", lambda _text, **_kwargs: next(answers))
 
-    connection = setup._collect_provider_connection("openai-compatible")  # noqa: SLF001
+    connection = provider_picker.collect_provider_connection(
+        "openai-compatible", console=ScriptedConsole("")
+    )
 
     assert connection == ConnectionConfig(
         provider="openai-compatible",
@@ -108,12 +125,8 @@ def test_bedrock_provider_connection_uses_the_aws_credential_chain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Bedrock setup records only an optional region and never invents an API-key variable."""
-    monkeypatch.setattr(
-        setup.typer,
-        "prompt",
-        lambda _text, **_kwargs: "us-east-1",
-    )
+    monkeypatch.setattr(provider_picker, "ask_text", lambda _text, **_kwargs: "us-east-1")
 
-    connection = setup._collect_provider_connection("bedrock")  # noqa: SLF001
+    connection = provider_picker.collect_provider_connection("bedrock", console=ScriptedConsole(""))
 
     assert connection == ConnectionConfig(provider="bedrock", region="us-east-1")

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -86,11 +86,13 @@ def test_azure_provider_connection_collects_required_endpoint_fields(
 def test_openai_compatible_provider_connection_collects_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """OpenAI-compatible setup retains its explicit endpoint and canonical credential reference."""
+    """OpenAI-compatible setup retains its endpoint and credential-variable override."""
+    answers = iter(("https://gateway.example.test/v1", "COMPATIBLE_API_KEY"))
+
     monkeypatch.setattr(
         setup.typer,
         "prompt",
-        lambda _text, **_kwargs: "https://gateway.example.test/v1",
+        lambda _text, **_kwargs: next(answers),
     )
 
     connection = setup._collect_provider_connection("openai-compatible")  # noqa: SLF001
@@ -98,7 +100,7 @@ def test_openai_compatible_provider_connection_collects_endpoint(
     assert connection == ConnectionConfig(
         provider="openai-compatible",
         base_url="https://gateway.example.test/v1",
-        api_key_env="OPENAI_COMPATIBLE_API_KEY",
+        api_key_env="COMPATIBLE_API_KEY",
     )
 
 

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -86,7 +86,7 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First-run setup persists selected connections without inventing public aliases."""
+    """First-run setup accepts all displayed defaults with one empty line."""
     connections = (
         ("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),
         ("anthropic", ConnectionConfig(provider="anthropic", api_key_env="ANTHROPIC_API_KEY")),
@@ -99,26 +99,48 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     monkeypatch.setattr(
         setup, "collect_provider_connections", lambda *_args, **_kwargs: connections
     )
-    answers = iter(
-        (
-            "gpt-5",
-            "logical-openai",
-            "openai-alias",
-            "default",
-        )
-    )
-    monkeypatch.setattr(setup.typer, "prompt", lambda *_args, **_kwargs: next(answers))
-    monkeypatch.setattr(setup.typer, "confirm", lambda *_args, **_kwargs: True)
+    console = ScriptedConsole("\n")
 
-    result = setup.interactive_gateway_setup(tmp_path)
+    result = setup.interactive_gateway_setup(tmp_path, console=console)
 
-    assert result.alias == "openai-alias"
+    assert result.alias == "gpt-5-6-luna"
+    assert "gpt-5.6-luna" in console.output
+    assert "Press Enter to accept all defaults" in console.output
+    assert "Planned local mutations" not in console.output
+    assert "Create this gateway configuration?" not in console.output
+    assert "Gateway configured" in console.output
     manager = setup.GatewayManagement(tmp_path)
     assert {item.connection_id for item in manager.provider_connections()} == {
         "openai",
         "anthropic",
     }
-    assert {item.alias_id for item in manager.aliases()} == {"openai-alias"}
+    assert {item.alias_id for item in manager.aliases()} == {"gpt-5-6-luna"}
+
+
+def test_gateway_setup_can_edit_the_displayed_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-run setup keeps the defaults visible while allowing every value to be edited."""
+    connections = (("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),)
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(
+        setup, "collect_provider_connections", lambda *_args, **_kwargs: connections
+    )
+    console = ScriptedConsole("edit\ncustom-model\nlogical-model\ncustom-alias\noperator\n")
+
+    result = setup.interactive_gateway_setup(tmp_path, console=console)
+
+    assert result.alias == "custom-alias"
+    assert result.identity_id == "operator"
+    assert "Provider model" in console.output
+    assert "Exact model ID" in console.output
+    assert "Alias" in console.output
+    assert "Identity ID" in console.output
 
 
 @pytest.mark.parametrize(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -121,6 +121,25 @@ def test_openai_compatible_provider_connection_collects_endpoint(
     )
 
 
+def test_openai_compatible_provider_connection_defaults_whitespace_credential_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only compatible credential input falls back to the canonical variable."""
+    answers = iter(("https://gateway.example.test/v1", "   "))
+
+    monkeypatch.setattr(provider_picker, "ask_text", lambda _text, **_kwargs: next(answers))
+
+    connection = provider_picker.collect_provider_connection(
+        "openai-compatible", console=ScriptedConsole("")
+    )
+
+    assert connection == ConnectionConfig(
+        provider="openai-compatible",
+        base_url="https://gateway.example.test/v1",
+        api_key_env="OPENAI_COMPATIBLE_API_KEY",
+    )
+
+
 def test_bedrock_provider_connection_uses_the_aws_credential_chain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from exp.cli.gateway import setup
@@ -13,8 +15,8 @@ from exp.common.models import ConnectionConfig
 
 def test_gateway_setup_uses_the_shared_provider_setup_seams() -> None:
     """Gateway first-run setup does not maintain a second provider picker implementation."""
-    assert setup.select_single_provider is provider_picker.select_single_provider
-    assert setup.collect_provider_connection is provider_picker.collect_provider_connection
+    assert setup.select_providers is provider_picker.select_providers
+    assert setup.collect_provider_connections is provider_picker.collect_provider_connections
 
 
 @pytest.mark.parametrize(
@@ -34,11 +36,24 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
     """The line fallback presents the four primary providers and the legacy compatible path."""
     console = ScriptedConsole(f"{answer}\n\n")
 
-    selected = provider_picker.select_single_provider(console=console, environment={})
+    selected = provider_picker.select_providers(
+        provider_picker.SetupSession(), console=console, environment={}
+    )
 
-    assert selected == provider
+    assert selected == ((provider,), provider in {"azure", "bedrock"})
     for expected in ("openai", "anthropic", "azure", "bedrock", "openai-compatible"):
         assert expected in console.output
+
+
+def test_gateway_provider_selector_accepts_multiple_providers() -> None:
+    """The gateway uses the builder's multi-select semantics instead of forcing one provider."""
+    console = ScriptedConsole("1,2,6,7\n\n")
+
+    selected = provider_picker.select_providers(
+        provider_picker.SetupSession(), console=console, environment={}
+    )
+
+    assert selected == (("openai", "anthropic", "azure", "bedrock"), True)
 
 
 def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
@@ -54,16 +69,62 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
     )
     console = ScriptedConsole("")
 
-    selected = provider_picker.select_single_provider(
+    selected = provider_picker.select_providers(
+        provider_picker.SetupSession(),
         console=console,
         environment={},
         read_key=lambda: next(keys),
     )
 
-    assert selected == "azure"
+    assert selected == (("azure",), True)
     assert "Providers" in console.output
     assert "openai" in console.output
     assert "bedrock" in console.output
+
+
+def test_gateway_setup_creates_one_alias_for_each_selected_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-run gateway setup persists every selected provider instead of discarding extras."""
+    connections = (
+        ("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),
+        ("anthropic", ConnectionConfig(provider="anthropic", api_key_env="ANTHROPIC_API_KEY")),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai", "anthropic"), False),
+    )
+    monkeypatch.setattr(
+        setup, "collect_provider_connections", lambda *_args, **_kwargs: connections
+    )
+    answers = iter(
+        (
+            "gpt-5",
+            "logical-openai",
+            "openai-alias",
+            "claude-sonnet",
+            "logical-anthropic",
+            "anthropic-alias",
+            "default",
+        )
+    )
+    monkeypatch.setattr(setup.typer, "prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr(setup.typer, "confirm", lambda *_args, **_kwargs: True)
+
+    result = setup.interactive_gateway_setup(tmp_path)
+
+    assert result.aliases == ("openai-alias", "anthropic-alias")
+    manager = setup.GatewayManagement(tmp_path)
+    assert {item.connection_id for item in manager.provider_connections()} == {
+        "openai",
+        "anthropic",
+    }
+    assert {item.alias_id for item in manager.aliases()} == {
+        "openai-alias",
+        "anthropic-alias",
+    }
 
 
 @pytest.mark.parametrize(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -1,0 +1,92 @@
+"""First-run gateway provider selector and connection metadata tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.cli.gateway import setup
+from exp.cli.shared.picker import PickerKey
+from exp.cli.shared.picker_test import ScriptedConsole
+from exp.common.models import ConnectionConfig
+
+
+@pytest.mark.parametrize(
+    ("answer", "provider"),
+    (("1", "openai"), ("2", "anthropic"), ("3", "azure"), ("4", "bedrock")),
+)
+def test_gateway_provider_selector_exposes_the_four_first_run_providers(
+    answer: str,
+    provider: str,
+) -> None:
+    """The line fallback presents and accepts each supported first-run provider."""
+    console = ScriptedConsole(f"{answer}\n")
+
+    selected = setup.select_gateway_provider(console=console)
+
+    assert selected == provider
+    for expected in ("openai", "anthropic", "azure", "bedrock"):
+        assert expected in console.output
+
+
+def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
+    """The gateway selector accepts the same Up, Down, and Enter interaction as the builder."""
+    keys = iter((PickerKey.DOWN, PickerKey.DOWN, PickerKey.ENTER))
+    console = ScriptedConsole("")
+
+    selected = setup.select_gateway_provider(console=console, read_key=lambda: next(keys))
+
+    assert selected == "azure"
+    assert "Provider" in console.output
+    assert "openai" in console.output
+    assert "bedrock" in console.output
+
+
+@pytest.mark.parametrize(
+    ("provider", "credential_env"),
+    (("openai", "OPENAI_API_KEY"), ("anthropic", "ANTHROPIC_API_KEY")),
+)
+def test_native_provider_connection_uses_its_canonical_credential_env(
+    provider: str,
+    credential_env: str,
+) -> None:
+    """Native providers use the same canonical credential references as builder setup."""
+    connection = setup._collect_provider_connection(provider)  # noqa: SLF001
+
+    assert connection == ConnectionConfig(provider=provider, api_key_env=credential_env)
+
+
+def test_azure_provider_connection_collects_required_endpoint_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Azure setup collects the resource endpoint and defaults its API version to v1."""
+    answers = iter(("https://resource.openai.azure.com", "v1"))
+
+    def _prompt(_text: str, **_kwargs: object) -> str:
+        """Return the next scripted Azure connection field."""
+        return next(answers)
+
+    monkeypatch.setattr(setup.typer, "prompt", _prompt)
+
+    connection = setup._collect_provider_connection("azure")  # noqa: SLF001
+
+    assert connection == ConnectionConfig(
+        provider="azure",
+        base_url="https://resource.openai.azure.com",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        api_version="v1",
+    )
+
+
+def test_bedrock_provider_connection_uses_the_aws_credential_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bedrock setup records only an optional region and never invents an API-key variable."""
+    monkeypatch.setattr(
+        setup.typer,
+        "prompt",
+        lambda _text, **_kwargs: "us-east-1",
+    )
+
+    connection = setup._collect_provider_connection("bedrock")  # noqa: SLF001
+
+    assert connection == ConnectionConfig(provider="bedrock", region="us-east-1")

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -165,6 +165,22 @@ def test_gateway_setup_aborts_when_connection_prompt_is_cancelled(
         setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole(""))
 
 
+def test_gateway_setup_aborts_when_provider_selector_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-run setup converts selector EOF into the same clean CLI abort."""
+
+    def _cancel(*_args: object, **_kwargs: object) -> None:
+        """Raise the terminal EOF surfaced by the line-input fallback."""
+        raise EOFError
+
+    monkeypatch.setattr(setup, "select_providers", _cancel)
+
+    with pytest.raises(typer.Abort):
+        setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole(""))
+
+
 @pytest.mark.parametrize(
     ("provider", "credential_env"),
     (("openai", "OPENAI_API_KEY"), ("anthropic", "ANTHROPIC_API_KEY")),

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -10,6 +10,7 @@ screen.
 
 from __future__ import annotations
 
+import re
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass, field
 from getpass import getpass
@@ -69,6 +70,7 @@ _RECOVERY_RETRY = "retry"
 _RECOVERY_SKIP = "skip"
 _RECOVERY_BACK = "back"
 _PROVIDER_VISIBLE_ROWS = 3
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class SetupCancelled(Exception):
@@ -345,14 +347,23 @@ def collect_provider_connection(
         )
     api_key_env = CANONICAL_CREDENTIAL_ENV.get(provider)
     if provider == "openai-compatible":
-        api_key_env = (
-            ask_text(
-                "Credential environment variable name",
-                console=console,
-                default=CANONICAL_CREDENTIAL_ENV[provider],
-            ).strip()
-            or CANONICAL_CREDENTIAL_ENV[provider]
-        )
+        while True:
+            candidate = (
+                ask_text(
+                    "Credential environment variable name",
+                    console=console,
+                    default=CANONICAL_CREDENTIAL_ENV[provider],
+                ).strip()
+                or CANONICAL_CREDENTIAL_ENV[provider]
+            )
+            if _ENVIRONMENT_NAME.fullmatch(candidate):
+                api_key_env = candidate
+                break
+            console.print(
+                "Credential environment variable names must match [A-Za-z_][A-Za-z0-9_]*.",
+                style="yellow",
+                markup=False,
+            )
     return ConnectionConfig(
         provider=provider,
         base_url=base_url,

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -376,10 +376,13 @@ def collect_provider_connection(
         )
     api_key_env = CANONICAL_CREDENTIAL_ENV.get(provider)
     if provider == "openai-compatible":
-        api_key_env = ask_text(
-            "Credential environment variable name",
-            console=console,
-            default=CANONICAL_CREDENTIAL_ENV[provider],
+        api_key_env = (
+            ask_text(
+                "Credential environment variable name",
+                console=console,
+                default=CANONICAL_CREDENTIAL_ENV[provider],
+            ).strip()
+            or CANONICAL_CREDENTIAL_ENV[provider]
         )
     return ConnectionConfig(
         provider=provider,

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -277,37 +277,6 @@ def select_providers(
         return providers, any(provider in _MANUAL_MODEL_PROVIDERS for provider in providers)
 
 
-def select_single_provider(
-    *,
-    console: Console,
-    environment: MutableMapping[str, str],
-    read_key: PickerKeyReader | None = None,
-) -> str | None:
-    """Use the shared provider screen when a gateway needs one provider.
-
-    Args:
-        console: Terminal used for the shared provider screen.
-        environment: Process environment passed through the common provider-selection seam.
-        read_key: Optional keyboard source used by tests instead of the controlling terminal.
-
-    Returns:
-        The one selected provider, or ``None`` when the operator cancels.
-    """
-    while True:
-        selection = select_providers(
-            SetupSession(),
-            console=console,
-            environment=environment,
-            read_key=read_key,
-        )
-        if selection is None:
-            return None
-        providers, _manual_models = selection
-        if len(providers) == 1:
-            return providers[0]
-        console.print("[yellow]Select exactly one provider for the gateway.[/yellow]")
-
-
 def _select_provider_rows(
     console: Console,
     *,
@@ -391,6 +360,34 @@ def collect_provider_connection(
         api_version=api_version,
         region=region,
     )
+
+
+def collect_provider_connections(
+    providers: Sequence[str],
+    *,
+    console: Console,
+) -> tuple[tuple[str, ConnectionConfig], ...]:
+    """Collect connection metadata for every provider selected in the shared screen.
+
+    Args:
+        providers: Supported providers returned by ``select_providers``.
+        console: Terminal used for provider-specific fields.
+
+    Returns:
+        Provider names paired with the metadata accepted for each provider. A provider whose
+        optional endpoint field is left empty is skipped using the same rule as normal setup.
+
+    Raises:
+        ValueError: A provider is unsupported or its collected metadata is invalid.
+    """
+    connections: list[tuple[str, ConnectionConfig]] = []
+    for provider in providers:
+        connection = collect_provider_connection(provider, console=console)
+        if connection is None:
+            console.print(f"[yellow]Skipping {SETUP_PROVIDER_LABELS[provider]}.[/yellow]")
+            continue
+        connections.append((provider, connection))
+    return tuple(connections)
 
 
 def prepare_providers(

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -26,6 +26,7 @@ from exp.cli.shared.picker import (
     choose_one,
 )
 from exp.common.models import (
+    ConnectionConfig,
     ModelCapabilities,
     PricingSource,
     ProviderConnection,
@@ -276,6 +277,37 @@ def select_providers(
         return providers, any(provider in _MANUAL_MODEL_PROVIDERS for provider in providers)
 
 
+def select_single_provider(
+    *,
+    console: Console,
+    environment: MutableMapping[str, str],
+    read_key: PickerKeyReader | None = None,
+) -> str | None:
+    """Use the shared provider screen when a gateway needs one provider.
+
+    Args:
+        console: Terminal used for the shared provider screen.
+        environment: Process environment passed through the common provider-selection seam.
+        read_key: Optional keyboard source used by tests instead of the controlling terminal.
+
+    Returns:
+        The one selected provider, or ``None`` when the operator cancels.
+    """
+    while True:
+        selection = select_providers(
+            SetupSession(),
+            console=console,
+            environment=environment,
+            read_key=read_key,
+        )
+        if selection is None:
+            return None
+        providers, _manual_models = selection
+        if len(providers) == 1:
+            return providers[0]
+        console.print("[yellow]Select exactly one provider for the gateway.[/yellow]")
+
+
 def _select_provider_rows(
     console: Console,
     *,
@@ -301,6 +333,60 @@ def _select_provider_rows(
         preselected=preselected,
         read_key=read_key,
         visible_rows=_PROVIDER_VISIBLE_ROWS,
+    )
+
+
+def collect_provider_connection(
+    provider: str,
+    *,
+    console: Console,
+) -> ConnectionConfig | None:
+    """Collect the provider-specific connection metadata shared by setup entry points.
+
+    Args:
+        provider: Supported provider selected on the shared provider screen.
+        console: Terminal used for provider-specific fields.
+
+    Returns:
+        Secret-free connection metadata, or ``None`` when an optional endpoint field is skipped.
+
+    Raises:
+        ValueError: The provider is unsupported or the collected metadata is invalid.
+    """
+    if provider not in SETUP_PROVIDER_LABELS:
+        raise ValueError(f"unsupported provider {provider!r}")
+    base_url = None
+    api_version = None
+    region = None
+    if provider in ("openai-compatible", "azure"):
+        base_url = ask_text(f"{SETUP_PROVIDER_LABELS[provider]} base URL", console=console)
+        if not base_url:
+            return None
+    if provider == "azure":
+        api_version = ask_text("Azure OpenAI API version", console=console, default="v1")
+        if not api_version:
+            return None
+    if provider == "bedrock":
+        region = (
+            ask_text(
+                "AWS region (empty uses the AWS credential or session configuration)",
+                console=console,
+            )
+            or None
+        )
+    api_key_env = CANONICAL_CREDENTIAL_ENV.get(provider)
+    if provider == "openai-compatible":
+        api_key_env = ask_text(
+            "Credential environment variable name",
+            console=console,
+            default=CANONICAL_CREDENTIAL_ENV[provider],
+        )
+    return ConnectionConfig(
+        provider=provider,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_version=api_version,
+        region=region,
     )
 
 
@@ -415,43 +501,26 @@ def _resolve_endpoint(
         SetupCancelled: The user cancelled setup at a prompt.
     """
     label = SETUP_PROVIDER_LABELS[provider]
-    base_url = None
-    api_version = None
-    region = None
-    if provider in ("openai-compatible", "azure"):
-        base_url = ask_text(f"{label} base URL", console=console)
-        if not base_url:
-            return None
-    if provider == "azure":
-        api_version = ask_text("Azure OpenAI API version", console=console, default="v1")
-        if not api_version:
-            return None
-    if provider == "bedrock":
-        region = (
-            ask_text(
-                "AWS region (empty uses the AWS credential or session configuration)",
-                console=console,
-            )
-            or None
-        )
-    api_key_env = CANONICAL_CREDENTIAL_ENV.get(provider)
+    config = collect_provider_connection(provider, console=console)
+    if config is None:
+        return None
     connection = _reused_connection(
         existing_connections,
         provider=provider,
-        api_key_env=api_key_env,
-        base_url=base_url,
-        api_version=api_version,
-        region=region,
+        api_key_env=config.api_key_env,
+        base_url=config.base_url,
+        api_version=config.api_version,
+        region=config.region,
     )
     configured = connection is not None
     if connection is None:
         connection = ProviderConnection(
             name=derive_connection_name(provider, taken_names),
             provider=provider,
-            api_key_env=api_key_env,
-            base_url=base_url,
-            api_version=api_version,
-            region=region,
+            api_key_env=config.api_key_env,
+            base_url=config.base_url,
+            api_version=config.api_version,
+            region=config.region,
         )
     if provider == "bedrock":
         return PreparedEndpoint(connection=connection, api_key="", configured=configured)

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -604,9 +604,9 @@ def test_an_identical_configured_connection_is_reused_instead_of_duplicated() ->
     assert models[0].connection == "primary"
 
 
-def test_openai_compatible_endpoint_asks_only_for_its_base_url() -> None:
-    """A compatible endpoint defaults its credential variable after its explicit base URL."""
-    console = ScriptedConsole("https://models.example.test/v1\n\n")
+def test_openai_compatible_endpoint_retries_invalid_credential_env_names() -> None:
+    """A compatible endpoint retries invalid names before resolving its custom variable."""
+    console = ScriptedConsole("https://models.example.test/v1\nnot-a-variable\nINTERNAL_API_KEY\n")
     lister = _FakeLister(
         {
             "openai-compatible": [
@@ -628,13 +628,16 @@ def test_openai_compatible_endpoint_asks_only_for_its_base_url() -> None:
         console,
         providers=("openai-compatible",),
         lister=lister,
-        environment={"OPENAI_COMPATIBLE_API_KEY": "compat-secret"},
+        environment={"INTERNAL_API_KEY": "compat-secret"},
     )
 
     assert prepared is not None
     endpoints, models = prepared
     assert endpoints[0].connection.base_url == "https://models.example.test/v1"
+    assert endpoints[0].connection.api_key_env == "INTERNAL_API_KEY"
     assert lister.requests[0].base_url == "https://models.example.test/v1"
+    assert lister.requests[0].api_key == "compat-secret"
+    assert "must match" in console.output
     assert models[0].pricing_source is PricingSource.PROVIDER
 
 

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -605,8 +605,8 @@ def test_an_identical_configured_connection_is_reused_instead_of_duplicated() ->
 
 
 def test_openai_compatible_endpoint_asks_only_for_its_base_url() -> None:
-    """A compatible endpoint needs an explicit base URL and nothing else by hand."""
-    console = ScriptedConsole("https://models.example.test/v1\n")
+    """A compatible endpoint defaults its credential variable after its explicit base URL."""
+    console = ScriptedConsole("https://models.example.test/v1\n\n")
     lister = _FakeLister(
         {
             "openai-compatible": [

--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -8,10 +8,13 @@ import sys
 from pathlib import Path
 
 import typer
+from rich.console import Console
 
 from exp.cli.shared.options import ROOT_OPTION, usage_error
+from exp.cli.shared.theme import EXP_THEME
 
 _LOOPBACK_HOST = "127.0.0.1"
+_console = Console(theme=EXP_THEME)
 _POLICY_OPTION = typer.Option(
     None,
     "--policy",
@@ -209,28 +212,24 @@ def _emit_gateway_ready(
     compatibility: object | None,
     ghost: bool,
 ) -> None:
-    """Print human startup instructions and an optional one-time setup key."""
-    typer.echo(f"Gateway ready at http://{_LOOPBACK_HOST}:{port}/v1")
-    typer.echo(f"Usage view: http://{_LOOPBACK_HOST}:{port}/usage")
+    """Print the green startup result and only the exports needed to use the gateway."""
+    _console.print(
+        f"[green]✓ Gateway ready[/green] http://{_LOOPBACK_HOST}:{port}/v1",
+        markup=True,
+    )
     if compatibility is not None:
         from exp.cli.gateway.compatibility import ProjectGatewayCompatibility
 
         if not isinstance(compatibility, ProjectGatewayCompatibility):
             raise TypeError("project gateway compatibility returned an invalid result")
-        typer.echo(f"Project alias: {compatibility.alias} (policy {compatibility.policy_id})")
-        typer.echo(f"Gateway key file: {compatibility.key_file}")
-        typer.echo(f"export OPENAI_API_KEY=\"$(tr -d '\\n' < {compatibility.key_file})\"")
-        if ghost:
-            typer.echo(
-                "ghost compatibility: project journals are disabled; gateway accounting is enabled"
-            )
+        _console.print(
+            f"export OPENAI_API_KEY=\"$(tr -d '\\n' < {compatibility.key_file})\"",
+            markup=False,
+        )
     if setup is not None:
         from exp.cli.gateway.setup import InteractiveSetupResult
 
         if not isinstance(setup, InteractiveSetupResult):
             raise TypeError("interactive setup returned an invalid result")
-        typer.echo(f"Default identity: {setup.identity_id}")
-        typer.echo(f"Granted alias: {setup.alias}")
-        typer.echo("")
-        typer.echo(f"export OPENAI_BASE_URL=http://{_LOOPBACK_HOST}:{port}/v1")
-        typer.echo(f"export OPENAI_API_KEY={setup.raw_key}")
+        _console.print(f"export OPENAI_BASE_URL=http://{_LOOPBACK_HOST}:{port}/v1", markup=False)
+        _console.print(f"export OPENAI_API_KEY={setup.raw_key}", markup=False)

--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -230,7 +230,7 @@ def _emit_gateway_ready(
         if not isinstance(setup, InteractiveSetupResult):
             raise TypeError("interactive setup returned an invalid result")
         typer.echo(f"Default identity: {setup.identity_id}")
-        typer.echo(f"Granted aliases: {setup.alias}")
+        typer.echo(f"Granted aliases: {', '.join(setup.aliases)}")
         typer.echo("")
         typer.echo(f"export OPENAI_BASE_URL=http://{_LOOPBACK_HOST}:{port}/v1")
         typer.echo(f"export OPENAI_API_KEY={setup.raw_key}")

--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -230,7 +230,7 @@ def _emit_gateway_ready(
         if not isinstance(setup, InteractiveSetupResult):
             raise TypeError("interactive setup returned an invalid result")
         typer.echo(f"Default identity: {setup.identity_id}")
-        typer.echo(f"Granted aliases: {', '.join(setup.aliases)}")
+        typer.echo(f"Granted alias: {setup.alias}")
         typer.echo("")
         typer.echo(f"export OPENAI_BASE_URL=http://{_LOOPBACK_HOST}:{port}/v1")
         typer.echo(f"export OPENAI_API_KEY={setup.raw_key}")


### PR DESCRIPTION
## Summary

- Reuse the builder's shared provider selector for first-run gateway setup while persisting every selected provider connection.
- Show the provider model, exact logical model ID, public alias, and identity ID together with sensible defaults.
- Accept all defaults with one Enter; type edit to change the fields.
- Replace mutation-plan and confirmation noise with one progress display and an Experiential-green completion state.
- Keep non-interactive provider overrides and the singleton first-run gateway bootstrap intact.
- Keep `exp run` startup output limited to the green ready state and the exports needed to use the gateway.
- Abort cleanly on selector or shared metadata prompt cancellation and retry invalid custom credential environment names.

## Validation

- Focused build/config/gateway/run pytest suite: 135 passed.
- Ruff check and format check passed.
- ty check passed.