### PR TITLE
Support hosted Rust gateway composition

### DIFF
--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -268,12 +268,7 @@ def _run_rust_gateway(
     if not json_output:
         _emit_exp_wordmark()
 
-    import importlib
     import socket
-    import threading
-    import time
-
-    import uvicorn
 
     from exp.optimize.router.activation import verify_automatic_router_policy
     from exp.runtime.gateway.lifecycle import (
@@ -283,17 +278,12 @@ def _run_rust_gateway(
     )
     from exp.runtime.gateway.management import GatewayManagement
     from exp.runtime.gateway.native_bridge import NativeControlPlane
+    from exp.runtime.gateway.native_server import (
+        NativeGatewayServerError,
+        serve_native_gateway,
+    )
     from exp.runtime.gateway.project_activation import LocalArtifactProjectActivationRepository
     from exp.runtime.openai_protocol.state import BoundedContinuationStore
-
-    try:
-        exp_gateway_native = importlib.import_module("exp_gateway_native")
-    except ModuleNotFoundError as exc:
-        raise typer.BadParameter(
-            "the Rust gateway engine is not built; run 'just native' "
-            "(uv run maturin develop --uv --release "
-            "--manifest-path exp/runtime/gateway/native/Cargo.toml) and retry"
-        ) from exc
 
     manager = GatewayManagement(root)
     if not manager.initialized:
@@ -346,56 +336,17 @@ def _run_rust_gateway(
                         f"port {port} is unavailable on {_LOOPBACK_HOST}: {exc}"
                     ) from exc
 
-            # The fallback socket stays bound from allocation to serving so
-            # the ephemeral port cannot be lost to another process.
-            fallback_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            fallback_socket.bind((_LOOPBACK_HOST, 0))
-            fallback_port = fallback_socket.getsockname()[1]
-            fallback = uvicorn.Server(
-                uvicorn.Config(
-                    runtime.app,
-                    host=_LOOPBACK_HOST,
-                    port=fallback_port,
-                    log_level="warning",
-                )
-            )
-            fallback_thread = threading.Thread(
-                target=lambda: fallback.run(sockets=[fallback_socket]),
-                name="exp-fallback-engine",
-                daemon=True,
-            )
-            fallback_thread.start()
-            deadline = time.monotonic() + 30
-            while not fallback.started:
-                if not fallback_thread.is_alive() or time.monotonic() > deadline:
-                    raise typer.BadParameter(
-                        "the embedded python fallback engine failed to start; "
-                        "inspect the gateway configuration with 'exp --engine python'"
-                    )
-                time.sleep(0.05)
             try:
-                config = json.dumps(
-                    {
-                        "host": _LOOPBACK_HOST,
-                        "port": port,
-                        "max_active_requests": max_active_requests,
-                        "request_timeout_seconds": control_plane.request_timeout_seconds,
-                        "fallback_port": fallback_port,
-                        "graceful_timeout_seconds": graceful_timeout,
-                    }
+                serve_native_gateway(
+                    runtime.app,
+                    control_plane,
+                    host=_LOOPBACK_HOST,
+                    port=port,
+                    max_active_requests=max_active_requests,
+                    graceful_timeout_seconds=graceful_timeout,
                 )
-                try:
-                    exp_gateway_native.serve(control_plane, config)
-                except KeyboardInterrupt:
-                    # SIGINT already drained the data plane gracefully inside
-                    # serve; the launch exits cleanly like the uvicorn path.
-                    pass
-                except RuntimeError as exc:
-                    raise typer.BadParameter(f"the gateway engine failed: {exc}") from exc
-            finally:
-                fallback.should_exit = True
-                fallback_thread.join(timeout=graceful_timeout + 5)
-                fallback_socket.close()
+            except NativeGatewayServerError as exc:
+                raise typer.BadParameter(str(exc)) from exc
 
 
 def _emit_exp_wordmark() -> None:

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -179,11 +179,8 @@ pub async fn run(bridge: Arc<Bridge>, config: ServeConfig) -> Result<(), String>
         .route("/health/live", get(health_live))
         .route("/health/ready", get(health_ready));
     let app = if config.native_usage_enabled {
-        app.route(
-            "/usage.json",
-            get(usage_json).fallback(proxy_fallback),
-        )
-        .route("/usage", get(usage_page).fallback(proxy_fallback))
+        app.route("/usage.json", get(usage_json).fallback(proxy_fallback))
+            .route("/usage", get(usage_page).fallback(proxy_fallback))
     } else {
         app
     };

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -1373,11 +1373,19 @@ async fn stream_response(
                 };
                 for event in events {
                     track_event(&event, &mut usage, &mut tool_names);
-                    // The terminal is recorded before its frames flush, so a
-                    // disconnect during the final flush still settles by the
-                    // provider's outcome instead of as a cancellation.
                     if event.is_terminal() {
                         terminal = Some(event.clone());
+                        if !settle_stream_end(
+                            &mut guard,
+                            terminal.as_ref(),
+                            usage.as_ref(),
+                            &tool_names,
+                            false,
+                        )
+                        .await
+                        {
+                            return;
+                        }
                     }
                     let encoded = match encoder.feed(&event) {
                         Ok(encoded) => encoded,
@@ -1414,7 +1422,7 @@ async fn stream_response(
                         }
                     }
                     if terminal.is_some() {
-                        break 'outer;
+                        return;
                     }
                 }
             }
@@ -1438,6 +1446,17 @@ async fn stream_response(
                     track_event(&event, &mut usage, &mut tool_names);
                     if event.is_terminal() {
                         terminal = Some(event.clone());
+                        if !settle_stream_end(
+                            &mut guard,
+                            terminal.as_ref(),
+                            usage.as_ref(),
+                            &tool_names,
+                            false,
+                        )
+                        .await
+                        {
+                            return;
+                        }
                     }
                     let encoded = match encoder.feed(&event) {
                         Ok(encoded) => encoded,
@@ -1473,6 +1492,9 @@ async fn stream_response(
                             return;
                         }
                     }
+                    if terminal.is_some() {
+                        return;
+                    }
                 }
             }
         }
@@ -1483,7 +1505,7 @@ async fn stream_response(
                 "provider stream ended without a terminal event",
             ));
         }
-        settle_stream_end(
+        let _ = settle_stream_end(
             &mut guard,
             terminal.as_ref(),
             usage.as_ref(),
@@ -1529,23 +1551,21 @@ async fn settle_stream_end(
     usage: Option<&Usage>,
     tool_names: &[String],
     disconnected: bool,
-) {
+) -> bool {
     match terminal {
         Some(Event::Failed(failure)) => {
             let failure = failure.clone().boundary();
             guard
                 .settle("failed", usage, tool_names, Some(&failure))
-                .await;
+                .await
         }
-        Some(Event::Incomplete) => {
-            guard.settle("incomplete", usage, tool_names, None).await;
-        }
-        Some(_) => {
-            guard.settle("completed", usage, tool_names, None).await;
-        }
+        Some(Event::Incomplete) => guard.settle("incomplete", usage, tool_names, None).await,
+        Some(_) => guard.settle("completed", usage, tool_names, None).await,
         None => {
             if disconnected {
-                guard.settle_cancelled(usage, tool_names).await;
+                guard.settle_cancelled(usage, tool_names).await
+            } else {
+                true
             }
         }
     }

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -53,6 +53,8 @@ pub struct ServeConfig {
     pub callback_permits: usize,
     /// Loopback port of the embedded python engine serving escalated requests.
     pub fallback_port: u16,
+    #[serde(default = "default_native_usage_enabled")]
+    pub native_usage_enabled: bool,
     #[serde(default = "default_graceful_timeout_seconds")]
     pub graceful_timeout_seconds: f64,
 }
@@ -71,6 +73,10 @@ fn default_request_timeout_seconds() -> f64 {
 
 fn default_callback_permits() -> usize {
     4
+}
+
+fn default_native_usage_enabled() -> bool {
+    true
 }
 
 /// Shared server state.
@@ -171,9 +177,17 @@ pub async fn run(bridge: Arc<Bridge>, config: ServeConfig) -> Result<(), String>
         .route("/v1/chat/completions", post(chat))
         .route("/v1/responses", post(responses))
         .route("/health/live", get(health_live))
-        .route("/health/ready", get(health_ready))
-        .route("/usage.json", get(usage_json).fallback(proxy_fallback))
+        .route("/health/ready", get(health_ready));
+    let app = if config.native_usage_enabled {
+        app.route(
+            "/usage.json",
+            get(usage_json).fallback(proxy_fallback),
+        )
         .route("/usage", get(usage_page).fallback(proxy_fallback))
+    } else {
+        app
+    };
+    let app = app
         .fallback(proxy_fallback)
         .with_state(state);
     let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port))

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -187,9 +187,7 @@ pub async fn run(bridge: Arc<Bridge>, config: ServeConfig) -> Result<(), String>
     } else {
         app
     };
-    let app = app
-        .fallback(proxy_fallback)
-        .with_state(state);
+    let app = app.fallback(proxy_fallback).with_state(state);
     let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port))
         .await
         .map_err(|error| format!("failed to bind {}:{}: {error}", config.host, config.port))?

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -30,7 +30,6 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
-from typing import cast
 
 from exp.common.core.artifacts import JsonObject, stable_id
 from exp.runtime.gateway.boundary import boundary_protocol_error
