### PR TITLE
feat(cli): make exp the default gateway flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,15 @@ uv run pytest -q
   may not import optimize or cli; optimize may not import cli. Optimize owns application
   orchestration and may depend inward on common, runtime, and simulation. The AST gate rejects
   every current forbidden edge directly and proves that the package graph is acyclic.
-- The root CLI command set is exact: `build`, `config`, `optimize`, and `run`;
-  `exp/cli/app_test.py` and the release tests enforce the current command and distribution shape.
+- The root CLI command set is exact: `build`, `config`, and `optimize`. An invocation without a
+  subcommand opens the default gateway home screen. `exp/cli/app_test.py` and the release tests
+  enforce the current command and distribution shape.
 
 ## CLI package ownership
 
 - `exp/cli/app.py` owns root command composition only. Command implementations live in the
-  `build/`, `config/`, `judge/`, `optimize/`, `run/`, and `gateway/` packages.
+  `build/`, `config/`, `judge/`, `optimize/`, and `gateway/` packages. Gateway serving and the
+  default home screen live under `gateway/`.
 - `exp/cli/providers/` owns provider discovery, model selection, and catalog setup shared by
   commands. Command-specific orchestration stays with its command package. In particular,
   router-candidate collection belongs to `exp/cli/optimize/`.
@@ -73,9 +75,10 @@ uv run pytest -q
   World-model fidelity testing is a separately invoked common-evaluation mode with no authority
   over router fitting or runtime activation. Its reports contain measurements only and never carry
   an approval, denial, gate, threshold, or decision.
-- `exp run` starts the initialized authenticated multi-alias gateway on loopback.
-  `exp run PROJECT --root ROOT --port PORT [--ghost]` retains the single-project compatibility
-  server. Both expose OpenAI Chat Completions, Responses, and Models routes. Public request and
+- `exp` opens the branded home screen. Its `Default Gateway` choice starts the initialized
+  authenticated multi-alias gateway on loopback, while `exp --project PROJECT --root ROOT --port
+  PORT [--ghost]` retains the single-project compatibility server. Both expose OpenAI Chat
+  Completions, Responses, and Models routes. Public request and
   response types come
   from the official OpenAI SDK. Chat retries use the standard `Idempotency-Key`; Responses
   continuations use `previous_response_id`. Experiential never joins unrelated Chat callers by transcript
@@ -88,8 +91,8 @@ uv run pytest -q
 - Agent execution code lives under `exp/runtime/`: whole-episode customer agents, executable
   environments, model clients, and frozen router execution. Optimization may depend on runtime;
   runtime code must not depend on simulation or optimization algorithms.
-- No-argument `exp run` serves only explicit active gateway aliases. The legacy project form serves
-  one frozen router policy. Simulation callers choose an `AgentRuntime` and `EnvironmentRuntime`
+- No-subcommand `exp` serves only explicit active gateway aliases. The `--project` form serves one
+  frozen router policy. Simulation callers choose an `AgentRuntime` and `EnvironmentRuntime`
   directly, in process.
 - Local Pi and process-environment adapters execute external code on the user's machine only when
   a caller explicitly selects them. Preserve bounded processes, the explicit working directory,
@@ -116,7 +119,7 @@ uv run pytest -q
   orchestration lives in `automatic/`, manual judge calibration in `judging/`, offline policy work
   in `fit/`, and evaluation preparation in `evaluation/`. The durable judgment ledger remains at
   `judgment_budget.py`.
-- The root CLI is locked to `build`, `optimize`, `run`, and `config`. The optimize group is locked
+- The root CLI is locked to `build`, `optimize`, and `config`. The optimize group is locked
   to `router` and `model`; the config group is locked to `budget`, `gateway`, `judge`, `providers`,
   and `telemetry`. Widening any of those three sets, whether with a command, an alias, or a flag, is a
   deliberate change to the locked surface and needs the same scrutiny as a public API change.
@@ -246,7 +249,8 @@ uv run pytest -q
    writeup → `docs/research/`, verified how-to → `docs/reference/`, reusable code → `exp/`.
 
 6. **Benchmark data is external input, not a repository directory.** Give `exp build` one explicit
-   local OTLP or PostHog export, then use only the locked `config`, `optimize`, and `run` surfaces
+   local OTLP or PostHog export, then use only the locked `config` and `optimize` surfaces plus the
+   default gateway home screen
    for persisted project artifacts. Do not vendor benchmark data, gold dirs, or capture scripts.
 
 7. **Give reusable workflows a clear owner.** A workflow has exactly one home, inside `exp/`.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -2,7 +2,8 @@
 
 ## Supported surface
 
-Bare `exp` and no-argument `exp run` start an authenticated multi-alias gateway on `127.0.0.1`.
+`exp` opens the default gateway home screen. Its `Default Gateway` choice starts an authenticated
+multi-alias gateway on `127.0.0.1`.
 It serves:
 
 - `GET /v1/models`
@@ -12,13 +13,13 @@ It serves:
 - `GET /health/live` and `GET /health/ready`
 - `GET /usage` and `GET /usage.json`
 
-`exp run PROJECT` is compatibility sugar that activates one project-backed alias and launches this
-same gateway application. It does not create a router HTTP server. Gateway startup and readiness
+`exp --project PROJECT` is compatibility sugar that activates one project-backed alias and launches
+this same gateway application. It does not create a router HTTP server. Gateway startup and readiness
 perform no provider request. Only an authorized model request may cross the provider boundary.
 
 ## Data-plane engines
 
-The gateway has two data planes over one control plane. `exp run` resolves
+The gateway has two data planes over one control plane. The default `exp` flow resolves
 `--engine auto` (the default) to the native engine when the `exp_gateway_native`
 extension is built, and otherwise prints the reason and serves through the
 python engine. `--engine rust` and `--engine python` force one engine.

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -55,10 +55,10 @@ exp config gateway alias create coding \
 exp config gateway identity create default --root ROOT --non-interactive --json
 exp config gateway grant add default coding --root ROOT --non-interactive --json
 exp config gateway key issue default --key-id key-one --root ROOT --json
