### PR TITLE
docs: point README docs link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Experiential is an open source gateway and router for agent workflows:
 
 <p align="center">
   🌐 <a href="https://platform.experientiallabs.ai">Platform</a> |
-  📚 <a href="https://github.com/experientiallabs/experiential/tree/main/docs">Docs</a> |
+  📚 <a href="https://platform.experientiallabs.ai/docs">Docs</a> |
   <a href="https://discord.gg/B6sM8xTVwU"><img src="https://cdn.simpleicons.org/discord/5865F2" alt="" width="16" height="16"> Discord</a>
 </p>
 


### PR DESCRIPTION
## Summary

- Point the README Docs link to the hosted website documentation.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache-experiential-docs uv run ruff check .`
- `UV_CACHE_DIR=/private/tmp/uv-cache-experiential-docs uv run ruff format --check .`
- `UV_CACHE_DIR=/private/tmp/uv-cache-experiential-docs uv run ty check`
- Hosted docs URL returns HTTP 200.
- Full pytest: 2,310 passed, 2 skipped, 13 failures in existing terminal-rendering assertions and release-evidence cleanliness checks from the pre-commit dirty checkout.