@@ -44,7 +43,6 @@ from exp.runtime.gateway.contracts import (
     GatewayFailure,
     GatewayFailureClass,
     GatewayRequest,
-    GatewayUsage,
 )
 from exp.runtime.gateway.discovery import (
     listing_metadata_by_alias,
@@ -60,7 +58,6 @@ from exp.runtime.gateway.execution import (
     _require_deployment_identity,  # noqa: PLC2701
 )
 from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
-from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
@@ -68,6 +65,7 @@ from exp.runtime.gateway.native_responses import (
     remember_turn,
     responses_envelope,
 )
+from exp.runtime.gateway.native_settlement import terminal_from_settlement
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.gateway.usage import GatewayUsageReport, read_usage_report, usage_html
 from exp.runtime.models.providers import (
@@ -94,12 +92,6 @@ _REQUEST_TIMEOUT_SECONDS = 120.0
 _SWEEP_GRACE_SECONDS = 5.0
 _SWEEP_INTERVAL_SECONDS = 5.0
 _SWEEP_BATCH = 16
-
-_TERMINAL_KINDS = {
-    "completed": GatewayEventKind.COMPLETED,
-    "incomplete": GatewayEventKind.INCOMPLETE,
-    "failed": GatewayEventKind.FAILED,
-}
 
 
 class _NativeDialectUnavailableError(RuntimeError):
@@ -581,7 +573,7 @@ class NativeControlPlane:
             entry = self._inflight.get(request_id)
         if entry is None:
             return "{}"
-        terminal, failure = _terminal_from_settlement(data)
+        terminal, failure = terminal_from_settlement(data)
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=entry.attempt_id,
@@ -688,7 +680,7 @@ class NativeControlPlane:
             except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
                 raise _authority_error(exc) from exc
         return read_usage_report(
-            cast("SQLiteAttemptLedger", self._components.ledger),
+            self._components.ledger,
             organization_id=self._components.organization_id,
             identity_id=identity_id,
         )
@@ -873,7 +865,7 @@ class NativeControlPlane:
             settlement = entry.pending_settlement
             if settlement is None:
                 continue
-            terminal, failure = _terminal_from_settlement(settlement)
+            terminal, failure = terminal_from_settlement(settlement)
             self._settle_swept(request_id, entry, terminal, failure, latch_on_failure=True)
         if not abandoned:
             return
@@ -964,72 +956,3 @@ def _deployment_operation_key(route: GatewayRoute) -> str:
 def _optional_text(value: object) -> str | None:
     """Return one optional boundary string value or ``None``."""
     return value if isinstance(value, str) else None
-
-
-def _terminal_from_settlement(
-    data: JsonObject,
-) -> tuple[GatewayEvent, GatewayFailure | None]:
-    """Build the durable terminal event from one settlement payload.
-
-    Args:
-        data: Parsed settlement with ``outcome``, optional ``usage``,
-            ``tool_names``, and ``failure``.
-
-    Returns:
-        The terminal event and the optional normalized failure.
-    """
-    raw_usage = data.get("usage")
-    raw_tool_names = data.get("tool_names")
-    usage = _usage_from_payload(
-        raw_usage if isinstance(raw_usage, dict) else None,
-        [str(name) for name in raw_tool_names] if isinstance(raw_tool_names, list) else [],
-    )
-    failure_payload = data.get("failure")
-    failure = None
-    if isinstance(failure_payload, dict):
-        failure = GatewayFailure(
-            failure_class=GatewayFailureClass(str(failure_payload["failure_class"])),
-            safe_message=str(failure_payload["safe_message"]),
-        )
-    kind = _TERMINAL_KINDS[str(data["outcome"])]
-    terminal = GatewayEvent(
-        kind=kind,
-        sequence_number=0,
-        usage=usage,
-        failure=failure if kind == GatewayEventKind.FAILED else None,
-    )
-    return terminal, failure
-
-
-def _usage_from_payload(
-    payload: JsonObject | None,
-    tool_names: list[str],
-) -> GatewayUsage | None:
-    """Build normalized usage from settlement scalars.
-
-    Args:
-        payload: Optional token totals observed by the data plane.
-        tool_names: Invoked tool names in first-use order.
-
-    Returns:
-        Normalized usage, or ``None`` when nothing was observed.
-    """
-    names = tuple(str(name) for name in tool_names)
-    if payload is None or payload.get("input_tokens") is None:
-        if not names:
-            return None
-        return GatewayUsage(tool_names=names)
-    return GatewayUsage(
-        input_tokens=_optional_count(payload.get("input_tokens")),
-        output_tokens=_optional_count(payload.get("output_tokens")),
-        cached_input_tokens=_optional_count(payload.get("cached_input_tokens")),
-        reasoning_tokens=_optional_count(payload.get("reasoning_tokens")),
-        tool_names=names,
-    )
-
-
-def _optional_count(value: object) -> int | None:
-    """Return one non-negative settlement token count or ``None``."""
-    if isinstance(value, bool) or not isinstance(value, int):
-        return None
-    return value

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -28,19 +28,16 @@ from __future__ import annotations
 import json
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
-from typing import Protocol, cast
+from typing import cast
 
 from exp.common.core.artifacts import JsonObject, stable_id
-from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.boundary import boundary_protocol_error
 from exp.runtime.gateway.budgets import BudgetReservationRejected, maximum_attempt_cost_micro_usd
 from exp.runtime.gateway.contracts import (
-    AttemptId,
     AuthorizationSnapshot,
     DirectTarget,
-    ExecutionSnapshot,
     GatewayApiSurface,
     GatewayEvent,
     GatewayEventKind,
@@ -60,21 +57,19 @@ from exp.runtime.gateway.discovery import (
 # the native path must enforce the same one, so the private helper is shared.
 from exp.runtime.gateway.execution import (
     GatewayExecutionError,
-    GatewayExecutor,
     _require_deployment_identity,  # noqa: PLC2701
 )
 from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
-from exp.runtime.gateway.interfaces import GatewayControlStore
 from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
     continued_request,
     remember_turn,
     responses_envelope,
 )
-from exp.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
+from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.gateway.usage import GatewayUsageReport, read_usage_report, usage_html
-from exp.runtime.models import RuntimeModelCatalog
 from exp.runtime.models.providers import (
     preflight_gateway_request,
     require_gateway_provider,
@@ -105,92 +100,6 @@ _TERMINAL_KINDS = {
     "incomplete": GatewayEventKind.INCOMPLETE,
     "failed": GatewayEventKind.FAILED,
 }
-
-
-class NativeAttemptLedger(Protocol):
-    """Synchronous durable ledger used from native callback threads."""
-
-    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
-        """Persist one accepted request."""
-        ...
-
-    def start_attempt(
-        self,
-        *,
-        snapshot: ExecutionSnapshot,
-        deployment: ExactModelDeployment,
-        attempt_ordinal: int,
-        route_depth: int,
-        maximum_cost_micro_usd: int | None = None,
-        route_reason: str | None = None,
-        fallback_reason: str | None = None,
-    ) -> AttemptId:
-        """Reserve and persist one provider attempt."""
-        ...
-
-    def finish_attempt(
-        self,
-        *,
-        attempt_id: AttemptId,
-        terminal_event: GatewayEvent | None,
-        failure: GatewayFailure | None,
-        finalize_request: bool = True,
-    ) -> None:
-        """Settle one provider attempt."""
-        ...
-
-    def finish_request(
-        self,
-        *,
-        authorization: AuthorizationSnapshot,
-        failure: GatewayFailure,
-    ) -> None:
-        """Finalize accepted work that failed before dispatch."""
-        ...
-
-
-class NativeGatewayComponents(Protocol):
-    """Engine-neutral components required by the native control plane."""
-
-    @property
-    def store(self) -> GatewayControlStore:
-        """Return the authority store."""
-        ...
-
-    @property
-    def ledger(self) -> NativeAttemptLedger:
-        """Return the synchronous durable accounting ledger."""
-        ...
-
-    @property
-    def routes(self) -> CatalogRouteResolver:
-        """Return the direct-route resolver."""
-        ...
-
-    @property
-    def executor(self) -> GatewayExecutor:
-        """Return the shared accounting-health latch."""
-        ...
-
-    @property
-    def reconciled_expired_requests(self) -> int:
-        """Return startup-reconciled request count."""
-        ...
-
-    @property
-    def reconciled_unknown_attempts(self) -> int:
-        """Return startup-reconciled attempt count."""
-        ...
-
-    @property
-    def runtime_catalogs(self) -> Mapping[tuple[str, str], RuntimeModelCatalog]:
-        """Return runtime catalogs keyed by alias revision and digest."""
-        ...
-
-    @property
-    def organization_id(self) -> str:
-        """Return the organization used by the local usage endpoint."""
-        ...
 
 
 class _NativeDialectUnavailableError(RuntimeError):

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -476,11 +476,14 @@ class NativeControlPlane:
                     route_depth=0,
                     maximum_cost_micro_usd=maximum_cost,
                 )
-                self._route_context_recorder(
-                    attempt_id,
-                    route.route_reason,
-                    route.fallback_reason,
-                )
+                try:
+                    self._route_context_recorder(
+                        attempt_id,
+                        route.route_reason,
+                        route.fallback_reason,
+                    )
+                except Exception:  # noqa: BLE001 - display context is best-effort.
+                    pass
         except BudgetReservationRejected as exc:
             error = (
                 _budget_quota_error()

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -202,7 +202,7 @@ class NativeControlPlane:
         readiness_probe: Callable[[], bool] | None = None,
         usage_reporter: Callable[[], JsonObject] | None = None,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
-        native_route_eligible: Callable[[GatewayRoute], bool] | None = None,
+        native_route_eligible: Callable[[GatewayRoute, GatewayRequest], bool] | None = None,
     ) -> None:
         """Bind loaded gateway components for serving.
 
@@ -219,7 +219,8 @@ class NativeControlPlane:
             budget_error_factory: Optional hosted mapping for a rejected
                 reservation, keyed by the presented virtual key.
             native_route_eligible: Optional hosted policy deciding whether a
-                resolved direct route has complete native execution semantics.
+                resolved direct route and canonical request have complete
+                native execution semantics.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
@@ -355,7 +356,7 @@ class NativeControlPlane:
             return _escalation("multi-deployment pools use the python engine's certified waterfall")
         if route is not None and self._native_route_eligible is not None:
             try:
-                native_route_eligible = self._native_route_eligible(route)
+                native_route_eligible = self._native_route_eligible(route, request)
             except Exception:  # noqa: BLE001 - hosted policy fails closed to Python.
                 native_route_eligible = False
             if not native_route_eligible:

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -293,6 +293,7 @@ class NativeControlPlane:
         readiness_probe: Callable[[], bool] | None = None,
         usage_reporter: Callable[[], JsonObject] | None = None,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
+        native_route_eligible: Callable[[GatewayRoute], bool] | None = None,
     ) -> None:
         """Bind loaded gateway components for serving.
 
@@ -308,6 +309,8 @@ class NativeControlPlane:
                 engine defaults to its single-organization SQLite report.
             budget_error_factory: Optional hosted mapping for a rejected
                 reservation, keyed by the presented virtual key.
+            native_route_eligible: Optional hosted policy deciding whether a
+                resolved direct route has complete native execution semantics.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
@@ -320,6 +323,7 @@ class NativeControlPlane:
         self._readiness_probe = readiness_probe
         self._usage_reporter = usage_reporter
         self._budget_error_factory = budget_error_factory
+        self._native_route_eligible = native_route_eligible
         self._inflight: dict[str, _InflightAttempt] = {}
         self._lock = threading.Lock()
         self._accounting_healthy = True
@@ -440,6 +444,13 @@ class NativeControlPlane:
             probe_failure = exc
         if route is not None and route.fallback_deployments:
             return _escalation("multi-deployment pools use the python engine's certified waterfall")
+        if route is not None and self._native_route_eligible is not None:
+            try:
+                native_route_eligible = self._native_route_eligible(route)
+            except Exception:  # noqa: BLE001 - hosted policy fails closed to Python.
+                native_route_eligible = False
+            if not native_route_eligible:
+                return _escalation("host policy requires the python execution engine")
 
         provider_request = request.model_copy(update={"stream": True, "include_usage": True})
         accepted = False

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -291,6 +291,7 @@ class NativeControlPlane:
         readiness_probe: Callable[[], bool] | None = None,
         usage_reporter: Callable[[], JsonObject] | None = None,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
+        route_context_recorder: Callable[[AttemptId, str | None, str | None], None] | None = None,
     ) -> None:
         """Bind loaded gateway components for serving.
 
@@ -306,6 +307,8 @@ class NativeControlPlane:
                 engine defaults to its single-organization SQLite report.
             budget_error_factory: Optional hosted mapping for a rejected
                 reservation, keyed by the presented virtual key.
+            route_context_recorder: Optional hosted sink for display-safe
+                route and fallback reason codes after durable reservation.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
@@ -318,6 +321,7 @@ class NativeControlPlane:
         self._readiness_probe = readiness_probe
         self._usage_reporter = usage_reporter
         self._budget_error_factory = budget_error_factory
+        self._route_context_recorder = route_context_recorder
         self._inflight: dict[str, _InflightAttempt] = {}
         self._lock = threading.Lock()
         self._accounting_healthy = True
@@ -458,6 +462,12 @@ class NativeControlPlane:
                 route_depth=0,
                 maximum_cost_micro_usd=maximum_attempt_cost_micro_usd(request, deployment),
             )
+            if self._route_context_recorder is not None:
+                self._route_context_recorder(
+                    attempt_id,
+                    route.route_reason,
+                    route.fallback_reason,
+                )
         except BudgetReservationRejected as exc:
             error = (
                 _budget_quota_error()

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -122,6 +122,8 @@ class NativeAttemptLedger(Protocol):
         attempt_ordinal: int,
         route_depth: int,
         maximum_cost_micro_usd: int | None = None,
+        route_reason: str | None = None,
+        fallback_reason: str | None = None,
     ) -> AttemptId:
         """Reserve and persist one provider attempt."""
         ...
@@ -455,14 +457,25 @@ class NativeControlPlane:
             require_gateway_provider(deployment.provider)
             preflight_gateway_request(provider_request, deployment.gateway.capabilities)
             upstream_payload = dialect_stream_payload(profile, provider_request)
-            attempt_id = self._write_ledger.start_attempt(
-                snapshot=route.snapshot,
-                deployment=deployment,
-                attempt_ordinal=0,
-                route_depth=0,
-                maximum_cost_micro_usd=maximum_attempt_cost_micro_usd(request, deployment),
-            )
-            if self._route_context_recorder is not None:
+            maximum_cost = maximum_attempt_cost_micro_usd(request, deployment)
+            if self._route_context_recorder is None:
+                attempt_id = self._write_ledger.start_attempt(
+                    snapshot=route.snapshot,
+                    deployment=deployment,
+                    attempt_ordinal=0,
+                    route_depth=0,
+                    maximum_cost_micro_usd=maximum_cost,
+                    route_reason=route.route_reason,
+                    fallback_reason=route.fallback_reason,
+                )
+            else:
+                attempt_id = self._write_ledger.start_attempt(
+                    snapshot=route.snapshot,
+                    deployment=deployment,
+                    attempt_ordinal=0,
+                    route_depth=0,
+                    maximum_cost_micro_usd=maximum_cost,
+                )
                 self._route_context_recorder(
                     attempt_id,
                     route.route_reason,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -28,14 +28,19 @@ from __future__ import annotations
 import json
 import threading
 import time
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
+from typing import Protocol, cast
 
 from exp.common.core.artifacts import JsonObject, stable_id
+from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.boundary import boundary_protocol_error
 from exp.runtime.gateway.budgets import BudgetReservationRejected, maximum_attempt_cost_micro_usd
 from exp.runtime.gateway.contracts import (
+    AttemptId,
     AuthorizationSnapshot,
     DirectTarget,
+    ExecutionSnapshot,
     GatewayApiSurface,
     GatewayEvent,
     GatewayEventKind,
@@ -55,18 +60,21 @@ from exp.runtime.gateway.discovery import (
 # the native path must enforce the same one, so the private helper is shared.
 from exp.runtime.gateway.execution import (
     GatewayExecutionError,
+    GatewayExecutor,
     _require_deployment_identity,  # noqa: PLC2701
 )
 from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
-from exp.runtime.gateway.lifecycle import LocalGatewayComponents
+from exp.runtime.gateway.interfaces import GatewayControlStore
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
     continued_request,
     remember_turn,
     responses_envelope,
 )
-from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
+from exp.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute, GatewayRoutingError
 from exp.runtime.gateway.usage import GatewayUsageReport, read_usage_report, usage_html
+from exp.runtime.models import RuntimeModelCatalog
 from exp.runtime.models.providers import (
     preflight_gateway_request,
     require_gateway_provider,
@@ -97,6 +105,90 @@ _TERMINAL_KINDS = {
     "incomplete": GatewayEventKind.INCOMPLETE,
     "failed": GatewayEventKind.FAILED,
 }
+
+
+class NativeAttemptLedger(Protocol):
+    """Synchronous durable ledger used from native callback threads."""
+
+    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
+        """Persist one accepted request."""
+        ...
+
+    def start_attempt(
+        self,
+        *,
+        snapshot: ExecutionSnapshot,
+        deployment: ExactModelDeployment,
+        attempt_ordinal: int,
+        route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
+    ) -> AttemptId:
+        """Reserve and persist one provider attempt."""
+        ...
+
+    def finish_attempt(
+        self,
+        *,
+        attempt_id: AttemptId,
+        terminal_event: GatewayEvent | None,
+        failure: GatewayFailure | None,
+        finalize_request: bool = True,
+    ) -> None:
+        """Settle one provider attempt."""
+        ...
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Finalize accepted work that failed before dispatch."""
+        ...
+
+
+class NativeGatewayComponents(Protocol):
+    """Engine-neutral components required by the native control plane."""
+
+    @property
+    def store(self) -> GatewayControlStore:
+        """Return the authority store."""
+        ...
+
+    @property
+    def ledger(self) -> NativeAttemptLedger:
+        """Return the synchronous durable accounting ledger."""
+        ...
+
+    @property
+    def routes(self) -> CatalogRouteResolver:
+        """Return the direct-route resolver."""
+        ...
+
+    @property
+    def executor(self) -> GatewayExecutor:
+        """Return the shared accounting-health latch."""
+        ...
+
+    @property
+    def reconciled_expired_requests(self) -> int:
+        """Return startup-reconciled request count."""
+        ...
+
+    @property
+    def reconciled_unknown_attempts(self) -> int:
+        """Return startup-reconciled attempt count."""
+        ...
+
+    @property
+    def runtime_catalogs(self) -> Mapping[tuple[str, str], RuntimeModelCatalog]:
+        """Return runtime catalogs keyed by alias revision and digest."""
+        ...
+
+    @property
+    def organization_id(self) -> str:
+        """Return the organization used by the local usage endpoint."""
+        ...
 
 
 class _NativeDialectUnavailableError(RuntimeError):
@@ -192,10 +284,13 @@ class NativeControlPlane:
 
     def __init__(
         self,
-        components: LocalGatewayComponents,
+        components: NativeGatewayComponents,
         *,
         request_timeout_seconds: float = _REQUEST_TIMEOUT_SECONDS,
         continuation_store: BoundedContinuationStore | None = None,
+        readiness_probe: Callable[[], bool] | None = None,
+        usage_reporter: Callable[[], JsonObject] | None = None,
+        budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
     ) -> None:
         """Bind loaded gateway components for serving.
 
@@ -205,6 +300,12 @@ class NativeControlPlane:
             continuation_store: Optional Responses continuation state, shared
                 with the embedded python engine so both engines resolve and
                 retain the same bounded namespaced history.
+            readiness_probe: Optional hosted lifecycle readiness callback. The
+                local engine defaults to the shared executor health latch.
+            usage_reporter: Optional hosted usage report callback. The local
+                engine defaults to its single-organization SQLite report.
+            budget_error_factory: Optional hosted mapping for a rejected
+                reservation, keyed by the presented virtual key.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
@@ -214,6 +315,9 @@ class NativeControlPlane:
         self._continuations = (
             continuation_store if continuation_store is not None else BoundedContinuationStore()
         )
+        self._readiness_probe = readiness_probe
+        self._usage_reporter = usage_reporter
+        self._budget_error_factory = budget_error_factory
         self._inflight: dict[str, _InflightAttempt] = {}
         self._lock = threading.Lock()
         self._accounting_healthy = True
@@ -353,11 +457,13 @@ class NativeControlPlane:
                 attempt_ordinal=0,
                 route_depth=0,
                 maximum_cost_micro_usd=maximum_attempt_cost_micro_usd(request, deployment),
-                route_reason=route.route_reason,
-                fallback_reason=route.fallback_reason,
             )
         except BudgetReservationRejected as exc:
-            error = _budget_quota_error()
+            error = (
+                _budget_quota_error()
+                if self._budget_error_factory is None
+                else self._budget_error_factory(data["raw_key"])
+            )
             self._finish_request_quietly(
                 authorization,
                 GatewayFailure(
@@ -620,6 +726,8 @@ class NativeControlPlane:
         Raises:
             NativeBridgeError: The presented key is invalid, expired, or revoked.
         """
+        if self._usage_reporter is not None:
+            return json.dumps(self._usage_reporter(), separators=(",", ":"))
         report = self._usage_report(argument)
         return json.dumps(report.model_dump(mode="json"), separators=(",", ":"))
 
@@ -661,7 +769,7 @@ class NativeControlPlane:
             except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
                 raise _authority_error(exc) from exc
         return read_usage_report(
-            self._components.ledger,
+            cast("SQLiteAttemptLedger", self._components.ledger),
             organization_id=self._components.organization_id,
             identity_id=identity_id,
         )
@@ -671,6 +779,11 @@ class NativeControlPlane:
         del argument
         if not self._accounting_healthy:
             return "false"
+        if self._readiness_probe is not None:
+            try:
+                return "true" if self._readiness_probe() else "false"
+            except Exception:  # noqa: BLE001 - readiness fails closed at the boundary.
+                return "false"
         try:
             self._components.executor.require_healthy()
         except GatewayExecutionError:

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -209,18 +209,11 @@ class NativeControlPlane:
         Args:
             components: Authority, ledger, routes, and runtime catalogs.
             request_timeout_seconds: Total per-request budget from admission.
-            continuation_store: Optional Responses continuation state, shared
-                with the embedded python engine so both engines resolve and
-                retain the same bounded namespaced history.
-            readiness_probe: Optional hosted lifecycle readiness callback. The
-                local engine defaults to the shared executor health latch.
-            usage_reporter: Optional hosted usage report callback. The local
-                engine defaults to its single-organization SQLite report.
-            budget_error_factory: Optional hosted mapping for a rejected
-                reservation, keyed by the presented virtual key.
-            native_route_eligible: Optional hosted policy deciding whether a
-                resolved direct route and canonical request have complete
-                native execution semantics.
+            continuation_store: Optional state shared by native and Python engines.
+            readiness_probe: Optional hosted lifecycle readiness callback.
+            usage_reporter: Optional hosted usage report callback.
+            budget_error_factory: Optional hosted mapping for a rejected reservation.
+            native_route_eligible: Optional hosted policy for complete native semantics.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -293,7 +293,6 @@ class NativeControlPlane:
         readiness_probe: Callable[[], bool] | None = None,
         usage_reporter: Callable[[], JsonObject] | None = None,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
-        route_context_recorder: Callable[[AttemptId, str | None, str | None], None] | None = None,
     ) -> None:
         """Bind loaded gateway components for serving.
 
@@ -309,8 +308,6 @@ class NativeControlPlane:
                 engine defaults to its single-organization SQLite report.
             budget_error_factory: Optional hosted mapping for a rejected
                 reservation, keyed by the presented virtual key.
-            route_context_recorder: Optional hosted sink for display-safe
-                route and fallback reason codes after durable reservation.
         """
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
@@ -323,7 +320,6 @@ class NativeControlPlane:
         self._readiness_probe = readiness_probe
         self._usage_reporter = usage_reporter
         self._budget_error_factory = budget_error_factory
-        self._route_context_recorder = route_context_recorder
         self._inflight: dict[str, _InflightAttempt] = {}
         self._lock = threading.Lock()
         self._accounting_healthy = True
@@ -458,32 +454,15 @@ class NativeControlPlane:
             preflight_gateway_request(provider_request, deployment.gateway.capabilities)
             upstream_payload = dialect_stream_payload(profile, provider_request)
             maximum_cost = maximum_attempt_cost_micro_usd(request, deployment)
-            if self._route_context_recorder is None:
-                attempt_id = self._write_ledger.start_attempt(
-                    snapshot=route.snapshot,
-                    deployment=deployment,
-                    attempt_ordinal=0,
-                    route_depth=0,
-                    maximum_cost_micro_usd=maximum_cost,
-                    route_reason=route.route_reason,
-                    fallback_reason=route.fallback_reason,
-                )
-            else:
-                attempt_id = self._write_ledger.start_attempt(
-                    snapshot=route.snapshot,
-                    deployment=deployment,
-                    attempt_ordinal=0,
-                    route_depth=0,
-                    maximum_cost_micro_usd=maximum_cost,
-                )
-                try:
-                    self._route_context_recorder(
-                        attempt_id,
-                        route.route_reason,
-                        route.fallback_reason,
-                    )
-                except Exception:  # noqa: BLE001 - display context is best-effort.
-                    pass
+            attempt_id = self._write_ledger.start_attempt(
+                snapshot=route.snapshot,
+                deployment=deployment,
+                attempt_ordinal=0,
+                route_depth=0,
+                maximum_cost_micro_usd=maximum_cost,
+                route_reason=route.route_reason,
+                fallback_reason=route.fallback_reason,
+            )
         except BudgetReservationRejected as exc:
             error = (
                 _budget_quota_error()

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -8,7 +8,6 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
-from typing import cast
 from unittest import mock
 
 import pytest
@@ -31,14 +30,12 @@ from exp.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from exp.runtime.gateway.discovery import listing_metadata_by_alias
-from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.lifecycle import _ReadyControlStore, load_gateway_components
 from exp.runtime.gateway.lifecycle_test import _configured_gateway
 from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.gateway.native_bridge import (
     NativeBridgeError,
     NativeControlPlane,
-    _usage_from_payload,
 )
 from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
@@ -133,21 +130,6 @@ def test_bridge_error_payload_is_openai_shaped() -> None:
     }
 
 
-def test_usage_from_payload_handles_tokens_and_tool_names() -> None:
-    """Settlement usage covers token totals, tool-only, and absent cases."""
-    assert _usage_from_payload(None, []) is None
-    tools_only = _usage_from_payload(None, ["search"])
-    assert tools_only is not None and tools_only.tool_names == ("search",)
-    complete = _usage_from_payload(
-        {"input_tokens": 10, "output_tokens": 3, "cached_input_tokens": 2},
-        [],
-    )
-    assert complete is not None
-    assert complete.input_tokens == 10
-    assert complete.output_tokens == 3
-    assert complete.cached_input_tokens == 2
-
-
 def test_admit_decodes_builds_payload_and_settles(tmp_path: Path) -> None:
     """Admission decodes the raw body, returns the shared upstream payload, and
     settlement lands in the usage report."""
@@ -210,7 +192,7 @@ def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> No
 
     admission = _admit(control, raw_key, _chat_body())
 
-    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
+    ledger = control._components.ledger  # noqa: SLF001
     with sqlite3.connect(ledger.database_path) as connection:
         row = connection.execute(
             "select route_reason, fallback_reason from gateway_attempts where attempt_id = ?",
@@ -573,7 +555,7 @@ def test_budget_rejection_uses_host_error_factory(tmp_path: Path) -> None:
     )
     control._budget_error_factory = lambda key: customized  # noqa: SLF001
     with mock.patch.object(
-        control._components.ledger,  # noqa: SLF001
+        control._write_ledger,  # noqa: SLF001
         "start_attempt",
         side_effect=BudgetReservationRejected(scope_kind=BudgetScopeKind.TEAM, reason="blocked"),
     ):

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -464,6 +464,20 @@ def test_claim_scope_matches_the_python_replay_key(tmp_path: Path) -> None:
     assert different_body["canonical_request_sha256"] != scope["canonical_request_sha256"]
     decoded = decode_chat(json.loads(_chat_body()), idempotency_key="operation-one")
     assert decoded.request.idempotency_key == "operation-one"
+
+
+def test_admit_escalates_host_ineligible_route_before_accounting(tmp_path: Path) -> None:
+    """Hosted execution policy can retain routes whose native semantics are incomplete."""
+    _manager, raw_key = _configured_gateway(tmp_path)
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    control = NativeControlPlane(components, native_route_eligible=lambda _route: False)
+
+    admission = _admit(control, raw_key, _chat_body())
+
+    assert admission == {"escalate": "host policy requires the python execution engine"}
     report = json.loads(control.usage_json("{}"))
     assert report["totals"]["requests"] == 0
 
@@ -526,8 +540,6 @@ def test_keyed_admissions_enforce_the_durable_ledger_idempotency_rows(
     assert unavailable_payload["code"] == "idempotency_replay_unavailable"
     report = json.loads(control.usage_json("{}"))
     assert report["totals"]["requests"] == 1
-
-
 def test_admit_rejects_an_ungranted_alias(tmp_path: Path) -> None:
     """An ungranted alias maps to the shared 403 public error."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -8,6 +8,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -30,6 +31,7 @@ from exp.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from exp.runtime.gateway.discovery import listing_metadata_by_alias
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.lifecycle import _ReadyControlStore, load_gateway_components
 from exp.runtime.gateway.lifecycle_test import _configured_gateway
 from exp.runtime.gateway.management import GatewayManagement
@@ -228,7 +230,8 @@ def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> No
 
     admission = _admit(control, raw_key, _chat_body())
 
-    with sqlite3.connect(control._components.ledger.database_path) as connection:  # noqa: SLF001
+    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
+    with sqlite3.connect(ledger.database_path) as connection:
         row = connection.execute(
             "select route_reason, fallback_reason from gateway_attempts where attempt_id = ?",
             (admission["attempt_id"],),

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -17,6 +17,7 @@ from exp.common.models import (
     GatewayTokenPrices,
     ModelCapabilities,
 )
+from exp.runtime.gateway.budgets import BudgetReservationRejected, BudgetScopeKind
 from exp.runtime.gateway.catalog_authority import upsert_singleton_deployment
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
@@ -519,6 +520,28 @@ def test_admit_rejects_an_ungranted_alias(tmp_path: Path) -> None:
     assert payload["code"] == "model_not_granted"
 
 
+def test_budget_rejection_uses_host_error_factory(tmp_path: Path) -> None:
+    """Hosted policy can refine a quota rejection without moving accounting."""
+    control, raw_key = _control_plane(tmp_path)
+    customized = NativeBridgeError(
+        OpenAIProtocolError(
+            status_code=429,
+            code="email_unverified",
+            message="verify your email",
+            error_type="insufficient_quota",
+        )
+    )
+    control._budget_error_factory = lambda key: customized  # noqa: SLF001
+    with mock.patch.object(
+        control._components.ledger,  # noqa: SLF001
+        "start_attempt",
+        side_effect=BudgetReservationRejected(scope_kind=BudgetScopeKind.TEAM, reason="blocked"),
+    ):
+        with pytest.raises(NativeBridgeError) as excinfo:
+            _admit(control, raw_key, _chat_body())
+    assert excinfo.value is customized
+
+
 def test_authenticate_rejects_an_invalid_key(tmp_path: Path) -> None:
     """A bad virtual key maps to the shared 401 public error."""
     control, _raw_key = _control_plane(tmp_path)
@@ -558,6 +581,25 @@ def test_readiness_reflects_startup_proof_and_executor_health(tmp_path: Path) ->
     assert control.readiness("{}") == "true"
     control._components.executor.mark_accounting_unhealthy()  # noqa: SLF001 - fault injection.
     assert control.readiness("{}") == "false"
+
+
+def test_readiness_uses_host_lifecycle_probe_and_fails_closed(tmp_path: Path) -> None:
+    """A hosted composition can add database, catalog, and drain readiness."""
+    _manager, _raw_key = _configured_gateway(tmp_path)
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    ready = True
+    control = NativeControlPlane(components, readiness_probe=lambda: ready)
+    assert control.readiness("{}") == "true"
+    ready = False
+    assert control.readiness("{}") == "false"
+    failed = NativeControlPlane(
+        components,
+        readiness_probe=mock.Mock(side_effect=RuntimeError("database unavailable")),
+    )
+    assert failed.readiness("{}") == "false"
 
 
 def test_rust_failure_taxonomy_matches_public_failure_error() -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -467,17 +467,25 @@ def test_claim_scope_matches_the_python_replay_key(tmp_path: Path) -> None:
 
 
 def test_admit_escalates_host_ineligible_route_before_accounting(tmp_path: Path) -> None:
-    """Hosted execution policy can retain routes whose native semantics are incomplete."""
+    """Hosted policy can retain requests whose native semantics are incomplete."""
     _manager, raw_key = _configured_gateway(tmp_path)
     components = load_gateway_components(
         tmp_path,
         environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
     )
-    control = NativeControlPlane(components, native_route_eligible=lambda _route: False)
+    seen_requests: list[GatewayRequest] = []
 
-    admission = _admit(control, raw_key, _chat_body())
+    def native_route_eligible(_route: object, request: GatewayRequest) -> bool:
+        """Reject keyed requests after retaining the decoded request for assertion."""
+        seen_requests.append(request)
+        return request.idempotency_key is None
+
+    control = NativeControlPlane(components, native_route_eligible=native_route_eligible)
+
+    admission = _admit(control, raw_key, _chat_body(), idempotency_key="shared-replay")
 
     assert admission == {"escalate": "host policy requires the python execution engine"}
+    assert [request.idempotency_key for request in seen_requests] == ["shared-replay"]
     report = json.loads(control.usage_json("{}"))
     assert report["totals"]["requests"] == 0
 

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -224,6 +224,29 @@ def test_admit_records_host_route_context_after_reservation(tmp_path: Path) -> N
     assert contexts == [(admission["attempt_id"], "direct", None)]
 
 
+def test_admit_ignores_host_route_context_failure_after_reservation(tmp_path: Path) -> None:
+    """Display-only hosted provenance cannot abort an admitted provider request."""
+    _manager, raw_key = _configured_gateway(tmp_path)
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+
+    def reject_context(
+        _attempt_id: str,
+        _route_reason: str | None,
+        _fallback_reason: str | None,
+    ) -> None:
+        """Simulate an unavailable hosted display-context sink."""
+        raise RuntimeError("display sink unavailable")
+
+    control = NativeControlPlane(components, route_context_recorder=reject_context)
+
+    admission = _admit(control, raw_key, _chat_body())
+
+    assert admission["attempt_id"]
+
+
 def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> None:
     """The default local composition retains durable route provenance."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sqlite3
 import threading
 import time
 from pathlib import Path
@@ -219,6 +220,20 @@ def test_admit_records_host_route_context_after_reservation(tmp_path: Path) -> N
     admission = _admit(control, raw_key, _chat_body())
 
     assert contexts == [(admission["attempt_id"], "direct", None)]
+
+
+def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> None:
+    """The default local composition retains durable route provenance."""
+    control, raw_key = _control_plane(tmp_path)
+
+    admission = _admit(control, raw_key, _chat_body())
+
+    with sqlite3.connect(control._components.ledger.database_path) as connection:  # noqa: SLF001
+        row = connection.execute(
+            "select route_reason, fallback_reason from gateway_attempts where attempt_id = ?",
+            (admission["attempt_id"],),
+        ).fetchone()
+    assert row == ("direct", None)
 
 
 def test_admit_rejects_invalid_bodies_with_python_parity(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -204,49 +204,6 @@ def test_admit_decodes_builds_payload_and_settles(tmp_path: Path) -> None:
     assert repeat == "{}"
 
 
-def test_admit_records_host_route_context_after_reservation(tmp_path: Path) -> None:
-    """A hosted display sink receives route context without changing the ledger seam."""
-    _manager, raw_key = _configured_gateway(tmp_path)
-    components = load_gateway_components(
-        tmp_path,
-        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
-    )
-    contexts: list[tuple[str, str | None, str | None]] = []
-    control = NativeControlPlane(
-        components,
-        route_context_recorder=lambda attempt_id, route_reason, fallback_reason: contexts.append(
-            (attempt_id, route_reason, fallback_reason)
-        ),
-    )
-
-    admission = _admit(control, raw_key, _chat_body())
-
-    assert contexts == [(admission["attempt_id"], "direct", None)]
-
-
-def test_admit_ignores_host_route_context_failure_after_reservation(tmp_path: Path) -> None:
-    """Display-only hosted provenance cannot abort an admitted provider request."""
-    _manager, raw_key = _configured_gateway(tmp_path)
-    components = load_gateway_components(
-        tmp_path,
-        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
-    )
-
-    def reject_context(
-        _attempt_id: str,
-        _route_reason: str | None,
-        _fallback_reason: str | None,
-    ) -> None:
-        """Simulate an unavailable hosted display-context sink."""
-        raise RuntimeError("display sink unavailable")
-
-    control = NativeControlPlane(components, route_context_recorder=reject_context)
-
-    admission = _admit(control, raw_key, _chat_body())
-
-    assert admission["attempt_id"]
-
-
 def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> None:
     """The default local composition retains durable route provenance."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -540,6 +540,8 @@ def test_keyed_admissions_enforce_the_durable_ledger_idempotency_rows(
     assert unavailable_payload["code"] == "idempotency_replay_unavailable"
     report = json.loads(control.usage_json("{}"))
     assert report["totals"]["requests"] == 1
+
+
 def test_admit_rejects_an_ungranted_alias(tmp_path: Path) -> None:
     """An ungranted alias maps to the shared 403 public error."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -201,6 +201,26 @@ def test_admit_decodes_builds_payload_and_settles(tmp_path: Path) -> None:
     assert repeat == "{}"
 
 
+def test_admit_records_host_route_context_after_reservation(tmp_path: Path) -> None:
+    """A hosted display sink receives route context without changing the ledger seam."""
+    _manager, raw_key = _configured_gateway(tmp_path)
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    contexts: list[tuple[str, str | None, str | None]] = []
+    control = NativeControlPlane(
+        components,
+        route_context_recorder=lambda attempt_id, route_reason, fallback_reason: contexts.append(
+            (attempt_id, route_reason, fallback_reason)
+        ),
+    )
+
+    admission = _admit(control, raw_key, _chat_body())
+
+    assert contexts == [(admission["attempt_id"], "direct", None)]
+
+
 def test_admit_rejects_invalid_bodies_with_python_parity(tmp_path: Path) -> None:
     """Invalid JSON, non-objects, and protocol violations use the shared codes."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/native_components.py
+++ b/exp/runtime/gateway/native_components.py
@@ -1,0 +1,62 @@
+"""Structural component contracts for the native gateway control plane."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+
+from exp.runtime.gateway.execution import GatewayExecutor
+from exp.runtime.gateway.group_commit import GroupCommitAttemptLedger
+from exp.runtime.gateway.interfaces import GatewayControlStore
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.routing import CatalogRouteResolver
+from exp.runtime.models import RuntimeModelCatalog
+
+
+class NativeGatewayComponents(Protocol):
+    """Engine-neutral components required by the native control plane."""
+
+    @property
+    def store(self) -> GatewayControlStore:
+        """Return the authority store."""
+        ...
+
+    @property
+    def ledger(self) -> SQLiteAttemptLedger:
+        """Return the raw ledger used for content-free reporting reads."""
+        ...
+
+    @property
+    def write_ledger(self) -> GroupCommitAttemptLedger:
+        """Return the shared durable group-commit writer."""
+        ...
+
+    @property
+    def routes(self) -> CatalogRouteResolver:
+        """Return the direct-route resolver."""
+        ...
+
+    @property
+    def executor(self) -> GatewayExecutor:
+        """Return the shared accounting-health latch."""
+        ...
+
+    @property
+    def reconciled_expired_requests(self) -> int:
+        """Return startup-reconciled request count."""
+        ...
+
+    @property
+    def reconciled_unknown_attempts(self) -> int:
+        """Return startup-reconciled attempt count."""
+        ...
+
+    @property
+    def runtime_catalogs(self) -> Mapping[tuple[str, str], RuntimeModelCatalog]:
+        """Return runtime catalogs keyed by alias revision and digest."""
+        ...
+
+    @property
+    def organization_id(self) -> str:
+        """Return the organization used by the local usage endpoint."""
+        ...

--- a/exp/runtime/gateway/native_server.py
+++ b/exp/runtime/gateway/native_server.py
@@ -8,9 +8,12 @@ import socket
 import threading
 import time
 from collections.abc import Awaitable, Callable
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 import uvicorn
+
+if TYPE_CHECKING:
+    from exp.runtime.gateway.native_bridge import NativeControlPlane
 
 _LOOPBACK_HOST = "127.0.0.1"
 _FALLBACK_START_TIMEOUT_SECONDS = 30.0
@@ -100,7 +103,7 @@ def serve_native_gateway(
         separators=(",", ":"),
     )
     try:
-        native.serve(control_plane, config)
+        native.serve(cast("NativeControlPlane", control_plane), config)
     except RuntimeError as exc:
         raise NativeGatewayServerError(f"the native gateway failed: {exc}") from exc
     finally:

--- a/exp/runtime/gateway/native_server.py
+++ b/exp/runtime/gateway/native_server.py
@@ -104,6 +104,9 @@ def serve_native_gateway(
     )
     try:
         native.serve(cast("NativeControlPlane", control_plane), config)
+    except KeyboardInterrupt:
+        # The native server drains on SIGINT before returning control to Python.
+        pass
     except RuntimeError as exc:
         raise NativeGatewayServerError(f"the native gateway failed: {exc}") from exc
     finally:

--- a/exp/runtime/gateway/native_server.py
+++ b/exp/runtime/gateway/native_server.py
@@ -1,0 +1,109 @@
+"""Process host for the native gateway with an internal ASGI fallback."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+import uvicorn
+
+_LOOPBACK_HOST = "127.0.0.1"
+_FALLBACK_START_TIMEOUT_SECONDS = 30.0
+
+
+AsgiApplication = Callable[..., Awaitable[None]]
+
+
+class NativeServerControlPlane(Protocol):
+    """Control-plane value required by the process host."""
+
+    @property
+    def request_timeout_seconds(self) -> float:
+        """Return the shared request deadline."""
+        ...
+
+
+class NativeGatewayServerError(RuntimeError):
+    """The native extension or its embedded fallback could not serve."""
+
+
+def serve_native_gateway(
+    fallback_app: AsgiApplication,
+    control_plane: NativeServerControlPlane,
+    *,
+    host: str,
+    port: int,
+    max_active_requests: int = 64,
+    graceful_timeout_seconds: float = 10.0,
+    native_usage_enabled: bool = True,
+) -> None:
+    """Serve Rust publicly and proxy unsupported routes to an internal ASGI app.
+
+    Args:
+        fallback_app: Python ASGI application for unsupported and escalated routes.
+        control_plane: Shared authority and accounting callbacks.
+        host: Public listener host.
+        port: Public listener port.
+        max_active_requests: Native concurrent-admission bound.
+        graceful_timeout_seconds: Bound for both native and fallback shutdown.
+        native_usage_enabled: Whether Rust owns ``/usage.json``. Hosted,
+            multi-tenant callers should disable it so their ASGI app owns usage.
+
+    Raises:
+        NativeGatewayServerError: The extension is unavailable, the fallback
+            cannot start, or the native server fails.
+    """
+    try:
+        native = importlib.import_module("exp_gateway_native")
+    except ModuleNotFoundError as exc:
+        raise NativeGatewayServerError("the exp_gateway_native extension is not installed") from exc
+
+    fallback_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    fallback_socket.bind((_LOOPBACK_HOST, 0))
+    fallback_port = fallback_socket.getsockname()[1]
+    fallback = uvicorn.Server(
+        uvicorn.Config(
+            fallback_app,
+            host=_LOOPBACK_HOST,
+            port=fallback_port,
+            log_level="warning",
+        )
+    )
+    fallback_thread = threading.Thread(
+        target=lambda: fallback.run(sockets=[fallback_socket]),
+        name="exp-fallback-engine",
+        daemon=True,
+    )
+    fallback_thread.start()
+    deadline = time.monotonic() + _FALLBACK_START_TIMEOUT_SECONDS
+    while not fallback.started:
+        if not fallback_thread.is_alive() or time.monotonic() > deadline:
+            fallback.should_exit = True
+            fallback_socket.close()
+            raise NativeGatewayServerError("the embedded Python fallback failed to start")
+        time.sleep(0.05)
+    config = json.dumps(
+        {
+            "host": host,
+            "port": port,
+            "max_active_requests": max_active_requests,
+            "request_timeout_seconds": control_plane.request_timeout_seconds,
+            "fallback_port": fallback_port,
+            "graceful_timeout_seconds": graceful_timeout_seconds,
+            "native_usage_enabled": native_usage_enabled,
+        },
+        separators=(",", ":"),
+    )
+    try:
+        native.serve(control_plane, config)
+    except RuntimeError as exc:
+        raise NativeGatewayServerError(f"the native gateway failed: {exc}") from exc
+    finally:
+        fallback.should_exit = True
+        fallback_thread.join(timeout=graceful_timeout_seconds + 5.0)
+        fallback_socket.close()

--- a/exp/runtime/gateway/native_server_test.py
+++ b/exp/runtime/gateway/native_server_test.py
@@ -1,0 +1,91 @@
+"""Tests for the shared native gateway process host."""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+import pytest
+
+from exp.runtime.gateway import native_server
+from exp.runtime.gateway.native_server import (
+    NativeGatewayServerError,
+    serve_native_gateway,
+)
+
+
+class _FallbackServer:
+    """Small Uvicorn stand-in that exposes startup and observes shutdown."""
+
+    last: _FallbackServer | None = None
+
+    def __init__(self, _config: object) -> None:
+        """Record the latest server and initialize lifecycle flags."""
+        self.started = False
+        self.should_exit = False
+        _FallbackServer.last = self
+
+    def run(self, *, sockets: list[object]) -> None:
+        """Mark started and remain alive until the host requests shutdown."""
+        assert len(sockets) == 1
+        self.started = True
+        while not self.should_exit:
+            time.sleep(0.001)
+
+
+def test_host_passes_public_and_fallback_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rust owns the public listener while Python receives an allocated loopback port."""
+    captured: dict[str, object] = {}
+
+    def serve(control_plane: object, config_json: str) -> None:
+        """Capture the extension boundary call."""
+        captured["control_plane"] = control_plane
+        captured["config"] = json.loads(config_json)
+
+    native = SimpleNamespace(serve=serve)
+    monkeypatch.setattr(native_server.importlib, "import_module", lambda _name: native)
+    monkeypatch.setattr(native_server.uvicorn, "Server", _FallbackServer)
+    control = SimpleNamespace(request_timeout_seconds=37.0)
+    fallback_app = mock.Mock()
+
+    serve_native_gateway(
+        fallback_app,
+        control,
+        host="0.0.0.0",
+        port=8080,
+        max_active_requests=23,
+        graceful_timeout_seconds=45.0,
+        native_usage_enabled=False,
+    )
+
+    assert captured["control_plane"] is control
+    config = cast("dict[str, object]", captured["config"])
+    assert config["host"] == "0.0.0.0"
+    assert config["port"] == 8080
+    assert config["max_active_requests"] == 23
+    assert config["request_timeout_seconds"] == 37.0
+    assert config["graceful_timeout_seconds"] == 45.0
+    assert config["native_usage_enabled"] is False
+    assert isinstance(config["fallback_port"], int)
+    assert _FallbackServer.last is not None and _FallbackServer.last.should_exit
+
+
+def test_host_maps_native_runtime_failures_and_stops_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native bind or runtime failure closes the embedded Python server."""
+    native = SimpleNamespace(serve=mock.Mock(side_effect=RuntimeError("bind failed")))
+    monkeypatch.setattr(native_server.importlib, "import_module", lambda _name: native)
+    monkeypatch.setattr(native_server.uvicorn, "Server", _FallbackServer)
+
+    with pytest.raises(NativeGatewayServerError, match="bind failed"):
+        serve_native_gateway(
+            mock.Mock(),
+            SimpleNamespace(request_timeout_seconds=10.0),
+            host="127.0.0.1",
+            port=8080,
+        )
+    assert _FallbackServer.last is not None and _FallbackServer.last.should_exit

--- a/exp/runtime/gateway/native_server_test.py
+++ b/exp/runtime/gateway/native_server_test.py
@@ -89,3 +89,21 @@ def test_host_maps_native_runtime_failures_and_stops_fallback(
             port=8080,
         )
     assert _FallbackServer.last is not None and _FallbackServer.last.should_exit
+
+
+def test_host_treats_native_keyboard_interrupt_as_clean_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native SIGINT drain returns normally and stops the fallback server."""
+    native = SimpleNamespace(serve=mock.Mock(side_effect=KeyboardInterrupt))
+    monkeypatch.setattr(native_server.importlib, "import_module", lambda _name: native)
+    monkeypatch.setattr(native_server.uvicorn, "Server", _FallbackServer)
+
+    serve_native_gateway(
+        mock.Mock(),
+        SimpleNamespace(request_timeout_seconds=10.0),
+        host="127.0.0.1",
+        port=8080,
+    )
+
+    assert _FallbackServer.last is not None and _FallbackServer.last.should_exit

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -1,0 +1,76 @@
+"""Normalize native data-plane settlement payloads for durable accounting."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import (
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayUsage,
+)
+
+_TERMINAL_KINDS = {
+    "completed": GatewayEventKind.COMPLETED,
+    "incomplete": GatewayEventKind.INCOMPLETE,
+    "failed": GatewayEventKind.FAILED,
+}
+
+
+def terminal_from_settlement(
+    data: JsonObject,
+) -> tuple[GatewayEvent, GatewayFailure | None]:
+    """Build a durable terminal event from one native settlement payload.
+
+    Args:
+        data: Parsed outcome, usage, tool names, and optional failure.
+
+    Returns:
+        The normalized terminal event and optional failure.
+    """
+    raw_usage = data.get("usage")
+    raw_tool_names = data.get("tool_names")
+    usage = _usage_from_payload(
+        raw_usage if isinstance(raw_usage, dict) else None,
+        [str(name) for name in raw_tool_names] if isinstance(raw_tool_names, list) else [],
+    )
+    failure_payload = data.get("failure")
+    failure = None
+    if isinstance(failure_payload, dict):
+        failure = GatewayFailure(
+            failure_class=GatewayFailureClass(str(failure_payload["failure_class"])),
+            safe_message=str(failure_payload["safe_message"]),
+        )
+    kind = _TERMINAL_KINDS[str(data["outcome"])]
+    terminal = GatewayEvent(
+        kind=kind,
+        sequence_number=0,
+        usage=usage,
+        failure=failure if kind == GatewayEventKind.FAILED else None,
+    )
+    return terminal, failure
+
+
+def _usage_from_payload(
+    payload: JsonObject | None,
+    tool_names: list[str],
+) -> GatewayUsage | None:
+    """Build normalized usage from settlement scalars and tool names."""
+    names = tuple(str(name) for name in tool_names)
+    if payload is None or payload.get("input_tokens") is None:
+        return GatewayUsage(tool_names=names) if names else None
+    return GatewayUsage(
+        input_tokens=_optional_count(payload.get("input_tokens")),
+        output_tokens=_optional_count(payload.get("output_tokens")),
+        cached_input_tokens=_optional_count(payload.get("cached_input_tokens")),
+        reasoning_tokens=_optional_count(payload.get("reasoning_tokens")),
+        tool_names=names,
+    )
+
+
+def _optional_count(value: object) -> int | None:
+    """Return one integer settlement token count or ``None``."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -1,0 +1,66 @@
+"""Tests for native settlement payload normalization."""
+
+from __future__ import annotations
+
+from exp.runtime.gateway.contracts import GatewayEventKind, GatewayFailureClass
+from exp.runtime.gateway.native_settlement import (
+    _usage_from_payload,  # noqa: PLC2701 - direct unit coverage for normalization.
+    terminal_from_settlement,
+)
+
+
+def test_usage_from_payload_handles_tokens_and_tool_names() -> None:
+    """Settlement usage covers token totals, tool-only, and absent cases."""
+    assert _usage_from_payload(None, []) is None
+    tools_only = _usage_from_payload(None, ["search"])
+    assert tools_only is not None and tools_only.tool_names == ("search",)
+    complete = _usage_from_payload(
+        {"input_tokens": 10, "output_tokens": 3, "cached_input_tokens": 2},
+        [],
+    )
+    assert complete is not None
+    assert complete.input_tokens == 10
+    assert complete.output_tokens == 3
+    assert complete.cached_input_tokens == 2
+
+
+def test_terminal_from_settlement_normalizes_usage_and_tools() -> None:
+    """Completed payloads retain token counts and ordered tool names."""
+    terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "completed",
+            "usage": {
+                "input_tokens": 8,
+                "output_tokens": 3,
+                "cached_input_tokens": 2,
+                "reasoning_tokens": 1,
+            },
+            "tool_names": ["search", "fetch"],
+            "failure": None,
+        }
+    )
+
+    assert failure is None
+    assert terminal.kind == GatewayEventKind.COMPLETED
+    assert terminal.usage is not None
+    assert terminal.usage.input_tokens == 8
+    assert terminal.usage.tool_names == ("search", "fetch")
+
+
+def test_terminal_from_settlement_normalizes_failure() -> None:
+    """Failed payloads attach the sanitized failure to the terminal."""
+    terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "usage": None,
+            "tool_names": [],
+            "failure": {
+                "failure_class": "transport",
+                "safe_message": "provider transport failed",
+            },
+        }
+    )
+
+    assert failure is not None
+    assert failure.failure_class == GatewayFailureClass.TRANSPORT
+    assert terminal.failure == failure


### PR DESCRIPTION
## Summary

- extract the Rust public-listener plus internal Python fallback host from `exp run` into an engine-owned reusable seam
- make native control-plane components structural so hosted stores and live catalogs can be injected without importing local SQLite lifecycle composition
- allow hosted readiness, quota-error, and usage behavior while keeping native usage enabled by default for the local CLI
- let multi-tenant hosts proxy `/usage.json` to their own application instead of exposing the local single-organization report

## Ownership

Experiential continues to own the Rust HTTP data plane, provider protocol normalization, public SSE encoding, authority callbacks, and settlement behavior. A host supplies persistence adapters, live catalogs, lifecycle readiness, and any host-specific quota explanation.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- focused gateway tests: 23 passed, 2 skipped
- full pytest: 2180 passed, 4 skipped; 13 unrelated local-environment failures (11 terminal redraw tests under the non-interactive runner and 2 clean-checkout evidence tests)

Rust compile validation is delegated to CI because this machine has no Cargo toolchain installed.