-exp run --root ROOT --check --non-interactive --json
+exp --root ROOT --check --non-interactive --json
 ```
 
-`exp run --check` proves readiness without a paid call; drop `--check` to serve, then use
+`exp --check` proves readiness without a paid call; drop `--check` to serve, then use
 the caller loop (`exp config gateway key check`, `models`, and `call`) against the live
 gateway.
 

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -6,16 +6,16 @@ on the exact release checkout.
 
 ## Supported and verified
 
-- Root CLI commands are exactly `build`, `config`, `optimize`, and `run`; optimizer commands are
-  exactly `router` and `model`.
+- Root CLI commands are exactly `build`, `config`, and `optimize`; an invocation with no subcommand
+  opens the default gateway home screen. Optimizer commands are exactly `router` and `model`.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
   singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
   provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
   content-free SQLite accounting, monthly integer micro-USD enforcement, and loopback-only health
   and usage views.
-- Bare `exp` and the explicit no-argument `exp run` gateway launch, plus the retained
-  `exp run PROJECT [--ghost]` compatibility form, are installed-wheel surfaces. Gateway startup
-  is provider-idle and requires explicit authority.
+- The no-subcommand default gateway launch and the `exp --project PROJECT [--ghost]` compatibility
+  form are installed-wheel surfaces. Gateway startup is provider-idle and requires explicit
+  authority.
 - The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
   upstream, and OpenAI `3.0.0`. It covers `OpenAI` and `AsyncOpenAI` across Chat Completions and
   Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same

--- a/docs/research/rust-gateway-engine.md
+++ b/docs/research/rust-gateway-engine.md
@@ -8,7 +8,7 @@ serves Responses, replay-keyed chat, project-backed aliases, and the usage
 page. This report records the benchmark evidence behind that design and where
 each engine's limits actually are. Reproduction: build the extension
 (`just native`), configure direct aliases with `exp config gateway`, serve
-with `exp run`, and drive `POST /v1/chat/completions` at fixed concurrency
+with `exp`, and drive `POST /v1/chat/completions` at fixed concurrency
 ladders; every number below is the summary of one such arm.
 
 All measurements ran on one 16-vCPU Azure VM (Standard_D16ds_v5), with the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,12 +4,12 @@ The root surface is deliberately small:
 
 | Command | Purpose | Local result |
 |---|---|---|
-| `exp` | Shortcut for `exp run`; use `exp --help` or `exp help` for root CLI help. | Start the authenticated gateway on loopback. |
+| `exp` | Open the branded home screen. `Default Gateway` is the recommended setup-and-start path. | Interactive gateway menu, or the default gateway in a non-interactive terminal. |
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |
 | `exp optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `exp optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
-| `exp run --root ROOT [--check] [--engine auto\|rust\|python]` | Validate or start the initialized authenticated gateway on loopback; the default engine is the native data plane when built, with the python engine embedded for Responses, replay, and project aliases. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
-| `exp run PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as no-argument `exp run`. |
+| `exp --root ROOT [--check] [--engine auto\|rust\|python]` | Validate or start the initialized authenticated default gateway on loopback; the default engine is the native data plane when built, with the python engine embedded for Responses, replay, and project aliases. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
+| `exp --project PROJECT --root ROOT [--ghost]` | Activate a frozen policy as one project-backed alias and launch the normal gateway. | The same authenticated OpenAI endpoint and SQLite accounting as the default gateway. |
 | `exp config gateway ...` | Author provider references, identities, virtual keys, grants, aliases, certified exact-model pools, monthly limits, status, and usage without optimizer roles. | Private SQLite authority, immutable catalog snapshots, and versioned receipts. |
 | `exp config gateway call ALIAS PROMPT [--json]` | Send one chat completion to a live gateway as a caller, streaming text to stdout. | One HTTP request against the running gateway; no local state. |
 | `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
@@ -27,7 +27,7 @@ credentials or provider clients when no terminal is available. Set the determini
 the ceiling. Exact completed replays report a zero-dollar estimate and do not prompt.
 
 Successful build, router, simulation, and SFT operations preserve anonymous aggregate PostHog
-product telemetry, which may send unless disabled. `run` makes no provider call at startup.
+product telemetry, which may send unless disabled. Gateway startup makes no provider call.
 `build --dry-run` and exact completed-build replay make zero paid provider calls. A new grounded
 build calls only the configured embedder; automatic router optimization separately executes the
 bounded candidate, world-model, and judge schedule shown in its cost preflight.
@@ -36,16 +36,16 @@ remain frozen for the process lifetime and return only an exact model pool. `--g
 compatibility flag for project-journal behavior; gateway authentication, replay, attempts, and
 usage accounting stay enabled.
 
