### PR TITLE
Keep OpenAI-compatible discovery independent of listing metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ results, and plans do not live here.
 | File | Purpose |
 |---|---|
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
-| `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata. |
+| `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata plus identity-only operator declaration. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
 | `reference/openai-compatible-recipes.md` | Verified Fireworks and Modal connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ results, and plans do not live here.
 | File | Purpose |
 |---|---|
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
-| `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, and the Bedrock credential chain. |
+| `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
 | `reference/openai-compatible-recipes.md` | Verified Fireworks and Modal connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -154,8 +154,8 @@ idempotency, request, or provider values.
 
 `GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
 enriched with a `wmo` object carrying the alias revision and catalog digest of the granted
-authority. When that alias resolves to exactly one active catalog deployment, the same object
-also carries optional extension fields copied from that deployment: `supports_completions`,
+authority. When that alias revision targets exactly one direct singleton pool, the same object
+also carries optional extension fields copied from that pool's deployment: `supports_completions`,
 `supports_tools`, `supports_structured_output`, `maximum_output_tokens`, `context_window_tokens`
 when the catalog declares a window, and a `pricing` object of configured micro-USD-per-million-token
 rates. The gateway never invents a context window or a cache-write price, and it never hard-codes

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -154,7 +154,12 @@ idempotency, request, or provider values.
 
 `GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
 enriched with a `wmo` object carrying the alias revision and catalog digest of the granted
-authority. Its list envelope carries `wmo.authority_schema_version`, including when `data` is
+authority. When that alias resolves to exactly one active catalog deployment, the same object
+also carries optional extension fields copied from that deployment: `supports_completions`,
+`supports_tools`, `supports_structured_output`, `maximum_output_tokens`, `context_window_tokens`
+when the catalog declares a window, and a `pricing` object of configured micro-USD-per-million-token
+rates. The gateway never invents a context window or a cache-write price, and it never hard-codes
+hosted alias names. Its list envelope carries `wmo.authority_schema_version`, including when `data` is
 empty, so caller-side key validation can distinguish this gateway from a generic OpenAI proxy.
 `GET /v1/models/{model_id}` describes one granted alias with the same object and
 returns the identical `model_not_found` 404 for every other model ID, so the route never confirms

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -101,3 +101,10 @@ The same two connections work for evidence builds and router optimization throug
 `exp config providers` by choosing the `openai-compatible` provider with the identical
 `base_url` and credential environment variable; see `reference/providers.md` for that
 flow.
+
+A hosted WMO gateway is the same provider family. Point `base_url` at its `/v1` origin and
+present a granted virtual key. `GET /v1/models` keeps the OpenAI list shape and publishes
+per-alias completion capabilities, limits, and configured micro-USD prices from the active
+catalog. `exp config providers --provider openai-compatible` reads those optional fields,
+converts micro-USD prices to USD per million tokens, and leaves unknown any field the catalog
+did not declare. It does not treat official OpenAI listing metadata the same way.

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -102,9 +102,17 @@ The same two connections work for evidence builds and router optimization throug
 `base_url` and credential environment variable; see `reference/providers.md` for that
 flow.
 
-A hosted WMO gateway is the same provider family. Point `base_url` at its `/v1` origin and
-present a granted virtual key. `GET /v1/models` keeps the OpenAI list shape and publishes
-per-alias completion capabilities, limits, and configured micro-USD prices from the active
-catalog. `exp config providers --provider openai-compatible` reads those optional fields,
-converts micro-USD prices to USD per million tokens, and leaves unknown any field the catalog
-did not declare. It does not treat official OpenAI listing metadata the same way.
+Any trusted OpenAI-compatible host is usable from that command, including an identity-only
+`GET /v1/models` response. Setup lists those identities and labels missing capabilities and
+prices as unknown. The operator then declares the minimum fields for the selected role in the
+interactive screens, or authors the same configured metadata with `--non-interactive`
+`--connection-json` / `--model-json` (or a hand-written `.exp/models.toml` record). Setup never
+infers tools, structured output, token limits, or prices.
+
+A hosted Experiential gateway is the same provider family and an optional richer listing. Point
+`base_url` at its `/v1` origin and present a granted virtual key. `GET /v1/models` keeps the
+OpenAI list shape and may publish per-alias completion capabilities, limits, and configured
+micro-USD prices from the active catalog. `exp config providers --provider openai-compatible`
+reads those optional fields, converts micro-USD prices to USD per million tokens, and leaves
+unknown any field the catalog did not declare. It does not treat official OpenAI listing
+metadata the same way.

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -36,9 +36,19 @@ third-party OpenAI-compatible host.
 extension fields. Official `openai` listing stays identity-only: extra keys on a model object are
 discarded so unofficial metadata cannot become verified OpenAI capabilities or prices.
 
-When an OpenAI-compatible host publishes the following optional fields, setup copies only values
-that match the declared types. Absent or wrongly typed fields stay unknown. No context window or
-cache-write price is inferred from a neighboring value.
+Discovery and verification stay separate. `exp config providers --provider openai-compatible`
+lists every identity returned by a trusted operator-supplied endpoint. Official `openai` listing
+never becomes a capability source. When the compatible host also publishes the following optional
+fields, setup copies only values that match the declared types. Absent or wrongly typed fields
+stay unknown. No context window or cache-write price is inferred from a neighboring value.
+
+Identity-only rows remain visible and selectable. Setup labels them `unknown capabilities/prices`
+and does not assign a build role until the operator declares the minimum fields that role needs.
+The interactive flow confirms published values and asks only for missing required fields. The
+deterministic equivalent is `exp config providers --non-interactive` with `--connection-json` and
+`--model-json`, or a hand-authored `.exp/models.toml` record. Those declarations become configured
+catalog metadata. Downstream cost and router-candidate preflights stay fail-closed while a
+required price or limit remains unknown.
 
 | Field | Type | Meaning |
 |---|---|---|
@@ -52,14 +62,15 @@ cache-write price is inferred from a neighboring value.
 | `pricing.cached_input_micro_usd_per_million_tokens` | integer `>= 0` | Configured cached-input price in micro-USD per million tokens |
 
 Micro-USD prices convert to catalog USD-per-million-token prices by dividing by `1_000_000`. A
-hosted WMO gateway publishes these fields from the granted alias revision's direct singleton
-pool. Project aliases and multi-deployment pools stay identity-only. That is enough for
-world-model and judge setup when tools, structured output, and input/output prices are present.
-Router-candidate setup still requires a published context window and both cache prices; WMO does
-not invent those.
+hosted Experiential gateway publishes these fields from the granted alias revision's direct
+singleton pool. Project aliases and multi-deployment pools stay identity-only. Published
+completion, tool, structured-output, and input/output price fields are enough to assign
+world-model and judge roles without a questionnaire. Router-candidate setup still requires a
+published or operator-declared context window and both cache prices. The gateway never invents
+those values, and setup never infers them.
 
-The hosted WMO `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`, and
-the four OpenAI model keys) and only adds these extension fields plus the existing `wmo`
+The hosted gateway `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`,
+and the four OpenAI model keys) and only adds these extension fields plus the existing `wmo`
 authority marker.
 
 ## Azure

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -52,10 +52,11 @@ cache-write price is inferred from a neighboring value.
 | `pricing.cached_input_micro_usd_per_million_tokens` | integer `>= 0` | Configured cached-input price in micro-USD per million tokens |
 
 Micro-USD prices convert to catalog USD-per-million-token prices by dividing by `1_000_000`. A
-hosted WMO gateway publishes these fields from its active catalog for each granted alias that
-resolves to one deployment. That is enough for world-model and judge setup when tools, structured
-output, and input/output prices are present. Router-candidate setup still requires a published
-context window and both cache prices; WMO does not invent those.
+hosted WMO gateway publishes these fields from the granted alias revision's direct singleton
+pool. Project aliases and multi-deployment pools stay identity-only. That is enough for
+world-model and judge setup when tools, structured output, and input/output prices are present.
+Router-candidate setup still requires a published context window and both cache prices; WMO does
+not invent those.
 
 The hosted WMO `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`, and
 the four OpenAI model keys) and only adds these extension fields plus the existing `wmo`

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -30,6 +30,37 @@ Setup writes only secret-free catalog fields and never prints a credential value
 Native fixed-origin providers reject a custom `base_url`. Use `openai-compatible` for a trusted
 third-party OpenAI-compatible host.
 
+## OpenAI-compatible listing metadata
+
+`provider = "openai-compatible"` is the only OpenAI-shaped listing path that reads optional
+extension fields. Official `openai` listing stays identity-only: extra keys on a model object are
+discarded so unofficial metadata cannot become verified OpenAI capabilities or prices.
+
+When an OpenAI-compatible host publishes the following optional fields, setup copies only values
+that match the declared types. Absent or wrongly typed fields stay unknown. No context window or
+cache-write price is inferred from a neighboring value.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `supports_completions` | boolean | The alias serves chat or responses completions |
+| `supports_tools` | boolean | The alias accepts tools |
+| `supports_structured_output` | boolean | The alias accepts structured output |
+| `maximum_output_tokens` | positive integer | Declared output ceiling |
+| `context_window_tokens` | positive integer | Declared context window, only when the host publishes one |
+| `pricing.input_micro_usd_per_million_tokens` | integer `>= 0` | Configured input price in micro-USD per million tokens |
+| `pricing.output_micro_usd_per_million_tokens` | integer `>= 0` | Configured output price in micro-USD per million tokens |
+| `pricing.cached_input_micro_usd_per_million_tokens` | integer `>= 0` | Configured cached-input price in micro-USD per million tokens |
+
+Micro-USD prices convert to catalog USD-per-million-token prices by dividing by `1_000_000`. A
+hosted WMO gateway publishes these fields from its active catalog for each granted alias that
+resolves to one deployment. That is enough for world-model and judge setup when tools, structured
+output, and input/output prices are present. Router-candidate setup still requires a published
+context window and both cache prices; WMO does not invent those.
+
+The hosted WMO `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`, and
+the four OpenAI model keys) and only adds these extension fields plus the existing `wmo`
+authority marker.
+
 ## Azure
 
 Use `provider = "azure"`. The connection needs:

