### PR TITLE
Point Experiential Cloud setup at the hosted Platform gateway

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ results, and plans do not live here.
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata plus identity-only operator declaration. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
-| `reference/openai-compatible-recipes.md` | Verified Fireworks and Modal connection recipes through the openai-compatible provider family. |
+| `reference/openai-compatible-recipes.md` | Verified Fireworks, Modal, and Experiential Cloud connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -116,3 +116,29 @@ micro-USD prices from the active catalog. `exp config providers --provider opena
 reads those optional fields, converts micro-USD prices to USD per million tokens, and leaves
 unknown any field the catalog did not declare. It does not treat official OpenAI listing
 metadata the same way.
+
+## Experiential Cloud
+
+Experiential Cloud is the first-party hosted Platform lane, not a local gateway recipe. Customers
+call `https://api.experientiallabs.ai/v1` with a durable Platform `xpl_` key stored as
+`EXPLABS_API_KEY`. Setup does not prompt for a base URL and does not write a local `gateway.db`
+authority for this path.
+
+```bash
+export EXPLABS_API_KEY=...   # from https://platform.experientiallabs.ai/settings/api-keys
+
+exp config providers --provider experiential-cloud --root ROOT
+```
+
+Preview or staging may replace the origin with `EXP_GATEWAY_URL`. Non-interactive automation uses
+the frozen catalog provider:
+
+```bash
+exp config providers --non-interactive --root ROOT \
+  --connection-json '{"name":"experiential-cloud","provider":"openai-compatible","api_key_env":"EXPLABS_API_KEY","base_url":"https://api.experientiallabs.ai/v1"}' \
+  --model-json '...'
+```
+
+`exp config gateway call`, `models`, and `key check` already accept `--url` / `EXP_GATEWAY_URL`
+plus the Platform key. Use those as callers against the hosted gateway. Keep `exp run` and
+`exp config gateway` for genuine local or offline serving.

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -8,9 +8,15 @@ Configure connections with `exp config providers` or the first `exp build` on a 
 An interactive terminal opens a provider list: Up and Down move focus, Enter selects or deselects
 the focused provider, and the Complete row submits the selection. Agents skip that list with
 repeatable `--provider` flags (`openai`, `anthropic`, `gemini`, `openrouter`,
-`openai-compatible`, `azure`, `bedrock`). Unsupported or duplicate values fail before any catalog
-write. Azure and Bedrock still require manual model IDs. Other selected providers use account
-model discovery when credentials are available.
+`openai-compatible`, `azure`, `bedrock`, `experiential-cloud`). Unsupported or duplicate values
+fail before any catalog write. Azure and Bedrock still require manual model IDs. Other selected
+providers use account model discovery when credentials are available.
+
+`experiential-cloud` is a setup picker for the hosted Platform gateway. It persists
+`provider = "openai-compatible"` with `base_url` `https://api.experientiallabs.ai/v1` (or
+`EXP_GATEWAY_URL` when that override is set) and `api_key_env = "EXPLABS_API_KEY"`. The CLI does
+not rebuild a local gateway authority for that hosted path. Local `exp run` first-run setup keeps
+the offline provider list and does not offer Experiential Cloud.
 
 Setup writes only secret-free catalog fields and never prints a credential value. Interactive
 `exp config providers` persists pasted API keys outside the repository in the platform
@@ -41,6 +47,7 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 | Anthropic | `anthropic` | `api_key_env` (suggested `ANTHROPIC_API_KEY`) | Official Anthropic origin |
 | Gemini | `gemini` | `api_key_env` (suggested `GEMINI_API_KEY`) | Official Gemini origin |
 | OpenAI-compatible | `openai-compatible` | `api_key_env` plus explicit `base_url` | Catalog `base_url` |
