### PR TITLE
feat(cli): expose slash search in provider and model pickers

### DIFF
--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -202,6 +202,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
     assert selection == (("openai", "anthropic"), False)
     assert "\u276f [x] openai" in console.output
     assert "Complete" in console.output
+    assert "/ search" in console.output
     assert "Numbers or ranges" not in console.output
 
 

--- a/exp/cli/shared/picker.py
+++ b/exp/cli/shared/picker.py
@@ -159,14 +159,16 @@ def select_many(
         if word in _ALL_WORDS:
             selected = _merged(selected, tuple(option.value for option in visible))
             continue
-        if answer == "/":
-            searching = True
-            continue
         if answer.startswith("/"):
-            answer = answer[1:]
-            if not answer:
+            query = answer[1:]
+            if not query:
                 searching = True
                 continue
+            expanded = False
+            if not _filtered(options, query):
+                console.print(f"[yellow]No row matches {query!r}.[/yellow]")
+                query = ""
+            continue
         positions = _positions(answer, count=len(visible))
         if positions is None:
             query = answer
@@ -236,14 +238,16 @@ def select_one(
         if word in _MORE_WORDS:
             expanded = True
             continue
-        if answer == "/":
-            searching = True
-            continue
         if answer.startswith("/"):
-            answer = answer[1:]
-            if not answer:
+            query = answer[1:]
+            if not query:
                 searching = True
                 continue
+            expanded = False
+            if not _filtered(options, query):
+                console.print(f"[yellow]No row matches {query!r}.[/yellow]")
+                query = ""
+            continue
         positions = _positions(answer, count=len(visible))
         if positions is not None and len(positions) == 1:
             return PickerResult(values=(visible[positions[0] - 1].value,))

--- a/exp/cli/shared/picker.py
+++ b/exp/cli/shared/picker.py
@@ -6,7 +6,8 @@ toggles a row on a multi-select screen whose Complete row submits, and Enter con
 row on a single-select screen. Slash opens a search line that narrows long lists as the user
 types: Backspace edits the query, Enter keeps the matches, and Esc clears the search. A console
 without a terminal cannot be driven by raw keys, so the same screens fall back to the line-based
-path, which reads whole lines and accepts numbers, ranges, filter text, and back or cancel words.
+path, which reads whole lines and accepts numbers, ranges, slash-prefixed searches, filter text,
+and back or cancel words.
 """
 
 from __future__ import annotations
@@ -120,16 +121,25 @@ def select_many(
     values = {option.value for option in options}
     selected = [value for value in preselected if value in values]
     query = ""
+    searching = False
     expanded = False
     console.print(f"[bold]{title}[/bold]")
     while True:
         visible = _filtered(options, query)
         _render(console, visible, selected=selected, expanded=expanded, query=query)
         console.print(
-            "[dim]Numbers or ranges toggle rows, 'all' selects, 'none' clears, text filters, "
-            "empty line accepts, 'b' goes back, 'q' cancels.[/dim]"
+            "[dim]Numbers/ranges toggle, 'all' selects, 'none' clears, '/text' filters, "
+            "empty accepts, 'b' back, 'q' cancels.[/dim]"
         )
-        answer = console.input("> ").strip()
+        answer = console.input("search> " if searching else "> ").strip()
+        if searching:
+            query = answer
+            searching = False
+            expanded = False
+            if query and not _filtered(options, query):
+                console.print(f"[yellow]No row matches {query!r}.[/yellow]")
+                query = ""
+            continue
         word = answer.casefold()
         if word in _BACK_WORDS:
             return PickerResult(action=PickerAction.BACK)
@@ -149,6 +159,14 @@ def select_many(
         if word in _ALL_WORDS:
             selected = _merged(selected, tuple(option.value for option in visible))
             continue
+        if answer == "/":
+            searching = True
+            continue
+        if answer.startswith("/"):
+            answer = answer[1:]
+            if not answer:
+                searching = True
+                continue
         positions = _positions(answer, count=len(visible))
         if positions is None:
             query = answer
@@ -191,16 +209,23 @@ def select_one(
     values = {option.value for option in options}
     fallback = default if default in values else None
     query = ""
+    searching = False
     expanded = False
     console.print(f"[bold]{title}[/bold]")
     while True:
         visible = _filtered(options, query)
         _render(console, visible, selected=[], expanded=expanded, query=query)
         suffix = f" [dim](empty line keeps {fallback})[/dim]" if fallback is not None else ""
-        console.print(
-            f"[dim]Enter one number, text filters, 'b' goes back, 'q' cancels.[/dim]{suffix}"
-        )
-        answer = console.input("> ").strip()
+        console.print(f"[dim]Number selects, '/text' filters, 'b' back, 'q' cancels.[/dim]{suffix}")
+        answer = console.input("search> " if searching else "> ").strip()
+        if searching:
+            query = answer
+            searching = False
+            expanded = False
+            if query and not _filtered(options, query):
+                console.print(f"[yellow]No row matches {query!r}.[/yellow]")
+                query = ""
+            continue
         word = answer.casefold()
         if word in _BACK_WORDS:
             return PickerResult(action=PickerAction.BACK)
@@ -211,6 +236,14 @@ def select_one(
         if word in _MORE_WORDS:
             expanded = True
             continue
+        if answer == "/":
+            searching = True
+            continue
+        if answer.startswith("/"):
+            answer = answer[1:]
+            if not answer:
+                searching = True
+                continue
         positions = _positions(answer, count=len(visible))
         if positions is not None and len(positions) == 1:
             return PickerResult(values=(visible[positions[0] - 1].value,))

--- a/exp/cli/shared/picker_test.py
+++ b/exp/cli/shared/picker_test.py
@@ -124,6 +124,35 @@ def test_typed_text_filters_a_long_list_and_all_selects_only_matches() -> None:
     assert "filter: model-12" in console.output
 
 
+def test_line_picker_accepts_a_slash_prefixed_search_query() -> None:
+    """The non-terminal fallback accepts the same slash-prefixed search affordance."""
+    console = _console("/model-12\n1\n\n")
+
+    result = select_many(console, title="Models", options=_options(20))
+
+    assert result.values == ("model-12",)
+    assert "filter: model-12" in console.output
+
+
+def test_line_picker_can_open_a_search_prompt_with_slash() -> None:
+    """A standalone slash opens a second line for search text before selection continues."""
+    console = _console("/\nmodel-12\n1\n\n")
+
+    result = select_many(console, title="Models", options=_options(20))
+
+    assert result.values == ("model-12",)
+    assert "search>" in console.output
+
+
+def test_single_select_accepts_a_slash_prefixed_search_query() -> None:
+    """Single-select screens use the same explicit slash query in the line fallback."""
+    console = _console("/model-12\n1\n")
+
+    result = select_one(console, title="Model", options=_options(20))
+
+    assert result.values == ("model-12",)
+
+
 def test_preselected_values_survive_reentering_a_screen() -> None:
     """Answers already given stay selected when a screen is shown again."""
     console = _console("\n")

--- a/exp/cli/shared/picker_test.py
+++ b/exp/cli/shared/picker_test.py
@@ -153,6 +153,24 @@ def test_single_select_accepts_a_slash_prefixed_search_query() -> None:
     assert result.values == ("model-12",)
 
 
+def test_numeric_slash_query_is_not_parsed_as_a_multi_select_row_number() -> None:
+    """A numeric slash query filters model IDs before the row-number parser can run."""
+    console = _console("/2\n2\n\n")
+
+    result = select_many(console, title="Models", options=_options(20))
+
+    assert result.values == ("model-12",)
+
+
+def test_numeric_slash_query_is_not_parsed_as_a_single_select_row_number() -> None:
+    """Single-select numeric searches also choose the matching model, not row two."""
+    console = _console("/2\n2\n")
+
+    result = select_one(console, title="Model", options=_options(20))
+
+    assert result.values == ("model-12",)
+
+
 def test_preselected_values_survive_reentering_a_screen() -> None:
     """Answers already given stay selected when a screen is shown again."""
     console = _console("\n")

--- a/exp/cli/shared/picker_view.py
+++ b/exp/cli/shared/picker_view.py
@@ -25,8 +25,8 @@ _MAXIMUM_VISIBLE_ROWS = 5
 _RESERVED_LINES = 6
 _ROW_INDENT = " "
 
-_MULTI_HINT = "up/down + space, Enter on Complete"
-_SINGLE_HINT = "up/down + Enter"
+_MULTI_HINT = "up/down + space, Enter on Complete, / search"
+_SINGLE_HINT = "up/down + Enter, / search"
 _MULTI_SEARCH_HINT = "type to search; Enter keeps matches, Esc clears"
 _SINGLE_SEARCH_HINT = "type to search; Enter confirms, Esc clears"
 

--- a/exp/cli/shared/picker_view_test.py
+++ b/exp/cli/shared/picker_view_test.py
@@ -132,6 +132,7 @@ def test_multi_select_marks_selection_and_names_the_submit_row() -> None:
     assert "[ ] anthropic" in text
     assert "\u276f Complete" in text
     assert "Enter on Complete" in text
+    assert "/ search" in text
 
 
 def test_single_select_shows_metadata_without_selection_marks() -> None:
@@ -145,6 +146,7 @@ def test_single_select_shows_metadata_without_selection_marks() -> None:
     text = _plain(console)
     assert "\u276f sonnet (anthropic)" in text
     assert "[ ]" not in text
+    assert "/ search" in text
     assert "up/down + Enter" in text
 
 


### PR DESCRIPTION
Summary:
- Advertise the / search shortcut in the shared provider/model picker UI.
- Support /query and a standalone / prompt in the line-based fallback.
- Cover single-select and multi-select search behavior.

Verification:
- uv run --extra dev ruff check .
- uv run --extra dev ty check
- 121 picker/provider/model tests and 9 picker-view tests pass outside the pre-existing Rich PTY cleanup assertions.