--- a/exp/cli/optimize/router_candidates.py
+++ b/exp/cli/optimize/router_candidates.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
+from exp.cli.providers.declaration import can_declare_role, merge_declared_models
 from exp.cli.providers.model_picker import (
     available_models,
     configured_models,
@@ -121,8 +122,11 @@ def run_router_candidate_picker(
         eligible = tuple(
             item
             for item in available
-            if item.capabilities is not None
-            and serves_role(item.capabilities, SetupRole.ROUTER_CANDIDATE)
+            if (
+                item.capabilities is not None
+                and serves_role(item.capabilities, SetupRole.ROUTER_CANDIDATE)
+            )
+            or can_declare_role(item, SetupRole.ROUTER_CANDIDATE)
         )
         if len(eligible) < 2:
             console.print(
@@ -131,16 +135,22 @@ def run_router_candidate_picker(
                 "path.[/yellow]"
             )
             continue
+        declared: list[AvailableModel] = []
         selection = select_router_candidates(
             available,
             preselected=preselected,
             incumbent=incumbent,
             effort_defaults=catalog.roles.candidate_reasoning_efforts,
             console=console,
+            declared_models=declared,
         )
         if selection is None:
             continue
-        selected_models = tuple(item for item in available if item.alias in selection.candidates)
+        selected_models = tuple(
+            item
+            for item in merge_declared_models(available, tuple(declared))
+            if item.alias in selection.candidates
+        )
         used_connections = {item.connection for item in selected_models}
         candidate_models = tuple(
             model_selection(item) for item in selected_models if not item.configured

--- a/exp/cli/providers/declaration.py
+++ b/exp/cli/providers/declaration.py
@@ -1,0 +1,524 @@
+"""Operator-declared capability and price metadata for discovered model identities.
+
+Discovery may list an OpenAI-compatible identity before any capability or price is proven.
+This module collects only the minimum fields a selected build role needs, confirms published
+values when they exist, and never infers tools, structured output, token limits, or prices.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from rich.console import Console
+from rich.prompt import Confirm, IntPrompt
+
+from exp.cli.providers.provider_picker import (
+    UNKNOWN_METADATA_LABEL,
+    AvailableModel,
+    SetupCancelled,
+    SetupSession,
+    ask_price,
+    ask_text,
+)
+from exp.cli.shared.picker import PickerAction, PickerOption, choose_one
+from exp.common.models import (
+    ModelCapabilities,
+    PricingSource,
+    ReasoningEffort,
+    SetupRole,
+    derive_model_alias,
+    served_roles,
+    serves_role,
+)
+
+_NO_REASONING_EFFORT = "none"
+_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = get_args(ReasoningEffort)
+_COMPLETION_PRICE_FIELDS = (
+    ("input_cost_per_million_tokens_usd", "Input cost per million tokens in USD"),
+    ("output_cost_per_million_tokens_usd", "Output cost per million tokens in USD"),
+    ("cached_input_cost_per_million_tokens_usd", "Cached input cost per million tokens in USD"),
+    ("cache_write_cost_per_million_tokens_usd", "Cache write cost per million tokens in USD"),
+)
+
+
+def role_row_detail(item: AvailableModel) -> str:
+    """Annotate one role row without claiming unverified capabilities.
+
+    Args:
+        item: Model offered for a build role.
+
+    Returns:
+        A retain-only note, an unknown-metadata label, or an empty verified marker.
+    """
+    if item.capabilities is None or not served_roles(item.capabilities):
+        roles = ", ".join(sorted(role.value for role in item.retainable_roles))
+        return f"retain only: {roles}" if roles else UNKNOWN_METADATA_LABEL
+    return ""
+
+
+def can_declare_role(item: AvailableModel, role: SetupRole) -> bool:
+    """Report whether the operator may declare the minimum metadata for one role.
+
+    Args:
+        item: Discovered or already configured model.
+        role: Build role the operator selected.
+
+    Returns:
+        ``True`` only for OpenAI-compatible identities that do not already prove the role.
+    """
+    if item.provider != "openai-compatible":
+        return False
+    return item.capabilities is None or not serves_role(item.capabilities, role)
+
+
+def eligible_for_role(item: AvailableModel, role: SetupRole) -> bool:
+    """Report whether a model can be assigned a role now or after operator declaration.
+
+    Args:
+        item: Model offered for assignment.
+        role: Build role being filled.
+
+    Returns:
+        ``True`` when verified metadata serves the role, the exact prior binding retains it,
+        or the operator can declare the missing fields.
+    """
+    return (
+        (item.capabilities is not None and serves_role(item.capabilities, role))
+        or role in item.retainable_roles
+        or can_declare_role(item, role)
+    )
+
+
+def merge_declared_models(
+    pool: tuple[AvailableModel, ...],
+    declared: tuple[AvailableModel, ...],
+) -> tuple[AvailableModel, ...]:
+    """Replace pool rows with operator-declared metadata for the same alias.
+
+    Args:
+        pool: Models visible before declaration.
+        declared: Models whose capabilities the operator just confirmed.
+
+    Returns:
+        The pool with declared aliases replaced in their original order, then any new aliases.
+    """
+    by_alias = {item.alias: item for item in pool}
+    extra: list[AvailableModel] = []
+    for item in declared:
+        if item.alias in by_alias:
+            by_alias[item.alias] = item
+        else:
+            extra.append(item)
+    return tuple(by_alias[item.alias] for item in pool) + tuple(extra)
+
+
+def declare_role_metadata(
+    item: AvailableModel,
+    role: SetupRole,
+    *,
+    console: Console,
+) -> AvailableModel | None:
+    """Collect the minimum operator-declared metadata one selected role requires.
+
+    Published values are confirmed. Missing required fields are asked. Advanced capabilities
+    and prices that the role does not need stay unknown.
+
+    Args:
+        item: Identity-only or incomplete model selected for ``role``.
+        role: Build role that needs explicit metadata.
+        console: Terminal used for confirmation and numeric prompts.
+
+    Returns:
+        The same identity with configured capabilities, or ``None`` when the operator goes back
+        or declines a required field.
+
+    Raises:
+        SetupCancelled: The operator cancelled setup at a prompt.
+    """
+    console.print(
+        f"[dim]{item.alias} has {UNKNOWN_METADATA_LABEL}. "
+        f"Declare the minimum {role.value.replace('_', ' ')} metadata to use it.[/dim]"
+    )
+    try:
+        capabilities = _capabilities_for_role(item, role, console=console)
+    except _DeclarationRejected:
+        return None
+    if capabilities is None:
+        return None
+    return AvailableModel(
+        alias=item.alias,
+        connection=item.connection,
+        provider=item.provider,
+        model=item.model,
+        capabilities=capabilities,
+        pricing_source=PricingSource.CONFIGURED,
+        configured=item.configured,
+        retainable_roles=item.retainable_roles,
+        published=item.published,
+    )
+
+
+def declare_model(session: SetupSession, *, console: Console) -> AvailableModel | None:
+    """Declare one model and its capabilities by hand under the advanced path.
+
+    Args:
+        session: Prepared endpoints and aliases already used in this session.
+        console: Terminal used for prompts.
+
+    Returns:
+        The declared model, or ``None`` when no prepared connection can host it.
+
+    Raises:
+        SetupCancelled: The user cancelled setup at a prompt.
+    """
+    if not session.endpoints:
+        console.print("[yellow]Prepare a provider connection first.[/yellow]")
+        return None
+    connections = [
+        PickerOption(
+            value=endpoint.connection.name,
+            label=endpoint.connection.name,
+            detail=f"{endpoint.connection.provider}",
+        )
+        for endpoint in session.endpoints
+    ]
+    chosen = choose_one(console, title="Connection for the declared model", options=connections)
+    if chosen.action is PickerAction.CANCEL:
+        raise SetupCancelled
+    if chosen.action is PickerAction.BACK:
+        return None
+    connection_name = chosen.values[0]
+    provider = next(
+        endpoint.connection.provider
+        for endpoint in session.endpoints
+        if endpoint.connection.name == connection_name
+    )
+    model = ask_text("Provider model ID", console=console)
+    if not model:
+        return None
+    supports_completions = Confirm.ask("Supports chat completions?", default=True, console=console)
+    supports_embeddings = Confirm.ask("Supports embeddings?", default=False, console=console)
+    capabilities = ModelCapabilities(
+        supports_completions=supports_completions,
+        supports_embeddings=supports_embeddings,
+        supports_tools=Confirm.ask("Supports tools?", default=False, console=console),
+        supports_structured_output=Confirm.ask(
+            "Supports structured output?", default=False, console=console
+        ),
+        context_window_tokens=_optional_positive_int("Context window tokens", console=console),
+        maximum_output_tokens=_optional_positive_int("Maximum output tokens", console=console),
+        input_cost_per_million_tokens_usd=ask_price(
+            "Input cost per million tokens in USD", console=console
+        )
+        if supports_completions or supports_embeddings
+        else None,
+        output_cost_per_million_tokens_usd=ask_price(
+            "Output cost per million tokens in USD", console=console
+        )
+        if supports_completions
+        else None,
+        cached_input_cost_per_million_tokens_usd=ask_price(
+            "Cached input cost per million tokens in USD", console=console
+        )
+        if supports_completions
+        else None,
+        cache_write_cost_per_million_tokens_usd=ask_price(
+            "Cache write cost per million tokens in USD", console=console
+        )
+        if supports_completions
+        else None,
+        reasoning_effort=_ask_reasoning_effort(console=console) if supports_completions else None,
+    )
+    taken = frozenset(item.alias for item in (*session.available, *session.manual))
+    return AvailableModel(
+        alias=derive_model_alias(provider, model, taken),
+        connection=connection_name,
+        provider=provider,
+        model=model,
+        capabilities=capabilities,
+        pricing_source=PricingSource.CONFIGURED,
+        configured=False,
+    )
+
+
+class _DeclarationRejected(Exception):
+    """The operator declined a field the selected role requires."""
+
+
+def _capabilities_for_role(
+    item: AvailableModel,
+    role: SetupRole,
+    *,
+    console: Console,
+) -> ModelCapabilities | None:
+    """Build configured capabilities that satisfy one role and persist its protocol prices.
+
+    Args:
+        item: Selected model, including any published or earlier declared fields.
+        role: Build role being filled.
+        console: Terminal used for prompts.
+
+    Returns:
+        Explicit capabilities for the role.
+
+    Raises:
+        SetupCancelled: The operator cancelled setup.
+        _DeclarationRejected: A required capability was declined.
+    """
+    base = item.capabilities or ModelCapabilities()
+    updates: dict[str, bool | float | int | None] = {}
+    if role is SetupRole.EMBEDDER:
+        _require_flag(
+            item,
+            field="supports_embeddings",
+            question="Supports embeddings?",
+            console=console,
+        )
+        updates["supports_embeddings"] = True
+        updates["input_cost_per_million_tokens_usd"] = _require_price(
+            item,
+            field="input_cost_per_million_tokens_usd",
+            label="Input cost per million tokens in USD",
+            console=console,
+        )
+        return base.model_copy(update=updates)
+    _require_flag(
+        item,
+        field="supports_completions",
+        question="Supports chat completions?",
+        console=console,
+    )
+    updates["supports_completions"] = True
+    if role is SetupRole.JUDGE:
+        _require_flag(
+            item,
+            field="supports_structured_output",
+            question="Supports structured output?",
+            console=console,
+        )
+        updates["supports_structured_output"] = True
+    for field, label in _COMPLETION_PRICE_FIELDS:
+        updates[field] = _require_price(item, field=field, label=label, console=console)
+    if role is SetupRole.ROUTER_CANDIDATE:
+        updates["context_window_tokens"] = _require_positive_int(
+            item,
+            field="context_window_tokens",
+            label="Context window tokens",
+            console=console,
+        )
+        updates["maximum_output_tokens"] = _require_positive_int(
+            item,
+            field="maximum_output_tokens",
+            label="Maximum output tokens",
+            console=console,
+        )
+    return base.model_copy(update=updates)
+
+
+def _require_flag(
+    item: AvailableModel,
+    *,
+    field: str,
+    question: str,
+    console: Console,
+) -> None:
+    """Confirm a required boolean capability, using a published value as the default.
+
+    Args:
+        item: Selected model.
+        field: Capability field name.
+        question: Confirmation prompt.
+        console: Terminal used for the prompt.
+
+    Raises:
+        SetupCancelled: The operator cancelled setup.
+        _DeclarationRejected: The operator declined the required capability.
+    """
+    published = _known_bool(item, field)
+    default = True if published is None else published
+    try:
+        accepted = Confirm.ask(question, default=default, console=console)
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise SetupCancelled from exc
+    if not accepted:
+        console.print(f"[yellow]This role requires {question[:-1].casefold()}.[/yellow]")
+        raise _DeclarationRejected
+
+
+def _require_price(
+    item: AvailableModel,
+    *,
+    field: str,
+    label: str,
+    console: Console,
+) -> float:
+    """Confirm a published price or read an explicit nonnegative USD-per-million price.
+
+    Args:
+        item: Selected model.
+        field: Price field name.
+        label: Prompt text.
+        console: Terminal used for the prompt.
+
+    Returns:
+        The confirmed or newly declared price.
+
+    Raises:
+        SetupCancelled: The operator cancelled setup.
+    """
+    published = _known_price(item, field)
+    if published is not None:
+        try:
+            if Confirm.ask(
+                f"Use published {label.casefold()} {published:g}?",
+                default=True,
+                console=console,
+            ):
+                return published
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise SetupCancelled from exc
+    return ask_price(label, console=console)
+
+
+def _require_positive_int(
+    item: AvailableModel,
+    *,
+    field: str,
+    label: str,
+    console: Console,
+) -> int:
+    """Confirm a published positive limit or read a new one.
+
+    Args:
+        item: Selected model.
+        field: Limit field name.
+        label: Prompt text.
+        console: Terminal used for the prompt.
+
+    Returns:
+        The confirmed or newly declared positive integer.
+
+    Raises:
+        SetupCancelled: The operator cancelled setup.
+        _DeclarationRejected: The entered value is not a positive integer.
+    """
+    published = _known_positive_int(item, field)
+    if published is not None:
+        try:
+            if Confirm.ask(
+                f"Use published {label.casefold()} {published}?",
+                default=True,
+                console=console,
+            ):
+                return published
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise SetupCancelled from exc
+    try:
+        value = IntPrompt.ask(label, console=console)
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise SetupCancelled from exc
+    if value <= 0:
+        console.print(f"[yellow]{label} must be a positive integer.[/yellow]")
+        raise _DeclarationRejected
+    return value
+
+
+def _optional_positive_int(label: str, *, console: Console) -> int | None:
+    """Read one optional positive integer under the advanced declaration path.
+
+    Args:
+        label: Prompt text.
+        console: Terminal used for the prompt.
+
+    Returns:
+        The positive value, or ``None`` when the field is left unknown.
+
+    Raises:
+        SetupCancelled: The prompt reached end of input.
+    """
+    try:
+        if not Confirm.ask(f"Record {label.casefold()}?", default=False, console=console):
+            return None
+        value = IntPrompt.ask(label, console=console)
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise SetupCancelled from exc
+    return value if value > 0 else None
+
+
+def _ask_reasoning_effort(*, console: Console) -> ReasoningEffort | None:
+    """Choose an optional reasoning-effort pin for one manually declared completion model.
+
+    Args:
+        console: Terminal used for the screen.
+
+    Returns:
+        The chosen effort, or ``None`` so the parameter is never sent.
+
+    Raises:
+        SetupCancelled: The user cancelled setup.
+    """
+    result = choose_one(
+        console,
+        title="Reasoning effort (pin only for models accepting the OpenAI reasoning parameter)",
+        options=[
+            PickerOption(
+                value=_NO_REASONING_EFFORT,
+                label="none",
+                detail="never send the reasoning parameter",
+            ),
+            *(PickerOption(value=effort, label=effort) for effort in _REASONING_EFFORTS),
+        ],
+        default=_NO_REASONING_EFFORT,
+    )
+    if result.action is PickerAction.CANCEL:
+        raise SetupCancelled
+    if result.action is PickerAction.BACK:
+        return None
+    return next((effort for effort in _REASONING_EFFORTS if effort == result.values[0]), None)
+
+
+def _known_bool(item: AvailableModel, field: str) -> bool | None:
+    """Return a previously declared or provider-published boolean, if one exists.
+
+    ``ModelCapabilities.supports_structured_output`` defaults to ``False``, so a configured
+    snapshot created for another role does not count as an explicit denial of that field.
+    """
+    if item.published is not None:
+        value = getattr(item.published, field)
+        if isinstance(value, bool):
+            return value
+    if item.capabilities is None or item.pricing_source is not PricingSource.CONFIGURED:
+        return None
+    value = getattr(item.capabilities, field)
+    if value is True:
+        return True
+    declared_false = {"supports_completions", "supports_embeddings", "supports_tools"}
+    if field in declared_false and value is False:
+        return False
+    return None
+
+
+def _known_price(item: AvailableModel, field: str) -> float | None:
+    """Return a previously declared or provider-published price, if one exists."""
+    if item.capabilities is not None:
+        value = getattr(item.capabilities, field)
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            return float(value)
+    if item.published is None:
+        return None
+    value = getattr(item.published, field)
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _known_positive_int(item: AvailableModel, field: str) -> int | None:
+    """Return a previously declared or provider-published positive limit, if one exists."""
+    if item.capabilities is not None:
+        value = getattr(item.capabilities, field)
+        if isinstance(value, int) and value > 0:
+            return value
+    if item.published is None:
+        return None
+    value = getattr(item.published, field)
+    return value if isinstance(value, int) and value > 0 else None

--- a/exp/cli/providers/declaration_test.py
+++ b/exp/cli/providers/declaration_test.py
@@ -1,0 +1,200 @@
+"""Operator declaration tests for identity-only OpenAI-compatible models."""
+
+from __future__ import annotations
+
+from exp.cli.providers.declaration import (
+    can_declare_role,
+    declare_role_metadata,
+    eligible_for_role,
+    merge_declared_models,
+    role_row_detail,
+)
+from exp.cli.providers.provider_picker import UNKNOWN_METADATA_LABEL, AvailableModel
+from exp.cli.shared.picker_test import ScriptedConsole
+from exp.common.models import (
+    DiscoveredModel,
+    ModelCapabilities,
+    PricingSource,
+    SetupRole,
+    serves_role,
+)
+
+
+def _identity(
+    model: str = "hosted-chat",
+    *,
+    published: DiscoveredModel | None = None,
+    capabilities: ModelCapabilities | None = None,
+    pricing_source: PricingSource = PricingSource.UNKNOWN,
+) -> AvailableModel:
+    """Build one OpenAI-compatible identity offered for role assignment.
+
+    Args:
+        model: Provider-side model ID.
+        published: Optional listing metadata to confirm.
+        capabilities: Optional capabilities already attached to the row.
+        pricing_source: Provenance of any attached prices.
+
+    Returns:
+        A selectable setup row.
+    """
+    return AvailableModel(
+        alias=model,
+        connection="hosted",
+        provider="openai-compatible",
+        model=model,
+        capabilities=capabilities,
+        pricing_source=pricing_source,
+        configured=False,
+        published=published,
+    )
+
+
+def test_identity_only_rows_are_labeled_unknown_and_declarable() -> None:
+    """An identity without proven metadata stays selectable and unnamed as capable."""
+    item = _identity()
+
+    assert role_row_detail(item) == UNKNOWN_METADATA_LABEL
+    assert can_declare_role(item, SetupRole.WORLD_MODEL)
+    assert eligible_for_role(item, SetupRole.WORLD_MODEL)
+    assert item.detail() == f"openai-compatible, {UNKNOWN_METADATA_LABEL}"
+
+
+def test_world_model_declaration_asks_only_completion_prices() -> None:
+    """World-model setup persists completion prices without inventing advanced fields."""
+    console = ScriptedConsole("\n1.5\n2.5\n0\n0\n")
+
+    declared = declare_role_metadata(_identity(), SetupRole.WORLD_MODEL, console=console)
+
+    assert declared is not None
+    assert declared.pricing_source is PricingSource.CONFIGURED
+    capabilities = declared.capabilities
+    assert capabilities is not None
+    assert capabilities.supports_completions is True
+    assert capabilities.input_cost_per_million_tokens_usd == 1.5
+    assert capabilities.output_cost_per_million_tokens_usd == 2.5
+    assert capabilities.cached_input_cost_per_million_tokens_usd == 0
+    assert capabilities.cache_write_cost_per_million_tokens_usd == 0
+    assert capabilities.supports_tools is None
+    assert capabilities.supports_structured_output is False
+    assert capabilities.context_window_tokens is None
+    assert capabilities.maximum_output_tokens is None
+    assert serves_role(capabilities, SetupRole.WORLD_MODEL)
+    assert not serves_role(capabilities, SetupRole.JUDGE)
+    assert not serves_role(capabilities, SetupRole.ROUTER_CANDIDATE)
+    assert "Supports tools" not in console.output
+    assert "Context window" not in console.output
+
+
+def test_judge_declaration_requires_structured_output_and_keeps_tools_unknown() -> None:
+    """Judge setup confirms structured output and does not infer tool support."""
+    console = ScriptedConsole("\n\n0\n0\n0\n0\n")
+
+    declared = declare_role_metadata(_identity(), SetupRole.JUDGE, console=console)
+
+    assert declared is not None
+    assert declared.capabilities is not None
+    assert declared.capabilities.supports_structured_output is True
+    assert declared.capabilities.supports_tools is None
+    assert serves_role(declared.capabilities, SetupRole.JUDGE)
+
+
+def test_embedder_declaration_asks_only_embedding_support_and_input_price() -> None:
+    """Embedder setup does not invent completion support or cache prices."""
+    console = ScriptedConsole("\n0.02\n")
+
+    declared = declare_role_metadata(_identity("hosted-embed"), SetupRole.EMBEDDER, console=console)
+
+    assert declared is not None
+    assert declared.capabilities is not None
+    assert declared.capabilities.supports_embeddings is True
+    assert declared.capabilities.supports_completions is None
+    assert declared.capabilities.input_cost_per_million_tokens_usd == 0.02
+    assert declared.capabilities.output_cost_per_million_tokens_usd is None
+    assert serves_role(declared.capabilities, SetupRole.EMBEDDER)
+
+
+def test_router_declaration_requires_limits_and_does_not_invent_cache_from_neighbors() -> None:
+    """Router setup asks for token limits and keeps unpublished advanced fields unknown."""
+    console = ScriptedConsole("\n1\n2\n3\n4\n128000\n8192\n")
+
+    declared = declare_role_metadata(_identity(), SetupRole.ROUTER_CANDIDATE, console=console)
+
+    assert declared is not None
+    assert declared.capabilities is not None
+    assert declared.capabilities.context_window_tokens == 128000
+    assert declared.capabilities.maximum_output_tokens == 8192
+    assert declared.capabilities.supports_tools is None
+    assert serves_role(declared.capabilities, SetupRole.ROUTER_CANDIDATE)
+
+
+def test_published_prices_are_confirmed_instead_of_retyped() -> None:
+    """Provider-published prices are confirmed and never replaced by an inferred value."""
+    published = DiscoveredModel(
+        provider="openai-compatible",
+        model="hosted-chat",
+        supports_completions=True,
+        input_cost_per_million_tokens_usd=1.0,
+        output_cost_per_million_tokens_usd=2.0,
+        cached_input_cost_per_million_tokens_usd=0.1,
+        cache_write_cost_per_million_tokens_usd=0.2,
+    )
+    console = ScriptedConsole("\n\n\n\n\n")
+
+    declared = declare_role_metadata(
+        _identity(published=published),
+        SetupRole.WORLD_MODEL,
+        console=console,
+    )
+
+    assert declared is not None
+    assert declared.capabilities is not None
+    assert declared.capabilities.input_cost_per_million_tokens_usd == 1.0
+    assert declared.capabilities.output_cost_per_million_tokens_usd == 2.0
+    assert declared.capabilities.cached_input_cost_per_million_tokens_usd == 0.1
+    assert declared.capabilities.cache_write_cost_per_million_tokens_usd == 0.2
+    assert "Use published input cost" in console.output
+
+
+def test_declining_a_required_capability_keeps_the_model_unassigned() -> None:
+    """Refusing a required protocol feature does not fabricate a passing declaration."""
+    console = ScriptedConsole("n\n")
+
+    declared = declare_role_metadata(_identity(), SetupRole.WORLD_MODEL, console=console)
+
+    assert declared is None
+    assert "requires supports chat completions" in console.output.casefold()
+
+
+def test_official_models_are_not_declarable() -> None:
+    """Maintained official listings stay on the verified path, not a questionnaire."""
+    item = AvailableModel(
+        alias="luna",
+        connection="openai",
+        provider="openai",
+        model="gpt-5.6-luna",
+        capabilities=None,
+        pricing_source=PricingSource.UNKNOWN,
+        configured=False,
+    )
+
+    assert not can_declare_role(item, SetupRole.WORLD_MODEL)
+    assert not eligible_for_role(item, SetupRole.WORLD_MODEL)
+
+
+def test_merge_declared_models_replaces_the_same_alias() -> None:
+    """Later operator declarations replace the identity-only row for that alias."""
+    original = _identity()
+    declared = original.__class__(
+        alias=original.alias,
+        connection=original.connection,
+        provider=original.provider,
+        model=original.model,
+        capabilities=ModelCapabilities(supports_completions=True),
+        pricing_source=PricingSource.CONFIGURED,
+        configured=False,
+    )
+
+    merged = merge_declared_models((original,), (declared,))
+
+    assert merged == (declared,)

--- a/exp/cli/providers/model_picker.py
+++ b/exp/cli/providers/model_picker.py
@@ -3,10 +3,12 @@
 These screens run after every selected provider has been prepared. Setup asks for each model
 role in turn: world model, judge, embedder, then optional router candidates and their incumbent.
 Every screen uses the shared picker with concise shorthand aliases, sorted so the recommended
-model for each role comes first. The screens filter new build-role assignments to models whose
-verified metadata can serve them, preserve exact prior assignments as retain-only choices, ask
-for a role-specific reasoning effort directly after each completion role names a reasoning-capable
-model, and render the single compact summary shown before setup saves anything.
+model for each role comes first. Verified metadata can be assigned immediately. Identity-only
+OpenAI-compatible models stay visible as unknown; selecting one collects an explicit operator
+declaration of the minimum capabilities and prices that role needs. Exact prior assignments remain
+retain-only choices. Each completion role then asks for a role-specific reasoning effort when the
+selected model already carries a reasoning pin, and the compact summary is shown before setup
+saves anything.
 """
 
 from __future__ import annotations
@@ -17,8 +19,14 @@ from dataclasses import dataclass, field
 from typing import get_args
 
 from rich.console import Console
-from rich.prompt import Confirm
 
+from exp.cli.providers.declaration import (
+    can_declare_role,
+    declare_model,
+    declare_role_metadata,
+    eligible_for_role,
+    role_row_detail,
+)
 from exp.cli.providers.provider_picker import (
     AvailableModel,
     PreparedEndpoint,
@@ -26,8 +34,6 @@ from exp.cli.providers.provider_picker import (
     SetupCancelled,
     SetupRoleInputs,
     SetupSession,
-    ask_positive_int,
-    ask_price,
     ask_text,
 )
 from exp.cli.shared.picker import PickerAction, PickerOption, choose_many, choose_one
@@ -46,6 +52,12 @@ from exp.common.models import (
 )
 from exp.common.models.known_models import recommended_model_rank
 
+_CandidateAssignment = tuple[
+    tuple[str, ...],
+    str | None,
+    dict[str, ReasoningEffort],
+    tuple[AvailableModel, ...],
+]
 _MANUAL_MODEL_ROW = "declare-model-manually"
 _NO_REASONING_EFFORT = "none"
 _REASONING_EFFORTS: tuple[ReasoningEffort, ...] = get_args(ReasoningEffort)
@@ -63,6 +75,7 @@ class RoleAssignment:
     world_model_reasoning_effort: ReasoningEffort | None = None
     judge_reasoning_effort: ReasoningEffort | None = None
     candidate_reasoning_efforts: dict[str, ReasoningEffort] = field(default_factory=dict)
+    declared_models: tuple[AvailableModel, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -92,11 +105,8 @@ def _role_options(items: tuple[AvailableModel, ...]) -> list[PickerOption]:
 
 
 def _role_detail(item: AvailableModel) -> str:
-    """Annotate one role row, keeping only retain-only notes."""
-    if item.capabilities is None:
-        roles = ", ".join(sorted(role.value for role in item.retainable_roles))
-        return f"retain only: {roles}" if roles else "unverified"
-    return ""
+    """Annotate one role row, keeping unknown and retain-only notes."""
+    return role_row_detail(item)
 
 
 def recommendation_key(
@@ -149,8 +159,8 @@ def _role_ordered(
     """
 
     def key(item: AvailableModel) -> tuple[int, tuple[int, int, int, float, str, str]]:
-        """Sort verified models by recommendation and retain-only models after them."""
-        if item.capabilities is None:
+        """Sort verified models by recommendation and unknown or retain-only models after them."""
+        if item.capabilities is None or not serves_role(item.capabilities, role):
             return (1, (0, 0, 0, 0.0, item.provider, item.model))
         return (0, recommendation_key(item.provider, item.model, item.capabilities, role))
 
@@ -330,89 +340,6 @@ def _declare_gateway_model(
     )
 
 
-def declare_model(session: SetupSession, *, console: Console) -> AvailableModel | None:
-    """Declare one model and its capabilities by hand under the advanced path.
-
-    Args:
-        session: Prepared endpoints and aliases already used in this session.
-        console: Terminal used for prompts.
-
-    Returns:
-        The declared model, or ``None`` when no prepared connection can host it.
-
-    Raises:
-        SetupCancelled: The user cancelled setup at a prompt.
-    """
-    if not session.endpoints:
-        console.print("[yellow]Prepare a provider connection first.[/yellow]")
-        return None
-    connections = [
-        PickerOption(
-            value=endpoint.connection.name,
-            label=endpoint.connection.name,
-            detail=f"{endpoint.connection.provider}",
-        )
-        for endpoint in session.endpoints
-    ]
-    chosen = choose_one(console, title="Connection for the declared model", options=connections)
-    if chosen.action is PickerAction.CANCEL:
-        raise SetupCancelled
-    if chosen.action is PickerAction.BACK:
-        return None
-    connection_name = chosen.values[0]
-    provider = next(
-        endpoint.connection.provider
-        for endpoint in session.endpoints
-        if endpoint.connection.name == connection_name
-    )
-    model = ask_text("Provider model ID", console=console)
-    if not model:
-        return None
-    supports_completions = Confirm.ask("Supports chat completions?", default=True, console=console)
-    supports_embeddings = Confirm.ask("Supports embeddings?", default=False, console=console)
-    capabilities = ModelCapabilities(
-        supports_completions=supports_completions,
-        supports_embeddings=supports_embeddings,
-        supports_tools=Confirm.ask("Supports tools?", default=False, console=console),
-        supports_structured_output=Confirm.ask(
-            "Supports structured output?", default=False, console=console
-        ),
-        context_window_tokens=ask_positive_int("Context window tokens", console=console),
-        maximum_output_tokens=ask_positive_int("Maximum output tokens", console=console),
-        input_cost_per_million_tokens_usd=ask_price(
-            "Input cost per million tokens in USD", console=console
-        )
-        if supports_completions or supports_embeddings
-        else None,
-        output_cost_per_million_tokens_usd=ask_price(
-            "Output cost per million tokens in USD", console=console
-        )
-        if supports_completions
-        else None,
-        cached_input_cost_per_million_tokens_usd=ask_price(
-            "Cached input cost per million tokens in USD", console=console
-        )
-        if supports_completions
-        else None,
-        cache_write_cost_per_million_tokens_usd=ask_price(
-            "Cache write cost per million tokens in USD", console=console
-        )
-        if supports_completions
-        else None,
-        reasoning_effort=_ask_reasoning_effort(console=console) if supports_completions else None,
-    )
-    taken = frozenset(item.alias for item in available_models(session))
-    return AvailableModel(
-        alias=derive_model_alias(provider, model, taken),
-        connection=connection_name,
-        provider=provider,
-        model=model,
-        capabilities=capabilities,
-        pricing_source=PricingSource.CONFIGURED,
-        configured=False,
-    )
-
-
 def _parse_reasoning_effort(value: str) -> ReasoningEffort | None:
     """Return the reasoning effort named by a picker value, or ``None`` for no pin."""
     return next((effort for effort in _REASONING_EFFORTS if effort == value), None)
@@ -519,68 +446,88 @@ def assign_roles(
     Raises:
         SetupCancelled: The user cancelled setup.
     """
-    world_model = _assign_one_role(
-        chosen,
+    models = {item.alias: item for item in chosen}
+
+    def pool() -> tuple[AvailableModel, ...]:
+        """Return the current role-assignment pool, including declared metadata."""
+        return tuple(models.values())
+
+    world_item = _assign_one_role(
+        pool(),
         role=SetupRole.WORLD_MODEL,
         title="World model",
         role_name="world model",
         default=role_inputs.world_model,
         console=console,
     )
-    if world_model is None:
+    if world_item is None:
         return None
+    models[world_item.alias] = world_item
     world_effort = _ask_role_reasoning_effort(
-        chosen,
-        alias=world_model,
+        pool(),
+        alias=world_item.alias,
         role_name="world model",
         default=role_inputs.world_model_reasoning_effort
-        if world_model == role_inputs.world_model
+        if world_item.alias == role_inputs.world_model
         else None,
         console=console,
     )
     if isinstance(world_effort, _RoleEffortBack):
         return None
-    judge = _assign_one_role(
-        chosen,
+    judge_item = _assign_one_role(
+        pool(),
         role=SetupRole.JUDGE,
         title="Judge",
         role_name="judge",
         default=role_inputs.judge,
         console=console,
     )
-    if judge is None:
+    if judge_item is None:
         return None
+    models[judge_item.alias] = judge_item
     judge_effort = _ask_role_reasoning_effort(
-        chosen,
-        alias=judge,
+        pool(),
+        alias=judge_item.alias,
         role_name="judge",
-        default=role_inputs.judge_reasoning_effort if judge == role_inputs.judge else None,
+        default=(
+            role_inputs.judge_reasoning_effort if judge_item.alias == role_inputs.judge else None
+        ),
         console=console,
     )
     if isinstance(judge_effort, _RoleEffortBack):
         return None
-    embedder = _assign_one_role(
-        chosen,
+    embedder_item = _assign_one_role(
+        pool(),
         role=SetupRole.EMBEDDER,
         title="Embedder",
         role_name="embedder",
         default=role_inputs.embedder,
         console=console,
     )
-    if embedder is None:
+    if embedder_item is None:
         return None
-    candidates = _assign_candidates(chosen, role_inputs=role_inputs, console=console)
+    models[embedder_item.alias] = embedder_item
+    candidates = _assign_candidates(pool(), role_inputs=role_inputs, console=console)
     if candidates is None:
         return None
+    for item in candidates[3]:
+        models[item.alias] = item
+    used = {
+        world_item.alias,
+        judge_item.alias,
+        embedder_item.alias,
+        *candidates[0],
+    }
     return RoleAssignment(
-        world_model=world_model,
-        judge=judge,
-        embedder=embedder,
+        world_model=world_item.alias,
+        judge=judge_item.alias,
+        embedder=embedder_item.alias,
         candidates=candidates[0],
         incumbent=candidates[1],
         world_model_reasoning_effort=world_effort,
         judge_reasoning_effort=judge_effort,
         candidate_reasoning_efforts=candidates[2],
+        declared_models=tuple(models[alias] for alias in used if alias in models),
     )
 
 
@@ -592,7 +539,7 @@ def _assign_one_role(
     role_name: str,
     default: str | None,
     console: Console,
-) -> str | None:
+) -> AvailableModel | None:
     """Choose one model for a role from the compatible selected models.
 
     Args:
@@ -604,13 +551,14 @@ def _assign_one_role(
         console: Terminal used for the screen.
 
     Returns:
-        The chosen alias, or ``None`` when the model selection must change.
+        The chosen model, possibly with operator-declared metadata, or ``None`` when the
+        model selection must change.
 
     Raises:
         SetupCancelled: The user cancelled setup.
     """
     eligible = _role_ordered(
-        tuple(item for item in chosen if _serves_or_retains(item, role)),
+        tuple(item for item in chosen if eligible_for_role(item, role)),
         role,
     )
     if not eligible:
@@ -629,7 +577,14 @@ def _assign_one_role(
         raise SetupCancelled
     if result.action is PickerAction.BACK:
         return None
-    return result.values[0]
+    item = next(entry for entry in eligible if entry.alias == result.values[0])
+    if item.capabilities is not None and serves_role(item.capabilities, role):
+        return item
+    if role in item.retainable_roles and not can_declare_role(item, role):
+        return item
+    if can_declare_role(item, role):
+        return declare_role_metadata(item, role, console=console)
+    return item
 
 
 def _assign_candidates(
@@ -637,7 +592,7 @@ def _assign_candidates(
     *,
     role_inputs: SetupRoleInputs,
     console: Console,
-) -> tuple[tuple[str, ...], str | None, dict[str, ReasoningEffort]] | None:
+) -> _CandidateAssignment | None:
     """Choose optional router candidates, their efforts, and the incumbent.
 
     Args:
@@ -646,8 +601,8 @@ def _assign_candidates(
         console: Terminal used for the screens.
 
     Returns:
-        Candidate aliases, incumbent, and per-candidate reasoning efforts, or ``None`` when
-        the selection must change.
+        Candidate aliases, incumbent, per-candidate reasoning efforts, and any models whose
+        metadata the operator declared, or ``None`` when the selection must change.
 
     Raises:
         SetupCancelled: The user cancelled setup.
@@ -669,6 +624,7 @@ def select_router_candidates(
     incumbent: str | None = None,
     effort_defaults: Mapping[str, ReasoningEffort] | None = None,
     console: Console,
+    declared_models: list[AvailableModel] | None = None,
 ) -> RouterCandidateSelection | None:
     """Choose at least two eligible completion models, their efforts, and one incumbent.
 
@@ -678,6 +634,7 @@ def select_router_candidates(
         incumbent: Explicit incumbent that skips the incumbent screen.
         effort_defaults: Persisted per-candidate efforts accepted with an empty line.
         console: Terminal used for the screens.
+        declared_models: Optional list that receives operator-declared candidate metadata.
 
     Returns:
         A confirmed candidate selection, or ``None`` when the caller should return to its
@@ -697,6 +654,8 @@ def select_router_candidates(
     )
     if picked is None or picked[1] is None:
         return None
+    if declared_models is not None:
+        declared_models.extend(picked[3])
     return RouterCandidateSelection(
         candidates=picked[0],
         incumbent=picked[1],
@@ -712,7 +671,7 @@ def _assign_router_candidates(
     effort_defaults: Mapping[str, ReasoningEffort],
     console: Console,
     required: bool,
-) -> tuple[tuple[str, ...], str | None, dict[str, ReasoningEffort]] | None:
+) -> _CandidateAssignment | None:
     """Share router-candidate selection between optional setup and required router setup.
 
     Args:
@@ -724,8 +683,8 @@ def _assign_router_candidates(
         required: Whether fewer than two selected candidates is an error instead of a skip.
 
     Returns:
-        Candidate aliases, incumbent, and per-candidate reasoning efforts, or ``None`` when
-        the caller should go back.
+        Candidate aliases, incumbent, per-candidate reasoning efforts, and declared models,
+        or ``None`` when the caller should go back.
 
     Raises:
         SetupCancelled: The user cancelled interactive setup.
@@ -739,6 +698,7 @@ def _assign_router_candidates(
                 item.capabilities is not None
                 and serves_role(item.capabilities, SetupRole.ROUTER_CANDIDATE)
             )
+            or (required and can_declare_role(item, SetupRole.ROUTER_CANDIDATE))
             or (not required and SetupRole.ROUTER_CANDIDATE in item.retainable_roles)
         ),
         SetupRole.ROUTER_CANDIDATE,
@@ -754,7 +714,7 @@ def _assign_router_candidates(
             "[dim]Router candidates need two priced models with explicit token limits. "
             "Skipping that role for now.[/dim]"
         )
-        return (), None, {}
+        return (), None, {}, ()
     eligible_aliases = {item.alias for item in eligible}
     unknown = tuple(alias for alias in preselected if alias not in eligible_aliases)
     if unknown:
@@ -778,11 +738,31 @@ def _assign_router_candidates(
             console.print("[yellow]Router candidates need at least two models.[/yellow]")
             return None
         console.print("[dim]Router candidates need at least two models. Skipping that role.[/dim]")
-        return (), None, {}
+        return (), None, {}, ()
+    by_alias = {item.alias: item for item in chosen}
+    declared: list[AvailableModel] = []
+    for alias in result.values:
+        item = by_alias[alias]
+        if item.capabilities is not None and serves_role(
+            item.capabilities, SetupRole.ROUTER_CANDIDATE
+        ):
+            continue
+        if SetupRole.ROUTER_CANDIDATE in item.retainable_roles and not can_declare_role(
+            item, SetupRole.ROUTER_CANDIDATE
+        ):
+            continue
+        if not can_declare_role(item, SetupRole.ROUTER_CANDIDATE):
+            continue
+        declared_item = declare_role_metadata(item, SetupRole.ROUTER_CANDIDATE, console=console)
+        if declared_item is None:
+            return None
+        by_alias[alias] = declared_item
+        declared.append(declared_item)
+    updated = tuple(by_alias[alias] for alias in result.values)
     efforts: dict[str, ReasoningEffort] = {}
     for alias in result.values:
         effort = _ask_role_reasoning_effort(
-            chosen,
+            updated,
             alias=alias,
             role_name="router candidate",
             default=effort_defaults.get(alias),
@@ -795,7 +775,7 @@ def _assign_router_candidates(
     if incumbent is not None:
         if incumbent not in result.values:
             raise ValueError("router incumbent must also be a selected candidate")
-        return result.values, incumbent, efforts
+        return result.values, incumbent, efforts, tuple(declared)
     incumbent_result = choose_one(
         console,
         title="Router incumbent",
@@ -810,7 +790,7 @@ def _assign_router_candidates(
         raise SetupCancelled
     if incumbent_result.action is PickerAction.BACK:
         return None
-    return result.values, incumbent_result.values[0], efforts
+    return result.values, incumbent_result.values[0], efforts, tuple(declared)
 
 
 def build_result(

--- a/exp/cli/providers/model_picker_test.py
+++ b/exp/cli/providers/model_picker_test.py
@@ -15,6 +15,7 @@ from exp.cli.providers.model_picker import (
     select_models,
 )
 from exp.cli.providers.provider_picker import (
+    UNKNOWN_METADATA_LABEL,
     AvailableModel,
     PreparedEndpoint,
     SetupCancelled,
@@ -422,6 +423,46 @@ def test_unassigned_and_unsupported_models_are_never_asked_for_effort() -> None:
     assert "World model effort (luna)" in console.output
     assert "(terra)" not in console.output.split("Router candidates")[-1]
     assert "Embedder effort" not in console.output
+
+
+def test_identity_only_openai_compatible_models_can_be_declared_for_a_role() -> None:
+    """Selecting an unknown compatible identity collects configured role metadata."""
+    chat = AvailableModel(
+        alias="hosted-chat",
+        connection="hosted",
+        provider="openai-compatible",
+        model="hosted-chat",
+        capabilities=None,
+        pricing_source=PricingSource.UNKNOWN,
+        configured=False,
+    )
+    embedder = AvailableModel(
+        alias="hosted-embed",
+        connection="hosted",
+        provider="openai-compatible",
+        model="hosted-embed",
+        capabilities=None,
+        pricing_source=PricingSource.UNKNOWN,
+        configured=False,
+    )
+    console = ScriptedConsole("1\n\n1.5\n2.5\n0\n0\n1\n\n\n\n\n\n\n2\n\n0.02\n")
+
+    roles = assign_roles((chat, embedder), role_inputs=SetupRoleInputs(), console=console)
+
+    assert roles is not None
+    assert (roles.world_model, roles.judge, roles.embedder) == (
+        "hosted-chat",
+        "hosted-chat",
+        "hosted-embed",
+    )
+    declared = {item.alias: item for item in roles.declared_models}
+    assert declared["hosted-chat"].pricing_source is PricingSource.CONFIGURED
+    assert declared["hosted-chat"].capabilities is not None
+    assert declared["hosted-chat"].capabilities.supports_structured_output
+    assert declared["hosted-chat"].capabilities.supports_tools is None
+    assert declared["hosted-embed"].capabilities is not None
+    assert declared["hosted-embed"].capabilities.supports_embeddings is True
+    assert UNKNOWN_METADATA_LABEL in console.output
 
 
 def test_manual_declaration_stays_behind_the_advanced_row() -> None:

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -2,10 +2,10 @@
 
 Setup opens with one provider screen, resolves each selected provider's credential from its
 canonical environment variable or a masked paste, then asks that provider which models the
-authenticated account may call. Discovered metadata is merged with EXP's maintained capability and
-price table, so a model whose metadata cannot satisfy any build role is hidden rather than turned
-into a questionnaire. Providers without a safe listing API keep manual declaration on the model
-screen.
+authenticated account may call. Discovery lists identities. Verification is a separate step:
+maintained or provider-published metadata can prove a role, and identity-only OpenAI-compatible
+models stay visible as unknown until the operator declares the minimum fields for a selected role.
+Providers without a safe listing API keep manual declaration on the model screen.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from exp.cli.shared.picker import (
 )
 from exp.common.models import (
     ConnectionConfig,
+    DiscoveredModel,
     ModelCapabilities,
     PricingSource,
     ProviderConnection,
@@ -65,7 +66,9 @@ CANONICAL_CREDENTIAL_ENV = {
     "openai-compatible": "OPENAI_COMPATIBLE_API_KEY",
 }
 _MANUAL_MODEL_PROVIDERS = frozenset({"azure", "bedrock"})
+_OPERATOR_DECLARED_PROVIDERS = frozenset({"openai-compatible"})
 _CONFIGURED_ONLY = "configured-models-only"
+UNKNOWN_METADATA_LABEL = "unknown capabilities/prices"
 _RECOVERY_RETRY = "retry"
 _RECOVERY_SKIP = "skip"
 _RECOVERY_BACK = "back"
@@ -113,18 +116,19 @@ class AvailableModel:
     pricing_source: PricingSource
     configured: bool
     retainable_roles: frozenset[SetupRole] = frozenset()
+    published: DiscoveredModel | None = None
 
     def label(self) -> str:
         """Describe this model as one picker row by its shorthand alias."""
         return self.alias
 
     def detail(self) -> str:
-        """Annotate this model with its provider, marking retain-only prior roles."""
-        if self.capabilities is None:
+        """Annotate this model with its provider, marking unknown or retain-only rows."""
+        if self.capabilities is None or not served_roles(self.capabilities):
             roles = ", ".join(sorted(role.value for role in self.retainable_roles))
             if roles:
                 return f"{self.provider}, retain only: {roles}"
-            return f"{self.provider}, unverified"
+            return f"{self.provider}, {UNKNOWN_METADATA_LABEL}"
         return self.provider
 
 
@@ -592,7 +596,11 @@ def _discover_models(
     configured_identities: frozenset[tuple[str, str]] = frozenset(),
     environment: MutableMapping[str, str],
 ) -> _ProviderDiscoveryResult | None:
-    """List one provider account's models and keep the ones with usable metadata.
+    """List one provider account's models and keep selectable identities.
+
+    Verified metadata stays attached. Identity-only OpenAI-compatible models remain visible and
+    are labeled unknown rather than hidden. Official listings without maintained metadata stay
+    out of the normal path.
 
     Args:
         endpoint: Prepared connection and resolved credential.
@@ -650,39 +658,57 @@ def _discover_models(
                     )
                 continue
             return _ProviderDiscoveryResult(endpoint, ()) if recovery == _RECOVERY_SKIP else None
+        if not discovered:
+            console.print(f"[yellow]{label} published no model identity.[/yellow]")
+            recovery = _recover(f"{label} has no configurable model", console=console)
+            if recovery == _RECOVERY_RETRY:
+                continue
+            return _ProviderDiscoveryResult(endpoint, ()) if recovery == _RECOVERY_SKIP else None
+        published = {model.model: model for model in discovered}
         resolved = tuple(resolve_discovered_model(model) for model in discovered)
-        usable = _canonical_models(
+        verified = _canonical_models(
             tuple(model for model in resolved if served_roles(model.capabilities)),
             provider=provider,
         )
-        if not usable:
+        unknown = _canonical_models(
+            tuple(model for model in resolved if not served_roles(model.capabilities)),
+            provider=provider,
+        )
+        if provider not in _OPERATOR_DECLARED_PROVIDERS:
+            unknown = ()
+        if not verified and not unknown:
             console.print(f"[yellow]{label} published no model with verified metadata.[/yellow]")
             recovery = _recover(f"{label} has no configurable model", console=console)
             if recovery == _RECOVERY_RETRY:
                 continue
             return _ProviderDiscoveryResult(endpoint, ()) if recovery == _RECOVERY_SKIP else None
-        fresh = tuple(
-            model
-            for model in usable
-            if (provider, canonical_model_id(provider, model.model)) not in configured_identities
+        fresh_verified = _fresh_models(
+            verified, provider=provider, configured=configured_identities
         )
-        if not fresh:
+        fresh_unknown = _fresh_models(unknown, provider=provider, configured=configured_identities)
+        if not fresh_verified and not fresh_unknown:
             console.print(f"  [green]\u2713[/green] {label}: models already configured")
             return _ProviderDiscoveryResult(endpoint, ())
-        console.print(f"  [green]\u2713[/green] {label}: {len(fresh)} models")
+        console.print(
+            _discovery_status(label, verified=len(fresh_verified), unknown=len(fresh_unknown))
+        )
         models = []
-        for model in fresh:
+        for model in (*fresh_verified, *fresh_unknown):
             alias = derive_model_alias(provider, model.model, frozenset(aliases))
             aliases.add(alias)
+            verified_row = served_roles(model.capabilities)
             models.append(
                 AvailableModel(
                     alias=alias,
                     connection=endpoint.connection.name,
                     provider=provider,
                     model=model.model,
-                    capabilities=model.capabilities,
-                    pricing_source=model.pricing_source,
+                    capabilities=model.capabilities if verified_row else None,
+                    pricing_source=(
+                        model.pricing_source if verified_row else PricingSource.UNKNOWN
+                    ),
                     configured=False,
+                    published=published.get(model.model),
                 )
             )
         return _ProviderDiscoveryResult(endpoint, tuple(models))
@@ -691,6 +717,50 @@ def _discover_models(
 def _is_credential_rejection(error: ProviderListingError) -> bool:
     """Return whether a listing error asks the user to replace a rejected credential."""
     return str(error).endswith(" rejected the configured credential")
+
+
+def _fresh_models(
+    models: tuple[ResolvedDiscoveredModel, ...],
+    *,
+    provider: str,
+    configured: frozenset[tuple[str, str]],
+) -> tuple[ResolvedDiscoveredModel, ...]:
+    """Keep discovered identities that are not already present in the catalog.
+
+    Args:
+        models: Canonical discovered rows.
+        provider: Selected provider kind.
+        configured: Canonical (provider, model) identities already in the catalog.
+
+    Returns:
+        Models that still need a new alias in this session.
+    """
+    return tuple(
+        model
+        for model in models
+        if (provider, canonical_model_id(provider, model.model)) not in configured
+    )
+
+
+def _discovery_status(label: str, *, verified: int, unknown: int) -> str:
+    """Describe how many listed identities are verified versus still unknown.
+
+    Args:
+        label: Readable provider name.
+        verified: Newly listed models with role-proven metadata.
+        unknown: Newly listed identities that still need operator declaration.
+
+    Returns:
+        One compact status line for the discovery transcript.
+    """
+    if verified and unknown:
+        return (
+            f"  [green]\u2713[/green] {label}: {verified} models, "
+            f"{unknown} with {UNKNOWN_METADATA_LABEL}"
+        )
+    if unknown:
+        return f"  [green]\u2713[/green] {label}: {unknown} models with {UNKNOWN_METADATA_LABEL}"
+    return f"  [green]\u2713[/green] {label}: {verified} models"
 
 
 def _canonical_models(

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -508,11 +508,11 @@ def test_empty_model_list_offers_recovery_and_can_skip_the_provider() -> None:
     assert prepared is not None
     _, models = prepared
     assert [model.alias for model in models] == ["claude-sonnet-5"]
-    assert "published no model with verified metadata" in console.output
+    assert "published no model identity" in console.output
 
 
 def test_models_without_verified_metadata_are_hidden_from_the_normal_path() -> None:
-    """An unverified model cannot serve a role, so setup never offers or claims it."""
+    """An official listing without maintained metadata stays off the verified path."""
     console = ScriptedConsole("")
     lister = _FakeLister({"openai": [(_LUNA, _UNVERIFIED, _EMBEDDING)]})
 
@@ -527,6 +527,75 @@ def test_models_without_verified_metadata_are_hidden_from_the_normal_path() -> N
     _, models = prepared
     assert [model.model for model in models] == ["gpt-5.6-luna", "text-embedding-3-small"]
     assert "internal-preview-model" not in console.output
+
+
+def test_openai_compatible_identity_only_models_stay_visible_as_unknown() -> None:
+    """A trusted compatible listing remains selectable when the host publishes only identities."""
+    console = ScriptedConsole("https://models.example.test/v1\n\n")
+    lister = _FakeLister(
+        {
+            "openai-compatible": [
+                (DiscoveredModel(provider="openai-compatible", model="hosted-chat"),)
+            ]
+        }
+    )
+
+    prepared = _prepare(
+        console,
+        providers=("openai-compatible",),
+        lister=lister,
+        environment={"OPENAI_COMPATIBLE_API_KEY": "compat-secret"},
+    )
+
+    assert prepared is not None
+    _, models = prepared
+    assert [model.model for model in models] == ["hosted-chat"]
+    assert models[0].capabilities is None
+    assert models[0].pricing_source is PricingSource.UNKNOWN
+    assert models[0].published is not None
+    assert models[0].published.model == "hosted-chat"
+    assert f"1 models with {provider_picker.UNKNOWN_METADATA_LABEL}" in console.output
+    assert "published no model with verified metadata" not in console.output
+
+
+def test_openai_compatible_keeps_verified_and_unknown_identities() -> None:
+    """Published extension metadata stays verified beside identity-only siblings."""
+    console = ScriptedConsole("https://models.example.test/v1\n\n")
+    lister = _FakeLister(
+        {
+            "openai-compatible": [
+                (
+                    DiscoveredModel(
+                        provider="openai-compatible",
+                        model="hosted-chat",
+                        supports_completions=True,
+                        supports_structured_output=True,
+                        input_cost_per_million_tokens_usd=1.0,
+                        output_cost_per_million_tokens_usd=2.0,
+                    ),
+                    DiscoveredModel(provider="openai-compatible", model="hosted-preview"),
+                )
+            ]
+        }
+    )
+
+    prepared = _prepare(
+        console,
+        providers=("openai-compatible",),
+        lister=lister,
+        environment={"OPENAI_COMPATIBLE_API_KEY": "compat-secret"},
+    )
+
+    assert prepared is not None
+    _, models = prepared
+    by_model = {item.model: item for item in models}
+    assert set(by_model) == {"hosted-chat", "hosted-preview"}
+    assert by_model["hosted-chat"].pricing_source is PricingSource.PROVIDER
+    assert by_model["hosted-chat"].capabilities is not None
+    assert serves_role(by_model["hosted-chat"].capabilities, SetupRole.WORLD_MODEL)
+    assert by_model["hosted-preview"].capabilities is None
+    assert by_model["hosted-preview"].pricing_source is PricingSource.UNKNOWN
+    assert f"1 models, 1 with {provider_picker.UNKNOWN_METADATA_LABEL}" in console.output
 
 
 def test_discovered_metadata_and_roles_come_from_the_maintained_table() -> None:

--- a/exp/cli/providers/setup.py
+++ b/exp/cli/providers/setup.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.prompt import Confirm
 
+from exp.cli.providers.declaration import merge_declared_models
 from exp.cli.providers.model_picker import (
     RoleAssignment,
     assign_roles,
@@ -424,9 +425,10 @@ def _collect_models_and_roles(
 ) -> ProviderSetupResult | None:
     """Run the role-first assignment and confirmation screens for one prepared provider set.
 
-    Discovered models go straight to one picker per role. Providers whose model IDs must be
-    declared by hand first run the model-declaration screen, then the same role pickers. Only
-    the models actually assigned a role are persisted.
+    Discovered models go straight to one picker per role. Identity-only OpenAI-compatible
+    models stay visible; assigning one collects an explicit capability and price declaration.
+    Providers whose model IDs must be declared by hand first run the model-declaration screen,
+    then the same role pickers. Only the models actually assigned a role are persisted.
 
     Args:
         session: Answers already collected in this setup session.
@@ -456,7 +458,11 @@ def _collect_models_and_roles(
                 continue
             return None
         used = {roles.world_model, roles.judge, roles.embedder, *roles.candidates}
-        chosen = tuple(item for item in pool if item.alias in used)
+        chosen = tuple(
+            item
+            for item in merge_declared_models(pool, roles.declared_models)
+            if item.alias in used
+        )
         result = build_result(
             chosen,
             roles=roles,

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -470,6 +470,87 @@ def test_structured_input_rejects_openai_compatible_without_capabilities(tmp_pat
     assert not (tmp_path / ".exp" / "models.toml").exists()
 
 
+def test_noninteractive_setup_authors_openai_compatible_identity_metadata(
+    tmp_path: Path,
+) -> None:
+    """Manual JSON is the deterministic path for an identity-only compatible host.
+
+    Args:
+        tmp_path: Temporary EXP root receiving the authored catalog.
+    """
+    root = tmp_path / ".exp"
+    connection = json.dumps(
+        {
+            "name": "hosted",
+            "provider": "openai-compatible",
+            "api_key_env": "HOSTED_API_KEY",
+            "base_url": "https://models.example.test/v1",
+        }
+    )
+    chat = json.dumps(
+        {
+            "alias": "hosted-chat",
+            "connection": "hosted",
+            "model": "hosted-chat",
+            "capabilities": {
+                "supports_completions": True,
+                "supports_structured_output": True,
+                "input_cost_per_million_tokens_usd": 1.5,
+                "output_cost_per_million_tokens_usd": 2.5,
+                "cached_input_cost_per_million_tokens_usd": 0,
+                "cache_write_cost_per_million_tokens_usd": 0,
+            },
+        }
+    )
+    embed = json.dumps(
+        {
+            "alias": "hosted-embed",
+            "connection": "hosted",
+            "model": "hosted-embed",
+            "capabilities": {
+                "supports_embeddings": True,
+                "input_cost_per_million_tokens_usd": 0.02,
+            },
+        }
+    )
+
+    result = _RUNNER.invoke(
+        app,
+        [
+            "config",
+            "providers",
+            "--root",
+            str(root),
+            "--non-interactive",
+            "--connection-json",
+            connection,
+            "--model-json",
+            chat,
+            "--model-json",
+            embed,
+            "--world-model",
+            "hosted-chat",
+            "--judge",
+            "hosted-chat",
+            "--embedder",
+            "hosted-embed",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    catalog = load_model_catalog(root / "models.toml")
+    assert catalog.roles.world_model == "hosted-chat"
+    assert catalog.roles.judge == "hosted-chat"
+    assert catalog.roles.embedder == "hosted-embed"
+    chat_caps = catalog.models["hosted-chat"].capabilities
+    assert chat_caps is not None
+    assert chat_caps.supports_completions is True
+    assert chat_caps.supports_tools is None
+    assert chat_caps.context_window_tokens is None
+    assert catalog.models["hosted-embed"].capabilities is not None
+    assert catalog.models["hosted-embed"].capabilities.supports_embeddings is True
+
+
 def _setup(
     root: Path,
     answers: str,

--- a/exp/cli/tests/openai_compatible_recipes_test.py
+++ b/exp/cli/tests/openai_compatible_recipes_test.py
@@ -207,7 +207,9 @@ def test_recipes_doc_pins_the_verified_constants_and_is_indexed() -> None:
     assert ".modal.run" in doc
     assert "exp config gateway provider add" in doc
     assert "--provider openai-compatible" in doc.replace(" \\\n  ", " ")
-    assert "hosted WMO gateway" in doc
+    assert "hosted Experiential gateway" in doc
+    assert "identity-only" in doc
+    assert "unknown" in doc
     assert "micro-USD prices" in doc
     assert "exp/cli/tests/openai_compatible_recipes_test.py" in doc
     assert "`reference/openai-compatible-recipes.md`" in index

--- a/exp/cli/tests/openai_compatible_recipes_test.py
+++ b/exp/cli/tests/openai_compatible_recipes_test.py
@@ -207,5 +207,7 @@ def test_recipes_doc_pins_the_verified_constants_and_is_indexed() -> None:
     assert ".modal.run" in doc
     assert "exp config gateway provider add" in doc
     assert "--provider openai-compatible" in doc.replace(" \\\n  ", " ")
+    assert "hosted WMO gateway" in doc
+    assert "micro-USD prices" in doc
     assert "exp/cli/tests/openai_compatible_recipes_test.py" in doc
     assert "`reference/openai-compatible-recipes.md`" in index

--- a/exp/common/models/discovery.py
+++ b/exp/common/models/discovery.py
@@ -5,7 +5,8 @@ providers also publish capabilities, token limits, and prices there. This module
 response with EXP's maintained metadata into one resolved record per model, decides which build
 roles the record can serve, and derives the stable connection names and readable aliases that setup
 writes to ``.exp/models.toml``. Every value stays unknown unless a provider or the maintained table
-proves it, so an unverified model is hidden instead of being claimed as capable.
+proves it. Setup may still list an identity with unknown metadata; it never claims that identity is
+capable until the operator or a proven source declares the required fields.
 """
 
 from __future__ import annotations

--- a/exp/runtime/gateway/discovery.py
+++ b/exp/runtime/gateway/discovery.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
 from exp.common.core.artifacts import JsonObject
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.common.models.model import ModelCapabilities
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 AliasAuthority = tuple[str, str, str]
@@ -12,41 +18,174 @@ MODEL_AUTHORITY_SCHEMA_VERSION = 1
 """Version of the gateway-specific model-list authority envelope."""
 
 
-def public_model_object(authority: AliasAuthority) -> JsonObject:
-    """Build one OpenAI model object enriched with the granted alias authority.
+class AliasMetadataLookup(Protocol):
+    """Look up catalog-backed listing fields for one granted alias."""
 
-    The four OpenAI keys keep their exact meaning for official clients; the ``wmo``
+    def __call__(
+        self,
+        *,
+        alias: str,
+        revision_id: str,
+        catalog_sha256: str,
+    ) -> PublishedAliasMetadata | None:
+        """Return declared listing fields, or ``None`` when the alias is not unique."""
+        ...
+
+
+@dataclass(frozen=True)
+class PublishedAliasMetadata:
+    """Catalog-backed listing fields published beside one OpenAI model object.
+
+    Every optional field is omitted from the wire object when the active catalog does not
+    declare it. The gateway never invents a context window or a cache-write price.
+    """
+
+    supports_completions: bool | None = None
+    supports_tools: bool | None = None
+    supports_structured_output: bool | None = None
+    maximum_output_tokens: int | None = None
+    context_window_tokens: int | None = None
+    input_micro_usd_per_million_tokens: int | None = None
+    output_micro_usd_per_million_tokens: int | None = None
+    cached_input_micro_usd_per_million_tokens: int | None = None
+
+    def extension_fields(self) -> JsonObject:
+        """Return only the declared extension fields for one public model object."""
+        fields: JsonObject = {}
+        _put_optional(fields, "supports_completions", self.supports_completions)
+        _put_optional(fields, "supports_tools", self.supports_tools)
+        _put_optional(fields, "supports_structured_output", self.supports_structured_output)
+        _put_optional(fields, "maximum_output_tokens", self.maximum_output_tokens)
+        _put_optional(fields, "context_window_tokens", self.context_window_tokens)
+        pricing: JsonObject = {}
+        _put_optional(
+            pricing, "input_micro_usd_per_million_tokens", self.input_micro_usd_per_million_tokens
+        )
+        _put_optional(
+            pricing, "output_micro_usd_per_million_tokens", self.output_micro_usd_per_million_tokens
+        )
+        _put_optional(
+            pricing,
+            "cached_input_micro_usd_per_million_tokens",
+            self.cached_input_micro_usd_per_million_tokens,
+        )
+        if pricing:
+            fields["pricing"] = pricing
+        return fields
+
+
+def published_alias_metadata(
+    deployment: ExactModelDeployment | None,
+) -> PublishedAliasMetadata | None:
+    """Project one active catalog deployment onto public listing extension fields.
+
+    A granted alias that does not resolve to exactly one catalog deployment publishes no
+    extra fields. Completion support is published for a resolved deployment unless the
+    catalog explicitly denies it. Tools, structured output, limits, and prices are copied
+    only when the catalog declares them.
+
+    Args:
+        deployment: The unique active catalog deployment for the granted alias, if any.
+
+    Returns:
+        Catalog-backed metadata, or ``None`` when the alias has no unique deployment.
+    """
+    if deployment is None:
+        return None
+    capabilities = deployment.capabilities
+    prices = deployment.gateway.prices
+    return PublishedAliasMetadata(
+        supports_completions=_completion_support(capabilities),
+        supports_tools=None if capabilities is None else capabilities.supports_tools,
+        supports_structured_output=(
+            None if capabilities is None else capabilities.supports_structured_output
+        ),
+        maximum_output_tokens=(
+            None if capabilities is None else capabilities.maximum_output_tokens
+        ),
+        context_window_tokens=(
+            None if capabilities is None else capabilities.context_window_tokens
+        ),
+        input_micro_usd_per_million_tokens=prices.input_micro_usd_per_million_tokens,
+        output_micro_usd_per_million_tokens=prices.output_micro_usd_per_million_tokens,
+        cached_input_micro_usd_per_million_tokens=(
+            prices.cached_input_micro_usd_per_million_tokens
+        ),
+    )
+
+
+def listing_metadata_by_alias(
+    authorities: tuple[AliasAuthority, ...],
+    lookup: AliasMetadataLookup,
+) -> dict[str, PublishedAliasMetadata]:
+    """Collect catalog-backed listing fields for granted aliases that have them.
+
+    Args:
+        authorities: Granted alias, revision, and catalog digest triples.
+        lookup: Keyword lookup of ``alias``, ``revision_id``, and ``catalog_sha256``.
+
+    Returns:
+        Metadata keyed by alias for every unique active catalog deployment.
+    """
+    published: dict[str, PublishedAliasMetadata] = {}
+    for alias, revision, digest in authorities:
+        metadata = lookup(alias=alias, revision_id=revision, catalog_sha256=digest)
+        if metadata is not None:
+            published[alias] = metadata
+    return published
+
+
+def public_model_object(
+    authority: AliasAuthority,
+    metadata: PublishedAliasMetadata | None = None,
+) -> JsonObject:
+    """Build one OpenAI model object enriched with granted authority and catalog fields.
+
+    The four OpenAI keys keep their exact meaning for official clients. The ``wmo``
     object carries only authority metadata the gateway already exposes to callers
     through response headers and grants, never provider or credential detail.
+    Optional capability, limit, and price fields are catalog copies, never guesses.
 
     Args:
         authority: Granted alias, active revision, and catalog digest triple.
+        metadata: Catalog-backed extension fields for the granted alias, when unique.
 
     Returns:
         JSON-compatible public model object.
     """
     alias, revision, digest = authority
-    return {
+    payload: JsonObject = {
         "id": alias,
         "object": "model",
         "created": 0,
         "owned_by": "wmo",
         "wmo": {"alias_revision_id": revision, "catalog_sha256": digest},
     }
+    if metadata is not None:
+        payload.update(metadata.extension_fields())
+    return payload
 
 
-def public_model_list(authorities: tuple[AliasAuthority, ...]) -> JsonObject:
+def public_model_list(
+    authorities: tuple[AliasAuthority, ...],
+    metadata_by_alias: Mapping[str, PublishedAliasMetadata] | None = None,
+) -> JsonObject:
     """Build a caller model list with an authority marker even when it is empty.
 
     Args:
         authorities: Granted alias, revision, and catalog digest triples.
+        metadata_by_alias: Catalog-backed extension fields keyed by granted alias.
 
     Returns:
         OpenAI-compatible model-list envelope with the gateway authority marker.
     """
+    published = {} if metadata_by_alias is None else metadata_by_alias
     return {
         "object": "list",
-        "data": [public_model_object(authority) for authority in authorities],
+        "data": [
+            public_model_object(authority, metadata=published.get(authority[0]))
+            for authority in authorities
+        ],
         "wmo": {"authority_schema_version": MODEL_AUTHORITY_SCHEMA_VERSION},
     }
 
@@ -80,3 +219,27 @@ def require_granted_authority(
         ),
         param="model",
     )
+
+
+def _completion_support(capabilities: ModelCapabilities | None) -> bool:
+    """Publish completion support unless the catalog explicitly denies it.
+
+    Args:
+        capabilities: Authored capability snapshot, or ``None`` when undeclared.
+
+    Returns:
+        ``False`` only when the catalog records an explicit completion denial.
+    """
+    return not (capabilities is not None and capabilities.supports_completions is False)
+
+
+def _put_optional(target: JsonObject, key: str, value: bool | int | None) -> None:
+    """Copy one declared field onto a public JSON object.
+
+    Args:
+        target: Object receiving the field.
+        key: Public extension field name.
+        value: Catalog value, or ``None`` when the catalog omitted it.
+    """
+    if value is not None:
+        target[key] = value

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -10,9 +10,9 @@ from exp.common.models.model import ModelCapabilities
 from exp.runtime.gateway.discovery import (
     PublishedAliasMetadata,
     listing_metadata_by_alias,
-    published_alias_metadata,
     public_model_list,
     public_model_object,
+    published_alias_metadata,
     require_granted_authority,
 )
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
+from exp.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.common.models.model import ModelCapabilities
 from exp.runtime.gateway.discovery import (
+    PublishedAliasMetadata,
+    listing_metadata_by_alias,
+    published_alias_metadata,
     public_model_list,
     public_model_object,
     require_granted_authority,
@@ -12,6 +18,50 @@ from exp.runtime.gateway.discovery import (
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 _AUTHORITY = ("coding", "revision-one", "a" * 64)
+_WMO_LISTING_CONTRACT = {
+    "id": "coding",
+    "object": "model",
+    "created": 0,
+    "owned_by": "wmo",
+    "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+    "supports_completions": True,
+    "supports_tools": True,
+    "supports_structured_output": True,
+    "maximum_output_tokens": 16_000,
+    "pricing": {
+        "input_micro_usd_per_million_tokens": 1_250_000,
+        "output_micro_usd_per_million_tokens": 10_000_000,
+        "cached_input_micro_usd_per_million_tokens": 125_000,
+    },
+}
+
+
+def _deployment(
+    *,
+    capabilities: ModelCapabilities | None,
+    prices: GatewayTokenPrices | None = None,
+) -> ExactModelDeployment:
+    """Build one catalog deployment used only for public listing projection.
+
+    Args:
+        capabilities: Authored capability snapshot, or ``None`` when undeclared.
+        prices: Configured gateway prices, or defaults when omitted.
+
+    Returns:
+        A secret-free deployment whose public alias is ``coding``.
+    """
+    return ExactModelDeployment(
+        deployment_id="coding",
+        source_alias="coding",
+        exact_model_id="exact-coding",
+        connection="hosted",
+        provider="openai-compatible",
+        provider_model="hosted-coding",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        capabilities=capabilities,
+        gateway=GatewayDeploymentMetadata(prices=prices or GatewayTokenPrices()),
+    )
 
 
 def test_public_model_object_keeps_the_openai_keys_and_adds_authority() -> None:
@@ -54,3 +104,121 @@ def test_unknown_and_ungranted_aliases_raise_the_identical_404() -> None:
         "GET /v1/models lists the model aliases available to this key."
         in ungranted.value.detail.message
     )
+
+
+def test_public_model_object_copies_catalog_capabilities_limits_and_prices() -> None:
+    """A unique catalog deployment publishes its declared fields and no invented ones."""
+    metadata = published_alias_metadata(
+        _deployment(
+            capabilities=ModelCapabilities(
+                supports_tools=True,
+                supports_structured_output=True,
+                maximum_output_tokens=16_000,
+            ),
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=1_250_000,
+                output_micro_usd_per_million_tokens=10_000_000,
+                cached_input_micro_usd_per_million_tokens=125_000,
+            ),
+        )
+    )
+
+    payload = public_model_object(_AUTHORITY, metadata=metadata)
+
+    assert payload == _WMO_LISTING_CONTRACT
+    assert "context_window_tokens" not in payload
+    assert "cache_write" not in str(payload)
+
+
+def test_public_model_object_omits_undeclared_catalog_fields() -> None:
+    """An undeclared snapshot still marks completion support and invents nothing else."""
+    payload = public_model_object(
+        _AUTHORITY, metadata=published_alias_metadata(_deployment(capabilities=None))
+    )
+
+    assert payload["supports_completions"] is True
+    assert "supports_tools" not in payload
+    assert "supports_structured_output" not in payload
+    assert "maximum_output_tokens" not in payload
+    assert "pricing" not in payload
+    assert "context_window_tokens" not in payload
+
+
+def test_explicit_completion_denial_is_published() -> None:
+    """A catalog ``supports_completions=False`` is copied instead of being overridden."""
+    metadata = published_alias_metadata(
+        _deployment(capabilities=ModelCapabilities(supports_completions=False))
+    )
+
+    assert metadata is not None
+    assert metadata.supports_completions is False
+    assert public_model_object(_AUTHORITY, metadata=metadata)["supports_completions"] is False
+
+
+def test_missing_deployment_publishes_no_extension_fields() -> None:
+    """A granted alias without a unique catalog deployment stays identity-only."""
+    assert published_alias_metadata(None) is None
+    assert public_model_object(_AUTHORITY) == {
+        "id": "coding",
+        "object": "model",
+        "created": 0,
+        "owned_by": "wmo",
+        "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+    }
+
+
+def test_public_model_list_attaches_per_alias_catalog_metadata() -> None:
+    """List entries receive only the metadata keyed to that granted alias."""
+    metadata = published_alias_metadata(
+        _deployment(
+            capabilities=ModelCapabilities(
+                supports_tools=True,
+                supports_structured_output=True,
+                maximum_output_tokens=16_000,
+            ),
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=1_250_000,
+                output_micro_usd_per_million_tokens=10_000_000,
+                cached_input_micro_usd_per_million_tokens=125_000,
+            ),
+        )
+    )
+    assert metadata is not None
+
+    assert public_model_list((_AUTHORITY,), metadata_by_alias={"coding": metadata}) == {
+        "object": "list",
+        "data": [_WMO_LISTING_CONTRACT],
+        "wmo": {"authority_schema_version": 1},
+    }
+
+
+def test_listing_metadata_by_alias_keeps_only_successful_lookups() -> None:
+    """Failed catalog lookups are omitted so unmatched aliases stay identity-only."""
+
+    def lookup(
+        *, alias: str, revision_id: str, catalog_sha256: str
+    ) -> PublishedAliasMetadata | None:
+        """Return metadata only for the coding alias.
+
+        Args:
+            alias: Granted public alias.
+            revision_id: Active revision.
+            catalog_sha256: Frozen catalog digest.
+
+        Returns:
+            Catalog metadata for ``coding``, otherwise ``None``.
+        """
+        del revision_id, catalog_sha256
+        if alias != "coding":
+            return None
+        return published_alias_metadata(
+            _deployment(capabilities=ModelCapabilities(supports_tools=True))
+        )
+
+    published = listing_metadata_by_alias(
+        (_AUTHORITY, ("other", "revision-two", "b" * 64)),
+        lookup,
+    )
+
+    assert set(published) == {"coding"}
+    assert published["coding"].supports_tools is True

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -309,7 +309,20 @@ def load_local_gateway(
         ProjectTargetResolver | None,
         RouterProjectTargetResolver(activations, exact_models) if activations else None,
     )
-    routes = CatalogRouteResolver(normalized_catalogs, project_resolver=project_resolver)
+    listing_pools = {
+        (
+            item.authorization.alias,
+            item.authorization.alias_revision_id,
+            item.authorization.catalog_sha256,
+        ): item.authorization.target.pool_id
+        for item in readiness
+        if isinstance(item.authorization.target, DirectTarget)
+    }
+    routes = CatalogRouteResolver(
+        normalized_catalogs,
+        project_resolver=project_resolver,
+        listing_pools=listing_pools,
+    )
     executor = GatewayExecutor(runtime_catalogs, ledger)
     proof = readiness[0]
 

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -20,6 +20,7 @@ from exp.runtime.gateway.contracts import (
     ProjectSelection,
     ProjectTarget,
 )
+from exp.runtime.gateway.discovery import PublishedAliasMetadata, published_alias_metadata
 from exp.runtime.gateway.interfaces import ProjectTargetResolver
 from exp.runtime.models.providers.async_transport import ProviderDeadlineExceeded, RequestDeadline
 from exp.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
@@ -82,6 +83,44 @@ class CatalogRouteResolver:
                     deployment.deployment_id: deployment for deployment in catalog.deployments
                 },
             )
+
+    def published_metadata(
+        self,
+        *,
+        alias: str,
+        revision_id: str,
+        catalog_sha256: str,
+    ) -> PublishedAliasMetadata | None:
+        """Return catalog-backed listing fields for one granted public alias.
+
+        The alias must resolve to exactly one active deployment: a deployment whose
+        ID or source alias matches, or a singleton pool named by the public alias.
+        Multi-deployment pools and unmatched project aliases publish nothing extra.
+
+        Args:
+            alias: Granted public alias name.
+            revision_id: Active alias revision loaded in this process.
+            catalog_sha256: Frozen catalog digest bound to that revision.
+
+        Returns:
+            Declared capability, limit, and price fields, or ``None`` when the alias
+            has no unique catalog deployment in the active snapshot.
+        """
+        view = self._catalogs.get((revision_id, catalog_sha256))
+        if view is None:
+            return None
+        deployment = view.deployments.get(alias)
+        if deployment is None:
+            for candidate in view.deployments.values():
+                if candidate.source_alias == alias:
+                    deployment = candidate
+                    break
+        if deployment is None:
+            pool = view.pools.get(alias)
+            if pool is None or len(pool.deployment_ids) != 1:
+                return None
+            deployment = view.deployments.get(pool.deployment_ids[0])
+        return published_alias_metadata(deployment)
 
     async def resolve(
         self,

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -63,14 +63,18 @@ class CatalogRouteResolver:
         catalogs: Mapping[tuple[str, str], NormalizedGatewayCatalog],
         *,
         project_resolver: ProjectTargetResolver | None = None,
+        listing_pools: Mapping[tuple[str, str, str], str] | None = None,
     ) -> None:
         """Index one immutable catalog and optional learned-selection seam.
 
         Args:
             catalogs: Alias-revision and digest pairs mapped to normalized snapshots.
             project_resolver: Optional resolver for project-backed targets.
+            listing_pools: Direct-target pool IDs keyed by granted alias, revision,
+                and catalog digest. Project aliases are omitted and stay identity-only.
         """
         self._project_resolver = project_resolver
+        self._listing_pools = dict(listing_pools or {})
         self._catalogs: dict[tuple[str, str], _CatalogView] = {}
         for key, catalog in catalogs.items():
             revision_id, catalog_sha256 = key
@@ -93,9 +97,9 @@ class CatalogRouteResolver:
     ) -> PublishedAliasMetadata | None:
         """Return catalog-backed listing fields for one granted public alias.
 
-        The alias must resolve to exactly one active deployment: a deployment whose
-        ID or source alias matches, or a singleton pool named by the public alias.
-        Multi-deployment pools and unmatched project aliases publish nothing extra.
+        Lookup uses the alias revision's authoritative direct pool, never a public
+        name that happens to match a deployment or source alias. Multi-deployment
+        pools and project aliases publish nothing extra.
 
         Args:
             alias: Granted public alias name.
@@ -104,23 +108,18 @@ class CatalogRouteResolver:
 
         Returns:
             Declared capability, limit, and price fields, or ``None`` when the alias
-            has no unique catalog deployment in the active snapshot.
+            has no unique catalog deployment on its frozen direct target.
         """
+        pool_id = self._listing_pools.get((alias, revision_id, catalog_sha256))
+        if pool_id is None:
+            return None
         view = self._catalogs.get((revision_id, catalog_sha256))
         if view is None:
             return None
-        deployment = view.deployments.get(alias)
-        if deployment is None:
-            for candidate in view.deployments.values():
-                if candidate.source_alias == alias:
-                    deployment = candidate
-                    break
-        if deployment is None:
-            pool = view.pools.get(alias)
-            if pool is None or len(pool.deployment_ids) != 1:
-                return None
-            deployment = view.deployments.get(pool.deployment_ids[0])
-        return published_alias_metadata(deployment)
+        pool = view.pools.get(pool_id)
+        if pool is None or len(pool.deployment_ids) != 1:
+            return None
+        return published_alias_metadata(view.deployments.get(pool.deployment_ids[0]))
 
     async def resolve(
         self,

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -25,6 +25,7 @@ def _deployment(
     deployment_id: str,
     source_alias: str,
     exact_model_id: str = "exact-one",
+    input_price: int = 900_000,
 ) -> ExactModelDeployment:
     """Build one priced completion deployment for lookup tests.
 
@@ -32,6 +33,7 @@ def _deployment(
         deployment_id: Catalog deployment identifier.
         source_alias: Source alias recorded on the deployment.
         exact_model_id: Exact logical model identity shared with its pool.
+        input_price: Configured input micro-USD per million tokens.
 
     Returns:
         A secret-free deployment with declared tools, output limit, and prices.
@@ -52,47 +54,71 @@ def _deployment(
         ),
         gateway=GatewayDeploymentMetadata(
             prices=GatewayTokenPrices(
-                input_micro_usd_per_million_tokens=900_000,
+                input_micro_usd_per_million_tokens=input_price,
                 output_micro_usd_per_million_tokens=900_000,
             )
         ),
     )
 
 
-def _resolver(
+def _catalog(
     deployments: tuple[ExactModelDeployment, ...],
     pools: tuple[ExactModelPool, ...],
-) -> tuple[CatalogRouteResolver, str]:
-    """Index one catalog snapshot and return the resolver plus its digest.
+) -> tuple[NormalizedGatewayCatalog, str]:
+    """Build one catalog snapshot and its digest.
 
     Args:
         deployments: Deployments stored in the snapshot.
         pools: Exact-model pools stored in the snapshot.
 
     Returns:
-        The resolver and the catalog digest used as the revision key.
+        The catalog and the digest used as the revision key.
     """
     catalog = NormalizedGatewayCatalog(deployments=deployments, pools=pools)
-    digest = catalog.identity_sha256()
-    return CatalogRouteResolver({(_REVISION, digest): catalog}), digest
+    return catalog, catalog.identity_sha256()
 
 
-def test_published_metadata_uses_the_deployment_named_by_the_public_alias() -> None:
-    """A direct alias copies fields from the deployment that shares its name."""
-    deployment = _deployment(deployment_id="coding", source_alias="coding")
-    resolver, digest = _resolver(
+def _resolver(
+    catalog: NormalizedGatewayCatalog,
+    digest: str,
+    listing_pools: dict[tuple[str, str, str], str] | None = None,
+) -> CatalogRouteResolver:
+    """Index one catalog with optional authoritative listing targets.
+
+    Args:
+        catalog: Snapshot served by the resolver.
+        digest: Frozen catalog digest.
+        listing_pools: Direct-target pool IDs keyed by granted alias authority.
+
+    Returns:
+        A resolver ready for metadata lookup.
+    """
+    return CatalogRouteResolver(
+        {(_REVISION, digest): catalog},
+        listing_pools=listing_pools,
+    )
+
+
+def test_published_metadata_uses_the_revision_direct_pool_not_the_public_name() -> None:
+    """A differently named public alias still publishes its frozen direct pool."""
+    deployment = _deployment(deployment_id="deployment-one", source_alias="source-one")
+    catalog, digest = _catalog(
         (deployment,),
         (
             ExactModelPool(
-                pool_id="coding",
+                pool_id="pool-one",
                 exact_model_id="exact-one",
-                deployment_ids=("coding",),
+                deployment_ids=("deployment-one",),
             ),
         ),
     )
 
-    metadata = resolver.published_metadata(
-        alias="coding",
+    metadata = _resolver(
+        catalog,
+        digest,
+        {("public-model", _REVISION, digest): "pool-one"},
+    ).published_metadata(
+        alias="public-model",
         revision_id=_REVISION,
         catalog_sha256=digest,
     )
@@ -106,35 +132,50 @@ def test_published_metadata_uses_the_deployment_named_by_the_public_alias() -> N
     assert metadata.cached_input_micro_usd_per_million_tokens is None
 
 
-def test_published_metadata_accepts_a_singleton_pool_named_by_the_public_alias() -> None:
-    """A public alias may name the singleton pool rather than the deployment ID."""
-    deployment = _deployment(deployment_id="deployment-one", source_alias="source-one")
-    resolver, digest = _resolver(
-        (deployment,),
+def test_published_metadata_ignores_a_deployment_that_only_shares_the_public_name() -> None:
+    """A name collision with another deployment does not override the frozen target."""
+    decoy = _deployment(
+        deployment_id="public-model",
+        source_alias="public-model",
+        exact_model_id="exact-decoy",
+        input_price=1,
+    )
+    target = _deployment(deployment_id="deployment-one", source_alias="source-one")
+    catalog, digest = _catalog(
+        (decoy, target),
         (
             ExactModelPool(
-                pool_id="coding",
+                pool_id="decoy-pool",
+                exact_model_id="exact-decoy",
+                deployment_ids=("public-model",),
+            ),
+            ExactModelPool(
+                pool_id="pool-one",
                 exact_model_id="exact-one",
                 deployment_ids=("deployment-one",),
             ),
         ),
     )
 
-    metadata = resolver.published_metadata(
-        alias="coding",
+    metadata = _resolver(
+        catalog,
+        digest,
+        {("public-model", _REVISION, digest): "pool-one"},
+    ).published_metadata(
+        alias="public-model",
         revision_id=_REVISION,
         catalog_sha256=digest,
     )
 
     assert metadata is not None
-    assert metadata.output_micro_usd_per_million_tokens == 900_000
+    assert metadata.input_micro_usd_per_million_tokens == 900_000
 
 
 def test_published_metadata_stays_closed_for_multi_deployment_pools() -> None:
     """A pool with more than one route does not pick a deployment to advertise."""
     first = _deployment(deployment_id="one", source_alias="one")
     second = _deployment(deployment_id="two", source_alias="two")
-    resolver, digest = _resolver(
+    catalog, digest = _catalog(
         (first, second),
         (
             ExactModelPool(
@@ -152,7 +193,11 @@ def test_published_metadata_stays_closed_for_multi_deployment_pools() -> None:
     )
 
     assert (
-        resolver.published_metadata(
+        _resolver(
+            catalog,
+            digest,
+            {("coding", _REVISION, digest): "coding"},
+        ).published_metadata(
             alias="coding",
             revision_id=_REVISION,
             catalog_sha256=digest,
@@ -161,22 +206,22 @@ def test_published_metadata_stays_closed_for_multi_deployment_pools() -> None:
     )
 
 
-def test_published_metadata_stays_closed_when_the_alias_is_not_in_the_catalog() -> None:
-    """Project aliases and other unmatched names publish no extra fields."""
-    deployment = _deployment(deployment_id="source-one", source_alias="source-one")
-    resolver, digest = _resolver(
+def test_published_metadata_stays_closed_when_the_revision_has_no_direct_pool() -> None:
+    """Project aliases and other unmapped names stay identity-only, even on name hits."""
+    deployment = _deployment(deployment_id="public-model", source_alias="public-model")
+    catalog, digest = _catalog(
         (deployment,),
         (
             ExactModelPool(
                 pool_id="pool-one",
                 exact_model_id="exact-one",
-                deployment_ids=("source-one",),
+                deployment_ids=("public-model",),
             ),
         ),
     )
 
     assert (
-        resolver.published_metadata(
+        _resolver(catalog, digest).published_metadata(
             alias="public-model",
             revision_id=_REVISION,
             catalog_sha256=digest,

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -1,0 +1,185 @@
+"""Tests for catalog-backed public alias metadata lookup."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from exp.common.models.catalog import (
+    GatewayDeploymentMetadata,
+    GatewayEquivalenceCertification,
+    GatewayTokenPrices,
+)
+from exp.common.models.gateway_catalog import (
+    ExactModelDeployment,
+    ExactModelPool,
+    NormalizedGatewayCatalog,
+)
+from exp.common.models.model import ModelCapabilities
+from exp.runtime.gateway.routing import CatalogRouteResolver
+
+_REVISION = "revision-one"
+
+
+def _deployment(
+    *,
+    deployment_id: str,
+    source_alias: str,
+    exact_model_id: str = "exact-one",
+) -> ExactModelDeployment:
+    """Build one priced completion deployment for lookup tests.
+
+    Args:
+        deployment_id: Catalog deployment identifier.
+        source_alias: Source alias recorded on the deployment.
+        exact_model_id: Exact logical model identity shared with its pool.
+
+    Returns:
+        A secret-free deployment with declared tools, output limit, and prices.
+    """
+    return ExactModelDeployment(
+        deployment_id=deployment_id,
+        source_alias=source_alias,
+        exact_model_id=exact_model_id,
+        connection="hosted",
+        provider="openai-compatible",
+        provider_model="hosted-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supports_structured_output=True,
+            maximum_output_tokens=8_192,
+        ),
+        gateway=GatewayDeploymentMetadata(
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=900_000,
+                output_micro_usd_per_million_tokens=900_000,
+            )
+        ),
+    )
+
+
+def _resolver(
+    deployments: tuple[ExactModelDeployment, ...],
+    pools: tuple[ExactModelPool, ...],
+) -> tuple[CatalogRouteResolver, str]:
+    """Index one catalog snapshot and return the resolver plus its digest.
+
+    Args:
+        deployments: Deployments stored in the snapshot.
+        pools: Exact-model pools stored in the snapshot.
+
+    Returns:
+        The resolver and the catalog digest used as the revision key.
+    """
+    catalog = NormalizedGatewayCatalog(deployments=deployments, pools=pools)
+    digest = catalog.identity_sha256()
+    return CatalogRouteResolver({(_REVISION, digest): catalog}), digest
+
+
+def test_published_metadata_uses_the_deployment_named_by_the_public_alias() -> None:
+    """A direct alias copies fields from the deployment that shares its name."""
+    deployment = _deployment(deployment_id="coding", source_alias="coding")
+    resolver, digest = _resolver(
+        (deployment,),
+        (
+            ExactModelPool(
+                pool_id="coding",
+                exact_model_id="exact-one",
+                deployment_ids=("coding",),
+            ),
+        ),
+    )
+
+    metadata = resolver.published_metadata(
+        alias="coding",
+        revision_id=_REVISION,
+        catalog_sha256=digest,
+    )
+
+    assert metadata is not None
+    assert metadata.supports_completions is True
+    assert metadata.supports_tools is True
+    assert metadata.maximum_output_tokens == 8_192
+    assert metadata.input_micro_usd_per_million_tokens == 900_000
+    assert metadata.context_window_tokens is None
+    assert metadata.cached_input_micro_usd_per_million_tokens is None
+
+
+def test_published_metadata_accepts_a_singleton_pool_named_by_the_public_alias() -> None:
+    """A public alias may name the singleton pool rather than the deployment ID."""
+    deployment = _deployment(deployment_id="deployment-one", source_alias="source-one")
+    resolver, digest = _resolver(
+        (deployment,),
+        (
+            ExactModelPool(
+                pool_id="coding",
+                exact_model_id="exact-one",
+                deployment_ids=("deployment-one",),
+            ),
+        ),
+    )
+
+    metadata = resolver.published_metadata(
+        alias="coding",
+        revision_id=_REVISION,
+        catalog_sha256=digest,
+    )
+
+    assert metadata is not None
+    assert metadata.output_micro_usd_per_million_tokens == 900_000
+
+
+def test_published_metadata_stays_closed_for_multi_deployment_pools() -> None:
+    """A pool with more than one route does not pick a deployment to advertise."""
+    first = _deployment(deployment_id="one", source_alias="one")
+    second = _deployment(deployment_id="two", source_alias="two")
+    resolver, digest = _resolver(
+        (first, second),
+        (
+            ExactModelPool(
+                pool_id="coding",
+                exact_model_id="exact-one",
+                deployment_ids=("one", "two"),
+                equivalence=GatewayEquivalenceCertification(
+                    certification_id="certification-one",
+                    provenance="operator comparison for listing fail-closed lookup",
+                    evidence_sha256="d" * 64,
+                    certified_at=datetime(2026, 8, 18, tzinfo=UTC),
+                ),
+            ),
+        ),
+    )
+
+    assert (
+        resolver.published_metadata(
+            alias="coding",
+            revision_id=_REVISION,
+            catalog_sha256=digest,
+        )
+        is None
+    )
+
+
+def test_published_metadata_stays_closed_when_the_alias_is_not_in_the_catalog() -> None:
+    """Project aliases and other unmatched names publish no extra fields."""
+    deployment = _deployment(deployment_id="source-one", source_alias="source-one")
+    resolver, digest = _resolver(
+        (deployment,),
+        (
+            ExactModelPool(
+                pool_id="pool-one",
+                exact_model_id="exact-one",
+                deployment_ids=("source-one",),
+            ),
+        ),
+    )
+
+    assert (
+        resolver.published_metadata(
+            alias="public-model",
+            revision_id=_REVISION,
+            catalog_sha256=digest,
+        )
+        is None
+    )

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -27,6 +27,8 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
 )
 from exp.runtime.gateway.discovery import (
+    PublishedAliasMetadata,
+    listing_metadata_by_alias,
     public_model_list,
     public_model_object,
     require_granted_authority,
@@ -252,6 +254,14 @@ class GatewayService:
         return require_granted_authority(
             self._control.granted_alias_authorities(raw_key=raw_key),
             model_id,
+        )
+
+    def published_alias_metadata(
+        self, *, alias: str, revision_id: str, catalog_sha256: str
+    ) -> PublishedAliasMetadata | None:
+        """Return catalog-backed listing fields for one granted public alias."""
+        return self._routes.published_metadata(
+            alias=alias, revision_id=revision_id, catalog_sha256=catalog_sha256
         )
 
     def authenticate(self, *, raw_key: str) -> None:
@@ -656,7 +666,14 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         try:
             raw_key = _bearer_key(authorization)
             authorities = service.model_authorities(raw_key=raw_key)
-            return JSONResponse(public_model_list(authorities))
+            return JSONResponse(
+                public_model_list(
+                    authorities,
+                    metadata_by_alias=listing_metadata_by_alias(
+                        authorities, service.published_alias_metadata
+                    ),
+                )
+            )
         except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
             return _exception_response(exc)
 
@@ -669,7 +686,14 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         try:
             raw_key = _bearer_key(authorization)
             authority = service.model_authority(raw_key=raw_key, model_id=model_id)
-            return JSONResponse(public_model_object(authority))
+            return JSONResponse(
+                public_model_object(
+                    authority,
+                    metadata=listing_metadata_by_alias(
+                        (authority,), service.published_alias_metadata
+                    ).get(authority[0]),
+                )
+            )
         except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
             return _exception_response(exc)
 

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -22,7 +22,11 @@ from exp.common.models import (
     ModelSnapshot,
     ToolCall,
 )
-from exp.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
+from exp.common.models.catalog import (
+    GatewayDeploymentCapabilities,
+    GatewayDeploymentMetadata,
+    GatewayTokenPrices,
+)
 from exp.common.models.gateway_catalog import (
     ExactModelDeployment,
     ExactModelPool,
@@ -495,12 +499,17 @@ def _service(
     replay_store: ResponseReplayStore | None = None,
     continuation_store: ResponseContinuationStore | None = None,
     request_digest: Callable[[GatewayRequest], str] | None = None,
+    listing_pools: dict[tuple[str, str, str], str] | None = None,
+    catalog_bundle: tuple[NormalizedGatewayCatalog, ExactModelDeployment] | None = None,
 ) -> tuple[GatewayService, _ControlStore, _Ledger, ExecutionSnapshot]:
     """Compose the full launch data plane with deterministic injected dependencies."""
-    catalog, deployment = _catalog()
+    catalog, deployment = _catalog() if catalog_bundle is None else catalog_bundle
     control = _ControlStore(catalog.identity_sha256(), request_digest)
     ledger = _Ledger()
-    routes = CatalogRouteResolver({("revision-one", catalog.identity_sha256()): catalog})
+    routes = CatalogRouteResolver(
+        {("revision-one", catalog.identity_sha256()): catalog},
+        listing_pools=listing_pools,
+    )
     authorization = control.authorize_request(
         raw_key="preflight-not-a-caller-secret",
         alias="public-model",
@@ -1646,6 +1655,89 @@ def test_model_discovery_is_enriched_and_detail_is_not_an_existence_oracle() -> 
         assert "GET /v1/models lists the model aliases available to this key." in error["message"]
         assert "other-model" not in error["message"]
         assert unauthenticated.status_code == 401
+        assert len(provider.streams) == 0
+
+    asyncio.run(scenario())
+
+
+def test_model_discovery_publishes_the_revision_direct_pool_not_a_name_match() -> None:
+    """GET /v1/models copies fields from the frozen direct pool, not a public-name hit."""
+
+    async def scenario() -> None:
+        """Serve one granted alias whose public name differs from its deployment."""
+        deployment = ExactModelDeployment(
+            deployment_id="deployment-one",
+            source_alias="source-one",
+            exact_model_id="exact-one",
+            connection="connection-one",
+            provider="openai",
+            provider_model="provider-model",
+            connection_sha256="b" * 64,
+            capabilities_sha256="c" * 64,
+            capabilities=ModelCapabilities(
+                supports_tools=True,
+                supports_structured_output=True,
+                maximum_output_tokens=16_000,
+            ),
+            gateway=GatewayDeploymentMetadata(
+                capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                prices=GatewayTokenPrices(
+                    input_micro_usd_per_million_tokens=1_250_000,
+                    output_micro_usd_per_million_tokens=10_000_000,
+                    cached_input_micro_usd_per_million_tokens=125_000,
+                ),
+            ),
+        )
+        catalog = NormalizedGatewayCatalog(
+            deployments=(deployment,),
+            pools=(
+                ExactModelPool(
+                    pool_id="pool-one",
+                    exact_model_id="exact-one",
+                    deployment_ids=("deployment-one",),
+                ),
+            ),
+        )
+        digest = catalog.identity_sha256()
+        provider = _Provider(lambda: _EventStream(()))
+        service, _control, _ledger, _proof = _service(
+            provider,
+            catalog_bundle=(catalog, deployment),
+            listing_pools={("public-model", "revision-one", digest): "pool-one"},
+        )
+        transport = httpx.ASGITransport(app=create_gateway_app(service))
+        async with httpx.AsyncClient(transport=transport, base_url="http://gateway") as client:
+            listed = await client.get(
+                "/v1/models", headers={"authorization": "Bearer caller-secret"}
+            )
+            granted = await client.get(
+                "/v1/models/public-model", headers={"authorization": "Bearer caller-secret"}
+            )
+
+        expected = {
+            "id": "public-model",
+            "object": "model",
+            "created": 0,
+            "owned_by": "wmo",
+            "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
+            "supports_completions": True,
+            "supports_tools": True,
+            "supports_structured_output": True,
+            "maximum_output_tokens": 16_000,
+            "pricing": {
+                "input_micro_usd_per_million_tokens": 1_250_000,
+                "output_micro_usd_per_million_tokens": 10_000_000,
+                "cached_input_micro_usd_per_million_tokens": 125_000,
+            },
+        }
+        assert listed.status_code == 200
+        assert listed.json() == {
+            "object": "list",
+            "data": [expected],
+            "wmo": {"authority_schema_version": 1},
+        }
+        assert granted.status_code == 200
+        assert granted.json() == expected
         assert len(provider.streams) == 0
 
     asyncio.run(scenario())

--- a/exp/runtime/models/providers/listing.py
+++ b/exp/runtime/models/providers/listing.py
@@ -109,8 +109,10 @@ class HttpProviderModelLister:
             models = self._anthropic_models(endpoint)
         elif endpoint.provider == "openrouter":
             models = self._openrouter_models(endpoint)
-        elif endpoint.provider in ("openai", "openai-compatible"):
+        elif endpoint.provider == "openai":
             models = self._openai_models(endpoint)
+        elif endpoint.provider == "openai-compatible":
+            models = self._openai_compatible_models(endpoint)
         else:
             raise ProviderListingError(f"provider {endpoint.provider!r} cannot list models")
         return tuple(sorted(models, key=lambda model: model.model))
@@ -129,17 +131,35 @@ class HttpProviderModelLister:
             raise ProviderListingError(_listing_message(endpoint.provider, exc)) from exc
 
     def _openai_models(self, endpoint: ProviderEndpoint) -> list[DiscoveredModel]:
-        """List OpenAI or OpenAI-compatible models, which publish only model identities."""
+        """List official OpenAI models as identities only.
+
+        Official OpenAI listing objects may carry extra keys. Those keys are discarded so
+        setup never treats unofficial metadata as verified OpenAI capabilities or prices.
+        """
+        return [
+            DiscoveredModel(provider=endpoint.provider, model=identity)
+            for identity in _identities(endpoint.provider, self._openai_listing(endpoint), "id")
+        ]
+
+    def _openai_compatible_models(self, endpoint: ProviderEndpoint) -> list[DiscoveredModel]:
+        """List OpenAI-compatible models, keeping only validated optional metadata."""
+        models = []
+        for entry in _entries(endpoint.provider, self._openai_listing(endpoint)):
+            identity = _text(entry.get("id"))
+            if identity is None:
+                continue
+            models.append(_openai_compatible_model(endpoint.provider, identity, entry))
+        return models
+
+    def _openai_listing(self, endpoint: ProviderEndpoint) -> object:
+        """Read one OpenAI-shaped ``/models`` array from the configured origin."""
         base_url = _base_url(endpoint, default=OPENAI_BASE_URL)
         body = self._read(
             endpoint,
             f"{base_url}/models",
             {"Authorization": f"Bearer {endpoint.api_key}"},
         )
-        return [
-            DiscoveredModel(provider=endpoint.provider, model=identity)
-            for identity in _identities(endpoint.provider, body.get("data"), "id")
-        ]
+        return body.get("data")
 
     def _anthropic_models(self, endpoint: ProviderEndpoint) -> list[DiscoveredModel]:
         """List Anthropic models, which publish only model identities."""
@@ -196,6 +216,42 @@ class HttpProviderModelLister:
             if page_token is None:
                 break
         return models
+
+
+def _openai_compatible_model(provider: str, identity: str, entry: JsonObject) -> DiscoveredModel:
+    """Build one discovered model from an OpenAI-compatible listing entry.
+
+    Only explicitly typed extension fields are kept. Unknown, absent, or wrongly typed
+    values stay unknown. Official OpenAI listing never calls this parser.
+
+    Args:
+        provider: Setup provider kind, always ``openai-compatible``.
+        identity: Provider-published model ID.
+        entry: One object from the OpenAI-shaped ``data`` array.
+
+    Returns:
+        The identity plus any validated optional capability, limit, and price fields.
+    """
+    pricing = entry.get("pricing")
+    prices: JsonObject = cast(JsonObject, pricing) if isinstance(pricing, dict) else {}
+    return DiscoveredModel(
+        provider=provider,
+        model=identity,
+        supports_completions=_strict_bool(entry.get("supports_completions")),
+        supports_tools=_strict_bool(entry.get("supports_tools")),
+        supports_structured_output=_strict_bool(entry.get("supports_structured_output")),
+        context_window_tokens=_strict_positive_int(entry.get("context_window_tokens")),
+        maximum_output_tokens=_strict_positive_int(entry.get("maximum_output_tokens")),
+        input_cost_per_million_tokens_usd=_micro_usd_price(
+            prices.get("input_micro_usd_per_million_tokens")
+        ),
+        output_cost_per_million_tokens_usd=_micro_usd_price(
+            prices.get("output_micro_usd_per_million_tokens")
+        ),
+        cached_input_cost_per_million_tokens_usd=_micro_usd_price(
+            prices.get("cached_input_micro_usd_per_million_tokens")
+        ),
+    )
 
 
 def _openrouter_model(provider: str, identity: str, entry: JsonObject) -> DiscoveredModel:
@@ -296,6 +352,34 @@ def _positive_int(value: object) -> int | None:
         return None
     limit = int(value)
     return limit if limit > 0 else None
+
+
+def _strict_positive_int(value: object) -> int | None:
+    """Read one exact positive integer, rejecting floats and other shapes."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def _strict_bool(value: object) -> bool | None:
+    """Read one exact boolean, rejecting truthy integers and other shapes."""
+    return value if isinstance(value, bool) else None
+
+
+def _micro_usd_price(value: object) -> float | None:
+    """Convert one configured micro-USD-per-million-token price to USD.
+
+    Args:
+        value: Integer micro-USD per million tokens published by the endpoint.
+
+    Returns:
+        USD per million tokens, or ``None`` when the value is absent or unusable.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value / 1_000_000
 
 
 def _million_token_price(value: object) -> float | None:

--- a/exp/runtime/models/providers/listing_test.py
+++ b/exp/runtime/models/providers/listing_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from exp.common.core.artifacts import JsonObject
+from exp.common.models.discovery import SetupRole, resolve_discovered_model, served_roles
 from exp.runtime.models.providers.listing import (
     HttpProviderModelLister,
     ProviderEndpoint,
@@ -86,7 +87,133 @@ def test_openai_compatible_listing_uses_the_configured_base_url() -> None:
     )
 
     assert [model.model for model in models] == ["local-model"]
+    assert models[0].supports_completions is None
+    assert models[0].input_cost_per_million_tokens_usd is None
     assert transport.requests[0].url == "https://gateway.internal/v1/models"
+
+
+def test_openai_listing_discards_optional_entry_metadata() -> None:
+    """Official OpenAI listing stays identity-only even when extra keys are present."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "gpt-5.1",
+                        "supports_completions": True,
+                        "supports_tools": True,
+                        "maximum_output_tokens": 16_000,
+                        "pricing": {"input_micro_usd_per_million_tokens": 1_250_000},
+                    }
+                ]
+            }
+        )
+    )
+
+    models = _lister(transport).list_models(
+        ProviderEndpoint(provider="openai", api_key="secret-key")
+    )
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.model == "gpt-5.1"
+    assert model.supports_completions is None
+    assert model.supports_tools is None
+    assert model.maximum_output_tokens is None
+    assert model.input_cost_per_million_tokens_usd is None
+
+
+def test_openai_compatible_listing_reads_validated_wmo_gateway_metadata() -> None:
+    """The hosted gateway contract supplies capabilities, limits, and micro-USD prices."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "coding",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "wmo",
+                        "wmo": {
+                            "alias_revision_id": "revision-one",
+                            "catalog_sha256": "a" * 64,
+                        },
+                        "supports_completions": True,
+                        "supports_tools": True,
+                        "supports_structured_output": True,
+                        "maximum_output_tokens": 16_000,
+                        "pricing": {
+                            "input_micro_usd_per_million_tokens": 1_250_000,
+                            "output_micro_usd_per_million_tokens": 10_000_000,
+                            "cached_input_micro_usd_per_million_tokens": 125_000,
+                        },
+                    }
+                ]
+            }
+        )
+    )
+
+    models = _lister(transport).list_models(
+        ProviderEndpoint(
+            provider="openai-compatible",
+            api_key="secret-key",
+            base_url="https://gateway.internal/v1",
+        )
+    )
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.model == "coding"
+    assert model.supports_completions is True
+    assert model.supports_tools is True
+    assert model.supports_structured_output is True
+    assert model.maximum_output_tokens == 16_000
+    assert model.context_window_tokens is None
+    assert model.input_cost_per_million_tokens_usd == pytest.approx(1.25)
+    assert model.output_cost_per_million_tokens_usd == pytest.approx(10.0)
+    assert model.cached_input_cost_per_million_tokens_usd == pytest.approx(0.125)
+    assert model.cache_write_cost_per_million_tokens_usd is None
+    resolved = resolve_discovered_model(model)
+    assert served_roles(resolved.capabilities) == (SetupRole.WORLD_MODEL, SetupRole.JUDGE)
+
+
+def test_openai_compatible_listing_preserves_unknowns_for_absent_or_invalid_fields() -> None:
+    """Wrong types and omitted keys stay unknown instead of being coerced or guessed."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "local-model",
+                        "supports_tools": 1,
+                        "supports_structured_output": "true",
+                        "maximum_output_tokens": 16_000.0,
+                        "pricing": {
+                            "input_micro_usd_per_million_tokens": "1250000",
+                            "output_micro_usd_per_million_tokens": -1,
+                        },
+                    }
+                ]
+            }
+        )
+    )
+
+    models = _lister(transport).list_models(
+        ProviderEndpoint(
+            provider="openai-compatible",
+            api_key="secret-key",
+            base_url="https://gateway.internal/v1",
+        )
+    )
+
+    model = models[0]
+    assert model.supports_completions is None
+    assert model.supports_tools is None
+    assert model.supports_structured_output is None
+    assert model.maximum_output_tokens is None
+    assert model.input_cost_per_million_tokens_usd is None
+    assert model.output_cost_per_million_tokens_usd is None
+    assert model.cache_write_cost_per_million_tokens_usd is None
 
 
 def test_anthropic_listing_reads_identities_and_sends_version_header() -> None:

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -3167,6 +3167,7 @@ def test_documentation_index_commands_and_release_scope_are_current() -> None:
 
     architecture = (docs / "reference" / "gateway-architecture.md").read_text(encoding="utf-8")
     assert "GET /v1/models" in architecture
+    assert "micro-USD-per-million-token" in architecture
     assert "POST /v1/chat/completions" in architecture
     assert "POST /v1/responses" in architecture
     assert "provider_certification.py" in architecture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Hosted `GET /v1/models` previously returned only OpenAI identity fields, so `exp config providers --provider openai-compatible` hid every listed model and reported that the provider published no verified metadata. The first fix published catalog-backed extension fields from a hosted gateway pool. That path is still required for rich hosted listings, but it must not be the only way an OpenAI-compatible model becomes usable.

Experiential is the only canonical product and repository. Discovery and verification are separate.

## Contract

Hosted listings may still publish optional per-alias extension fields from the unique active catalog deployment:

- `supports_completions`, `supports_tools`, `supports_structured_output`
- `maximum_output_tokens` and `context_window_tokens` only when the catalog declares them
- `pricing.{input,output,cached_input}_micro_usd_per_million_tokens` from configured gateway prices

The standard OpenAI list shape is unchanged. The gateway never invents a context window or a cache-write price, and it never hard-codes hosted alias names. Lookup stays on the alias revision's frozen direct-target pool.

`provider=openai-compatible` still parses only those optional fields when present. Official `provider=openai` listing remains identity-only.

Identity-only models from any trusted operator-supplied OpenAI-compatible endpoint stay visible and selectable. Setup labels them `unknown capabilities/prices`. Assigning a build role collects an explicit operator declaration of the minimum capabilities and prices that role needs. Published values are confirmed. Tools, structured output, token limits, and prices are never inferred.

The deterministic equivalent is `exp config providers --non-interactive` with `--connection-json` and `--model-json`, or a hand-authored `.exp/models.toml` record. Those declarations become configured catalog metadata. Downstream cost and router-candidate preflights stay fail-closed while a required price or limit remains unknown.

## Tests and docs

- Gateway discovery and routing regressions for catalog-backed publish and fail-closed lookup
- Listing contract tests for hosted payloads, official OpenAI identity-only behavior, and invalid or absent fields
- Provider setup tests for visible unknown identities, interactive role declaration, and non-interactive JSON authoring
- Provider and OpenAI-compatible recipe docs updated for discovery versus verification

world-model-optimizer now redirects to this repository, so this is the single PR for both local checkouts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f01038d-a76a-4227-9bd3-1a623b3c1ee2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f01038d-a76a-4227-9bd3-1a623b3c1ee2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