+| Experiential Cloud | `openai-compatible` (picker `experiential-cloud`) | `EXPLABS_API_KEY` plus the hosted Platform `/v1` origin | `https://api.experientiallabs.ai/v1` or `EXP_GATEWAY_URL` |
 | Azure OpenAI / Foundry | `azure` | `api_key_env` plus explicit resource endpoint and `api_version` | Endpoint and API version |
 | Amazon Bedrock | `bedrock` | AWS credential chain. No `api_key_env` | Optional catalog `region` |
 | Tinker sampling | `tinker` | `api_key_env` | Official Tinker origin |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ The root surface is deliberately small:
 | `exp config gateway call ALIAS PROMPT [--json]` | Send one chat completion to a live gateway as a caller, streaming text to stdout. | One HTTP request against the running gateway; no local state. |
 | `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
 | `exp config gateway key check [--json]` | Validate one raw virtual key against a live gateway and print its granted aliases without storing the key. | One HTTP request against the running gateway; no local state. |
-| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. Interactive setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
+| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. `experiential-cloud` points at the hosted Platform gateway. Interactive setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
 | `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command (default `$50.00`). | Local `.exp/settings.toml`. |
 | `exp config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.exp/settings.toml`. |
 

--- a/exp/cli/build/app.py
+++ b/exp/cli/build/app.py
@@ -88,7 +88,7 @@ _PROVIDER_OPTION = typer.Option(
     help=(
         "Repeatable provider to configure during first-build setup. "
         "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
-        "azure, bedrock."
+        "azure, bedrock, experiential-cloud."
     ),
 )
 

--- a/exp/cli/config/app.py
+++ b/exp/cli/config/app.py
@@ -55,7 +55,7 @@ _PROVIDER_OPTION = typer.Option(
     help=(
         "Repeatable provider that skips the opening list during interactive setup. "
         "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
-        "azure, bedrock."
+        "azure, bedrock, experiential-cloud."
     ),
 )
 

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.text import Text
 
