### PR TITLE
Name gateway authority metadata after Experiential

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -155,13 +155,13 @@ emitted only after an execution snapshot exists. Stable public IDs do not expose
 idempotency, request, or provider values.
 
 `GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
-enriched with a `wmo` object carrying the alias revision and catalog digest of the granted
+enriched with an `exp` object carrying the alias revision and catalog digest of the granted
 authority. When that alias revision targets exactly one direct singleton pool, the same object
 also carries optional extension fields copied from that pool's deployment: `supports_completions`,
 `supports_tools`, `supports_structured_output`, `maximum_output_tokens`, `context_window_tokens`
 when the catalog declares a window, and a `pricing` object of configured micro-USD-per-million-token
 rates. The gateway never invents a context window or a cache-write price, and it never hard-codes
-hosted alias names. Its list envelope carries `wmo.authority_schema_version`, including when `data` is
+hosted alias names. Its list envelope carries `exp.authority_schema_version`, including when `data` is
 empty, so caller-side key validation can distinguish this gateway from a generic OpenAI proxy.
 `GET /v1/models/{model_id}` describes one granted alias with the same object and
 returns the identical `model_not_found` 404 for every other model ID, so the route never confirms

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -88,7 +88,7 @@ published or operator-declared context window and both cache prices. The gateway
 those values, and setup never infers them.
 
 The hosted gateway `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`,
-and the four OpenAI model keys) and only adds these extension fields plus the existing `wmo`
+and the four OpenAI model keys) and only adds these extension fields plus the existing `exp`
 authority marker.
 
 ## Azure

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -101,7 +101,7 @@ def caller_models(
         return
     for model in _listed_models(response):
         identity = str(model.get("id", ""))
-        authority = model.get("wmo")
+        authority = model.get("exp")
         if isinstance(authority, dict) and "alias_revision_id" in authority:
             typer.echo(f"{identity} (revision {authority['alias_revision_id']})")
         else:
@@ -416,7 +416,7 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
         return None
     if not isinstance(payload, dict) or payload.get("object") != "list":
         return None
-    authority_marker = payload.get("wmo")
+    authority_marker = payload.get("exp")
     if (
         not isinstance(authority_marker, dict)
         or authority_marker.get("authority_schema_version") != 1
@@ -448,11 +448,11 @@ def _is_authority_model(model: JsonObject) -> bool:
     if (
         model.get("object") != "model"
         or model.get("created") != 0
-        or model.get("owned_by") != "wmo"
+        or model.get("owned_by") != "exp"
     ):
         return False
     model_id = model.get("id")
-    authority = model.get("wmo")
+    authority = model.get("exp")
     if not isinstance(model_id, str) or not model_id or not isinstance(authority, dict):
         return False
     revision = authority.get("alias_revision_id")

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -251,11 +251,11 @@ def test_models_prints_the_caller_view_with_granted_revisions(
                 "id": "coding",
                 "object": "model",
                 "created": 0,
-                "owned_by": "wmo",
-                "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+                "owned_by": "exp",
+                "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
             }
         ],
-        "wmo": {"authority_schema_version": 1},
+        "exp": {"authority_schema_version": 1},
     }
 
     def respond(request: httpx.Request) -> httpx.Response:
@@ -292,14 +292,14 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
                         "id": "coding",
                         "object": "model",
                         "created": 0,
-                        "owned_by": "wmo",
-                        "wmo": {
+                        "owned_by": "exp",
+                        "exp": {
                             "alias_revision_id": "revision-one",
                             "catalog_sha256": "a" * 64,
                         },
                     }
                 ],
-                "wmo": {"authority_schema_version": 1},
+                "exp": {"authority_schema_version": 1},
             },
         )
 
@@ -372,7 +372,7 @@ def test_key_check_accepts_a_gateway_authority_envelope_with_no_grants(
             json={
                 "object": "list",
                 "data": [],
-                "wmo": {"authority_schema_version": 1},
+                "exp": {"authority_schema_version": 1},
             },
         )
 

--- a/exp/runtime/gateway/discovery.py
+++ b/exp/runtime/gateway/discovery.py
@@ -141,7 +141,7 @@ def public_model_object(
 ) -> JsonObject:
     """Build one OpenAI model object enriched with granted authority and catalog fields.
 
-    The four OpenAI keys keep their exact meaning for official clients. The ``wmo``
+    The four OpenAI keys keep their exact meaning for official clients. The ``exp``
     object carries only authority metadata the gateway already exposes to callers
     through response headers and grants, never provider or credential detail.
     Optional capability, limit, and price fields are catalog copies, never guesses.
@@ -158,8 +158,8 @@ def public_model_object(
         "id": alias,
         "object": "model",
         "created": 0,
-        "owned_by": "wmo",
-        "wmo": {"alias_revision_id": revision, "catalog_sha256": digest},
+        "owned_by": "exp",
+        "exp": {"alias_revision_id": revision, "catalog_sha256": digest},
     }
     if metadata is not None:
         payload.update(metadata.extension_fields())
@@ -186,7 +186,7 @@ def public_model_list(
             public_model_object(authority, metadata=published.get(authority[0]))
             for authority in authorities
         ],
-        "wmo": {"authority_schema_version": MODEL_AUTHORITY_SCHEMA_VERSION},
+        "exp": {"authority_schema_version": MODEL_AUTHORITY_SCHEMA_VERSION},
     }
 
 

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -18,12 +18,12 @@ from exp.runtime.gateway.discovery import (
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 _AUTHORITY = ("coding", "revision-one", "a" * 64)
-_WMO_LISTING_CONTRACT = {
+_EXP_LISTING_CONTRACT = {
     "id": "coding",
     "object": "model",
     "created": 0,
-    "owned_by": "wmo",
-    "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+    "owned_by": "exp",
+    "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
     "supports_completions": True,
     "supports_tools": True,
     "supports_structured_output": True,
@@ -70,8 +70,8 @@ def test_public_model_object_keeps_the_openai_keys_and_adds_authority() -> None:
         "id": "coding",
         "object": "model",
         "created": 0,
-        "owned_by": "wmo",
-        "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+        "owned_by": "exp",
+        "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
     }
 
 
@@ -80,7 +80,7 @@ def test_public_model_list_marks_even_an_empty_authority_envelope() -> None:
     assert public_model_list(()) == {
         "object": "list",
         "data": [],
-        "wmo": {"authority_schema_version": 1},
+        "exp": {"authority_schema_version": 1},
     }
 
 
@@ -125,7 +125,7 @@ def test_public_model_object_copies_catalog_capabilities_limits_and_prices() -> 
 
     payload = public_model_object(_AUTHORITY, metadata=metadata)
 
-    assert payload == _WMO_LISTING_CONTRACT
+    assert payload == _EXP_LISTING_CONTRACT
     assert "context_window_tokens" not in payload
     assert "cache_write" not in str(payload)
 
@@ -162,8 +162,8 @@ def test_missing_deployment_publishes_no_extension_fields() -> None:
         "id": "coding",
         "object": "model",
         "created": 0,
-        "owned_by": "wmo",
-        "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
+        "owned_by": "exp",
+        "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
     }
 
 
@@ -187,8 +187,8 @@ def test_public_model_list_attaches_per_alias_catalog_metadata() -> None:
 
     assert public_model_list((_AUTHORITY,), metadata_by_alias={"coding": metadata}) == {
         "object": "list",
-        "data": [_WMO_LISTING_CONTRACT],
-        "wmo": {"authority_schema_version": 1},
+        "data": [_EXP_LISTING_CONTRACT],
+        "exp": {"authority_schema_version": 1},
     }
 
 

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -252,8 +252,8 @@ def test_local_gateway_preflights_real_state_and_serves_health_and_usage(
         assert detail.status_code == 200
         assert detail.json() == models.json()["data"][0]
         assert detail.json()["object"] == "model"
-        assert detail.json()["wmo"]["alias_revision_id"]
-        assert detail.json()["wmo"]["catalog_sha256"]
+        assert detail.json()["exp"]["alias_revision_id"]
+        assert detail.json()["exp"]["catalog_sha256"]
         missing = client.get(
             "/v1/models/ungranted",
             headers={"Authorization": f"Bearer {raw_key}"},
@@ -426,10 +426,10 @@ def test_live_alias_revision_update_hot_reloads_discovery_without_restart(
             headers={"Authorization": f"Bearer {raw_key}"},
         )
 
-    assert initial.json()["wmo"]["alias_revision_id"] == "revision-one"
+    assert initial.json()["exp"]["alias_revision_id"] == "revision-one"
     assert [item["id"] for item in reloaded.json()["data"]] == ["coding"]
     assert detail.status_code == 200
-    assert detail.json()["wmo"]["alias_revision_id"] == "revision-two"
+    assert detail.json()["exp"]["alias_revision_id"] == "revision-two"
     connection = sqlite3.connect(manager.database_path)
     try:
         assert connection.execute("SELECT COUNT(*) FROM gateway_requests").fetchone()[0] == 0
@@ -505,7 +505,7 @@ def test_unrelated_invalid_snapshot_does_not_block_a_valid_alias_reload(tmp_path
 
     assert [item["id"] for item in models.json()["data"]] == ["coding"]
     assert detail.status_code == 200
-    assert detail.json()["wmo"]["alias_revision_id"] == "revision-two"
+    assert detail.json()["exp"]["alias_revision_id"] == "revision-two"
     assert broken.status_code == 503
     assert broken.json()["error"]["code"] == "unavailable_route"
 
@@ -576,7 +576,7 @@ def test_broken_project_sibling_does_not_block_a_valid_alias_reload(tmp_path: Pa
 
     assert [item["id"] for item in models.json()["data"]] == ["coding"]
     assert detail.status_code == 200
-    assert detail.json()["wmo"]["alias_revision_id"] == "revision-two"
+    assert detail.json()["exp"]["alias_revision_id"] == "revision-two"
     assert broken.status_code == 503
     assert broken.json()["error"]["code"] == "unavailable_route"
 
@@ -629,7 +629,7 @@ def test_invalid_new_revision_fails_closed_and_recovers_after_fix(tmp_path: Path
     assert unavailable.json()["error"]["code"] == "unavailable_route"
     assert hidden.json()["data"] == []
     assert recovered.status_code == 200
-    assert recovered.json()["wmo"]["alias_revision_id"] == "revision-repaired"
+    assert recovered.json()["exp"]["alias_revision_id"] == "revision-repaired"
     connection = sqlite3.connect(manager.database_path)
     try:
         assert connection.execute("SELECT COUNT(*) FROM gateway_attempts").fetchone()[0] == 0
@@ -755,7 +755,7 @@ def test_alias_update_serves_new_model_while_in_flight_requests_finish_on_old(
         assert first_contents == ["old-model-canary"]
         assert second.status_code == 200
         assert second.json()["choices"][0]["message"]["content"] == "new-model-canary"
-        assert detail.json()["wmo"]["alias_revision_id"] == "revision-two"
+        assert detail.json()["exp"]["alias_revision_id"] == "revision-two"
         assert dispatched == ["provider-model-exact", "provider-model-next"]
         with sqlite3.connect(manager.database_path) as connection:
             attempts = connection.execute(
@@ -953,8 +953,8 @@ def test_concurrent_traffic_survives_pool_recertification_hot_swap(tmp_path: Pat
         assert solo_contents == {"solo-model"}
         assert dispatched[-1] in {"beta-model", "solo-model"}
         assert "beta-model" in dispatched
-        assert detail.json()["wmo"]["alias_revision_id"] == "rev-chat-2"
-        assert solo_detail.json()["wmo"]["alias_revision_id"] == "rev-solo-1"
+        assert detail.json()["exp"]["alias_revision_id"] == "rev-chat-2"
+        assert solo_detail.json()["exp"]["alias_revision_id"] == "rev-solo-1"
     finally:
         server.shutdown()
         server.server_close()

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -1620,8 +1620,8 @@ def test_model_discovery_is_enriched_and_detail_is_not_an_existence_oracle() -> 
             "id": "public-model",
             "object": "model",
             "created": 0,
-            "owned_by": "wmo",
-            "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
+            "owned_by": "exp",
+            "exp": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
         }
         transport = httpx.ASGITransport(app=create_gateway_app(service))
         async with httpx.AsyncClient(transport=transport, base_url="http://gateway") as client:
@@ -1635,7 +1635,7 @@ def test_model_discovery_is_enriched_and_detail_is_not_an_existence_oracle() -> 
         assert listed.json() == {
             "object": "list",
             "data": [expected],
-            "wmo": {"authority_schema_version": 1},
+            "exp": {"authority_schema_version": 1},
         }
         assert granted.status_code == 200
         assert granted.json() == expected
@@ -1710,8 +1710,8 @@ def test_model_discovery_publishes_the_revision_direct_pool_not_a_name_match() -
             "id": "public-model",
             "object": "model",
             "created": 0,
-            "owned_by": "wmo",
-            "wmo": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
+            "owned_by": "exp",
+            "exp": {"alias_revision_id": "revision-one", "catalog_sha256": digest},
             "supports_completions": True,
             "supports_tools": True,
             "supports_structured_output": True,
@@ -1726,7 +1726,7 @@ def test_model_discovery_publishes_the_revision_direct_pool_not_a_name_match() -
         assert listed.json() == {
             "object": "list",
             "data": [expected],
-            "wmo": {"authority_schema_version": 1},
+            "exp": {"authority_schema_version": 1},
         }
         assert granted.status_code == 200
         assert granted.json() == expected

--- a/exp/runtime/models/providers/listing_test.py
+++ b/exp/runtime/models/providers/listing_test.py
@@ -123,7 +123,7 @@ def test_openai_listing_discards_optional_entry_metadata() -> None:
     assert model.input_cost_per_million_tokens_usd is None
 
 
-def test_openai_compatible_listing_reads_validated_wmo_gateway_metadata() -> None:
+def test_openai_compatible_listing_reads_validated_exp_gateway_metadata() -> None:
     """The hosted gateway contract supplies capabilities, limits, and micro-USD prices."""
     transport = _transport(
         _ok(
@@ -133,8 +133,8 @@ def test_openai_compatible_listing_reads_validated_wmo_gateway_metadata() -> Non
                         "id": "coding",
                         "object": "model",
                         "created": 0,
-                        "owned_by": "wmo",
-                        "wmo": {
+                        "owned_by": "exp",
+                        "exp": {
                             "alias_revision_id": "revision-one",
                             "catalog_sha256": "a" * 64,
                         },


### PR DESCRIPTION
## Summary

- Publish owned_by: exp from the Experiential gateway model endpoints.
- Move immutable alias authority metadata from the stale wmo extension namespace to exp.
- Keep the gateway caller, model listing, and live reload contract tests aligned with the owning package.

## Validation

- UV_CACHE_DIR=/tmp/.uv-cache uv run ruff format --check .
- UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check .
- UV_CACHE_DIR=/tmp/.uv-cache uv run ty check
- Focused gateway/caller suite: 87 passed.
- Full suite: 2113 passed, 2 skipped. Eighteen unrelated terminal and release-evidence failures remain: PTY redraw checks on this host and dirty-checkout evidence tests. The gateway lifecycle contract failures caused by the old namespace were corrected by this PR.