### PR TITLE
Add bare exp gateway shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ defaults for the public alias, identity, and `$50.00` command budget before prin
 
 ```bash
 pip install experiential
-exp run
+exp
 ```
+
+Bare `exp` is a shortcut for `exp run`; the explicit form remains available. Use `exp --help`
+or `exp help` for the root command help.
 
 Choose a public alias such as `support-agent`, capture the issued key, and send a request:
 

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -2,7 +2,7 @@
 
 ## Supported surface
 
-No-argument `exp run` starts an authenticated multi-alias gateway on `127.0.0.1`.
+Bare `exp` and no-argument `exp run` start an authenticated multi-alias gateway on `127.0.0.1`.
 It serves:
 
 - `GET /v1/models`

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -13,8 +13,9 @@ on the exact release checkout.
   provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
   content-free SQLite accounting, monthly integer micro-USD enforcement, and loopback-only health
   and usage views.
-- Both no-argument gateway launch and the retained `exp run PROJECT [--ghost]` compatibility form
-  are installed-wheel surfaces. Gateway startup is provider-idle and requires explicit authority.
+- Bare `exp` and the explicit no-argument `exp run` gateway launch, plus the retained
+  `exp run PROJECT [--ghost]` compatibility form, are installed-wheel surfaces. Gateway startup
+  is provider-idle and requires explicit authority.
 - The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
   upstream, and OpenAI `3.0.0`. It covers `OpenAI` and `AsyncOpenAI` across Chat Completions and
   Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,7 @@ The root surface is deliberately small:
 
 | Command | Purpose | Local result |
 |---|---|---|
+| `exp` | Shortcut for `exp run`; use `exp --help` or `exp help` for root CLI help. | Start the authenticated gateway on loopback. |
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |
 | `exp optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `exp optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |
@@ -35,7 +36,7 @@ remain frozen for the process lifetime and return only an exact model pool. `--g
 compatibility flag for project-journal behavior; gateway authentication, replay, attempts, and
 usage accounting stay enabled.
 
-Both `exp run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
+Bare `exp` and both `exp run` forms use one gateway lifecycle. It binds only `127.0.0.1`, starts with no
 provider call, and requires an explicit provider environment reference, exact model alias, identity,
 grant, and a virtual key. Interactive first-run setup can persist multiple provider connections and
 creates one initial gateway alias; additional deployments and certified pools remain explicit

--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 
 import typer
 
