### PR TITLE
feat(cli): restore explicit exp run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ uv run pytest -q
   may not import optimize or cli; optimize may not import cli. Optimize owns application
   orchestration and may depend inward on common, runtime, and simulation. The AST gate rejects
   every current forbidden edge directly and proves that the package graph is acyclic.
-- The root CLI command set is exact: `build`, `config`, and `optimize`. An invocation without a
+- The root CLI command set is exact: `build`, `config`, `optimize`, and `run`. An invocation without a
   subcommand opens the default gateway home screen. `exp/cli/app_test.py` and the release tests
   enforce the current command and distribution shape.
 
@@ -119,7 +119,7 @@ uv run pytest -q
   orchestration lives in `automatic/`, manual judge calibration in `judging/`, offline policy work
   in `fit/`, and evaluation preparation in `evaluation/`. The durable judgment ledger remains at
   `judgment_budget.py`.
-- The root CLI is locked to `build`, `optimize`, and `config`. The optimize group is locked
+- The root CLI is locked to `build`, `optimize`, `config`, and `run`. The optimize group is locked
   to `router` and `model`; the config group is locked to `budget`, `gateway`, `judge`, `providers`,
   and `telemetry`. Widening any of those three sets, whether with a command, an alias, or a flag, is a
   deliberate change to the locked surface and needs the same scrutiny as a public API change.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ pip install experiential
 exp
 ```
 
-Bare `exp` is a shortcut for `exp run`; the explicit form remains available. Use `exp --help`
-or `exp help` for the root command help.
-
 Choose a public alias such as `support-agent`, capture the issued key, and send a request:
 
 ```bash

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -6,16 +6,16 @@ on the exact release checkout.
 
 ## Supported and verified
 
-- Root CLI commands are exactly `build`, `config`, and `optimize`; an invocation with no subcommand
+- Root CLI commands are exactly `build`, `config`, `optimize`, and `run`; an invocation with no subcommand
   opens the default gateway home screen. Optimizer commands are exactly `router` and `model`.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
   singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
   provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
   content-free SQLite accounting, monthly integer micro-USD enforcement, and loopback-only health
   and usage views.
-- The no-subcommand default gateway launch and the `exp --project PROJECT [--ghost]` compatibility
-  form are installed-wheel surfaces. Gateway startup is provider-idle and requires explicit
-  authority.
+- The no-subcommand default gateway launch, the direct `exp run [PROJECT]` form, and the
+  `exp --project PROJECT [--ghost]` compatibility form are installed-wheel surfaces. Gateway
+  startup is provider-idle and requires explicit authority.
 - The installed-wheel gateway lane uses real SQLite, a real subprocess listener, a real loopback
   upstream, and OpenAI `3.0.0`. It covers `OpenAI` and `AsyncOpenAI` across Chat Completions and
   Responses, with both stream and non-stream requests. HTML and JSON usage are checked for the same

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,7 @@ The root surface is deliberately small:
 | Command | Purpose | Local result |
 |---|---|---|
 | `exp` | Open the branded home screen. `Default Gateway` is the recommended setup-and-start path. | Interactive gateway menu, or the default gateway in a non-interactive terminal. |
