### PR TITLE
Route native-engine ledger writes through the group-commit writer

### DIFF
--- a/exp/runtime/gateway/group_commit.py
+++ b/exp/runtime/gateway/group_commit.py
@@ -7,6 +7,12 @@ proceeding, so acceptance, budget reservation, and terminal settlement keep
 their exact fail-closed semantics while the per-request fsync cost is
 amortized across all operations sharing a batch. There is no flush window:
 no caller observes success before its write is durable on disk.
+
+Two callers share the one queue and writer thread: the asyncio engine awaits
+:class:`GroupCommitAttemptLedger`, while threads without an event loop (the
+native data plane's worker threads) block on :class:`SyncGroupCommitLedger`.
+Operations from both interleave in the same batches, so the two gateway
+engines amortize their fsyncs together.
 """
 
 from __future__ import annotations
@@ -125,6 +131,9 @@ class GroupCommitAttemptLedger:
         self._max_batch_size = max_batch_size
         self._queue: queue.SimpleQueue[_PendingWrite | None] = queue.SimpleQueue()
         self._closed = False
+        # Serializes enqueue against close so no operation can land behind the
+        # stop sentinel and strand its caller after the writer thread exits.
+        self._submit_lock = threading.Lock()
         self._thread = threading.Thread(
             target=self._run,
             name="gateway-ledger-writer",
@@ -231,19 +240,30 @@ class GroupCommitAttemptLedger:
         await self._submit(lambda connection: None)
 
     def close(self) -> None:
-        """Stop the writer thread after draining every queued operation."""
-        if self._closed:
-            return
-        self._closed = True
-        self._queue.put(None)
+        """Stop the writer thread after draining every queued operation.
+
+        Operations enqueued before close still commit durably; the enqueue
+        lock guarantees nothing can be queued behind the stop sentinel, and
+        every later submission fails fast with a closed-writer error.
+        """
+        with self._submit_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(None)
         self._thread.join(timeout=30)
 
     def _run(self) -> None:
         """Drain queued operations into one durable SQLite transaction per batch."""
-        connection = connect_database(
-            self.core.database_path,
-            busy_timeout_ms=self.core.busy_timeout_ms,
-        )
+        try:
+            connection = connect_database(
+                self.core.database_path,
+                busy_timeout_ms=self.core.busy_timeout_ms,
+            )
+        except Exception:  # noqa: BLE001 - every blocked caller receives the closed error.
+            _logger.exception("gateway ledger writer failed to open its connection")
+            self._fail_pending()
+            return
         try:
             stopping = False
             while not stopping:
@@ -263,6 +283,25 @@ class GroupCommitAttemptLedger:
                 self._commit_batch(connection, batch)
         finally:
             connection.close()
+            self._fail_pending()
+
+    def _fail_pending(self) -> None:
+        """Latch closed and fail every still-queued operation with a clear error.
+
+        Runs on the writer thread as it exits, whether by graceful close or by
+        an unexpected failure, so no blocked caller (async or sync) can be
+        stranded waiting on an operation the writer will never commit.
+        """
+        with self._submit_lock:
+            self._closed = True
+            while True:
+                try:
+                    item = self._queue.get_nowait()
+                except queue.Empty:
+                    return
+                if item is None:
+                    continue
+                _resolve_exception(item.future, _closed_error())
 
     @staticmethod
     def _commit_batch(
@@ -315,6 +354,27 @@ class GroupCommitAttemptLedger:
             else:
                 _resolve_result(pending.future, value)
 
+    def submit_blocking(self, apply: Callable[[sqlite3.Connection], _T]) -> _T:
+        """Enqueue one operation and block the calling thread on its durable commit.
+
+        For threads with no running event loop, such as the native data
+        plane's worker threads. The operation shares the queue and writer
+        thread with async submissions, so both engines' writes interleave in
+        the same batches. The writer is a separate dedicated thread, so
+        blocking here can never deadlock a caller.
+
+        Args:
+            apply: Operation run on the writer connection inside the batch transaction.
+
+        Returns:
+            The operation's return value after its batch has committed.
+
+        Raises:
+            RuntimeError: The writer is closed, before or while waiting.
+            Exception: The operation itself failed and was rolled back.
+        """
+        return self._enqueue(apply).result()
+
     async def _submit(self, apply: Callable[[sqlite3.Connection], _T]) -> _T:
         """Enqueue one operation and await its durable batch commit.
 
@@ -328,13 +388,155 @@ class GroupCommitAttemptLedger:
         Returns:
             The operation's return value after its batch has committed.
         """
-        if self._closed:
-            raise RuntimeError("gateway ledger writer is closed")
+        return await asyncio.shield(asyncio.wrap_future(self._enqueue(apply)))
+
+    def _enqueue(self, apply: Callable[[sqlite3.Connection], _T]) -> concurrent.futures.Future[_T]:
+        """Queue one operation for the writer thread and return its commit future.
+
+        Args:
+            apply: Operation run on the writer connection inside the batch transaction.
+
+        Returns:
+            Future resolved only after the operation's batch has committed.
+
+        Raises:
+            RuntimeError: The writer is closed and can accept no operation.
+        """
         future: concurrent.futures.Future[_T] = concurrent.futures.Future()
-        self._queue.put(
-            _PendingWrite(
-                apply=apply,
-                future=cast("concurrent.futures.Future[object]", future),
+        with self._submit_lock:
+            if self._closed:
+                raise _closed_error()
+            self._queue.put(
+                _PendingWrite(
+                    apply=apply,
+                    future=cast("concurrent.futures.Future[object]", future),
+                )
+            )
+        return future
+
+
+def _closed_error() -> RuntimeError:
+    """Build the error every closed-writer submission or stranded wait receives."""
+    return RuntimeError(
+        "gateway ledger writer is closed; the gateway is shutting down, retry after restart"
+    )
+
+
+class SyncGroupCommitLedger:
+    """Blocking attempt-ledger facade over one shared group-commit writer.
+
+    Mirrors the async ledger surface with plain synchronous methods for
+    callers that run on threads without an event loop (the native data
+    plane's worker threads and its settlement sweep). Every method enqueues
+    onto the same queue and writer thread as the async path, so operations
+    from both engines share batches, and returns only after its own
+    operation's batch is durable on disk. A failed or rolled-back operation
+    raises its original exception; a closed writer raises a clear
+    RuntimeError instead of blocking forever.
+    """
+
+    def __init__(self, writer: GroupCommitAttemptLedger) -> None:
+        """Bind the shared group-commit writer.
+
+        Args:
+            writer: The engine-shared batching writer to submit through.
+        """
+        self._writer = writer
+
+    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
+        """Durably persist accepted authority before route selection or dispatch.
+
+        Args:
+            authorization: Frozen authority and request identity.
+        """
+        self._writer.submit_blocking(
+            lambda connection: self._writer.core.apply_accept_request(
+                connection, authorization=authorization
             )
         )
-        return await asyncio.shield(asyncio.wrap_future(future))
+
+    def start_attempt(
+        self,
+        *,
+        snapshot: ExecutionSnapshot,
+        deployment: ExactModelDeployment,
+        attempt_ordinal: int,
+        route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
+        route_reason: str | None = None,
+        fallback_reason: str | None = None,
+    ) -> AttemptId:
+        """Durably reserve budget and record one dispatch before provider work.
+
+        Args:
+            snapshot: Route-bound immutable request plan.
+            deployment: Exact deployment about to receive the request.
+            attempt_ordinal: Zero-based physical dispatch position for this request.
+            route_depth: Zero-based operational route position.
+            maximum_cost_micro_usd: Conservative charge reserved before dispatch.
+            route_reason: Optional learned-selection reason code.
+            fallback_reason: Optional embedding or router fallback reason code.
+
+        Returns:
+            Stable new attempt ID.
+        """
+        return self._writer.submit_blocking(
+            lambda connection: self._writer.core.apply_start_attempt(
+                connection,
+                snapshot=snapshot,
+                deployment=deployment,
+                attempt_ordinal=attempt_ordinal,
+                route_depth=route_depth,
+                maximum_cost_micro_usd=maximum_cost_micro_usd,
+                route_reason=route_reason,
+                fallback_reason=fallback_reason,
+            )
+        )
+
+    def finish_attempt(
+        self,
+        *,
+        attempt_id: AttemptId,
+        terminal_event: GatewayEvent | None,
+        failure: GatewayFailure | None,
+        finalize_request: bool = True,
+    ) -> None:
+        """Durably settle one attempt with normalized content-free fields.
+
+        Args:
+            attempt_id: Stable attempt ID.
+            terminal_event: Provider terminal event, possibly carrying usage.
+            failure: Sanitized failure when no successful terminal event exists.
+            finalize_request: Whether this attempt is the final route for its parent request.
+        """
+        self._writer.submit_blocking(
+            lambda connection: self._writer.core.apply_finish_attempt(
+                connection,
+                attempt_id=attempt_id,
+                terminal_event=terminal_event,
+                failure=failure,
+                finalize_request=finalize_request,
+            )
+        )
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Durably terminalize accepted work that never reached dispatch.
+
+        Args:
+            authorization: Frozen authority identifying the accepted request.
+            failure: Sanitized pre-dispatch terminal failure.
+        """
+        self._writer.submit_blocking(
+            lambda connection: self._writer.core.apply_finish_request(
+                connection, authorization=authorization, failure=failure
+            )
+        )
+
+    def flush(self) -> None:
+        """Return after every previously enqueued operation is durably committed."""
+        self._writer.submit_blocking(lambda connection: None)

--- a/exp/runtime/gateway/group_commit.py
+++ b/exp/runtime/gateway/group_commit.py
@@ -280,7 +280,20 @@ class GroupCommitAttemptLedger:
                         stopping = True
                         break
                     batch.append(extra)
-                self._commit_batch(connection, batch)
+                try:
+                    self._commit_batch(connection, batch)
+                except Exception as exc:  # noqa: BLE001 - blocked callers receive the failure.
+                    _logger.exception("gateway ledger batch failed outside its own transaction")
+                    for pending in batch:
+                        if not pending.future.done():
+                            _resolve_exception(pending.future, exc)
+                    if connection.in_transaction:
+                        try:
+                            connection.execute("ROLLBACK")
+                        except sqlite3.Error:
+                            _logger.exception(
+                                "gateway ledger batch rollback failed after batch failure"
+                            )
         finally:
             connection.close()
             self._fail_pending()

--- a/exp/runtime/gateway/group_commit_test.py
+++ b/exp/runtime/gateway/group_commit_test.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -22,7 +24,11 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayUsage,
 )
-from exp.runtime.gateway.group_commit import GroupCommitAttemptLedger, abandoned_write_outcome
+from exp.runtime.gateway.group_commit import (
+    GroupCommitAttemptLedger,
+    SyncGroupCommitLedger,
+    abandoned_write_outcome,
+)
 from exp.runtime.gateway.ledger import GatewayLedgerError, SQLiteAttemptLedger
 from exp.runtime.gateway.sqlite.store import SQLiteGatewayStore
 
@@ -295,6 +301,137 @@ def test_max_batch_size_must_be_positive(tmp_path: Path) -> None:
     _, core, _ = _authority_fixture(tmp_path, clock)
     with pytest.raises(ValueError, match="at least one"):
         GroupCommitAttemptLedger(core, max_batch_size=0)
+
+
+def test_sync_facade_commits_full_lifecycle_durably_without_an_event_loop(
+    tmp_path: Path,
+) -> None:
+    """The blocking facade lands acceptance, dispatch, and settlement exactly."""
+    clock = FakeLedgerClock()
+    store, core, raw_key = _authority_fixture(tmp_path, clock)
+    grouped = GroupCommitAttemptLedger(core)
+    facade = SyncGroupCommitLedger(grouped)
+    authorization = _authorize(store, clock, raw_key, "sync-prompt")
+    facade.accept_request(authorization=authorization)
+    attempt_id = facade.start_attempt(
+        snapshot=_execution(authorization),
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+        route_reason="direct_alias",
+        fallback_reason=None,
+    )
+    facade.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=100, output_tokens=40),
+        ),
+        failure=None,
+    )
+    facade.flush()
+    grouped.close()
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    connection.row_factory = sqlite3.Row
+    row = connection.execute(
+        "SELECT state, input_tokens, output_tokens FROM gateway_attempts WHERE attempt_id = ?",
+        (attempt_id,),
+    ).fetchone()
+    request = connection.execute("SELECT terminal_state FROM gateway_requests").fetchone()
+    connection.close()
+    assert row is not None
+    assert str(row["state"]) == "completed"
+    assert int(row["input_tokens"]) == 100
+    assert int(row["output_tokens"]) == 40
+    assert str(request["terminal_state"]) == "completed"
+
+
+def test_sync_facade_raises_the_original_failure_and_stays_usable(tmp_path: Path) -> None:
+    """A rolled-back sync operation re-raises to its caller; the writer keeps
+    serving later operations."""
+    clock = FakeLedgerClock()
+    store, core, raw_key = _authority_fixture(tmp_path, clock)
+    grouped = GroupCommitAttemptLedger(core)
+    facade = SyncGroupCommitLedger(grouped)
+    with pytest.raises(GatewayLedgerError):
+        facade.finish_attempt(attempt_id="attempt-missing", terminal_event=None, failure=None)
+    survivor = _authorize(store, clock, raw_key, "survivor-prompt")
+    facade.accept_request(authorization=survivor)
+    grouped.close()
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    count = connection.execute("SELECT COUNT(*) FROM gateway_requests").fetchone()[0]
+    connection.close()
+    assert int(count) == 1
+
+
+def test_concurrent_sync_threads_all_commit_exactly_once(tmp_path: Path) -> None:
+    """Blocking callers on many threads each observe exactly their own durable row."""
+    clock = FakeLedgerClock()
+    store, core, raw_key = _authority_fixture(tmp_path, clock)
+    grouped = GroupCommitAttemptLedger(core)
+    facade = SyncGroupCommitLedger(grouped)
+    authorizations = [_authorize(store, clock, raw_key, f"thread-{index}") for index in range(16)]
+    barrier = threading.Barrier(len(authorizations))
+    errors: list[BaseException] = []
+
+    def accept(authorization: AuthorizationSnapshot) -> None:
+        """Block one thread on its own durable acceptance.
+
+        Args:
+            authorization: This thread's frozen authority snapshot.
+        """
+        try:
+            barrier.wait(timeout=10)
+            facade.accept_request(authorization=authorization)
+        except BaseException as exc:  # noqa: BLE001 - the test asserts no error.
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=accept, args=(authorization,)) for authorization in authorizations
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+    grouped.close()
+    assert errors == []
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    request_ids = [
+        str(row[0])
+        for row in connection.execute("SELECT request_id FROM gateway_requests").fetchall()
+    ]
+    connection.close()
+    assert sorted(request_ids) == sorted(item.request_id for item in authorizations)
+
+
+def test_closed_writer_rejects_sync_operations(tmp_path: Path) -> None:
+    """Sync submissions after close fail fast with a clear closed-writer error."""
+    clock = FakeLedgerClock()
+    _, core, _ = _authority_fixture(tmp_path, clock)
+    grouped = GroupCommitAttemptLedger(core)
+    facade = SyncGroupCommitLedger(grouped)
+    grouped.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        facade.flush()
+
+
+def test_writer_startup_failure_fails_sync_callers_instead_of_hanging(
+    tmp_path: Path,
+) -> None:
+    """A writer thread that dies before serving rejects callers rather than
+    stranding them on a queue nothing will ever drain."""
+    clock = FakeLedgerClock()
+    _, core, _ = _authority_fixture(tmp_path, clock)
+    with mock.patch(
+        "exp.runtime.gateway.group_commit.connect_database",
+        side_effect=sqlite3.OperationalError("simulated writer connection loss"),
+    ):
+        grouped = GroupCommitAttemptLedger(core)
+        grouped._thread.join(timeout=10)  # noqa: SLF001 - deterministic crash ordering.
+    facade = SyncGroupCommitLedger(grouped)
+    with pytest.raises(RuntimeError, match="closed"):
+        facade.flush()
 
 
 def test_abandoned_write_returns_committed_attempt_id() -> None:

