### PR TITLE
feat(cli): sync Experiential models during login

### DIFF
--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -126,9 +126,13 @@ authority for this path. Run `exp login` in an interactive terminal to open Plat
 store the returned key after the loopback callback completes.
 
 ```bash
-exp login
-exp config providers --provider experiential-cloud --root ROOT
+exp login --root ROOT
 ```
+
+Login registers the `experiential-cloud` connection and synchronizes every model identity returned
+by the hosted `/v1/models` endpoint for the authenticated account. Local gateway setup can select
+those models immediately. Use `exp config providers --provider experiential-cloud --root ROOT`
+later only when assigning build roles or explicitly refreshing the catalog.
 
 For headless or CI setup, export `EXPLABS_API_KEY` before running the same command. Preview or
 staging may replace the browser origin with `EXP_PLATFORM_URL` and the API origin with

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -18,13 +18,16 @@ callback, and stores that key in the user-data credential file. `experiential-cl
 picker for the same gateway. It persists
 `provider = "openai-compatible"` with `base_url` `https://api.experientiallabs.ai/v1` (or
 `EXP_GATEWAY_URL` when that override is set) and `api_key_env = "EXPLABS_API_KEY"`. The CLI does
-not rebuild a local gateway authority for that hosted path. Local `exp run` first-run setup keeps
-the offline provider list and does not offer Experiential Cloud.
+not rebuild a local gateway authority for that hosted path. Login also registers the
+`experiential-cloud` connection in the selected `.exp/models.toml` and synchronizes every model
+identity returned for the authenticated account. Local gateway setup can then select that
+provider without a second provider-configuration command.
 
-After `exp login`, run `exp config providers --provider experiential-cloud` to discover and select
-hosted models. When that setup flow has no environment or stored key, it can also open the same
-Platform approval flow as a convenience. Set `EXP_PLATFORM_URL` for a preview or staging Platform
-web origin. Headless and CI setup should provide `EXPLABS_API_KEY` instead.
+`exp config providers --provider experiential-cloud` remains available when roles need to be
+assigned, or when an explicit refresh or replacement workflow is preferred. When that setup flow
+has no environment or stored key, it can also open the same Platform approval flow as a
+convenience. Set `EXP_PLATFORM_URL` for a preview or staging Platform web origin. Headless and CI
+setup should provide `EXPLABS_API_KEY` instead.
 
 Setup writes only secret-free catalog fields and never prints a credential value. Interactive
 `exp config providers` persists browser-approved or pasted API keys outside the repository in the platform

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -8,8 +8,10 @@ on the exact release checkout.
 
 - Root CLI commands are exactly `build`, `config`, `login`, `optimize`, and `run`; an invocation with no subcommand
   opens the default gateway home screen. Optimizer commands are exactly `router` and `model`.
-- `exp login` opens the Platform approval flow for Experiential Cloud and stores the returned
-  organization key in the user-data credential file; no credential value is written to the project.
+- `exp login` opens the Platform approval flow for Experiential Cloud, stores the returned
+  organization key in the user-data credential file, and synchronizes the authenticated account's
+  hosted provider/model identities into the secret-free project catalog; no credential value is
+  written to the project.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
   singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
   provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ The root surface is deliberately small:
 | Command | Purpose | Local result |
 |---|---|---|
 | `exp` | Open the branded home screen. `Default Gateway` is the recommended setup-and-start path. | Interactive gateway menu, or the default gateway in a non-interactive terminal. |
-| `exp login` | Sign in to Experiential Cloud through the Platform browser approval flow and save the returned organization key. | User-local credential record outside the repository. |
+| `exp login [--root ROOT]` | Sign in to Experiential Cloud through the Platform browser approval flow, save the returned organization key, and synchronize the authenticated account's model identities. | User-local credential plus secret-free hosted provider/model records in `.exp/models.toml`. |
 | `exp run [PROJECT] [--root ROOT] [--check] [--engine auto\|rust\|python]` | Start the local gateway directly, optionally with one project-backed alias. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |
 | `exp optimize router PROJECT --root ROOT [--yes]` | Complete bounded simulation and judgment, fit a frozen router, then verify held-out evidence. | Fit evaluation, policy, held-out evaluation, and router report. |
@@ -16,7 +16,7 @@ The root surface is deliberately small:
 | `exp config gateway call ALIAS PROMPT [--json]` | Send one chat completion to a live gateway as a caller, streaming text to stdout. | One HTTP request against the running gateway; no local state. |
 | `exp config gateway models [--json]` | List the aliases a live gateway grants to the presented key (caller view of `GET /v1/models`). | One HTTP request against the running gateway; no local state. |
 | `exp config gateway key check [--json]` | Validate one raw virtual key against a live gateway and print its granted aliases without storing the key. | One HTTP request against the running gateway; no local state. |
-| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. `experiential-cloud` points at the hosted Platform gateway and reuses the credential from `exp login`. Setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
+| `exp config providers [--provider NAME ...]` | Collect secret-free provider connections, model aliases, and build roles. `experiential-cloud` points at the hosted Platform gateway and reuses the credential from `exp login`; login already performs its provider/model synchronization. Setup also persists, replaces, or removes user-local provider keys. | Local `.exp/models.toml` plus optional records in the user-data credential file. |
 | `exp config budget [USD] --root ROOT` | Read or set the maximum conservative estimate allowed for one paid command (default `$50.00`). | Local `.exp/settings.toml`. |
 | `exp config telemetry status\|enable\|disable` | Read or update aggregate product telemetry preference. | Local `.exp/settings.toml`. |
 

--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -36,7 +36,10 @@ add_deferred_typer(
 )
 app.command("build", help="Build a reusable grounded world model from local trace evidence.")(build)
 app.command("run", help="Run the local gateway, optionally with one project-backed alias.")(run)
-app.command("login", help="Sign in to Experiential Cloud through Platform.")(login)
+app.command(
+    "login",
+    help="Sign in to Experiential Cloud through Platform and sync account models.",
+)(login)
 
 
 @app.callback()

--- a/exp/cli/auth.py
+++ b/exp/cli/auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Mapping
 from getpass import getpass
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -15,8 +16,12 @@ from exp.cli.providers.experiential_cloud import (
     hosted_platform_login,
     read_hosted_key_fallback,
 )
+from exp.cli.providers.sync import sync_account_models
+from exp.cli.shared.options import ROOT_OPTION
 from exp.cli.shared.theme import EXP_THEME
 from exp.common.auth import ProviderAuthStore
