### PR TITLE
Unify gateway provider, model, and effort setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Experiential is an open source gateway and router for agent workflows:
 
 ## Getting Started
 
-Start a local OpenAI-compatible gateway. On first run, the setup wizard uses the provider selector,
-persists the selected provider connections, then collects one initial model and public alias before
-printing a one-time virtual key:
+Start a local OpenAI-compatible gateway. On first run, the setup wizard uses the shared provider,
+model, and reasoning-effort selectors, persists every selected provider connection, then shows
+defaults for the public alias, identity, and `$50.00` command budget before printing a one-time key:
 
 ```bash
 pip install experiential

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ The root surface is deliberately small:
 | `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
 | `exp config gateway key check [--json]` | Validate one raw virtual key against a live gateway and print its granted aliases without storing the key. | One HTTP request against the running gateway; no local state. |
 | `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. | Local `.exp/models.toml`. |
-| `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command. | Local `.exp/settings.toml`. |
+| `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command (default `$50.00`). | Local `.exp/settings.toml`. |
 | `exp config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.exp/settings.toml`. |
 
 `build`, judge calibration, `optimize router`, and `optimize model` use the same cost authorization

--- a/exp/cli/config/app_test.py
+++ b/exp/cli/config/app_test.py
@@ -20,7 +20,7 @@ def test_budget_status_reports_the_default_without_writing(tmp_path: Path) -> No
     result = _RUNNER.invoke(app, ["config", "budget", "--root", str(root)])
 
     assert result.exit_code == 0, result.output
-    assert "maximum command cost: $10.00" in unstyle(result.output)
+    assert "maximum command cost: $50.00" in unstyle(result.output)
     assert not root.exists()
 
 

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -149,10 +149,10 @@ def interactive_gateway_setup(
                 detail=detail,
             )
 
-        manager.initialize()
-        advance("initialize")
         set_maximum_command_cost_usd(values.maximum_cost_usd, root)
         advance("save budget")
+        manager.initialize()
+        advance("initialize")
         for endpoint in session.endpoints:
             manager.upsert_provider_connection(
                 connection_id=endpoint.connection.name,

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import uuid
+from collections.abc import MutableMapping
 from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,21 +14,25 @@ from rich.console import Console
 from rich.table import Table
 from rich.text import Text
 
+from exp.cli.providers.model_picker import GatewayModelSelection, select_gateway_model
 from exp.cli.providers.provider_picker import (
+    AvailableModel,
     SetupCancelled,
     SetupSession,
+    ask_price,
     ask_text,
-    collect_provider_connections,
+    prepare_providers,
     select_providers,
 )
 from exp.cli.shared.progress import progress_display
 from exp.cli.shared.theme import EXP_THEME
+from exp.common.config import resolve_command_budget_usd, set_maximum_command_cost_usd
+from exp.common.core.artifacts import stable_id
 from exp.common.models import (
     GatewayDeploymentCapabilities,
     GatewayTokenPrices,
     ModelCapabilities,
     ModelCatalog,
-    derive_model_alias,
 )
 from exp.common.progress import report
 from exp.runtime.gateway.catalog_authority import (
@@ -34,6 +40,7 @@ from exp.runtime.gateway.catalog_authority import (
     upsert_singleton_deployment,
 )
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.models.providers import HttpProviderModelLister, ProviderModelLister
 
 
 @dataclass(frozen=True)
@@ -49,33 +56,25 @@ class InteractiveSetupResult:
 class _GatewaySetupValues:
     """Values shown on the first-run gateway defaults screen."""
 
-    provider_model: str
-    exact_model_id: str
     alias: str
     identity_id: str
-
-
-_DEFAULT_GATEWAY_MODELS = {
-    "openai": "gpt-5.6-luna",
-    "anthropic": "claude-sonnet-4-5",
-    "gemini": "gemini-3.6-flash",
-    "openrouter": "openai/gpt-5.4",
-    "openai-compatible": "gpt-5.4",
-    "azure": "gpt-5-deployment",
-    "bedrock": "anthropic.claude-sonnet-4-5",
-}
+    maximum_cost_usd: float
 
 
 def interactive_gateway_setup(
     root: Path,
     *,
     console: Console | None = None,
+    lister: ProviderModelLister | None = None,
+    environment: MutableMapping[str, str] | None = None,
 ) -> InteractiveSetupResult:
     """Collect and create one minimal provider-backed singleton gateway.
 
     Args:
         root: Empty EXP root selected by the operator.
         console: Optional terminal override used by tests and embedding callers.
+        lister: Optional authenticated model-listing seam used by tests.
+        environment: Environment consulted for provider credentials.
 
     Returns:
         Created identity, alias, and one-time key material.
@@ -88,27 +87,49 @@ def interactive_gateway_setup(
     if manager.initialized:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     console = console or Console(theme=EXP_THEME)
+    environment = os.environ if environment is None else environment
+    lister = lister or HttpProviderModelLister()
+    session = SetupSession()
     try:
-        selection = select_providers(
-            SetupSession(),
-            console=console,
-            environment={},
-        )
+        while True:
+            selection = select_providers(
+                session,
+                console=console,
+                environment=environment,
+            )
+            if selection is None:
+                raise typer.Abort()
+            session.providers, session.advanced_models = selection
+            prepared = prepare_providers(
+                session,
+                existing_connections=(),
+                existing_aliases=(),
+                console=console,
+                lister=lister,
+                environment=environment,
+            )
+            if prepared is None:
+                continue
+            session.endpoints, session.available = prepared
+            model_selection = select_gateway_model(session, console=console)
+            if model_selection is None:
+                continue
+            values = _collect_gateway_values(
+                model_selection,
+                root=root,
+                console=console,
+            )
+            break
     except (EOFError, KeyboardInterrupt, SetupCancelled):
         raise typer.Abort from None
-    if selection is None:
-        raise typer.Abort()
-    providers, _manual_models = selection
-    try:
-        connections = collect_provider_connections(providers, console=console)
-    except SetupCancelled:
-        raise typer.Abort from None
-    if not connections:
-        raise typer.Abort()
-    provider_name, _provider_connection = connections[0]
-    values = _collect_gateway_values(provider_name, console=console)
 
-    total_steps = len(connections) + 6
+    selected = model_selection.model
+    capabilities = selected.capabilities or ModelCapabilities()
+    if model_selection.reasoning_effort is not None:
+        capabilities = capabilities.model_copy(
+            update={"reasoning_effort": model_selection.reasoning_effort}
+        )
+    total_steps = len(session.endpoints) + 7
     completed_steps = 0
 
     progress_context = (
@@ -130,20 +151,25 @@ def interactive_gateway_setup(
 
         manager.initialize()
         advance("initialize")
-        for connection_id, connection in connections:
-            manager.upsert_provider_connection(connection_id=connection_id, config=connection)
-            advance(f"connect {connection_id}")
+        set_maximum_command_cost_usd(values.maximum_cost_usd, root)
+        advance("save budget")
+        for endpoint in session.endpoints:
+            manager.upsert_provider_connection(
+                connection_id=endpoint.connection.name,
+                config=endpoint.connection.catalog_config(),
+            )
+            advance(f"connect {endpoint.connection.name}")
         serving_connections = {
             item.connection_id: item.config for item in manager.provider_connections()
         }
         normalized, snapshot, _changed = upsert_singleton_deployment(
             root,
             deployment_alias=values.alias,
-            connection_name=provider_name,
-            provider_model=values.provider_model,
-            exact_model_id=values.exact_model_id,
+            connection_name=selected.connection,
+            provider_model=selected.model,
+            exact_model_id=_gateway_exact_model_id(selected),
             revision=None,
-            capabilities=ModelCapabilities(),
+            capabilities=capabilities,
             gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
             prices=GatewayTokenPrices(),
             pricing_source=None,
@@ -180,28 +206,33 @@ def interactive_gateway_setup(
     )
 
 
-def _collect_gateway_values(provider: str, *, console: Console) -> _GatewaySetupValues:
-    """Show gateway defaults and collect edits only when the operator requests them.
+def _collect_gateway_values(
+    model_selection: GatewayModelSelection,
+    *,
+    root: Path,
+    console: Console,
+) -> _GatewaySetupValues:
+    """Show and optionally edit only the user-owned gateway defaults.
 
     Args:
-        provider: First selected provider that receives the initial singleton alias.
+        model_selection: Provider/model and effort already selected by the shared picker.
+        root: EXP root owning the shared command budget setting.
         console: Terminal used for the defaults screen and optional field edits.
 
     Returns:
-        Gateway values accepted from the defaults screen or edited by the operator.
+        Alias, identity, and maximum command budget accepted by the operator.
 
     Raises:
         typer.Abort: The operator reaches end of input or interrupts the screen.
     """
-    defaults = _gateway_defaults(provider)
+    defaults = _gateway_defaults(model_selection, root=root)
     table = Table.grid(padding=(0, 2))
     table.add_column(style="dim")
     table.add_column(style="green")
     for label, value in (
-        ("Provider model", defaults.provider_model),
-        ("Exact model ID", defaults.exact_model_id),
         ("Alias", defaults.alias),
         ("Identity ID", defaults.identity_id),
+        ("Budget", f"${defaults.maximum_cost_usd:.2f}"),
     ):
         table.add_row(label, Text(value, style="green"))
     console.print(table)
@@ -216,32 +247,46 @@ def _collect_gateway_values(provider: str, *, console: Console) -> _GatewaySetup
 
     try:
         return _GatewaySetupValues(
-            provider_model=ask_text(
-                "Provider model", console=console, default=defaults.provider_model
-            ),
-            exact_model_id=ask_text(
-                "Exact model ID", console=console, default=defaults.exact_model_id
-            ),
             alias=ask_text("Alias", console=console, default=defaults.alias),
             identity_id=ask_text("Identity ID", console=console, default=defaults.identity_id),
+            maximum_cost_usd=ask_price(
+                "Budget (USD)",
+                console=console,
+                default=f"{defaults.maximum_cost_usd:g}",
+            ),
         )
     except SetupCancelled as exc:
         raise typer.Abort from exc
 
 
-def _gateway_defaults(provider: str) -> _GatewaySetupValues:
-    """Return the concise first-run defaults for one provider-backed singleton.
+def _gateway_defaults(
+    model_selection: GatewayModelSelection,
+    *,
+    root: Path,
+) -> _GatewaySetupValues:
+    """Return defaults after the shared provider/model/effort flow has completed.
 
     Args:
-        provider: Supported provider receiving the initial singleton alias.
+        model_selection: Selected provider model and optional effort pin.
+        root: EXP root owning the shared command budget setting.
 
     Returns:
-        Provider model, logical identity, alias, and caller identity defaults.
+        Alias, default identity, and current command-budget ceiling.
     """
-    provider_model = _DEFAULT_GATEWAY_MODELS[provider]
     return _GatewaySetupValues(
-        provider_model=provider_model,
-        exact_model_id=provider_model,
-        alias=derive_model_alias(provider, provider_model, frozenset()),
+        alias=model_selection.model.alias,
         identity_id="default",
+        maximum_cost_usd=resolve_command_budget_usd(root, None),
+    )
+
+
+def _gateway_exact_model_id(model: AvailableModel) -> str:
+    """Derive the hidden singleton identity from the selected provider model."""
+    return stable_id(
+        "gateway-model",
+        {
+            "connection": model.connection,
+            "provider": model.provider,
+            "model": model.model,
+        },
     )

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -8,16 +8,43 @@ import pytest
 import typer
 
 from exp.cli.gateway import setup
-from exp.cli.providers import provider_picker
+from exp.cli.providers import model_picker, provider_picker
 from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
-from exp.common.models import ConnectionConfig
+from exp.common.config import load_settings
+from exp.common.models import ConnectionConfig, ModelCapabilities, PricingSource, ProviderConnection
+
+
+def _prepared_gateway_models() -> tuple[
+    tuple[provider_picker.PreparedEndpoint, ...],
+    tuple[provider_picker.AvailableModel, ...],
+]:
+    """Build prepared endpoints and one discovered completion model for gateway tests."""
+    connections = (
+        ProviderConnection(name="openai", provider="openai", api_key_env="OPENAI_API_KEY"),
+        ProviderConnection(name="anthropic", provider="anthropic", api_key_env="ANTHROPIC_API_KEY"),
+    )
+    endpoints = tuple(
+        provider_picker.PreparedEndpoint(connection=connection, api_key="secret", configured=False)
+        for connection in connections
+    )
+    model = provider_picker.AvailableModel(
+        alias="gpt-5-6-luna",
+        connection="openai",
+        provider="openai",
+        model="gpt-5.6-luna",
+        capabilities=ModelCapabilities(supports_completions=True, reasoning_effort="medium"),
+        pricing_source=PricingSource.EXP_CATALOG,
+        configured=False,
+    )
+    return endpoints, (model,)
 
 
 def test_gateway_setup_uses_the_shared_provider_setup_seams() -> None:
     """Gateway first-run setup does not maintain a second provider picker implementation."""
     assert setup.select_providers is provider_picker.select_providers
-    assert setup.collect_provider_connections is provider_picker.collect_provider_connections
+    assert setup.prepare_providers is provider_picker.prepare_providers
+    assert setup.select_gateway_model is model_picker.select_gateway_model
 
 
 @pytest.mark.parametrize(
@@ -88,25 +115,29 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """First-run setup accepts all displayed defaults with one empty line."""
-    connections = (
-        ("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),
-        ("anthropic", ConnectionConfig(provider="anthropic", api_key_env="ANTHROPIC_API_KEY")),
-    )
+    endpoints, models = _prepared_gateway_models()
     monkeypatch.setattr(
         setup,
         "select_providers",
         lambda *_args, **_kwargs: (("openai", "anthropic"), False),
     )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
     monkeypatch.setattr(
-        setup, "collect_provider_connections", lambda *_args, **_kwargs: connections
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
     )
     console = ScriptedConsole("\n")
 
     result = setup.interactive_gateway_setup(tmp_path, console=console)
 
     assert result.alias == "gpt-5-6-luna"
-    assert "gpt-5.6-luna" in console.output
     assert "Press Enter to accept all defaults" in console.output
+    assert "Alias" in console.output
+    assert "Identity ID" in console.output
+    assert "Budget" in console.output
+    assert "$50.00" in console.output
+    assert "Exact model ID" not in console.output
     assert "Planned local mutations" not in console.output
     assert "Create this gateway configuration?" not in console.output
     assert "Gateway configured" in console.output
@@ -116,6 +147,7 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
         "anthropic",
     }
     assert {item.alias_id for item in manager.aliases()} == {"gpt-5-6-luna"}
+    assert load_settings(tmp_path).commands.maximum_cost_usd == 50.0
 
 
 def test_gateway_setup_can_edit_the_displayed_defaults(
@@ -123,25 +155,29 @@ def test_gateway_setup_can_edit_the_displayed_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """First-run setup keeps the defaults visible while allowing every value to be edited."""
-    connections = (("openai", ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")),)
+    endpoints, models = _prepared_gateway_models()
     monkeypatch.setattr(
         setup,
         "select_providers",
         lambda *_args, **_kwargs: (("openai",), False),
     )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
     monkeypatch.setattr(
-        setup, "collect_provider_connections", lambda *_args, **_kwargs: connections
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
     )
-    console = ScriptedConsole("edit\ncustom-model\nlogical-model\ncustom-alias\noperator\n")
+    console = ScriptedConsole("edit\ncustom-alias\noperator\n75\n")
 
     result = setup.interactive_gateway_setup(tmp_path, console=console)
 
     assert result.alias == "custom-alias"
     assert result.identity_id == "operator"
-    assert "Provider model" in console.output
-    assert "Exact model ID" in console.output
     assert "Alias" in console.output
     assert "Identity ID" in console.output
+    assert "Budget" in console.output
+    assert "Exact model ID" not in console.output
+    assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
 
 
 def test_gateway_setup_aborts_when_connection_prompt_is_cancelled(
@@ -159,7 +195,7 @@ def test_gateway_setup_aborts_when_connection_prompt_is_cancelled(
         """Raise the shared picker cancellation sentinel."""
         raise provider_picker.SetupCancelled
 
-    monkeypatch.setattr(setup, "collect_provider_connections", _cancel)
+    monkeypatch.setattr(setup, "prepare_providers", _cancel)
 
     with pytest.raises(typer.Abort):
         setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole(""))

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -180,6 +180,37 @@ def test_gateway_setup_can_edit_the_displayed_defaults(
     assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
 
 
+def test_gateway_setup_writes_budget_before_gateway_initialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed budget write leaves first-run setup eligible for a retry."""
+    endpoints, models = _prepared_gateway_models()
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
+    )
+
+    def _fail_budget(_maximum_cost_usd: float, root: Path) -> None:
+        """Fail before gateway initialization, as a settings write can in production."""
+        assert root == tmp_path
+        assert not setup.GatewayManagement(root).initialized
+        raise OSError("settings unavailable")
+
+    monkeypatch.setattr(setup, "set_maximum_command_cost_usd", _fail_budget)
+
+    with pytest.raises(OSError, match="settings unavailable"):
+        setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+    assert not setup.GatewayManagement(tmp_path).initialized
+
+
 def test_gateway_setup_aborts_when_connection_prompt_is_cancelled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/exp/cli/providers/model_picker.py
+++ b/exp/cli/providers/model_picker.py
@@ -65,6 +65,14 @@ class RoleAssignment:
     candidate_reasoning_efforts: dict[str, ReasoningEffort] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class GatewayModelSelection:
+    """One first-run gateway model and its optional reasoning-effort pin."""
+
+    model: AvailableModel
+    reasoning_effort: ReasoningEffort | None = None
+
+
 def available_models(session: SetupSession) -> tuple[AvailableModel, ...]:
     """List every configurable model, including models declared by hand."""
     return (*session.available, *session.manual)
@@ -190,6 +198,136 @@ def select_models(session: SetupSession, *, console: Console) -> tuple[str, ...]
                 session.selected = (*session.selected, declared.alias)
             continue
         return result.values
+
+
+def select_gateway_model(
+    session: SetupSession,
+    *,
+    console: Console,
+) -> GatewayModelSelection | None:
+    """Select one completion model and reuse the build effort picker for gateway setup.
+
+    The gateway has one initial public alias, so it selects one completion model from the same
+    provider/model rows used by provider setup. Azure and Bedrock keep their provider model entry
+    behind the same model screen because those providers do not expose a safe listing endpoint.
+
+    Args:
+        session: Prepared provider endpoints and discovered model rows.
+        console: Terminal used for the model and reasoning-effort screens.
+
+    Returns:
+        The selected model and effort, or ``None`` when the operator goes back to providers.
+
+    Raises:
+        SetupCancelled: The user cancelled setup.
+    """
+    while True:
+        available = tuple(
+            item
+            for item in available_models(session)
+            if item.capabilities is None or item.capabilities.supports_completions is not False
+        )
+        options = [_option(item) for item in available]
+        if session.advanced_models:
+            options.append(
+                PickerOption(
+                    value=_MANUAL_MODEL_ROW,
+                    label="Add a provider model",
+                    detail="Azure or Bedrock deployment",
+                )
+            )
+        if not options:
+            console.print(
+                "[yellow]No completion model is available for the selected providers. "
+                "Choose another provider.[/yellow]"
+            )
+            return None
+        default = next(
+            (alias for alias in session.selected if any(item.alias == alias for item in available)),
+            None,
+        )
+        result = choose_one(
+            console,
+            title="Model",
+            options=options,
+            default=default,
+        )
+        if result.action is PickerAction.CANCEL:
+            raise SetupCancelled
+        if result.action is PickerAction.BACK:
+            return None
+        selected = result.values[0]
+        if selected == _MANUAL_MODEL_ROW:
+            declared = _declare_gateway_model(session, console=console)
+            if declared is None:
+                continue
+            session.manual.append(declared)
+            item = declared
+        else:
+            item = next(item for item in available if item.alias == selected)
+        session.selected = (item.alias,)
+        effort = _ask_role_reasoning_effort(
+            (item,),
+            alias=item.alias,
+            role_name="model",
+            default=(item.capabilities.reasoning_effort if item.capabilities is not None else None),
+            console=console,
+        )
+        if isinstance(effort, _RoleEffortBack):
+            continue
+        return GatewayModelSelection(model=item, reasoning_effort=effort)
+
+
+def _declare_gateway_model(
+    session: SetupSession,
+    *,
+    console: Console,
+) -> AvailableModel | None:
+    """Add one minimally declared provider model for a gateway singleton.
+
+    Args:
+        session: Prepared provider endpoints and aliases already used in this session.
+        console: Terminal used for the connection and provider-model pickers.
+
+    Returns:
+        The declared model, or ``None`` when the operator goes back.
+
+    Raises:
+        SetupCancelled: The user cancelled setup.
+    """
+    connections = [
+        PickerOption(
+            value=endpoint.connection.name,
+            label=endpoint.connection.name,
+            detail=endpoint.connection.provider,
+        )
+        for endpoint in session.endpoints
+    ]
+    if not connections:
+        console.print("[yellow]Prepare a provider connection first.[/yellow]")
+        return None
+    chosen = choose_one(console, title="Provider connection", options=connections)
+    if chosen.action is PickerAction.CANCEL:
+        raise SetupCancelled
+    if chosen.action is PickerAction.BACK:
+        return None
+    connection_name = chosen.values[0]
+    endpoint = next(
+        endpoint for endpoint in session.endpoints if endpoint.connection.name == connection_name
+    )
+    model = ask_text("Provider model", console=console)
+    if not model:
+        return None
+    taken = frozenset(item.alias for item in available_models(session))
+    return AvailableModel(
+        alias=derive_model_alias(endpoint.connection.provider, model, taken),
+        connection=connection_name,
+        provider=endpoint.connection.provider,
+        model=model,
+        capabilities=ModelCapabilities(),
+        pricing_source=PricingSource.UNKNOWN,
+        configured=False,
+    )
 
 
 def declare_model(session: SetupSession, *, console: Console) -> AvailableModel | None:

--- a/exp/cli/providers/model_picker_test.py
+++ b/exp/cli/providers/model_picker_test.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import pytest
 
 from exp.cli.providers.model_picker import (
+    GatewayModelSelection,
     assign_roles,
     build_result,
     configured_models,
     declare_model,
     render_summary,
+    select_gateway_model,
     select_models,
 )
 from exp.cli.providers.provider_picker import (
@@ -113,6 +115,41 @@ def test_model_screen_cancellation_ends_setup() -> None:
     """Cancelling the model screen cancels the whole session."""
     with pytest.raises(SetupCancelled):
         select_models(_session(_CHAT), console=ScriptedConsole("q\n"))
+
+
+def test_gateway_model_screen_reuses_model_and_effort_picker_defaults() -> None:
+    """Gateway model setup selects one shared model row and accepts its effort default."""
+    console = ScriptedConsole("1\n\n")
+
+    selected = select_gateway_model(_session(_CHAT), console=console)
+
+    assert selected == GatewayModelSelection(model=_CHAT, reasoning_effort="medium")
+    assert "Model effort (luna)" in console.output
+
+
+def test_gateway_model_screen_keeps_manual_provider_model_inside_model_flow() -> None:
+    """Azure and Bedrock deployment names stay inside the shared model-selection screen."""
+    azure = ProviderConnection(
+        name="azure",
+        provider="azure",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        base_url="https://resource.openai.azure.com",
+        api_version="v1",
+    )
+    bedrock = ProviderConnection(name="bedrock", provider="bedrock", region="us-east-1")
+    session = SetupSession(
+        providers=("azure", "bedrock"),
+        advanced_models=True,
+        endpoints=(_endpoint(azure), _endpoint(bedrock)),
+    )
+    console = ScriptedConsole("1\n1\nmy-deployment\n")
+
+    selected = select_gateway_model(session, console=console)
+
+    assert selected is not None
+    assert selected.model.provider == "azure"
+    assert selected.model.model == "my-deployment"
+    assert "Exact model ID" not in console.output
 
 
 def test_roles_are_filtered_to_the_selected_models_that_can_serve_them() -> None:

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -373,34 +373,6 @@ def collect_provider_connection(
     )
 
 
-def collect_provider_connections(
-    providers: Sequence[str],
-    *,
-    console: Console,
-) -> tuple[tuple[str, ConnectionConfig], ...]:
-    """Collect connection metadata for every provider selected in the shared screen.
-
-    Args:
-        providers: Supported providers returned by ``select_providers``.
-        console: Terminal used for provider-specific fields.
-
-    Returns:
-        Provider names paired with the metadata accepted for each provider. A provider whose
-        optional endpoint field is left empty is skipped using the same rule as normal setup.
-
-    Raises:
-        ValueError: A provider is unsupported or its collected metadata is invalid.
-    """
-    connections: list[tuple[str, ConnectionConfig]] = []
-    for provider in providers:
-        connection = collect_provider_connection(provider, console=console)
-        if connection is None:
-            console.print(f"[yellow]Skipping {SETUP_PROVIDER_LABELS[provider]}.[/yellow]")
-            continue
-        connections.append((provider, connection))
-    return tuple(connections)
-
-
 def prepare_providers(
     session: SetupSession,
     *,
@@ -819,12 +791,13 @@ def ask_positive_int(label: str, *, console: Console) -> int | None:
     return value if value > 0 else None
 
 
-def ask_price(label: str, *, console: Console) -> float:
+def ask_price(label: str, *, console: Console, default: str = "0") -> float:
     """Read one nonnegative price under the advanced path.
 
     Args:
         label: Prompt text.
         console: Terminal used for the prompt.
+        default: Value accepted with an empty line.
 
     Returns:
         The nonnegative price per million tokens in USD.
@@ -833,7 +806,7 @@ def ask_price(label: str, *, console: Console) -> float:
         SetupCancelled: The prompt reached end of input.
     """
     while True:
-        answer = ask_text(label, console=console, default="0")
+        answer = ask_text(label, console=console, default=default)
         try:
             value = float(answer)
         except ValueError:

--- a/exp/common/config/settings.py
+++ b/exp/common/config/settings.py
@@ -15,7 +15,7 @@ from exp.common.core.files import write_text_atomic
 from exp.common.core.locks import file_write_lock
 
 SETTINGS_FILENAME = "settings.toml"
-DEFAULT_COMMAND_BUDGET_USD = 10.0
+DEFAULT_COMMAND_BUDGET_USD = 50.0
 
 
 class TelemetrySettings(BaseModel):


### PR DESCRIPTION
## Summary

- Reuse the builder provider preparation path for first-run gateway setup, including the shared provider selector, credential resolution, discovery, and Azure/Bedrock connection handling.
- Reuse the provider model and reasoning-effort picker for the initial gateway model; remove the separate logical exact-model-ID field from the interactive UX.
- Keep only alias, identity ID, and budget in the one-screen defaults step, with a $50.00 default budget and one-Enter acceptance.
- Preserve every selected provider connection while keeping one initial gateway alias, derive the hidden singleton identity internally, and retain CLI overrides for non-interactive setup.
- Persist the budget before initializing the gateway so a settings failure leaves first-run setup retryable.

## Validation

- Focused provider/gateway/config/settings suite: 116 passed.
- Ruff check and format check passed.
- ty check passed.
- The local full non-live run reached 1,980 passed and 11 failures in existing terminal redraw/cursor tests under this macOS session; none touched the changed provider/gateway paths.