### PR TITLE
Show measured gateway latency on the README badge

### DIFF
--- a/.github/workflows/gateway-latency.yml
+++ b/.github/workflows/gateway-latency.yml
@@ -32,11 +32,60 @@ jobs:
         run: >-
           uv run python -m exp.runtime.gateway.latency_report
           --output-json gateway-latency.json
+          --output-badge gateway-overhead.json
           --github-summary "$GITHUB_STEP_SUMMARY"
       - name: Upload the versioned latency report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: gateway-latency-report
-          path: gateway-latency.json
+          path: |
+            gateway-latency.json
+            gateway-overhead.json
           if-no-files-found: warn
+
+  publish-badge:
+    # Update the public Shields endpoint only after a successful routine
+    # ubuntu-latest run on main. Do not publish PR measurements or the
+    # 32-core workflow_dispatch runner. Pushing the orphan badges branch
+    # does not trigger gate, latency, or package workflows, and GITHUB_TOKEN
+    # pushes do not start new workflow runs.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: latency
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gateway-overhead-badge
+      cancel-in-progress: false
+    steps:
+      - name: Download the latency report artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: gateway-latency-report
+          path: report
+      - name: Publish the Shields endpoint on the badges branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test -f report/gateway-overhead.json
+          test -f report/gateway-latency.json
+          git init badges-work
+          cd badges-work
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads origin badges >/dev/null; then
+            git fetch origin badges
+            git checkout -B badges origin/badges
+          else
+            git checkout --orphan badges
+          fi
+          cp ../report/gateway-overhead.json gateway-overhead.json
+          git add gateway-overhead.json
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Update gateway overhead badge [skip ci]"
+          git push origin HEAD:badges

--- a/.github/workflows/gateway-latency.yml
+++ b/.github/workflows/gateway-latency.yml
@@ -1,6 +1,6 @@
 name: gateway latency
 
-# Mock-isolated gateway overhead report. No paid providers and no secrets.
+# Mock-isolated gateway latency report. No paid providers and no secrets.
 on:
   push:
     branches: [main]
@@ -25,14 +25,14 @@ jobs:
           workspaces: exp/runtime/gateway/native
       - name: Install the project and its dev extras
         run: uv sync --extra dev
-      - name: Measure Experiential gateway overhead against a local mock
+      - name: Measure Experiential gateway latency against a local mock
         env:
           EXP_TELEMETRY: "0"
           DO_NOT_TRACK: "1"
         run: >-
           uv run python -m exp.runtime.gateway.latency_report
           --output-json gateway-latency.json
-          --output-badge gateway-overhead.json
+          --output-badge shields/gateway-latency.json
           --github-summary "$GITHUB_STEP_SUMMARY"
       - name: Upload the versioned latency report
         if: always()
@@ -41,7 +41,7 @@ jobs:
           name: gateway-latency-report
           path: |
             gateway-latency.json
-            gateway-overhead.json
+            shields/gateway-latency.json
           if-no-files-found: warn
 
   publish-badge:
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: write
     concurrency:
-      group: gateway-overhead-badge
+      group: gateway-latency-badge
       cancel-in-progress: false
     steps:
       - name: Download the latency report artifact
@@ -69,8 +69,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test -f report/gateway-overhead.json
           test -f report/gateway-latency.json
+          test -f report/shields/gateway-latency.json
           git init badges-work
           cd badges-work
           git config user.name "github-actions[bot]"
@@ -82,10 +82,10 @@ jobs:
           else
             git checkout --orphan badges
           fi
-          cp ../report/gateway-overhead.json gateway-overhead.json
-          git add gateway-overhead.json
+          cp ../report/shields/gateway-latency.json gateway-latency.json
+          git add gateway-latency.json
           if git diff --cached --quiet; then
             exit 0
           fi
-          git commit -m "Update gateway overhead badge [skip ci]"
+          git commit -m "Update gateway latency badge [skip ci]"
           git push origin HEAD:badges

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Experiential
 