--- a/exp/runtime/gateway/group_commit_test.py
+++ b/exp/runtime/gateway/group_commit_test.py
@@ -416,6 +416,31 @@ def test_closed_writer_rejects_sync_operations(tmp_path: Path) -> None:
         facade.flush()
 
 
+def test_batch_machinery_failure_fails_blocked_callers_and_writer_recovers(
+    tmp_path: Path,
+) -> None:
+    """A batch that fails outside its own transaction still fails its callers
+    instead of stranding them, and the writer keeps serving afterwards."""
+    clock = FakeLedgerClock()
+    store, core, raw_key = _authority_fixture(tmp_path, clock)
+    grouped = GroupCommitAttemptLedger(core)
+    facade = SyncGroupCommitLedger(grouped)
+    with mock.patch.object(
+        grouped,
+        "_commit_batch",
+        side_effect=RuntimeError("simulated savepoint machinery loss"),
+    ):
+        with pytest.raises(RuntimeError, match="savepoint machinery"):
+            facade.flush()
+    survivor = _authorize(store, clock, raw_key, "post-failure-prompt")
+    facade.accept_request(authorization=survivor)
+    grouped.close()
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    count = connection.execute("SELECT COUNT(*) FROM gateway_requests").fetchone()[0]
+    connection.close()
+    assert int(count) == 1
+
+
 def test_writer_startup_failure_fails_sync_callers_instead_of_hanging(
     tmp_path: Path,
 ) -> None:

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -6,8 +6,11 @@ protocol- and authority-shaped happens here, in the same code the python
 engine runs: request decoding through ``decode_chat``, authorization through
 the shared control store, upstream payload construction through the shared
 ``streaming_requests`` builders, and the same durable SQLite ledger
