### PR TITLE
Replace boxed run banner with EXP text art

### DIFF
--- a/exp/cli/run/app.py
+++ b/exp/cli/run/app.py
@@ -8,9 +8,7 @@ import sys
 from pathlib import Path
 
 import typer
-from rich import box
 from rich.console import Console
-from rich.panel import Panel
 from rich.text import Text
 
 from exp.cli.shared.options import ROOT_OPTION, usage_error
@@ -18,6 +16,16 @@ from exp.cli.shared.theme import EXP_THEME
 
 _LOOPBACK_HOST = "127.0.0.1"
 _console = Console(theme=EXP_THEME)
+_EXP_WORDMARK = "\n".join(
+    (
+        "███████╗██╗  ██╗██████╗ ",
+        "██╔════╝╚██╗██╔╝██╔══██╗",
+        "█████╗   ╚███╔╝ ██████╔╝",
+        "██╔══╝   ██╔██╗ ██╔═══╝ ",
+        "███████╗██╔╝ ██╗██║     ",
+        "╚══════╝╚═╝  ╚═╝╚═╝     ",
+    )
+)
 _POLICY_OPTION = typer.Option(
     None,
     "--policy",
@@ -187,16 +195,8 @@ def _run_gateway(
 
 
 def _emit_exp_wordmark() -> None:
-    """Render the compact EXP wordmark for human-facing gateway startup output."""
-    _console.print(
-        Panel(
-            Text("EXP", style="bold"),
-            border_style="green",
-            box=box.SQUARE,
-            expand=False,
-            padding=(0, 1),
-        )
-    )
+    """Render the block-letter EXP wordmark for human-facing gateway startup output."""
+    _console.print(Text(_EXP_WORDMARK, style="bold green"))
 
 
 def _gateway_not_initialized(*, json_output: bool) -> None:

--- a/exp/cli/run/app_test.py
+++ b/exp/cli/run/app_test.py
@@ -222,7 +222,14 @@ def test_first_run_delivers_credentials_before_readiness_failure(
         )
 
     transcript = output.getvalue()
-    assert transcript.startswith("┌─────┐\n│ EXP │\n└─────┘\n")
+    assert transcript.startswith(
+        "███████╗██╗  ██╗██████╗ \n"
+        "██╔════╝╚██╗██╔╝██╔══██╗\n"
+        "█████╗   ╚███╔╝ ██████╔╝\n"
+        "██╔══╝   ██╔██╗ ██╔═══╝ \n"
+        "███████╗██╔╝ ██╗██║     \n"
+        "╚══════╝╚═╝  ╚═╝╚═╝     \n"
+    )
     assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in transcript
     assert f"export EXP_GATEWAY_KEY={raw_key}" in transcript
     assert "export OPENAI_API_KEY" not in transcript


### PR DESCRIPTION
## Summary\n\n- replace the merged boxed EXP placeholder with a six-line block-letter EXP wordmark\n- keep the banner human-facing only; JSON output remains unchanged\n- update the first-run transcript assertion\n\n## Validation\n\n- uv run --extra dev pytest -q exp/cli/run/app_test.py\n- uv run --extra dev ruff check .\n- uv run --extra dev ruff format --check .\n- uv run --extra dev ty check\n\nFollow-up to #565.