### PR TITLE
Accept OpenCode Chat Completions cache_control and drop it before routing

### DIFF
--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -38,6 +38,7 @@ from exp.runtime.openai_protocol.manifest import (
 
 _CHAT_OFFICIAL = TypeAdapter(CompletionCreateParams)
 _RESPONSES_OFFICIAL = TypeAdapter(ResponseCreateParams)
+_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 
 
 class DecodedGatewayRequest(ContractModel):
@@ -51,6 +52,13 @@ class _WireModel(BaseModel):
     """Strict private OpenAI wire model used only after official shape validation."""
 
     model_config = ConfigDict(extra="forbid")
+
+
+class _EphemeralCacheControl(_WireModel):
+    """OpenCode/Anthropic cache breakpoint accepted only so it can be dropped."""
+
+    type: Literal["ephemeral"]
+    ttl: Literal["5m", "1h"] | None = None
 
 
 class _TextPart(_WireModel):
@@ -268,6 +276,11 @@ def decode_chat(
 ) -> DecodedGatewayRequest:
     """Decode one Chat Completions body without silently dropping fields.
 
+    OpenCode may attach an Anthropic-style ``cache_control`` annotation on
+    Chat messages and on text content parts. Supported ephemeral forms are
+    validated and removed before official OpenAI validation and before
+    canonical conversion. Other unknown nested fields stay rejected.
+
     Args:
         payload: Parsed JSON request body.
         idempotency_key: Optional standard caller operation identity.
@@ -279,6 +292,7 @@ def decode_chat(
     Raises:
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
     """
+    payload = _drop_opencode_cache_control(payload)
     _validate_manifest(payload, CHAT_MANIFEST)
     _validate_official(_CHAT_OFFICIAL, payload)
     request = _validate_wire(_ChatRequest, payload)
@@ -361,6 +375,123 @@ def decode_responses(
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
     return DecodedGatewayRequest(alias=request.model, request=canonical)
+
+
+def _drop_opencode_cache_control(payload: JsonObject) -> JsonObject:
+    """Remove supported OpenCode ``cache_control`` annotations from Chat messages.
+
+    Args:
+        payload: Parsed Chat Completions body.
+
+    Returns:
+        The original payload, or a shallow copy whose messages no longer carry
+        a supported ``cache_control`` annotation.
+
+    Raises:
+        OpenAIProtocolError: A ``cache_control`` value is malformed or unsupported.
+    """
+    raw_messages = payload.get("messages")
+    if not isinstance(raw_messages, list):
+        return payload
+    cleaned_messages: list[JsonValue] = []
+    changed = False
+    for index, raw_message in enumerate(raw_messages):
+        message, message_changed = _without_message_cache_control(raw_message, index)
+        cleaned_messages.append(message)
+        changed = changed or message_changed
+    if not changed:
+        return payload
+    cleaned_payload = dict(payload)
+    cleaned_payload["messages"] = cleaned_messages
+    return cleaned_payload
+
+
+def _without_message_cache_control(raw_message: JsonValue, index: int) -> tuple[JsonValue, bool]:
+    """Drop a supported ``cache_control`` annotation from one Chat message.
+
+    Args:
+        raw_message: One ``messages`` entry.
+        index: Zero-based message index used in public error paths.
+
+    Returns:
+        The message (copied when an annotation is removed) and whether it changed.
+
+    Raises:
+        OpenAIProtocolError: The annotation is present but not a supported form.
+    """
+    if not isinstance(raw_message, dict):
+        return raw_message, False
+    message = cast(JsonObject, raw_message)
+    changed = False
+    if "cache_control" in message:
+        _require_supported_cache_control(
+            message["cache_control"], f"messages.{index}.cache_control"
+        )
+        message = {key: value for key, value in message.items() if key != "cache_control"}
+        changed = True
+    content = message.get("content")
+    if isinstance(content, list):
+        cleaned_content, content_changed = _without_text_part_cache_control(
+            cast(list[JsonValue], content), index
+        )
+        if content_changed:
+            if not changed:
+                message = dict(message)
+            message["content"] = cleaned_content
+            changed = True
+    return message, changed
+
+
+def _without_text_part_cache_control(
+    parts: list[JsonValue], message_index: int
+) -> tuple[list[JsonValue], bool]:
+    """Drop supported ``cache_control`` from OpenCode text content parts.
+
+    Args:
+        parts: Message ``content`` array.
+        message_index: Zero-based parent message index used in public error paths.
+
+    Returns:
+        The content array (copied when an annotation is removed) and whether it changed.
+
+    Raises:
+        OpenAIProtocolError: A text-part annotation is present but not a supported form.
+    """
+    cleaned: list[JsonValue] = []
+    changed = False
+    for part_index, raw_part in enumerate(parts):
+        if not isinstance(raw_part, dict) or "cache_control" not in raw_part:
+            cleaned.append(raw_part)
+            continue
+        part = cast(JsonObject, raw_part)
+        if part.get("type") not in _TEXT_PART_TYPES:
+            cleaned.append(raw_part)
+            continue
+        _require_supported_cache_control(
+            part["cache_control"],
+            f"messages.{message_index}.content.{part_index}.cache_control",
+        )
+        cleaned.append({key: value for key, value in part.items() if key != "cache_control"})
+        changed = True
+    return (cleaned, True) if changed else (parts, False)
+
+
+def _require_supported_cache_control(value: JsonValue, param: str) -> None:
+    """Accept null or a supported ephemeral ``cache_control`` object.
+
+    Args:
+        value: Raw ``cache_control`` annotation.
+        param: Public dotted field path used in the error.
+
+    Raises:
+        OpenAIProtocolError: The annotation is malformed or unsupported.
+    """
+    if value is None:
+        return
+    try:
+        _EphemeralCacheControl.model_validate(value)
+    except ValidationError as exc:
+        raise invalid_field(param) from exc
 
 
 def _validate_manifest(payload: JsonObject, manifest: CompatibilityManifest) -> None:

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -14,6 +14,7 @@ from pydantic import (
     JsonValue,
     TypeAdapter,
     ValidationError,
+    field_validator,
     model_validator,
 )
 
@@ -55,10 +56,22 @@ class _WireModel(BaseModel):
 
 
 class _EphemeralCacheControl(_WireModel):
-    """OpenCode/Anthropic cache breakpoint accepted only so it can be dropped."""
+    """OpenCode/Anthropic cache breakpoint accepted only so it can be dropped.
+
+    The object form is ``{"type": "ephemeral"}`` with an optional ``ttl`` of
+    ``5m`` or ``1h``. An explicit ``ttl: null`` is not in that allowlist.
+    """
 
     type: Literal["ephemeral"]
     ttl: Literal["5m", "1h"] | None = None
+
+    @field_validator("ttl", mode="before")
+    @classmethod
+    def _reject_null_ttl(cls, value: object) -> object:
+        """Reject an explicit null TTL while still allowing the key to be omitted."""
+        if value is None:
+            raise ValueError("ttl must be 5m or 1h when present")
+        return value
 
 
 class _TextPart(_WireModel):

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -10,6 +10,7 @@ from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayNamedToolChoice
 from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+from exp.runtime.openai_protocol.model_adapter import model_request
 from exp.runtime.openai_protocol.requests import (
     DecodedGatewayRequest,
     decode_chat,
@@ -300,6 +301,186 @@ def test_invalid_tool_arguments_and_conflicting_operation_headers_are_specific()
         )
     assert operation.value.detail.code == "idempotency_conflict"
     assert operation.value.detail.param == "Idempotency-Key"
+
+
+def _assert_no_cache_control(decoded: DecodedGatewayRequest) -> None:
+    """Require cache_control to be absent from canonical and provider-bound messages."""
+    for message in decoded.request.messages:
+        assert "cache_control" not in message.model_dump(mode="json")
+    adapted = model_request(decoded.request)
+    for message in adapted.messages:
+        assert "cache_control" not in message.model_dump(mode="json")
+
+
+def test_chat_decoder_drops_opencode_message_cache_control() -> None:
+    """OpenCode Chat Completions annotate messages with Anthropic cache_control.
+
+    The live failure is Invalid value for 'messages.0.cache_control' because the
+    closed Chat wire model forbids that nested field before routing. Supported
+    ephemeral forms must decode and never reach the canonical or provider-bound
+    message.
+    """
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are concise.",
+                    "cache_control": {"type": "ephemeral"},
+                },
+                {
+                    "role": "user",
+                    "content": "hello",
+                    "cache_control": {"type": "ephemeral", "ttl": "5m"},
+                },
+                {
+                    "role": "assistant",
+                    "content": "hi",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                },
+                {"role": "user", "content": "again", "cache_control": None},
+            ],
+            "top_p": 1,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    )
+
+    assert tuple(message.content for message in decoded.request.messages) == (
+        "You are concise.",
+        "hello",
+        "hi",
+        "again",
+    )
+    assert decoded.request.top_p == 1.0
+    assert decoded.request.stream
+    assert decoded.request.include_usage
+    _assert_no_cache_control(decoded)
+
+
+def test_chat_decoder_drops_opencode_text_part_cache_control() -> None:
+    """OpenCode openai-compatible conversion can put cache_control on text parts.
+
+    applyCaching marks the last content part, and @ai-sdk/openai-compatible
+    keeps that annotation on the text block when the user message has more
+    than one part.
+    """
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "prefix "},
+                        {
+                            "type": "text",
+                            "text": "cached suffix",
+                            "cache_control": {"type": "ephemeral"},
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert decoded.request.messages[0].content == "prefix cached suffix"
+    _assert_no_cache_control(decoded)
+
+
+@pytest.mark.parametrize(
+    "cache_control",
+    (
+        {"type": "persistent"},
+        {"type": "ephemeral", "ttl": "2h"},
+        {"type": "ephemeral", "extra": True},
+        "ephemeral",
+        1,
+        [],
+    ),
+)
+def test_chat_decoder_rejects_malformed_message_cache_control(cache_control: object) -> None:
+    """Unsupported cache_control shapes fail at messages.<index>.cache_control."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hello", "cache_control": cache_control}],
+            }
+        )
+    assert captured.value.detail.code == "invalid_parameter"
+    assert captured.value.detail.param == "messages.0.cache_control"
+    assert captured.value.detail.message == "Invalid value for 'messages.0.cache_control'."
+
+
+def test_chat_decoder_rejects_malformed_text_part_cache_control() -> None:
+    """Unsupported text-part cache_control stays a field-specific invalid value."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "hello",
+                                "cache_control": {"type": "persistent"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    assert captured.value.detail.code == "invalid_parameter"
+    assert captured.value.detail.param == "messages.0.content.0.cache_control"
+
+
+def test_chat_decoder_still_rejects_unknown_nested_message_fields() -> None:
+    """Dropping cache_control must not weaken unrelated unknown nested fields."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "hello",
+                        "cache_control": {"type": "ephemeral"},
+                        "providerOptions": {},
+                    }
+                ],
+            }
+        )
+    param = captured.value.detail.param
+    assert param == "messages.0.providerOptions"
+
+
+def test_chat_decoder_still_rejects_unknown_text_part_fields_with_cache_control() -> None:
+    """A valid text-part cache_control drop still rejects other extra part keys."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "hello",
+                                "cache_control": {"type": "ephemeral"},
+                                "future": 1,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    param = captured.value.detail.param
+    assert param is not None and param.startswith("messages.0.content")
 
 
 def test_chat_decoder_accepts_opencode_nucleus_and_usage_stream_shape() -> None:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -394,6 +394,7 @@ def test_chat_decoder_drops_opencode_text_part_cache_control() -> None:
     (
         {"type": "persistent"},
         {"type": "ephemeral", "ttl": "2h"},
+        {"type": "ephemeral", "ttl": None},
         {"type": "ephemeral", "extra": True},
         "ephemeral",
         1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom

Live OpenCode calls to the OpenAI-compatible `POST /v1/chat/completions` path fail before routing:

```
Invalid value for 'messages.0.cache_control'.
```

## Root cause

OpenCode (`@ai-sdk/openai-compatible` plus `applyCaching`) attaches an Anthropic-style `cache_control` annotation to Chat Completions messages. Typical wire shape:

```json
{
  "model": "coding",
  "messages": [
    {
      "role": "system",
      "content": "You are concise.",
      "cache_control": {"type": "ephemeral"}
    },
    {"role": "user", "content": "hello", "cache_control": {"type": "ephemeral"}}
  ],
  "top_p": 1,
  "stream": true,
  "stream_options": {"include_usage": true}
}
```

`decode_chat()` validates that body against the closed Chat wire model (`extra="forbid"`). `cache_control` is not an official Chat message field, so decode fails at `messages.0.cache_control` and the gateway never routes.

Platform PR #692 only fixed the separate Anthropic `POST /v1/messages` adapter. That path is not involved here.

## Compatibility behavior

Chat Completions now accepts and intentionally drops OpenCode's annotation **before** official OpenAI validation and **before** canonical `GatewayMessage` conversion.

Supported forms, matching OpenCode/Anthropic ephemeral cache breakpoints:

- `{"type": "ephemeral"}`
- `{"type": "ephemeral", "ttl": "5m"}`
- `{"type": "ephemeral", "ttl": "1h"}`
- `null` for the whole `cache_control` field

`{"type": "ephemeral", "ttl": null}` is rejected. Malformed or unsupported shapes fail with the existing field-specific error at `messages.<index>.cache_control` (or `messages.<index>.content.<part>.cache_control` on text parts). Unrelated unknown nested fields stay rejected.

OpenCode evidence also puts the same annotation on text content parts when a user message has more than one part (`applyCaching` marks the last part; `@ai-sdk/openai-compatible` keeps it on the text block). That form is accepted and dropped too, with an explicit test. No other nested annotations were added.

The public Responses surface is unchanged.

## Verification

- `exp/runtime/openai_protocol/requests_test.py`: OpenCode-shaped payload decodes; canonical and provider-bound messages contain no `cache_control`; ttl/null forms accepted; explicit `ttl: null` and other malformed shapes fail at the exact field path; unknown nested message and text-part fields still fail
- Focused protocol suite: 25 passed in `requests_test.py`; 75 passed across `openai_protocol`
- `ruff check .`, `ruff format --check .`, and `ty check` passed over the whole project
- GitHub CI: all required checks green

## Greptile

First review scored 4/5 because nullable `ttl` accepted `{"type":"ephemeral","ttl":null}`. That form is now rejected. Re-review is **5/5** with no remaining comments.

Do not merge from this agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13b68e5-1cbb-4db7-a9b2-cbc86d93204f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13b68e5-1cbb-4db7-a9b2-cbc86d93204f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

