### PR TITLE
Add EXP wordmark to exp run

### DIFF
--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -8,7 +8,10 @@ import sys
 from pathlib import Path
 
 import typer
+from rich import box
 from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
 
 from exp.cli.shared.options import ROOT_OPTION, usage_error
 from exp.cli.shared.theme import EXP_THEME
@@ -100,6 +103,9 @@ def _run_gateway(
     graceful_timeout: float,
 ) -> None:
     """Validate and optionally serve the normal gateway application."""
+    if not json_output:
+        _emit_exp_wordmark()
+
     import uvicorn
 
     from exp.cli.gateway.compatibility import prepare_project_gateway
@@ -178,6 +184,19 @@ def _run_gateway(
         if setup is not None:
             _emit_setup_recovery(setup=setup)
         raise
+
+
+def _emit_exp_wordmark() -> None:
+    """Render the compact EXP wordmark for human-facing gateway startup output."""
+    _console.print(
+        Panel(
+            Text("EXP", style="bold"),
+            border_style="green",
+            box=box.SQUARE,
+            expand=False,
+            padding=(0, 1),
+        )
+    )
 
 
 def _gateway_not_initialized(*, json_output: bool) -> None:

--- a/exp/cli/run/app_test.py
+++ b/exp/cli/run/app_test.py
@@ -222,6 +222,7 @@ def test_first_run_delivers_credentials_before_readiness_failure(
         )
 
     transcript = output.getvalue()
+    assert transcript.startswith("┌─────┐\n│ EXP │\n└─────┘\n")
     assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in transcript
     assert f"export EXP_GATEWAY_KEY={raw_key}" in transcript
     assert "export OPENAI_API_KEY" not in transcript


### PR DESCRIPTION
## Summary

- Add the website-inspired square `EXP` wordmark to human-facing `exp run` startup output.
- Keep `--json` output machine-readable by omitting the wordmark in JSON mode.
- Cover startup ordering in the run-command regression test.

## Verification

- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ty check`
- `uv run --extra dev pytest -q exp/cli/run/app_test.py` (`4 passed`)
- Release-evidence tests (`2 passed` after commit)
- PR checks: aggregate gate, build, CodeQL, Python analysis, Darwin evidence, and Greptile review all pass.

The initial full local suite reported `2043 passed, 2 skipped, 13 failed`. The 11 pseudo-terminal picker failures reproduce unchanged on `origin/main` in the existing checkout environment. The other 2 failures were release-evidence checks rejecting the uncommitted tracked diff, and both pass from the committed revision.
