### PR TITLE
feat(cli): add Platform login for Experiential Cloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Anthropic direct (Opus 4.8)
 ANTHROPIC_API_KEY=
 
+# Experiential Cloud (interactive setup opens Platform login; CI may export the key)
+EXPLABS_API_KEY=
+EXP_PLATFORM_URL=
+EXP_GATEWAY_URL=
+
 # AWS Bedrock (catalog provider = "bedrock"; the standard AWS chain supplies credentials)
 AWS_REGION=
 AWS_DEFAULT_REGION=

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -120,18 +120,18 @@ metadata the same way.
 ## Experiential Cloud
 
 Experiential Cloud is the first-party hosted Platform lane, not a local gateway recipe. Customers
-call `https://api.experientiallabs.ai/v1` with a durable Platform `xpl_` key stored as
-`EXPLABS_API_KEY`. Setup does not prompt for a base URL and does not write a local `gateway.db`
-authority for this path.
+call `https://api.experientiallabs.ai/v1` with a durable Platform `xpl_` key resolved from
+`EXPLABS_API_KEY` or the user-data credential file. Setup does not prompt for a base URL and does not write a local `gateway.db`
+authority for this path. In an interactive terminal, the command opens Platform approval and
+stores the returned key after the loopback callback completes.
 
 ```bash
-export EXPLABS_API_KEY=...   # from https://platform.experientiallabs.ai/settings/api-keys
-
 exp config providers --provider experiential-cloud --root ROOT
 ```
 
-Preview or staging may replace the origin with `EXP_GATEWAY_URL`. Non-interactive automation uses
-the frozen catalog provider:
+For headless or CI setup, export `EXPLABS_API_KEY` before running the same command. Preview or
+staging may replace the browser origin with `EXP_PLATFORM_URL` and the API origin with
+`EXP_GATEWAY_URL`. Non-interactive automation uses the frozen catalog provider:
 
 ```bash
 exp config providers --non-interactive --root ROOT \

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -7,8 +7,8 @@ embedding alias must declare the protocol features and token prices it uses.
 Configure connections with `exp config providers` or the first `exp build` on a clean checkout.
 An interactive terminal opens a provider list: Up and Down move focus, Enter selects or deselects
 the focused provider, and the Complete row submits the selection. Agents skip that list with
-repeatable `--provider` flags (`openai`, `anthropic`, `gemini`, `openrouter`,
-`openai-compatible`, `azure`, `bedrock`, `experiential-cloud`). Unsupported or duplicate values
+repeatable `--provider` flags (`experiential-cloud`, `openai`, `anthropic`, `gemini`, `openrouter`,
+`openai-compatible`, `azure`, `bedrock`). Unsupported or duplicate values
 fail before any catalog write. Azure and Bedrock still require manual model IDs. Other selected
 providers use account model discovery when credentials are available.
 
@@ -18,8 +18,14 @@ providers use account model discovery when credentials are available.
 not rebuild a local gateway authority for that hosted path. Local `exp run` first-run setup keeps
 the offline provider list and does not offer Experiential Cloud.
 
+When an interactive terminal selects Experiential Cloud without an environment or stored key,
+setup opens the Platform `/cli/auth` approval page. After approval, the new `xpl_` key returns
+through a loopback callback, is verified by model discovery, and is stored in the user-data
+credential file. Set `EXP_PLATFORM_URL` for a preview or staging Platform web origin. Headless
+and CI setup should provide `EXPLABS_API_KEY` instead.
+
 Setup writes only secret-free catalog fields and never prints a credential value. Interactive
-`exp config providers` persists pasted API keys outside the repository in the platform
+`exp config providers` persists browser-approved or pasted API keys outside the repository in the platform
 user-data file (`$XDG_DATA_HOME/exp/auth.json` or `~/.local/share/exp/auth.json` on Linux).
 When the operator edits an existing provider that already has a stored key, the same wizard
 can keep, replace, or remove that record. Known providers keep their canonical environment

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ The root surface is deliberately small:
 | `exp config gateway call ALIAS PROMPT [--json]` | Send one chat completion to a live gateway as a caller, streaming text to stdout. | One HTTP request against the running gateway; no local state. |
 | `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
 | `exp config gateway key check [--json]` | Validate one raw virtual key against a live gateway and print its granted aliases without storing the key. | One HTTP request against the running gateway; no local state. |
-| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. `experiential-cloud` points at the hosted Platform gateway. Interactive setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
+| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. `experiential-cloud` points at the hosted Platform gateway and interactive setup can open Platform login. Setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
 | `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command (default `$50.00`). | Local `.exp/settings.toml`. |
 | `exp config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.exp/settings.toml`. |
 

--- a/exp/cli/build/app.py
+++ b/exp/cli/build/app.py
@@ -87,8 +87,8 @@ _PROVIDER_OPTION = typer.Option(
     "--provider",
     help=(
         "Repeatable provider to configure during first-build setup. "
-        "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
-        "azure, bedrock, experiential-cloud."
+        "Supported values: experiential-cloud, openai, anthropic, gemini, openrouter, "
+        "openai-compatible, azure, bedrock."
     ),
 )
 

--- a/exp/cli/config/app.py
+++ b/exp/cli/config/app.py
@@ -54,8 +54,8 @@ _PROVIDER_OPTION = typer.Option(
     "--provider",
     help=(
         "Repeatable provider that skips the opening list during interactive setup. "
-        "Supported values: openai, anthropic, gemini, openrouter, openai-compatible, "
-        "azure, bedrock, experiential-cloud."
+        "Supported values: experiential-cloud, openai, anthropic, gemini, openrouter, "
+        "openai-compatible, azure, bedrock."
     ),
 )
 

--- a/exp/cli/optimize/router_candidates_test.py
+++ b/exp/cli/optimize/router_candidates_test.py
@@ -80,7 +80,7 @@ def test_router_candidate_picker_discovers_only_eligible_completion_models(
 
     picked = run_router_candidate_picker(
         catalog,
-        console=ScriptedConsole("1\n\n1,2\n\n\n\n1\n"),
+        console=ScriptedConsole("2\n\n1,2\n\n\n\n1\n"),
         lister=_FakeLister(),
         environment={"OPENAI_API_KEY": "openai-secret"},
     )

--- a/exp/cli/providers/experiential_cloud.py
+++ b/exp/cli/providers/experiential_cloud.py
@@ -103,7 +103,9 @@ class BrowserLogin:
                 params = parse_qs(parsed.query)
                 token = (params.get("token") or [""])[0]
                 state = (params.get("state") or [""])[0]
-                if not token or not secrets.compare_digest(state, expected_state):
+                if not token.startswith("xpl_") or not secrets.compare_digest(
+                    state, expected_state
+                ):
                     self._respond(400, _FAILURE_PAGE)
                     return
                 try:
@@ -242,6 +244,7 @@ def hosted_platform_login(
             opened = False
         if not opened:
             console.print(f"[yellow]Open this URL to connect Experiential Cloud:[/yellow] {url}")
+            return None
         console.print("[dim]Approve the connection in your browser to continue.[/dim]")
         token = attempt.wait(timeout)
         if token is None:

--- a/exp/cli/providers/experiential_cloud.py
+++ b/exp/cli/providers/experiential_cloud.py
@@ -1,16 +1,28 @@
-"""Hosted Experiential Cloud connection for local CLI provider setup.
+"""Hosted Experiential Cloud connection and Platform browser login.
 
 Experiential Cloud is a setup picker for the hosted Platform gateway. The
 persisted catalog provider stays ``openai-compatible``: the CLI does not invent
 a new runtime provider family, and it does not rebuild a local gateway
-authority for this hosted path. Local ``exp run`` / ``exp config gateway``
-workflows stay available for genuine offline serving.
+authority for this hosted path. When no saved or environment credential is
+available, interactive setup uses the Platform approval page and a loopback
+callback to receive the new organization key.
 """
 
 from __future__ import annotations
 
+import html
 import os
-from collections.abc import Mapping
+import queue
+import secrets
+import threading
+import webbrowser
+from collections.abc import Callable, Mapping
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from rich.console import Console
+
+from exp.common.models import ProviderConnection
 
 SETUP_PICKER_NAME = "experiential-cloud"
 SETUP_PICKER_LABEL = "Experiential Cloud"
@@ -18,6 +30,148 @@ CATALOG_PROVIDER = "openai-compatible"
 HOSTED_GATEWAY_DEFAULT_BASE_URL = "https://api.experientiallabs.ai/v1"
 HOSTED_GATEWAY_API_KEY_ENV = "EXPLABS_API_KEY"
 HOSTED_GATEWAY_URL_ENV = "EXP_GATEWAY_URL"
+HOSTED_PLATFORM_DEFAULT_URL = "https://platform.experientiallabs.ai"
+HOSTED_PLATFORM_URL_ENV = "EXP_PLATFORM_URL"
+PLATFORM_LOGIN_TIMEOUT_SECONDS = 300.0
+PLATFORM_LOGIN_KEY_NAME = "exp CLI"
+
+_FAILURE_PAGE = b"""<!doctype html>
+<html><body style="font-family: system-ui; padding: 48px; color: #171717;">
+<h1 style="font-size: 18px;">That did not match</h1>
+<p>This callback was not for the login attempt waiting in your terminal.
+Re-run <code>exp config providers --provider experiential-cloud</code> and use the new URL.</p>
+</body></html>"""
+
+
+class BrowserLogin:
+    """One Platform approval attempt backed by an ephemeral loopback listener."""
+
+    def __init__(self, web_url: str) -> None:
+        """Prepare one browser login against a Platform web origin.
+
+        Args:
+            web_url: Browser-facing Platform origin, without a trailing slash.
+        """
+        self.web_url = web_url.rstrip("/")
+        self.state = secrets.token_urlsafe(24)
+        self._tokens: queue.Queue[str] = queue.Queue(maxsize=1)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def port(self) -> int:
+        """Return the ephemeral loopback port assigned by ``start``.
+
+        Raises:
+            RuntimeError: The callback listener has not started.
+        """
+        if self._server is None:
+            raise RuntimeError("browser login listener is not running; call start() first")
+        return self._server.server_address[1]
+
+    def start(self) -> int:
+        """Bind 127.0.0.1 and serve one-time Platform callbacks in a daemon thread.
+
+        Returns:
+            The ephemeral loopback port.
+
+        Raises:
+            RuntimeError: This login attempt has already started.
+        """
+        if self._server is not None:
+            raise RuntimeError("browser login listener is already running")
+        tokens = self._tokens
+        expected_state = self.state
+        platform_url = html.escape(self.web_url, quote=True)
+        success_page = f"""<!doctype html>
+<html><head><meta http-equiv="refresh" content="1;url={platform_url}"></head>
+<body style="font-family: system-ui; padding: 48px; color: #171717;">
+<h1 style="font-size: 18px;">Experiential Cloud is connected</h1>
+<p>The key was handed to your terminal. You can return to
+<a href="{platform_url}">the Platform</a>.</p>
+</body></html>""".encode()
+
+        class _CallbackHandler(BaseHTTPRequestHandler):
+            """Accept the Platform key only on the matching loopback callback."""
+
+            def do_GET(self) -> None:  # noqa: N802 - http.server contract
+                """Validate one callback and place its key on the login queue."""
+                parsed = urlparse(self.path)
+                if parsed.path != "/callback":
+                    self.send_error(404)
+                    return
+                params = parse_qs(parsed.query)
+                token = (params.get("token") or [""])[0]
+                state = (params.get("state") or [""])[0]
+                if not token or not secrets.compare_digest(state, expected_state):
+                    self._respond(400, _FAILURE_PAGE)
+                    return
+                try:
+                    tokens.put_nowait(token)
+                except queue.Full:
+                    self._respond(400, _FAILURE_PAGE)
+                    return
+                self._respond(200, success_page)
+
+            def _respond(self, status: int, body: bytes) -> None:
+                """Write one bounded HTML response to the browser."""
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                """Suppress callback request logs so credentials never reach stderr."""
+                del format, args
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _CallbackHandler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self.port
+
+    def authorize_url(self, *, key_name: str = PLATFORM_LOGIN_KEY_NAME) -> str:
+        """Return the Platform approval URL for this login attempt.
+
+        Args:
+            key_name: Display name the Platform should use for the minted key.
+
+        Returns:
+            URL carrying only the loopback port, key name, and one-time state.
+
+        Raises:
+            RuntimeError: The callback listener has not started.
+        """
+        query = urlencode({"state": self.state, "port": self.port, "name": key_name})
+        return f"{self.web_url}/cli/auth?{query}"
+
+    def wait(self, timeout: float = PLATFORM_LOGIN_TIMEOUT_SECONDS) -> str | None:
+        """Wait for the Platform key or return ``None`` after the bounded timeout.
+
+        Args:
+            timeout: Maximum wait in seconds.
+
+        Returns:
+            The new organization API key, or ``None`` when no callback arrived.
+
+        Raises:
+            ValueError: The timeout is not positive.
+        """
+        if timeout <= 0:
+            raise ValueError("browser login timeout must be positive")
+        try:
+            return self._tokens.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def close(self) -> None:
+        """Stop the callback listener; repeated cleanup is safe."""
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None
+        self._thread = None
 
 
 def hosted_gateway_base_url(environment: Mapping[str, str] | None = None) -> str:
@@ -33,3 +187,81 @@ def hosted_gateway_base_url(environment: Mapping[str, str] | None = None) -> str
     source: Mapping[str, str] = os.environ if environment is None else environment
     value = source.get(HOSTED_GATEWAY_URL_ENV, "").strip()
     return value or HOSTED_GATEWAY_DEFAULT_BASE_URL
+
+
+def hosted_platform_url(environment: Mapping[str, str] | None = None) -> str:
+    """Return the browser-facing Platform origin for Experiential Cloud login.
+
+    Args:
+        environment: Optional process environment. ``None`` reads ``os.environ``.
+
+    Returns:
+        ``EXP_PLATFORM_URL`` when non-empty, otherwise the production Platform origin.
+    """
+    source: Mapping[str, str] = os.environ if environment is None else environment
+    value = source.get(HOSTED_PLATFORM_URL_ENV, "").strip()
+    return value.rstrip("/") or HOSTED_PLATFORM_DEFAULT_URL
+
+
+def hosted_platform_login(
+    connection: ProviderConnection,
+    *,
+    console: Console,
+    environment: Mapping[str, str] | None = None,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+    timeout: float = PLATFORM_LOGIN_TIMEOUT_SECONDS,
+) -> str | None:
+    """Receive an Experiential Cloud key through the Platform browser approval flow.
+
+    The function is a no-op for other provider connections or non-terminal consoles. Returning
+    ``None`` in those cases lets the caller use its normal masked-paste fallback.
+
+    Args:
+        connection: Secret-free connection being prepared.
+        console: Terminal receiving login progress and recovery guidance.
+        environment: Optional process environment used for the Platform origin.
+        open_browser: Browser opener, injectable for deterministic tests.
+        timeout: Maximum time to wait for the browser callback.
+
+    Returns:
+        The new Platform organization key, or ``None`` when browser login is unavailable
+        or times out.
+    """
+    if not _is_experiential_cloud_connection(connection, environment=environment):
+        return None
+    if not console.is_terminal:
+        return None
+    attempt = BrowserLogin(hosted_platform_url(environment))
+    try:
+        attempt.start()
+        url = attempt.authorize_url()
+        console.print("[dim]Opening Platform login for Experiential Cloud...[/dim]")
+        try:
+            opened = open_browser(url)
+        except (OSError, webbrowser.Error):
+            opened = False
+        if not opened:
+            console.print(f"[yellow]Open this URL to connect Experiential Cloud:[/yellow] {url}")
+        console.print("[dim]Approve the connection in your browser to continue.[/dim]")
+        token = attempt.wait(timeout)
+        if token is None:
+            console.print("[yellow]Platform login timed out.[/yellow]")
+            return None
+        console.print("[green]Platform login received.[/green]")
+        return token
+    finally:
+        attempt.close()
+
+
+def _is_experiential_cloud_connection(
+    connection: ProviderConnection,
+    *,
+    environment: Mapping[str, str] | None,
+) -> bool:
+    """Return whether a connection is the first-party hosted Cloud lane."""
+    configured_url = (connection.base_url or "").rstrip("/")
+    return (
+        connection.provider == CATALOG_PROVIDER
+        and connection.api_key_env == HOSTED_GATEWAY_API_KEY_ENV
+        and configured_url == hosted_gateway_base_url(environment).rstrip("/")
+    )

--- a/exp/cli/providers/experiential_cloud_test.py
+++ b/exp/cli/providers/experiential_cloud_test.py
@@ -1,16 +1,58 @@
-"""Hosted Experiential Cloud setup constants and origin resolution."""
+"""Hosted Experiential Cloud setup, origin, and browser-login tests."""
 
 from __future__ import annotations
+
+import io
+from collections.abc import Iterator, Mapping
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.request import urlopen
+
+import pytest
+from rich.console import Console
 
 from exp.cli.providers.experiential_cloud import (
     CATALOG_PROVIDER,
     HOSTED_GATEWAY_API_KEY_ENV,
     HOSTED_GATEWAY_DEFAULT_BASE_URL,
     HOSTED_GATEWAY_URL_ENV,
+    HOSTED_PLATFORM_DEFAULT_URL,
+    HOSTED_PLATFORM_URL_ENV,
     SETUP_PICKER_LABEL,
     SETUP_PICKER_NAME,
+    BrowserLogin,
     hosted_gateway_base_url,
+    hosted_platform_login,
+    hosted_platform_url,
 )
+from exp.common.models import ProviderConnection
+
+
+@pytest.fixture
+def running_login() -> Iterator[BrowserLogin]:
+    """Start one loopback callback listener and close it after the test."""
+    login = BrowserLogin("https://platform.test")
+    login.start()
+    yield login
+    login.close()
+
+
+def _request(url: str, params: Mapping[str, str] | None = None) -> tuple[int, str]:
+    """Make one local callback request and normalize success and error responses.
+
+    Args:
+        url: Loopback URL to request.
+        params: Optional query parameters to encode.
+
+    Returns:
+        HTTP status and decoded response body.
+    """
+    target = f"{url}?{urlencode(params)}" if params else url
+    try:
+        with urlopen(target, timeout=2) as response:
+            return response.status, response.read().decode("utf-8")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
 
 
 def test_picker_persists_the_hosted_openai_compatible_lane() -> None:
@@ -34,3 +76,90 @@ def test_hosted_origin_defaults_to_production_and_honors_override() -> None:
         )
         == "https://api.staging.experientiallabs.ai/v1"
     )
+
+
+def test_platform_origin_defaults_to_production_and_strips_override_slashes() -> None:
+    """Browser login uses the production Platform origin unless explicitly overridden."""
+    assert hosted_platform_url({}) == HOSTED_PLATFORM_DEFAULT_URL
+    assert hosted_platform_url({HOSTED_PLATFORM_URL_ENV: "  "}) == HOSTED_PLATFORM_DEFAULT_URL
+    assert (
+        hosted_platform_url({HOSTED_PLATFORM_URL_ENV: "https://platform.preview.test///"})
+        == "https://platform.preview.test"
+    )
+
+
+def test_browser_login_builds_the_platform_authorization_url(running_login: BrowserLogin) -> None:
+    """Authorization carries the ephemeral port, state, and display name."""
+    parsed = urlparse(running_login.authorize_url(key_name="exp staging"))
+    query = parse_qs(parsed.query)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == ("https://platform.test/cli/auth")
+    assert query["state"] == [running_login.state]
+    assert query["port"] == [str(running_login.port)]
+    assert query["name"] == ["exp staging"]
+
+
+def test_browser_login_accepts_matching_loopback_callback(running_login: BrowserLogin) -> None:
+    """A matching Platform callback returns success and releases its key to the waiter."""
+    status, body = _request(
+        f"http://127.0.0.1:{running_login.port}/callback",
+        {"state": running_login.state, "token": "xpl_test_key"},
+    )
+
+    assert status == 200
+    assert "Experiential Cloud is connected" in body
+    assert running_login.wait(timeout=1) == "xpl_test_key"
+
+
+def test_browser_login_rejects_invalid_callbacks(running_login: BrowserLogin) -> None:
+    """Wrong state, missing key, and wrong paths cannot complete the login attempt."""
+    wrong_state, _ = _request(
+        f"http://127.0.0.1:{running_login.port}/callback",
+        {"state": "wrong", "token": "xpl_wrong_state"},
+    )
+    missing_token, _ = _request(
+        f"http://127.0.0.1:{running_login.port}/callback",
+        {"state": running_login.state},
+    )
+    wrong_path, _ = _request(
+        f"http://127.0.0.1:{running_login.port}/not-callback",
+        {"state": running_login.state, "token": "xpl_wrong_path"},
+    )
+
+    assert (wrong_state, missing_token, wrong_path) == (400, 400, 404)
+    assert running_login.wait(timeout=0.01) is None
+
+
+def test_hosted_platform_login_receives_key_without_printing_it() -> None:
+    """Interactive Cloud login opens approval, receives the key, and keeps it out of output."""
+    transcript = io.StringIO()
+    console = Console(file=transcript, force_terminal=True, no_color=True)
+    connection = ProviderConnection(
+        name="experiential-cloud",
+        provider="openai-compatible",
+        api_key_env=HOSTED_GATEWAY_API_KEY_ENV,
+        base_url=HOSTED_GATEWAY_DEFAULT_BASE_URL,
+    )
+
+    def approve(url: str) -> bool:
+        """Approve the generated URL through its local callback in the test."""
+        params = parse_qs(urlparse(url).query)
+        port = params["port"][0]
+        status, _ = _request(
+            f"http://127.0.0.1:{port}/callback",
+            {"state": params["state"][0], "token": "xpl_browser_key"},
+        )
+        assert status == 200
+        return True
+
+    token = hosted_platform_login(
+        connection,
+        console=console,
+        environment={HOSTED_PLATFORM_URL_ENV: "https://platform.preview.test"},
+        open_browser=approve,
+        timeout=1,
+    )
+
+    assert token == "xpl_browser_key"
+    assert token not in transcript.getvalue()
+    assert "Platform login received." in transcript.getvalue()

--- a/exp/cli/providers/experiential_cloud_test.py
+++ b/exp/cli/providers/experiential_cloud_test.py
@@ -112,7 +112,7 @@ def test_browser_login_accepts_matching_loopback_callback(running_login: Browser
 
 
 def test_browser_login_rejects_invalid_callbacks(running_login: BrowserLogin) -> None:
-    """Wrong state, missing key, and wrong paths cannot complete the login attempt."""
+    """Wrong state, malformed keys, missing keys, and wrong paths cannot complete the login."""
     wrong_state, _ = _request(
         f"http://127.0.0.1:{running_login.port}/callback",
         {"state": "wrong", "token": "xpl_wrong_state"},
@@ -121,12 +121,16 @@ def test_browser_login_rejects_invalid_callbacks(running_login: BrowserLogin) ->
         f"http://127.0.0.1:{running_login.port}/callback",
         {"state": running_login.state},
     )
+    malformed_token, _ = _request(
+        f"http://127.0.0.1:{running_login.port}/callback",
+        {"state": running_login.state, "token": "not-an-experiential-key"},
+    )
     wrong_path, _ = _request(
         f"http://127.0.0.1:{running_login.port}/not-callback",
         {"state": running_login.state, "token": "xpl_wrong_path"},
     )
 
-    assert (wrong_state, missing_token, wrong_path) == (400, 400, 404)
+    assert (wrong_state, missing_token, malformed_token, wrong_path) == (400, 400, 400, 404)
     assert running_login.wait(timeout=0.01) is None
 
 
@@ -163,3 +167,31 @@ def test_hosted_platform_login_receives_key_without_printing_it() -> None:
     assert token == "xpl_browser_key"
     assert token not in transcript.getvalue()
     assert "Platform login received." in transcript.getvalue()
+
+
+def test_hosted_platform_login_falls_back_when_browser_cannot_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A browserless terminal returns to masked paste instead of waiting for a callback."""
+    transcript = io.StringIO()
+    console = Console(file=transcript, force_terminal=True, no_color=True)
+    connection = ProviderConnection(
+        name="experiential-cloud",
+        provider="openai-compatible",
+        api_key_env=HOSTED_GATEWAY_API_KEY_ENV,
+        base_url=HOSTED_GATEWAY_DEFAULT_BASE_URL,
+    )
+
+    def unexpected_wait(*_args: object, **_kwargs: object) -> str | None:
+        """Fail if browser-unavailable setup waits for a callback."""
+        raise AssertionError("browser-unavailable login should not wait for a callback")
+
+    monkeypatch.setattr(BrowserLogin, "wait", unexpected_wait)
+    token = hosted_platform_login(
+        connection,
+        console=console,
+        open_browser=lambda _url: False,
+    )
+
+    assert token is None
+    assert "Open this URL to connect Experiential Cloud:" in transcript.getvalue()

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -25,6 +25,7 @@ from exp.cli.providers.experiential_cloud import (
 from exp.cli.providers.experiential_cloud import (
     HOSTED_GATEWAY_API_KEY_ENV,
     hosted_gateway_base_url,
+    hosted_platform_login,
 )
 from exp.cli.providers.experiential_cloud import (
     SETUP_PICKER_LABEL as HOSTED_SETUP_LABEL,
@@ -65,6 +66,7 @@ from exp.runtime.models.providers import (
 )
 
 SETUP_PROVIDER_LABELS = {
+    HOSTED_SETUP_PICKER: HOSTED_SETUP_LABEL,
     "openai": "openai",
     "anthropic": "anthropic",
     "gemini": "gemini",
@@ -72,7 +74,6 @@ SETUP_PROVIDER_LABELS = {
     "openai-compatible": "openai-compatible",
     "azure": "azure",
     "bedrock": "bedrock",
-    HOSTED_SETUP_PICKER: HOSTED_SETUP_LABEL,
 }
 CANONICAL_CREDENTIAL_ENV = CANONICAL_API_KEY_ENV
 _MANUAL_MODEL_PROVIDERS = frozenset({"azure", "bedrock"})
@@ -566,7 +567,7 @@ def _reused_connection(
             or connection.region != region
         ):
             continue
-        if provider != "openai-compatible" and connection.api_key_env != api_key_env:
+        if api_key_env is not None and connection.api_key_env != api_key_env:
             continue
         matches.append(connection)
     if len(matches) == 1:
@@ -666,6 +667,9 @@ def _resolve_credential(
         Raises:
             SetupCancelled: The prompt reached end of input.
         """
+        platform_key = hosted_platform_login(connection, console=console, environment=environment)
+        if platform_key is not None:
+            return platform_key
         console.print(f"[dim]{label} API key[/dim]")
         try:
             return getpass(f"{label} API key (hidden, empty line skips this provider): ")

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -152,7 +152,7 @@ def _forbid_getpass(prompt: str = "") -> str:
 
 def test_provider_screen_never_names_credential_variables() -> None:
     """The one opening screen shows plain provider names without credential status."""
-    console = ScriptedConsole("1\n\n")
+    console = ScriptedConsole("2\n\n")
 
     selection = select_providers(
         SetupSession(), console=console, environment={"OPENAI_API_KEY": "secret-key"}
@@ -165,7 +165,7 @@ def test_provider_screen_never_names_credential_variables() -> None:
 
 def test_provider_screen_selects_several_providers_in_one_session() -> None:
     """A user selects every provider they want before setup contacts any of them."""
-    console = ScriptedConsole("1,2,4\n\n")
+    console = ScriptedConsole("2,3,5\n\n")
 
     selection = select_providers(
         SetupSession(), console=console, environment={"OPENAI_API_KEY": "secret-key"}
@@ -183,10 +183,11 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
     """Up, Down, and Enter toggle providers; Complete is the only submit action."""
     keys = iter(
         (
+            PickerKey.DOWN,
             PickerKey.ENTER,
             PickerKey.DOWN,
             PickerKey.ENTER,
-            *(PickerKey.DOWN for _ in range(7)),
+            *(PickerKey.DOWN for _ in range(6)),
             PickerKey.ENTER,
         )
     )
@@ -388,6 +389,49 @@ def test_missing_credential_is_pasted_masked_and_persisted(
     assert "kept in this process only" not in console.output
     assert ProviderAuthStore(default_auth_path()).get("openai") == "pasted-secret"
     assert tmp_path.exists()
+
+
+def test_experiential_cloud_uses_platform_login_before_masked_paste(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hosted Cloud connection stores the browser key without invoking getpass."""
+    monkeypatch.setattr(
+        provider_picker,
+        "hosted_platform_login",
+        lambda _connection, **_kwargs: "xpl_browser_key",
+    )
+    monkeypatch.setattr(provider_picker, "getpass", _forbid_getpass)
+    console = ScriptedConsole("")
+    lister = _FakeLister(
+        {
+            "openai-compatible": [
+                (
+                    DiscoveredModel(
+                        provider="openai-compatible",
+                        model="deepseek-v4-flash",
+                        supports_completions=True,
+                        supports_structured_output=True,
+                        input_cost_per_million_tokens_usd=0.072,
+                        output_cost_per_million_tokens_usd=0.162,
+                    ),
+                )
+            ]
+        }
+    )
+
+    prepared = _prepare(
+        console,
+        providers=("experiential-cloud",),
+        lister=lister,
+        environment={},
+    )
+
+    assert prepared is not None
+    endpoints, _ = prepared
+    assert endpoints[0].api_key == "xpl_browser_key"
+    assert endpoints[0].connection.api_key_env == HOSTED_GATEWAY_API_KEY_ENV
+    assert ProviderAuthStore(default_auth_path()).get("experiential-cloud") == ("xpl_browser_key")
+    assert "xpl_browser_key" not in console.output
 
 
 def test_empty_masked_paste_skips_that_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1048,9 +1092,9 @@ def test_release_tty_walk_selects_azure_then_completes() -> None:
     """The installed-wheel provider walk still lands on Azure, then Complete."""
     keys = iter(
         (
-            *(PickerKey.DOWN for _ in range(5)),
+            *(PickerKey.DOWN for _ in range(6)),
             PickerKey.ENTER,
-            *(PickerKey.DOWN for _ in range(3)),
+            *(PickerKey.DOWN for _ in range(2)),
             PickerKey.ENTER,
         )
     )
@@ -1069,7 +1113,7 @@ def test_release_tty_walk_selects_azure_then_completes() -> None:
 
 def test_azure_and_bedrock_force_explicit_manual_model_declaration() -> None:
     """Providers without a safe listing API make the manual model row available explicitly."""
-    console = ScriptedConsole("6,7\n\n")
+    console = ScriptedConsole("7,8\n\n")
 
     selection = select_providers(SetupSession(), console=console, environment={})
 
@@ -1182,14 +1226,14 @@ def test_experiential_cloud_lists_through_the_openai_compatible_family() -> None
 def test_resolve_setup_providers_accepts_experiential_cloud() -> None:
     """The hosted picker is a first-class --provider value."""
     assert resolve_setup_providers(("experiential-cloud", "openai")) == (
-        "openai",
         "experiential-cloud",
+        "openai",
     )
 
 
 def test_provider_screen_lists_experiential_cloud() -> None:
     """Builder setup shows the hosted Platform picker as its own row."""
-    console = ScriptedConsole("8\n\n")
+    console = ScriptedConsole("1\n\n")
 
     selection = select_providers(SetupSession(), console=console, environment={})
 

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -286,8 +286,8 @@ def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_pa
     assert "unsupported --provider value 'not-a-provider'" in output
     assert "duplicate --provider value 'openai'" in output
     assert (
-        "choose from: openai, anthropic, gemini, openrouter, openai-compatible, azure, "
-        "bedrock, experiential-cloud" in output
+        "choose from: experiential-cloud, openai, anthropic, gemini, openrouter, "
+        "openai-compatible, azure, bedrock" in output
     )
     assert "Select the providers you want to use" not in output
     assert not (root / "models.toml").exists()
@@ -604,7 +604,7 @@ def test_wizard_recommended_setup_needs_only_provider_and_one_default_choice(
     root = tmp_path / ".exp"
     console, catalog = _setup(
         root,
-        "1\n\n\n",
+        "2\n\n\n",
         monkeypatch=monkeypatch,
         offer_recommended_defaults=True,
     )
@@ -648,7 +648,7 @@ def test_wizard_recommended_setup_prefers_provider_diversity_for_router_candidat
 
     console, catalog = _setup(
         tmp_path / ".exp",
-        "1,2\n\n\n",
+        "2,3\n\n\n",
         monkeypatch=monkeypatch,
         lister=lister,
         offer_recommended_defaults=True,
@@ -698,7 +698,7 @@ def test_wizard_recommended_setup_falls_back_by_verified_capability_and_cost(
 
     _console, catalog = _setup(
         tmp_path / ".exp",
-        "2,3\n\n\n",
+        "3,4\n\n\n",
         monkeypatch=monkeypatch,
         lister=lister,
         offer_recommended_defaults=True,
@@ -757,7 +757,7 @@ def test_interactive_setup_saves_providers_models_and_roles_it_derived(
     """
     root = tmp_path / ".exp"
 
-    console, catalog = _setup(root, "1\n\n1\n\n1\n\n2\n1,2\n\n\n\n1\ny\n", monkeypatch=monkeypatch)
+    console, catalog = _setup(root, "2\n\n1\n\n1\n\n2\n1,2\n\n\n\n1\ny\n", monkeypatch=monkeypatch)
 
     assert catalog is not None
     saved = load_model_catalog(root / "models.toml")
@@ -799,7 +799,7 @@ def test_interactive_final_rejection_writes_no_catalog(
     """
     root = tmp_path / ".exp"
 
-    console, catalog = _setup(root, "1\n\n1\n\n1\n\n1\n\nn\n", monkeypatch=monkeypatch)
+    console, catalog = _setup(root, "2\n\n1\n\n1\n\n1\n\nn\n", monkeypatch=monkeypatch)
 
     assert catalog is None
     assert "Configuration" in console.output
@@ -818,7 +818,7 @@ def test_interactive_cancellation_writes_no_catalog(
     """
     root = tmp_path / ".exp"
 
-    console, catalog = _setup(root, "1\n\nq\n", monkeypatch=monkeypatch)
+    console, catalog = _setup(root, "2\n\nq\n", monkeypatch=monkeypatch)
 
     assert catalog is None
     assert "Setup cancelled. Nothing was written." in console.output
@@ -848,7 +848,7 @@ def test_back_from_the_model_screen_reselects_providers_without_losing_answers(
 
     console, catalog = _setup(
         root,
-        "1\n\nb\n2\n\n1\n\n1\n\n1\n1,2\n\n\n1\ny\n",
+        "2\n\nb\n3\n\n1\n\n1\n\n1\n1,2\n\n\n1\ny\n",
         monkeypatch=monkeypatch,
         lister=lister,
     )
@@ -891,7 +891,7 @@ def test_rerunning_setup_preserves_unrelated_models_and_router_state(
         ),
     )
 
-    _, catalog = _setup(root, "2\n\n2,4\n\n1\n\n1\n\n1\n\n\ny\n", monkeypatch=monkeypatch)
+    _, catalog = _setup(root, "3\n\n2,4\n\n1\n\n1\n\n1\n\n\ny\n", monkeypatch=monkeypatch)
 
     assert catalog is not None
     saved = load_model_catalog(root / "models.toml")
@@ -930,7 +930,7 @@ def test_setup_preserves_entries_owned_by_providers_it_does_not_configure(
         ),
     )
 
-    console, catalog = _setup(root, "1\n\n1\n\n1\n\n1\n\ny\n", monkeypatch=monkeypatch)
+    console, catalog = _setup(root, "2\n\n1\n\n1\n\n1\n\ny\n", monkeypatch=monkeypatch)
 
     assert catalog is not None
     saved = load_model_catalog(root / "models.toml")
@@ -1243,7 +1243,7 @@ def test_role_flags_preselect_the_roles_the_picker_offers(
 
     _, catalog = _setup(
         root,
-        "1\n\n1,2,3\n\n\n\n\n\n\n\ny\n",
+        "2\n\n1,2,3\n\n\n\n\n\n\n\ny\n",
         monkeypatch=monkeypatch,
         options=options,
     )

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -2463,9 +2463,9 @@ def _installed_release_driver() -> None:
     setup_answers = [
         (
             "Providers",
-            # openai through openai-compatible, then Azure; Complete is after
-            # Bedrock and Experiential Cloud.
-            (down * 5) + enter + (down * 3) + enter,
+            # Experiential Cloud is first, then openai through openai-compatible and Azure;
+            # Complete is after Bedrock.
+            (down * 6) + enter + (down * 2) + enter,
         ),
         ("azure base URL", azure_endpoint),
         ("Azure OpenAI API version", ""),


### PR DESCRIPTION
## Summary

- Make Experiential Cloud the first provider in interactive setup.
- Open the Platform /cli/auth approval flow when no Cloud credential is available.
- Receive and validate the xpl_ key over an ephemeral loopback callback, then persist it through the existing user-local auth store.
- Document interactive, preview, headless, and CI setup paths.

## Validation

- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ty check exp`
- `uv run --extra dev python -m pytest -q exp/cli/providers/experiential_cloud_test.py exp/cli/providers/provider_picker_test.py exp/cli/providers/setup_test.py exp/cli/gateway/setup_test.py exp/cli/optimize/router_candidates_test.py::test_router_candidate_picker_discovers_only_eligible_completion_models` (99 passed)
- Installed-wheel smoke test passed.

The live Platform flow is exercised with a local callback fixture; no real credential was minted during tests.