### PR TITLE
gateway: surface first-token time (TTFT) and caller app identity for platform telemetry

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -315,6 +315,10 @@ class AuthorizationSnapshot(ContractModel):
     caller_operation_sha256: Sha256 | None = None
     refusal_failover: bool = False
     deadline_monotonic: float = Field(gt=0)
+    app_referer: str | None = Field(default=None, max_length=2_048)
+    """Caller-supplied ``HTTP-Referer`` app identity, content-free and never a credential."""
+    app_title: str | None = Field(default=None, max_length=256)
+    """Caller-supplied ``X-Title`` app label used only for content-free app attribution."""
 
 
 class ExecutionSnapshot(ContractModel):

--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -239,6 +239,8 @@ class GatewayExecutionStream:
                 and self._refusal_failover
                 and not self._committed
             ):
+                if current.first_token_at is None:
+                    current.first_token_at = self._clock.now()
                 event_bytes = len((event.text_delta or "").encode("utf-8"))
                 if (
                     current.withheld_refusal_bytes + event_bytes > _MAX_WITHHELD_REFUSAL_BYTES
@@ -666,8 +668,6 @@ class GatewayExecutionStream:
             current: Physical attempt holding in-memory refusal deltas.
             *following: Semantic or terminal events that arrived after the refusal.
         """
-        if current.first_token_at is None:
-            current.first_token_at = self._clock.now()
         self._committed = True
         current.visible_refusal = True
         self._pending_outward.extend(current.withheld_refusals)

--- a/exp/runtime/gateway/execution.py
+++ b/exp/runtime/gateway/execution.py
@@ -6,6 +6,7 @@ import asyncio
 from collections import deque
 from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import cast
 
 from exp.common.core.artifacts import stable_id
@@ -25,9 +26,10 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.group_commit import abandoned_write_outcome
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
-from exp.runtime.gateway.interfaces import AttemptLedger, ProviderStream
+from exp.runtime.gateway.interfaces import AttemptLedger, GatewayClock, ProviderStream
 from exp.runtime.gateway.ledger import AttemptRejectedError, GatewayLedgerError
 from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.gateway.sqlite.store import SystemGatewayClock
 from exp.runtime.models import ResolvedModel, RuntimeModelCatalog
 from exp.runtime.models.providers import (
     AsyncGatewayProvider,
@@ -89,6 +91,7 @@ class _PhysicalAttempt:
     stream: ProviderStream | None = None
     iterator: AsyncIterator[GatewayEvent] | None = None
     latest_usage: GatewayUsage | None = None
+    first_token_at: datetime | None = None
     tool_names: list[str] = field(default_factory=list)
     last_provider_sequence: int = -1
     withheld_refusals: list[GatewayEvent] = field(default_factory=list)
@@ -114,6 +117,7 @@ class GatewayExecutionStream:
         maximum_total_attempts: int,
         maximum_same_deployment_attempts: int,
         refusal_failover: bool,
+        clock: GatewayClock,
     ) -> None:
         """Bind one frozen logical route to its finite physical-attempt policy.
 
@@ -129,6 +133,7 @@ class GatewayExecutionStream:
             maximum_total_attempts: Hard cap across retries and deployments.
             maximum_same_deployment_attempts: Initial dispatch plus safe retries per deployment.
             refusal_failover: Whether a typed precommit refusal may advance to another deployment.
+            clock: Wall clock stamping the winning attempt's first streamed token.
         """
         self._route = route
         self._request = request
@@ -141,6 +146,7 @@ class GatewayExecutionStream:
         self._maximum_total_attempts = maximum_total_attempts
         self._maximum_same_deployment_attempts = maximum_same_deployment_attempts
         self._refusal_failover = refusal_failover
+        self._clock = clock
         self._attempt_counts = [0 for _ in resolved]
         self._total_attempts = 0
         self._current: _PhysicalAttempt | None = None
@@ -249,6 +255,8 @@ class GatewayExecutionStream:
             if event.kind in _SEMANTIC_EVENTS:
                 if event.kind == GatewayEventKind.REFUSAL_DELTA:
                     current.visible_refusal = True
+                if current.first_token_at is None:
+                    current.first_token_at = self._clock.now()
                 self._committed = True
                 return self._outward(event)
             if event.kind not in _TERMINAL_EVENTS:
@@ -394,6 +402,7 @@ class GatewayExecutionStream:
                     terminal_event=terminal,
                     failure=failure,
                     finalize_request=True,
+                    first_token_at=current.first_token_at,
                 )
                 current.settled = True
                 self._parent_finalized = True
@@ -559,6 +568,7 @@ class GatewayExecutionStream:
                     terminal_event=terminal,
                     failure=failure,
                     finalize_request=finalize_request,
+                    first_token_at=current.first_token_at,
                 )
                 current.settled = True
                 if finalize_request:
@@ -656,6 +666,8 @@ class GatewayExecutionStream:
             current: Physical attempt holding in-memory refusal deltas.
             *following: Semantic or terminal events that arrived after the refusal.
         """
+        if current.first_token_at is None:
+            current.first_token_at = self._clock.now()
         self._committed = True
         current.visible_refusal = True
         self._pending_outward.extend(current.withheld_refusals)
@@ -736,6 +748,7 @@ class GatewayExecutor:
         maximum_total_attempts: int = 8,
         maximum_same_deployment_attempts: int = 2,
         health: DeploymentHealthRegistry | None = None,
+        clock: GatewayClock | None = None,
     ) -> None:
         """Bind runtime providers, attempt policy, health, and finite request admission.
 
@@ -759,6 +772,7 @@ class GatewayExecutor:
         self._maximum_total_attempts = maximum_total_attempts
         self._maximum_same_deployment_attempts = maximum_same_deployment_attempts
         self._health = health or DeploymentHealthRegistry()
+        self._clock = clock or SystemGatewayClock()
         self._accounting_healthy = True
 
     def swap_catalogs(self, catalogs: Mapping[tuple[str, str], RuntimeModelCatalog]) -> None:
@@ -828,6 +842,7 @@ class GatewayExecutor:
             maximum_total_attempts=self._maximum_total_attempts,
             maximum_same_deployment_attempts=self._maximum_same_deployment_attempts,
             refusal_failover=route.snapshot.authorization.refusal_failover,
+            clock=self._clock,
         )
         try:
             await execution.open()

--- a/exp/runtime/gateway/group_commit.py
+++ b/exp/runtime/gateway/group_commit.py
@@ -25,6 +25,7 @@ import sqlite3
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TypeVar, cast
 
 from exp.common.models.gateway_catalog import ExactModelDeployment
@@ -198,6 +199,7 @@ class GroupCommitAttemptLedger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -206,6 +208,7 @@ class GroupCommitAttemptLedger:
             terminal_event: Provider terminal event, possibly carrying usage.
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
+            first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
         """
         await self._submit(
             lambda connection: self.core.apply_finish_attempt(
@@ -214,6 +217,7 @@ class GroupCommitAttemptLedger:
                 terminal_event=terminal_event,
                 failure=failure,
                 finalize_request=finalize_request,
+                first_token_at=first_token_at,
             )
         )
 