+from exp.cli.providers.experiential_cloud import SETUP_PICKER_NAME as HOSTED_SETUP_PICKER
 from exp.cli.providers.model_picker import GatewayModelSelection, select_gateway_model
 from exp.cli.providers.provider_picker import (
     AvailableModel,
@@ -96,6 +97,7 @@ def interactive_gateway_setup(
                 session,
                 console=console,
                 environment=environment,
+                exclude=frozenset({HOSTED_SETUP_PICKER}),
             )
             if selection is None:
                 raise typer.Abort()

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -9,6 +9,9 @@ import typer
 
 from exp.cli.gateway import setup
 from exp.cli.providers import model_picker, provider_picker
+from exp.cli.providers.experiential_cloud import SETUP_PICKER_LABEL, SETUP_PICKER_NAME
+
+_LOCAL_GATEWAY_EXCLUDE = frozenset({SETUP_PICKER_NAME})
 from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.config import load_settings
@@ -65,12 +68,16 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
     console = ScriptedConsole(f"{answer}\n\n")
 
     selected = provider_picker.select_providers(
-        provider_picker.SetupSession(), console=console, environment={}
+        provider_picker.SetupSession(),
+        console=console,
+        environment={},
+        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
     assert selected == ((provider,), provider in {"azure", "bedrock"})
     for expected in ("openai", "anthropic", "azure", "bedrock", "openai-compatible"):
         assert expected in console.output
+    assert SETUP_PICKER_LABEL not in console.output
 
 
 def test_gateway_provider_selector_accepts_multiple_providers() -> None:
@@ -78,7 +85,10 @@ def test_gateway_provider_selector_accepts_multiple_providers() -> None:
     console = ScriptedConsole("1,2,6,7\n\n")
 
     selected = provider_picker.select_providers(
-        provider_picker.SetupSession(), console=console, environment={}
+        provider_picker.SetupSession(),
+        console=console,
+        environment={},
+        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
     assert selected == (("openai", "anthropic", "azure", "bedrock"), True)
@@ -102,6 +112,7 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
         console=console,
         environment={},
         read_key=lambda: next(keys),
+        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
     assert selected == (("azure",), True)
@@ -302,6 +313,21 @@ def test_openai_compatible_provider_connection_collects_endpoint(
         base_url="https://gateway.example.test/v1",
     )
     assert connection.api_key_env is None
+
+
+def test_experiential_cloud_connection_uses_the_hosted_platform_gateway() -> None:
+    """Experiential Cloud does not collect a local base URL or credential name."""
+    connection = provider_picker.collect_provider_connection(
+        "experiential-cloud",
+        console=ScriptedConsole(""),
+        environment={},
+    )
+
+    assert connection == ConnectionConfig(
+        provider="openai-compatible",
+        base_url="https://api.experientiallabs.ai/v1",
+        api_key_env="EXPLABS_API_KEY",
+    )
 
 
 def test_bedrock_provider_connection_uses_the_aws_credential_chain(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -10,12 +10,12 @@ import typer
 from exp.cli.gateway import setup
 from exp.cli.providers import model_picker, provider_picker
 from exp.cli.providers.experiential_cloud import SETUP_PICKER_LABEL, SETUP_PICKER_NAME
-
-_LOCAL_GATEWAY_EXCLUDE = frozenset({SETUP_PICKER_NAME})
 from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.config import load_settings
 from exp.common.models import ConnectionConfig, ModelCapabilities, PricingSource, ProviderConnection
+
+_LOCAL_GATEWAY_EXCLUDE = frozenset({SETUP_PICKER_NAME})
 
 
 def _prepared_gateway_models() -> tuple[

--- a/exp/cli/providers/experiential_cloud.py
+++ b/exp/cli/providers/experiential_cloud.py
@@ -1,0 +1,35 @@
+"""Hosted Experiential Cloud connection for local CLI provider setup.
+
+Experiential Cloud is a setup picker for the hosted Platform gateway. The
+persisted catalog provider stays ``openai-compatible``: the CLI does not invent
+a new runtime provider family, and it does not rebuild a local gateway
+authority for this hosted path. Local ``exp run`` / ``exp config gateway``
+workflows stay available for genuine offline serving.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+SETUP_PICKER_NAME = "experiential-cloud"
+SETUP_PICKER_LABEL = "Experiential Cloud"
+CATALOG_PROVIDER = "openai-compatible"
+HOSTED_GATEWAY_DEFAULT_BASE_URL = "https://api.experientiallabs.ai/v1"
+HOSTED_GATEWAY_API_KEY_ENV = "EXPLABS_API_KEY"
+HOSTED_GATEWAY_URL_ENV = "EXP_GATEWAY_URL"
+
+
+def hosted_gateway_base_url(environment: Mapping[str, str] | None = None) -> str:
+    """Return the hosted Platform ``/v1`` origin for Experiential Cloud setup.
+
+    Args:
+        environment: Optional process environment. ``None`` reads ``os.environ``.
+
+    Returns:
+        ``EXP_GATEWAY_URL`` when that value is non-empty (preview or staging),
+        otherwise the production Platform origin.
+    """
+    source: Mapping[str, str] = os.environ if environment is None else environment
+    value = source.get(HOSTED_GATEWAY_URL_ENV, "").strip()
+    return value or HOSTED_GATEWAY_DEFAULT_BASE_URL

--- a/exp/cli/providers/experiential_cloud_test.py
+++ b/exp/cli/providers/experiential_cloud_test.py
@@ -1,0 +1,36 @@
+"""Hosted Experiential Cloud setup constants and origin resolution."""
+
+from __future__ import annotations
+
+from exp.cli.providers.experiential_cloud import (
+    CATALOG_PROVIDER,
+    HOSTED_GATEWAY_API_KEY_ENV,
+    HOSTED_GATEWAY_DEFAULT_BASE_URL,
+    HOSTED_GATEWAY_URL_ENV,
+    SETUP_PICKER_LABEL,
+    SETUP_PICKER_NAME,
+    hosted_gateway_base_url,
+)
+
+
+def test_picker_persists_the_hosted_openai_compatible_lane() -> None:
+    """The picker name is product copy; the catalog provider stays frozen."""
+    assert SETUP_PICKER_NAME == "experiential-cloud"
+    assert SETUP_PICKER_LABEL == "Experiential Cloud"
+    assert CATALOG_PROVIDER == "openai-compatible"
+    assert HOSTED_GATEWAY_API_KEY_ENV == "EXPLABS_API_KEY"
+    assert HOSTED_GATEWAY_DEFAULT_BASE_URL == "https://api.experientiallabs.ai/v1"
+
+
+def test_hosted_origin_defaults_to_production_and_honors_override() -> None:
+    """Empty override keeps production; preview or staging may replace it."""
+    assert hosted_gateway_base_url({}) == HOSTED_GATEWAY_DEFAULT_BASE_URL
+    assert hosted_gateway_base_url({HOSTED_GATEWAY_URL_ENV: "  "}) == (
+        HOSTED_GATEWAY_DEFAULT_BASE_URL
+    )
+    assert (
+        hosted_gateway_base_url(
+            {HOSTED_GATEWAY_URL_ENV: "https://api.staging.experientiallabs.ai/v1"}
+        )
+        == "https://api.staging.experientiallabs.ai/v1"
+    )

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -12,13 +12,20 @@ Providers without a safe listing API keep manual declaration on the model screen
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from getpass import getpass
 
 from rich.console import Console
 from rich.prompt import Confirm, IntPrompt, Prompt
 
+from exp.cli.providers.experiential_cloud import (
+    CATALOG_PROVIDER as HOSTED_CATALOG_PROVIDER,
+    HOSTED_GATEWAY_API_KEY_ENV,
+    SETUP_PICKER_LABEL as HOSTED_SETUP_LABEL,
+    SETUP_PICKER_NAME as HOSTED_SETUP_PICKER,
+    hosted_gateway_base_url,
+)
 from exp.cli.shared.picker import (
     PickerAction,
     PickerKeyReader,
@@ -59,6 +66,7 @@ SETUP_PROVIDER_LABELS = {
     "openai-compatible": "openai-compatible",
     "azure": "azure",
     "bedrock": "bedrock",
+    HOSTED_SETUP_PICKER: HOSTED_SETUP_LABEL,
 }
 CANONICAL_CREDENTIAL_ENV = CANONICAL_API_KEY_ENV
 _MANUAL_MODEL_PROVIDERS = frozenset({"azure", "bedrock"})
@@ -231,6 +239,7 @@ def select_providers(
     environment: MutableMapping[str, str],
     configured: bool = False,
     read_key: PickerKeyReader | None = None,
+    exclude: frozenset[str] = frozenset(),
 ) -> tuple[tuple[str, ...], bool] | None:
     """Show the one provider screen that opens setup.
 
@@ -241,6 +250,8 @@ def select_providers(
         configured: Whether the catalog already holds usable models, which makes provider
             selection optional so roles can be edited offline.
         read_key: Optional keyboard source used by tests instead of the controlling terminal.
+        exclude: Provider keys omitted from this screen. Local gateway first-run
+            hides Experiential Cloud so it cannot wrap the hosted Platform path.
 
     Returns:
         Selected providers plus whether manual model declaration is needed, or ``None`` when the
@@ -250,6 +261,7 @@ def select_providers(
     options = [
         PickerOption(value=provider, label=label)
         for provider, label in SETUP_PROVIDER_LABELS.items()
+        if provider not in exclude
     ]
     if configured:
         options.insert(
@@ -313,12 +325,15 @@ def collect_provider_connection(
     provider: str,
     *,
     console: Console,
+    environment: Mapping[str, str] | None = None,
 ) -> ConnectionConfig | None:
     """Collect the provider-specific connection metadata shared by setup entry points.
 
     Args:
         provider: Supported provider selected on the shared provider screen.
         console: Terminal used for provider-specific fields.
+        environment: Optional process environment. Experiential Cloud reads
+            ``EXP_GATEWAY_URL`` from it; other providers ignore it.
 
     Returns:
         Secret-free connection metadata, or ``None`` when an optional endpoint field is skipped.
@@ -328,6 +343,12 @@ def collect_provider_connection(
     """
     if provider not in SETUP_PROVIDER_LABELS:
         raise ValueError(f"unsupported provider {provider!r}")
+    if provider == HOSTED_SETUP_PICKER:
+        return ConnectionConfig(
+            provider=HOSTED_CATALOG_PROVIDER,
+            api_key_env=HOSTED_GATEWAY_API_KEY_ENV,
+            base_url=hosted_gateway_base_url(environment),
+        )
     base_url = None
     api_version = None
     region = None
@@ -431,6 +452,7 @@ def prepare_providers(
             not discovered
             and provider not in _MANUAL_MODEL_PROVIDERS
             and provider not in configured_providers
+            and endpoint.connection.provider not in configured_providers
             and not session.advanced_models
         ):
             console.print(f"[yellow]Skipping {label}.[/yellow]")
@@ -470,12 +492,12 @@ def _resolve_endpoint(
         SetupCancelled: The user cancelled setup at a prompt.
     """
     label = SETUP_PROVIDER_LABELS[provider]
-    config = collect_provider_connection(provider, console=console)
+    config = collect_provider_connection(provider, console=console, environment=environment)
     if config is None:
         return None
     connection = _reused_connection(
         existing_connections,
-        provider=provider,
+        provider=config.provider,
         api_key_env=config.api_key_env,
         base_url=config.base_url,
         api_version=config.api_version,
@@ -486,8 +508,8 @@ def _resolve_endpoint(
         name = derive_connection_name(provider, taken_names)
         connection = ProviderConnection(
             name=name,
-            provider=provider,
-            api_key_env=config.api_key_env or derived_api_key_env(provider, name),
+            provider=config.provider,
+            api_key_env=config.api_key_env or derived_api_key_env(config.provider, name),
             base_url=config.base_url,
             api_version=config.api_version,
             region=config.region,
@@ -693,8 +715,9 @@ def _discover_models(
         SetupCancelled: The user cancelled setup during recovery.
     """
     label = SETUP_PROVIDER_LABELS[provider]
+    runtime_provider = endpoint.connection.provider
     request = ProviderEndpoint(
-        provider=provider,
+        provider=runtime_provider,
         api_key=endpoint.api_key,
         base_url=endpoint.connection.base_url,
     )
@@ -723,7 +746,7 @@ def _discover_models(
                         configured=endpoint.configured,
                     )
                     request = ProviderEndpoint(
-                        provider=provider,
+                        provider=runtime_provider,
                         api_key=api_key,
                         base_url=endpoint.connection.base_url,
                     )
@@ -739,13 +762,13 @@ def _discover_models(
         resolved = tuple(resolve_discovered_model(model) for model in discovered)
         verified = _canonical_models(
             tuple(model for model in resolved if served_roles(model.capabilities)),
-            provider=provider,
+            provider=runtime_provider,
         )
         unknown = _canonical_models(
             tuple(model for model in resolved if not served_roles(model.capabilities)),
-            provider=provider,
+            provider=runtime_provider,
         )
-        if provider not in _OPERATOR_DECLARED_PROVIDERS:
+        if runtime_provider not in _OPERATOR_DECLARED_PROVIDERS:
             unknown = ()
         if not verified and not unknown:
             console.print(f"[yellow]{label} published no model with verified metadata.[/yellow]")
@@ -754,9 +777,11 @@ def _discover_models(
                 continue
             return _ProviderDiscoveryResult(endpoint, ()) if recovery == _RECOVERY_SKIP else None
         fresh_verified = _fresh_models(
-            verified, provider=provider, configured=configured_identities
+            verified, provider=runtime_provider, configured=configured_identities
         )
-        fresh_unknown = _fresh_models(unknown, provider=provider, configured=configured_identities)
+        fresh_unknown = _fresh_models(
+            unknown, provider=runtime_provider, configured=configured_identities
+        )
         if not fresh_verified and not fresh_unknown:
             console.print(f"  [green]\u2713[/green] {label}: models already configured")
             return _ProviderDiscoveryResult(endpoint, ())
@@ -765,14 +790,14 @@ def _discover_models(
         )
         models = []
         for model in (*fresh_verified, *fresh_unknown):
-            alias = derive_model_alias(provider, model.model, frozenset(aliases))
+            alias = derive_model_alias(runtime_provider, model.model, frozenset(aliases))
             aliases.add(alias)
             verified_row = served_roles(model.capabilities)
             models.append(
                 AvailableModel(
                     alias=alias,
                     connection=endpoint.connection.name,
-                    provider=provider,
+                    provider=runtime_provider,
                     model=model.model,
                     capabilities=model.capabilities if verified_row else None,
                     pricing_source=(

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -21,10 +21,16 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 
 from exp.cli.providers.experiential_cloud import (
     CATALOG_PROVIDER as HOSTED_CATALOG_PROVIDER,
+)
+from exp.cli.providers.experiential_cloud import (
     HOSTED_GATEWAY_API_KEY_ENV,
-    SETUP_PICKER_LABEL as HOSTED_SETUP_LABEL,
-    SETUP_PICKER_NAME as HOSTED_SETUP_PICKER,
     hosted_gateway_base_url,
+)
+from exp.cli.providers.experiential_cloud import (
+    SETUP_PICKER_LABEL as HOSTED_SETUP_LABEL,
+)
+from exp.cli.providers.experiential_cloud import (
+    SETUP_PICKER_NAME as HOSTED_SETUP_PICKER,
 )
 from exp.cli.shared.picker import (
     PickerAction,

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -1044,6 +1044,29 @@ def test_bedrock_prepares_credential_chain_without_listing_or_identity_invention
     assert "declare deployment model IDs" in console.output
 
 
+def test_release_tty_walk_selects_azure_then_completes() -> None:
+    """The installed-wheel provider walk still lands on Azure, then Complete."""
+    keys = iter(
+        (
+            *(PickerKey.DOWN for _ in range(5)),
+            PickerKey.ENTER,
+            *(PickerKey.DOWN for _ in range(3)),
+            PickerKey.ENTER,
+        )
+    )
+    console = ScriptedConsole("")
+
+    selection = select_providers(
+        SetupSession(),
+        console=console,
+        environment={},
+        read_key=lambda: next(keys),
+    )
+
+    assert selection == (("azure",), True)
+    assert "Experiential Cloud" in console.output
+
+
 def test_azure_and_bedrock_force_explicit_manual_model_declaration() -> None:
     """Providers without a safe listing API make the manual model row available explicitly."""
     console = ScriptedConsole("6,7\n\n")

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -7,6 +7,11 @@ from pathlib import Path
 import pytest
 
 from exp.cli.providers import provider_picker
+from exp.cli.providers.experiential_cloud import (
+    HOSTED_GATEWAY_API_KEY_ENV,
+    HOSTED_GATEWAY_DEFAULT_BASE_URL,
+    HOSTED_GATEWAY_URL_ENV,
+)
 from exp.cli.providers.provider_picker import (
     SetupCancelled,
     SetupSession,
@@ -181,7 +186,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
             PickerKey.ENTER,
             PickerKey.DOWN,
             PickerKey.ENTER,
-            *(PickerKey.DOWN for _ in range(6)),
+            *(PickerKey.DOWN for _ in range(7)),
             PickerKey.ENTER,
         )
     )
@@ -1066,3 +1071,104 @@ def test_no_prepared_provider_returns_to_the_provider_screen(
 
     assert prepared is None
     assert "No provider was prepared" in console.output
+
+
+def test_experiential_cloud_persists_the_hosted_platform_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Experiential Cloud writes openai-compatible plus the Platform origin."""
+
+    def _fail_prompt(_label: str, **_kwargs: object) -> str:
+        """Fail if setup asks for a local endpoint or credential variable."""
+        raise AssertionError(f"unexpected prompt: {_label}")
+
+    monkeypatch.setattr(provider_picker, "ask_text", _fail_prompt)
+    connection = provider_picker.collect_provider_connection(
+        "experiential-cloud",
+        console=ScriptedConsole(""),
+        environment={},
+    )
+
+    assert connection is not None
+    assert connection.provider == "openai-compatible"
+    assert connection.base_url == HOSTED_GATEWAY_DEFAULT_BASE_URL
+    assert connection.api_key_env == HOSTED_GATEWAY_API_KEY_ENV
+
+
+def test_experiential_cloud_honors_the_hosted_gateway_url_override() -> None:
+    """Preview or staging may replace the production Platform origin."""
+    connection = provider_picker.collect_provider_connection(
+        "experiential-cloud",
+        console=ScriptedConsole(""),
+        environment={HOSTED_GATEWAY_URL_ENV: "https://api-pr-12.preview.experientiallabs.ai/v1"},
+    )
+
+    assert connection is not None
+    assert connection.base_url == "https://api-pr-12.preview.experientiallabs.ai/v1"
+
+
+def test_experiential_cloud_lists_through_the_openai_compatible_family() -> None:
+    """Discovery uses the persisted provider so Platform listing metadata applies."""
+    console = ScriptedConsole("")
+    lister = _FakeLister(
+        {
+            "openai-compatible": [
+                (
+                    DiscoveredModel(
+                        provider="openai-compatible",
+                        model="deepseek-v4-flash",
+                        supports_completions=True,
+                        supports_structured_output=True,
+                        input_cost_per_million_tokens_usd=0.072,
+                        output_cost_per_million_tokens_usd=0.162,
+                    ),
+                )
+            ]
+        }
+    )
+
+    prepared = _prepare(
+        console,
+        providers=("experiential-cloud",),
+        lister=lister,
+        environment={HOSTED_GATEWAY_API_KEY_ENV: "xpl_test_key"},
+    )
+
+    assert prepared is not None
+    endpoints, models = prepared
+    assert len(endpoints) == 1
+    assert endpoints[0].connection.name == "experiential-cloud"
+    assert endpoints[0].connection.provider == "openai-compatible"
+    assert endpoints[0].connection.base_url == HOSTED_GATEWAY_DEFAULT_BASE_URL
+    assert endpoints[0].connection.api_key_env == HOSTED_GATEWAY_API_KEY_ENV
+    assert lister.requests == [
+        ProviderEndpoint(
+            provider="openai-compatible",
+            api_key="xpl_test_key",
+            base_url=HOSTED_GATEWAY_DEFAULT_BASE_URL,
+        )
+    ]
+    assert [model.model for model in models] == ["deepseek-v4-flash"]
+    assert models[0].provider == "openai-compatible"
+    assert models[0].capabilities is not None
+    assert serves_role(models[0].capabilities, SetupRole.WORLD_MODEL)
+    assert "xpl_test_key" not in console.output
+    assert "https://gateway.example.test" not in console.output
+
+
+def test_resolve_setup_providers_accepts_experiential_cloud() -> None:
+    """The hosted picker is a first-class --provider value."""
+    assert resolve_setup_providers(("experiential-cloud", "openai")) == (
+        "openai",
+        "experiential-cloud",
+    )
+
+
+def test_provider_screen_lists_experiential_cloud() -> None:
+    """Builder setup shows the hosted Platform picker as its own row."""
+    console = ScriptedConsole("8\n\n")
+
+    selection = select_providers(SetupSession(), console=console, environment={})
+
+    assert selection == (("experiential-cloud",), False)
+    assert "Experiential Cloud" in console.output

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -286,7 +286,8 @@ def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_pa
     assert "unsupported --provider value 'not-a-provider'" in output
     assert "duplicate --provider value 'openai'" in output
     assert (
-        "choose from: openai, anthropic, gemini, openrouter, openai-compatible, azure, bedrock"
+        "choose from: openai, anthropic, gemini, openrouter, openai-compatible, azure, "
+        "bedrock, experiential-cloud"
         in output
     )
     assert "Select the providers you want to use" not in output

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -287,8 +287,7 @@ def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_pa
     assert "duplicate --provider value 'openai'" in output
     assert (
         "choose from: openai, anthropic, gemini, openrouter, openai-compatible, azure, "
-        "bedrock, experiential-cloud"
-        in output
+        "bedrock, experiential-cloud" in output
     )
     assert "Select the providers you want to use" not in output
     assert not (root / "models.toml").exists()

--- a/exp/cli/tests/openai_compatible_recipes_test.py
+++ b/exp/cli/tests/openai_compatible_recipes_test.py
@@ -9,6 +9,11 @@ import pytest
 from typer.testing import CliRunner
 
 from exp.cli.app import app
+from exp.cli.providers.experiential_cloud import (
+    HOSTED_GATEWAY_API_KEY_ENV,
+    HOSTED_GATEWAY_DEFAULT_BASE_URL,
+    SETUP_PICKER_NAME,
+)
 
 FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1"
 _RECIPES_DOC = Path(__file__).parents[3] / "docs" / "reference" / "openai-compatible-recipes.md"
@@ -208,6 +213,10 @@ def test_recipes_doc_pins_the_verified_constants_and_is_indexed() -> None:
     assert "exp config gateway provider add" in doc
     assert "--provider openai-compatible" in doc.replace(" \\\n  ", " ")
     assert "hosted Experiential gateway" in doc
+    assert HOSTED_GATEWAY_DEFAULT_BASE_URL in doc
+    assert HOSTED_GATEWAY_API_KEY_ENV in doc
+    assert f"--provider {SETUP_PICKER_NAME}" in doc
+    assert "does not write a local `gateway.db`" in doc
     assert "identity-only" in doc
     assert "unknown" in doc
     assert "micro-USD prices" in doc

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -2463,7 +2463,9 @@ def _installed_release_driver() -> None:
     setup_answers = [
         (
             "Providers",
-            (down * 5) + enter + (down * 2) + enter,
+            # openai through openai-compatible, then Azure; Complete is after
+            # Bedrock and Experiential Cloud.
+            (down * 5) + enter + (down * 3) + enter,
         ),
         ("azure base URL", azure_endpoint),
         ("Azure OpenAI API version", ""),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an **Experiential Cloud** setup picker so local CLI clients consume the hosted Platform gateway and a Platform-issued `xpl_` key. The CLI does not invent a new runtime provider family and does not rebuild a local gateway authority for this hosted path.

Companion Platform PR: https://github.com/experientiallabs/platform/pull/618

## What this does

- Picker name `experiential-cloud`, label **Experiential Cloud**.
- Persists `provider = "openai-compatible"` with `base_url` `https://api.experientiallabs.ai/v1` (or `EXP_GATEWAY_URL` for preview/staging) and `api_key_env = "EXPLABS_API_KEY"`.
- Discovery lists through the openai-compatible family so Platform `/v1/models` capability and micro-USD price extensions apply.
- `exp config providers` and first-build `--provider` accept `experiential-cloud`.
- Local `exp run` / `exp config gateway` first-run setup keeps the offline provider list and does not offer Experiential Cloud. Genuine local/offline serving is unchanged.

## Tests

- Picker constants and origin override
- Collection writes the hosted Platform lane without prompting for a base URL
- Discovery uses `openai-compatible` and never prints the key
- `--provider` help/error list includes `experiential-cloud`
- Local gateway selector still hides the hosted picker
- Recipe doc pins the production origin and `EXPLABS_API_KEY`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-372b67b1-74fb-4f60-905a-e23ab1369f8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-372b67b1-74fb-4f60-905a-e23ab1369f8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

