### PR TITLE
gateway: surface a provider 4xx as an actionable 400, not all_routes_failed

### DIFF
--- a/wmo/runtime/models/providers/errors.py
+++ b/wmo/runtime/models/providers/errors.py
@@ -160,6 +160,21 @@ def _transport_failure(status_code: int | None) -> GatewayFailure:
             failover_eligible=True,
             safe_details=details,
         )
+    if status_code is not None and 400 <= status_code < 500:
+        # A client-side 4xx (an unsupported or out-of-range parameter, an
+        # oversized prompt, an otherwise malformed request) is deterministic:
+        # every rung rejects it identically, so this is not a transient outage.
+        # Classify it as an invalid request the caller can correct rather than
+        # letting it collapse into the generic all-routes-failed 502, which
+        # tells an agent to retry with backoff. It stays failover eligible so a
+        # sibling deployment that DOES accept the request can still serve it;
+        # only when every rung rejects it the same way does the caller see 400.
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.INVALID_REQUEST,
+            safe_message="provider rejected the request as invalid",
+            failover_eligible=True,
+            safe_details=details,
+        )
     if status_code is not None:
         return GatewayFailure(
             failure_class=GatewayFailureClass.PROVIDER_INTERNAL,

--- a/wmo/runtime/models/providers/errors_test.py
+++ b/wmo/runtime/models/providers/errors_test.py
@@ -16,6 +16,7 @@ from wmo.runtime.models.providers.errors import (
     normalized_provider_failure,
 )
 from wmo.runtime.models.providers.transport import ProviderTransportError
+from wmo.runtime.openai_protocol.errors import public_failure_error
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,18 @@ from wmo.runtime.models.providers.transport import ProviderTransportError
         (
             ProviderTransportError("raw throttle canary", status_code=429),
             GatewayFailureClass.THROTTLED,
+            False,
+            True,
+        ),
+        (
+            ProviderTransportError("raw bad-request canary", status_code=400),
+            GatewayFailureClass.INVALID_REQUEST,
+            False,
+            True,
+        ),
+        (
+            ProviderTransportError("raw unprocessable canary", status_code=422),
+            GatewayFailureClass.INVALID_REQUEST,
             False,
             True,
         ),
@@ -88,6 +101,34 @@ def test_refusal_and_capability_failures_keep_only_safe_signals() -> None:
     assert refusal.safe_details == {"signal": "safety"}
     assert capability.failure_class is GatewayFailureClass.UNSUPPORTED_CAPABILITY
     assert capability.safe_details == {"capability": "strict_tools"}
+
+
+def test_client_4xx_surfaces_as_an_actionable_400_not_all_routes_failed() -> None:
+    """A deterministic provider 4xx reaches the caller as a correctable 400.
+
+    Reasoning models reject a non-default ``temperature`` with a provider 400,
+    and an oversized prompt or bad parameter does the same. Before, every such
+    rejection collapsed into the generic 502 ``all_routes_failed`` (an outage
+    signal telling an agent to retry with backoff). It must instead surface as
+    an ``invalid_request_error`` 400 with the offending status retained for
+    telemetry, so the caller self-corrects rather than retrying a doomed call.
+    """
+    failure = normalized_provider_failure(
+        ProviderTransportError("raw temperature canary", status_code=400)
+    )
+    assert failure.failure_class is GatewayFailureClass.INVALID_REQUEST
+    assert failure.safe_details == {"status_code": 400}
+
+    error = public_failure_error(failure)
+    assert error.status_code == 400
+    assert error.detail.code == "invalid_request"
+    assert error.detail.type == "invalid_request_error"
+
+    server = normalized_provider_failure(
+        ProviderTransportError("raw outage canary", status_code=503)
+    )
+    # A genuine multi-provider outage keeps its all-routes-failed 502 semantics.
+    assert public_failure_error(server).status_code == 502
 
 
 def test_cancellation_has_a_dedicated_nonretryable_failure() -> None:


### PR DESCRIPTION
## Problem

Calling a reasoning model (Claude 5, gpt-5.x-reasoning) with a non-default `temperature`, an oversized prompt, or another parameter the provider rejects returns **HTTP 502 `all_routes_failed`** — "every provider in the waterfall failed." That is an outage signal telling an agent to retry with backoff, but the request is a deterministic client-side 400: every rung rejects it identically, so retrying only repeats it.

## Cause

`wmo/runtime/models/providers/errors.py::_transport_failure` normalizes a generic provider 4xx to `PROVIDER_INTERNAL`, and `openai_protocol/errors.py::public_failure_error` has no mapping for that class, so it falls to the default `(502, all_routes_failed, api_error)`.

## Fix

A provider client-side 4xx now classifies as `INVALID_REQUEST` → `public_failure_error` returns `400 invalid_request_error` with the upstream status kept in `safe_details` for telemetry. It stays **failover-eligible** so a sibling deployment that accepts the request can still serve it; only when every rung rejects it the same way does the caller see the 400. Genuine 5xx / transport failures keep their `all_routes_failed` 502 outage semantics.

Tests: `errors_test.py` — 400/422 → `INVALID_REQUEST` (non-retryable, failover-eligible); full chain proving a provider 400 → HTTP 400 `invalid_request` while a 503 stays 502.

## Context / coupling

Paired with platform PR experientiallabs/platform#564 (branch `gw/actionable-route-errors`), which fixes the streaming/deadline cutoff (ingress + timeouts), exposes per-model `supported_params`, and marks `claude-fable-5` temperature-unsupported. Once this merges, bump the platform's wmo pin to the merged SHA.

### Follow-ups (same root-cause family, not in this PR)
- Per-model **temperature-value** validation before dispatch (400 that *names* `temperature`), using the catalog `supports_temperature` the platform now sets — so temp=1 succeeds and temp≠1 on a reasoning model 400s cleanly rather than round-tripping to the provider.
- Validate `max_tokens` ≤ model max output **before** the cost pre-reservation (a huge `max_tokens` currently overflows the allocation and returns a false 429 "monthly allocation exhausted").
- Flush `finish_reason` + a usage chunk on the stream **abort** path (`gateway/service.py::_stream_body`) so aborted streams are not an accounting blind spot.
- Unknown `/v1` routes / unsupported endpoints (e.g. `/v1/embeddings`) → 404/405, not 401.