@@ -513,6 +517,7 @@ class SyncGroupCommitLedger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -521,6 +526,7 @@ class SyncGroupCommitLedger:
             terminal_event: Provider terminal event, possibly carrying usage.
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
+            first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
         """
         self._writer.submit_blocking(
             lambda connection: self._writer.core.apply_finish_attempt(
@@ -529,6 +535,7 @@ class SyncGroupCommitLedger:
                 terminal_event=terminal_event,
                 failure=failure,
                 finalize_request=finalize_request,
+                first_token_at=first_token_at,
             )
         )
 

--- a/exp/runtime/gateway/interfaces.py
+++ b/exp/runtime/gateway/interfaces.py
@@ -38,8 +38,14 @@ class GatewayControlStore(Protocol):
         alias: str,
         request: GatewayRequest,
         deadline_monotonic: float,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> AuthorizationSnapshot:
-        """Authenticate, authorize, and freeze authority before route selection."""
+        """Authenticate, authorize, and freeze authority before route selection.
+
+        ``app_referer`` and ``app_title`` carry the caller's OpenRouter-style app identity
+        (the ``HTTP-Referer`` and ``X-Title`` request headers) for content-free attribution.
+        """
         ...
 
     def granted_aliases(self, *, raw_key: str) -> tuple[str, ...]:
@@ -92,8 +98,14 @@ class AttemptLedger(Protocol):
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
-        """Settle one physical attempt and optionally finalize its parent request."""
+        """Settle one physical attempt and optionally finalize its parent request.
+
+        ``first_token_at`` is the wall-clock time this attempt streamed its first token,
+        surfaced only for the winning attempt and left ``None`` for attempts that produced
+        no token.
+        """
         ...
 
     async def finish_request(

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -239,8 +239,9 @@ class SQLiteAttemptLedger:
             INSERT INTO gateway_requests (
                 request_id, organization_id, identity_id, key_id, alias_id,
                 alias_revision_id, api_surface, canonical_request_sha256,
-                caller_operation_sha256, accepted_at, deadline_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                caller_operation_sha256, accepted_at, deadline_at,
+                app_referer, app_title
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 authorization.request_id,
@@ -254,6 +255,8 @@ class SQLiteAttemptLedger:
                 authorization.caller_operation_sha256,
                 utc_text(now),
                 utc_text(deadline_at),
+                authorization.app_referer,
+                authorization.app_title,
             ),
         )
 
@@ -414,6 +417,7 @@ class SQLiteAttemptLedger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Idempotently settle one attempt with normalized content-free fields.
 
@@ -422,6 +426,7 @@ class SQLiteAttemptLedger:
             terminal_event: Provider terminal event, possibly carrying usage.
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
+            first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
         """
         with self._transaction() as connection:
             self.apply_finish_attempt(
@@ -430,6 +435,7 @@ class SQLiteAttemptLedger:
                 terminal_event=terminal_event,
                 failure=failure,
                 finalize_request=finalize_request,
+                first_token_at=first_token_at,
             )
 
     def apply_finish_attempt(
@@ -440,6 +446,7 @@ class SQLiteAttemptLedger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Run the attempt settlement inside the caller's open write transaction.
 
@@ -449,6 +456,7 @@ class SQLiteAttemptLedger:
             terminal_event: Provider terminal event, possibly carrying usage.
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
+            first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
         """
         state, normalized_failure, usage = _terminal_values(terminal_event, failure)
         row = connection.execute(
@@ -482,7 +490,7 @@ class SQLiteAttemptLedger:
         connection.execute(
             """
             UPDATE gateway_attempts
-            SET state = ?, terminal_at = ?, failure_class = ?,
+            SET state = ?, terminal_at = ?, first_token_at = ?, failure_class = ?,
                 input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
                 reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?,
                 budget_settled_micro_usd = ?
@@ -491,6 +499,7 @@ class SQLiteAttemptLedger:
             (
                 state,
                 terminal_at,
+                None if first_token_at is None else utc_text(first_token_at),
                 normalized_failure,
                 None if usage is None else usage.input_tokens,
                 None if usage is None else usage.cached_input_tokens,

--- a/exp/runtime/gateway/ledger_test.py
+++ b/exp/runtime/gateway/ledger_test.py
@@ -849,3 +849,102 @@ def test_concurrent_multi_identity_wal_preserves_receipts_grants_and_attempts(
         assert connection.execute("SELECT COUNT(*) FROM identity_alias_grants").fetchone()[0] == 8
     finally:
         connection.close()
+
+
+def test_accept_and_finish_persist_app_attribution_and_first_token_at(tmp_path: Path) -> None:
+    """Accept freezes the caller app identity and finish records the first-token time."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("prompt-content-canary"),
+        deadline_monotonic=clock.monotonic() + 30,
+        app_referer="https://app.example.com",
+        app_title="Example App",
+    )
+    assert authorization.app_referer == "https://app.example.com"
+    assert authorization.app_title == "Example App"
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization),
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    clock.advance(0.2)
+    first_token_at = clock.now()
+    clock.advance(0.3)
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=10, output_tokens=5),
+        ),
+        failure=None,
+        first_token_at=first_token_at,
+    )
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    connection.row_factory = sqlite3.Row
+    try:
+        attempt_row = connection.execute(
+            "SELECT first_token_at, terminal_at FROM gateway_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+        request_row = connection.execute(
+            "SELECT app_referer, app_title FROM gateway_requests WHERE request_id = ?",
+            (authorization.request_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert datetime.fromisoformat(str(attempt_row["first_token_at"])) == first_token_at
+    assert str(attempt_row["terminal_at"]) != str(attempt_row["first_token_at"])
+    assert str(request_row["app_referer"]) == "https://app.example.com"
+    assert str(request_row["app_title"]) == "Example App"
+
+
+def test_first_token_and_app_attribution_default_to_null(tmp_path: Path) -> None:
+    """An attempt that never streamed a token and a caller without app headers stay null."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("prompt"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    assert authorization.app_referer is None
+    assert authorization.app_title is None
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization),
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="upstream unavailable",
+        ),
+    )
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    connection.row_factory = sqlite3.Row
+    try:
+        attempt_row = connection.execute(
+            "SELECT first_token_at FROM gateway_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+        request_row = connection.execute(
+            "SELECT app_referer, app_title FROM gateway_requests WHERE request_id = ?",
+            (authorization.request_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert attempt_row["first_token_at"] is None
+    assert request_row["app_referer"] is None
+    assert request_row["app_title"] is None

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -331,19 +331,22 @@ class _ReadyControlStore:
         alias: str,
         request: GatewayRequest,
         deadline_monotonic: float,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> AuthorizationSnapshot:
         """Authorize only an alias revision this process can serve, reloading once on drift.
 
-        A revision retired by a concurrent activation stays authorized while its
-        retained catalogs can still serve it, so a request whose SQLite authority
-        was minted an instant before the swap is pinned to its revision instead
-        of being rejected at the swap boundary.
+        A revision retired by a concurrent activation stays authorized while its retained
+        catalogs can still serve it, so a request whose SQLite authority was minted an instant
+        before the swap is pinned to its revision instead of being rejected at the swap boundary.
         """
         authorization = self.store.authorize_request(
             raw_key=raw_key,
             alias=alias,
             request=request,
             deadline_monotonic=deadline_monotonic,
+            app_referer=app_referer,
+            app_title=app_title,
         )
         authority = (
             authorization.alias,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -290,8 +290,9 @@ class NativeControlPlane:
 
         Args:
             argument: JSON object with ``raw_key``, ``body`` (raw request
-                body text), and optional ``surface`` (``"chat"`` or
-                ``"responses"``, defaulting to chat).
+                body text), optional ``surface`` (``"chat"`` or
+                ``"responses"``, defaulting to chat), and optional
+                ``app_referer``/``app_title`` caller app identity.
 
         Returns:
             JSON wire configuration for the single resolved deployment,
@@ -315,11 +316,16 @@ class NativeControlPlane:
         request = decoded.request
         deadline = time.monotonic() + self._request_timeout_seconds
         try:
+            # ``app_referer``/``app_title`` are forwarded when the native engine includes the
+            # caller HTTP-Referer/X-Title in its admit payload; absent them app attribution
+            # stays null on the default path until the Rust engine populates them.
             authorization = self._components.store.authorize_request(
                 raw_key=data["raw_key"],
                 alias=decoded.alias,
                 request=request,
                 deadline_monotonic=deadline,
+                app_referer=optional_text(data.get("app_referer")),
+                app_title=optional_text(data.get("app_title")),
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             raise _authority_error(exc) from exc
@@ -495,6 +501,8 @@ class NativeControlPlane:
                 alias=decoded.alias,
                 request=request,
                 deadline_monotonic=deadline,
+                app_referer=optional_text(data.get("app_referer")),
+                app_title=optional_text(data.get("app_title")),
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             raise _authority_error(exc) from exc

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -67,6 +67,7 @@ from exp.runtime.gateway.native_responses import (
 )
 from exp.runtime.gateway.native_settlement import (
     deployment_operation_key,
+    first_token_at_from_settlement,
     optional_text,
     terminal_from_settlement,
 )
@@ -588,12 +589,14 @@ class NativeControlPlane:
         if entry is None:
             return "{}"
         terminal, failure = terminal_from_settlement(data)
+        first_token_at = first_token_at_from_settlement(data)
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=entry.attempt_id,
                 terminal_event=terminal,
                 failure=failure,
                 finalize_request=True,
+                first_token_at=first_token_at,
             )
         except Exception as exc:  # noqa: BLE001 - the data plane retries.
             # The exact settlement is retained so a retry (from the data

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -865,6 +865,8 @@ def test_admission_authorized_at_the_swap_instant_stays_pinned_to_its_revision(
         alias: str,
         request: GatewayRequest,
         deadline_monotonic: float,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> AuthorizationSnapshot:
         """Mint the authorization, then stall until the activation swap lands."""
         authorization = original(
@@ -872,6 +874,8 @@ def test_admission_authorized_at_the_swap_instant_stays_pinned_to_its_revision(
             alias=alias,
             request=request,
             deadline_monotonic=deadline_monotonic,
+            app_referer=app_referer,
+            app_title=app_title,
         )
         minted.set()
         assert swapped.wait(timeout=10)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1639,3 +1639,34 @@ def test_project_alias_native_selection_matches_the_python_resolver(tmp_path: Pa
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_admit_persists_caller_app_identity_for_attribution(tmp_path: Path) -> None:
+    """The native admit path forwards caller HTTP-Referer/X-Title to durable attribution."""
+    control, raw_key = _control_plane(tmp_path)
+
+    admission = json.loads(
+        control.admit(
+            json.dumps(
+                {
+                    "raw_key": raw_key,
+                    "body": _chat_body(),
+                    "app_referer": "https://app.example.com",
+                    "app_title": "Example App",
+                }
+            )
+        )
+    )
+
+    ledger = control._components.ledger  # noqa: SLF001
+    with sqlite3.connect(ledger.database_path) as connection:
+        row = connection.execute(
+            """
+            SELECT r.app_referer, r.app_title
+            FROM gateway_requests AS r
+            JOIN gateway_attempts AS a ON a.request_id = r.request_id
+            WHERE a.attempt_id = ?
+            """,
+            (admission["attempt_id"],),
+        ).fetchone()
+    assert row == ("https://app.example.com", "Example App")

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from exp.common.core.artifacts import JsonObject, stable_id
 from exp.runtime.gateway.contracts import (
     GatewayEvent,
@@ -51,6 +53,28 @@ def terminal_from_settlement(
         failure=failure if kind == GatewayEventKind.FAILED else None,
     )
     return terminal, failure
+
+
+def first_token_at_from_settlement(data: JsonObject) -> datetime | None:
+    """Return the winning attempt's first-token wall-clock time from a settlement payload.
+
+    The native data plane includes ``first_token_at`` as an ISO-8601 timestamp only when it
+    observed a first streamed token. A missing, non-string, or unparseable value yields
+    ``None`` so accounting stays backward-compatible with engines that omit the field.
+
+    Args:
+        data: Parsed native settlement payload.
+
+    Returns:
+        The timezone-aware first-token time, or ``None`` when it is absent or malformed.
+    """
+    raw = data.get("first_token_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
 
 
 def _usage_from_payload(

--- a/exp/runtime/gateway/platform.py
+++ b/exp/runtime/gateway/platform.py
@@ -315,6 +315,8 @@ class AttemptSettlementRequest(ContractModel):
     terminal_event: GatewayEvent | None = None
     failure: GatewayFailure | None = None
     finalize_request: bool = True
+    first_token_at: AwareDatetime | None = None
+    """Wall-clock time the winning attempt streamed its first token, or ``None``."""
 
     @model_validator(mode="after")
     def _require_terminal_input(self) -> AttemptSettlementRequest:
@@ -366,6 +368,13 @@ class AttemptSettlementRecord(ContractModel):
     usage_source: AttemptUsageSource
     estimated_cost_micro_usd: int | None = Field(default=None, ge=0)
     settled_micro_usd: int | None = Field(default=None, ge=0)
+    first_token_at: AwareDatetime | None = None
+    """Wall-clock time this attempt streamed its first token, or ``None`` when it never did.
+
+    The platform stores this alongside ``terminal_at`` to derive time-to-first-token relative
+    to the parent request's ``accepted_at`` and to narrow generation duration to the streaming
+    window. It is absent for attempts that failed before any token or crashed unobserved.
+    """
 
     @model_validator(mode="after")
     def _require_settlement_coherence(self) -> AttemptSettlementRecord:
@@ -387,6 +396,7 @@ class AttemptSettlementRecord(ContractModel):
             self.failure_class is not None
             or self.usage is not None
             or self.usage_source is not AttemptUsageSource.UNKNOWN
+            or self.first_token_at is not None
         ):
             raise ValueError("unknown crash settlement cannot claim failure or usage evidence")
         if self.usage is None and self.usage_source is AttemptUsageSource.OBSERVED:

--- a/exp/runtime/gateway/service.py
+++ b/exp/runtime/gateway/service.py
@@ -267,12 +267,16 @@ class GatewayService:
         *,
         raw_key: str,
         decoded: DecodedGatewayRequest,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> Response:
         """Authorize and execute one decoded Chat or Responses request.
 
         Args:
             raw_key: Presented virtual key.
             decoded: Validated public alias and canonical request.
+            app_referer: Caller ``HTTP-Referer`` app identity for content-free attribution.
+            app_title: Caller ``X-Title`` app label for content-free attribution.
 
         Returns:
             Streaming or completed OpenAI-compatible HTTP response.
@@ -284,7 +288,12 @@ class GatewayService:
                 self._active_tasks.add(current_task)
         streaming = False
         try:
-            response = await self._complete_admitted(raw_key=raw_key, decoded=decoded)
+            response = await self._complete_admitted(
+                raw_key=raw_key,
+                decoded=decoded,
+                app_referer=app_referer,
+                app_title=app_title,
+            )
             streaming = isinstance(response, StreamingResponse)
         finally:
             if current_task is not None:
@@ -299,6 +308,8 @@ class GatewayService:
         *,
         raw_key: str,
         decoded: DecodedGatewayRequest,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> Response:
         """Execute one request after lifecycle admission has been reserved."""
         deadline = self._clock.monotonic() + self._request_timeout_seconds
@@ -307,6 +318,8 @@ class GatewayService:
             alias=decoded.alias,
             request=decoded.request,
             deadline_monotonic=deadline,
+            app_referer=app_referer,
+            app_title=app_title,
         )
         namespace = _protocol_namespace(authorization)
         execution_request, episode = await self._continued_request(
@@ -699,6 +712,8 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         authorization: str | None = Header(default=None),
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
         client_request_id: str | None = Header(default=None, alias="X-Client-Request-Id"),
+        app_referer: str | None = Header(default=None, alias="HTTP-Referer"),
+        app_title: str | None = Header(default=None, alias="X-Title"),
     ) -> Response:
         """Decode, authorize, and serve one Chat Completions request."""
         return await _dispatch(
@@ -708,6 +723,8 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
             decoder=decode_chat,
             idempotency_key=idempotency_key,
             client_request_id=client_request_id,
+            app_referer=app_referer,
+            app_title=app_title,
         )
 
     @app.post("/v1/responses")
@@ -716,6 +733,8 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
         authorization: str | None = Header(default=None),
         idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
         client_request_id: str | None = Header(default=None, alias="X-Client-Request-Id"),
+        app_referer: str | None = Header(default=None, alias="HTTP-Referer"),
+        app_title: str | None = Header(default=None, alias="X-Title"),
     ) -> Response:
         """Decode, authorize, and serve one Responses request."""
         return await _dispatch(
@@ -725,6 +744,8 @@ def create_gateway_app(service: GatewayService) -> FastAPI:
             decoder=decode_responses,
             idempotency_key=idempotency_key,
             client_request_id=client_request_id,
+            app_referer=app_referer,
+            app_title=app_title,
         )
 
     return app
@@ -738,6 +759,8 @@ async def _dispatch(
     decoder: Callable[..., DecodedGatewayRequest],
     idempotency_key: str | None,
     client_request_id: str | None,
+    app_referer: str | None = None,
+    app_title: str | None = None,
 ) -> Response:
     """Decode one body and translate every sanitized gateway boundary failure."""
     try:
@@ -765,6 +788,8 @@ async def _dispatch(
         return await service.complete(
             raw_key=raw_key,
             decoded=decoded,
+            app_referer=app_referer,
+            app_title=app_title,
         )
     except Exception as exc:  # noqa: BLE001 - HTTP boundary sanitizes every failure.
         return _exception_response(exc)

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 
 class GatewaySchemaError(RuntimeError):
@@ -523,6 +523,12 @@ _MIGRATION_8 = (
     """,
 )
 
+_MIGRATION_9 = (
+    "ALTER TABLE gateway_attempts ADD COLUMN first_token_at TEXT",
+    "ALTER TABLE gateway_requests ADD COLUMN app_referer TEXT",
+    "ALTER TABLE gateway_requests ADD COLUMN app_title TEXT",
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -532,6 +538,7 @@ _MIGRATIONS = {
     6: _MIGRATION_6,
     7: _MIGRATION_7,
     8: _MIGRATION_8,
+    9: _MIGRATION_9,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -592,7 +592,7 @@ def test_v8_migration_adds_default_off_strict_unknown_cost(tmp_path: Path) -> No
             "SELECT strict_unknown_cost FROM gateway_monthly_budgets WHERE budget_id = 'budget-one'"
         ).fetchone()
         assert row == (0,)
-        assert current.execute("PRAGMA user_version").fetchone() == (8,)
+        assert current.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
     finally:
         current.close()
     prior = sqlite3.connect(backup)

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -64,6 +64,9 @@ from exp.runtime.gateway.sqlite.platform_records import (
     key_record as _key_record,
 )
 from exp.runtime.gateway.sqlite.platform_records import (
+    optional_datetime as _optional_datetime,
+)
+from exp.runtime.gateway.sqlite.platform_records import (
     optional_int as _optional_int,
 )
 from exp.runtime.gateway.sqlite.platform_records import (
@@ -574,6 +577,7 @@ class SQLiteGatewayPlatform:
             terminal_event=request.terminal_event,
             failure=request.failure,
             finalize_request=request.finalize_request,
+            first_token_at=request.first_token_at,
         )
         row = self._attempt_row(
             organization_id=request.organization_id,
@@ -610,6 +614,7 @@ class SQLiteGatewayPlatform:
             usage_source=AttemptUsageSource(str(row["usage_source"] or "unknown")),
             estimated_cost_micro_usd=_optional_int(row["estimated_cost_micro_usd"]),
             settled_micro_usd=_optional_int(row["budget_settled_micro_usd"]),
+            first_token_at=_optional_datetime(row["first_token_at"]),
         )
         _require_settlement_replay(settlement, request=request)
         return settlement

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -687,3 +687,94 @@ def test_attempt_wrapper_returns_precise_reservation_and_settlement(
                 ),
             )
         )
+
+
+def test_settlement_surfaces_first_token_time_for_ttft(tmp_path: Path) -> None:
+    """A settlement request carrying first_token_at durably surfaces it on the record."""
+    platform = _platform(tmp_path)
+    platform.control.create_identity(
+        organization_id="org-one",
+        identity_id="builders",
+        display_name="Builders",
+    )
+    platform.control.register_catalog_snapshot(
+        organization_id="org-one",
+        snapshot_ref="catalog-one",
+        catalog_sha256=_DIGEST,
+    )
+    platform.control.activate_alias_revision(
+        organization_id="org-one",
+        alias_id="coding",
+        alias_name="coding",
+        revision_id="alias-revision-one",
+        target=DirectTarget(pool_id="coding-pool"),
+        snapshot_ref="catalog-one",
+        catalog_sha256=_DIGEST,
+    )
+    platform.control.grant_alias(
+        organization_id="org-one",
+        identity_id="builders",
+        alias_id="coding",
+    )
+    raw_key = platform.control.issue_virtual_key(
+        organization_id="org-one",
+        identity_id="builders",
+        key_id="builders-key",
+    ).raw_key
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="bounded request"),),
+    )
+    authorization = platform.control.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=request,
+        deadline_monotonic=10**9,
+    )
+    platform.attempts.accept_request(authorization=authorization)
+    snapshot = ExecutionSnapshot(
+        authorization=authorization,
+        exact_model_id="exact-coding",
+        pool_id="coding-pool",
+        deployment_ids=("deployment-one",),
+    )
+    deployment = ExactModelDeployment(
+        deployment_id="deployment-one",
+        source_alias="deployment-one",
+        exact_model_id="exact-coding",
+        connection="openai",
+        provider="openai",
+        provider_model="gpt-test",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=1_000_000,
+                output_micro_usd_per_million_tokens=1_000_000,
+            )
+        ),
+    )
+    reservation = platform.reserve_attempt(
+        AttemptReservationRequest(
+            organization_id="org-one",
+            snapshot=snapshot,
+            deployment=deployment,
+            attempt_ordinal=0,
+            route_depth=0,
+            maximum_cost_micro_usd=100,
+        )
+    )
+    first_token_at = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    settlement = platform.settle_attempt(
+        AttemptSettlementRequest(
+            organization_id="org-one",
+            attempt_id=reservation.attempt_id,
+            terminal_event=GatewayEvent(
+                kind=GatewayEventKind.COMPLETED,
+                sequence_number=0,
+                usage=GatewayUsage(input_tokens=10, output_tokens=5),
+            ),
+            first_token_at=first_token_at,
+        )
+    )
+    assert settlement.first_token_at == first_token_at

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -668,6 +668,8 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
         alias: str,
         request: GatewayRequest,
         deadline_monotonic: float,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> AuthorizationSnapshot:
         """Authenticate and authorize before any model or provider work.
 
@@ -676,6 +678,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             alias: Requested public model alias.
             request: Canonical content-bearing request used only for its digest.
             deadline_monotonic: Absolute request-wide monotonic deadline.
+            app_referer: Caller ``HTTP-Referer`` and ``app_title`` its ``X-Title`` app identity.
 
         Returns:
             Immutable content-free authority snapshot.
@@ -735,6 +738,8 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             surface=request.surface,
             caller_operation_sha256=caller_operation,
             refusal_failover=bool(row["refusal_failover"]),
+            app_referer=app_referer,
+            app_title=app_title,
         )
 
     def authenticate_key(self, *, raw_key: str) -> None:

--- a/exp/runtime/gateway/tests/data_plane_test.py
+++ b/exp/runtime/gateway/tests/data_plane_test.py
@@ -109,6 +109,7 @@ class _ControlStore:
         self._catalog_sha256 = catalog_sha256
         self._request_digest = request_digest
         self.raw_keys_seen: list[str] = []
+        self.app_seen: list[tuple[str | None, str | None]] = []
 
     def authorize_request(
         self,
@@ -117,9 +118,12 @@ class _ControlStore:
         alias: str,
         request: GatewayRequest,
         deadline_monotonic: float,
+        app_referer: str | None = None,
+        app_title: str | None = None,
     ) -> AuthorizationSnapshot:
         """Return one frozen direct-target authority snapshot."""
         self.raw_keys_seen.append(raw_key)
+        self.app_seen.append((app_referer, app_title))
         return AuthorizationSnapshot(
             request_id="request-one",
             organization_id="organization-one",
@@ -134,6 +138,8 @@ class _ControlStore:
                 self._request_digest(request) if self._request_digest is not None else _DIGEST
             ),
             deadline_monotonic=deadline_monotonic,
+            app_referer=app_referer,
+            app_title=app_title,
         )
 
     def authenticate_key(self, *, raw_key: str) -> None:
@@ -164,6 +170,7 @@ class _Ledger:
         self.started: list[ExecutionSnapshot] = []
         self.routes: list[tuple[str | None, str | None]] = []
         self.finished: list[tuple[GatewayEvent | None, GatewayFailure | None]] = []
+        self.first_token_ats: list[datetime | None] = []
         self.fail_finishes = False
         self.fail_starts = False
         self.reject_starts: AttemptRejectedError | None = None
@@ -200,12 +207,14 @@ class _Ledger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Capture one terminal settlement."""
         del attempt_id, finalize_request
         if self.fail_finishes:
             raise RuntimeError("terminal ledger unavailable")
         self.finished.append((terminal_event, failure))
