### PR TITLE
Hosted compositions compose without the local group-commit writer

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -30,6 +30,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
+from typing import cast
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.boundary import boundary_protocol_error
@@ -58,7 +59,8 @@ from exp.runtime.gateway.execution import (
     _require_deployment_identity,  # noqa: PLC2701
 )
 from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
-from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
     continued_request,
@@ -66,6 +68,7 @@ from exp.runtime.gateway.native_responses import (
     responses_envelope,
 )
 from exp.runtime.gateway.native_settlement import (
+    budget_quota_protocol_error,
     deployment_operation_key,
     first_token_at_from_settlement,
     optional_text,
@@ -168,15 +171,6 @@ def _escalation(reason: str) -> str:
     return json.dumps({"escalate": reason}, separators=(",", ":"))
 
 
-def _budget_quota_error() -> NativeBridgeError:
-    """Return the public quota error for an exhausted monthly allocation."""
-    failure = GatewayFailure(
-        failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
-        safe_message="monthly gateway allocation is exhausted",
-    )
-    return NativeBridgeError(public_failure_error(failure))
-
-
 class NativeControlPlane:
     """Authority and accounting callbacks for the native data plane.
 
@@ -222,7 +216,12 @@ class NativeControlPlane:
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
         self._components = components
-        self._write_ledger = SyncGroupCommitLedger(components.write_ledger)
+        # Hosted compositions have no local group-commit writer; they settle
+        # directly through their own synchronous ledger.
+        group_writer = getattr(components, "write_ledger", None)
+        self._write_ledger: SyncWriteLedger = (
+            SyncGroupCommitLedger(group_writer) if group_writer is not None else components.ledger
+        )
         self._request_timeout_seconds = request_timeout_seconds
         self._data_plane_metrics = data_plane_metrics
         self._continuations = (
@@ -392,7 +391,7 @@ class NativeControlPlane:
             )
         except BudgetReservationRejected as exc:
             error = (
-                _budget_quota_error()
+                NativeBridgeError(budget_quota_protocol_error())
                 if self._budget_error_factory is None
                 else self._budget_error_factory(data["raw_key"])
             )
@@ -704,8 +703,10 @@ class NativeControlPlane:
                 _, identity_id = self._components.store.authenticated_identity(raw_key=str(raw_key))
             except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
                 raise _authority_error(exc) from exc
+        # Only the local composition (SQLite ledger) serves native usage;
+        # hosted compositions disable it and own their own usage surface.
         return read_usage_report(
-            self._components.ledger,
+            cast("SQLiteAttemptLedger", self._components.ledger),
             organization_id=self._components.organization_id,
             identity_id=identity_id,
         )

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -8,6 +8,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -30,6 +31,7 @@ from exp.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from exp.runtime.gateway.discovery import listing_metadata_by_alias
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.lifecycle import _ReadyControlStore, load_gateway_components
 from exp.runtime.gateway.lifecycle_test import _configured_gateway
 from exp.runtime.gateway.management import GatewayManagement
@@ -37,6 +39,7 @@ from exp.runtime.gateway.native_bridge import (
     NativeBridgeError,
     NativeControlPlane,
 )
+from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
 from exp.runtime.openai_protocol.requests import decode_chat, decode_responses
@@ -192,7 +195,7 @@ def test_local_admit_persists_route_context_in_the_attempt(tmp_path: Path) -> No
 
     admission = _admit(control, raw_key, _chat_body())
 
-    ledger = control._components.ledger  # noqa: SLF001
+    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
     with sqlite3.connect(ledger.database_path) as connection:
         row = connection.execute(
             "select route_reason, fallback_reason from gateway_attempts where attempt_id = ?",
@@ -291,7 +294,9 @@ def test_closed_writer_makes_settle_raise_and_keeps_the_entry_retryable(
     boundary error and retains the exact settlement for later replay."""
     control, raw_key = _control_plane(tmp_path)
     admission = _admit(control, raw_key, _chat_body())
-    control._components.write_ledger.close()  # noqa: SLF001 - shutdown-ordering fault injection.
+    writer = control._components.write_ledger  # noqa: SLF001 - shutdown-ordering fault injection.
+    assert writer is not None
+    writer.close()
     settlement = json.dumps(
         {
             "request_id": admission["request_id"],
@@ -1658,7 +1663,7 @@ def test_admit_persists_caller_app_identity_for_attribution(tmp_path: Path) -> N
         )
     )
 
-    ledger = control._components.ledger  # noqa: SLF001
+    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
     with sqlite3.connect(ledger.database_path) as connection:
         row = connection.execute(
             """
@@ -1670,3 +1675,64 @@ def test_admit_persists_caller_app_identity_for_attribution(tmp_path: Path) -> N
             (admission["attempt_id"],),
         ).fetchone()
     assert row == ("https://app.example.com", "Example App")
+
+
+class _HostedComponents:
+    """Hosted-shaped components: no group-commit writer, sync ledger only.
+
+    Mirrors a platform composition over its own store (for example Postgres),
+    which cannot provide the local engine's SQLite batching writer. Both the
+    protocol-conformant ``write_ledger = None`` and a components object with
+    no such attribute at all must compose, because the hosted seam promises
+    settlement through the plain synchronous ledger.
+    """
+
+    def __init__(self, inner: object, *, omit_write_ledger: bool) -> None:
+        self._inner = inner
+        if not omit_write_ledger:
+            self.write_ledger = None
+
+    def __getattr__(self, name: str) -> object:
+        if name == "write_ledger":
+            raise AttributeError(name)
+        return getattr(self._inner, name)
+
+
+@pytest.mark.parametrize("omit_write_ledger", [False, True])
+def test_hosted_components_without_group_commit_writer_settle(
+    tmp_path: Path,
+    omit_write_ledger: bool,
+) -> None:
+    """A composition without the local batching writer settles via its ledger.
+
+    Regression: the control plane once accessed ``components.write_ledger``
+    unconditionally, so a hosted composition (platform #620) crashed with
+    AttributeError before binding anything.
+    """
+    _manager, raw_key = _configured_gateway(tmp_path)
+    inner = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    hosted = _HostedComponents(inner, omit_write_ledger=omit_write_ledger)
+    control = NativeControlPlane(
+        cast("NativeGatewayComponents", hosted),
+        request_timeout_seconds=120.0,
+    )
+    admission = _admit(control, raw_key, _chat_body())
+    settled = control.settle(
+        json.dumps(
+            {
+                "request_id": admission["request_id"],
+                "attempt_id": admission["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 4, "output_tokens": 2},
+                "tool_names": [],
+                "failure": None,
+            }
+        )
+    )
+    assert settled == "{}"
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 1
+    assert report["totals"]["terminal_counts"] == [{"state": "completed", "attempts": 1}]

--- a/exp/runtime/gateway/native_components.py
+++ b/exp/runtime/gateway/native_components.py
@@ -3,14 +3,72 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Protocol
 
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AttemptId,
+    AuthorizationSnapshot,
+    ExecutionSnapshot,
+    GatewayEvent,
+    GatewayFailure,
+)
 from exp.runtime.gateway.execution import GatewayExecutor
 from exp.runtime.gateway.group_commit import GroupCommitAttemptLedger
 from exp.runtime.gateway.interfaces import GatewayControlStore
-from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.routing import CatalogRouteResolver
 from exp.runtime.models import RuntimeModelCatalog
+
+
+class SyncWriteLedger(Protocol):
+    """Synchronous durable write surface the native data plane settles through.
+
+    Methods are called from data-plane worker threads with no event loop and
+    must return only after their write is durable. The local engine satisfies
+    this with the group-commit facade; a hosted store satisfies it with its
+    own thread-safe synchronous ledger (for example one SQL call per method
+    on a pooled connection).
+    """
+
+    def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
+        """Durably accept one authorized request."""
+        ...
+
+    def start_attempt(
+        self,
+        *,
+        snapshot: ExecutionSnapshot,
+        deployment: ExactModelDeployment,
+        attempt_ordinal: int,
+        route_depth: int,
+        maximum_cost_micro_usd: int | None = None,
+        route_reason: str | None = None,
+        fallback_reason: str | None = None,
+    ) -> AttemptId:
+        """Durably mark one provider dispatch before network work."""
+        ...
+
+    def finish_attempt(
+        self,
+        *,
+        attempt_id: AttemptId,
+        terminal_event: GatewayEvent | None,
+        failure: GatewayFailure | None,
+        finalize_request: bool = True,
+        first_token_at: datetime | None = None,
+    ) -> None:
+        """Durably settle one attempt exactly once."""
+        ...
+
+    def finish_request(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        failure: GatewayFailure,
+    ) -> None:
+        """Durably finalize one request that produced no billable attempt."""
+        ...
 
 
 class NativeGatewayComponents(Protocol):
@@ -22,13 +80,24 @@ class NativeGatewayComponents(Protocol):
         ...
 
     @property
-    def ledger(self) -> SQLiteAttemptLedger:
-        """Return the raw ledger used for content-free reporting reads."""
+    def ledger(self) -> SyncWriteLedger:
+        """Return the synchronous durable ledger.
+
+        The control plane reads content-free reports through this object and,
+        when :attr:`write_ledger` is ``None``, also settles through it, so a
+        hosted implementation must be thread-safe for data-plane callers.
+        """
         ...
 
     @property
-    def write_ledger(self) -> GroupCommitAttemptLedger:
-        """Return the shared durable group-commit writer."""
+    def write_ledger(self) -> GroupCommitAttemptLedger | None:
+        """Return the local engine's shared group-commit writer, if any.
+
+        The local composition provides the batching writer so both engines
+        share fsync batches. Hosted compositions over their own stores return
+        ``None`` (or omit the attribute); the control plane then settles
+        directly through :attr:`ledger`.
+        """
         ...
 
     @property

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -13,6 +13,7 @@ from exp.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
 
 _TERMINAL_KINDS = {
     "completed": GatewayEventKind.COMPLETED,
@@ -128,3 +129,12 @@ def deployment_operation_key(route: GatewayRoute) -> str:
 def optional_text(value: object) -> str | None:
     """Return one optional boundary string value or ``None``."""
     return value if isinstance(value, str) else None
+
+
+def budget_quota_protocol_error() -> OpenAIProtocolError:
+    """Return the public quota error for an exhausted monthly allocation."""
+    failure = GatewayFailure(
+        failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+        safe_message="monthly gateway allocation is exhausted",
+    )
+    return public_failure_error(failure)


### PR DESCRIPTION
Platform #620 (merged) composes the native control plane over Postgres-backed components with no `write_ledger`; at the pinned revision `NativeControlPlane.__init__` unconditionally runs `SyncGroupCommitLedger(components.write_ledger)`, so the hosted worker crashes at startup:

```
AttributeError: 'HostedNativeGatewayComponents' object has no attribute 'write_ledger'
```

(reproduced against platform main's exact pin before writing this fix.)

Root cause: the hosted seam leaked local-engine implementation details — the components protocol demanded the SQLite group-commit batching writer, which a Postgres host cannot honestly provide.

- `write_ledger` is now `GroupCommitAttemptLedger | None`; hosted stores return `None` or omit the attribute (`getattr` fallback keeps platform's current dataclass working with just a pin bump)
- `ledger` is retyped as a structural `SyncWriteLedger` protocol: the synchronous, thread-safe durable surface data-plane threads settle through; the local composition still batches through the group-commit facade unchanged
- Regression tests construct the control plane over hosted-shaped components (attribute absent, and `None`) and settle a request end to end through the raw path

After this merges, platform only needs to bump its experiential pin — no platform code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)