### PR TITLE
Release 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.4.0"
+version = "0.5.0"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.5.0 release: the native rust gateway data plane (#570) ships as the default engine through prebuilt abi3 wheels (#575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)