+        self.first_token_ats.append(first_token_at)
 
     async def finish_request(
         self,
@@ -1801,5 +1810,48 @@ def test_model_discovery_publishes_the_revision_direct_pool_not_a_name_match() -
         assert granted.status_code == 200
         assert granted.json() == expected
         assert len(provider.streams) == 0
+
+    asyncio.run(scenario())
+
+
+def test_app_identity_headers_reach_authorization_for_attribution() -> None:
+    """HTTP-Referer and X-Title app headers reach the frozen authority for attribution."""
+
+    async def scenario() -> None:
+        """Post one chat request carrying OpenRouter-style app identity headers."""
+        provider = _Provider(
+            lambda: _EventStream(
+                (
+                    GatewayEvent(
+                        kind=GatewayEventKind.TEXT_DELTA,
+                        sequence_number=0,
+                        text_delta="hi",
+                    ),
+                    GatewayEvent(
+                        kind=GatewayEventKind.COMPLETED,
+                        sequence_number=1,
+                        usage=GatewayUsage(input_tokens=3, output_tokens=1),
+                    ),
+                )
+            )
+        )
+        service, control, _ledger, _proof = _service(provider)
+        transport = httpx.ASGITransport(app=create_gateway_app(service))
+        async with httpx.AsyncClient(transport=transport, base_url="http://gateway") as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "public-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={
+                    "authorization": "Bearer caller-secret",
+                    "HTTP-Referer": "https://app.example.com",
+                    "X-Title": "Example App",
+                },
+            )
+
+        assert response.status_code == 200
+        assert ("https://app.example.com", "Example App") in control.app_seen
 
     asyncio.run(scenario())