+[![Gateway latency](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml/badge.svg?branch=main)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
+
 Experiential is an open source gateway and router for agent workflows:
 
 1. Use hosted, BYOK, and local models through one OpenAI-compatible API.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Experiential
 
-[![Gateway latency](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml/badge.svg?branch=main)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
+[![gateway overhead](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-overhead.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
 
 Experiential is an open source gateway and router for agent workflows:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Experiential
 
-[![gateway overhead](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-overhead.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
+[![gateway latency](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-latency.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
 
 Experiential is an open source gateway and router for agent workflows:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ results, and plans do not live here.
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata plus identity-only operator declaration. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
-| `reference/gateway-latency.md` | Routine CI gateway-overhead report against a local mock: schedule, artifact schema, and status badge. |
+| `reference/gateway-latency.md` | Routine CI gateway-overhead report against a local mock: schedule, artifact schema, and numeric overhead badge. |
 | `reference/openai-compatible-recipes.md` | Verified Fireworks, Modal, and Experiential Cloud connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ results, and plans do not live here.
 | `usage.md` | Locked CLI map for build, bounded optimize model, optimize router, run, and config. |
 | `reference/providers.md` | Catalog providers, first-build `--provider` flags, environment variables, Azure endpoint and deployment rules, the Bedrock credential chain, and OpenAI-compatible listing metadata plus identity-only operator declaration. |
 | `reference/gateway-architecture.md` | Operational local gateway contracts, certified exact-model routing, ownership boundaries, and compatibility locks. |
-| `reference/gateway-latency.md` | Routine CI gateway-overhead report against a local mock: schedule, artifact schema, and numeric overhead badge. |
+| `reference/gateway-latency.md` | Routine CI gateway-latency report against a local mock: schedule, artifact schema, and numeric latency badge. |
 | `reference/openai-compatible-recipes.md` | Verified Fireworks, Modal, and Experiential Cloud connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |

--- a/docs/reference/gateway-latency.md
+++ b/docs/reference/gateway-latency.md
@@ -38,14 +38,16 @@ Local report:
 ```bash
 uv sync --extra dev
 uv run python -m exp.runtime.gateway.latency_report \
-  --output-json gateway-latency.json
+  --output-json gateway-latency.json \
+  --output-badge gateway-overhead.json
 ```
 
 Focused tests:
 
 ```bash
 uv run pytest -q exp/runtime/gateway/latency_report_test.py \
-  exp/runtime/gateway/latency_measure_test.py
+  exp/runtime/gateway/latency_measure_test.py \
+  exp/runtime/gateway/latency_badge_test.py
 ```
 
 The workflow `.github/workflows/gateway-latency.yml` runs on every push to
@@ -57,16 +59,37 @@ There is no hard latency threshold.
 ## Artifact
 
 The job uploads `gateway-latency.json` with schema
-`exp.gateway.latency_report` version 1 and writes a Markdown table to the
-GitHub Actions job summary. The JSON records the commit SHA, runner OS, CPU
-count and model, Python version, resolved Experiential engine, every repeat,
-and the median run by gateway non-stream p50.
+`exp.gateway.latency_report` version 1, plus the derived Shields endpoint
+`gateway-overhead.json`. It also writes a Markdown table to the GitHub Actions
+job summary. The report records the commit SHA, runner OS, CPU count and model,
+Python version, resolved Experiential engine, every repeat, and the median run
+by gateway non-stream p50.
 
-## Status badge
+## Numeric overhead badge
 
-A workflow-status badge is the zero-secret signal. It does not embed a
-latency number. The root README includes this badge:
+The root README shows the latest **representative p50 gateway-added
+non-stream latency** from a successful routine run on `main`. The badge is a
+Shields endpoint, not a GitHub Actions pass/fail status image. The label is
+`gateway overhead` and the message is the measured value, for example
+`14.6 ms`.
+
+After each successful `push` to `main`, the workflow copies
+`gateway-overhead.json` to the `badges` branch. Pull requests and
+`workflow_dispatch` (including the 32-core runner) measure and upload the
+artifact but do not publish the badge. That branch is not `main`, so the
+update does not require a protected-branch push and does not start gate,
+latency, or package workflows.
+
+Stable endpoint:
+
+`https://raw.githubusercontent.com/experientiallabs/experiential/badges/gateway-overhead.json`
+
+README image:
 
 ```markdown
-[![Gateway latency](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml/badge.svg?branch=main)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
+[![gateway overhead](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-overhead.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
 ```
+
+The `badges` branch is created by the first successful main run after this
+workflow lands. Until that run finishes, the Shields image may render as
+invalid. Later successful main runs overwrite the same public file.

--- a/docs/reference/gateway-latency.md
+++ b/docs/reference/gateway-latency.md
@@ -65,7 +65,7 @@ and the median run by gateway non-stream p50.
 ## Status badge
 
 A workflow-status badge is the zero-secret signal. It does not embed a
-latency number. Proposed README insertion (requires explicit README approval):
+latency number. The root README includes this badge:
 
 ```markdown
 [![Gateway latency](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml/badge.svg?branch=main)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)

--- a/docs/reference/gateway-latency.md
+++ b/docs/reference/gateway-latency.md
@@ -17,8 +17,8 @@ The runner starts a loopback mock, then measures the same
 2. the Experiential native gateway
 
 The gateway aliases the public model name `latency` to the same mock, so the
-request body is identical. Reported overhead is the client-observed difference
-(gateway minus mock) for p50, p95, and p99.
+request body is identical. The report records gateway p50, p95, and p99, and
+also the client-observed difference versus the mock for those percentiles.
 
 The schedule is:
 
@@ -39,7 +39,7 @@ Local report:
 uv sync --extra dev
 uv run python -m exp.runtime.gateway.latency_report \
   --output-json gateway-latency.json \
-  --output-badge gateway-overhead.json
+  --output-badge shields/gateway-latency.json
 ```
 
 Focused tests:
@@ -60,21 +60,21 @@ There is no hard latency threshold.
 
 The job uploads `gateway-latency.json` with schema
 `exp.gateway.latency_report` version 1, plus the derived Shields endpoint
-`gateway-overhead.json`. It also writes a Markdown table to the GitHub Actions
-job summary. The report records the commit SHA, runner OS, CPU count and model,
-Python version, resolved Experiential engine, every repeat, and the median run
-by gateway non-stream p50.
+`shields/gateway-latency.json`. It also writes a Markdown table to the GitHub
+Actions job summary. The report records the commit SHA, runner OS, CPU count
+and model, Python version, resolved Experiential engine, every repeat, and the
+median run by gateway non-stream p50.
 
-## Numeric overhead badge
+## Numeric latency badge
 
-The root README shows the latest **representative p50 gateway-added
-non-stream latency** from a successful routine run on `main`. The badge is a
-Shields endpoint, not a GitHub Actions pass/fail status image. The label is
-`gateway overhead` and the message is the measured value, for example
-`14.6 ms`.
+The root README shows the latest **representative gateway p50 request
+latency** (`representative_run.gateway.p50_ms`) from a successful routine run
+on `main`. The badge is a Shields endpoint, not a GitHub Actions pass/fail
+status image. The label is `gateway latency` and the message is the measured
+value, for example `22.2 ms`.
 
-After each successful `push` to `main`, the workflow copies
-`gateway-overhead.json` to the `badges` branch. Pull requests and
+After each successful `push` to `main`, the workflow publishes
+`gateway-latency.json` on the `badges` branch. Pull requests and
 `workflow_dispatch` (including the 32-core runner) measure and upload the
 artifact but do not publish the badge. That branch is not `main`, so the
 update does not require a protected-branch push and does not start gate,
@@ -82,12 +82,12 @@ latency, or package workflows.
 
 Stable endpoint:
 
-`https://raw.githubusercontent.com/experientiallabs/experiential/badges/gateway-overhead.json`
+`https://raw.githubusercontent.com/experientiallabs/experiential/badges/gateway-latency.json`
 
 README image:
 
 ```markdown
-[![gateway overhead](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-overhead.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
+[![gateway latency](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-latency.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
 ```
 
 The `badges` branch is created by the first successful main run after this

--- a/exp/runtime/gateway/latency_badge.py
+++ b/exp/runtime/gateway/latency_badge.py
@@ -1,0 +1,98 @@
+"""Shields.io endpoint payload for the README gateway-overhead badge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exp.common.core.artifacts import JsonObject
+
+BADGE_BRANCH = "badges"
+BADGE_FILENAME = "gateway-overhead.json"
+SHIELDS_LABEL = "gateway overhead"
+SHIELDS_COLOR = "0070f3"
+SHIELDS_CACHE_SECONDS = 300
+RAW_ENDPOINT_URL = (
+    "https://raw.githubusercontent.com/experientiallabs/experiential/"
+    f"{BADGE_BRANCH}/{BADGE_FILENAME}"
+)
+SHIELDS_IMAGE_URL = (
+    "https://img.shields.io/endpoint?url="
+    "https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2F"
+    f"{BADGE_BRANCH}%2F{BADGE_FILENAME}"
+)
+
+
+def format_overhead_ms(p50_ms: float) -> str:
+    """Format representative p50 gateway-added latency for the badge message.
+
+    Args:
+        p50_ms: Client-observed gateway minus mock-direct p50, in milliseconds.
+
+    Returns:
+        One-decimal millisecond message such as ``14.6 ms``.
+    """
+    return f"{p50_ms:.1f} ms"
+
+
+def shields_endpoint(*, p50_ms: float) -> JsonObject:
+    """Build a Shields endpoint document from one measured overhead value.
+
+    Args:
+        p50_ms: Representative non-stream gateway-added p50, in milliseconds.
+
+    Returns:
+        Shields schemaVersion 1 object. ``message`` is the formatted latency.
+    """
+    return {
+        "schemaVersion": 1,
+        "label": SHIELDS_LABEL,
+        "message": format_overhead_ms(p50_ms),
+        "color": SHIELDS_COLOR,
+        "cacheSeconds": SHIELDS_CACHE_SECONDS,
+    }
+
+
+def write_shields_endpoint(*, p50_ms: float, path: Path) -> JsonObject:
+    """Write the Shields endpoint JSON for ``p50_ms`` and return the payload.
+
+    Args:
+        p50_ms: Representative non-stream gateway-added p50, in milliseconds.
+        path: Destination file. Parent directories are created when missing.
+
+    Returns:
+        The JSON object written to ``path``.
+    """
+    payload = shields_endpoint(p50_ms=p50_ms)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def overhead_p50_ms_from_report_json(path: Path) -> float:
+    """Read representative non-stream gateway-added p50 from a report file.
+
+    Args:
+        path: Versioned ``exp.gateway.latency_report`` JSON artifact.
+
+    Returns:
+        ``representative_run.gateway_added.p50_ms``.
+
+    Raises:
+        ValueError: The file is not a report object with a numeric p50.
+        OSError: The file cannot be read.
+        json.JSONDecodeError: The file is not JSON.
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("latency report must be a JSON object")
+    run = raw.get("representative_run")
+    if not isinstance(run, dict):
+        raise ValueError("latency report is missing representative_run")
+    added = run.get("gateway_added")
+    if not isinstance(added, dict):
+        raise ValueError("latency report is missing representative_run.gateway_added")
+    p50 = added.get("p50_ms")
+    if isinstance(p50, bool) or not isinstance(p50, int | float):
+        raise ValueError("latency report representative_run.gateway_added.p50_ms must be a number")
+    return float(p50)

--- a/exp/runtime/gateway/latency_badge.py
+++ b/exp/runtime/gateway/latency_badge.py
@@ -1,4 +1,4 @@
-"""Shields.io endpoint payload for the README gateway-overhead badge."""
+"""Shields.io endpoint payload for the README gateway-latency badge."""
 
 from __future__ import annotations
 
@@ -8,8 +8,8 @@ from pathlib import Path
 from exp.common.core.artifacts import JsonObject
 
 BADGE_BRANCH = "badges"
-BADGE_FILENAME = "gateway-overhead.json"
-SHIELDS_LABEL = "gateway overhead"
+BADGE_FILENAME = "gateway-latency.json"
+SHIELDS_LABEL = "gateway latency"
 SHIELDS_COLOR = "0070f3"
 SHIELDS_CACHE_SECONDS = 300
 RAW_ENDPOINT_URL = (
@@ -23,23 +23,23 @@ SHIELDS_IMAGE_URL = (
 )
 
 
-def format_overhead_ms(p50_ms: float) -> str:
-    """Format representative p50 gateway-added latency for the badge message.
+def format_latency_ms(p50_ms: float) -> str:
+    """Format representative gateway p50 request latency for the badge message.
 
     Args:
-        p50_ms: Client-observed gateway minus mock-direct p50, in milliseconds.
+        p50_ms: Client-observed gateway p50, in milliseconds.
 
     Returns:
-        One-decimal millisecond message such as ``14.6 ms``.
+        One-decimal millisecond message such as ``22.2 ms``.
     """
     return f"{p50_ms:.1f} ms"
 
 
 def shields_endpoint(*, p50_ms: float) -> JsonObject:
-    """Build a Shields endpoint document from one measured overhead value.
+    """Build a Shields endpoint document from one measured gateway p50.
 
     Args:
-        p50_ms: Representative non-stream gateway-added p50, in milliseconds.
+        p50_ms: Representative non-stream gateway p50, in milliseconds.
 
     Returns:
         Shields schemaVersion 1 object. ``message`` is the formatted latency.
@@ -47,7 +47,7 @@ def shields_endpoint(*, p50_ms: float) -> JsonObject:
     return {
         "schemaVersion": 1,
         "label": SHIELDS_LABEL,
-        "message": format_overhead_ms(p50_ms),
+        "message": format_latency_ms(p50_ms),
         "color": SHIELDS_COLOR,
         "cacheSeconds": SHIELDS_CACHE_SECONDS,
     }
@@ -57,7 +57,7 @@ def write_shields_endpoint(*, p50_ms: float, path: Path) -> JsonObject:
     """Write the Shields endpoint JSON for ``p50_ms`` and return the payload.
 
     Args:
-        p50_ms: Representative non-stream gateway-added p50, in milliseconds.
+        p50_ms: Representative non-stream gateway p50, in milliseconds.
         path: Destination file. Parent directories are created when missing.
 
     Returns:
@@ -69,14 +69,14 @@ def write_shields_endpoint(*, p50_ms: float, path: Path) -> JsonObject:
     return payload
 
 
-def overhead_p50_ms_from_report_json(path: Path) -> float:
-    """Read representative non-stream gateway-added p50 from a report file.
+def gateway_p50_ms_from_report_json(path: Path) -> float:
+    """Read representative non-stream gateway p50 from a report file.
 
     Args:
         path: Versioned ``exp.gateway.latency_report`` JSON artifact.
 
     Returns:
-        ``representative_run.gateway_added.p50_ms``.
+        ``representative_run.gateway.p50_ms``.
 
     Raises:
         ValueError: The file is not a report object with a numeric p50.
@@ -89,10 +89,10 @@ def overhead_p50_ms_from_report_json(path: Path) -> float:
     run = raw.get("representative_run")
     if not isinstance(run, dict):
         raise ValueError("latency report is missing representative_run")
-    added = run.get("gateway_added")
-    if not isinstance(added, dict):
-        raise ValueError("latency report is missing representative_run.gateway_added")
-    p50 = added.get("p50_ms")
+    gateway = run.get("gateway")
+    if not isinstance(gateway, dict):
+        raise ValueError("latency report is missing representative_run.gateway")
+    p50 = gateway.get("p50_ms")
     if isinstance(p50, bool) or not isinstance(p50, int | float):
-        raise ValueError("latency report representative_run.gateway_added.p50_ms must be a number")
+        raise ValueError("latency report representative_run.gateway.p50_ms must be a number")
     return float(p50)

--- a/exp/runtime/gateway/latency_badge_test.py
+++ b/exp/runtime/gateway/latency_badge_test.py
@@ -1,0 +1,100 @@
+"""Tests for the Shields gateway-overhead badge payload."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from exp.runtime.gateway.latency_badge import (
+    BADGE_FILENAME,
+    RAW_ENDPOINT_URL,
+    SHIELDS_COLOR,
+    SHIELDS_IMAGE_URL,
+    SHIELDS_LABEL,
+    format_overhead_ms,
+    overhead_p50_ms_from_report_json,
+    shields_endpoint,
+    write_shields_endpoint,
+)
+
+
+def test_format_overhead_ms_uses_one_decimal() -> None:
+    """The badge message rounds the representative p50 to one decimal place."""
+    assert format_overhead_ms(14.58) == "14.6 ms"
+    assert format_overhead_ms(3.0) == "3.0 ms"
+    assert format_overhead_ms(-1.24) == "-1.2 ms"
+
+
+def test_shields_endpoint_is_schema_version_one() -> None:
+    """The payload is a Shields endpoint with a numeric millisecond message."""
+    payload = shields_endpoint(p50_ms=14.58)
+    assert payload == {
+        "schemaVersion": 1,
+        "label": SHIELDS_LABEL,
+        "message": "14.6 ms",
+        "color": SHIELDS_COLOR,
+        "cacheSeconds": 300,
+    }
+    assert SHIELDS_LABEL == "gateway overhead"
+    message = payload["message"]
+    assert isinstance(message, str)
+    assert message.endswith(" ms")
+    assert "badge.svg" not in SHIELDS_IMAGE_URL
+    assert BADGE_FILENAME in RAW_ENDPOINT_URL
+    assert "img.shields.io/endpoint" in SHIELDS_IMAGE_URL
+
+
+def test_write_shields_endpoint_round_trips(tmp_path: Path) -> None:
+    """The written file is pretty-printed Shields JSON sourced from p50_ms."""
+    path = tmp_path / "nested" / BADGE_FILENAME
+    written = write_shields_endpoint(p50_ms=22.204, path=path)
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded == written
+    assert loaded["message"] == "22.2 ms"
+
+
+def test_overhead_p50_ms_from_report_json_reads_representative_run(tmp_path: Path) -> None:
+    """Badge generation reads p50 from the versioned report, not a constant."""
+    report = tmp_path / "gateway-latency.json"
+    report.write_text(
+        json.dumps(
+            {
+                "representative_run": {"gateway_added": {"p50_ms": 8.44}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert overhead_p50_ms_from_report_json(report) == pytest.approx(8.44)
+    payload = write_shields_endpoint(
+        p50_ms=overhead_p50_ms_from_report_json(report),
+        path=tmp_path / BADGE_FILENAME,
+    )
+    assert payload["message"] == "8.4 ms"
+
+
+def test_overhead_p50_ms_from_report_json_rejects_missing_fields(tmp_path: Path) -> None:
+    """A report without a numeric representative p50 fails closed."""
+    report = tmp_path / "bad.json"
+    report.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        overhead_p50_ms_from_report_json(report)
+    report.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="representative_run"):
+        overhead_p50_ms_from_report_json(report)
+    report.write_text(
+        json.dumps({"representative_run": {"gateway_added": {"p50_ms": "fast"}}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must be a number"):
+        overhead_p50_ms_from_report_json(report)
+
+
+def test_readme_uses_shields_endpoint_not_actions_status() -> None:
+    """The root README renders the numeric Shields badge, not a workflow status."""
+    readme = Path(__file__).resolve().parents[3] / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    assert SHIELDS_IMAGE_URL in text
+    assert RAW_ENDPOINT_URL.split("https://")[1] in text or "endpoint?url=" in text
+    assert "actions/workflows/gateway-latency.yml/badge.svg" not in text

--- a/exp/runtime/gateway/latency_badge_test.py
+++ b/exp/runtime/gateway/latency_badge_test.py
@@ -1,4 +1,4 @@
-"""Tests for the Shields gateway-overhead badge payload."""
+"""Tests for the Shields gateway-latency badge payload."""
 
 from __future__ import annotations
 
@@ -13,37 +13,41 @@ from exp.runtime.gateway.latency_badge import (
     SHIELDS_COLOR,
     SHIELDS_IMAGE_URL,
     SHIELDS_LABEL,
-    format_overhead_ms,
-    overhead_p50_ms_from_report_json,
+    format_latency_ms,
+    gateway_p50_ms_from_report_json,
     shields_endpoint,
     write_shields_endpoint,
 )
 
 
-def test_format_overhead_ms_uses_one_decimal() -> None:
-    """The badge message rounds the representative p50 to one decimal place."""
-    assert format_overhead_ms(14.58) == "14.6 ms"
-    assert format_overhead_ms(3.0) == "3.0 ms"
-    assert format_overhead_ms(-1.24) == "-1.2 ms"
+def test_format_latency_ms_uses_one_decimal() -> None:
+    """The badge message rounds the representative gateway p50 to one decimal."""
+    assert format_latency_ms(22.204) == "22.2 ms"
+    assert format_latency_ms(3.0) == "3.0 ms"
+    assert format_latency_ms(14.58) == "14.6 ms"
 
 
 def test_shields_endpoint_is_schema_version_one() -> None:
     """The payload is a Shields endpoint with a numeric millisecond message."""
-    payload = shields_endpoint(p50_ms=14.58)
+    payload = shields_endpoint(p50_ms=22.204)
     assert payload == {
         "schemaVersion": 1,
         "label": SHIELDS_LABEL,
-        "message": "14.6 ms",
+        "message": "22.2 ms",
         "color": SHIELDS_COLOR,
         "cacheSeconds": 300,
     }
-    assert SHIELDS_LABEL == "gateway overhead"
+    assert SHIELDS_LABEL == "gateway latency"
     message = payload["message"]
     assert isinstance(message, str)
     assert message.endswith(" ms")
     assert "badge.svg" not in SHIELDS_IMAGE_URL
+    assert BADGE_FILENAME == "gateway-latency.json"
     assert BADGE_FILENAME in RAW_ENDPOINT_URL
     assert "img.shields.io/endpoint" in SHIELDS_IMAGE_URL
+    assert "overhead" not in SHIELDS_LABEL
+    assert "overhead" not in RAW_ENDPOINT_URL
+    assert "overhead" not in SHIELDS_IMAGE_URL
 
 
 def test_write_shields_endpoint_round_trips(tmp_path: Path) -> None:
@@ -53,48 +57,61 @@ def test_write_shields_endpoint_round_trips(tmp_path: Path) -> None:
     loaded = json.loads(path.read_text(encoding="utf-8"))
     assert loaded == written
     assert loaded["message"] == "22.2 ms"
+    assert loaded["label"] == "gateway latency"
 
 
-def test_overhead_p50_ms_from_report_json_reads_representative_run(tmp_path: Path) -> None:
-    """Badge generation reads p50 from the versioned report, not a constant."""
-    report = tmp_path / "gateway-latency.json"
+def test_gateway_p50_ms_from_report_json_reads_representative_gateway(tmp_path: Path) -> None:
+    """Badge generation reads gateway p50 from the report, not a constant."""
+    report = tmp_path / "report.json"
     report.write_text(
         json.dumps(
             {
-                "representative_run": {"gateway_added": {"p50_ms": 8.44}},
+                "representative_run": {
+                    "gateway": {"p50_ms": 22.204},
+                    "gateway_added": {"p50_ms": 14.58},
+                },
             }
         ),
         encoding="utf-8",
     )
-    assert overhead_p50_ms_from_report_json(report) == pytest.approx(8.44)
+    assert gateway_p50_ms_from_report_json(report) == pytest.approx(22.204)
     payload = write_shields_endpoint(
-        p50_ms=overhead_p50_ms_from_report_json(report),
+        p50_ms=gateway_p50_ms_from_report_json(report),
         path=tmp_path / BADGE_FILENAME,
     )
-    assert payload["message"] == "8.4 ms"
+    assert payload["message"] == "22.2 ms"
+    assert payload["message"] != "14.6 ms"
 
 
-def test_overhead_p50_ms_from_report_json_rejects_missing_fields(tmp_path: Path) -> None:
-    """A report without a numeric representative p50 fails closed."""
+def test_gateway_p50_ms_from_report_json_rejects_missing_fields(tmp_path: Path) -> None:
+    """A report without a numeric representative gateway p50 fails closed."""
     report = tmp_path / "bad.json"
     report.write_text("[]", encoding="utf-8")
     with pytest.raises(ValueError, match="JSON object"):
-        overhead_p50_ms_from_report_json(report)
+        gateway_p50_ms_from_report_json(report)
     report.write_text("{}", encoding="utf-8")
     with pytest.raises(ValueError, match="representative_run"):
-        overhead_p50_ms_from_report_json(report)
+        gateway_p50_ms_from_report_json(report)
     report.write_text(
-        json.dumps({"representative_run": {"gateway_added": {"p50_ms": "fast"}}}),
+        json.dumps({"representative_run": {"gateway_added": {"p50_ms": 14.58}}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="representative_run.gateway"):
+        gateway_p50_ms_from_report_json(report)
+    report.write_text(
+        json.dumps({"representative_run": {"gateway": {"p50_ms": "fast"}}}),
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="must be a number"):
-        overhead_p50_ms_from_report_json(report)
+        gateway_p50_ms_from_report_json(report)
 
 
 def test_readme_uses_shields_endpoint_not_actions_status() -> None:
     """The root README renders the numeric Shields badge, not a workflow status."""
     readme = Path(__file__).resolve().parents[3] / "README.md"
     text = readme.read_text(encoding="utf-8")
-    assert SHIELDS_IMAGE_URL in text
-    assert RAW_ENDPOINT_URL.split("https://")[1] in text or "endpoint?url=" in text
+    first_lines = "\n".join(text.splitlines()[:6])
+    assert SHIELDS_IMAGE_URL in first_lines
+    assert "gateway latency" in first_lines
+    assert "overhead" not in first_lines
     assert "actions/workflows/gateway-latency.yml/badge.svg" not in text

--- a/exp/runtime/gateway/latency_report.py
+++ b/exp/runtime/gateway/latency_report.py
@@ -25,6 +25,7 @@ from pydantic import Field
 from rich.console import Console
 
 from exp.common.core.artifacts import ContractModel, JsonObject
+from exp.runtime.gateway.latency_badge import write_shields_endpoint
 from exp.runtime.gateway.latency_measure import (
     ALIAS_ID,
     CHAT_PATH,
@@ -572,14 +573,16 @@ def write_report_outputs(
     report: LatencyReport,
     *,
     output_json: Path | None,
+    output_badge: Path | None,
     github_summary: Path | None,
     console: Console,
 ) -> None:
-    """Write the JSON artifact, optional job summary, and console Markdown.
+    """Write the JSON artifact, optional badge endpoint, and console Markdown.
 
     Args:
         report: Completed report.
         output_json: Optional destination for the versioned JSON artifact.
+        output_badge: Optional Shields endpoint JSON for the README badge.
         github_summary: Optional GitHub Actions step-summary path.
         console: User-facing console for the Markdown table.
     """
@@ -589,6 +592,11 @@ def write_report_outputs(
         output_json.write_text(
             report.model_dump_json(indent=2) + "\n",
             encoding="utf-8",
+        )
+    if output_badge is not None:
+        write_shields_endpoint(
+            p50_ms=report.representative_run.gateway_added.p50_ms,
+            path=output_badge,
         )
     if github_summary is not None:
         github_summary.write_text(markdown, encoding="utf-8")
@@ -608,6 +616,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output-json",
         type=Path,
         help="Write the versioned JSON report to this path.",
+    )
+    parser.add_argument(
+        "--output-badge",
+        type=Path,
+        help="Write the Shields endpoint JSON for the README overhead badge.",
     )
     parser.add_argument(
         "--github-summary",
@@ -663,15 +676,20 @@ def main(argv: list[str] | None = None) -> int:
         if env_summary:
             summary = Path(env_summary)
     if args.work_root is not None:
-        return _run_and_write(args.work_root, config, args.output_json, summary, console)
+        return _run_and_write(
+            args.work_root, config, args.output_json, args.output_badge, summary, console
+        )
     with tempfile.TemporaryDirectory(prefix="exp-gateway-latency-") as tmp_dir:
-        return _run_and_write(Path(tmp_dir), config, args.output_json, summary, console)
+        return _run_and_write(
+            Path(tmp_dir), config, args.output_json, args.output_badge, summary, console
+        )
 
 
 def _run_and_write(
     work_root: Path,
     config: LatencyRunConfig,
     output_json: Path | None,
+    output_badge: Path | None,
     github_summary: Path | None,
     console: Console,
 ) -> int:
@@ -681,6 +699,7 @@ def _run_and_write(
         work_root: EXP root for the temporary gateway.
         config: Fixed request schedule.
         output_json: Optional JSON artifact path.
+        output_badge: Optional Shields endpoint JSON path.
         github_summary: Optional GitHub Actions summary path.
         console: User-facing console.
 
@@ -695,6 +714,7 @@ def _run_and_write(
     write_report_outputs(
         report,
         output_json=output_json,
+        output_badge=output_badge,
         github_summary=github_summary,
         console=console,
     )

--- a/exp/runtime/gateway/latency_report.py
+++ b/exp/runtime/gateway/latency_report.py
@@ -582,7 +582,7 @@ def write_report_outputs(
     Args:
         report: Completed report.
         output_json: Optional destination for the versioned JSON artifact.
-        output_badge: Optional Shields endpoint JSON for the README badge.
+        output_badge: Optional Shields endpoint JSON for the README latency badge.
         github_summary: Optional GitHub Actions step-summary path.
         console: User-facing console for the Markdown table.
     """
@@ -595,7 +595,7 @@ def write_report_outputs(
         )
     if output_badge is not None:
         write_shields_endpoint(
-            p50_ms=report.representative_run.gateway_added.p50_ms,
+            p50_ms=report.representative_run.gateway.p50_ms,
             path=output_badge,
         )
     if github_summary is not None:
@@ -620,7 +620,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--output-badge",
         type=Path,
-        help="Write the Shields endpoint JSON for the README overhead badge.",
+        help="Write the Shields endpoint JSON for the README latency badge.",
     )
     parser.add_argument(
         "--github-summary",

--- a/exp/runtime/gateway/latency_report_test.py
+++ b/exp/runtime/gateway/latency_report_test.py
@@ -202,7 +202,7 @@ def test_render_markdown_states_mock_and_gateway() -> None:
 
 
 def test_write_report_outputs_writes_badge_from_representative_p50(tmp_path: Path) -> None:
-    """The Shields file uses representative gateway-added p50, not a constant."""
+    """The Shields file uses representative gateway p50, not a constant."""
     mock = _stats(p50_ms=2.0, p95_ms=3.0, p99_ms=4.0, requests=40)
     gateway = _stats(p50_ms=16.58, p95_ms=20.0, p99_ms=24.0, requests=40)
     report = LatencyReport(
@@ -223,8 +223,8 @@ def test_write_report_outputs_writes_badge_from_representative_p50(tmp_path: Pat
         ),
         runs=(_run(1, gateway_p50=16.58, mock_p50=2.0),),
     )
-    report_path = tmp_path / "gateway-latency.json"
-    badge_path = tmp_path / "gateway-overhead.json"
+    report_path = tmp_path / "gateway-latency-report.json"
+    badge_path = tmp_path / "gateway-latency.json"
     write_report_outputs(
         report,
         output_json=report_path,
@@ -233,8 +233,9 @@ def test_write_report_outputs_writes_badge_from_representative_p50(tmp_path: Pat
         console=Console(width=200),
     )
     badge = json.loads(badge_path.read_text(encoding="utf-8"))
-    assert badge["label"] == "gateway overhead"
-    assert badge["message"] == "14.6 ms"
+    assert badge["label"] == "gateway latency"
+    assert badge["message"] == "16.6 ms"
+    assert "overhead" not in badge["label"]
     assert json.loads(report_path.read_text(encoding="utf-8"))["schema_name"] == SCHEMA_NAME
 
 

--- a/exp/runtime/gateway/latency_report_test.py
+++ b/exp/runtime/gateway/latency_report_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from rich.console import Console
 
 from exp.runtime.gateway.latency_measure import (
     MockOpenAIServer,
@@ -34,6 +35,7 @@ from exp.runtime.gateway.latency_report import (
     run_latency_report,
     select_representative_run,
     summarize_samples,
+    write_report_outputs,
 )
 
 
@@ -199,6 +201,43 @@ def test_render_markdown_states_mock_and_gateway() -> None:
     assert parsed.schema_version == 1
 
 
+def test_write_report_outputs_writes_badge_from_representative_p50(tmp_path: Path) -> None:
+    """The Shields file uses representative gateway-added p50, not a constant."""
+    mock = _stats(p50_ms=2.0, p95_ms=3.0, p99_ms=4.0, requests=40)
+    gateway = _stats(p50_ms=16.58, p95_ms=20.0, p99_ms=24.0, requests=40)
+    report = LatencyReport(
+        measured_at=datetime(2026, 8, 22, 18, 0, tzinfo=UTC),
+        config=default_config(),
+        runner=RunnerContext(
+            commit_sha="abc123def456",
+            python_version="3.12.11",
+            platform_name="Linux",
+            runner_name="GitHub Actions ubuntu-latest",
+            gateway_engine="rust",
+        ),
+        representative_run=LatencyMeasuredRun(
+            run_index=1,
+            mock_direct=mock,
+            gateway=gateway,
+            gateway_added=gateway_added(gateway, mock),
+        ),
+        runs=(_run(1, gateway_p50=16.58, mock_p50=2.0),),
+    )
+    report_path = tmp_path / "gateway-latency.json"
+    badge_path = tmp_path / "gateway-overhead.json"
+    write_report_outputs(
+        report,
+        output_json=report_path,
+        output_badge=badge_path,
+        github_summary=None,
+        console=Console(width=200),
+    )
+    badge = json.loads(badge_path.read_text(encoding="utf-8"))
+    assert badge["label"] == "gateway overhead"
+    assert badge["message"] == "14.6 ms"
+    assert json.loads(report_path.read_text(encoding="utf-8"))["schema_name"] == SCHEMA_NAME
+
+
 def test_mock_server_answers_json_and_first_token() -> None:
     """The loopback mock serves non-streaming JSON and an immediate first token."""
     server = MockOpenAIServer()
@@ -247,6 +286,7 @@ def test_parse_args_keeps_ci_defaults() -> None:
     assert args.repeats == config.repeats
     assert args.stream_requests == config.stream_measured_requests
     assert args.no_stream_ttft is False
+    assert args.output_badge is None
 
 
 def test_run_latency_report_against_local_mock(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The README badge shows the latest **representative gateway p50 request latency** from the Experiential-only mock benchmark on `main`. The value comes from `representative_run.gateway.p50_ms` in the generated report, not from a difference versus the mock and not from a workflow pass/fail image.

The badge label is `gateway latency`. The message is formatted like `22.2 ms`.

## How it updates

1. The latency job writes the full report as `gateway-latency.json` and the Shields endpoint as `shields/gateway-latency.json`. Both stay in the uploaded artifact.
2. After a **successful** `push` to `main` on ubuntu-latest, `publish-badge` publishes `gateway-latency.json` to the `badges` branch.
3. Pull requests and `workflow_dispatch` (including the 32-core runner) still measure and keep the artifact. They do not publish the badge.
4. Publishing does not push to protected `main`. The `badges` branch does not trigger gate, latency, or package workflows. `GITHUB_TOKEN` pushes also do not start new workflow runs.

## Seeded public endpoint

The `badges` branch is live now, seeded from the latest successful main artifact (run [32608210921](https://github.com/experientiallabs/experiential/actions/runs/32608210921)). That report's `representative_run.gateway.p50_ms` is `28.365618999998787`, which the PR formatter publishes as `28.4 ms`. `main` was not modified.

Verified:

- `https://raw.githubusercontent.com/experientiallabs/experiential/badges/gateway-latency.json` returns Shields schemaVersion 1 with `"message": "28.4 ms"`
- `https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-latency.json` returns an SVG labeled `gateway latency: 28.4 ms`

README image:

```markdown
[![gateway latency](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fexperientiallabs%2Fexperiential%2Fbadges%2Fgateway-latency.json)](https://github.com/experientiallabs/experiential/actions/workflows/gateway-latency.yml?query=branch%3Amain)
```

## Verification

- `uv run pytest -q exp/runtime/gateway/latency_badge_test.py exp/runtime/gateway/latency_report_test.py exp/runtime/gateway/latency_measure_test.py`
- `uv run ruff check . && uv run ruff format --check . && uv run ty check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ec22bb-1009-4cd4-beed-8974719c4935?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ec22bb-1009-4cd4-beed-8974719c4935&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