+| `exp run [PROJECT] [--root ROOT] [--check] [--engine auto\|rust\|python]` | Start the local gateway directly, optionally with one project-backed alias. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |
 | `exp optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
 | `exp optimize model PROJECT --root ROOT [--yes]` | Verify one project-bound W12 dataset and conservatively preflight bounded managed Tinker SFT. | Completed W13 result and registered frozen alias, or a fail-closed preflight with no paid dispatch. |

--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -14,6 +14,7 @@ from exp.cli.gateway.serve import (
     DEFAULT_GATEWAY_PORT,
     DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
     DEFAULT_MAX_ACTIVE_REQUESTS,
+    run,
 )
 from exp.cli.shared.defer import add_deferred_typer
 from exp.cli.shared.options import ROOT_OPTION
@@ -33,6 +34,7 @@ add_deferred_typer(
     known_names=("router", "model"),
 )
 app.command("build", help="Build a reusable grounded world model from local trace evidence.")(build)
+app.command("run", help="Run the local gateway, optionally with one project-backed alias.")(run)
 
 
 @app.callback()

--- a/exp/cli/app_test.py
+++ b/exp/cli/app_test.py
@@ -1,4 +1,4 @@
-"""Tests for the locked command surface exposed by the root Typer application."""
+"""Tests for the supported command surface exposed by the root Typer application."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ def test_root_cli_and_subgroups_are_exact() -> None:
     """
     root = get_group(app)
     root_context = Context(root)
-    assert set(root.list_commands(root_context)) == {"build", "config", "optimize"}
+    assert set(root.list_commands(root_context)) == {"build", "config", "optimize", "run"}
 
     for name, expected in EXPECTED_SUBCOMMANDS.items():
         command = root.get_command(root_context, name)

--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -11,7 +11,7 @@ import typer
 from rich.console import Console
 from rich.text import Text
 
-from exp.cli.shared.options import usage_error
+from exp.cli.shared.options import ROOT_OPTION, usage_error
 from exp.cli.shared.theme import EXP_THEME
 
 LOOPBACK_HOST = "127.0.0.1"
@@ -31,6 +31,92 @@ _EXP_WORDMARK = "\n".join(
     )
 )
 _MAX_ACTIVE_REQUESTS_DEFAULT = DEFAULT_MAX_ACTIVE_REQUESTS
+
+
+def run(
+    project: str | None = typer.Argument(
+        None,
+        help="Optional project to expose as one project-backed gateway alias.",
+    ),
+    root: Path = ROOT_OPTION,
+    policy: str | None = typer.Option(
+        None,
+        "--policy",
+        help="Exact frozen policy ID for the optional project-backed alias.",
+    ),
+    port: int = typer.Option(DEFAULT_GATEWAY_PORT, "--port", min=1, max=65_535),
+    ghost: bool = typer.Option(
+        False,
+        "--ghost",
+        help=(
+            "Compatibility flag: project journals stay disabled while gateway accounting "
+            "remains on."
+        ),
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Never open first-run prompts.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Write a versioned launch receipt."),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Validate readiness and exit without binding.",
+    ),
+    graceful_timeout: float = typer.Option(
+        DEFAULT_GRACEFUL_TIMEOUT_SECONDS,
+        "--graceful-timeout",
+        min=0.1,
+        help="Seconds to drain admitted gateway work during shutdown.",
+    ),
+    engine: str = typer.Option(
+        "auto",
+        "--engine",
+        help=(
+            "Data-plane engine: 'auto' (rust when built, otherwise python), 'rust' "
+            "(native data plane with an embedded python engine for Responses, "
+            "replay, and project aliases), or 'python' (uvicorn only)."
+        ),
+    ),
+    max_active_requests: int = typer.Option(
+        DEFAULT_MAX_ACTIVE_REQUESTS,
+        "--max-active-requests",
+        min=1,
+        help="Rust engine only: maximum concurrently admitted requests.",
+    ),
+) -> None:
+    """Start the local gateway directly, optionally with one project-backed alias.
+
+    Args:
+        project: Optional project identifier and endpoint alias.
+        root: Local artifact and model-catalog root.
+        policy: Exact policy for an ambiguous project.
+        port: Local loopback TCP port.
+        ghost: Compatibility marker for project traffic, which always uses gateway accounting.
+        non_interactive: Whether first-run gateway prompts are forbidden.
+        json_output: Whether startup output is one versioned JSON receipt.
+        check: Whether to validate gateway readiness without binding.
+        graceful_timeout: Gateway shutdown drain bound in seconds.
+        engine: Data-plane engine: ``auto``, ``rust``, or ``python``.
+        max_active_requests: Rust engine concurrent-admission bound.
+
+    Raises:
+        typer.BadParameter: The selected project form or activation is invalid.
+    """
+    start_gateway(
+        project=project,
+        root=root,
+        policy=policy,
+        port=port,
+        ghost=ghost,
+        non_interactive=non_interactive,
+        json_output=json_output,
+        check=check,
+        graceful_timeout=graceful_timeout,
+        engine=engine,
+        max_active_requests=max_active_requests,
+    )
 
 
 def start_gateway(

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -21,6 +21,101 @@ from exp.cli.gateway.compatibility import ProjectGatewayCompatibility
 from exp.cli.gateway.setup import InteractiveSetupResult
 
 
+def test_run_command_starts_the_gateway_directly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The explicit run command forwards its arguments to the shared gateway launcher."""
+    captured: list[
+        tuple[
+            str | None,
+            Path,
+            str | None,
+            int,
+            bool,
+            bool,
+            bool,
+            bool,
+            float,
+            str,
+            int,
+        ]
+    ] = []
+
+    def capture_start(
+        *,
+        project: str | None,
+        root: Path,
+        policy: str | None,
+        port: int,
+        ghost: bool,
+        non_interactive: bool,
+        json_output: bool,
+        check: bool,
+        graceful_timeout: float,
+        engine: str,
+        max_active_requests: int,
+    ) -> None:
+        """Capture the shared launcher arguments without starting a server."""
+        captured.append(
+            (
+                project,
+                root,
+                policy,
+                port,
+                ghost,
+                non_interactive,
+                json_output,
+                check,
+                graceful_timeout,
+                engine,
+                max_active_requests,
+            )
+        )
+
+    monkeypatch.setattr(run_app, "start_gateway", capture_start)
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "project-a",
+            "--root",
+            str(tmp_path),
+            "--policy",
+            "policy-a",
+            "--port",
+            "8123",
+            "--ghost",
+            "--non-interactive",
+            "--json",
+            "--check",
+            "--graceful-timeout",
+            "4.5",
+            "--engine",
+            "python",
+            "--max-active-requests",
+            "7",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == [
+        (
+            "project-a",
+            tmp_path,
+            "policy-a",
+            8123,
+            True,
+            True,
+            True,
+            True,
+            4.5,
+            "python",
+            7,
+        )
+    ]
+
+
 @pytest.mark.parametrize("ghost", [False, True])
 def test_project_option_launches_the_normal_gateway_on_loopback(
     monkeypatch: pytest.MonkeyPatch,

--- a/exp/cli/tests/cli_help_test.py
+++ b/exp/cli/tests/cli_help_test.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the locked customer CLI help surface."""
+"""Regression coverage for the supported customer CLI help surface."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from exp.cli.app import app
     [
         ["--help"],
         ["build", "--help"],
+        ["run", "--help"],
         ["config", "telemetry", "--help"],
         ["config", "budget", "--help"],
         ["config", "providers", "--help"],
@@ -25,6 +26,7 @@ from exp.cli.app import app
     ids=[
         "root",
         "build",
+        "run",
         "telemetry",
         "budget",
         "providers",


### PR DESCRIPTION
## Summary

- Restore exp run [PROJECT] as an explicit direct gateway command backed by the shared launcher.
- Add root, help, and argument-forwarding regression coverage.
- Remove the stale README shortcut and help claim, and update the CLI usage and release scope.

## Validation

- Focused CLI tests: 23 passed.
- ruff check: passed.
- ruff format --check: passed.
- ty check: passed.
- Non-interactive exp run smoke: expected gateway_not_initialized response.
- Post-commit release evidence checks: 2 passed.
- Full pre-commit suite: 2,247 passed, 2 skipped, 13 failures. Eleven terminal picker failures reproduce on untouched main. Two release evidence failures were caused by the intentionally uncommitted tracked diff and pass on the committed checkout.