--- a/exp/runtime/gateway/tests/waterfall_test.py
+++ b/exp/runtime/gateway/tests/waterfall_test.py
@@ -1384,6 +1384,7 @@ class _WaterfallLedger:
         self.started: list[tuple[str, int, int]] = []
         self.finished: list[tuple[str, GatewayFailure | None, bool]] = []
         self.finished_events: list[GatewayEvent | None] = []
+        self.first_token_ats: list[datetime | None] = []
         self.parent_finishes: list[GatewayFailure] = []
         self.rejected_deployments = rejected_deployments or set()
         self.rejected_scope = rejected_scope
@@ -1429,10 +1430,12 @@ class _WaterfallLedger:
         terminal_event: GatewayEvent | None,
         failure: GatewayFailure | None,
         finalize_request: bool = True,
+        first_token_at: datetime | None = None,
     ) -> None:
         """Record physical settlement and whether it owns parent terminalization."""
         self.finished_events.append(terminal_event)
         self.finished.append((attempt_id, failure, finalize_request))
+        self.first_token_ats.append(first_token_at)
 
     async def finish_request(
         self,
@@ -1545,3 +1548,71 @@ def _authorization(catalog_sha256: str) -> AuthorizationSnapshot:
         canonical_request_sha256=_DIGEST,
         deadline_monotonic=1.0,
     )