-transactions. Every boundary call takes and returns one JSON string so the
-boundary stays narrow and typed on both sides.
+transactions. Ledger writes go through the blocking facade over the shared
+group-commit writer, so both engines' writes interleave in the same batched
+fsyncs while every caller still blocks until its own write is durable. Every
+boundary call takes and returns one JSON string so the boundary stays narrow
+and typed on both sides.
 
 Boundary errors raise :class:`NativeBridgeError`, whose ``public_error_json``
 attribute carries the sanitized OpenAI-shaped error the data plane returns to
@@ -52,6 +55,7 @@ from exp.runtime.gateway.execution import (
     GatewayExecutionError,
     _require_deployment_identity,  # noqa: PLC2701
 )
+from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
 from exp.runtime.gateway.lifecycle import LocalGatewayComponents
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.gateway.usage import read_usage_report
@@ -159,11 +163,14 @@ def _budget_quota_error() -> NativeBridgeError:
 class NativeControlPlane:
     """Authority and accounting callbacks for the native data plane.
 
-    Methods are called from multiple Rust worker threads. SQLite access is
-    safe through the per-thread connection cache in the gateway store and
-    ledger; the in-flight request registry is guarded by one lock and swept
-    opportunistically so an abandoned reservation cannot outlive its request
-    deadline by more than the sweep grace.
+    Methods are called from multiple Rust worker threads. Ledger writes block
+    on the shared group-commit writer's blocking facade, so concurrent
+    settlements from both engines amortize one fsync per batch while each
+    caller still observes only its own durable commit; reads use the raw
+    ledger's per-thread connection cache. The in-flight request registry is
+    guarded by one lock and swept opportunistically so an abandoned
+    reservation cannot outlive its request deadline by more than the sweep
+    grace.
     """
 
     def __init__(
@@ -181,6 +188,7 @@ class NativeControlPlane:
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
         self._components = components
+        self._write_ledger = SyncGroupCommitLedger(components.write_ledger)
         self._request_timeout_seconds = request_timeout_seconds
         self._inflight: dict[str, _InflightAttempt] = {}
         self._lock = threading.Lock()
@@ -288,7 +296,7 @@ class NativeControlPlane:
         accepted = False
         attempt_id: str | None = None
         try:
-            self._components.ledger.accept_request(authorization=authorization)
+            self._write_ledger.accept_request(authorization=authorization)
             accepted = True
             if probe_failure is not None or route is None or profile is None:
                 raise probe_failure or GatewayRoutingError(
@@ -298,7 +306,7 @@ class NativeControlPlane:
             require_gateway_provider(deployment.provider)
             preflight_gateway_request(provider_request, deployment.gateway.capabilities)
             upstream_payload = _build_upstream_payload(profile, provider_request)
-            attempt_id = self._components.ledger.start_attempt(
+            attempt_id = self._write_ledger.start_attempt(
                 snapshot=route.snapshot,
                 deployment=deployment,
                 attempt_ordinal=0,
@@ -386,7 +394,7 @@ class NativeControlPlane:
             return "{}"
         terminal, failure = _terminal_from_settlement(data)
         try:
-            self._components.ledger.finish_attempt(
+            self._write_ledger.finish_attempt(
                 attempt_id=entry.attempt_id,
                 terminal_event=terminal,
                 failure=failure,
@@ -594,7 +602,7 @@ class NativeControlPlane:
     ) -> None:
         """Land one swept settlement; keep the entry for retry on failure."""
         try:
-            self._components.ledger.finish_attempt(
+            self._write_ledger.finish_attempt(
                 attempt_id=entry.attempt_id,
                 terminal_event=terminal,
                 failure=failure,
@@ -614,7 +622,7 @@ class NativeControlPlane:
     ) -> None:
         """Finalize accepted pre-dispatch work without masking the primary failure."""
         try:
-            self._components.ledger.finish_request(
+            self._write_ledger.finish_request(
                 authorization=authorization,
                 failure=failure,
             )
@@ -625,7 +633,7 @@ class NativeControlPlane:
         """Settle one started attempt without masking the primary failure."""
         terminal = GatewayEvent(kind=GatewayEventKind.FAILED, sequence_number=0, failure=failure)
         try:
-            self._components.ledger.finish_attempt(
+            self._write_ledger.finish_attempt(
                 attempt_id=attempt_id,
                 terminal_event=terminal,
                 failure=failure,

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -195,7 +195,7 @@ def test_failed_settlement_keeps_the_attempt_retryable(tmp_path: Path) -> None:
     ledger = control._components.ledger  # noqa: SLF001 - fault injection for the test.
     with mock.patch.object(
         ledger,
-        "finish_attempt",
+        "apply_finish_attempt",
         side_effect=RuntimeError("simulated terminal write loss"),
     ):
         with pytest.raises(NativeBridgeError):
@@ -205,6 +205,67 @@ def test_failed_settlement_keeps_the_attempt_retryable(tmp_path: Path) -> None:
     assert control.settle(settlement) == "{}"
     report = json.loads(control.usage_json("{}"))
     assert report["totals"]["requests"] == 1
+
+
+def test_bridge_writes_route_through_the_group_commit_writer(tmp_path: Path) -> None:
+    """Admission and settlement never use the raw ledger's one-fsync-per-write
+    methods; every bridge write reaches SQLite through the shared batching
+    writer and still lands in the usage report."""
+    control, raw_key = _control_plane(tmp_path)
+    ledger = control._components.ledger  # noqa: SLF001 - wiring assertion for the test.
+    direct_writes = mock.Mock(side_effect=AssertionError("bridge used the raw per-write path"))
+    with (
+        mock.patch.object(ledger, "accept_request", direct_writes),
+        mock.patch.object(ledger, "start_attempt", direct_writes),
+        mock.patch.object(ledger, "finish_attempt", direct_writes),
+        mock.patch.object(ledger, "finish_request", direct_writes),
+    ):
+        admission = _admit(control, raw_key, _chat_body())
+        assert (
+            control.settle(
+                json.dumps(
+                    {
+                        "request_id": admission["request_id"],
+                        "attempt_id": admission["attempt_id"],
+                        "outcome": "completed",
+                        "usage": {"input_tokens": 7, "output_tokens": 2},
+                        "tool_names": [],
+                        "failure": None,
+                    }
+                )
+            )
+            == "{}"
+        )
+    direct_writes.assert_not_called()
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 1
+    assert report["totals"]["input_tokens"] == 7
+
+
+def test_closed_writer_makes_settle_raise_and_keeps_the_entry_retryable(
+    tmp_path: Path,
+) -> None:
+    """A settle against a closed group-commit writer raises the sanitized
+    boundary error and retains the exact settlement for later replay."""
+    control, raw_key = _control_plane(tmp_path)
+    admission = _admit(control, raw_key, _chat_body())
+    control._components.write_ledger.close()  # noqa: SLF001 - shutdown-ordering fault injection.
+    settlement = json.dumps(
+        {
+            "request_id": admission["request_id"],
+            "attempt_id": admission["attempt_id"],
+            "outcome": "completed",
+            "usage": {"input_tokens": 4, "output_tokens": 1},
+            "tool_names": [],
+            "failure": None,
+        }
+    )
+    with pytest.raises(NativeBridgeError):
+        control.settle(settlement)
+    with control._lock:  # noqa: SLF001 - registry state assertion.
+        entry = control._inflight[str(admission["request_id"])]  # noqa: SLF001
+    assert entry.pending_settlement is not None
+    assert entry.pending_settlement["outcome"] == "completed"
 
 
 def test_sweep_replays_the_original_completed_settlement(tmp_path: Path) -> None:
@@ -225,7 +286,7 @@ def test_sweep_replays_the_original_completed_settlement(tmp_path: Path) -> None
     ledger = control._components.ledger  # noqa: SLF001 - fault injection for the test.
     with mock.patch.object(
         ledger,
-        "finish_attempt",
+        "apply_finish_attempt",
         side_effect=RuntimeError("simulated terminal write loss"),
     ):
         with pytest.raises(NativeBridgeError):


### PR DESCRIPTION
## What

The native (Rust) gateway engine's control bridge previously wrote every ledger operation (accept, start attempt, settle, sweep replay, pre-dispatch finish) through the raw `SQLiteAttemptLedger`, paying one fsync per write. This PR routes all of those writes through the existing group-commit writer that the embedded python engine already uses, so both engines share one batched-fsync path. Usage reads stay on the raw ledger. The extension crate and wire contract are unchanged.

## The sync facade

`SyncGroupCommitLedger` (in `group_commit.py`) mirrors the ledger write surface with plain blocking methods for threads that have no event loop, which is exactly what the Rust worker threads and the bridge's settlement sweep are. Each method enqueues its operation onto the same queue and writer thread as the async path (so batches interleave across both engines) and blocks on the operation's own `concurrent.futures.Future.result()`. No event loop is created; the writer is a separate dedicated thread, so blocking a tokio `spawn_blocking` callback thread here can never deadlock: that block is the point of amortized fsync.

## Fail-closed semantics preserved

- A caller never observes success before its own write is durable: futures resolve only after the batch `COMMIT` returns, exactly as on the async path.
- A failed operation rolls back to its savepoint and re-raises its original exception to the blocking caller; batch siblings still commit.
- The bridge's retained-settlement retry and sweep semantics are untouched: a failed settle keeps the in-flight entry with the exact original settlement, which the sweep replays verbatim.
- A batch failure escaping the commit machinery itself (savepoint bookkeeping raising) now fails its blocked callers with the original error and best-effort rolls back, instead of leaving their futures pending forever; the writer keeps serving later batches.
- Shutdown ordering cannot strand a blocked caller: enqueue is now serialized against `close()` so nothing can be queued behind the stop sentinel, and the writer thread fails every still-queued and later operation with a clear closed-writer `RuntimeError` when it exits (gracefully or on startup failure). The bridge already tolerates that error through its latch/retry paths; a new test covers settle-against-closed-writer keeping the entry retryable.

## Batching evidence (local micro-benchmark, not committed)

8 threads x 100 settles each (800 durable settlements) on a tmpfs-free local SQLite root:

| path | wall | throughput | durable commits (fsyncs) |
|---|---|---|---|
| raw ledger | 0.138 s | 5,792 settles/s | 800 |
| sync facade | 0.059 s | 13,449 settles/s | 201 (mean batch 4.0, max 8) |

Same durability, roughly 4x fewer fsyncs and 2.3x throughput under 8-way concurrency.

## Tests

- Sync facade: full lifecycle durability without an event loop, original-exception re-raise with the writer staying usable, 16 concurrent threads each committing exactly once, closed-writer fast failure, and writer-startup-failure failing callers instead of hanging.
- Bridge: admission and settlement proven to bypass the raw per-write path entirely (raw write methods patched to raise) while still landing in the usage report; settle against a closed writer raises and retains the entry for replay.
- Existing fault-injection tests updated to patch `apply_finish_attempt` (the operation the writer runs) instead of the now-unused raw `finish_attempt`.

Gate: ruff check, ruff format, ty, `pytest exp/runtime/gateway/ exp/tests/`, and the full gate.yml non-live selection (2168 passed, 1 skipped) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