@@ -28,6 +29,30 @@ add_deferred_typer(
 app.command("build", help="Build a reusable grounded world model from local trace evidence.")(build)
 app.command("run", help="Run the local gateway, optionally with one project-backed alias.")(run)
 
+_ROOT_COMMANDS = frozenset(("build", "config", "optimize", "run"))
+
+
+def _dispatch_arguments(arguments: list[str]) -> list[str]:
+    """Resolve the root invocation into the existing command parser.
+
+    Bare invocations and gateway options use ``run`` as an implicit command. The explicit root
+    help forms and existing root subcommands remain unchanged, so the shortcut does not duplicate
+    or bypass the gateway command's option validation.
+
+    Args:
+        arguments: User-provided arguments after the ``exp`` executable name.
+
+    Returns:
+        Arguments suitable for the root Typer application.
+    """
+    if not arguments:
+        return ["run"]
+    if arguments[0] == "help":
+        return ["--help", *arguments[1:]]
+    if arguments[0] in {"--help", "-h"} or arguments[0] in _ROOT_COMMANDS:
+        return arguments
+    return ["run", *arguments]
+
 
 def _quiet_http_logs() -> None:
     """Cap noisy per-request loggers at WARNING."""
@@ -39,11 +64,12 @@ def main() -> None:
     """Load local environment settings, quiet HTTP logs, and dispatch the CLI.
 
     The explicit entrypoint keeps environment loading out of import time, so library imports
-    cannot mutate an operator's process environment.
+    cannot mutate an operator's process environment. A bare invocation is routed through the
+    existing gateway command while explicit root help remains available.
     """
     load_env_file()
     _quiet_http_logs()
-    app()
+    app(args=_dispatch_arguments(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -30,6 +30,7 @@ app.command("build", help="Build a reusable grounded world model from local trac
 app.command("run", help="Run the local gateway, optionally with one project-backed alias.")(run)
 
 _ROOT_COMMANDS = frozenset(("build", "config", "optimize", "run"))
+_ROOT_OPTIONS = frozenset(("--help", "-h", "--install-completion", "--show-completion"))
 
 
 def _dispatch_arguments(arguments: list[str]) -> list[str]:
@@ -49,7 +50,7 @@ def _dispatch_arguments(arguments: list[str]) -> list[str]:
         return ["run"]
     if arguments[0] == "help":
         return ["--help", *arguments[1:]]
-    if arguments[0] in {"--help", "-h"} or arguments[0] in _ROOT_COMMANDS:
+    if arguments[0] in _ROOT_OPTIONS or arguments[0] in _ROOT_COMMANDS:
         return arguments
     return ["run", *arguments]
 

--- a/exp/cli/app_test.py
+++ b/exp/cli/app_test.py
@@ -2,16 +2,59 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
+import pytest
 from typer import Context
 from typer.core import TyperGroup
 from typer.main import get_group
 
 from exp.cli.app import app
 
+app_module = import_module("exp.cli.app")
+
 EXPECTED_SUBCOMMANDS = {
     "config": {"budget", "gateway", "judge", "providers", "telemetry"},
     "optimize": {"model", "router"},
 }
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        ([], ["run"]),
+        (["--help"], ["--help"]),
+        (["help"], ["--help"]),
+        (["build", "--help"], ["build", "--help"]),
+        (["config", "gateway", "status"], ["config", "gateway", "status"]),
+        (["run", "project-a"], ["run", "project-a"]),
+        (["project-a", "--check"], ["run", "project-a", "--check"]),
+        (["--check", "--json"], ["run", "--check", "--json"]),
+    ],
+)
+def test_root_dispatch_preserves_help_and_existing_commands(
+    arguments: list[str],
+    expected: list[str],
+) -> None:
+    """Route bare gateway forms without changing root help or explicit subcommands."""
+    assert app_module._dispatch_arguments(arguments) == expected
+
+
+def test_main_routes_bare_invocation_through_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The installed entrypoint turns a bare invocation into the existing run command."""
+    captured: list[list[str]] = []
+
+    def capture_app(*, args: list[str]) -> None:
+        """Capture parsed arguments passed to the root application."""
+        captured.append(args)
+
+    monkeypatch.setattr(app_module, "app", capture_app)
+    monkeypatch.setattr(app_module, "load_env_file", lambda: None)
+    monkeypatch.setattr(app_module.sys, "argv", ["exp"])
+
+    app_module.main()
+
+    assert captured == [["run"]]
 
 
 def test_root_cli_and_subgroups_are_exact() -> None:

--- a/exp/cli/app_test.py
+++ b/exp/cli/app_test.py
@@ -25,6 +25,8 @@ EXPECTED_SUBCOMMANDS = {
         ([], ["run"]),
         (["--help"], ["--help"]),
         (["help"], ["--help"]),
+        (["--install-completion"], ["--install-completion"]),
+        (["--show-completion"], ["--show-completion"]),
         (["build", "--help"], ["build", "--help"]),
         (["config", "gateway", "status"], ["config", "gateway", "status"]),
         (["run", "project-a"], ["run", "project-a"]),

--- a/exp/tests/repo_layout_test.py
+++ b/exp/tests/repo_layout_test.py
@@ -36,6 +36,7 @@ ALLOWED_TOP_FILES = {
     "conftest.py",
     "justfile",
     "pyproject.toml",
+    "setup.md",
     "uv.lock",
 }
 


### PR DESCRIPTION
## Summary
- route bare `exp` gateway invocations through the existing `exp run` parser
- preserve `exp --help` and add `exp help` for root CLI help
- keep `exp run` compatibility and document the shortcut

## Validation
- `uv run pytest -q exp/cli/app_test.py exp/cli/tests/cli_help_test.py exp/cli/tests/startup_test.py exp/cli/run/app_test.py` — 34 passed
- `uv run pytest -q exp/optimize/router/tests/composition_evidence_test.py::test_w16_public_router_evidence_is_complete_replay_safe_and_openai_native exp/simulation/tests/comparison_evidence_test.py::test_w16_actual_text_and_local_process_comparison_preserves_failure_denominator` — 2 passed
- `uv run ruff check .`
- `uv run ruff format --check .`