+
+
+class _FixedClock:
+    """Wall and monotonic clock returning one fixed instant for TTFT stamping."""
+
+    def __init__(self, wall: datetime) -> None:
+        """Retain the fixed wall time reported to first-token stamping."""
+        self._wall = wall
+
+    def now(self) -> datetime:
+        """Return the fixed timezone-aware wall time."""
+        return self._wall
+
+    def monotonic(self) -> float:
+        """Return a fixed monotonic reading unused by the request deadline."""
+        return 0.0
+
+
+def test_first_token_time_is_stamped_on_the_winning_attempt() -> None:
+    """The winning attempt's first streamed token time reaches durable settlement."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    provider = _ScriptedProvider([_completed_stream("hello world")])
+    ledger = _WaterfallLedger()
+    catalog = cast(
+        RuntimeModelCatalog,
+        _WaterfallRuntimeCatalog((first,), {first.source_alias: provider}),
+    )
+    stamped = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    executor = GatewayExecutor(
+        {("revision-one", _DIGEST): catalog},
+        ledger,
+        clock=_FixedClock(stamped),
+    )
+
+    async def consume() -> list[GatewayEvent]:
+        """Run one logical request and collect its outward events."""
+        stream = await executor.start(route=_route((first,)), request=_request())
+        return [event async for event in stream]
+
+    events = asyncio.run(consume())
+
+    assert any(event.text_delta == "hello world" for event in events)
+    assert ledger.first_token_ats == [stamped]
+
+
+def test_first_token_time_is_absent_when_no_token_is_streamed() -> None:
+    """An attempt that fails before its first token records no first-token time."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    provider = _ScriptedProvider([ProviderTransportError("connection failed")])
+    ledger = _WaterfallLedger()
+    catalog = cast(
+        RuntimeModelCatalog,
+        _WaterfallRuntimeCatalog((first,), {first.source_alias: provider}),
+    )
+    executor = GatewayExecutor(
+        {("revision-one", _DIGEST): catalog},
+        ledger,
+        maximum_same_deployment_attempts=1,
+    )
+
+    async def consume() -> None:
+        """Run one logical request that fails before any streamed token."""
+        with pytest.raises(GatewayExecutionError):
+            await executor.start(route=_route((first,)), request=_request())
+
+    asyncio.run(consume())
+
+    assert ledger.first_token_ats == [None]

