### PR TITLE
Release 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.5.1"
+version = "0.5.2"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Release 0.5.2

Bump the flagship package version and lockfile from 0.5.1 to 0.5.2 for the current remote main head.

The native gateway remains at 0.1.1, with its dependency floor unchanged.