-Bare `exp` and both `exp run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
+The default and project gateway forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
 provider call, and requires an explicit provider environment reference, exact model alias, identity,
 grant, and a virtual key. Interactive first-run setup can persist multiple provider connections and
 creates one initial gateway alias; additional deployments and certified pools remain explicit
-gateway configuration. `exp run --non-interactive --json` returns `gateway_not_initialized` plus
-exact next commands on an empty root. `exp run --check` validates local readiness without binding.
+gateway configuration. `exp --non-interactive --json` returns `gateway_not_initialized` plus exact
+next commands on an empty root. `exp --check` validates local readiness without binding.
 First-run setup prints `EXP_GATEWAY_URL` and the newly issued `EXP_GATEWAY_KEY` before readiness is
 checked, so the credentials remain available even when a provider route is not ready. The gateway-
 specific variables avoid overwriting an upstream provider's `OPENAI_API_KEY`. The error names the
-unavailable alias and provider configuration; fix that configuration and rerun `exp run`. If the
+unavailable alias and provider configuration; fix that configuration and rerun `exp`. If the
 one-time key was not saved, issue a replacement with
 `exp config gateway key issue IDENTITY --key-id KEY --json`.
 The gateway writes no prompts, responses, tool arguments, raw keys, or provider secrets to SQLite.

--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -3,19 +3,25 @@
 from __future__ import annotations
 
 import logging
-import sys
+from pathlib import Path
 
 import typer
 
 from exp.cli.build.app import build
 from exp.cli.config.app import config_app
-from exp.cli.run.app import run
+from exp.cli.gateway.home import default_gateway
+from exp.cli.gateway.serve import (
+    DEFAULT_GATEWAY_PORT,
+    DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+    DEFAULT_MAX_ACTIVE_REQUESTS,
+)
 from exp.cli.shared.defer import add_deferred_typer
+from exp.cli.shared.options import ROOT_OPTION
 from exp.common.config import load_env_file
 
 app = typer.Typer(
     help="Build grounded simulations, optimize model use, and serve routers locally.",
-    no_args_is_help=True,
+    invoke_without_command=True,
 )
 app.add_typer(config_app, name="config")
 add_deferred_typer(
@@ -27,32 +33,92 @@ add_deferred_typer(
     known_names=("router", "model"),
 )
 app.command("build", help="Build a reusable grounded world model from local trace evidence.")(build)
-app.command("run", help="Run the local gateway, optionally with one project-backed alias.")(run)
-
-_ROOT_COMMANDS = frozenset(("build", "config", "optimize", "run"))
-_ROOT_OPTIONS = frozenset(("--help", "-h", "--install-completion", "--show-completion"))
 
 
-def _dispatch_arguments(arguments: list[str]) -> list[str]:
-    """Resolve the root invocation into the existing command parser.
-
-    Bare invocations and gateway options use ``run`` as an implicit command. The explicit root
-    help forms and existing root subcommands remain unchanged, so the shortcut does not duplicate
-    or bypass the gateway command's option validation.
+@app.callback()
+def root_callback(
+    ctx: typer.Context,
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        help="Expose one frozen project as the gateway's project-backed alias.",
+    ),
+    root: Path = ROOT_OPTION,
+    policy: str | None = typer.Option(
+        None,
+        "--policy",
+        help="Exact frozen policy ID used with --project.",
+    ),
+    port: int = typer.Option(DEFAULT_GATEWAY_PORT, "--port", min=1, max=65_535),
+    ghost: bool = typer.Option(
+        False,
+        "--ghost",
+        help="Disable project journaling while keeping gateway accounting enabled.",
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Never open first-run prompts.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Write a versioned launch receipt."),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Validate gateway readiness and exit without binding.",
+    ),
+    graceful_timeout: float = typer.Option(
+        DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+        "--graceful-timeout",
+        min=0.1,
+        help="Seconds to drain admitted gateway work during shutdown.",
+    ),
+    engine: str = typer.Option(
+        "auto",
+        "--engine",
+        help=(
+            "Data-plane engine: 'auto' (rust when built, otherwise python), 'rust' "
+            "(native data plane with an embedded python engine for Responses, "
+            "replay, and project aliases), or 'python' (uvicorn only)."
+        ),
+    ),
+    max_active_requests: int = typer.Option(
+        DEFAULT_MAX_ACTIVE_REQUESTS,
+        "--max-active-requests",
+        min=1,
+        help="Rust engine only: maximum concurrently admitted requests.",
+    ),
+) -> None:
+    """Open the default gateway home screen when no subcommand was selected.
 
     Args:
-        arguments: User-provided arguments after the ``exp`` executable name.
-
-    Returns:
-        Arguments suitable for the root Typer application.
+        ctx: Click context used to distinguish the home screen from subcommands.
+        project: Optional frozen project to expose as a gateway alias.
+        root: Local artifact and gateway root.
+        policy: Optional exact policy for the project-backed alias.
+        port: Loopback TCP port used by the gateway.
+        ghost: Whether project journaling is disabled for the project-backed alias.
+        non_interactive: Whether prompts are forbidden.
+        json_output: Whether startup output must be JSON only.
+        check: Whether to validate readiness without binding.
+        graceful_timeout: Gateway shutdown drain bound in seconds.
+        engine: Data-plane engine selection.
+        max_active_requests: Rust engine concurrent-admission bound.
     """
-    if not arguments:
-        return ["run"]
-    if arguments[0] == "help":
-        return ["--help", *arguments[1:]]
-    if arguments[0] in _ROOT_OPTIONS or arguments[0] in _ROOT_COMMANDS:
-        return arguments
-    return ["run", *arguments]
+    if ctx.invoked_subcommand is not None:
+        return
+    default_gateway(
+        root=root,
+        project=project,
+        policy=policy,
+        port=port,
+        ghost=ghost,
+        non_interactive=non_interactive,
+        json_output=json_output,
+        check=check,
+        graceful_timeout=graceful_timeout,
+        engine=engine,
+        max_active_requests=max_active_requests,
+    )
 
 
 def _quiet_http_logs() -> None:
@@ -65,12 +131,11 @@ def main() -> None:
     """Load local environment settings, quiet HTTP logs, and dispatch the CLI.
 
     The explicit entrypoint keeps environment loading out of import time, so library imports
-    cannot mutate an operator's process environment. A bare invocation is routed through the
-    existing gateway command while explicit root help remains available.
+    cannot mutate an operator's process environment.
     """
     load_env_file()
     _quiet_http_logs()
-    app(args=_dispatch_arguments(sys.argv[1:]))
+    app()
 
 
 if __name__ == "__main__":

--- a/exp/cli/app_test.py
+++ b/exp/cli/app_test.py
@@ -2,61 +2,16 @@
 
 from __future__ import annotations
 
-from importlib import import_module
-
-import pytest
 from typer import Context
 from typer.core import TyperGroup
 from typer.main import get_group
 
 from exp.cli.app import app
 
-app_module = import_module("exp.cli.app")
-
 EXPECTED_SUBCOMMANDS = {
     "config": {"budget", "gateway", "judge", "providers", "telemetry"},
     "optimize": {"model", "router"},
 }
-
-
-@pytest.mark.parametrize(
-    ("arguments", "expected"),
-    [
-        ([], ["run"]),
-        (["--help"], ["--help"]),
-        (["help"], ["--help"]),
-        (["--install-completion"], ["--install-completion"]),
-        (["--show-completion"], ["--show-completion"]),
-        (["build", "--help"], ["build", "--help"]),
-        (["config", "gateway", "status"], ["config", "gateway", "status"]),
-        (["run", "project-a"], ["run", "project-a"]),
-        (["project-a", "--check"], ["run", "project-a", "--check"]),
-        (["--check", "--json"], ["run", "--check", "--json"]),
-    ],
-)
-def test_root_dispatch_preserves_help_and_existing_commands(
-    arguments: list[str],
-    expected: list[str],
-) -> None:
-    """Route bare gateway forms without changing root help or explicit subcommands."""
-    assert app_module._dispatch_arguments(arguments) == expected
-
-
-def test_main_routes_bare_invocation_through_run(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The installed entrypoint turns a bare invocation into the existing run command."""
-    captured: list[list[str]] = []
-
-    def capture_app(*, args: list[str]) -> None:
-        """Capture parsed arguments passed to the root application."""
-        captured.append(args)
-
-    monkeypatch.setattr(app_module, "app", capture_app)
-    monkeypatch.setattr(app_module, "load_env_file", lambda: None)
-    monkeypatch.setattr(app_module.sys, "argv", ["exp"])
-
-    app_module.main()
-
-    assert captured == [["run"]]
 
 
 def test_root_cli_and_subgroups_are_exact() -> None:
@@ -67,12 +22,7 @@ def test_root_cli_and_subgroups_are_exact() -> None:
     """
     root = get_group(app)
     root_context = Context(root)
-    assert set(root.list_commands(root_context)) == {
-        "build",
-        "config",
-        "optimize",
-        "run",
-    }
+    assert set(root.list_commands(root_context)) == {"build", "config", "optimize"}
 
     for name, expected in EXPECTED_SUBCOMMANDS.items():
         command = root.get_command(root_context, name)

--- a/exp/cli/build/wizard_test.py
+++ b/exp/cli/build/wizard_test.py
@@ -446,7 +446,7 @@ def test_fresh_bare_wizard_recommends_builds_and_composes_provisional_router(
         run_root: Path,
         *,
         graceful_timeout_seconds: float,
-        project_loader: object,
+        project_repository: object,
         only_aliases: frozenset[str] | None,
     ) -> SimpleNamespace:
         """Return a serving-ready gateway fixture for the mocked launch seam.
@@ -454,13 +454,13 @@ def test_fresh_bare_wizard_recommends_builds_and_composes_provisional_router(
         Args:
             run_root: Gateway and artifact root.
             graceful_timeout_seconds: Requested shutdown drain bound.
-            project_loader: Injected selection-only project loader.
+            project_repository: Injected selection-only project repository.
             only_aliases: Optional compatibility alias filter.
 
         Returns:
             Gateway runtime fixture passed to the normal server.
         """
-        del run_root, graceful_timeout_seconds, project_loader
+        del run_root, graceful_timeout_seconds, project_repository
         assert only_aliases == frozenset({"support"})
         return SimpleNamespace(
             app=object(),
@@ -484,10 +484,9 @@ def test_fresh_bare_wizard_recommends_builds_and_composes_provisional_router(
         )
         run_result = _RUNNER.invoke(
             app,
-            ["run", "support", "--root", str(root), "--port", "8123"],
+            ["--project", "support", "--root", str(root), "--port", "8123"],
         )
     assert run_result.exit_code == 0, run_result.output
-    assert f"policy {policy.policy_id}" in run_result.output
     assert "http://127.0.0.1:8123/v1" in run_result.output
     assert served == [("127.0.0.1", 8123)]
 

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -179,7 +179,7 @@ def test_noninteractive_management_story_emits_stable_secret_safe_json(
 
     readiness = runner.invoke(
         app,
-        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--check", "--non-interactive", "--json"],
     )
     assert readiness.exit_code == 0, readiness.output
     assert json.loads(readiness.stdout)["status"] == "ready"

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -1,6 +1,6 @@
 """Caller-side commands that drive one live authenticated gateway over HTTP.
 
-These commands cover the agent core loop against a running ``exp run`` gateway: discover
+These commands cover the agent core loop against a running default ``exp`` gateway: discover
 the aliases a virtual key can use, validate a key, and make one chat completion. They are
 pure HTTP callers: spend authority stays entirely with the gateway's key grants and
 monthly budgets, no provider client or provider credential is ever constructed, and the
@@ -502,6 +502,6 @@ def _unreachable_gateway(url: str) -> typer.BadParameter:
         Usage error naming the URL and the exact way to start or select a gateway.
     """
     return typer.BadParameter(
-        f"no gateway answered at {url}; start one with 'exp run' or point "
+        f"no gateway answered at {url}; start one with 'exp' or point "
         "--url (or EXP_GATEWAY_URL) at a live gateway"
     )

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -237,7 +237,7 @@ def test_unreachable_gateway_is_a_usage_error_naming_the_url(
     assert result.exit_code == 2
     normalized = " ".join(unstyle(result.output).replace("│", " ").split())
     assert "no gateway answered at http://127.0.0.1:9/v1" in normalized
-    assert "exp run" in normalized
+    assert "start one with 'exp'" in normalized
 
 
 def test_models_prints_the_caller_view_with_granted_revisions(

--- a/exp/cli/gateway/home.py
+++ b/exp/cli/gateway/home.py
@@ -1,0 +1,258 @@
+"""Interactive home screen for the default Experiential gateway flow."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.text import Text
+
+from exp.cli.gateway.serve import (
+    DEFAULT_GATEWAY_PORT,
+    DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+    DEFAULT_MAX_ACTIVE_REQUESTS,
+    emit_setup_credentials,
+    start_gateway,
+)
+from exp.cli.shared.picker import PickerAction, PickerOption, choose_one
+from exp.cli.shared.theme import EXP_THEME
+from exp.runtime.gateway.management import GatewayManagement
+
+_MENU_OPTIONS = (
+    PickerOption(
+        value="default",
+        label="Default Gateway",
+        detail="recommended happy path: setup if needed, then start",
+    ),
+    PickerOption(
+        value="run",
+        label="Run Gateway",
+        detail="start an already configured local gateway",
+    ),
+    PickerOption(
+        value="setup",
+        label="Setup Gateway",
+        detail="choose providers, a model, an alias, and a key",
+    ),
+    PickerOption(
+        value="status",
+        label="Gateway Status",
+        detail="show content-free local gateway counts",
+    ),
+    PickerOption(value="exit", label="Exit"),
+)
+
+
+def default_gateway(
+    *,
+    root: Path,
+    project: str | None = None,
+    policy: str | None = None,
+    port: int = DEFAULT_GATEWAY_PORT,
+    ghost: bool = False,
+    non_interactive: bool = False,
+    json_output: bool = False,
+    check: bool = False,
+    graceful_timeout: float = DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+    engine: str = "auto",
+    max_active_requests: int = DEFAULT_MAX_ACTIVE_REQUESTS,
+    console: Console | None = None,
+) -> None:
+    """Show the Experiential home screen or start a direct gateway invocation.
+
+    Args:
+        root: Local artifact and gateway root.
+        project: Optional frozen project to expose as one gateway alias.
+        policy: Optional exact policy for the project-backed gateway alias.
+        port: Loopback TCP port used by the gateway.
+        ghost: Whether the project-backed gateway disables project journaling.
+        non_interactive: Whether prompts are forbidden.
+        json_output: Whether startup output must be JSON only.
+        check: Whether to validate readiness without binding.
+        graceful_timeout: Gateway shutdown drain bound in seconds.
+        engine: Data-plane engine selection.
+        max_active_requests: Rust engine concurrent-admission bound.
+        console: Optional console used by tests or embedding callers.
+
+    Raises:
+        typer.BadParameter: The direct gateway options are invalid.
+        typer.Exit: A non-interactive gateway cannot be started from an empty root.
+    """
+    provided_console = console is not None
+    output = console or Console(theme=EXP_THEME)
+    if policy is not None or ghost or _requires_direct_start(
+        project=project,
+        non_interactive=non_interactive,
+        json_output=json_output,
+        check=check,
+        engine=engine,
+        max_active_requests=max_active_requests,
+        provided_console=provided_console,
+    ):
+        start_gateway(
+            project=project,
+            root=root,
+            policy=policy,
+            port=port,
+            ghost=ghost,
+            non_interactive=non_interactive or not provided_console,
+            json_output=json_output,
+            check=check,
+            graceful_timeout=graceful_timeout,
+            engine=engine,
+            max_active_requests=max_active_requests,
+        )
+        return
+
+    _render_home(output)
+    while True:
+        selection = choose_one(
+            output,
+            title="What would you like to do?",
+            options=_MENU_OPTIONS,
+            default="default",
+        )
+        if selection.action in {PickerAction.BACK, PickerAction.CANCEL}:
+            _render_exit(output)
+            return
+        if not selection.values:
+            _render_exit(output)
+            return
+        choice = selection.values[0]
+        if choice == "default":
+            if _start_from_menu(
+                output,
+                root=root,
+                port=port,
+                graceful_timeout=graceful_timeout,
+                engine=engine,
+                max_active_requests=max_active_requests,
+            ):
+                return
+        elif choice == "run":
+            if _start_from_menu(
+                output,
+                root=root,
+                port=port,
+                non_interactive=True,
+                graceful_timeout=graceful_timeout,
+                engine=engine,
+                max_active_requests=max_active_requests,
+            ):
+                return
+        elif choice == "setup":
+            _setup_from_menu(output, root=root, port=port)
+        elif choice == "status":
+            _show_status(output, root=root)
+        else:
+            _render_exit(output)
+            return
+
+
+def _requires_direct_start(
+    *,
+    project: str | None,
+    non_interactive: bool,
+    json_output: bool,
+    check: bool,
+    engine: str,
+    max_active_requests: int,
+    provided_console: bool,
+) -> bool:
+    """Return whether root options should bypass the interactive home screen."""
+    if provided_console:
+        return (
+            project is not None
+            or non_interactive
+            or json_output
+            or check
+            or engine != "auto"
+            or max_active_requests != DEFAULT_MAX_ACTIVE_REQUESTS
+        )
+    return (
+        project is not None
+        or non_interactive
+        or json_output
+        or check
+        or engine != "auto"
+        or max_active_requests != DEFAULT_MAX_ACTIVE_REQUESTS
+        or not sys.stdin.isatty()
+        or not sys.stdout.isatty()
+    )
+
+
+def _render_home(console: Console) -> None:
+    """Render the branded first screen for an interactive ``exp`` invocation."""
+    console.print(Text("exp", style="bold green"))
+    console.print(Text("Experiential gateway", style="dim"))
+    console.print()
+
+
+def _start_from_menu(
+    console: Console,
+    *,
+    root: Path,
+    port: int,
+    non_interactive: bool = False,
+    graceful_timeout: float,
+    engine: str,
+    max_active_requests: int,
+) -> bool:
+    """Start a gateway selected from the home screen.
+
+    Returns:
+        ``True`` when the menu should exit, or ``False`` after a user cancellation.
+    """
+    try:
+        start_gateway(
+            root=root,
+            port=port,
+            non_interactive=non_interactive,
+            graceful_timeout=graceful_timeout,
+            engine=engine,
+            max_active_requests=max_active_requests,
+        )
+    except typer.Abort:
+        console.print("[yellow]Gateway setup cancelled.[/yellow]")
+        return False
+    return True
+
+
+def _setup_from_menu(console: Console, *, root: Path, port: int) -> None:
+    """Run first-run setup without starting the server, then return to the menu."""
+    from exp.cli.gateway.setup import interactive_gateway_setup
+
+    try:
+        setup = interactive_gateway_setup(root, console=console)
+    except typer.Abort:
+        console.print("[yellow]Gateway setup cancelled.[/yellow]")
+        return
+    except ValueError as exc:
+        console.print(f"[yellow]{exc}[/yellow]")
+        return
+    emit_setup_credentials(port=port, setup=setup, console=console)
+    console.print("[green]✓ Gateway configured[/green] Choose Default Gateway to start it.")
+
+
+def _show_status(console: Console, *, root: Path) -> None:
+    """Render content-free gateway counts without creating local state."""
+    status = GatewayManagement(root).status()
+    if not status.initialized:
+        console.print("[yellow]Gateway not configured[/yellow]")
+        console.print("[dim]Choose Setup Gateway to create the default local gateway.[/dim]")
+        return
+    console.print("[green]✓ Gateway configured[/green]")
+    console.print(
+        "[dim]"
+        f"identities={status.active_identities} keys={status.active_keys} "
+        f"aliases={status.active_aliases} providers={status.active_provider_connections} "
+        f"grants={status.grants}"
+        "[/dim]"
+    )
+
+
+def _render_exit(console: Console) -> None:
+    """Render the short terminal message after leaving the home screen."""
+    console.print("[dim]Goodbye.[/dim]")

--- a/exp/cli/gateway/home.py
+++ b/exp/cli/gateway/home.py
@@ -82,14 +82,18 @@ def default_gateway(
     """
     provided_console = console is not None
     output = console or Console(theme=EXP_THEME)
-    if policy is not None or ghost or _requires_direct_start(
-        project=project,
-        non_interactive=non_interactive,
-        json_output=json_output,
-        check=check,
-        engine=engine,
-        max_active_requests=max_active_requests,
-        provided_console=provided_console,
+    if (
+        policy is not None
+        or ghost
+        or _requires_direct_start(
+            project=project,
+            non_interactive=non_interactive,
+            json_output=json_output,
+            check=check,
+            engine=engine,
+            max_active_requests=max_active_requests,
+            provided_console=provided_console,
+        )
     ):
         start_gateway(
             project=project,

--- a/exp/cli/gateway/home_test.py
+++ b/exp/cli/gateway/home_test.py
@@ -1,0 +1,114 @@
+"""Tests for the branded default gateway home screen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from exp.cli.gateway import home
+from exp.cli.gateway.serve import DEFAULT_MAX_ACTIVE_REQUESTS
+from exp.cli.gateway.setup import InteractiveSetupResult
+from exp.cli.shared.picker_test import ScriptedConsole
+
+
+def test_home_screen_starts_with_brand_and_recommends_default_gateway(tmp_path: Path) -> None:
+    """The first interactive screen presents the green EXP brand and happy path first."""
+    console = ScriptedConsole("5\n")
+
+    home.default_gateway(root=tmp_path, console=console)
+
+    assert "exp" in console.output
+    assert "Experiential gateway" in console.output
+    assert "Default Gateway" in console.output
+    assert "recommended happy path" in console.output
+    assert "Run Gateway" in console.output
+    assert "Setup Gateway" in console.output
+
+
+def test_default_gateway_menu_starts_the_recommended_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The focused default row starts an ordinary gateway with interactive setup allowed."""
+    calls: list[dict[str, object]] = []
+
+    def start(**kwargs: object) -> None:
+        """Capture the gateway launch selected by the home screen."""
+        calls.append(kwargs)
+
+    monkeypatch.setattr(home, "start_gateway", start)
+    home.default_gateway(root=tmp_path, console=ScriptedConsole("1\n"))
+
+    assert calls == [
+        {
+            "root": tmp_path,
+            "port": 8000,
+            "non_interactive": False,
+            "graceful_timeout": 10.0,
+            "engine": "auto",
+            "max_active_requests": DEFAULT_MAX_ACTIVE_REQUESTS,
+        }
+    ]
+
+
+def test_run_gateway_menu_uses_the_existing_configuration_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The explicit run row never opens first-run setup prompts."""
+    calls: list[dict[str, object]] = []
+
+    def start(**kwargs: object) -> None:
+        """Capture the gateway launch selected by the home screen."""
+        calls.append(kwargs)
+
+    monkeypatch.setattr(home, "start_gateway", start)
+    home.default_gateway(root=tmp_path, console=ScriptedConsole("2\n"))
+
+    assert calls[0]["root"] == tmp_path
+    assert calls[0]["non_interactive"] is True
+    assert calls[0]["engine"] == "auto"
+    assert calls[0]["max_active_requests"] == DEFAULT_MAX_ACTIVE_REQUESTS
+
+
+@pytest.mark.parametrize(
+    ("policy", "ghost"),
+    [("policy-a", False), (None, True)],
+)
+def test_project_only_gateway_options_validate_before_home_menu(
+    tmp_path: Path,
+    policy: str | None,
+    ghost: bool,
+) -> None:
+    """Invalid project-only options fail before the interactive menu can ignore them."""
+    with pytest.raises(typer.BadParameter, match="require --project"):
+        home.default_gateway(
+            root=tmp_path,
+            policy=policy,
+            ghost=ghost,
+            console=ScriptedConsole("5\n"),
+        )
+
+
+def test_setup_gateway_returns_to_home_with_one_time_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup is an explicit menu action and leaves the operator at the home screen."""
+    monkeypatch.setattr(
+        "exp.cli.gateway.setup.interactive_gateway_setup",
+        lambda _root, *, console: InteractiveSetupResult(
+            identity_id="default",
+            alias="default-gateway",
+            raw_key="exp_vk_test",
+        ),
+    )
+    console = ScriptedConsole("3\n5\n")
+
+    home.default_gateway(root=tmp_path, console=console)
+
+    assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in console.output
+    assert "export EXP_GATEWAY_KEY=exp_vk_test" in console.output
+    assert "Choose Default Gateway to start it." in console.output

--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -11,10 +11,14 @@ import typer
 from rich.console import Console
 from rich.text import Text
 
-from exp.cli.shared.options import ROOT_OPTION, usage_error
+from exp.cli.shared.options import usage_error
 from exp.cli.shared.theme import EXP_THEME
 
-_LOOPBACK_HOST = "127.0.0.1"
+LOOPBACK_HOST = "127.0.0.1"
+_LOOPBACK_HOST = LOOPBACK_HOST
+DEFAULT_GATEWAY_PORT = 8000
+DEFAULT_GRACEFUL_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_ACTIVE_REQUESTS = 1024
 _console = Console(theme=EXP_THEME)
 _EXP_WORDMARK = "\n".join(
     (
@@ -26,70 +30,29 @@ _EXP_WORDMARK = "\n".join(
         "╚══════╝╚═╝  ╚═╝╚═╝     ",
     )
 )
-_POLICY_OPTION = typer.Option(
-    None,
-    "--policy",
-    help="Exact frozen policy ID for the optional project-backed alias.",
-)
-_PORT_OPTION = typer.Option(8000, "--port", min=1, max=65_535)
-_GHOST_OPTION = typer.Option(
-    False,
-    "--ghost",
-    help="Compatibility flag: project journals stay disabled while gateway accounting remains on.",
-)
-_NON_INTERACTIVE_OPTION = typer.Option(
-    False,
-    "--non-interactive",
-    help="Never open first-run prompts.",
-)
-_JSON_OPTION = typer.Option(False, "--json", help="Write a versioned launch receipt.")
-_CHECK_OPTION = typer.Option(False, "--check", help="Validate readiness and exit without binding.")
-_GRACEFUL_TIMEOUT_OPTION = typer.Option(
-    10.0,
-    "--graceful-timeout",
-    min=0.1,
-    help="Seconds to drain admitted gateway work during shutdown.",
-)
-_ENGINE_OPTION = typer.Option(
-    "auto",
-    "--engine",
-    help=(
-        "Data-plane engine: 'auto' (rust when built, otherwise python), 'rust' "
-        "(native data plane with an embedded python engine for Responses, "
-        "replay, and project aliases), or 'python' (uvicorn only)."
-    ),
-)
-_MAX_ACTIVE_REQUESTS_DEFAULT = 1024
-_MAX_ACTIVE_REQUESTS_OPTION = typer.Option(
-    _MAX_ACTIVE_REQUESTS_DEFAULT,
-    "--max-active-requests",
-    min=1,
-    help="Rust engine only: maximum concurrently admitted requests.",
-)
+_MAX_ACTIVE_REQUESTS_DEFAULT = DEFAULT_MAX_ACTIVE_REQUESTS
 
 
-def run(
-    project: str | None = typer.Argument(
-        None,
-        help="Optional project to expose as one project-backed gateway alias.",
-    ),
-    root: Path = ROOT_OPTION,
-    policy: str | None = _POLICY_OPTION,
-    port: int = _PORT_OPTION,
-    ghost: bool = _GHOST_OPTION,
-    non_interactive: bool = _NON_INTERACTIVE_OPTION,
-    json_output: bool = _JSON_OPTION,
-    check: bool = _CHECK_OPTION,
-    graceful_timeout: float = _GRACEFUL_TIMEOUT_OPTION,
-    engine: str = _ENGINE_OPTION,
-    max_active_requests: int = _MAX_ACTIVE_REQUESTS_OPTION,
+def start_gateway(
+    *,
+    project: str | None = None,
+    root: Path,
+    policy: str | None = None,
+    port: int = DEFAULT_GATEWAY_PORT,
+    ghost: bool = False,
+    non_interactive: bool = False,
+    json_output: bool = False,
+    check: bool = False,
+    graceful_timeout: float = DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+    engine: str = "auto",
+    max_active_requests: int = DEFAULT_MAX_ACTIVE_REQUESTS,
 ) -> None:
     """Start the local gateway, optionally materializing one project-backed alias.
 
     Args:
         project: Optional project identifier and endpoint alias.
         root: Local artifact and model-catalog root.
-        policy: Exact policy for an ambiguous legacy project.
+        policy: Exact policy for an ambiguous project.
         port: Local loopback TCP port.
         ghost: Compatibility marker for project traffic, which always uses gateway accounting.
         non_interactive: Whether first-run gateway prompts are forbidden.
@@ -100,13 +63,13 @@ def run(
         max_active_requests: Rust engine concurrent-admission bound.
 
     Raises:
-        typer.BadParameter: The selected form or activation is invalid.
+        typer.BadParameter: The selected project form or activation is invalid.
     """
     if engine not in {"auto", "rust", "python"}:
         raise typer.BadParameter("--engine must be 'auto', 'rust', or 'python'")
     if policy is not None or ghost:
         if project is None:
-            raise typer.BadParameter("--policy and --ghost require the 'exp run PROJECT' form")
+            raise typer.BadParameter("--policy and --ghost require --project")
     if engine == "rust" and project is not None:
         raise typer.BadParameter(
             "--engine rust serves direct aliases only; project-backed serving "
@@ -401,7 +364,7 @@ def _run_rust_gateway(
                 if not fallback_thread.is_alive() or time.monotonic() > deadline:
                     raise typer.BadParameter(
                         "the embedded python fallback engine failed to start; "
-                        "inspect the gateway configuration with 'exp run --engine python'"
+                        "inspect the gateway configuration with 'exp --engine python'"
                     )
                 time.sleep(0.05)
             try:
@@ -463,12 +426,18 @@ def _gateway_not_initialized(*, json_output: bool) -> None:
     raise typer.Exit(2)
 
 
-def _emit_setup_credentials(*, port: int, setup: object) -> None:
+def _emit_setup_credentials(
+    *,
+    port: int,
+    setup: object,
+    console: Console | None = None,
+) -> None:
     """Deliver first-run gateway credentials before independent readiness checks run.
 
     Args:
         port: Loopback port that the gateway will serve when ready.
         setup: First-run setup result containing the one-time raw gateway key.
+        console: Optional console receiving the credentials.
 
     Raises:
         TypeError: The setup result is not the gateway setup contract.
@@ -477,8 +446,20 @@ def _emit_setup_credentials(*, port: int, setup: object) -> None:
 
     if not isinstance(setup, InteractiveSetupResult):
         raise TypeError("interactive setup returned an invalid result")
-    _console.print(f"export EXP_GATEWAY_URL=http://{_LOOPBACK_HOST}:{port}/v1", markup=False)
-    _console.print(f"export EXP_GATEWAY_KEY={setup.raw_key}", markup=False)
+    output = console or _console
+    output.print(f"export EXP_GATEWAY_URL=http://{_LOOPBACK_HOST}:{port}/v1", markup=False)
+    output.print(f"export EXP_GATEWAY_KEY={setup.raw_key}", markup=False)
+
+
+def emit_setup_credentials(*, port: int, setup: object, console: Console | None = None) -> None:
+    """Print the one-time credentials created by interactive gateway setup.
+
+    Args:
+        port: Loopback port used by the gateway.
+        setup: Result returned by the first-run setup flow.
+        console: Optional console receiving the user-facing exports.
+    """
+    _emit_setup_credentials(port=port, setup=setup, console=console)
 
 
 def _emit_setup_recovery(*, setup: object) -> None:
@@ -500,7 +481,7 @@ def _emit_setup_recovery(*, setup: object) -> None:
     )
     _console.print(
         "Keep the gateway credentials printed above, fix the listed provider configuration, "
-        "and rerun `exp run`.",
+        "and rerun `exp`.",
         markup=False,
     )
     _console.print(

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -1,4 +1,4 @@
-"""Development-only loopback run-command tests."""
+"""Loopback gateway serving tests for the root default flow."""
 
 from __future__ import annotations
 
@@ -15,14 +15,14 @@ import typer
 from rich.console import Console
 from typer.testing import CliRunner
 
-import exp.cli.run.app as run_app
+import exp.cli.gateway.serve as run_app
 from exp.cli.app import app
 from exp.cli.gateway.compatibility import ProjectGatewayCompatibility
 from exp.cli.gateway.setup import InteractiveSetupResult
 
 
 @pytest.mark.parametrize("ghost", [False, True])
-def test_project_form_launches_the_normal_gateway_on_loopback(
+def test_project_option_launches_the_normal_gateway_on_loopback(
     monkeypatch: pytest.MonkeyPatch,
     ghost: bool,
 ) -> None:
@@ -119,7 +119,7 @@ def test_project_form_launches_the_normal_gateway_on_loopback(
     monkeypatch.setattr("uvicorn.run", serve)
 
     arguments = [
-        "run",
+        "--project",
         "project-a",
         "--root",
         "/tmp/local-exp",
@@ -142,14 +142,14 @@ def test_project_form_launches_the_normal_gateway_on_loopback(
     assert receipt["base_url"] == "http://127.0.0.1:8123/v1"
     assert receipt["project_alias"] == "project-a"
     assert receipt["gateway_accounting"] == "enabled"
-    assert "--host" not in CliRunner().invoke(app, ["run", "--help"]).output
+    assert "--host" not in CliRunner().invoke(app, ["--help"]).output
 
 
-def test_no_argument_noninteractive_run_returns_stable_empty_state_json(tmp_path: Path) -> None:
+def test_noninteractive_default_gateway_returns_stable_empty_state_json(tmp_path: Path) -> None:
     """Automation receives exact setup commands instead of prompts or runtime seeds."""
     result = CliRunner().invoke(
         app,
-        ["run", "--root", str(tmp_path), "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--non-interactive", "--json"],
     )
 
     assert result.exit_code == 2
@@ -171,7 +171,7 @@ def test_engine_rust_without_the_extension_is_an_actionable_error(tmp_path: Path
         return real_find_spec(name, package)
 
     with mock.patch.object(importlib.util, "find_spec", side_effect=missing_extension):
-        result = CliRunner().invoke(app, ["run", "--root", str(tmp_path), "--engine", "rust"])
+        result = CliRunner().invoke(app, ["--root", str(tmp_path), "--engine", "rust"])
     assert result.exit_code == 2
     assert "exp_gateway_native" in result.output
 
@@ -180,7 +180,7 @@ def test_engine_auto_falls_back_to_python_on_an_uninitialized_root(tmp_path: Pat
     """The default auto engine keeps the python empty-state contract."""
     result = CliRunner().invoke(
         app,
-        ["run", "--root", str(tmp_path), "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--non-interactive", "--json"],
     )
     assert result.exit_code == 2
     assert json.loads(result.stdout)["error"]["code"] == "gateway_not_initialized"
@@ -188,7 +188,7 @@ def test_engine_auto_falls_back_to_python_on_an_uninitialized_root(tmp_path: Pat
 
 def test_engine_rejects_unknown_values(tmp_path: Path) -> None:
     """An unknown engine name is a usage error."""
-    result = CliRunner().invoke(app, ["run", "--root", str(tmp_path), "--engine", "zig"])
+    result = CliRunner().invoke(app, ["--root", str(tmp_path), "--engine", "zig"])
     assert result.exit_code == 2
 
 
@@ -226,7 +226,7 @@ def test_first_run_delivers_credentials_before_readiness_failure(
             "no granted active alias is locally available: "
             "gpt-5-6-luna (connection credential environment variable "
             "'OPENAI_API_KEY' is not set); fix the listed provider configuration and rerun "
-            "'exp run'"
+            "'exp'"
         )
 
     @contextmanager
@@ -268,5 +268,5 @@ def test_first_run_delivers_credentials_before_readiness_failure(
     assert f"export EXP_GATEWAY_KEY={raw_key}" in transcript
     assert "export OPENAI_API_KEY" not in transcript
     assert "First-run gateway setup completed, but the gateway is not ready." in transcript
-    assert "fix the listed provider configuration and rerun 'exp run'" in str(failure.value)
+    assert "fix the listed provider configuration and rerun 'exp'" in str(failure.value)
     assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript

--- a/exp/cli/run/__init__.py
+++ b/exp/cli/run/__init__.py
@@ -1,1 +1,0 @@
-"""Loopback gateway launch command modules."""

--- a/exp/cli/tests/cli_help_test.py
+++ b/exp/cli/tests/cli_help_test.py
@@ -21,7 +21,6 @@ from exp.cli.app import app
         ["config", "judge", "calibrate", "--help"],
         ["optimize", "router", "--help"],
         ["optimize", "model", "--help"],
-        ["run", "--help"],
     ],
     ids=[
         "root",
@@ -33,7 +32,6 @@ from exp.cli.app import app
         "judge-calibrate",
         "router",
         "model",
-        "run",
     ],
 )
 def test_help_renders_only_user_facing_descriptions(argv: list[str]) -> None:

--- a/exp/cli/tests/openai_compatible_recipes_test.py
+++ b/exp/cli/tests/openai_compatible_recipes_test.py
@@ -130,7 +130,7 @@ def test_fireworks_recipe_reaches_gateway_readiness_without_a_provider_call(
 
     readiness = CliRunner().invoke(
         app,
-        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--check", "--non-interactive", "--json"],
     )
 
     assert readiness.exit_code == 0, readiness.output
@@ -156,7 +156,7 @@ def test_modal_recipe_fails_closed_without_its_deployment_base_url(
 
     readiness = CliRunner().invoke(
         app,
-        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--check", "--non-interactive", "--json"],
     )
 
     assert readiness.exit_code == 2
@@ -189,7 +189,7 @@ def test_modal_recipe_reaches_readiness_with_its_deployment_base_url(
 
     readiness = CliRunner().invoke(
         app,
-        ["run", "--root", str(tmp_path), "--check", "--non-interactive", "--json"],
+        ["--root", str(tmp_path), "--check", "--non-interactive", "--json"],
     )
 
     assert readiness.exit_code == 0, readiness.output

--- a/exp/cli/tests/package_layout_test.py
+++ b/exp/cli/tests/package_layout_test.py
@@ -23,7 +23,6 @@ CLI_PACKAGES = frozenset(
         "judge",
         "optimize",
         "providers",
-        "run",
         "shared",
     }
 )

--- a/exp/cli/tests/terminal_tasks_live_pipeline_test.py
+++ b/exp/cli/tests/terminal_tasks_live_pipeline_test.py
@@ -308,7 +308,7 @@ def _wait_for_server(port: int, process: subprocess.Popen[bytes]) -> None:
     deadline = time.monotonic() + 120
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise AssertionError(f"exp run exited early with code {process.returncode}")
+            raise AssertionError(f"exp gateway exited early with code {process.returncode}")
         try:
             status, _ = _http_json(port, "GET", "/v1/models")
         except (ConnectionError, OSError):
@@ -317,7 +317,7 @@ def _wait_for_server(port: int, process: subprocess.Popen[bytes]) -> None:
         if status == 200:
             return
         time.sleep(1)
-    raise AssertionError("exp run never became ready on loopback")
+    raise AssertionError("exp gateway never became ready on loopback")
 
 
 def _serve_and_exercise(root: Path, *, ghost: bool) -> None:
@@ -326,7 +326,7 @@ def _serve_and_exercise(root: Path, *, ghost: bool) -> None:
         sys.executable,
         "-m",
         "exp",
-        "run",
+        "--project",
         _PROJECT,
         "--root",
         str(root),

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -680,7 +680,7 @@ def _load_alias_state(
         detail = f": {unavailable}" if unavailable else ""
         raise GatewayLifecycleError(
             "no granted active alias is locally available"
-            f"{detail}; fix the listed provider configuration and rerun 'exp run'"
+            f"{detail}; fix the listed provider configuration and rerun 'exp'"
         )
 
     return _AliasAuthorityState(

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -319,7 +319,7 @@ def test_unavailable_alias_reports_its_provider_readiness_reason(tmp_path: Path)
 
     with pytest.raises(
         GatewayLifecycleError,
-        match=r"coding.*TEST_PROVIDER_KEY.*rerun 'exp run'",
+        match=r"coding.*TEST_PROVIDER_KEY.*rerun 'exp'",
     ):
         load_local_gateway(tmp_path, graceful_timeout_seconds=1, environment={})
 

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -34,7 +34,7 @@ use crate::upstream::open_stream;
 /// real chat history (the python engine imposes no explicit cap).
 const MAXIMUM_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 
-/// Serve-time configuration passed from `exp run --engine rust`.
+/// Serve-time configuration passed from `exp --engine rust`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServeConfig {
     pub host: String,

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -330,7 +330,7 @@ def test_models_and_detail_mirror_the_python_discovery_bodies(tmp_path: Path) ->
 
     models = json.loads(control.models(json.dumps({"raw_key": raw_key})))
     assert [item["id"] for item in models["data"]] == ["coding"]
-    assert models["wmo"]["authority_schema_version"] == 1
+    assert models["exp"]["authority_schema_version"] == 1
     listed = models["data"][0]
     for key, value in metadata["coding"].extension_fields().items():
         assert listed[key] == value

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -120,7 +120,7 @@ def prepare_project_gateway_alias(
         manager.create_identity(
             identity_id=identity_id,
             display_name=f"Project {project}",
-            description="Compatibility identity for exp run PROJECT.",
+            description="Compatibility identity for an exp --project gateway.",
         )
         identity_changed = True
     grant_changed = manager.add_grant(identity_id=identity_id, alias_id=project)

--- a/exp/runtime/router/application.py
+++ b/exp/runtime/router/application.py
@@ -123,7 +123,8 @@ def load_router(
 
     Returns:
         Official OpenAI client whose Chat Completions and Responses resources call the same
-        authenticated gateway application as ``exp run``. Close it or use it as a context manager
+        authenticated gateway application as the default ``exp`` flow. Close it or use it as a
+        context manager
         to revoke its ephemeral virtual key.
     """
     if ghost and decision_sink is not None:

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -1374,13 +1374,13 @@ def _installed_release_driver() -> None:
         while time.monotonic() < deadline:
             if process.poll() is not None:
                 output = process.stdout.read() if process.stdout is not None else ""
-                raise AssertionError(f"exp run exited before startup:\n{output}")
+                raise AssertionError(f"exp gateway exited before startup:\n{output}")
             try:
                 with socket.create_connection(("127.0.0.1", port), timeout=0.2):
                     return
             except OSError:
                 time.sleep(0.05)
-        raise AssertionError(f"exp run did not listen on port {port}")
+        raise AssertionError(f"exp gateway did not listen on port {port}")
 
     def start_gateway(root: Path) -> tuple[subprocess.Popen[str], int, str]:
         """Start one installed gateway subprocess on an unused loopback port.
@@ -1395,7 +1395,6 @@ def _installed_release_driver() -> None:
         process = subprocess.Popen(
             [
                 str(executable),
-                "run",
                 "--root",
                 str(root),
                 "--port",
@@ -1435,7 +1434,6 @@ def _installed_release_driver() -> None:
     gateway_root = execution_root / "gateway-empty"
     gateway_database = gateway_root / "gateway" / "gateway.db"
     empty_gateway = run_cli(
-        "run",
         "--root",
         str(gateway_root),
         "--non-interactive",
@@ -2714,7 +2712,7 @@ def _installed_release_driver() -> None:
         router_process = subprocess.Popen(
             [
                 str(executable),
-                "run",
+                "--project",
                 "support-agent",
                 "--root",
                 str(root),
@@ -3147,7 +3145,7 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
     assert "exp optimize model" in usage
     assert "exp config gateway" in usage
     assert "exp config gateway pool certify" in usage
-    assert "exp run --root ROOT" in usage
+    assert "exp --root ROOT" in usage
     assert "OpenAI `3.0.0`" in usage
     assert "schema-v2" in usage
     assert "by_billing_source" in usage

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ test *ARGS:
     uv run pytest -q {{ARGS}}
 
 # Build the Rust gateway data-plane extension into the project venv (PoC).
-# Afterwards: uv run exp run --engine rust
+# Afterwards: uv run exp --engine rust
 native:
     uv run maturin develop --uv --release --manifest-path exp/runtime/gateway/native/Cargo.toml
 


### PR DESCRIPTION
## Summary
- Make a no-subcommand `exp` invocation open the branded green Experiential gateway home screen.
- Put `Default Gateway` first as the recommended happy path, followed by `Run Gateway`, `Setup Gateway`, `Gateway Status`, and `Exit`.
- Remove the public `exp run` command and move serving orchestration under `exp/cli/gateway/`.
- Preserve automation and project compatibility through root options such as `exp --root ROOT --check` and `exp --project PROJECT`.
- Update command-surface tests, package layout tests, release tests, docs, and gateway ownership contracts.

## Validation
- Focused gateway and CLI tests: 92 passed.
- Ruff: passed.
- Ruff format check: passed.
- ty: passed.
- Clean broad non-live suite excluding only the known terminal-picker tests: 1,877 passed, 1 skipped.
- The 11 excluded picker tests are existing macOS terminal redraw/cursor behavior assertions. The two clean-checkout-only release-evidence tests were rerun after commit and passed.
- GitHub checks: Analyze (actions), Analyze (python), and CodeQL all passed.
- Real WezTerm sandbox walkthrough captured at `/private/tmp/exp-default-gateway-terminal.mov`.

README was left unchanged because the repository instructions require explicit approval before modifying it.