--- a/exp/runtime/gateway/tests/waterfall_test.py
+++ b/exp/runtime/gateway/tests/waterfall_test.py
@@ -1616,3 +1616,47 @@ def test_first_token_time_is_absent_when_no_token_is_streamed() -> None:
     asyncio.run(consume())
 
     assert ledger.first_token_ats == [None]
+
+
+def test_buffered_refusal_stamps_first_token_at_receipt_not_commit() -> None:
+    """A buffered refusal that fails over records first-token at receipt, never null."""
+    first = _deployment("route-a", connection_sha256="b" * 64)
+    second = _deployment("route-b", connection_sha256="c" * 64)
+    first_events = (
+        GatewayEvent(kind=GatewayEventKind.REFUSAL_DELTA, sequence_number=0, text_delta="no"),
+        GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+    )
+    ledger = _WaterfallLedger()
+    catalog = cast(
+        RuntimeModelCatalog,
+        _WaterfallRuntimeCatalog(
+            (first, second),
+            {
+                first.source_alias: _ScriptedProvider([_WaterfallStream(first_events)]),
+                second.source_alias: _ScriptedProvider([_completed_stream("fallback")]),
+            },
+        ),
+    )
+    stamped = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+    executor = GatewayExecutor(
+        {("revision-one", _DIGEST): catalog},
+        ledger,
+        maximum_same_deployment_attempts=1,
+        clock=_FixedClock(stamped),
+    )
+
+    async def consume() -> list[GatewayEvent]:
+        """Run one refusal-failover request and collect its outward events."""
+        stream = await executor.start(
+            route=_route((first, second), refusal_failover=True),
+            request=_request(),
+        )
+        return [event async for event in stream]
+
+    events = asyncio.run(consume())
+
+    assert any(event.text_delta == "fallback" for event in events)
+    # The refused first attempt stamps first-token when the withheld refusal delta is
+    # received (not when the buffer later commits or fails over), so it is never null.
+    assert ledger.first_token_ats[0] == stamped
+    assert ledger.first_token_ats[-1] == stamped


