### PR TITLE
Give exp run an exact credential remediation command

### DIFF
--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -225,8 +225,8 @@ def test_first_run_delivers_credentials_before_readiness_failure(
         raise ValueError(
             "no granted active alias is locally available: "
             "gpt-5-6-luna (connection credential environment variable "
-            "'OPENAI_API_KEY' is not set); fix the listed provider configuration and rerun "
-            "'exp'"
+            "'OPENAI_API_KEY' is not set); run "
+            "'OPENAI_API_KEY=YOUR_API_KEY exp'"
         )
 
     @contextmanager
@@ -268,5 +268,5 @@ def test_first_run_delivers_credentials_before_readiness_failure(
     assert f"export EXP_GATEWAY_KEY={raw_key}" in transcript
     assert "export OPENAI_API_KEY" not in transcript
     assert "First-run gateway setup completed, but the gateway is not ready." in transcript
-    assert "fix the listed provider configuration and rerun 'exp'" in str(failure.value)
+    assert "run 'OPENAI_API_KEY=YOUR_API_KEY exp'" in str(failure.value)
     assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -56,7 +56,7 @@ from exp.runtime.gateway.service import GatewayService
 from exp.runtime.gateway.sqlite.store import SQLiteGatewayStore, SystemGatewayClock
 from exp.runtime.gateway.usage import read_usage_report
 from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
-from exp.runtime.models.credentials import ModelCredentialError
+from exp.runtime.models.credentials import MissingModelCredentialError, ModelCredentialError
 from exp.runtime.openai_protocol.state import ResponseContinuationStore, ResponseReplayStore
 from exp.runtime.router.errors import RouterApplicationError
 from exp.runtime.router.runtime import DecisionSink, RouterRuntime, RouterRuntimeIntegrityError
@@ -600,6 +600,7 @@ def _load_alias_state(
     exact_models: dict[tuple[str, str, str, str], str] = {}
     readiness: list[ExecutionSnapshot] = []
     unavailable_aliases: list[tuple[str, str]] = []
+    missing_credential_variables: set[str] = set()
 
     for alias in aliases:
         try:
@@ -614,7 +615,11 @@ def _load_alias_state(
             try:
                 proof = _direct_readiness(manager, alias, normalized, runtime_catalog)
             except (GatewayLifecycleError, ModelConnectionError, ModelCredentialError) as exc:
-                unavailable_aliases.append((alias.alias_name, str(exc)))
+                if isinstance(exc, MissingModelCredentialError):
+                    unavailable_aliases.append((alias.alias_name, exc.detail))
+                    missing_credential_variables.add(exc.environment_variable)
+                else:
+                    unavailable_aliases.append((alias.alias_name, str(exc)))
                 continue
             normalized_catalogs[key] = normalized
             runtime_catalogs[key] = runtime_catalog
@@ -666,7 +671,11 @@ def _load_alias_state(
             ProjectActivationError,
             RouterRuntimeIntegrityError,
         ) as exc:
-            unavailable_aliases.append((alias.alias_name, str(exc)))
+            if isinstance(exc, MissingModelCredentialError):
+                unavailable_aliases.append((alias.alias_name, exc.detail))
+                missing_credential_variables.add(exc.environment_variable)
+            else:
+                unavailable_aliases.append((alias.alias_name, str(exc)))
             continue
         activations[(project_ref, activation_ref, catalog_sha256)] = runtime
         normalized_catalogs[key] = normalized
@@ -678,9 +687,15 @@ def _load_alias_state(
             f"{alias_name} ({reason})" for alias_name, reason in sorted(unavailable_aliases)
         )
         detail = f": {unavailable}" if unavailable else ""
+        if missing_credential_variables:
+            assignments = " ".join(
+                f"{variable}=YOUR_API_KEY" for variable in sorted(missing_credential_variables)
+            )
+            remediation = f"; run '{assignments} exp'"
+        else:
+            remediation = "; fix the listed provider configuration and rerun 'exp'"
         raise GatewayLifecycleError(
-            "no granted active alias is locally available"
-            f"{detail}; fix the listed provider configuration and rerun 'exp'"
+            f"no granted active alias is locally available{detail}{remediation}"
         )
 
     return _AliasAuthorityState(

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -319,7 +319,7 @@ def test_unavailable_alias_reports_its_provider_readiness_reason(tmp_path: Path)
 
     with pytest.raises(
         GatewayLifecycleError,
-        match=r"coding.*TEST_PROVIDER_KEY.*rerun 'exp'",
+        match=r"coding.*TEST_PROVIDER_KEY.*run 'TEST_PROVIDER_KEY=YOUR_API_KEY exp'",
     ):
         load_local_gateway(tmp_path, graceful_timeout_seconds=1, environment={})
 

--- a/exp/runtime/models/credentials.py
+++ b/exp/runtime/models/credentials.py
@@ -148,6 +148,25 @@ def describe_connection_credential(
     )
 
 
+class MissingModelCredentialError(ModelCredentialError):
+    """A configured credential is absent from both the environment and local store."""
+
+    def __init__(self, environment_variable: str, *, connection_id: str) -> None:
+        """Record the missing references without reading or exposing a secret.
+
+        Args:
+            environment_variable: Name of the configured credential environment variable.
+            connection_id: Exact catalog or gateway connection name checked in the store.
+        """
+        self.environment_variable = environment_variable
+        self.connection_id = connection_id
+        self.detail = (
+            f"connection credential environment variable {environment_variable!r} is not set "
+            f"and no stored credential exists for connection {connection_id!r}"
+        )
+        super().__init__(f"{self.detail}; run 'exp config providers' or export the variable")
+
+
 def read_connection_api_key(
     connection: ConnectionConfig,
     *,
@@ -190,10 +209,9 @@ def read_connection_api_key(
                 f"no stored credential exists for connection {connection_id!r}; "
                 "run 'exp config providers' to supply one"
             )
-        raise ModelCredentialError(
-            f"connection credential environment variable {connection.api_key_env!r} is not set "
-            f"and no stored credential exists for connection {connection_id!r}; "
-            "run 'exp config providers' or export the variable"
+        raise MissingModelCredentialError(
+            connection.api_key_env,
+            connection_id=connection_id,
         )
     return resolved.value
 

--- a/exp/runtime/models/credentials_test.py
+++ b/exp/runtime/models/credentials_test.py
@@ -10,6 +10,7 @@ from exp.common.auth import ProviderAuthStore, StoredCredentialBinding
 from exp.common.models import ConnectionConfig
 from exp.runtime.models.credentials import (
     CredentialResolution,
+    MissingModelCredentialError,
     ModelCredentialError,
     lookup_connection_credential,
     read_connection_api_key,
@@ -137,10 +138,12 @@ def test_same_provider_connections_resolve_independently(tmp_path: Path) -> None
 
 def test_missing_environment_and_store_fails_without_prompting() -> None:
     """Noninteractive resolution names the env var and login command, never a secret."""
-    with pytest.raises(ModelCredentialError, match="OPENAI_API_KEY") as captured:
+    with pytest.raises(MissingModelCredentialError, match="OPENAI_API_KEY") as captured:
         read_connection_api_key(_openai(), connection_id="openai", environment={})
 
     message = str(captured.value)
+    assert captured.value.environment_variable == "OPENAI_API_KEY"
+    assert captured.value.connection_id == "openai"
     assert "exp config providers" in message
     assert _SECRET not in message
 


### PR DESCRIPTION
## Summary
- retain the missing credential variable as structured error data
- replace generic provider-fix guidance with a pasteable one-shot command
- combine multiple missing credential variables deterministically

Example: `OPENAI_API_KEY=YOUR_API_KEY exp run`

## Validation
- `uv run --extra dev ruff check exp`
- `uv run --extra dev ty check`
- `env -u NO_COLOR TERM=xterm-256color uv run --extra dev pytest -q` (2133 passed, 2 skipped)