### PR TITLE
Fix first-run gateway recovery output

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,12 @@ grant, and a virtual key. Interactive first-run setup can persist multiple provi
 creates one initial gateway alias; additional deployments and certified pools remain explicit
 gateway configuration. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
 exact next commands on an empty root. `exp run --check` validates local readiness without binding.
+First-run setup prints `EXP_GATEWAY_URL` and the newly issued `EXP_GATEWAY_KEY` before readiness is
+checked, so the credentials remain available even when a provider route is not ready. The gateway-
+specific variables avoid overwriting an upstream provider's `OPENAI_API_KEY`. The error names the
+unavailable alias and provider configuration; fix that configuration and rerun `exp run`. If the
+one-time key was not saved, issue a replacement with
+`exp config gateway key issue IDENTITY --key-id KEY --json`.
 The gateway writes no prompts, responses, tool arguments, raw keys, or provider secrets to SQLite.
 `GET /usage` and `GET /usage.json` expose the same schema-v2 content-free overall and per-identity
 counts, token usage, latency, terminal states, and attributed estimated cost. Their attempt-only

--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -123,53 +123,61 @@ def _run_gateway(
             _gateway_not_initialized(json_output=json_output)
         with usage_error(ValueError):
             setup = interactive_gateway_setup(root)
+        if setup is not None:
+            _emit_setup_credentials(port=port, setup=setup)
 
-    with usage_error(ValueError):
-        with gateway_instance_lock(root, port=port):
-            project_repository = LocalArtifactProjectActivationRepository(
-                root,
-                verifier=verify_automatic_router_policy,
-            )
-            runtime = load_local_gateway(
-                root,
-                graceful_timeout_seconds=graceful_timeout,
-                project_repository=project_repository,
-                only_aliases=(None if compatibility is None else frozenset({compatibility.alias})),
-            )
-            asyncio.run(runtime.service.preflight())
-            receipt = {
-                "schema_version": 1,
-                "operation": "gateway.check" if check else "gateway.run",
-                "status": "ready",
-                "base_url": f"http://{_LOOPBACK_HOST}:{port}/v1",
-                "usage_url": f"http://{_LOOPBACK_HOST}:{port}/usage",
-                "reconciled_expired_requests": runtime.reconciled_expired_requests,
-                "reconciled_unknown_attempts": runtime.reconciled_unknown_attempts,
-                "launch_mode": "gateway" if compatibility is None else "project_alias",
-            }
-            if compatibility is not None:
-                receipt.update(
-                    {
-                        "project_alias": compatibility.alias,
-                        "alias_revision_id": compatibility.alias_revision_id,
-                        "policy_id": compatibility.policy_id,
-                        "key_file": str(compatibility.key_file),
-                        "project_journal": "disabled",
-                        "gateway_accounting": "enabled",
-                    }
+    try:
+        with usage_error(ValueError):
+            with gateway_instance_lock(root, port=port):
+                project_repository = LocalArtifactProjectActivationRepository(
+                    root,
+                    verifier=verify_automatic_router_policy,
                 )
-            if json_output:
-                typer.echo(json.dumps(receipt, separators=(",", ":")))
-            else:
-                _emit_gateway_ready(
-                    port=port,
-                    setup=setup,
-                    compatibility=compatibility,
-                    ghost=ghost,
+                runtime = load_local_gateway(
+                    root,
+                    graceful_timeout_seconds=graceful_timeout,
+                    project_repository=project_repository,
+                    only_aliases=(
+                        None if compatibility is None else frozenset({compatibility.alias})
+                    ),
                 )
-            if check:
-                return
-            uvicorn.run(runtime.app, host=_LOOPBACK_HOST, port=port)
+                asyncio.run(runtime.service.preflight())
+                receipt = {
+                    "schema_version": 1,
+                    "operation": "gateway.check" if check else "gateway.run",
+                    "status": "ready",
+                    "base_url": f"http://{_LOOPBACK_HOST}:{port}/v1",
+                    "usage_url": f"http://{_LOOPBACK_HOST}:{port}/usage",
+                    "reconciled_expired_requests": runtime.reconciled_expired_requests,
+                    "reconciled_unknown_attempts": runtime.reconciled_unknown_attempts,
+                    "launch_mode": "gateway" if compatibility is None else "project_alias",
+                }
+                if compatibility is not None:
+                    receipt.update(
+                        {
+                            "project_alias": compatibility.alias,
+                            "alias_revision_id": compatibility.alias_revision_id,
+                            "policy_id": compatibility.policy_id,
+                            "key_file": str(compatibility.key_file),
+                            "project_journal": "disabled",
+                            "gateway_accounting": "enabled",
+                        }
+                    )
+                if json_output:
+                    typer.echo(json.dumps(receipt, separators=(",", ":")))
+                else:
+                    _emit_gateway_ready(
+                        port=port,
+                        compatibility=compatibility,
+                        ghost=ghost,
+                    )
+                if check:
+                    return
+                uvicorn.run(runtime.app, host=_LOOPBACK_HOST, port=port)
+    except typer.BadParameter:
+        if setup is not None:
+            _emit_setup_recovery(setup=setup)
+        raise
 
 
 def _gateway_not_initialized(*, json_output: bool) -> None:
@@ -205,14 +213,63 @@ def _gateway_not_initialized(*, json_output: bool) -> None:
     raise typer.Exit(2)
 
 
+def _emit_setup_credentials(*, port: int, setup: object) -> None:
+    """Deliver first-run gateway credentials before independent readiness checks run.
+
+    Args:
+        port: Loopback port that the gateway will serve when ready.
+        setup: First-run setup result containing the one-time raw gateway key.
+
+    Raises:
+        TypeError: The setup result is not the gateway setup contract.
+    """
+    from exp.cli.gateway.setup import InteractiveSetupResult
+
+    if not isinstance(setup, InteractiveSetupResult):
+        raise TypeError("interactive setup returned an invalid result")
+    _console.print(f"export EXP_GATEWAY_URL=http://{_LOOPBACK_HOST}:{port}/v1", markup=False)
+    _console.print(f"export EXP_GATEWAY_KEY={setup.raw_key}", markup=False)
+
+
+def _emit_setup_recovery(*, setup: object) -> None:
+    """Print recovery steps when first-run setup outlives a failed readiness check.
+
+    Args:
+        setup: First-run setup result identifying the identity that owns the key.
+
+    Raises:
+        TypeError: The setup result is not the gateway setup contract.
+    """
+    from exp.cli.gateway.setup import InteractiveSetupResult
+
+    if not isinstance(setup, InteractiveSetupResult):
+        raise TypeError("interactive setup returned an invalid result")
+    _console.print(
+        "[yellow]First-run gateway setup completed, but the gateway is not ready.[/yellow]",
+        markup=True,
+    )
+    _console.print(
+        "Keep the gateway credentials printed above, fix the listed provider configuration, "
+        "and rerun `exp run`.",
+        markup=False,
+    )
+    _console.print(
+        "If the key was not saved, issue a replacement with:",
+        markup=False,
+    )
+    _console.print(
+        f"  exp config gateway key issue {setup.identity_id} --key-id RECOVERY_KEY --json",
+        markup=False,
+    )
+
+
 def _emit_gateway_ready(
     *,
     port: int,
-    setup: object | None,
     compatibility: object | None,
     ghost: bool,
 ) -> None:
-    """Print the green startup result and only the exports needed to use the gateway."""
+    """Print the green startup result and project compatibility credentials."""
     _console.print(
         f"[green]✓ Gateway ready[/green] http://{_LOOPBACK_HOST}:{port}/v1",
         markup=True,
@@ -223,13 +280,10 @@ def _emit_gateway_ready(
         if not isinstance(compatibility, ProjectGatewayCompatibility):
             raise TypeError("project gateway compatibility returned an invalid result")
         _console.print(
-            f"export OPENAI_API_KEY=\"$(tr -d '\\n' < {compatibility.key_file})\"",
+            f"export EXP_GATEWAY_URL=http://{_LOOPBACK_HOST}:{port}/v1",
             markup=False,
         )
-    if setup is not None:
-        from exp.cli.gateway.setup import InteractiveSetupResult
-
-        if not isinstance(setup, InteractiveSetupResult):
-            raise TypeError("interactive setup returned an invalid result")
-        _console.print(f"export OPENAI_BASE_URL=http://{_LOOPBACK_HOST}:{port}/v1", markup=False)
-        _console.print(f"export OPENAI_API_KEY={setup.raw_key}", markup=False)
+        _console.print(
+            f"export EXP_GATEWAY_KEY=\"$(tr -d '\\n' < {compatibility.key_file})\"",
+            markup=False,
+        )

--- a/exp/cli/run/app_test.py
+++ b/exp/cli/run/app_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -9,10 +10,14 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import typer
+from rich.console import Console
 from typer.testing import CliRunner
 
+import exp.cli.run.app as run_app
 from exp.cli.app import app
 from exp.cli.gateway.compatibility import ProjectGatewayCompatibility
+from exp.cli.gateway.setup import InteractiveSetupResult
 
 
 @pytest.mark.parametrize("ghost", [False, True])
@@ -151,3 +156,75 @@ def test_no_argument_noninteractive_run_returns_stable_empty_state_json(tmp_path
     assert payload["error"]["code"] == "gateway_not_initialized"
     assert payload["error"]["next_commands"][0].startswith("exp config gateway init")
     assert not (tmp_path / "gateway").exists()
+
+
+def test_first_run_delivers_credentials_before_readiness_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-run credentials remain recoverable when local readiness rejects the route."""
+    raw_key = "exp_vk_test-first-run-key"
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True, highlight=False)
+    setup_result = InteractiveSetupResult(
+        identity_id="default",
+        alias="gpt-5-6-luna",
+        raw_key=raw_key,
+    )
+
+    def interactive_setup(root: Path) -> InteractiveSetupResult:
+        """Return the setup result that the launch path must deliver before preflight."""
+        assert root == tmp_path
+        return setup_result
+
+    def load_gateway(
+        root: Path,
+        *,
+        graceful_timeout_seconds: float,
+        project_repository: object,
+        only_aliases: frozenset[str] | None,
+    ) -> object:
+        """Fail readiness only after confirming that setup credentials were printed."""
+        del root, graceful_timeout_seconds, project_repository, only_aliases
+        transcript = output.getvalue()
+        assert transcript.index(f"export EXP_GATEWAY_KEY={raw_key}") < len(transcript)
+        raise ValueError(
+            "no granted active alias is locally available: "
+            "gpt-5-6-luna (connection credential environment variable "
+            "'OPENAI_API_KEY' is not set); fix the listed provider configuration and rerun "
+            "'exp run'"
+        )
+
+    @contextmanager
+    def instance_lock(root: Path, *, port: int) -> Iterator[None]:
+        """Provide the single-process seam without creating a real gateway lock."""
+        del root, port
+        yield
+
+    monkeypatch.setattr(run_app, "_console", console)
+    monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", interactive_setup)
+    monkeypatch.setattr("exp.runtime.gateway.lifecycle.load_local_gateway", load_gateway)
+    monkeypatch.setattr("exp.runtime.gateway.lifecycle.gateway_instance_lock", instance_lock)
+    monkeypatch.setattr(run_app.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(run_app.sys, "stdout", SimpleNamespace(isatty=lambda: True))
+
+    with pytest.raises(typer.BadParameter, match="OPENAI_API_KEY") as failure:
+        run_app._run_gateway(
+            project=None,
+            root=tmp_path,
+            policy=None,
+            port=8000,
+            ghost=False,
+            non_interactive=False,
+            json_output=False,
+            check=True,
+            graceful_timeout=10.0,
+        )
+
+    transcript = output.getvalue()
+    assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in transcript
+    assert f"export EXP_GATEWAY_KEY={raw_key}" in transcript
+    assert "export OPENAI_API_KEY" not in transcript
+    assert "First-run gateway setup completed, but the gateway is not ready." in transcript
+    assert "fix the listed provider configuration and rerun 'exp run'" in str(failure.value)
+    assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -233,7 +233,7 @@ def load_local_gateway(
     activations: dict[tuple[str, str], RouterRuntime] = {}
     exact_models: dict[tuple[str, str, str, str], str] = {}
     readiness: list[ExecutionSnapshot] = []
-    unavailable_aliases: list[str] = []
+    unavailable_aliases: list[tuple[str, str]] = []
 
     for alias in aliases:
         revision_id, catalog_sha256 = _required_revision(alias)
@@ -243,8 +243,8 @@ def load_local_gateway(
         if alias.target_kind == "direct":
             try:
                 proof = _direct_readiness(manager, alias, normalized, runtime_catalog)
-            except (ModelConnectionError, ModelCredentialError):
-                unavailable_aliases.append(alias.alias_name)
+            except (ModelConnectionError, ModelCredentialError) as exc:
+                unavailable_aliases.append((alias.alias_name, str(exc)))
                 continue
             normalized_catalogs[key] = normalized
             runtime_catalogs[key] = runtime_catalog
@@ -285,10 +285,10 @@ def load_local_gateway(
         except RouterApplicationError as exc:
             if not _caused_by_connection_error(exc):
                 raise
-            unavailable_aliases.append(alias.alias_name)
+            unavailable_aliases.append((alias.alias_name, str(exc)))
             continue
-        except (ModelConnectionError, ModelCredentialError):
-            unavailable_aliases.append(alias.alias_name)
+        except (ModelConnectionError, ModelCredentialError) as exc:
+            unavailable_aliases.append((alias.alias_name, str(exc)))
             continue
         activations[(project_ref, activation_ref)] = runtime
         normalized_catalogs[key] = normalized
@@ -296,9 +296,14 @@ def load_local_gateway(
         readiness.append(proof)
 
     if not readiness:
-        unavailable = ", ".join(sorted(unavailable_aliases))
+        unavailable = "; ".join(
+            f"{alias_name} ({reason})" for alias_name, reason in sorted(unavailable_aliases)
+        )
         detail = f": {unavailable}" if unavailable else ""
-        raise GatewayLifecycleError(f"no granted active alias is locally available{detail}")
+        raise GatewayLifecycleError(
+            "no granted active alias is locally available"
+            f"{detail}; fix the listed provider configuration and rerun 'exp run'"
+        )
 
     project_resolver = cast(
         ProjectTargetResolver | None,

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -290,6 +290,17 @@ def test_readiness_requires_an_explicit_grant(tmp_path: Path) -> None:
         load_local_gateway(tmp_path, graceful_timeout_seconds=1, environment={})
 
 
+def test_unavailable_alias_reports_its_provider_readiness_reason(tmp_path: Path) -> None:
+    """A failed direct alias names the missing provider configuration and retry command."""
+    _manager, _raw_key = _configured_gateway(tmp_path)
+
+    with pytest.raises(
+        GatewayLifecycleError,
+        match=r"coding.*TEST_PROVIDER_KEY.*rerun 'exp run'",
+    ):
+        load_local_gateway(tmp_path, graceful_timeout_seconds=1, environment={})
+
+
 def test_missing_secret_marks_only_its_direct_alias_unavailable(tmp_path: Path) -> None:
     """One absent provider secret does not block another complete granted alias."""
     manager, raw_key = _configured_gateway(tmp_path)


### PR DESCRIPTION
## Summary

- Deliver first-run gateway credentials before readiness can fail, and use `EXP_GATEWAY_URL`/`EXP_GATEWAY_KEY` so provider `OPENAI_API_KEY` is not overwritten.
- Include the unavailable alias and safe provider-readiness reason in startup errors.
- Print rerun and replacement-key recovery steps when first-run setup has already committed state.
- Add regression coverage and document the recovery contract.

## Verification

- Focused gateway/CLI tests: 16 passed.
- `ruff check .`: passed.
- `ruff format --check .`: passed.
- `ty check`: passed.
- CI-equivalent non-live suite: 1,979 passed, 1 skipped; 11 existing macOS/PTY picker failures reproduced on untouched `main` and unrelated to this diff.