### PR TITLE
gateway: typed pre-dispatch rejection escape from start_attempt

### DIFF
--- a/exp/runtime/gateway/boundary.py
+++ b/exp/runtime/gateway/boundary.py
@@ -15,6 +15,7 @@ from exp.runtime.gateway.aggregation import GatewayAggregationOverflowError
 from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
 from exp.runtime.gateway.execution import GatewayExecutionError
 from exp.runtime.gateway.ledger import (
+    AttemptRejectedError,
     IdempotencyConflictError,
     IdempotencyReplayUnavailableError,
 )
@@ -92,6 +93,11 @@ def boundary_protocol_error(exception: BaseException) -> OpenAIProtocolError:
             error_type="api_error",
             param="Idempotency-Key",
         )
+    elif isinstance(exception, AttemptRejectedError):
+        # A typed pre-dispatch rejection without a more specific branch above
+        # keeps the shape its ledger assigned (for example an injected ledger's
+        # dispatch-time key revocation surfacing as authentication).
+        error = public_failure_error(exception.failure)
     elif isinstance(exception, GatewayExecutionError):
         error = public_failure_error(exception.failure)
     elif isinstance(exception, ProviderDeadlineExceeded):

--- a/exp/runtime/gateway/boundary_test.py
+++ b/exp/runtime/gateway/boundary_test.py
@@ -1,0 +1,43 @@
+"""Boundary mapping for typed pre-dispatch ledger rejections."""
+
+from __future__ import annotations
+
+from exp.runtime.gateway.boundary import boundary_protocol_error
+from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.runtime.gateway.ledger import (
+    AttemptRejectedError,
+    IdempotencyConflictError,
+    IdempotencyReplayUnavailableError,
+)
+
+
+def test_idempotency_conflict_keeps_409_ahead_of_generic_rejection_mapping() -> None:
+    """The specific conflict branch outranks the generic typed-rejection branch."""
+    error = boundary_protocol_error(IdempotencyConflictError("reused operation"))
+    assert error.status_code == 409
+    assert error.detail.code == "idempotency_conflict"
+    assert error.detail.param == "Idempotency-Key"
+
+
+def test_idempotency_replay_unavailable_keeps_409() -> None:
+    """The replay-loss branch stays 409 after re-parenting under the typed rejection."""
+    error = boundary_protocol_error(IdempotencyReplayUnavailableError("replay lost"))
+    assert error.status_code == 409
+    assert error.detail.code == "idempotency_replay_unavailable"
+
+
+def test_generic_typed_rejection_maps_through_its_own_failure_shape() -> None:
+    """A ledger-assigned rejection shape reaches the caller unreshaped."""
+    error = boundary_protocol_error(
+        AttemptRejectedError(
+            "virtual key was revoked between accept and dispatch",
+            failure=GatewayFailure(
+                failure_class=GatewayFailureClass.AUTHENTICATION,
+                safe_message="the gateway key is invalid, expired, or revoked",
+            ),
+        )
+    )
+    assert error.status_code == 401
+    assert error.detail.code == "invalid_key"
+    assert error.detail.type == "authentication_error"
+    assert error.detail.message == "the gateway key is invalid, expired, or revoked"