### PR DESCRIPTION
## Why

The hosted platform's deep-telemetry (platform PR #674, already merged) can already store routing overhead, generation duration, cache-hit, token breakdown, and tok/s. Two metrics were blocked because they need runtime data the platform never sees:

1. **Time-to-first-token (TTFT)** — the runtime must record when the winning upstream attempt streamed its first token.
2. **App attribution** — the runtime must surface the caller's app identity (OpenRouter-style `HTTP-Referer` / `X-Title` headers) so the platform can group "top apps" by real app name instead of API-key label.

Both are additive and backward-compatible: every new field is optional/nullable, so a platform pinned to an older wmo revision keeps working.

## What

### Time-to-first-token
- `GatewayExecutionStream` stamps the winning attempt's **first streamed token** with an injected `GatewayClock` (captured when the first semantic/refusal event commits the attempt) and threads it through `AttemptLedger.finish_attempt(first_token_at=...)`.
- Persisted as a nullable **`gateway_attempts.first_token_at`** column (schema migration 9).
- Surfaced on the platform-facing contracts **`AttemptSettlementRequest.first_token_at`** and **`AttemptSettlementRecord.first_token_at`** (`exp/runtime/gateway/platform.py`).
- Threaded through the group-commit writer and the native settlement bridge (`native_settlement.first_token_at_from_settlement`) so **both** data planes carry it. The Rust engine only needs to include `first_token_at` in its settlement JSON to light up on the default path (follow-up).

