### PR TITLE
Release 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.5.0"
+version = "0.5.1"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for 0.5.1: group-commit batched accounting on the native bridge (#586), hosted Rust gateway composition (#576), native Responses and project-alias serving (#582/#585), the native metrics snapshot (#588), and the failure-path integration tests (#587).

🤖 Generated with [Claude Code](https://claude.com/claude-code)