### PR TITLE
fix(cli): allow confirmed gateway reconfiguration

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,9 @@ The default and project gateway forms use one gateway lifecycle. It binds only `
 provider call, and requires an explicit provider environment reference, exact model alias, identity,
 grant, and a virtual key. Interactive first-run setup can persist multiple provider connections and
 creates one initial gateway alias; additional deployments and certified pools remain explicit
-gateway configuration. `exp --non-interactive --json` returns `gateway_not_initialized` plus exact
+gateway configuration. From the interactive home screen, `Setup Gateway` also offers a confirmation-gated
+reconfiguration path for an initialized gateway: it replaces the selected provider and alias revisions
+while preserving existing identities, keys, grants, usage, and history. `exp --non-interactive --json` returns `gateway_not_initialized` plus exact
 next commands on an empty root. `exp --check` validates local readiness without binding.
 First-run setup prints `EXP_GATEWAY_URL` and the newly issued `EXP_GATEWAY_KEY` before readiness is
 checked, so the credentials remain available even when a provider route is not ready. The gateway-

--- a/exp/cli/gateway/home.py
+++ b/exp/cli/gateway/home.py
@@ -20,6 +20,7 @@ from exp.cli.gateway.serve import (
 from exp.cli.shared.picker import PickerAction, PickerOption, choose_one
 from exp.cli.shared.theme import EXP_THEME
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 _MENU_OPTIONS = (
     PickerOption(
@@ -261,6 +262,17 @@ def _setup_from_menu(console: Console, *, root: Path, port: int) -> None:
             setup = interactive_gateway_setup(root, console=console)
     except typer.Abort:
         console.print("[yellow]Gateway setup cancelled.[/yellow]")
+        return
+    except AliasActivationOutcomeUnknownError as exc:
+        console.print(
+            "[yellow]Gateway setup outcome is unknown; inspect gateway status before "
+            "retrying.[/yellow]"
+        )
+        if exc.issued is not None:
+            console.print(
+                f"Preserve this one-time gateway key: {exc.issued.raw_key}",
+                markup=False,
+            )
         return
     except ValueError as exc:
         console.print(f"[yellow]{exc}[/yellow]")

--- a/exp/cli/gateway/home.py
+++ b/exp/cli/gateway/home.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.prompt import Confirm
 from rich.text import Text
 
 from exp.cli.gateway.serve import (
@@ -225,11 +226,39 @@ def _start_from_menu(
 
 
 def _setup_from_menu(console: Console, *, root: Path, port: int) -> None:
-    """Run first-run setup without starting the server, then return to the menu."""
+    """Run setup or explicit reconfiguration without starting the server."""
     from exp.cli.gateway.setup import interactive_gateway_setup
 
+    reconfigure = GatewayManagement(root).initialized
+    if reconfigure:
+        console.print(
+            "[yellow]Gateway already configured.[/yellow]\n"
+            "Reconfiguration replaces the selected provider and public alias revisions. "
+            "Existing identities, keys, grants, usage, and history remain.",
+            markup=True,
+        )
+        try:
+            confirmed = Confirm.ask(
+                "Continue with gateway reconfiguration?",
+                default=False,
+                console=console,
+            )
+        except (EOFError, KeyboardInterrupt):
+            console.print("[yellow]Gateway reconfiguration cancelled.[/yellow]")
+            return
+        if not confirmed:
+            console.print("[yellow]Gateway reconfiguration cancelled.[/yellow]")
+            return
+
     try:
-        setup = interactive_gateway_setup(root, console=console)
+        if reconfigure:
+            setup = interactive_gateway_setup(
+                root,
+                console=console,
+                allow_reconfigure=True,
+            )
+        else:
+            setup = interactive_gateway_setup(root, console=console)
     except typer.Abort:
         console.print("[yellow]Gateway setup cancelled.[/yellow]")
         return
@@ -237,7 +266,8 @@ def _setup_from_menu(console: Console, *, root: Path, port: int) -> None:
         console.print(f"[yellow]{exc}[/yellow]")
         return
     emit_setup_credentials(port=port, setup=setup, console=console)
-    console.print("[green]✓ Gateway configured[/green] Choose Default Gateway to start it.")
+    outcome = "reconfigured" if reconfigure else "configured"
+    console.print(f"[green]✓ Gateway {outcome}[/green] Choose Default Gateway to start it.")
 
 
 def _show_status(console: Console, *, root: Path) -> None:

--- a/exp/cli/gateway/home_test.py
+++ b/exp/cli/gateway/home_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,9 @@ from exp.cli.gateway import home
 from exp.cli.gateway.serve import DEFAULT_MAX_ACTIVE_REQUESTS
 from exp.cli.gateway.setup import InteractiveSetupResult
 from exp.cli.shared.picker_test import ScriptedConsole
+from exp.runtime.gateway.auth import IssuedVirtualKey
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 
 def test_home_screen_starts_with_brand_and_recommends_default_gateway(tmp_path: Path) -> None:
@@ -143,6 +146,40 @@ def test_setup_gateway_warns_and_reconfigures_an_initialized_gateway(
     assert "history remain." in console.output
     assert "export EXP_GATEWAY_KEY=exp_vk_reconfigured" in console.output
     assert "Gateway reconfigured" in console.output
+
+
+def test_setup_gateway_preserves_a_key_when_reconfiguration_outcome_is_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambiguous activation surfaces the non-reconstructable key for recovery."""
+    GatewayManagement(tmp_path).initialize()
+    issued = IssuedVirtualKey(
+        key_id="key-unknown",
+        organization_id="local",
+        identity_id="default",
+        prefix="exp_vk_test",
+        raw_key="exp_vk_test_secret",
+        expires_at=None,
+        created_at=datetime.now(UTC),
+    )
+
+    def setup_gateway(_root: Path, **_: object) -> InteractiveSetupResult:
+        """Raise the same typed uncertainty produced by alias activation."""
+        raise AliasActivationOutcomeUnknownError(
+            alias_id="default-gateway",
+            revision_id="revision-unknown",
+            issued=issued,
+        )
+
+    monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
+    console = ScriptedConsole("3\ny\n5\n")
+
+    home.default_gateway(root=tmp_path, console=console)
+
+    assert "outcome is unknown" in console.output
+    assert "Preserve this one-time gateway key: exp_vk_test_secret" in console.output
+    assert "Gateway reconfigured" not in console.output
 
 
 def test_setup_gateway_declines_initialized_gateway_reconfiguration(

--- a/exp/cli/gateway/home_test.py
+++ b/exp/cli/gateway/home_test.py
@@ -11,6 +11,7 @@ from exp.cli.gateway import home
 from exp.cli.gateway.serve import DEFAULT_MAX_ACTIVE_REQUESTS
 from exp.cli.gateway.setup import InteractiveSetupResult
 from exp.cli.shared.picker_test import ScriptedConsole
+from exp.runtime.gateway.management import GatewayManagement
 
 
 def test_home_screen_starts_with_brand_and_recommends_default_gateway(tmp_path: Path) -> None:
@@ -112,3 +113,56 @@ def test_setup_gateway_returns_to_home_with_one_time_credentials(
     assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in console.output
     assert "export EXP_GATEWAY_KEY=exp_vk_test" in console.output
     assert "Choose Default Gateway to start it." in console.output
+
+
+def test_setup_gateway_warns_and_reconfigures_an_initialized_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An initialized gateway requires confirmation before the setup wizard replaces revisions."""
+    GatewayManagement(tmp_path).initialize()
+    calls: list[dict[str, object]] = []
+
+    def setup_gateway(_root: Path, **kwargs: object) -> InteractiveSetupResult:
+        """Capture the explicitly confirmed reconfiguration request."""
+        calls.append(kwargs)
+        return InteractiveSetupResult(
+            identity_id="default",
+            alias="default-gateway",
+            raw_key="exp_vk_reconfigured",
+        )
+
+    monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
+    console = ScriptedConsole("3\ny\n5\n")
+
+    home.default_gateway(root=tmp_path, console=console)
+
+    assert calls == [{"console": console, "allow_reconfigure": True}]
+    assert "Gateway already configured." in console.output
+    assert "Existing identities" in console.output
+    assert "history remain." in console.output
+    assert "export EXP_GATEWAY_KEY=exp_vk_reconfigured" in console.output
+    assert "Gateway reconfigured" in console.output
+
+
+def test_setup_gateway_declines_initialized_gateway_reconfiguration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reconfiguration warning defaults to a safe no-op when declined."""
+    GatewayManagement(tmp_path).initialize()
+    called = False
+
+    def setup_gateway(**_: object) -> InteractiveSetupResult:
+        """Fail if setup runs after the operator declines the warning."""
+        nonlocal called
+        called = True
+        raise AssertionError("setup should not run after a declined reconfiguration")
+
+    monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
+    console = ScriptedConsole("3\n\n5\n")
+
+    home.default_gateway(root=tmp_path, console=console)
+
+    assert not called
+    assert "Gateway reconfiguration cancelled." in console.output

--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -13,6 +13,7 @@ from rich.text import Text
 
 from exp.cli.shared.options import usage_error
 from exp.cli.shared.theme import EXP_THEME
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 LOOPBACK_HOST = "127.0.0.1"
 _LOOPBACK_HOST = LOOPBACK_HOST
@@ -149,8 +150,13 @@ def _run_gateway(
     elif not manager.initialized:
         if non_interactive or json_output or not sys.stdin.isatty() or not sys.stdout.isatty():
             _gateway_not_initialized(json_output=json_output)
-        with usage_error(ValueError):
+        try:
             setup = interactive_gateway_setup(root)
+        except AliasActivationOutcomeUnknownError as exc:
+            _emit_setup_unknown_recovery(port=port, error=exc)
+            raise typer.BadParameter(str(exc)) from None
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from None
         if setup is not None:
             _emit_setup_credentials(port=port, setup=setup)
 
@@ -421,6 +427,46 @@ def emit_setup_credentials(*, port: int, setup: object, console: Console | None 
         console: Optional console receiving the user-facing exports.
     """
     _emit_setup_credentials(port=port, setup=setup, console=console)
+
+
+def _emit_setup_unknown_recovery(
+    *,
+    port: int,
+    error: AliasActivationOutcomeUnknownError,
+) -> None:
+    """Deliver the only raw key when first-run setup has an unknown commit outcome.
+
+    Args:
+        port: Loopback port that the gateway will serve if the setup committed.
+        error: Typed activation error carrying the one-time key material when available.
+    """
+    if error.issued is None:
+        return
+    from exp.cli.gateway.setup import InteractiveSetupResult
+
+    setup = InteractiveSetupResult(
+        identity_id=error.issued.identity_id,
+        alias=error.alias_id,
+        raw_key=error.issued.raw_key,
+    )
+    _emit_setup_credentials(port=port, setup=setup)
+    _console.print(
+        "[yellow]First-run gateway setup outcome is unknown; inspect gateway status before "
+        "retrying.[/yellow]",
+        markup=True,
+    )
+    _console.print(
+        f"Preserve this one-time gateway key: {setup.raw_key}",
+        markup=False,
+    )
+    _console.print(
+        "If the key was not saved, issue a replacement with:",
+        markup=False,
+    )
+    _console.print(
+        f"  exp config gateway key issue {setup.identity_id} --key-id RECOVERY_KEY --json",
+        markup=False,
+    )
 
 
 def _emit_setup_recovery(*, setup: object) -> None:

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -6,6 +6,7 @@ import io
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -19,6 +20,8 @@ import exp.cli.gateway.serve as run_app
 from exp.cli.app import app
 from exp.cli.gateway.compatibility import ProjectGatewayCompatibility
 from exp.cli.gateway.setup import InteractiveSetupResult
+from exp.runtime.gateway.auth import IssuedVirtualKey
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 
 @pytest.mark.parametrize("ghost", [False, True])
@@ -269,4 +272,54 @@ def test_first_run_delivers_credentials_before_readiness_failure(
     assert "export OPENAI_API_KEY" not in transcript
     assert "First-run gateway setup completed, but the gateway is not ready." in transcript
     assert "run 'OPENAI_API_KEY=YOUR_API_KEY exp'" in str(failure.value)
+    assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript
+
+
+def test_first_run_unknown_setup_outcome_delivers_the_only_raw_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The serving boundary preserves a key attached to an indeterminate setup commit."""
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True, highlight=False)
+    issued = IssuedVirtualKey(
+        key_id="key-unknown",
+        organization_id="local",
+        identity_id="default",
+        prefix="exp_vk_test",
+        raw_key="exp_vk_unknown_secret",
+        expires_at=None,
+        created_at=datetime.now(UTC),
+    )
+
+    def interactive_setup(root: Path) -> InteractiveSetupResult:
+        """Raise the typed uncertainty that must retain its one-time secret."""
+        assert root == tmp_path
+        raise AliasActivationOutcomeUnknownError(
+            alias_id="default-gateway",
+            revision_id="revision-unknown",
+            issued=issued,
+        )
+
+    monkeypatch.setattr(run_app, "_console", console)
+    monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", interactive_setup)
+    monkeypatch.setattr(run_app.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(run_app.sys, "stdout", SimpleNamespace(isatty=lambda: True))
+
+    with pytest.raises(typer.BadParameter, match="operation_outcome_unknown"):
+        run_app._run_gateway(
+            project=None,
+            root=tmp_path,
+            policy=None,
+            port=8000,
+            ghost=False,
+            non_interactive=False,
+            json_output=False,
+            check=True,
+            graceful_timeout=10.0,
+        )
+
+    transcript = output.getvalue()
+    assert "export EXP_GATEWAY_KEY=exp_vk_unknown_secret" in transcript
+    assert "Preserve this one-time gateway key: exp_vk_unknown_secret" in transcript
     assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import os
 import uuid
-from collections.abc import MutableMapping
-from contextlib import nullcontext
+from collections.abc import Iterator, MutableMapping
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,8 +27,13 @@ from exp.cli.providers.provider_picker import (
 )
 from exp.cli.shared.progress import progress_display
 from exp.cli.shared.theme import EXP_THEME
-from exp.common.config import resolve_command_budget_usd, set_maximum_command_cost_usd
+from exp.common.config import (
+    resolve_command_budget_usd,
+    set_maximum_command_cost_usd,
+    settings_path,
+)
 from exp.common.core.artifacts import stable_id
+from exp.common.core.files import resolve_write_target, write_bytes_atomic
 from exp.common.core.locks import file_write_lock
 from exp.common.models import GatewayDeploymentCapabilities, GatewayTokenPrices, ModelCapabilities
 from exp.common.progress import report
@@ -50,6 +55,41 @@ class InteractiveSetupResult:
     identity_id: str
     alias: str
     raw_key: str
+
+
+@contextmanager
+def _command_budget_compensation(root: Path, maximum_cost_usd: float) -> Iterator[None]:
+    """Persist the selected budget and restore its exact preimage on setup failure.
+
+    Args:
+        root: EXP root owning the settings file.
+        maximum_cost_usd: Budget selected by the operator.
+
+    Yields:
+        Control to the rest of gateway setup.
+
+    Raises:
+        RuntimeError: The settings preimage cannot be restored after setup failure.
+    """
+    configured_path = settings_path(root)
+    target_path = resolve_write_target(configured_path)
+    original = target_path.read_bytes() if target_path.exists() else None
+    try:
+        set_maximum_command_cost_usd(maximum_cost_usd, root)
+        yield
+    except BaseException:
+        try:
+            with file_write_lock(configured_path, what="gateway setup budget compensation"):
+                if original is None:
+                    target_path.unlink(missing_ok=True)
+                else:
+                    write_bytes_atomic(target_path, original)
+        except BaseException as compensation_error:
+            raise RuntimeError(
+                "gateway setup settings compensation outcome is unknown; inspect settings "
+                "before retrying"
+            ) from compensation_error
+        raise
 
 
 @dataclass(frozen=True)
@@ -142,82 +182,82 @@ def interactive_gateway_setup(
     progress_context = (
         progress_display(console, single_line=True) if console.is_interactive else nullcontext(None)
     )
-    with progress_context as progress:
+    with _command_budget_compensation(root, values.maximum_cost_usd):
+        with progress_context as progress:
 
-        def advance(detail: str) -> None:
-            """Advance the gateway setup progress bar after one completed mutation."""
-            nonlocal completed_steps
-            completed_steps += 1
-            report(
-                progress,
-                "gateway setup",
-                completed=completed_steps,
-                total=total_steps,
-                detail=detail,
-            )
-
-        set_maximum_command_cost_usd(values.maximum_cost_usd, root)
-        advance("save budget")
-        manager.initialize()
-        advance("initialize")
-        serving_connections = {
-            item.connection_id: item.config for item in manager.provider_connections()
-        }
-        for endpoint in session.endpoints:
-            serving_connections[endpoint.connection.name] = endpoint.connection.catalog_config()
-            advance(f"prepare {endpoint.connection.name}")
-        catalog_path = root / "models.toml"
-        with file_write_lock(catalog_path, what="the interactive gateway setup"):
-            update = plan_singleton_deployment_update(
-                root,
-                deployment_alias=values.alias,
-                connection_name=selected.connection,
-                provider_model=selected.model,
-                exact_model_id=_gateway_exact_model_id(selected),
-                revision=None,
-                capabilities=capabilities,
-                gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
-                prices=GatewayTokenPrices(),
-                pricing_source=None,
-                replace=reconfigure,
-                serving_connections=serving_connections,
-            )
-            revision_id = f"revision-{uuid.uuid4().hex}"
-            key_id = f"key-{uuid.uuid4().hex}"
-            try:
-                apply_singleton_deployment_update(root, update)
-                identity_created, issued = manager.configure_direct_alias_with_identity(
-                    alias_id=values.alias,
-                    alias_name=values.alias,
-                    revision_id=revision_id,
-                    pool_id=values.alias,
-                    snapshot_ref=f"catalog-snapshots/{update.snapshot.name}",
-                    catalog_sha256=update.normalized.identity_sha256(),
-                    provider_connections=update.updated.connections,
-                    replace=reconfigure,
-                    identity_id=values.identity_id,
-                    identity_display_name=values.identity_id,
-                    key_id=key_id,
+            def advance(detail: str) -> None:
+                """Advance the gateway setup progress bar after one completed mutation."""
+                nonlocal completed_steps
+                completed_steps += 1
+                report(
+                    progress,
+                    "gateway setup",
+                    completed=completed_steps,
+                    total=total_steps,
+                    detail=detail,
                 )
-            except AliasActivationOutcomeUnknownError:
-                raise
-            except BaseException:
+
+            advance("save budget")
+            manager.initialize()
+            advance("initialize")
+            serving_connections = {
+                item.connection_id: item.config for item in manager.provider_connections()
+            }
+            for endpoint in session.endpoints:
+                serving_connections[endpoint.connection.name] = endpoint.connection.catalog_config()
+                advance(f"prepare {endpoint.connection.name}")
+            catalog_path = root / "models.toml"
+            with file_write_lock(catalog_path, what="the interactive gateway setup"):
+                update = plan_singleton_deployment_update(
+                    root,
+                    deployment_alias=values.alias,
+                    connection_name=selected.connection,
+                    provider_model=selected.model,
+                    exact_model_id=_gateway_exact_model_id(selected),
+                    revision=None,
+                    capabilities=capabilities,
+                    gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                    prices=GatewayTokenPrices(),
+                    pricing_source=None,
+                    replace=reconfigure,
+                    serving_connections=serving_connections,
+                )
+                revision_id = f"revision-{uuid.uuid4().hex}"
+                key_id = f"key-{uuid.uuid4().hex}"
                 try:
-                    rollback_singleton_deployment_update(root, update)
-                except GatewayCatalogCompensationError as compensation_error:
-                    raise RuntimeError(
-                        "gateway setup catalog compensation outcome is unknown; inspect "
-                        "catalog and gateway status before retrying"
-                    ) from compensation_error
-                raise
-            advance("write catalog")
-            advance("activate alias")
-            if identity_created:
-                advance("create identity")
-            else:
-                advance("reuse identity")
-            advance("grant alias")
-            advance("issue key")
+                    apply_singleton_deployment_update(root, update)
+                    identity_created, issued = manager.configure_direct_alias_with_identity(
+                        alias_id=values.alias,
+                        alias_name=values.alias,
+                        revision_id=revision_id,
+                        pool_id=values.alias,
+                        snapshot_ref=f"catalog-snapshots/{update.snapshot.name}",
+                        catalog_sha256=update.normalized.identity_sha256(),
+                        provider_connections=update.updated.connections,
+                        replace=reconfigure,
+                        identity_id=values.identity_id,
+                        identity_display_name=values.identity_id,
+                        key_id=key_id,
+                    )
+                except AliasActivationOutcomeUnknownError:
+                    raise
+                except BaseException:
+                    try:
+                        rollback_singleton_deployment_update(root, update)
+                    except GatewayCatalogCompensationError as compensation_error:
+                        raise RuntimeError(
+                            "gateway setup catalog compensation outcome is unknown; inspect "
+                            "catalog and gateway status before retrying"
+                        ) from compensation_error
+                    raise
+                advance("write catalog")
+                advance("activate alias")
+                if identity_created:
+                    advance("create identity")
+                else:
+                    advance("reuse identity")
+                advance("grant alias")
+                advance("issue key")
     console.print("[green]✓ Gateway configured[/green]")
     return InteractiveSetupResult(
         identity_id=values.identity_id,

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -46,7 +46,7 @@ from exp.runtime.models.providers import HttpProviderModelLister, ProviderModelL
 
 @dataclass(frozen=True)
 class InteractiveSetupResult:
-    """Explicit resources created by one accepted first-run summary."""
+    """Explicit resources created or reconfigured by one accepted setup summary."""
 
     identity_id: str
     alias: str
@@ -68,14 +68,17 @@ def interactive_gateway_setup(
     console: Console | None = None,
     lister: ProviderModelLister | None = None,
     environment: MutableMapping[str, str] | None = None,
+    allow_reconfigure: bool = False,
 ) -> InteractiveSetupResult:
-    """Collect and create one minimal provider-backed singleton gateway.
+    """Collect and create or reconfigure one minimal provider-backed gateway.
 
     Args:
-        root: Empty EXP root selected by the operator.
+        root: EXP root selected by the operator.
         console: Optional terminal override used by tests and embedding callers.
         lister: Optional authenticated model-listing seam used by tests.
         environment: Environment consulted for provider credentials.
+        allow_reconfigure: Whether the caller has explicitly confirmed replacing the selected
+            provider and alias revisions in an existing gateway.
 
     Returns:
         Created identity, alias, and one-time key material.
@@ -85,7 +88,8 @@ def interactive_gateway_setup(
         ValueError: Existing state or incomplete metadata prevents safe setup.
     """
     manager = GatewayManagement(root)
-    if manager.initialized:
+    reconfigure = manager.initialized
+    if reconfigure and not allow_reconfigure:
         raise ValueError("interactive first-run setup requires an uninitialized gateway")
     console = console or Console(theme=EXP_THEME)
     environment = os.environ if environment is None else environment
@@ -125,6 +129,8 @@ def interactive_gateway_setup(
     except (EOFError, KeyboardInterrupt, SetupCancelled):
         raise typer.Abort from None
 
+    _validate_setup_identity(manager, identity_id=values.identity_id)
+
     selected = model_selection.model
     capabilities = selected.capabilities or ModelCapabilities()
     if model_selection.reasoning_effort is not None:
@@ -159,6 +165,7 @@ def interactive_gateway_setup(
             manager.upsert_provider_connection(
                 connection_id=endpoint.connection.name,
                 config=endpoint.connection.catalog_config(),
+                replace=reconfigure,
             )
             advance(f"connect {endpoint.connection.name}")
         serving_connections = {
@@ -175,7 +182,7 @@ def interactive_gateway_setup(
             gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
             prices=GatewayTokenPrices(),
             pricing_source=None,
-            replace=False,
+            replace=reconfigure,
             serving_connections=serving_connections,
         )
         advance("write catalog")
@@ -191,8 +198,10 @@ def interactive_gateway_setup(
             provider_connections=manager.provider_bindings(authored),
         )
         advance("activate alias")
-        manager.create_identity(identity_id=values.identity_id, display_name=values.identity_id)
-        advance("create identity")
+        if _ensure_setup_identity(manager, identity_id=values.identity_id):
+            advance("create identity")
+        else:
+            advance("reuse identity")
         manager.add_grant(identity_id=values.identity_id, alias_id=values.alias)
         advance("grant alias")
         issued = manager.issue_key(
@@ -206,6 +215,39 @@ def interactive_gateway_setup(
         alias=values.alias,
         raw_key=issued.raw_key,
     )
+
+
+def _validate_setup_identity(manager: GatewayManagement, *, identity_id: str) -> None:
+    """Reject a reconfiguration that would target a disabled existing identity.
+
+    Args:
+        manager: Initialized gateway authority being configured.
+        identity_id: Identity selected by the operator.
+
+    Raises:
+        ValueError: The selected identity exists but is disabled.
+    """
+    for identity in manager.identities():
+        if identity.identity_id == identity_id and not identity.active:
+            raise ValueError(
+                f"identity {identity_id!r} is disabled; choose an active identity for setup"
+            )
+
+
+def _ensure_setup_identity(manager: GatewayManagement, *, identity_id: str) -> bool:
+    """Create a new setup identity or reuse an active one already in the gateway.
+
+    Args:
+        manager: Initialized gateway authority being configured.
+        identity_id: Identity selected by the operator.
+
+    Returns:
+        True when a new identity was created, or False when an existing identity was reused.
+    """
+    if any(identity.identity_id == identity_id for identity in manager.identities()):
+        return False
+    manager.create_identity(identity_id=identity_id, display_name=identity_id)
+    return True
 
 
 def _collect_gateway_values(

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -29,18 +29,17 @@ from exp.cli.shared.progress import progress_display
 from exp.cli.shared.theme import EXP_THEME
 from exp.common.config import resolve_command_budget_usd, set_maximum_command_cost_usd
 from exp.common.core.artifacts import stable_id
-from exp.common.models import (
-    GatewayDeploymentCapabilities,
-    GatewayTokenPrices,
-    ModelCapabilities,
-    ModelCatalog,
-)
+from exp.common.core.locks import file_write_lock
+from exp.common.models import GatewayDeploymentCapabilities, GatewayTokenPrices, ModelCapabilities
 from exp.common.progress import report
 from exp.runtime.gateway.catalog_authority import (
-    authored_snapshot_path,
-    upsert_singleton_deployment,
+    GatewayCatalogCompensationError,
+    apply_singleton_deployment_update,
+    plan_singleton_deployment_update,
+    rollback_singleton_deployment_update,
 )
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 from exp.runtime.models.providers import HttpProviderModelLister, ProviderModelLister
 
 
@@ -161,43 +160,54 @@ def interactive_gateway_setup(
         advance("save budget")
         manager.initialize()
         advance("initialize")
-        for endpoint in session.endpoints:
-            manager.upsert_provider_connection(
-                connection_id=endpoint.connection.name,
-                config=endpoint.connection.catalog_config(),
-                replace=reconfigure,
-            )
-            advance(f"connect {endpoint.connection.name}")
         serving_connections = {
             item.connection_id: item.config for item in manager.provider_connections()
         }
-        normalized, snapshot, _changed = upsert_singleton_deployment(
-            root,
-            deployment_alias=values.alias,
-            connection_name=selected.connection,
-            provider_model=selected.model,
-            exact_model_id=_gateway_exact_model_id(selected),
-            revision=None,
-            capabilities=capabilities,
-            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
-            prices=GatewayTokenPrices(),
-            pricing_source=None,
-            replace=reconfigure,
-            serving_connections=serving_connections,
-        )
-        advance("write catalog")
-        authored = ModelCatalog.model_validate_json(authored_snapshot_path(snapshot).read_bytes())
-        revision_id = f"revision-{uuid.uuid4().hex}"
-        manager.activate_direct_alias(
-            alias_id=values.alias,
-            alias_name=values.alias,
-            revision_id=revision_id,
-            pool_id=values.alias,
-            snapshot_ref=f"catalog-snapshots/{snapshot.name}",
-            catalog_sha256=normalized.identity_sha256(),
-            provider_connections=manager.provider_bindings(authored),
-        )
-        advance("activate alias")
+        for endpoint in session.endpoints:
+            serving_connections[endpoint.connection.name] = endpoint.connection.catalog_config()
+            advance(f"prepare {endpoint.connection.name}")
+        catalog_path = root / "models.toml"
+        with file_write_lock(catalog_path, what="the interactive gateway setup"):
+            update = plan_singleton_deployment_update(
+                root,
+                deployment_alias=values.alias,
+                connection_name=selected.connection,
+                provider_model=selected.model,
+                exact_model_id=_gateway_exact_model_id(selected),
+                revision=None,
+                capabilities=capabilities,
+                gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                prices=GatewayTokenPrices(),
+                pricing_source=None,
+                replace=reconfigure,
+                serving_connections=serving_connections,
+            )
+            revision_id = f"revision-{uuid.uuid4().hex}"
+            try:
+                apply_singleton_deployment_update(root, update)
+                manager.configure_direct_alias(
+                    alias_id=values.alias,
+                    alias_name=values.alias,
+                    revision_id=revision_id,
+                    pool_id=values.alias,
+                    snapshot_ref=f"catalog-snapshots/{update.snapshot.name}",
+                    catalog_sha256=update.normalized.identity_sha256(),
+                    provider_connections=update.updated.connections,
+                    replace=reconfigure,
+                )
+            except AliasActivationOutcomeUnknownError:
+                raise
+            except BaseException:
+                try:
+                    rollback_singleton_deployment_update(root, update)
+                except GatewayCatalogCompensationError as compensation_error:
+                    raise RuntimeError(
+                        "gateway setup catalog compensation outcome is unknown; inspect "
+                        "catalog and gateway status before retrying"
+                    ) from compensation_error
+                raise
+            advance("write catalog")
+            advance("activate alias")
         if _ensure_setup_identity(manager, identity_id=values.identity_id):
             advance("create identity")
         else:

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -59,7 +59,7 @@ class InteractiveSetupResult:
 
 @contextmanager
 def _command_budget_compensation(root: Path, maximum_cost_usd: float) -> Iterator[None]:
-    """Persist the selected budget and restore its exact preimage on setup failure.
+    """Persist the selected budget and compensate only proven setup failures.
 
     Args:
         root: EXP root owning the settings file.
@@ -77,6 +77,10 @@ def _command_budget_compensation(root: Path, maximum_cost_usd: float) -> Iterato
     try:
         set_maximum_command_cost_usd(maximum_cost_usd, root)
         yield
+    except AliasActivationOutcomeUnknownError:
+        # The SQLite commit may have landed, so keep the selected budget alongside the
+        # potentially committed serving authority for operator reconciliation.
+        raise
     except BaseException:
         try:
             with file_write_lock(configured_path, what="gateway setup budget compensation"):

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -183,9 +183,10 @@ def interactive_gateway_setup(
                 serving_connections=serving_connections,
             )
             revision_id = f"revision-{uuid.uuid4().hex}"
+            key_id = f"key-{uuid.uuid4().hex}"
             try:
                 apply_singleton_deployment_update(root, update)
-                manager.configure_direct_alias(
+                identity_created, issued = manager.configure_direct_alias_with_identity(
                     alias_id=values.alias,
                     alias_name=values.alias,
                     revision_id=revision_id,
@@ -194,6 +195,9 @@ def interactive_gateway_setup(
                     catalog_sha256=update.normalized.identity_sha256(),
                     provider_connections=update.updated.connections,
                     replace=reconfigure,
+                    identity_id=values.identity_id,
+                    identity_display_name=values.identity_id,
+                    key_id=key_id,
                 )
             except AliasActivationOutcomeUnknownError:
                 raise
@@ -208,17 +212,12 @@ def interactive_gateway_setup(
                 raise
             advance("write catalog")
             advance("activate alias")
-        if _ensure_setup_identity(manager, identity_id=values.identity_id):
-            advance("create identity")
-        else:
-            advance("reuse identity")
-        manager.add_grant(identity_id=values.identity_id, alias_id=values.alias)
-        advance("grant alias")
-        issued = manager.issue_key(
-            identity_id=values.identity_id,
-            key_id=f"key-{uuid.uuid4().hex}",
-        )
-        advance("issue key")
+            if identity_created:
+                advance("create identity")
+            else:
+                advance("reuse identity")
+            advance("grant alias")
+            advance("issue key")
     console.print("[green]✓ Gateway configured[/green]")
     return InteractiveSetupResult(
         identity_id=values.identity_id,
@@ -242,22 +241,6 @@ def _validate_setup_identity(manager: GatewayManagement, *, identity_id: str) ->
             raise ValueError(
                 f"identity {identity_id!r} is disabled; choose an active identity for setup"
             )
-
-
-def _ensure_setup_identity(manager: GatewayManagement, *, identity_id: str) -> bool:
-    """Create a new setup identity or reuse an active one already in the gateway.
-
-    Args:
-        manager: Initialized gateway authority being configured.
-        identity_id: Identity selected by the operator.
-
-    Returns:
-        True when a new identity was created, or False when an existing identity was reused.
-    """
-    if any(identity.identity_id == identity_id for identity in manager.identities()):
-        return False
-    manager.create_identity(identity_id=identity_id, display_name=identity_id)
-    return True
 
 
 def _collect_gateway_values(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -329,7 +329,7 @@ def test_gateway_setup_rolls_back_catalog_and_provider_when_alias_activation_fai
 
     monkeypatch.setattr(
         gateway_store,
-        "_activate_alias_revision_in_transaction",
+        "activate_alias_revision_in_transaction",
         fail_alias_activation,
     )
 

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,8 @@ from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.config import load_settings
 from exp.common.models import ConnectionConfig, ModelCapabilities, PricingSource, ProviderConnection
+from exp.runtime.gateway.auth import IssuedVirtualKey
+from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 _LOCAL_GATEWAY_EXCLUDE = frozenset({SETUP_PICKER_NAME})
 
@@ -423,6 +426,58 @@ def test_gateway_setup_rolls_back_all_authority_when_key_issue_fails(
         manager.keys(),
     )
     assert after == before
+
+
+def test_gateway_setup_keeps_selected_budget_when_activation_outcome_is_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown SQLite outcome keeps settings aligned with potentially committed authority."""
+    endpoints, models = _prepared_gateway_models()
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
+    )
+    first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+    issued = IssuedVirtualKey(
+        key_id="key-unknown",
+        organization_id="local",
+        identity_id=first.identity_id,
+        prefix="exp_vk_test",
+        raw_key="exp_vk_test_secret",
+        expires_at=None,
+        created_at=datetime.now(UTC),
+    )
+
+    def unknown_activation(*_args: object, **_kwargs: object) -> tuple[bool, IssuedVirtualKey]:
+        """Simulate an activation whose COMMIT acknowledgement is indeterminate."""
+        raise AliasActivationOutcomeUnknownError(
+            alias_id=first.alias,
+            revision_id="revision-unknown",
+            issued=issued,
+        )
+
+    monkeypatch.setattr(
+        setup.GatewayManagement,
+        "configure_direct_alias_with_identity",
+        unknown_activation,
+    )
+
+    with pytest.raises(AliasActivationOutcomeUnknownError, match="operation_outcome_unknown"):
+        setup.interactive_gateway_setup(
+            tmp_path,
+            console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n75\n"),
+            allow_reconfigure=True,
+        )
+
+    assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
 
 
 def test_gateway_setup_writes_budget_before_gateway_initialization(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import typer
 
+import exp.runtime.gateway.sqlite.setup_authority as setup_authority
 import exp.runtime.gateway.sqlite.store as gateway_store
 from exp.cli.gateway import setup
 from exp.cli.providers import model_picker, provider_picker
@@ -343,6 +344,83 @@ def test_gateway_setup_rolls_back_catalog_and_provider_when_alias_activation_fai
     assert (tmp_path / "models.toml").read_bytes() == catalog_before
     assert manager.provider_connections() == providers_before
     assert manager.aliases() == aliases_before
+
+
+def test_gateway_setup_rolls_back_all_authority_when_key_issue_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-alias credential failure rolls back every serving mutation atomically."""
+    endpoints, models = _prepared_gateway_models()
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
+    )
+    first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+    manager = setup.GatewayManagement(tmp_path)
+    before = (
+        (tmp_path / "models.toml").read_bytes(),
+        manager.provider_connections(),
+        manager.aliases(),
+        manager.identities(),
+        manager.grants(),
+        manager.keys(),
+    )
+
+    updated_model = provider_picker.AvailableModel(
+        alias=models[0].alias,
+        connection=models[0].connection,
+        provider=models[0].provider,
+        model="gpt-5-6-luna-v2",
+        capabilities=models[0].capabilities,
+        pricing_source=models[0].pricing_source,
+        configured=False,
+    )
+    updated_endpoint = provider_picker.PreparedEndpoint(
+        connection=endpoints[0].connection,
+        api_key="secret",
+        configured=False,
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((updated_endpoint,), (updated_model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(updated_model, "medium"),
+    )
+
+    def fail_key(*_args: object, **_kwargs: object) -> None:
+        """Fail after alias activation and grant staging inside the shared transaction."""
+        raise RuntimeError("key issue failed")
+
+    monkeypatch.setattr(setup_authority, "_issue_key", fail_key)
+
+    with pytest.raises(RuntimeError, match="key issue failed"):
+        setup.interactive_gateway_setup(
+            tmp_path,
+            console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n50\n"),
+            allow_reconfigure=True,
+        )
+
+    after = (
+        (tmp_path / "models.toml").read_bytes(),
+        manager.provider_connections(),
+        manager.aliases(),
+        manager.identities(),
+        manager.grants(),
+        manager.keys(),
+    )
+    assert after == before
 
 
 def test_gateway_setup_writes_budget_before_gateway_initialization(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import typer
 
+import exp.runtime.gateway.sqlite.store as gateway_store
 from exp.cli.gateway import setup
 from exp.cli.providers import model_picker, provider_picker
 from exp.cli.providers.experiential_cloud import SETUP_PICKER_LABEL, SETUP_PICKER_NAME
@@ -267,6 +268,81 @@ def test_gateway_setup_reconfigures_provider_alias_and_existing_identity(
     assert manager.status().active_keys == 2
     assert manager.status().grants == 1
     assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
+
+
+def test_gateway_setup_rolls_back_catalog_and_provider_when_alias_activation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed reconfiguration leaves the prior catalog and SQLite authority active."""
+    endpoints, models = _prepared_gateway_models()
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
+    )
+    first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+    manager = setup.GatewayManagement(tmp_path)
+    catalog_before = (tmp_path / "models.toml").read_bytes()
+    providers_before = manager.provider_connections()
+    aliases_before = manager.aliases()
+
+    updated_connection = ProviderConnection(
+        name="openai",
+        provider="openai",
+        api_key_env="UPDATED_OPENAI_API_KEY",
+    )
+    updated_endpoint = provider_picker.PreparedEndpoint(
+        connection=updated_connection,
+        api_key="secret",
+        configured=False,
+    )
+    updated_model = provider_picker.AvailableModel(
+        alias=models[0].alias,
+        connection="openai",
+        provider="openai",
+        model="gpt-5-6-luna-v2",
+        capabilities=models[0].capabilities,
+        pricing_source=models[0].pricing_source,
+        configured=False,
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((updated_endpoint,), (updated_model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(updated_model, "medium"),
+    )
+
+    def fail_alias_activation(*_args: object, **_kwargs: object) -> None:
+        """Fail after provider revisions have been staged in the shared transaction."""
+        raise RuntimeError("alias activation failed")
+
+    monkeypatch.setattr(
+        gateway_store,
+        "_activate_alias_revision_in_transaction",
+        fail_alias_activation,
+    )
+
+    with pytest.raises(RuntimeError, match="alias activation failed"):
+        setup.interactive_gateway_setup(
+            tmp_path,
+            console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n50\n"),
+            allow_reconfigure=True,
+        )
+
+    assert (tmp_path / "models.toml").read_bytes() == catalog_before
+    assert manager.provider_connections() == providers_before
+    assert manager.aliases() == aliases_before
 
 
 def test_gateway_setup_writes_budget_before_gateway_initialization(

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -191,6 +191,84 @@ def test_gateway_setup_can_edit_the_displayed_defaults(
     assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
 
 
+def test_gateway_setup_requires_explicit_reconfigure_opt_in(
+    tmp_path: Path,
+) -> None:
+    """An initialized gateway remains protected unless the caller supplies explicit consent."""
+    setup.GatewayManagement(tmp_path).initialize()
+
+    with pytest.raises(ValueError, match="requires an uninitialized gateway"):
+        setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole(""))
+
+
+def test_gateway_setup_reconfigures_provider_alias_and_existing_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirmed reconfiguration replaces serving revisions while retaining gateway authority."""
+    endpoints, models = _prepared_gateway_models()
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai",), False),
+    )
+    monkeypatch.setattr(setup, "prepare_providers", lambda *_args, **_kwargs: (endpoints, models))
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(models[0], "medium"),
+    )
+    first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+    manager = setup.GatewayManagement(tmp_path)
+    first_revision = manager.aliases()[0].revision_id
+
+    updated_connection = ProviderConnection(
+        name="openai",
+        provider="openai",
+        api_key_env="UPDATED_OPENAI_API_KEY",
+    )
+    updated_endpoint = provider_picker.PreparedEndpoint(
+        connection=updated_connection,
+        api_key="secret",
+        configured=False,
+    )
+    updated_model = provider_picker.AvailableModel(
+        alias=models[0].alias,
+        connection="openai",
+        provider="openai",
+        model="gpt-5-6-luna-v2",
+        capabilities=models[0].capabilities,
+        pricing_source=models[0].pricing_source,
+        configured=False,
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((updated_endpoint,), (updated_model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(updated_model, "medium"),
+    )
+
+    result = setup.interactive_gateway_setup(
+        tmp_path,
+        console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n75\n"),
+        allow_reconfigure=True,
+    )
+
+    assert result.alias == first.alias
+    assert result.identity_id == first.identity_id
+    connections = {item.connection_id: item for item in manager.provider_connections()}
+    assert connections["openai"].config.api_key_env == "UPDATED_OPENAI_API_KEY"
+    assert manager.aliases()[0].revision_id != first_revision
+    assert manager.status().active_identities == 1
+    assert manager.status().active_keys == 2
+    assert manager.status().grants == 1
+    assert setup.resolve_command_budget_usd(tmp_path, None) == 75.0
+
+
 def test_gateway_setup_writes_budget_before_gateway_initialization(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -366,6 +366,7 @@ def test_gateway_setup_rolls_back_all_authority_when_key_issue_fails(
     first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
     manager = setup.GatewayManagement(tmp_path)
     before = (
+        (tmp_path / "settings.toml").read_bytes(),
         (tmp_path / "models.toml").read_bytes(),
         manager.provider_connections(),
         manager.aliases(),
@@ -403,16 +404,17 @@ def test_gateway_setup_rolls_back_all_authority_when_key_issue_fails(
         """Fail after alias activation and grant staging inside the shared transaction."""
         raise RuntimeError("key issue failed")
 
-    monkeypatch.setattr(setup_authority, "_issue_key", fail_key)
+    monkeypatch.setattr(setup_authority, "_persist_key", fail_key)
 
     with pytest.raises(RuntimeError, match="key issue failed"):
         setup.interactive_gateway_setup(
             tmp_path,
-            console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n50\n"),
+            console=ScriptedConsole(f"edit\n{first.alias}\ndefault\n75\n"),
             allow_reconfigure=True,
         )
 
     after = (
+        (tmp_path / "settings.toml").read_bytes(),
         (tmp_path / "models.toml").read_bytes(),
         manager.provider_connections(),
         manager.aliases(),

--- a/exp/runtime/gateway/catalog_authority.py
+++ b/exp/runtime/gateway/catalog_authority.py
@@ -48,6 +48,17 @@ class CertifiedPoolUpdate:
     changed: bool
 
 
+@dataclass(frozen=True)
+class SingletonDeploymentUpdate:
+    """One lock-scoped singleton deployment update and its durable preimage."""
+
+    original: ModelCatalog | None
+    updated: ModelCatalog
+    normalized: NormalizedGatewayCatalog
+    snapshot: Path
+    changed: bool
+
+
 def upsert_connection(
     root: Path,
     *,
@@ -126,55 +137,219 @@ def upsert_singleton_deployment(
     Returns:
         Normalized catalog, immutable snapshot path, and whether authored metadata changed.
     """
+    path = root / "models.toml"
+    with file_write_lock(path, what="the gateway deployment catalog"):
+        update = plan_singleton_deployment_update(
+            root,
+            deployment_alias=deployment_alias,
+            connection_name=connection_name,
+            provider_model=provider_model,
+            exact_model_id=exact_model_id,
+            revision=revision,
+            capabilities=capabilities,
+            gateway_capabilities=gateway_capabilities,
+            prices=prices,
+            pricing_source=pricing_source,
+            billing_source=billing_source,
+            replace=replace,
+            serving_connections=serving_connections,
+        )
+        apply_singleton_deployment_update(root, update)
+    return update.normalized, update.snapshot, update.changed
+
+
+def plan_singleton_deployment_update(
+    root: Path,
+    *,
+    deployment_alias: str,
+    connection_name: str,
+    provider_model: str,
+    exact_model_id: str,
+    revision: str | None,
+    capabilities: ModelCapabilities,
+    gateway_capabilities: GatewayDeploymentCapabilities,
+    prices: GatewayTokenPrices,
+    pricing_source: str | None,
+    billing_source: BillingSource = BillingSource.CUSTOMER_MANAGED,
+    replace: bool,
+    serving_connections: dict[str, ConnectionConfig] | None = None,
+) -> SingletonDeploymentUpdate:
+    """Plan a singleton deployment mutation while the caller holds the catalog lock.
+
+    Args:
+        root: EXP root containing ``models.toml`` and gateway snapshots.
+        deployment_alias: Stable source alias used by the deployment record.
+        connection_name: Provider connection selected by the deployment.
+        provider_model: Exact provider-side model spelling.
+        exact_model_id: Operator-asserted exact logical model identity.
+        revision: Optional exact provider revision.
+        capabilities: Existing runtime capability declaration.
+        gateway_capabilities: Gateway protocol capability declaration.
+        prices: Integer attribution rates, with unknown represented by ``None``.
+        pricing_source: Optional provenance label for the rates.
+        billing_source: Credential ownership frozen for every dispatched attempt.
+        replace: Whether an existing deployment alias may change.
+        serving_connections: SQLite-authoritative connection metadata for serving snapshots.
+
+    Returns:
+        Immutable update plan containing the catalog preimage and desired snapshot.
+
+    Raises:
+        GatewayCatalogAuthoringError: Required metadata is missing or the deployment already
+            differs without explicit replacement.
+    """
     validate_artifact_id(deployment_alias)
     validate_artifact_id(exact_model_id)
     path = root / "models.toml"
-    with file_write_lock(path, what="the gateway deployment catalog"):
-        if path.exists():
-            current = load_model_catalog(path)
-            if serving_connections is not None:
-                current = current.model_copy(update={"connections": serving_connections})
-        elif serving_connections:
-            current = ModelCatalog(
-                connections=serving_connections,
-                models={},
-                roles=ModelRoles(),
-            )
-        else:
-            raise GatewayCatalogAuthoringError(
-                "gateway deployment authoring requires SQLite provider connections"
-            )
-        if connection_name not in current.connections:
-            raise GatewayCatalogAuthoringError(
-                f"unknown provider connection {connection_name!r}; add it first"
-            )
-        record = ModelRecord(
-            connection=connection_name,
-            model=provider_model,
-            revision=revision,
-            billing_source=billing_source,
-            capabilities=capabilities,
-            gateway=GatewayDeploymentMetadata(
-                exact_model_id=exact_model_id,
-                capabilities=gateway_capabilities,
-                prices=prices,
-                pricing_source=pricing_source,
-            ),
+    original = load_model_catalog(path) if path.exists() else None
+    if original is not None:
+        current = original
+        if serving_connections is not None:
+            current = current.model_copy(update={"connections": serving_connections})
+    elif serving_connections:
+        current = ModelCatalog(
+            connections=serving_connections,
+            models={},
+            roles=ModelRoles(),
         )
-        existing = current.models.get(deployment_alias)
-        if existing is not None and existing != record and not replace:
-            raise GatewayCatalogAuthoringError(
-                f"deployment {deployment_alias!r} exists; use alias update to replace it"
+    else:
+        raise GatewayCatalogAuthoringError(
+            "gateway deployment authoring requires SQLite provider connections"
+        )
+    if connection_name not in current.connections:
+        raise GatewayCatalogAuthoringError(
+            f"unknown provider connection {connection_name!r}; add it first"
+        )
+    record = ModelRecord(
+        connection=connection_name,
+        model=provider_model,
+        revision=revision,
+        billing_source=billing_source,
+        capabilities=capabilities,
+        gateway=GatewayDeploymentMetadata(
+            exact_model_id=exact_model_id,
+            capabilities=gateway_capabilities,
+            prices=prices,
+            pricing_source=pricing_source,
+        ),
+    )
+    existing = current.models.get(deployment_alias)
+    if existing is not None and existing != record and not replace:
+        raise GatewayCatalogAuthoringError(
+            f"deployment {deployment_alias!r} exists; use alias update to replace it"
+        )
+    updated = current
+    if existing != record:
+        updated = current.model_copy(
+            update={"models": {**current.models, deployment_alias: record}}
+        )
+    normalized = normalize_gateway_catalog(updated)
+    snapshot = root / "gateway" / "catalog-snapshots" / f"{normalized.identity_sha256()}.json"
+    return SingletonDeploymentUpdate(
+        original=original,
+        updated=updated,
+        normalized=normalized,
+        snapshot=snapshot,
+        changed=original != updated,
+    )
+
+
+def apply_singleton_deployment_update(root: Path, update: SingletonDeploymentUpdate) -> None:
+    """Persist a planned singleton deployment while its catalog lock remains held.
+
+    Args:
+        root: EXP root containing the locked catalog.
+        update: Previously validated singleton deployment mutation.
+    """
+    if update.changed:
+        write_model_catalog(root / "models.toml", update.updated)
+    _write_catalog_snapshot(root, update.updated, update.normalized)
+
+
+def rollback_singleton_deployment_update(
+    root: Path,
+    update: SingletonDeploymentUpdate,
+) -> None:
+    """Restore a failed setup's exact singleton catalog preimage.
+
+    Args:
+        root: EXP root containing the locked catalog.
+        update: Applied mutation plan whose SQLite authority mutation failed.
+
+    Raises:
+        GatewayCatalogCompensationError: The exact catalog preimage could not be proven restored.
+    """
+    if not update.changed:
+        return
+    path = root / "models.toml"
+    if update.original is None:
+        if not path.exists():
+            return
+        try:
+            current = load_model_catalog(path)
+        except BaseException as exc:
+            raise GatewayCatalogCompensationError(
+                "gateway catalog rollback outcome is unknown; inspect catalog authority before "
+                "retrying"
+            ) from exc
+        if current != update.updated:
+            raise GatewayCatalogCompensationError(
+                "gateway catalog changed during setup; inspect authority before retrying"
             )
-        changed = existing != record
-        if changed:
-            models = {**current.models, deployment_alias: record}
-            current = current.model_copy(update={"models": models})
-        normalized = normalize_gateway_catalog(current)
-        if changed:
-            write_model_catalog(path, current)
-    snapshot = _write_catalog_snapshot(root, current, normalized)
-    return normalized, snapshot, changed
+        try:
+            path.unlink()
+        except BaseException as exc:
+            if not path.exists():
+                return
+            raise GatewayCatalogCompensationError(
+                "gateway catalog rollback did not remove its newly created preimage; inspect "
+                "authority before retrying"
+            ) from exc
+        if path.exists():
+            raise GatewayCatalogCompensationError(
+                "gateway catalog rollback did not remove its newly created preimage; inspect "
+                "authority before retrying"
+            )
+        return
+    try:
+        current = load_model_catalog(path)
+    except BaseException as exc:
+        raise GatewayCatalogCompensationError(
+            "gateway catalog rollback outcome is unknown; inspect catalog authority before retrying"
+        ) from exc
+    if current == update.original:
+        return
+    if current != update.updated:
+        raise GatewayCatalogCompensationError(
+            "gateway catalog changed during setup; inspect authority before retrying"
+        )
+    try:
+        write_model_catalog(path, update.original)
+    except BaseException as exc:
+        try:
+            restored = load_model_catalog(path)
+        except BaseException as reconciliation_error:
+            raise GatewayCatalogCompensationError(
+                "gateway catalog rollback outcome is unknown; inspect catalog authority before "
+                "retrying"
+            ) from reconciliation_error
+        if restored == update.original:
+            return
+        raise GatewayCatalogCompensationError(
+            "gateway catalog rollback did not restore its exact preimage; inspect authority "
+            "before retrying"
+        ) from exc
+    try:
+        restored = load_model_catalog(path)
+    except BaseException as exc:
+        raise GatewayCatalogCompensationError(
+            "gateway catalog rollback could not be verified; inspect authority before retrying"
+        ) from exc
+    if restored != update.original:
+        raise GatewayCatalogCompensationError(
+            "gateway catalog rollback did not restore its exact preimage; inspect authority "
+            "before retrying"
+        )
 
 
 def upsert_certified_pool(

--- a/exp/runtime/gateway/management.py
+++ b/exp/runtime/gateway/management.py
@@ -17,6 +17,7 @@ from exp.runtime.gateway.sqlite.migrations import connect_database
 from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionAuthority,
     ProviderConnectionBinding,
+    ProviderConnectionMutation,
 )
 from exp.runtime.gateway.sqlite.store import GatewayStoreError, SQLiteGatewayStore
 
@@ -159,6 +160,59 @@ class GatewayManagement:
             connection_id=connection_id,
             revision_id=revision_id,
             config=config,
+            replace=replace,
+        )
+
+    def configure_direct_alias(
+        self,
+        *,
+        alias_id: str,
+        alias_name: str,
+        revision_id: str,
+        pool_id: str,
+        snapshot_ref: str,
+        catalog_sha256: str,
+        provider_connections: dict[str, ConnectionConfig],
+        replace: bool,
+    ) -> None:
+        """Atomically revise serving connections and activate one direct alias revision.
+
+        Args:
+            alias_id: Stable public alias identifier.
+            alias_name: Public model string.
+            revision_id: Immutable alias revision identifier.
+            pool_id: Direct target pool identifier.
+            snapshot_ref: Content-addressed catalog snapshot reference.
+            catalog_sha256: Exact normalized catalog digest.
+            provider_connections: Desired secret-free SQLite-authoritative connection metadata.
+            replace: Whether differing active connection metadata may be revised.
+
+        Raises:
+            GatewayStoreError: The requested authority violates an existing invariant.
+        """
+        mutations = tuple(
+            ProviderConnectionMutation(
+                connection_id=connection_id,
+                revision_id=stable_id(
+                    "provider-connection-revision",
+                    {
+                        "connection_id": connection_id,
+                        "config": config.model_dump(mode="json", exclude_none=False),
+                    },
+                ),
+                config=config,
+            )
+            for connection_id, config in sorted(provider_connections.items())
+        )
+        self.require_initialized().upsert_provider_connections_and_activate_direct_alias(
+            organization_id=self.organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            pool_id=pool_id,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            provider_connections=mutations,
             replace=replace,
         )
 

--- a/exp/runtime/gateway/management.py
+++ b/exp/runtime/gateway/management.py
@@ -216,6 +216,71 @@ class GatewayManagement:
             replace=replace,
         )
 
+    def configure_direct_alias_with_identity(
+        self,
+        *,
+        alias_id: str,
+        alias_name: str,
+        revision_id: str,
+        pool_id: str,
+        snapshot_ref: str,
+        catalog_sha256: str,
+        provider_connections: dict[str, ConnectionConfig],
+        replace: bool,
+        identity_id: str,
+        identity_display_name: str,
+        key_id: str,
+    ) -> tuple[bool, IssuedVirtualKey]:
+        """Atomically activate one alias and create or reuse its setup credentials.
+
+        Args:
+            alias_id: Stable public alias identifier.
+            alias_name: Public model string.
+            revision_id: Immutable alias revision identifier.
+            pool_id: Direct target pool identifier.
+            snapshot_ref: Content-addressed catalog snapshot reference.
+            catalog_sha256: Exact normalized catalog digest.
+            provider_connections: Desired secret-free connection metadata.
+            replace: Whether differing active connection metadata may be revised.
+            identity_id: Stable setup identity identifier.
+            identity_display_name: Operator-facing setup identity name.
+            key_id: Non-secret identifier for the newly issued key.
+
+        Returns:
+            Whether the identity was created, and the one-time key receipt.
+
+        Raises:
+            GatewayStoreError: The requested authority violates an existing invariant.
+        """
+        mutations = tuple(
+            ProviderConnectionMutation(
+                connection_id=connection_id,
+                revision_id=stable_id(
+                    "provider-connection-revision",
+                    {
+                        "connection_id": connection_id,
+                        "config": config.model_dump(mode="json", exclude_none=False),
+                    },
+                ),
+                config=config,
+            )
+            for connection_id, config in sorted(provider_connections.items())
+        )
+        return self.require_initialized().configure_direct_alias_with_identity(
+            organization_id=self.organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            pool_id=pool_id,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            provider_connections=mutations,
+            replace=replace,
+            identity_id=identity_id,
+            identity_display_name=identity_display_name,
+            key_id=key_id,
+        )
+
     def provider_connections(self) -> tuple[ProviderConnectionAuthority, ...]:
         """Return active SQLite-authoritative serving connections."""
         if not self.initialized:

--- a/exp/runtime/gateway/sqlite/alias_activation.py
+++ b/exp/runtime/gateway/sqlite/alias_activation.py
@@ -8,6 +8,10 @@ from contextlib import AbstractContextManager, contextmanager
 
 from exp.common.core.artifacts import Sha256
 from exp.runtime.gateway.contracts import DirectTarget, GatewayTarget, ProjectTarget
+from exp.runtime.gateway.sqlite.provider_authority import (
+    ProviderConnectionBinding,
+    bind_alias_provider_connections,
+)
 
 ConnectionFactory = Callable[[], AbstractContextManager[sqlite3.Connection]]
 
@@ -164,3 +168,203 @@ def reconcile_alias_activation(
         int(refusal_failover),
     )
     return tuple(row[index] for index in range(8)) == expected
+
+
+def register_catalog_snapshot_in_transaction(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    now: str,
+    store_error: type[ValueError],
+) -> None:
+    """Register one catalog snapshot idempotently inside a caller-owned transaction.
+
+    Args:
+        connection: Open SQLite transaction.
+        organization_id: Owning tenant.
+        snapshot_ref: Content-addressed external snapshot reference.
+        catalog_sha256: Normalized secret-free catalog digest.
+        now: Canonical transaction timestamp.
+        store_error: Gateway-specific error type for authority conflicts.
+
+    Raises:
+        ValueError: The snapshot reference or digest was previously assigned differently.
+    """
+    by_ref = connection.execute(
+        """
+        SELECT organization_id, catalog_sha256 FROM catalog_snapshot_refs
+        WHERE snapshot_ref = ?
+        """,
+        (snapshot_ref,),
+    ).fetchone()
+    if by_ref is not None:
+        if (
+            str(by_ref["organization_id"]) != organization_id
+            or str(by_ref["catalog_sha256"]) != catalog_sha256
+        ):
+            raise store_error("catalog snapshot reference was reused with another digest")
+        return
+    by_digest = connection.execute(
+        """
+        SELECT snapshot_ref FROM catalog_snapshot_refs
+        WHERE organization_id = ? AND catalog_sha256 = ?
+        """,
+        (organization_id, catalog_sha256),
+    ).fetchone()
+    if by_digest is not None:
+        raise store_error("catalog digest is already registered under another snapshot")
+    connection.execute(
+        """
+        INSERT INTO catalog_snapshot_refs (
+            snapshot_ref, organization_id, catalog_sha256, created_at
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (snapshot_ref, organization_id, catalog_sha256, now),
+    )
+
+
+def activate_alias_revision_in_transaction(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_name: str,
+    revision_id: str,
+    target: GatewayTarget,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    provider_connections: tuple[ProviderConnectionBinding, ...],
+    refusal_failover: bool,
+    now: str,
+    store_error: type[ValueError],
+) -> None:
+    """Create and activate one immutable alias revision in an open transaction.
+
+    Args:
+        connection: Open SQLite transaction.
+        organization_id: Owning tenant.
+        alias_id: Stable alias resource ID.
+        alias_name: Public model string.
+        revision_id: Immutable alias revision ID.
+        target: Direct pool or frozen project target.
+        snapshot_ref: Registered catalog snapshot reference.
+        catalog_sha256: Exact normalized catalog digest.
+        provider_connections: Exact active connection revisions for the snapshot.
+        refusal_failover: Whether typed precommit refusals may advance.
+        now: Canonical transaction timestamp.
+        store_error: Gateway-specific error type for authority conflicts.
+
+    Raises:
+        ValueError: The snapshot or alias invariants conflict.
+    """
+    snapshot = connection.execute(
+        """
+        SELECT 1 FROM catalog_snapshot_refs
+        WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
+        """,
+        (organization_id, snapshot_ref, catalog_sha256),
+    ).fetchone()
+    if snapshot is None:
+        raise store_error("catalog snapshot reference is not registered")
+    alias_row = connection.execute(
+        """
+        SELECT alias_name FROM gateway_aliases
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (organization_id, alias_id),
+    ).fetchone()
+    if alias_row is None:
+        connection.execute(
+            """
+            INSERT INTO gateway_aliases (
+                alias_id, organization_id, alias_name, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (alias_id, organization_id, alias_name, now, now),
+        )
+        revision_number = 1
+    else:
+        if str(alias_row["alias_name"]) != alias_name:
+            raise store_error("alias ID cannot be renamed")
+        revision_number = int(
+            connection.execute(
+                """
+                SELECT COALESCE(MAX(revision_number), 0) + 1
+                FROM alias_revisions WHERE organization_id = ? AND alias_id = ?
+                """,
+                (organization_id, alias_id),
+            ).fetchone()[0]
+        )
+    pool_id: str | None = None
+    project_ref: str | None = None
+    activation_ref: str | None = None
+    if isinstance(target, DirectTarget):
+        pool_id = target.pool_id
+    else:
+        project_ref = target.project_ref
+        activation_ref = target.activation_ref
+    connection.execute(
+        """
+        INSERT INTO alias_revisions (
+            revision_id, organization_id, alias_id, revision_number, target_kind,
+            pool_id, project_ref, activation_ref, catalog_sha256, snapshot_ref,
+            refusal_failover, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            revision_id,
+            organization_id,
+            alias_id,
+            revision_number,
+            target.kind,
+            pool_id,
+            project_ref,
+            activation_ref,
+            catalog_sha256,
+            snapshot_ref,
+            int(refusal_failover),
+            now,
+        ),
+    )
+    bind_alias_provider_connections(
+        connection,
+        organization_id=organization_id,
+        alias_id=alias_id,
+        alias_revision_id=revision_id,
+        bindings=provider_connections,
+        now=now,
+    )
+    connection.execute(
+        """
+        DELETE FROM project_activation_bindings
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (organization_id, alias_id),
+    )
+    if isinstance(target, ProjectTarget):
+        connection.execute(
+            """
+            INSERT INTO project_activation_bindings (
+                organization_id, project_ref, activation_ref,
+                alias_id, revision_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                organization_id,
+                target.project_ref,
+                target.activation_ref,
+                alias_id,
+                revision_id,
+                now,
+            ),
+        )
+    connection.execute(
+        """
+        UPDATE gateway_aliases
+        SET active_revision_id = ?, active = 1, updated_at = ?
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (revision_id, now, organization_id, alias_id),
+    )

--- a/exp/runtime/gateway/sqlite/alias_activation.py
+++ b/exp/runtime/gateway/sqlite/alias_activation.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, contextmanager
 
 from exp.common.core.artifacts import Sha256
+from exp.runtime.gateway.auth import IssuedVirtualKey
 from exp.runtime.gateway.contracts import DirectTarget, GatewayTarget, ProjectTarget
 from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionBinding,
@@ -19,15 +20,23 @@ ConnectionFactory = Callable[[], AbstractContextManager[sqlite3.Connection]]
 class AliasActivationOutcomeUnknownError(ValueError):
     """An alias activation could not prove whether its COMMIT landed."""
 
-    def __init__(self, *, alias_id: str, revision_id: str) -> None:
-        """Create a content-free recovery error for one immutable alias revision.
+    def __init__(
+        self,
+        *,
+        alias_id: str,
+        revision_id: str,
+        issued: IssuedVirtualKey | None = None,
+    ) -> None:
+        """Create a recovery error for one immutable alias revision.
 
         Args:
             alias_id: Stable public alias identifier.
             revision_id: Immutable revision whose commit outcome is unknown.
+            issued: Optional one-time credential whose raw secret must be preserved for recovery.
         """
         self.alias_id = alias_id
         self.revision_id = revision_id
+        self.issued = issued
         super().__init__(
             "operation_outcome_unknown: inspect alias "
             f"{alias_id!r} revision {revision_id!r} before retrying"

--- a/exp/runtime/gateway/sqlite/provider_authority.py
+++ b/exp/runtime/gateway/sqlite/provider_authority.py
@@ -20,6 +20,14 @@ class ProviderConnectionBinding(ContractModel):
     connection_sha256: Sha256
 
 
+class ProviderConnectionMutation(ContractModel):
+    """One provider connection revision staged inside an alias activation transaction."""
+
+    connection_id: str
+    revision_id: str
+    config: ConnectionConfig
+
+
 class ProviderConnectionAuthority(ContractModel):
     """One active or revision-pinned secret-free provider connection."""
 

--- a/exp/runtime/gateway/sqlite/setup_authority.py
+++ b/exp/runtime/gateway/sqlite/setup_authority.py
@@ -17,6 +17,7 @@ from exp.runtime.gateway.auth import (
 )
 from exp.runtime.gateway.contracts import DirectTarget
 from exp.runtime.gateway.sqlite.alias_activation import (
+    AliasActivationOutcomeUnknownError,
     alias_activation_transaction,
     register_catalog_snapshot_in_transaction,
 )
@@ -155,48 +156,21 @@ def configure_direct_alias_with_identity(
     """
     target = DirectTarget(pool_id=pool_id)
     now = utc_text(store._clock.now())
+    issued, fingerprint_version, fingerprint = _prepare_key(
+        store,
+        organization_id=organization_id,
+        identity_id=identity_id,
+        key_id=key_id,
+        created_at=now,
+    )
     connect = cast(
         Callable[[], AbstractContextManager[sqlite3.Connection]],
         store._connect,
     )
     identity_created = False
-    issued: IssuedVirtualKey | None = None
-    with alias_activation_transaction(
-        connect=connect,
-        organization_id=organization_id,
-        alias_id=alias_id,
-        alias_name=alias_name,
-        revision_id=revision_id,
-        target=target,
-        snapshot_ref=snapshot_ref,
-        catalog_sha256=catalog_sha256,
-        refusal_failover=False,
-    ) as connection:
-        identity_created = _ensure_identity(
-            connection,
-            organization_id=organization_id,
-            identity_id=identity_id,
-            display_name=identity_display_name,
-            now=now,
-            store_error=store._store_error,
-        )
-        bindings = _stage_provider_connections(
-            connection,
-            organization_id=organization_id,
-            provider_connections=provider_connections,
-            replace=replace,
-            now=now,
-        )
-        register_catalog_snapshot_in_transaction(
-            connection,
-            organization_id=organization_id,
-            snapshot_ref=snapshot_ref,
-            catalog_sha256=catalog_sha256,
-            now=now,
-            store_error=store._store_error,
-        )
-        activate_alias_revision(
-            connection,
+    try:
+        with alias_activation_transaction(
+            connect=connect,
             organization_id=organization_id,
             alias_id=alias_id,
             alias_name=alias_name,
@@ -204,28 +178,67 @@ def configure_direct_alias_with_identity(
             target=target,
             snapshot_ref=snapshot_ref,
             catalog_sha256=catalog_sha256,
-            provider_connections=bindings,
             refusal_failover=False,
-            now=now,
-            store_error=store._store_error,
-        )
-        connection.execute(
-            """
-            INSERT OR IGNORE INTO identity_alias_grants (
-                organization_id, identity_id, alias_id, created_at
-            ) VALUES (?, ?, ?, ?)
-            """,
-            (organization_id, identity_id, alias_id, now),
-        )
-        issued = _issue_key(
-            connection,
-            store=store,
-            organization_id=organization_id,
-            identity_id=identity_id,
-            key_id=key_id,
-            created_at=now,
-        )
-    assert issued is not None
+        ) as connection:
+            identity_created = _ensure_identity(
+                connection,
+                organization_id=organization_id,
+                identity_id=identity_id,
+                display_name=identity_display_name,
+                now=now,
+                store_error=store._store_error,
+            )
+            bindings = _stage_provider_connections(
+                connection,
+                organization_id=organization_id,
+                provider_connections=provider_connections,
+                replace=replace,
+                now=now,
+            )
+            register_catalog_snapshot_in_transaction(
+                connection,
+                organization_id=organization_id,
+                snapshot_ref=snapshot_ref,
+                catalog_sha256=catalog_sha256,
+                now=now,
+                store_error=store._store_error,
+            )
+            activate_alias_revision(
+                connection,
+                organization_id=organization_id,
+                alias_id=alias_id,
+                alias_name=alias_name,
+                revision_id=revision_id,
+                target=target,
+                snapshot_ref=snapshot_ref,
+                catalog_sha256=catalog_sha256,
+                provider_connections=bindings,
+                refusal_failover=False,
+                now=now,
+                store_error=store._store_error,
+            )
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO identity_alias_grants (
+                    organization_id, identity_id, alias_id, created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (organization_id, identity_id, alias_id, now),
+            )
+            _persist_key(
+                connection,
+                store=store,
+                issued=issued,
+                fingerprint_version=fingerprint_version,
+                fingerprint=fingerprint,
+                created_at=now,
+            )
+    except AliasActivationOutcomeUnknownError as activation_error:
+        raise AliasActivationOutcomeUnknownError(
+            alias_id=alias_id,
+            revision_id=revision_id,
+            issued=issued,
+        ) from activation_error
     return identity_created, issued
 
 
@@ -291,19 +304,43 @@ def _ensure_identity(
     return True
 
 
-def _issue_key(
-    connection: sqlite3.Connection,
-    *,
+def _prepare_key(
     store: SQLiteGatewayStore,
+    *,
     organization_id: str,
     identity_id: str,
     key_id: str,
     created_at: str,
-) -> IssuedVirtualKey:
-    """Generate and persist one setup key inside the serving transaction."""
+) -> tuple[IssuedVirtualKey, int, Sha256]:
+    """Generate setup key material before entering the ambiguous transaction boundary."""
     prefix, raw_key = issue_key_material()
     pepper = store._pepper.current()
     fingerprint = fingerprint_virtual_key(raw_key, pepper)
+    return (
+        IssuedVirtualKey(
+            key_id=key_id,
+            organization_id=organization_id,
+            identity_id=identity_id,
+            prefix=prefix,
+            raw_key=raw_key,
+            expires_at=None,
+            created_at=datetime.fromisoformat(created_at),
+        ),
+        pepper.version,
+        fingerprint,
+    )
+
+
+def _persist_key(
+    connection: sqlite3.Connection,
+    *,
+    store: SQLiteGatewayStore,
+    issued: IssuedVirtualKey,
+    fingerprint_version: int,
+    fingerprint: Sha256,
+    created_at: str,
+) -> None:
+    """Persist prepared setup key material inside the serving transaction."""
     try:
         connection.execute(
             """
@@ -313,11 +350,11 @@ def _issue_key(
             ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                key_id,
-                organization_id,
-                identity_id,
-                prefix,
-                pepper.version,
+                issued.key_id,
+                issued.organization_id,
+                issued.identity_id,
+                issued.prefix,
+                fingerprint_version,
                 fingerprint,
                 created_at,
             ),
@@ -326,12 +363,3 @@ def _issue_key(
         raise store._store_error(
             "virtual key issuance conflicts with existing gateway authority"
         ) from None
-    return IssuedVirtualKey(
-        key_id=key_id,
-        organization_id=organization_id,
-        identity_id=identity_id,
-        prefix=prefix,
-        raw_key=raw_key,
-        expires_at=None,
-        created_at=datetime.fromisoformat(created_at),
-    )

--- a/exp/runtime/gateway/sqlite/setup_authority.py
+++ b/exp/runtime/gateway/sqlite/setup_authority.py
@@ -1,0 +1,337 @@
+"""Atomic SQLite authority mutations used by interactive gateway setup."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import datetime
+from typing import TYPE_CHECKING, cast
+
+from exp.common.core.artifacts import Sha256
+from exp.runtime.gateway.auth import (
+    IssuedVirtualKey,
+    fingerprint_virtual_key,
+    issue_key_material,
+    utc_text,
+)
+from exp.runtime.gateway.contracts import DirectTarget
+from exp.runtime.gateway.sqlite.alias_activation import (
+    alias_activation_transaction,
+    register_catalog_snapshot_in_transaction,
+)
+from exp.runtime.gateway.sqlite.provider_authority import (
+    ProviderConnectionBinding,
+    ProviderConnectionMutation,
+    upsert_provider_connection,
+)
+
+if TYPE_CHECKING:
+    from exp.runtime.gateway.sqlite.store import SQLiteGatewayStore
+
+
+def upsert_provider_connections_and_activate_direct_alias(
+    store: SQLiteGatewayStore,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_name: str,
+    revision_id: str,
+    pool_id: str,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    provider_connections: tuple[ProviderConnectionMutation, ...],
+    replace: bool,
+    refusal_failover: bool,
+    activate_alias_revision: Callable[..., None],
+) -> None:
+    """Atomically revise providers, register a snapshot, and activate one direct alias.
+
+    Args:
+        store: SQLite gateway store owning the transaction connection.
+        organization_id: Owning tenant.
+        alias_id: Stable alias resource ID.
+        alias_name: Public model string.
+        revision_id: Immutable alias revision ID.
+        pool_id: Direct target pool identifier.
+        snapshot_ref: Content-addressed catalog snapshot reference.
+        catalog_sha256: Exact normalized catalog digest.
+        provider_connections: Desired provider connection revisions.
+        replace: Whether differing active provider metadata may be revised.
+        refusal_failover: Whether typed precommit refusals may advance.
+        activate_alias_revision: Alias activation seam supplied by the store module.
+
+    Raises:
+        ValueError: The requested authority violates an existing invariant.
+    """
+    target = DirectTarget(pool_id=pool_id)
+    now = utc_text(store._clock.now())
+    connect = cast(
+        Callable[[], AbstractContextManager[sqlite3.Connection]],
+        store._connect,
+    )
+    with alias_activation_transaction(
+        connect=connect,
+        organization_id=organization_id,
+        alias_id=alias_id,
+        alias_name=alias_name,
+        revision_id=revision_id,
+        target=target,
+        snapshot_ref=snapshot_ref,
+        catalog_sha256=catalog_sha256,
+        refusal_failover=refusal_failover,
+    ) as connection:
+        bindings = _stage_provider_connections(
+            connection,
+            organization_id=organization_id,
+            provider_connections=provider_connections,
+            replace=replace,
+            now=now,
+        )
+        register_catalog_snapshot_in_transaction(
+            connection,
+            organization_id=organization_id,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            now=now,
+            store_error=store._store_error,
+        )
+        activate_alias_revision(
+            connection,
+            organization_id=organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            target=target,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            provider_connections=bindings,
+            refusal_failover=refusal_failover,
+            now=now,
+            store_error=store._store_error,
+        )
+
+
+def configure_direct_alias_with_identity(
+    store: SQLiteGatewayStore,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_name: str,
+    revision_id: str,
+    pool_id: str,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    provider_connections: tuple[ProviderConnectionMutation, ...],
+    replace: bool,
+    identity_id: str,
+    identity_display_name: str,
+    key_id: str,
+    activate_alias_revision: Callable[..., None],
+) -> tuple[bool, IssuedVirtualKey]:
+    """Atomically configure serving authority and the setup caller's credentials.
+
+    Args:
+        store: SQLite gateway store owning the transaction connection.
+        organization_id: Owning tenant.
+        alias_id: Stable alias resource ID.
+        alias_name: Public model string.
+        revision_id: Immutable alias revision ID.
+        pool_id: Direct target pool identifier.
+        snapshot_ref: Content-addressed catalog snapshot reference.
+        catalog_sha256: Exact normalized catalog digest.
+        provider_connections: Desired provider connection revisions.
+        replace: Whether differing active provider metadata may be revised.
+        identity_id: Stable setup identity identifier.
+        identity_display_name: Operator-facing setup identity name.
+        key_id: Non-secret identifier for the newly issued key.
+        activate_alias_revision: Alias activation seam supplied by the store module.
+
+    Returns:
+        Whether the identity was created, and the one-time key receipt.
+
+    Raises:
+        ValueError: The requested authority violates an existing invariant.
+    """
+    target = DirectTarget(pool_id=pool_id)
+    now = utc_text(store._clock.now())
+    connect = cast(
+        Callable[[], AbstractContextManager[sqlite3.Connection]],
+        store._connect,
+    )
+    identity_created = False
+    issued: IssuedVirtualKey | None = None
+    with alias_activation_transaction(
+        connect=connect,
+        organization_id=organization_id,
+        alias_id=alias_id,
+        alias_name=alias_name,
+        revision_id=revision_id,
+        target=target,
+        snapshot_ref=snapshot_ref,
+        catalog_sha256=catalog_sha256,
+        refusal_failover=False,
+    ) as connection:
+        identity_created = _ensure_identity(
+            connection,
+            organization_id=organization_id,
+            identity_id=identity_id,
+            display_name=identity_display_name,
+            now=now,
+            store_error=store._store_error,
+        )
+        bindings = _stage_provider_connections(
+            connection,
+            organization_id=organization_id,
+            provider_connections=provider_connections,
+            replace=replace,
+            now=now,
+        )
+        register_catalog_snapshot_in_transaction(
+            connection,
+            organization_id=organization_id,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            now=now,
+            store_error=store._store_error,
+        )
+        activate_alias_revision(
+            connection,
+            organization_id=organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            target=target,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            provider_connections=bindings,
+            refusal_failover=False,
+            now=now,
+            store_error=store._store_error,
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO identity_alias_grants (
+                organization_id, identity_id, alias_id, created_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (organization_id, identity_id, alias_id, now),
+        )
+        issued = _issue_key(
+            connection,
+            store=store,
+            organization_id=organization_id,
+            identity_id=identity_id,
+            key_id=key_id,
+            created_at=now,
+        )
+    assert issued is not None
+    return identity_created, issued
+
+
+def _stage_provider_connections(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    provider_connections: tuple[ProviderConnectionMutation, ...],
+    replace: bool,
+    now: str,
+) -> tuple[ProviderConnectionBinding, ...]:
+    """Stage provider revisions and return bindings for the new alias revision."""
+    authorities = []
+    for mutation in provider_connections:
+        _changed, authority = upsert_provider_connection(
+            connection,
+            organization_id=organization_id,
+            connection_id=mutation.connection_id,
+            revision_id=mutation.revision_id,
+            config=mutation.config,
+            replace=replace,
+            now=now,
+        )
+        authorities.append(authority)
+    return tuple(
+        ProviderConnectionBinding(
+            connection_id=authority.connection_id,
+            connection_revision_id=authority.revision_id,
+            connection_sha256=authority.connection_sha256,
+        )
+        for authority in authorities
+    )
+
+
+def _ensure_identity(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    identity_id: str,
+    display_name: str,
+    now: str,
+    store_error: type[ValueError],
+) -> bool:
+    """Create or validate the active identity inside the setup transaction."""
+    row = connection.execute(
+        "SELECT organization_id, active FROM identities WHERE identity_id = ?",
+        (identity_id,),
+    ).fetchone()
+    if row is not None:
+        if str(row["organization_id"]) != organization_id:
+            raise store_error("identity ID belongs to another organization")
+        if not bool(row["active"]):
+            raise store_error(f"identity {identity_id!r} is disabled")
+        return False
+    connection.execute(
+        """
+        INSERT INTO identities (
+            identity_id, organization_id, display_name, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (identity_id, organization_id, display_name, now, now),
+    )
+    return True
+
+
+def _issue_key(
+    connection: sqlite3.Connection,
+    *,
+    store: SQLiteGatewayStore,
+    organization_id: str,
+    identity_id: str,
+    key_id: str,
+    created_at: str,
+) -> IssuedVirtualKey:
+    """Generate and persist one setup key inside the serving transaction."""
+    prefix, raw_key = issue_key_material()
+    pepper = store._pepper.current()
+    fingerprint = fingerprint_virtual_key(raw_key, pepper)
+    try:
+        connection.execute(
+            """
+            INSERT INTO virtual_keys (
+                key_id, organization_id, identity_id, prefix, fingerprint_version,
+                fingerprint_sha256, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                key_id,
+                organization_id,
+                identity_id,
+                prefix,
+                pepper.version,
+                fingerprint,
+                created_at,
+            ),
+        )
+    except sqlite3.IntegrityError:
+        raise store._store_error(
+            "virtual key issuance conflicts with existing gateway authority"
+        ) from None
+    return IssuedVirtualKey(
+        key_id=key_id,
+        organization_id=organization_id,
+        identity_id=identity_id,
+        prefix=prefix,
+        raw_key=raw_key,
+        expires_at=None,
+        created_at=datetime.fromisoformat(created_at),
+    )

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -34,15 +34,17 @@ from exp.runtime.gateway.sqlite import key_delivery
 from exp.runtime.gateway.sqlite.alias_activation import (
     activate_alias_revision_in_transaction,
     alias_activation_transaction,
-    register_catalog_snapshot_in_transaction,
 )
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionBinding,
     ProviderConnectionMutation,
-    upsert_provider_connection,
 )
 from exp.runtime.gateway.sqlite.provider_store import ProviderConnectionStoreMixin
+from exp.runtime.gateway.sqlite.setup_authority import (
+    configure_direct_alias_with_identity,
+    upsert_provider_connections_and_activate_direct_alias,
+)
 
 _LAST_USED_REFRESH_SECONDS = 60.0
 
@@ -514,80 +516,55 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
         replace: bool,
         refusal_failover: bool = False,
     ) -> None:
-        """Atomically revise providers, register a snapshot, and activate one direct alias.
-
-        Args:
-            organization_id: Owning tenant.
-            alias_id: Stable alias resource ID.
-            alias_name: Public model string.
-            revision_id: Immutable alias revision ID.
-            pool_id: Direct target pool identifier.
-            snapshot_ref: Content-addressed catalog snapshot reference.
-            catalog_sha256: Exact normalized catalog digest.
-            provider_connections: Desired provider connection revisions for the snapshot.
-            replace: Whether differing active provider metadata may be revised.
-            refusal_failover: Whether typed precommit refusals may advance.
-
-        Raises:
-            GatewayStoreError: The snapshot or alias invariants conflict.
-            ProviderAuthorityError: A provider replacement violates SQLite authority.
-            AliasActivationOutcomeUnknownError: SQLite COMMIT outcome is ambiguous.
-        """
-        target = DirectTarget(pool_id=pool_id)
-        now = utc_text(self._clock.now())
-        with alias_activation_transaction(
-            connect=self._connect,
+        """Atomically revise providers, register a snapshot, and activate one direct alias."""
+        upsert_provider_connections_and_activate_direct_alias(
+            self,
             organization_id=organization_id,
             alias_id=alias_id,
             alias_name=alias_name,
             revision_id=revision_id,
-            target=target,
+            pool_id=pool_id,
             snapshot_ref=snapshot_ref,
             catalog_sha256=catalog_sha256,
+            provider_connections=provider_connections,
+            replace=replace,
             refusal_failover=refusal_failover,
-        ) as connection:
-            authorities = []
-            for mutation in provider_connections:
-                _changed, authority = upsert_provider_connection(
-                    connection,
-                    organization_id=organization_id,
-                    connection_id=mutation.connection_id,
-                    revision_id=mutation.revision_id,
-                    config=mutation.config,
-                    replace=replace,
-                    now=now,
-                )
-                authorities.append(authority)
-            bindings = tuple(
-                ProviderConnectionBinding(
-                    connection_id=authority.connection_id,
-                    connection_revision_id=authority.revision_id,
-                    connection_sha256=authority.connection_sha256,
-                )
-                for authority in authorities
-            )
-            register_catalog_snapshot_in_transaction(
-                connection,
-                organization_id=organization_id,
-                snapshot_ref=snapshot_ref,
-                catalog_sha256=catalog_sha256,
-                now=now,
-                store_error=GatewayStoreError,
-            )
-            activate_alias_revision_in_transaction(
-                connection,
-                organization_id=organization_id,
-                alias_id=alias_id,
-                alias_name=alias_name,
-                revision_id=revision_id,
-                target=target,
-                snapshot_ref=snapshot_ref,
-                catalog_sha256=catalog_sha256,
-                provider_connections=bindings,
-                refusal_failover=refusal_failover,
-                now=now,
-                store_error=GatewayStoreError,
-            )
+            activate_alias_revision=activate_alias_revision_in_transaction,
+        )
+
+    def configure_direct_alias_with_identity(
+        self,
+        *,
+        organization_id: str,
+        alias_id: str,
+        alias_name: str,
+        revision_id: str,
+        pool_id: str,
+        snapshot_ref: str,
+        catalog_sha256: Sha256,
+        provider_connections: tuple[ProviderConnectionMutation, ...],
+        replace: bool,
+        identity_id: str,
+        identity_display_name: str,
+        key_id: str,
+    ) -> tuple[bool, IssuedVirtualKey]:
+        """Atomically configure serving authority and setup caller credentials."""
+        return configure_direct_alias_with_identity(
+            self,
+            organization_id=organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            pool_id=pool_id,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            provider_connections=provider_connections,
+            replace=replace,
+            identity_id=identity_id,
+            identity_display_name=identity_display_name,
+            key_id=key_id,
+            activate_alias_revision=activate_alias_revision_in_transaction,
+        )
 
     def disable_alias(self, *, organization_id: str, alias_id: str) -> bool:
         """Disable one alias and release its active project binding.

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -35,7 +35,9 @@ from exp.runtime.gateway.sqlite.alias_activation import alias_activation_transac
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionBinding,
+    ProviderConnectionMutation,
     bind_alias_provider_connections,
+    upsert_provider_connection,
 )
 from exp.runtime.gateway.sqlite.provider_store import ProviderConnectionStoreMixin
 
@@ -480,114 +482,105 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             catalog_sha256=catalog_sha256,
             refusal_failover=refusal_failover,
         ) as connection:
-            snapshot = connection.execute(
-                """
-                SELECT 1 FROM catalog_snapshot_refs
-                WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
-                """,
-                (organization_id, snapshot_ref, catalog_sha256),
-            ).fetchone()
-            if snapshot is None:
-                raise GatewayStoreError("catalog snapshot reference is not registered")
-            alias_row = connection.execute(
-                """
-                SELECT alias_name FROM gateway_aliases
-                WHERE organization_id = ? AND alias_id = ?
-                """,
-                (organization_id, alias_id),
-            ).fetchone()
-            if alias_row is None:
-                connection.execute(
-                    """
-                    INSERT INTO gateway_aliases (
-                        alias_id, organization_id, alias_name, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?)
-                    """,
-                    (alias_id, organization_id, alias_name, now, now),
-                )
-                revision_number = 1
-            else:
-                if str(alias_row["alias_name"]) != alias_name:
-                    raise GatewayStoreError("alias ID cannot be renamed")
-                revision_number = int(
-                    connection.execute(
-                        """
-                        SELECT COALESCE(MAX(revision_number), 0) + 1
-                        FROM alias_revisions WHERE organization_id = ? AND alias_id = ?
-                        """,
-                        (organization_id, alias_id),
-                    ).fetchone()[0]
-                )
-            pool_id: str | None = None
-            project_ref: str | None = None
-            activation_ref: str | None = None
-            if isinstance(target, DirectTarget):
-                pool_id = target.pool_id
-            else:
-                project_ref = target.project_ref
-                activation_ref = target.activation_ref
-            connection.execute(
-                """
-                INSERT INTO alias_revisions (
-                    revision_id, organization_id, alias_id, revision_number, target_kind,
-                    pool_id, project_ref, activation_ref, catalog_sha256, snapshot_ref,
-                    refusal_failover, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    revision_id,
-                    organization_id,
-                    alias_id,
-                    revision_number,
-                    target.kind,
-                    pool_id,
-                    project_ref,
-                    activation_ref,
-                    catalog_sha256,
-                    snapshot_ref,
-                    int(refusal_failover),
-                    now,
-                ),
-            )
-            bind_alias_provider_connections(
+            _activate_alias_revision_in_transaction(
                 connection,
                 organization_id=organization_id,
                 alias_id=alias_id,
-                alias_revision_id=revision_id,
-                bindings=provider_connections,
+                alias_name=alias_name,
+                revision_id=revision_id,
+                target=target,
+                snapshot_ref=snapshot_ref,
+                catalog_sha256=catalog_sha256,
+                provider_connections=provider_connections,
+                refusal_failover=refusal_failover,
                 now=now,
             )
-            connection.execute(
-                """
-                DELETE FROM project_activation_bindings
-                WHERE organization_id = ? AND alias_id = ?
-                """,
-                (organization_id, alias_id),
-            )
-            if isinstance(target, ProjectTarget):
-                connection.execute(
-                    """
-                    INSERT INTO project_activation_bindings (
-                        organization_id, project_ref, activation_ref,
-                        alias_id, revision_id, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        organization_id,
-                        target.project_ref,
-                        target.activation_ref,
-                        alias_id,
-                        revision_id,
-                        now,
-                    ),
+
+    def upsert_provider_connections_and_activate_direct_alias(
+        self,
+        *,
+        organization_id: str,
+        alias_id: str,
+        alias_name: str,
+        revision_id: str,
+        pool_id: str,
+        snapshot_ref: str,
+        catalog_sha256: Sha256,
+        provider_connections: tuple[ProviderConnectionMutation, ...],
+        replace: bool,
+        refusal_failover: bool = False,
+    ) -> None:
+        """Atomically revise providers, register a snapshot, and activate one direct alias.
+
+        Args:
+            organization_id: Owning tenant.
+            alias_id: Stable alias resource ID.
+            alias_name: Public model string.
+            revision_id: Immutable alias revision ID.
+            pool_id: Direct target pool identifier.
+            snapshot_ref: Content-addressed catalog snapshot reference.
+            catalog_sha256: Exact normalized catalog digest.
+            provider_connections: Desired provider connection revisions for the snapshot.
+            replace: Whether differing active provider metadata may be revised.
+            refusal_failover: Whether typed precommit refusals may advance.
+
+        Raises:
+            GatewayStoreError: The snapshot or alias invariants conflict.
+            ProviderAuthorityError: A provider replacement violates SQLite authority.
+            AliasActivationOutcomeUnknownError: SQLite COMMIT outcome is ambiguous.
+        """
+        target = DirectTarget(pool_id=pool_id)
+        now = utc_text(self._clock.now())
+        with alias_activation_transaction(
+            connect=self._connect,
+            organization_id=organization_id,
+            alias_id=alias_id,
+            alias_name=alias_name,
+            revision_id=revision_id,
+            target=target,
+            snapshot_ref=snapshot_ref,
+            catalog_sha256=catalog_sha256,
+            refusal_failover=refusal_failover,
+        ) as connection:
+            authorities = []
+            for mutation in provider_connections:
+                _changed, authority = upsert_provider_connection(
+                    connection,
+                    organization_id=organization_id,
+                    connection_id=mutation.connection_id,
+                    revision_id=mutation.revision_id,
+                    config=mutation.config,
+                    replace=replace,
+                    now=now,
                 )
-            connection.execute(
-                """
-                UPDATE gateway_aliases
-                SET active_revision_id = ?, active = 1, updated_at = ?
-                WHERE organization_id = ? AND alias_id = ?
-                """,
-                (revision_id, now, organization_id, alias_id),
+                authorities.append(authority)
+            bindings = tuple(
+                ProviderConnectionBinding(
+                    connection_id=authority.connection_id,
+                    connection_revision_id=authority.revision_id,
+                    connection_sha256=authority.connection_sha256,
+                )
+                for authority in authorities
+            )
+            _register_catalog_snapshot_in_transaction(
+                connection,
+                organization_id=organization_id,
+                snapshot_ref=snapshot_ref,
+                catalog_sha256=catalog_sha256,
+                now=now,
+            )
+            _activate_alias_revision_in_transaction(
+                connection,
+                organization_id=organization_id,
+                alias_id=alias_id,
+                alias_name=alias_name,
+                revision_id=revision_id,
+                target=target,
+                snapshot_ref=snapshot_ref,
+                catalog_sha256=catalog_sha256,
+                provider_connections=bindings,
+                refusal_failover=refusal_failover,
+                now=now,
             )
 
     def disable_alias(self, *, organization_id: str, alias_id: str) -> bool:
@@ -968,6 +961,202 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 created_at,
             ),
         )
+
+
+def _register_catalog_snapshot_in_transaction(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    now: str,
+) -> None:
+    """Register one catalog snapshot idempotently inside a caller-owned transaction.
+
+    Args:
+        connection: Open SQLite transaction.
+        organization_id: Owning tenant.
+        snapshot_ref: Content-addressed external snapshot reference.
+        catalog_sha256: Normalized secret-free catalog digest.
+        now: Canonical transaction timestamp.
+
+    Raises:
+        GatewayStoreError: The snapshot reference or digest was previously assigned differently.
+    """
+    by_ref = connection.execute(
+        """
+        SELECT organization_id, catalog_sha256 FROM catalog_snapshot_refs
+        WHERE snapshot_ref = ?
+        """,
+        (snapshot_ref,),
+    ).fetchone()
+    if by_ref is not None:
+        if (
+            str(by_ref["organization_id"]) != organization_id
+            or str(by_ref["catalog_sha256"]) != catalog_sha256
+        ):
+            raise GatewayStoreError("catalog snapshot reference was reused with another digest")
+        return
+    by_digest = connection.execute(
+        """
+        SELECT snapshot_ref FROM catalog_snapshot_refs
+        WHERE organization_id = ? AND catalog_sha256 = ?
+        """,
+        (organization_id, catalog_sha256),
+    ).fetchone()
+    if by_digest is not None:
+        raise GatewayStoreError("catalog digest is already registered under another snapshot")
+    connection.execute(
+        """
+        INSERT INTO catalog_snapshot_refs (
+            snapshot_ref, organization_id, catalog_sha256, created_at
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (snapshot_ref, organization_id, catalog_sha256, now),
+    )
+
+
+def _activate_alias_revision_in_transaction(
+    connection: sqlite3.Connection,
+    *,
+    organization_id: str,
+    alias_id: str,
+    alias_name: str,
+    revision_id: str,
+    target: GatewayTarget,
+    snapshot_ref: str,
+    catalog_sha256: Sha256,
+    provider_connections: tuple[ProviderConnectionBinding, ...],
+    refusal_failover: bool,
+    now: str,
+) -> None:
+    """Create and activate one immutable alias revision in an open transaction.
+
+    Args:
+        connection: Open SQLite transaction.
+        organization_id: Owning tenant.
+        alias_id: Stable alias resource ID.
+        alias_name: Public model string.
+        revision_id: Immutable alias revision ID.
+        target: Direct pool or frozen project target.
+        snapshot_ref: Registered catalog snapshot reference.
+        catalog_sha256: Exact normalized catalog digest.
+        provider_connections: Exact active connection revisions for the snapshot.
+        refusal_failover: Whether typed precommit refusals may advance.
+        now: Canonical transaction timestamp.
+
+    Raises:
+        GatewayStoreError: The snapshot or alias invariants conflict.
+    """
+    snapshot = connection.execute(
+        """
+        SELECT 1 FROM catalog_snapshot_refs
+        WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
+        """,
+        (organization_id, snapshot_ref, catalog_sha256),
+    ).fetchone()
+    if snapshot is None:
+        raise GatewayStoreError("catalog snapshot reference is not registered")
+    alias_row = connection.execute(
+        """
+        SELECT alias_name FROM gateway_aliases
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (organization_id, alias_id),
+    ).fetchone()
+    if alias_row is None:
+        connection.execute(
+            """
+            INSERT INTO gateway_aliases (
+                alias_id, organization_id, alias_name, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (alias_id, organization_id, alias_name, now, now),
+        )
+        revision_number = 1
+    else:
+        if str(alias_row["alias_name"]) != alias_name:
+            raise GatewayStoreError("alias ID cannot be renamed")
+        revision_number = int(
+            connection.execute(
+                """
+                SELECT COALESCE(MAX(revision_number), 0) + 1
+                FROM alias_revisions WHERE organization_id = ? AND alias_id = ?
+                """,
+                (organization_id, alias_id),
+            ).fetchone()[0]
+        )
+    pool_id: str | None = None
+    project_ref: str | None = None
+    activation_ref: str | None = None
+    if isinstance(target, DirectTarget):
+        pool_id = target.pool_id
+    else:
+        project_ref = target.project_ref
+        activation_ref = target.activation_ref
+    connection.execute(
+        """
+        INSERT INTO alias_revisions (
+            revision_id, organization_id, alias_id, revision_number, target_kind,
+            pool_id, project_ref, activation_ref, catalog_sha256, snapshot_ref,
+            refusal_failover, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            revision_id,
+            organization_id,
+            alias_id,
+            revision_number,
+            target.kind,
+            pool_id,
+            project_ref,
+            activation_ref,
+            catalog_sha256,
+            snapshot_ref,
+            int(refusal_failover),
+            now,
+        ),
+    )
+    bind_alias_provider_connections(
+        connection,
+        organization_id=organization_id,
+        alias_id=alias_id,
+        alias_revision_id=revision_id,
+        bindings=provider_connections,
+        now=now,
+    )
+    connection.execute(
+        """
+        DELETE FROM project_activation_bindings
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (organization_id, alias_id),
+    )
+    if isinstance(target, ProjectTarget):
+        connection.execute(
+            """
+            INSERT INTO project_activation_bindings (
+                organization_id, project_ref, activation_ref,
+                alias_id, revision_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                organization_id,
+                target.project_ref,
+                target.activation_ref,
+                alias_id,
+                revision_id,
+                now,
+            ),
+        )
+    connection.execute(
+        """
+        UPDATE gateway_aliases
+        SET active_revision_id = ?, active = 1, updated_at = ?
+        WHERE organization_id = ? AND alias_id = ?
+        """,
+        (revision_id, now, organization_id, alias_id),
+    )
 
 
 def _caller_operation_sha256(request: GatewayRequest) -> Sha256 | None:

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -31,12 +31,15 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.sqlite import key_delivery
-from exp.runtime.gateway.sqlite.alias_activation import alias_activation_transaction
+from exp.runtime.gateway.sqlite.alias_activation import (
+    activate_alias_revision_in_transaction,
+    alias_activation_transaction,
+    register_catalog_snapshot_in_transaction,
+)
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionBinding,
     ProviderConnectionMutation,
-    bind_alias_provider_connections,
     upsert_provider_connection,
 )
 from exp.runtime.gateway.sqlite.provider_store import ProviderConnectionStoreMixin
@@ -482,7 +485,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             catalog_sha256=catalog_sha256,
             refusal_failover=refusal_failover,
         ) as connection:
-            _activate_alias_revision_in_transaction(
+            activate_alias_revision_in_transaction(
                 connection,
                 organization_id=organization_id,
                 alias_id=alias_id,
@@ -494,6 +497,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 provider_connections=provider_connections,
                 refusal_failover=refusal_failover,
                 now=now,
+                store_error=GatewayStoreError,
             )
 
     def upsert_provider_connections_and_activate_direct_alias(
@@ -562,14 +566,15 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 )
                 for authority in authorities
             )
-            _register_catalog_snapshot_in_transaction(
+            register_catalog_snapshot_in_transaction(
                 connection,
                 organization_id=organization_id,
                 snapshot_ref=snapshot_ref,
                 catalog_sha256=catalog_sha256,
                 now=now,
+                store_error=GatewayStoreError,
             )
-            _activate_alias_revision_in_transaction(
+            activate_alias_revision_in_transaction(
                 connection,
                 organization_id=organization_id,
                 alias_id=alias_id,
@@ -581,6 +586,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 provider_connections=bindings,
                 refusal_failover=refusal_failover,
                 now=now,
+                store_error=GatewayStoreError,
             )
 
     def disable_alias(self, *, organization_id: str, alias_id: str) -> bool:
@@ -961,202 +967,6 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 created_at,
             ),
         )
-
-
-def _register_catalog_snapshot_in_transaction(
-    connection: sqlite3.Connection,
-    *,
-    organization_id: str,
-    snapshot_ref: str,
-    catalog_sha256: Sha256,
-    now: str,
-) -> None:
-    """Register one catalog snapshot idempotently inside a caller-owned transaction.
-
-    Args:
-        connection: Open SQLite transaction.
-        organization_id: Owning tenant.
-        snapshot_ref: Content-addressed external snapshot reference.
-        catalog_sha256: Normalized secret-free catalog digest.
-        now: Canonical transaction timestamp.
-
-    Raises:
-        GatewayStoreError: The snapshot reference or digest was previously assigned differently.
-    """
-    by_ref = connection.execute(
-        """
-        SELECT organization_id, catalog_sha256 FROM catalog_snapshot_refs
-        WHERE snapshot_ref = ?
-        """,
-        (snapshot_ref,),
-    ).fetchone()
-    if by_ref is not None:
-        if (
-            str(by_ref["organization_id"]) != organization_id
-            or str(by_ref["catalog_sha256"]) != catalog_sha256
-        ):
-            raise GatewayStoreError("catalog snapshot reference was reused with another digest")
-        return
-    by_digest = connection.execute(
-        """
-        SELECT snapshot_ref FROM catalog_snapshot_refs
-        WHERE organization_id = ? AND catalog_sha256 = ?
-        """,
-        (organization_id, catalog_sha256),
-    ).fetchone()
-    if by_digest is not None:
-        raise GatewayStoreError("catalog digest is already registered under another snapshot")
-    connection.execute(
-        """
-        INSERT INTO catalog_snapshot_refs (
-            snapshot_ref, organization_id, catalog_sha256, created_at
-        ) VALUES (?, ?, ?, ?)
-        """,
-        (snapshot_ref, organization_id, catalog_sha256, now),
-    )
-
-
-def _activate_alias_revision_in_transaction(
-    connection: sqlite3.Connection,
-    *,
-    organization_id: str,
-    alias_id: str,
-    alias_name: str,
-    revision_id: str,
-    target: GatewayTarget,
-    snapshot_ref: str,
-    catalog_sha256: Sha256,
-    provider_connections: tuple[ProviderConnectionBinding, ...],
-    refusal_failover: bool,
-    now: str,
-) -> None:
-    """Create and activate one immutable alias revision in an open transaction.
-
-    Args:
-        connection: Open SQLite transaction.
-        organization_id: Owning tenant.
-        alias_id: Stable alias resource ID.
-        alias_name: Public model string.
-        revision_id: Immutable alias revision ID.
-        target: Direct pool or frozen project target.
-        snapshot_ref: Registered catalog snapshot reference.
-        catalog_sha256: Exact normalized catalog digest.
-        provider_connections: Exact active connection revisions for the snapshot.
-        refusal_failover: Whether typed precommit refusals may advance.
-        now: Canonical transaction timestamp.
-
-    Raises:
-        GatewayStoreError: The snapshot or alias invariants conflict.
-    """
-    snapshot = connection.execute(
-        """
-        SELECT 1 FROM catalog_snapshot_refs
-        WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
-        """,
-        (organization_id, snapshot_ref, catalog_sha256),
-    ).fetchone()
-    if snapshot is None:
-        raise GatewayStoreError("catalog snapshot reference is not registered")
-    alias_row = connection.execute(
-        """
-        SELECT alias_name FROM gateway_aliases
-        WHERE organization_id = ? AND alias_id = ?
-        """,
-        (organization_id, alias_id),
-    ).fetchone()
-    if alias_row is None:
-        connection.execute(
-            """
-            INSERT INTO gateway_aliases (
-                alias_id, organization_id, alias_name, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?)
-            """,
-            (alias_id, organization_id, alias_name, now, now),
-        )
-        revision_number = 1
-    else:
-        if str(alias_row["alias_name"]) != alias_name:
-            raise GatewayStoreError("alias ID cannot be renamed")
-        revision_number = int(
-            connection.execute(
-                """
-                SELECT COALESCE(MAX(revision_number), 0) + 1
-                FROM alias_revisions WHERE organization_id = ? AND alias_id = ?
-                """,
-                (organization_id, alias_id),
-            ).fetchone()[0]
-        )
-    pool_id: str | None = None
-    project_ref: str | None = None
-    activation_ref: str | None = None
-    if isinstance(target, DirectTarget):
-        pool_id = target.pool_id
-    else:
-        project_ref = target.project_ref
-        activation_ref = target.activation_ref
-    connection.execute(
-        """
-        INSERT INTO alias_revisions (
-            revision_id, organization_id, alias_id, revision_number, target_kind,
-            pool_id, project_ref, activation_ref, catalog_sha256, snapshot_ref,
-            refusal_failover, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            revision_id,
-            organization_id,
-            alias_id,
-            revision_number,
-            target.kind,
-            pool_id,
-            project_ref,
-            activation_ref,
-            catalog_sha256,
-            snapshot_ref,
-            int(refusal_failover),
-            now,
-        ),
-    )
-    bind_alias_provider_connections(
-        connection,
-        organization_id=organization_id,
-        alias_id=alias_id,
-        alias_revision_id=revision_id,
-        bindings=provider_connections,
-        now=now,
-    )
-    connection.execute(
-        """
-        DELETE FROM project_activation_bindings
-        WHERE organization_id = ? AND alias_id = ?
-        """,
-        (organization_id, alias_id),
-    )
-    if isinstance(target, ProjectTarget):
-        connection.execute(
-            """
-            INSERT INTO project_activation_bindings (
-                organization_id, project_ref, activation_ref,
-                alias_id, revision_id, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                organization_id,
-                target.project_ref,
-                target.activation_ref,
-                alias_id,
-                revision_id,
-                now,
-            ),
-        )
-    connection.execute(
-        """
-        UPDATE gateway_aliases
-        SET active_revision_id = ?, active = 1, updated_at = ?
-        WHERE organization_id = ? AND alias_id = ?
-        """,
-        (revision_id, now, organization_id, alias_id),
-    )
 
 
 def _caller_operation_sha256(request: GatewayRequest) -> Sha256 | None:


### PR DESCRIPTION
## Summary

- add a confirmation-gated reconfiguration path from the interactive gateway home screen
- replace selected provider and alias revisions without deleting identities, keys, grants, usage, or history
- atomically stage provider revisions, snapshot registration, alias activation, identity reuse/creation, grants, and a fresh one-time key
- restore exact catalog and command-budget preimages on proven setup failure
- preserve the one-time key and print recovery guidance when SQLite commit outcome is ambiguous
- keep the selected budget and serving credentials recoverable across ambiguous first-run setup outcomes
- document the recovery path and cover post-activation credential rollback

## Validation

- `uv run pytest -q exp/cli/gateway exp/runtime/gateway/sqlite/store_test.py` — 112 passed
- Ruff, formatting, Ty, line-limit, and `git diff --check` — passed
- GitHub Actions `gate` and `python package` — passed for `6b0bee83`
- Greptile — 5/5 on `6b0bee83`