### App attribution
- **`AuthorizationSnapshot.app_referer`** and **`AuthorizationSnapshot.app_title`** carry the caller app identity, frozen before selection.
- The HTTP boundary (`/v1/chat/completions`, `/v1/responses`) parses `HTTP-Referer` and `X-Title` and threads them through `complete` -> `authorize_request`.
- `accept_request` persists them as nullable **`gateway_requests.app_referer`** / **`gateway_requests.app_title`** columns (migration 9). App identity is per-request, matching how the platform groups top apps.

## Contract for the follow-up platform PR

Consume at the settlement / authorization seams the platform already implements:

| Field | Type | Nullability | Where |
|---|---|---|---|
| `AttemptSettlementRecord.first_token_at` | `datetime` (tz-aware) | optional, `None` when no token streamed / crash | `exp.runtime.gateway.platform` |
| `AttemptSettlementRequest.first_token_at` | `datetime` (tz-aware) | optional | `exp.runtime.gateway.platform` |
| `AuthorizationSnapshot.app_referer` | `str` (<=2048) | optional | `exp.runtime.gateway.contracts` (via `ExecutionSnapshot` -> `AttemptReservationRequest.snapshot.authorization`) |
| `AuthorizationSnapshot.app_title` | `str` (<=256) | optional | same |
| `gateway_attempts.first_token_at` | `TEXT` ISO-8601 | nullable | sqlite ledger column |
| `gateway_requests.app_referer` / `app_title` | `TEXT` | nullable | sqlite ledger columns |

Platform wiring: store `first_token_at` on `gateway_attempts`, compute **TTFT = first_token_at − accepted_at**, and narrow generation_duration to `first_token_at → terminal_at`; read `app_referer`/`app_title` from the reservation's authorization (or the mirrored request columns) to group `/insights` top-apps.

## Pin / rename discrepancy (important)

The platform currently pins wmo rev `cb4c1607` (#526), which predates the `wmo` -> `exp` package rename (#536). This PR is against latest `main` (`exp/` layout, Rust-default data plane). To consume these fields the platform must bump its `world-model-optimizer` pin past this PR **and** adjust imports from `wmo.runtime.gateway.*` to `exp.runtime.gateway.*`. The new fields are additive/nullable, so the bump itself introduces no behavioral break for existing telemetry.

## Tests
- `ledger_test`: accept persists app identity; finish persists `first_token_at`; both default to null.
- `sqlite/platform_test`: `settle_attempt` surfaces `first_token_at` on the record.
- `tests/waterfall_test`: winning attempt stamps `first_token_at`; a pre-token failure records `None`.
- `tests/data_plane_test`: `HTTP-Referer` / `X-Title` reach the frozen authority over HTTP.
- `sqlite/migrations_test`: version assertion updated to `SCHEMA_VERSION`.

Local gate: `ruff check`, `ruff format --check`, `ty check`, and the affected pytest suites pass; all touched files stay under the 999-line limit. (Rust `cargo` gate and native-crate parity tests not run locally — no Rust changes in this PR.)

Do not merge yet — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)