+from exp.common.config import ARTIFACT_DIR
+from exp.runtime.models.providers import ProviderListingError, ProviderModelLister
 
 
 def run_login(
@@ -26,6 +31,8 @@ def run_login(
     store: ProviderAuthStore | None = None,
     open_browser: Callable[[str], bool] | None = None,
     read_key: Callable[[str], str | None] = getpass,
+    root: Path | None = None,
+    lister: ProviderModelLister | None = None,
 ) -> None:
     """Authenticate the CLI with Experiential Cloud through Platform.
 
@@ -35,6 +42,8 @@ def run_login(
         store: Optional credential store, primarily for deterministic tests.
         open_browser: Optional browser opener used by the Platform approval flow.
         read_key: Masked fallback reader used when a browser cannot be opened.
+        root: Local ``.exp`` root receiving the synchronized provider catalog.
+        lister: Optional account model-listing seam used by deterministic tests.
 
     Raises:
         typer.Abort: The operator cancels or provides an empty fallback key.
@@ -90,9 +99,21 @@ def run_login(
         key,
         binding=hosted_credential_binding(environment),
     )
+    try:
+        sync_account_models(
+            Path(ARTIFACT_DIR) if root is None else root,
+            connection=connection,
+            api_key=key,
+            console=console,
+            lister=lister,
+        )
+    except ProviderListingError as exc:
+        raise typer.BadParameter(
+            f"login succeeded, but Experiential Cloud model synchronization failed: {exc}"
+        ) from None
     console.print("[green]Logged in to Experiential Cloud.[/green]")
 
 
-def login() -> None:
-    """Open Platform login and save the returned Experiential Cloud credential."""
-    run_login(console=Console(theme=EXP_THEME), environment=os.environ)
+def login(root: Path = ROOT_OPTION) -> None:
+    """Open Platform login, save the credential, and synchronize account models."""
+    run_login(console=Console(theme=EXP_THEME), environment=os.environ, root=root)

--- a/exp/cli/auth.py
+++ b/exp/cli/auth.py
@@ -21,6 +21,7 @@ from exp.cli.shared.options import ROOT_OPTION
 from exp.cli.shared.theme import EXP_THEME
 from exp.common.auth import ProviderAuthStore
 from exp.common.config import ARTIFACT_DIR
+from exp.common.models import ProviderConnectionAuthoringError
 from exp.runtime.models.providers import ProviderListingError, ProviderModelLister
 
 
@@ -93,12 +94,6 @@ def run_login(
     if key is None or not key.strip():
         raise typer.Abort
 
-    auth_store = store if store is not None else ProviderAuthStore()
-    auth_store.put(
-        connection.name,
-        key,
-        binding=hosted_credential_binding(environment),
-    )
     try:
         sync_account_models(
             Path(ARTIFACT_DIR) if root is None else root,
@@ -107,10 +102,16 @@ def run_login(
             console=console,
             lister=lister,
         )
-    except ProviderListingError as exc:
+    except (ProviderConnectionAuthoringError, ProviderListingError) as exc:
         raise typer.BadParameter(
-            f"login succeeded, but Experiential Cloud model synchronization failed: {exc}"
+            f"Experiential Cloud authentication succeeded, but model synchronization failed: {exc}"
         ) from None
+    auth_store = store if store is not None else ProviderAuthStore()
+    auth_store.put(
+        connection.name,
+        key,
+        binding=hosted_credential_binding(environment),
+    )
     console.print("[green]Logged in to Experiential Cloud.[/green]")
 
 

--- a/exp/cli/auth_test.py
+++ b/exp/cli/auth_test.py
@@ -11,6 +11,24 @@ from rich.console import Console
 from exp.cli import auth
 from exp.cli.providers.experiential_cloud import hosted_credential_binding
 from exp.common.auth import ProviderAuthStore
+from exp.common.models import DiscoveredModel, load_model_catalog
+from exp.runtime.models.providers import ProviderEndpoint
+
+
+class _AccountModelLister:
+    """Return the model identities visible to the logged-in hosted account."""
+
+    def list_models(self, endpoint: ProviderEndpoint) -> tuple[DiscoveredModel, ...]:
+        """Assert login uses the hosted connection and return all account models."""
+        assert endpoint == ProviderEndpoint(
+            provider="openai-compatible",
+            api_key="xpl_browser_key",
+            base_url="https://api.preview.experientiallabs.ai/v1",
+        )
+        return (
+            DiscoveredModel(provider="openai-compatible", model="exp-chat"),
+            DiscoveredModel(provider="openai-compatible", model="exp-reasoning"),
+        )
 
 
 def test_login_persists_platform_key_in_the_shared_cloud_record(
@@ -28,7 +46,14 @@ def test_login_persists_platform_key_in_the_shared_cloud_record(
         lambda _connection, **_kwargs: "xpl_browser_key",
     )
 
-    auth.run_login(console=console, environment=environment, store=store)
+    root = tmp_path / ".exp"
+    auth.run_login(
+        console=console,
+        environment=environment,
+        store=store,
+        root=root,
+        lister=_AccountModelLister(),
+    )
 
     assert (
         store.get(
@@ -37,5 +62,14 @@ def test_login_persists_platform_key_in_the_shared_cloud_record(
         )
         == "xpl_browser_key"
     )
+    catalog = load_model_catalog(root / "models.toml")
+    assert catalog.connections["experiential-cloud"].provider == "openai-compatible"
+    assert {record.model for record in catalog.models.values()} == {
+        "exp-chat",
+        "exp-reasoning",
+    }
+    assert {record.billing_source.value for record in catalog.models.values()} == {"host_managed"}
     assert "xpl_browser_key" not in transcript.getvalue()
+    assert "Synced Experiential Cloud:" in transcript.getvalue()
+    assert "models." in transcript.getvalue()
     assert "Logged in to Experiential Cloud." in transcript.getvalue()

--- a/exp/cli/auth_test.py
+++ b/exp/cli/auth_test.py
@@ -23,6 +23,7 @@ from exp.common.models import (
     load_model_catalog,
     write_model_catalog,
 )
+from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.models.providers import ProviderEndpoint
 
 
@@ -127,6 +128,51 @@ def test_login_rejects_endpoint_replacement_for_an_active_gateway(
     monkeypatch.setattr(auth, "hosted_platform_login", lambda _connection, **_kwargs: "xpl_new_key")
 
     with pytest.raises(typer.BadParameter, match="active gateway deployments"):
+        auth.run_login(
+            console=Console(file=io.StringIO(), no_color=True),
+            environment=new_environment,
+            store=store,
+            root=root,
+            lister=_AccountModelLister("xpl_new_key"),
+        )
+
+    assert (
+        store.get(
+            "experiential-cloud",
+            binding=hosted_credential_binding(old_environment),
+        )
+        == "xpl_old_key"
+    )
+
+
+def test_login_rejects_endpoint_replacement_for_a_sqlite_owned_gateway_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gateway-owned provider remains protected before any catalog model is deployed."""
+    root = tmp_path / ".exp"
+    old_environment = {"EXP_GATEWAY_URL": "https://api.experientiallabs.ai/v1"}
+    old_connection = ProviderConnection(
+        name="experiential-cloud",
+        provider="openai-compatible",
+        api_key_env="EXPLABS_API_KEY",
+        base_url=old_environment["EXP_GATEWAY_URL"],
+    )
+    manager = GatewayManagement(root)
+    manager.initialize()
+    manager.upsert_provider_connection(
+        connection_id=old_connection.name,
+        config=old_connection.catalog_config(),
+    )
+    store = ProviderAuthStore(tmp_path / "auth.json")
+    store.put(
+        "experiential-cloud",
+        "xpl_old_key",
+        binding=hosted_credential_binding(old_environment),
+    )
+    new_environment = {"EXP_GATEWAY_URL": "https://api.preview.experientiallabs.ai/v1"}
+    monkeypatch.setattr(auth, "hosted_platform_login", lambda _connection, **_kwargs: "xpl_new_key")
+
+    with pytest.raises(typer.BadParameter, match="active gateway authority"):
         auth.run_login(
             console=Console(file=io.StringIO(), no_color=True),
             environment=new_environment,

--- a/exp/cli/auth_test.py
+++ b/exp/cli/auth_test.py
@@ -6,23 +6,38 @@ import io
 from pathlib import Path
 
 import pytest
+import typer
 from rich.console import Console
 
 from exp.cli import auth
 from exp.cli.providers.experiential_cloud import hosted_credential_binding
 from exp.common.auth import ProviderAuthStore
-from exp.common.models import DiscoveredModel, load_model_catalog
+from exp.common.models import (
+    BillingSource,
+    DiscoveredModel,
+    GatewayDeploymentMetadata,
+    ModelCapabilities,
+    ModelCatalog,
+    ModelRecord,
+    ProviderConnection,
+    load_model_catalog,
+    write_model_catalog,
+)
 from exp.runtime.models.providers import ProviderEndpoint
 
 
 class _AccountModelLister:
     """Return the model identities visible to the logged-in hosted account."""
 
+    def __init__(self, api_key: str = "xpl_browser_key") -> None:
+        """Expect one test-only credential while preserving the endpoint assertion."""
+        self.api_key = api_key
+
     def list_models(self, endpoint: ProviderEndpoint) -> tuple[DiscoveredModel, ...]:
         """Assert login uses the hosted connection and return all account models."""
         assert endpoint == ProviderEndpoint(
             provider="openai-compatible",
-            api_key="xpl_browser_key",
+            api_key=self.api_key,
             base_url="https://api.preview.experientiallabs.ai/v1",
         )
         return (
@@ -73,3 +88,57 @@ def test_login_persists_platform_key_in_the_shared_cloud_record(
     assert "Synced Experiential Cloud:" in transcript.getvalue()
     assert "models." in transcript.getvalue()
     assert "Logged in to Experiential Cloud." in transcript.getvalue()
+
+
+def test_login_rejects_endpoint_replacement_for_an_active_gateway(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A preview-origin login cannot rebind a connection used by an active deployment."""
+    root = tmp_path / ".exp"
+    old_environment = {"EXP_GATEWAY_URL": "https://api.experientiallabs.ai/v1"}
+    old_connection = ProviderConnection(
+        name="experiential-cloud",
+        provider="openai-compatible",
+        api_key_env="EXPLABS_API_KEY",
+        base_url=old_environment["EXP_GATEWAY_URL"],
+    )
+    write_model_catalog(
+        root / "models.toml",
+        ModelCatalog(
+            connections={"experiential-cloud": old_connection.catalog_config()},
+            models={
+                "exp-chat": ModelRecord(
+                    connection="experiential-cloud",
+                    model="exp-chat",
+                    billing_source=BillingSource.HOST_MANAGED,
+                    capabilities=ModelCapabilities(),
+                    gateway=GatewayDeploymentMetadata(exact_model_id="exp-chat"),
+                )
+            },
+        ),
+    )
+    store = ProviderAuthStore(tmp_path / "auth.json")
+    store.put(
+        "experiential-cloud",
+        "xpl_old_key",
+        binding=hosted_credential_binding(old_environment),
+    )
+    new_environment = {"EXP_GATEWAY_URL": "https://api.preview.experientiallabs.ai/v1"}
+    monkeypatch.setattr(auth, "hosted_platform_login", lambda _connection, **_kwargs: "xpl_new_key")
+
+    with pytest.raises(typer.BadParameter, match="active gateway deployments"):
+        auth.run_login(
+            console=Console(file=io.StringIO(), no_color=True),
+            environment=new_environment,
+            store=store,
+            root=root,
+            lister=_AccountModelLister("xpl_new_key"),
+        )
+
+    assert (
+        store.get(
+            "experiential-cloud",
+            binding=hosted_credential_binding(old_environment),
+        )
+        == "xpl_old_key"
+    )

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -35,7 +35,12 @@ from exp.common.config import (
 from exp.common.core.artifacts import stable_id
 from exp.common.core.files import resolve_write_target, write_bytes_atomic
 from exp.common.core.locks import file_write_lock
-from exp.common.models import GatewayDeploymentCapabilities, GatewayTokenPrices, ModelCapabilities
+from exp.common.models import (
+    BillingSource,
+    GatewayDeploymentCapabilities,
+    GatewayTokenPrices,
+    ModelCapabilities,
+)
 from exp.common.progress import report
 from exp.runtime.gateway.catalog_authority import (
     GatewayCatalogCompensationError,
@@ -144,7 +149,6 @@ def interactive_gateway_setup(
                 session,
                 console=console,
                 environment=environment,
-                exclude=frozenset({HOSTED_SETUP_PICKER}),
             )
             if selection is None:
                 raise typer.Abort()
@@ -223,6 +227,11 @@ def interactive_gateway_setup(
                     gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
                     prices=GatewayTokenPrices(),
                     pricing_source=None,
+                    billing_source=(
+                        BillingSource.HOST_MANAGED
+                        if selected.connection == HOSTED_SETUP_PICKER
+                        else BillingSource.CUSTOMER_MANAGED
+                    ),
                     replace=reconfigure,
                     serving_connections=serving_connections,
                 )

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -12,15 +12,20 @@ import exp.runtime.gateway.sqlite.setup_authority as setup_authority
 import exp.runtime.gateway.sqlite.store as gateway_store
 from exp.cli.gateway import setup
 from exp.cli.providers import model_picker, provider_picker
-from exp.cli.providers.experiential_cloud import SETUP_PICKER_LABEL, SETUP_PICKER_NAME
+from exp.cli.providers.experiential_cloud import SETUP_PICKER_LABEL
 from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.config import load_settings
-from exp.common.models import ConnectionConfig, ModelCapabilities, PricingSource, ProviderConnection
+from exp.common.models import (
+    BillingSource,
+    ConnectionConfig,
+    ModelCapabilities,
+    PricingSource,
+    ProviderConnection,
+    load_model_catalog,
+)
 from exp.runtime.gateway.auth import IssuedVirtualKey
 from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
-
-_LOCAL_GATEWAY_EXCLUDE = frozenset({SETUP_PICKER_NAME})
 
 
 def _prepared_gateway_models() -> tuple[
@@ -58,11 +63,12 @@ def test_gateway_setup_uses_the_shared_provider_setup_seams() -> None:
 @pytest.mark.parametrize(
     ("answer", "provider"),
     (
-        ("1", "openai"),
-        ("2", "anthropic"),
-        ("5", "openai-compatible"),
-        ("6", "azure"),
-        ("7", "bedrock"),
+        ("1", "experiential-cloud"),
+        ("2", "openai"),
+        ("3", "anthropic"),
+        ("6", "openai-compatible"),
+        ("7", "azure"),
+        ("8", "bedrock"),
     ),
 )
 def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
@@ -76,13 +82,19 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
         provider_picker.SetupSession(),
         console=console,
         environment={},
-        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
     assert selected == ((provider,), provider in {"azure", "bedrock"})
-    for expected in ("openai", "anthropic", "azure", "bedrock", "openai-compatible"):
+    for expected in (
+        "Experiential Cloud",
+        "openai",
+        "anthropic",
+        "azure",
+        "bedrock",
+        "openai-compatible",
+    ):
         assert expected in console.output
-    assert SETUP_PICKER_LABEL not in console.output
+    assert SETUP_PICKER_LABEL in console.output
 
 
 def test_gateway_provider_selector_accepts_multiple_providers() -> None:
@@ -93,10 +105,9 @@ def test_gateway_provider_selector_accepts_multiple_providers() -> None:
         provider_picker.SetupSession(),
         console=console,
         environment={},
-        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
-    assert selected == (("openai", "anthropic", "azure", "bedrock"), True)
+    assert selected == (("experiential-cloud", "openai", "openai-compatible", "azure"), True)
 
 
 def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
@@ -105,8 +116,7 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
         (
             *(PickerKey.DOWN for _ in range(5)),
             PickerKey.ENTER,
-            PickerKey.DOWN,
-            PickerKey.DOWN,
+            *(PickerKey.DOWN for _ in range(3)),
             PickerKey.ENTER,
         )
     )
@@ -117,10 +127,9 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
         console=console,
         environment={},
         read_key=lambda: next(keys),
-        exclude=_LOCAL_GATEWAY_EXCLUDE,
     )
 
-    assert selected == (("azure",), True)
+    assert selected == (("openai-compatible",), False)
     assert "Providers" in console.output
     assert "openai" in console.output
     assert "bedrock" in console.output
@@ -164,6 +173,53 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     }
     assert {item.alias_id for item in manager.aliases()} == {"gpt-5-6-luna"}
     assert load_settings(tmp_path).commands.maximum_cost_usd == 50.0
+
+
+def test_gateway_setup_marks_experiential_deployment_as_host_managed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selecting the hosted provider preserves platform-owned billing in the local catalog."""
+    connection = ProviderConnection(
+        name="experiential-cloud",
+        provider="openai-compatible",
+        api_key_env="EXPLABS_API_KEY",
+        base_url="https://api.experientiallabs.ai/v1",
+    )
+    endpoint = provider_picker.PreparedEndpoint(
+        connection=connection,
+        api_key="secret",
+        configured=True,
+    )
+    model = provider_picker.AvailableModel(
+        alias="exp-chat",
+        connection=connection.name,
+        provider=connection.provider,
+        model="exp-chat",
+        capabilities=ModelCapabilities(supports_completions=True),
+        pricing_source=PricingSource.UNKNOWN,
+        configured=True,
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("experiential-cloud",), False),
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((endpoint,), (model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(model, None),
+    )
+
+    setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\n"))
+
+    catalog = load_model_catalog(tmp_path / "models.toml")
+    assert catalog.models["exp-chat"].billing_source is BillingSource.HOST_MANAGED
 
 
 def test_gateway_setup_can_edit_the_displayed_defaults(

--- a/exp/cli/providers/experiential_cloud.py
+++ b/exp/cli/providers/experiential_cloud.py
@@ -3,9 +3,10 @@
 Experiential Cloud is a setup picker for the hosted Platform gateway. The
 persisted catalog provider stays ``openai-compatible``: the CLI does not invent
 a new runtime provider family, and it does not rebuild a local gateway
-authority for this hosted path. When no saved or environment credential is
-available, interactive setup uses the Platform approval page and a loopback
-callback to receive the new organization key.
+authority for this hosted path. Login registers the connection and synchronizes
+the authenticated account's model identities. When no saved or environment
+credential is available, interactive setup uses the Platform approval page and
+a loopback callback to receive the new organization key.
 """
 
 from __future__ import annotations

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -255,8 +255,7 @@ def select_providers(
         configured: Whether the catalog already holds usable models, which makes provider
             selection optional so roles can be edited offline.
         read_key: Optional keyboard source used by tests instead of the controlling terminal.
-        exclude: Provider keys omitted from this screen. Local gateway first-run
-            hides Experiential Cloud so it cannot wrap the hosted Platform path.
+        exclude: Provider keys omitted from this screen.
 
     Returns:
         Selected providers plus whether manual model declaration is needed, or ``None`` when the

--- a/exp/cli/providers/sync.py
+++ b/exp/cli/providers/sync.py
@@ -1,0 +1,98 @@
+"""Account-driven synchronization for hosted provider connections and model identities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.console import Console
+
+from exp.common.models import (
+    BillingSource,
+    ModelRecord,
+    ProviderConnection,
+    derive_model_alias,
+    load_model_catalog,
+    resolve_discovered_model,
+    sync_provider_models,
+)
+from exp.runtime.models.providers import (
+    HttpProviderModelLister,
+    ProviderEndpoint,
+    ProviderListingError,
+    ProviderModelLister,
+)
+
+
+def sync_account_models(
+    root: Path,
+    *,
+    connection: ProviderConnection,
+    api_key: str,
+    console: Console,
+    lister: ProviderModelLister | None = None,
+) -> tuple[str, ...]:
+    """Register a hosted provider and every model visible to its authenticated account.
+
+    Args:
+        root: Local ``.exp`` root receiving the secret-free model catalog.
+        connection: Named hosted connection to register.
+        api_key: Credential used only for the bounded model-listing request.
+        console: Terminal receiving a secret-free synchronization summary.
+        lister: Optional model-listing seam used by deterministic tests.
+
+    Returns:
+        Stable local aliases for every synchronized model identity.
+
+    Raises:
+        ProviderListingError: The account model listing fails or is empty.
+    """
+    model_lister = lister or HttpProviderModelLister()
+    discovered = model_lister.list_models(
+        ProviderEndpoint(
+            provider=connection.provider,
+            api_key=api_key,
+            base_url=connection.base_url,
+        )
+    )
+    if not discovered:
+        raise ProviderListingError("Experiential Cloud published no models for this account")
+    catalog_path = root / "models.toml"
+    existing_models = {}
+    if catalog_path.is_file():
+        existing = load_model_catalog(catalog_path)
+        existing_models = {
+            record.model: alias
+            for alias, record in existing.models.items()
+            if record.connection == connection.name
+        }
+        taken_aliases = set(existing.models)
+    else:
+        taken_aliases = set()
+
+    records: dict[str, ModelRecord] = {}
+    aliases: list[str] = []
+    seen_models: set[str] = set()
+    for item in discovered:
+        if item.model in seen_models:
+            continue
+        seen_models.add(item.model)
+        alias = existing_models.get(item.model)
+        if alias is None:
+            alias = derive_model_alias(item.provider, item.model, frozenset(taken_aliases))
+        taken_aliases.add(alias)
+        aliases.append(alias)
+        resolved = resolve_discovered_model(item)
+        records[alias] = ModelRecord(
+            connection=connection.name,
+            model=item.model,
+            billing_source=BillingSource.HOST_MANAGED,
+            capabilities=resolved.capabilities,
+        )
+
+    sync_provider_models(
+        catalog_path,
+        connection=connection,
+        models=records,
+    )
+    console.print(f"[green]Synced Experiential Cloud: {len(aliases)} models.[/green]")
+    return tuple(aliases)

--- a/exp/cli/providers/sync.py
+++ b/exp/cli/providers/sync.py
@@ -15,6 +15,7 @@ from exp.common.models import (
     resolve_discovered_model,
     sync_provider_models,
 )
+from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.models.providers import (
     HttpProviderModelLister,
     ProviderEndpoint,
@@ -93,6 +94,10 @@ def sync_account_models(
         catalog_path,
         connection=connection,
         models=records,
+        protected_connections={
+            authority.connection_id: authority.config
+            for authority in GatewayManagement(root).provider_connections()
+        },
     )
     console.print(f"[green]Synced Experiential Cloud: {len(aliases)} models.[/green]")
     return tuple(aliases)

--- a/exp/common/models/__init__.py
+++ b/exp/common/models/__init__.py
@@ -19,6 +19,7 @@ from exp.common.models.client import EmbeddingClient, IdempotentModelClient, Mod
 from exp.common.models.connection_authoring import (
     ProviderConnectionAuthoringError,
     configure_provider_connections,
+    sync_provider_models,
 )
 from exp.common.models.discovery import (
     DiscoveredModel,
@@ -165,6 +166,7 @@ __all__ = [
     "completion_request_cost_usd",
     "configure_provider_catalog",
     "configure_provider_connections",
+    "sync_provider_models",
     "configure_router_candidates",
     "derive_connection_name",
     "derive_model_alias",

--- a/exp/common/models/connection_authoring.py
+++ b/exp/common/models/connection_authoring.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from exp.common.core.artifacts import validate_artifact_id
 from exp.common.core.locks import file_write_lock
 from exp.common.models.catalog import (
+    ConnectionConfig,
     ModelCatalog,
     ModelRecord,
     ModelRoles,
@@ -94,6 +95,7 @@ def sync_provider_models(
     *,
     connection: ProviderConnection,
     models: Mapping[str, ModelRecord],
+    protected_connections: Mapping[str, ConnectionConfig] | None = None,
     replace: bool = True,
 ) -> ModelCatalog:
     """Atomically register one provider and its authenticated model identities.
@@ -105,6 +107,8 @@ def sync_provider_models(
         path: Local ``models.toml`` path.
         connection: Secret-free provider connection to register.
         models: Secret-free records keyed by their local catalog aliases.
+        protected_connections: Active SQLite gateway connections keyed by connection name. A
+            changed endpoint cannot replace one of these authorities during account sync.
         replace: Whether changed non-serving model metadata may be refreshed.
 
     Returns:
@@ -132,11 +136,18 @@ def sync_provider_models(
         current_models = dict(existing.models) if existing is not None else {}
         current = current_connections.get(connection.name)
         proposed_connection = connection.catalog_config()
+        protected = (protected_connections or {}).get(connection.name)
+        if protected is not None and protected != proposed_connection:
+            raise ProviderConnectionAuthoringError(
+                f"connection {connection.name!r} differs from active gateway authority; use the "
+                "existing endpoint or explicitly reconfigure the gateway"
+            )
         if current is not None and current != proposed_connection:
             protected_aliases = tuple(
                 alias
                 for alias, record in current_models.items()
-                if record.connection == connection.name and record.gateway is not None
+                if record.connection == connection.name
+                and (record.gateway is not None or protected is not None)
             )
             if protected_aliases:
                 raise ProviderConnectionAuthoringError(

--- a/exp/common/models/connection_authoring.py
+++ b/exp/common/models/connection_authoring.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
+from exp.common.core.artifacts import validate_artifact_id
 from exp.common.core.locks import file_write_lock
 from exp.common.models.catalog import (
     ModelCatalog,
+    ModelRecord,
     ModelRoles,
     load_model_catalog,
     write_model_catalog,
@@ -80,6 +83,77 @@ def configure_provider_connections(
             schema_version=existing.schema_version if existing is not None else 2,
             connections=current_connections,
             models=models,
+            roles=existing.roles if existing is not None else ModelRoles(),
+        )
+        write_model_catalog(path, catalog)
+        return catalog
+
+
+def sync_provider_models(
+    path: Path,
+    *,
+    connection: ProviderConnection,
+    models: Mapping[str, ModelRecord],
+    replace: bool = True,
+) -> ModelCatalog:
+    """Atomically register one provider and its authenticated model identities.
+
+    This role-free path is used by account login synchronization. It keeps every discovered
+    model visible without forcing the optimizer's world-model, judge, or embedder roles.
+
+    Args:
+        path: Local ``models.toml`` path.
+        connection: Secret-free provider connection to register.
+        models: Secret-free records keyed by their local catalog aliases.
+        replace: Whether changed non-serving model metadata may be refreshed.
+
+    Returns:
+        Complete catalog after the provider and model update.
+
+    Raises:
+        ProviderConnectionAuthoringError: Input is empty, inconsistent, or conflicts with
+            protected serving state.
+    """
+    if not models:
+        raise ProviderConnectionAuthoringError("provider model sync needs at least one model")
+    aliases = tuple(models)
+    try:
+        for alias in aliases:
+            validate_artifact_id(alias)
+    except ValueError as exc:
+        raise ProviderConnectionAuthoringError(str(exc)) from exc
+    if any(record.connection != connection.name for record in models.values()):
+        raise ProviderConnectionAuthoringError(
+            "provider model records must reference the synchronized connection"
+        )
+    with file_write_lock(path, what="provider model synchronization"):
+        existing = load_model_catalog(path) if path.exists() else None
+        current_connections = dict(existing.connections) if existing is not None else {}
+        current = current_connections.get(connection.name)
+        if current is not None and current != connection.catalog_config() and not replace:
+            raise ProviderConnectionAuthoringError(
+                f"connection {connection.name!r} already differs; rerun with replacement"
+            )
+        current_connections[connection.name] = connection.catalog_config()
+        current_models = dict(existing.models) if existing is not None else {}
+        for alias, proposed in models.items():
+            previous = current_models.get(alias)
+            if previous == proposed:
+                continue
+            if previous is not None and previous.gateway is not None:
+                # A gateway deployment owns its immutable serving record. The account sync still
+                # keeps the identity visible, but must not erase the active deployment metadata.
+                continue
+            if previous is not None and not replace:
+                raise ProviderConnectionAuthoringError(
+                    f"model alias {alias!r} already differs; rerun with replacement"
+                )
+            current_models[alias] = proposed
+        catalog = ModelCatalog(
+            schema_version=existing.schema_version if existing is not None else 2,
+            connections=current_connections,
+            models=current_models,
+            gateway_pools=existing.gateway_pools if existing is not None else {},
             roles=existing.roles if existing is not None else ModelRoles(),
         )
         write_model_catalog(path, catalog)

--- a/exp/common/models/connection_authoring.py
+++ b/exp/common/models/connection_authoring.py
@@ -129,13 +129,26 @@ def sync_provider_models(
     with file_write_lock(path, what="provider model synchronization"):
         existing = load_model_catalog(path) if path.exists() else None
         current_connections = dict(existing.connections) if existing is not None else {}
-        current = current_connections.get(connection.name)
-        if current is not None and current != connection.catalog_config() and not replace:
-            raise ProviderConnectionAuthoringError(
-                f"connection {connection.name!r} already differs; rerun with replacement"
-            )
-        current_connections[connection.name] = connection.catalog_config()
         current_models = dict(existing.models) if existing is not None else {}
+        current = current_connections.get(connection.name)
+        proposed_connection = connection.catalog_config()
+        if current is not None and current != proposed_connection:
+            protected_aliases = tuple(
+                alias
+                for alias, record in current_models.items()
+                if record.connection == connection.name and record.gateway is not None
+            )
+            if protected_aliases:
+                raise ProviderConnectionAuthoringError(
+                    f"connection {connection.name!r} differs from active gateway deployments "
+                    f"{', '.join(sorted(protected_aliases))}; use the existing endpoint or "
+                    "explicitly reconfigure the gateway"
+                )
+            if not replace:
+                raise ProviderConnectionAuthoringError(
+                    f"connection {connection.name!r} already differs; rerun with replacement"
+                )
+        current_connections[connection.name] = proposed_connection
         for alias, proposed in models.items():
             previous = current_models.get(alias)
             if previous == proposed:


### PR DESCRIPTION
## Summary

Follow-up to #610. `exp login` now:

- stores the endpoint-bound Experiential credential;
- lists every model returned for the authenticated account and registers `experiential-cloud` plus secret-free model records in the selected `.exp/models.toml`;
- preserves existing local aliases and active gateway deployment metadata;
- exposes Experiential Cloud in local gateway setup and marks selected hosted deployments `host_managed`.

`exp config providers` remains available for role assignment or explicit refresh.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `TERM=xterm-256color uv run pytest -n 4 --dist worksteal -q -k "not live" exp ...`: 2,285 passed, 1 skipped

The repository's terminal redraw tests require a non-`dumb` TERM; with the shell default `TERM=dumb`, those unrelated tests fail their terminal rendering assertions.