--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -26,7 +26,7 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.group_commit import abandoned_write_outcome
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.interfaces import AttemptLedger, ProviderStream
-from exp.runtime.gateway.ledger import GatewayLedgerError
+from exp.runtime.gateway.ledger import AttemptRejectedError, GatewayLedgerError
 from exp.runtime.gateway.routing import GatewayRoute
 from exp.runtime.models import ResolvedModel, RuntimeModelCatalog
 from exp.runtime.models.providers import (
@@ -505,7 +505,9 @@ class GatewayExecutionStream:
                 # The settlement path terminalizes the accepted request and latches only if
                 # that write is itself lost.
                 self._health.release_probe(binding.health_key)
-                if isinstance(exc, asyncio.CancelledError):
+                if isinstance(exc, (asyncio.CancelledError, AttemptRejectedError)):
+                    # A typed rejection owns its public shape: it propagates
+                    # unchanged, with no fallback and no reshaping.
                     raise
                 raise GatewayExecutionError(_pre_dispatch_failure(exc)) from exc
             failure = normalized_provider_failure(exc)

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -38,12 +38,54 @@ class GatewayLedgerError(ValueError):
     """A request or attempt transition violates the content-free ledger contract."""
 
 
-class IdempotencyConflictError(GatewayLedgerError):
+class AttemptRejectedError(GatewayLedgerError):
+    """A typed pre-dispatch rejection raised by ``start_attempt``.
+
+    The rejected reservation wrote nothing durable, so the executor must not
+    latch accounting health, must not dispatch a provider, and must not advance
+    the fallback waterfall; the exception reaches the protocol boundary
+    unchanged so the rejection keeps its own public error shape. ``failure`` is
+    the sanitized failure that settles the already-accepted parent request.
+    """
+
+    def __init__(self, message: str, *, failure: GatewayFailure) -> None:
+        """Retain the internal message and the sanitized settlement failure.
+
+        Args:
+            message: Internal diagnostic message, never shown to callers.
+            failure: Sanitized failure persisted on the accepted request and,
+                absent a more specific boundary mapping, shown to the caller.
+        """
+        super().__init__(message)
+        self.failure = failure
+
+
+class IdempotencyConflictError(AttemptRejectedError):
     """A caller operation key was reused with different canonical request content."""
 
+    def __init__(self, message: str) -> None:
+        """Retain the message with the canonical caller-error settlement shape."""
+        super().__init__(
+            message,
+            failure=GatewayFailure(
+                failure_class=GatewayFailureClass.INVALID_REQUEST,
+                safe_message="caller operation key was reused with different request content",
+            ),
+        )
 
-class IdempotencyReplayUnavailableError(GatewayLedgerError):
+
+class IdempotencyReplayUnavailableError(AttemptRejectedError):
     """A completed or accepted keyed request exists but its content cannot be replayed."""
+
+    def __init__(self, message: str) -> None:
+        """Retain the message with the canonical replay-loss settlement shape."""
+        super().__init__(
+            message,
+            failure=GatewayFailure(
+                failure_class=GatewayFailureClass.INTERNAL,
+                safe_message="completed keyed result is unavailable for durable replay",
+            ),
+        )
 
 
 class UsageTerminalCount(ContractModel):

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -44,6 +44,7 @@ from exp.runtime.gateway.execution import (
 )
 from exp.runtime.gateway.group_commit import abandoned_write_outcome
 from exp.runtime.gateway.interfaces import AttemptLedger, GatewayClock, GatewayControlStore
+from exp.runtime.gateway.ledger import AttemptRejectedError
 from exp.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute
 from exp.runtime.models.providers.errors import normalized_provider_failure
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
@@ -846,6 +847,8 @@ async def _abandon_quietly(lease: ReplayLease) -> None:
 def _failure_for_exception(exception: BaseException) -> GatewayFailure:
     """Return one sanitized durable failure for accepted pre-dispatch work."""
     if isinstance(exception, GatewayExecutionError):
+        return exception.failure
+    if isinstance(exception, AttemptRejectedError):
         return exception.failure
     if isinstance(exception, asyncio.CancelledError):
         return GatewayFailure(

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -53,7 +53,11 @@ from exp.runtime.gateway.execution import (
     GatewayExecutor,
     _require_deployment_identity,
 )
-from exp.runtime.gateway.ledger import GatewayLedgerError
+from exp.runtime.gateway.ledger import (
+    AttemptRejectedError,
+    GatewayLedgerError,
+    IdempotencyConflictError,
+)
 from exp.runtime.gateway.routing import (
     CatalogRouteResolver,
     GatewayRoute,
@@ -162,6 +166,7 @@ class _Ledger:
         self.finished: list[tuple[GatewayEvent | None, GatewayFailure | None]] = []
         self.fail_finishes = False
         self.fail_starts = False
+        self.reject_starts: AttemptRejectedError | None = None
 
     async def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
         """Capture accepted authority only."""
@@ -182,6 +187,8 @@ class _Ledger:
         del deployment, attempt_ordinal, route_depth, maximum_cost_micro_usd
         if self.fail_starts:
             raise GatewayLedgerError("attempt reservation unavailable")
+        if self.reject_starts is not None:
+            raise self.reject_starts
         self.started.append(snapshot)
         self.routes.append((route_reason, fallback_reason))
         return f"attempt-{len(self.started)}"
@@ -1139,6 +1146,45 @@ def test_pre_dispatch_start_failure_keeps_readiness_and_serves_other_requests() 
         await service.preflight()
 
         ledger.fail_starts = False
+        response = await asyncio.wait_for(
+            service.complete(raw_key="caller-secret", decoded=decoded),
+            timeout=0.5,
+        )
+        assert response.status_code == 200
+
+    asyncio.run(scenario())
+
+
+def test_typed_start_rejection_settles_request_with_its_own_shape() -> None:
+    """A typed reservation rejection keeps its exception type and settles the request."""
+
+    async def scenario() -> None:
+        """Reject one reservation with a 409-shaped conflict, then prove readiness and serving."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=0),)
+            )
+        )
+        service, _control, ledger, _proof = _service(provider)
+        ledger.reject_starts = IdempotencyConflictError(
+            "caller operation key was reused with different request content"
+        )
+        decoded = decode_chat(
+            {
+                "model": "public-model",
+                "messages": [{"role": "user", "content": "account"}],
+            }
+        )
+
+        with pytest.raises(IdempotencyConflictError) as raised:
+            await service.complete(raw_key="caller-secret", decoded=decoded)
+        assert raised.value.failure.failure_class == GatewayFailureClass.INVALID_REQUEST
+        assert ledger.started == []
+        assert ledger.finished == [(None, raised.value.failure)]
+
+        await service.preflight()
+
+        ledger.reject_starts = None
         response = await asyncio.wait_for(
             service.complete(raw_key="caller-secret", decoded=decoded),
             timeout=0.5,

--- a/exp/runtime/gateway/tests/waterfall_test.py
+++ b/exp/runtime/gateway/tests/waterfall_test.py
@@ -40,7 +40,7 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.execution import GatewayExecutionError, GatewayExecutor
 from exp.runtime.gateway.health import DeploymentHealthRegistry
-from exp.runtime.gateway.ledger import GatewayLedgerError
+from exp.runtime.gateway.ledger import AttemptRejectedError, GatewayLedgerError
 from exp.runtime.gateway.routing import CatalogRouteResolver, GatewayRoute
 from exp.runtime.models import ResolvedModel, RuntimeModelCatalog
 from exp.runtime.models.providers import ProviderDeadlineExceeded, RequestDeadline
@@ -740,6 +740,51 @@ def test_pre_dispatch_start_failure_does_not_latch_and_still_serves() -> None:
     asyncio.run(scenario())
 
 
+def test_typed_start_rejection_keeps_shape_without_latch_or_fallback() -> None:
+    """A typed pre-dispatch rejection propagates unchanged, skipping fallback and the latch."""
+
+    async def scenario() -> None:
+        """Reject one reservation with a typed shape, then reserve and serve a later request."""
+        first = _deployment("route-a", connection_sha256="b" * 64)
+        second = _deployment("route-b", connection_sha256="c" * 64)
+        ledger = _WaterfallLedger()
+        rejection = AttemptRejectedError(
+            "virtual key was revoked between accept and dispatch",
+            failure=GatewayFailure(
+                failure_class=GatewayFailureClass.AUTHENTICATION,
+                safe_message="the gateway key is invalid, expired, or revoked",
+            ),
+        )
+        ledger.reject_starts = rejection
+        provider = _ScriptedProvider([_completed_stream("served")])
+        fallback = _ScriptedProvider([_completed_stream("fallback")])
+        executor = _executor(
+            (first, second),
+            {first.source_alias: provider, second.source_alias: fallback},
+            ledger,
+        )
+
+        with pytest.raises(AttemptRejectedError) as raised:
+            await executor.start(route=_route((first, second)), request=_request())
+        assert raised.value is rejection
+        assert ledger.budget_checks == [first.deployment_id]
+        assert ledger.started == []
+        assert ledger.finished == []
+        assert ledger.parent_finishes == []
+        assert fallback.idempotency_keys == []
+
+        executor.require_healthy()
+
+        ledger.reject_starts = None
+        stream = await executor.start(route=_route((first, second)), request=_request())
+        events = [event async for event in stream]
+        assert events[-1].kind == GatewayEventKind.COMPLETED
+        assert [entry[0] for entry in ledger.started] == [first.deployment_id]
+        executor.require_healthy()
+
+    asyncio.run(scenario())
+
+
 def test_first_semantic_event_freezes_route_even_when_provider_later_fails() -> None:
     """Outward semantic output prevents a later provider failure from advancing routes."""
 
@@ -1325,6 +1370,7 @@ class _WaterfallLedger:
         self.rejected_scope = rejected_scope
         self.budget_checks: list[str] = []
         self.fail_starts = False
+        self.reject_starts: AttemptRejectedError | None = None
 
     async def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
         """Accept a parent request when a service-level test requires it."""
@@ -1347,6 +1393,8 @@ class _WaterfallLedger:
         self.budget_checks.append(deployment.deployment_id)
         if self.fail_starts:
             raise GatewayLedgerError("attempt reservation unavailable")
+        if self.reject_starts is not None:
+            raise self.reject_starts
         if deployment.deployment_id in self.rejected_deployments:
             raise BudgetReservationRejected(
                 scope_kind=self.rejected_scope,


### PR DESCRIPTION
## Why

An injected `AttemptLedger` that folds accept-time checks into the `start_attempt` reservation (idempotency conflicts, a key revoked between accept and dispatch) has no way to surface those rejections with their own public shape. Since #534 they no longer latch accounting health, but `_pre_dispatch_failure` reshapes every pre-dispatch ledger failure into a generic 500 `internal_error`, so a hosted ledger's 409/401 is indistinguishable from a lost reservation. This blocks the hosted Platform from folding its accept step into the reservation (its `DispatchLatchShield` currently has to disguise a dispatch-time key revocation as a 429 budget rejection).

## What

- **`AttemptRejectedError(GatewayLedgerError)`** (`exp/runtime/gateway/ledger.py`): a typed pre-dispatch rejection carrying the sanitized `GatewayFailure` that settles the accepted parent request. `IdempotencyConflictError` and `IdempotencyReplayUnavailableError` are re-parented under it with canonical settlement shapes (`invalid_request`, `internal`).
- **Executor** (`execution.py::_dispatch`): in the `attempt_id is None` branch, a typed rejection propagates unchanged — the health probe is released, nothing latches (nothing durable was written), no provider is dispatched, and the fallback waterfall does not advance. Plain `GatewayLedgerError` invariants keep the #534 behavior (500 internal, no latch).
- **Service** (`service.py::_failure_for_exception`): the accepted request settles durably with the rejection's own failure instead of a provider-normalized one.
- **Boundary** (`boundary.py`): rejections without a more specific branch map through `public_failure_error(exception.failure)`; the specific idempotency branches stay first and keep their 409 shapes on both data planes (HTTP layer and native bridge share this boundary).

## Error shapes when raised from `start_attempt`

| Cause | Before | After |
|---|---|---|
| `IdempotencyConflictError` | 500 `internal_error` | **409 `idempotency_conflict`** |
| `IdempotencyReplayUnavailableError` | 500 `internal_error` | **409 `idempotency_replay_unavailable`** |
| `AttemptRejectedError` with `AUTHENTICATION` failure (e.g. key revoked between accept and dispatch) | 500 `internal_error` | **401 `invalid_key`** |
| Plain `GatewayLedgerError` (real invariant violation) | 500 `internal_error` | 500 `internal_error` (unchanged) |
| `BudgetReservationRejected` | 429 / route skip by scope | unchanged |

None of these latch accounting health or advance the waterfall, before or after. Every consumer exists in this change (executor pass-through, service settlement, boundary mapping) plus the hosted Platform ledger, which adopts the seam in its WMO pin bump.

## Tests

- `tests/waterfall_test.py`: a typed rejection propagates as itself, skips the second route entirely, writes nothing, keeps `require_healthy()`, and the executor serves normally afterward.
- `tests/data_plane_test.py`: service-level — an `IdempotencyConflictError` from `start_attempt` keeps its type, settles the accepted request with its `invalid_request` shape, readiness stays green, next request serves 200.
- `boundary_test.py` (new): 409 conflict / 409 replay-unavailable branch precedence over the generic mapping; a generic `AUTHENTICATION` rejection maps to 401 `invalid_key`.

`ruff check` / `ruff format --check` / `ty check` clean; full suite: 2222 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)