### PR TITLE
feat(runtime): Vertex AI provider over the shared Gemini wire protocol

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -61,6 +61,7 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 | Experiential Cloud | `openai-compatible` (picker `experiential-cloud`) | `EXPLABS_API_KEY` plus the hosted Platform `/v1` origin | `https://api.experientiallabs.ai/v1` or `EXP_GATEWAY_URL` |
 | Azure OpenAI / Foundry | `azure` | `api_key_env` plus explicit resource endpoint and `api_version` | Endpoint and API version |
 | Amazon Bedrock | `bedrock` | AWS credential chain. No `api_key_env` | Optional catalog `region` |
+| Vertex AI | `vertex` | `api_key_env` holding service-account JSON | Project-and-location `base_url` |
 | Tinker sampling | `tinker` | `api_key_env` | Official Tinker origin |
 
 Native fixed-origin providers reject a custom `base_url`. Use `openai-compatible` for a trusted
@@ -196,6 +197,36 @@ model = "amazon.titan-embed-text-v2:0"
 [models.titan.capabilities]
 supports_embeddings = true
 input_cost_per_million_tokens_usd = 0
+```
+
+## Vertex AI
+
+Use `provider = "vertex"` for Google-published models served from a Google Cloud project.
+The connection needs two values: `base_url` naming the project-and-location root, and
+`api_key_env` naming an environment variable whose value is the full service-account JSON key
+file contents. The runtime mints short-lived OAuth bearer tokens from that credential; the
+JSON itself never travels on the wire. Requests use the same `generateContent` wire protocol
+as the Gemini provider on `publishers/google/models/` routes.
+
+Vertex is catalog-and-API configuration only: the interactive `exp config providers` picker
+does not offer it. Like Azure and Bedrock, provider names do not imply protocol support or
+prices, so every Vertex alias declares explicit capabilities. Embeddings are not supported on
+Vertex connections; use a `gemini` connection for Gemini embeddings.
+
+```toml
+[connections.vertex]
+provider = "vertex"
+base_url = "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/locations/us-central1"
+api_key_env = "VERTEX_SERVICE_ACCOUNT_JSON"
+
+[models.gemini-pro]
+connection = "vertex"
+model = "gemini-2.5-pro"
+[models.gemini-pro.capabilities]
+supports_completions = true
+supports_tools = true
+input_cost_per_million_tokens_usd = 0
+output_cost_per_million_tokens_usd = 0
 ```
 
 ## Errors

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -205,8 +205,10 @@ Use `provider = "vertex"` for Google-published models served from a Google Cloud
 The connection needs two values: `base_url` naming the project-and-location root, and
 `api_key_env` naming an environment variable whose value is the full service-account JSON key
 file contents. The runtime mints short-lived OAuth bearer tokens from that credential; the
-JSON itself never travels on the wire. Requests use the same `generateContent` wire protocol
-as the Gemini provider on `publishers/google/models/` routes.
+JSON itself never travels on the wire, and the endpoint host is pinned to HTTPS
+`*.aiplatform.googleapis.com` so the token can never be sent to an operator-chosen host.
+Requests use the same `generateContent` wire protocol as the Gemini provider on
+`publishers/google/models/` routes.
 
 Vertex is catalog-and-API configuration only: the interactive `exp config providers` picker
 does not offer it. Like Azure and Bedrock, provider names do not imply protocol support or

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -33,6 +33,7 @@ from exp.common.models.model import (
 _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _AZURE_API_VERSION = re.compile(r"^(?:v1|\d{4}-\d{2}-\d{2}(?:-preview)?)$")
 _AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+_VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
 _FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
 _EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
 
@@ -137,10 +138,7 @@ class ConnectionConfig(ContractModel):
             # endpoint host is pinned to Vertex AI service hosts and never operator-chosen.
             vertex_parts = urlsplit(self.base_url)
             vertex_host = (vertex_parts.hostname or "").lower()
-            if vertex_parts.scheme != "https" or not (
-                vertex_host == "aiplatform.googleapis.com"
-                or vertex_host.endswith("-aiplatform.googleapis.com")
-            ):
+            if vertex_parts.scheme != "https" or not _VERTEX_HOST.fullmatch(vertex_host):
                 raise ValueError(
                     "vertex base_url must use an HTTPS Vertex AI host such as "
                     "https://us-central1-aiplatform.googleapis.com; OAuth tokens are never "

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -133,6 +133,19 @@ class ConnectionConfig(ContractModel):
                     "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/"
                     "locations/us-central1"
                 )
+            # The runtime attaches a cloud-platform OAuth token to every request, so the
+            # endpoint host is pinned to Vertex AI service hosts and never operator-chosen.
+            vertex_parts = urlsplit(self.base_url)
+            vertex_host = (vertex_parts.hostname or "").lower()
+            if vertex_parts.scheme != "https" or not (
+                vertex_host == "aiplatform.googleapis.com"
+                or vertex_host.endswith("-aiplatform.googleapis.com")
+            ):
+                raise ValueError(
+                    "vertex base_url must use an HTTPS Vertex AI host such as "
+                    "https://us-central1-aiplatform.googleapis.com; OAuth tokens are never "
+                    "sent to other hosts"
+                )
             if self.api_key_env is None:
                 raise ValueError(
                     "vertex requires api_key_env naming the environment variable that holds "

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -34,7 +34,7 @@ _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _AZURE_API_VERSION = re.compile(r"^(?:v1|\d{4}-\d{2}-\d{2}(?:-preview)?)$")
 _AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 _FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
-_EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible"})
+_EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
 
 
 def _normalize_base_url(value: str) -> str:
@@ -126,6 +126,25 @@ class ConnectionConfig(ContractModel):
                 raise ValueError("api_version is only accepted for provider='azure'")
             if self.region is not None and not _AWS_REGION_NAME.fullmatch(self.region):
                 raise ValueError("bedrock region must be an AWS region name")
+        elif self.provider == "vertex":
+            if self.base_url is None:
+                raise ValueError(
+                    "vertex requires base_url naming the project-and-location root, such as "
+                    "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/"
+                    "locations/us-central1"
+                )
+            if self.api_key_env is None:
+                raise ValueError(
+                    "vertex requires api_key_env naming the environment variable that holds "
+                    "the service-account JSON credential"
+                )
+            if self.api_version is not None:
+                raise ValueError("api_version is only accepted for provider='azure'")
+            if self.region is not None:
+                raise ValueError(
+                    "region is only accepted for provider='bedrock'; the Vertex location "
+                    "lives inside base_url"
+                )
         else:
             if self.api_version is not None:
                 raise ValueError("api_version is only accepted for provider='azure'")

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -20,7 +20,16 @@ from exp.common.models.catalog import (
 from exp.common.models.model import BillingSource, ModelCapabilities, ReasoningEffort
 
 SETUP_PROVIDERS = frozenset(
-    {"anthropic", "azure", "bedrock", "gemini", "openai", "openai-compatible", "openrouter"}
+    {
+        "anthropic",
+        "azure",
+        "bedrock",
+        "gemini",
+        "openai",
+        "openai-compatible",
+        "openrouter",
+        "vertex",
+    }
 )
 
 
@@ -61,6 +70,17 @@ class ProviderConnection(ContractModel):
                 raise ValueError("bedrock does not accept base_url")
             if self.api_version is not None:
                 raise ValueError("api_version is only accepted for provider='azure'")
+        elif self.provider == "vertex":
+            if self.base_url is None:
+                raise ValueError("vertex requires an explicit project-and-location base_url")
+            if self.api_key_env is None:
+                raise ValueError(
+                    "vertex requires api_key_env naming the service-account JSON credential"
+                )
+            if self.api_version is not None:
+                raise ValueError("api_version is only accepted for provider='azure'")
+            if self.region is not None:
+                raise ValueError("region is only accepted for provider='bedrock'")
         else:
             if self.api_key_env is None:
                 raise ValueError(f"{self.provider} requires api_key_env")

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import threading
 from typing import Protocol
 from urllib.parse import urlsplit
@@ -40,6 +41,7 @@ VERTEX_TOKEN_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 """OAuth scope requested for every Vertex access token."""
 
 _MODEL_PATH_PREFIX = "publishers/google/models/"
+_VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
 
 
 class VertexCredentialError(ValueError):
@@ -300,9 +302,7 @@ def _require_vertex_host(base_url: str) -> None:
     """
     parts = urlsplit(base_url)
     host = (parts.hostname or "").lower()
-    if parts.scheme != "https" or not (
-        host == "aiplatform.googleapis.com" or host.endswith("-aiplatform.googleapis.com")
-    ):
+    if parts.scheme != "https" or not _VERTEX_HOST.fullmatch(host):
         raise ValueError(
             "Vertex clients only send OAuth tokens to HTTPS *.aiplatform.googleapis.com "
             f"hosts; got {base_url!r}"

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -9,9 +9,11 @@ tokens minted from a service-account JSON credential instead of a static API key
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from typing import Protocol
+from urllib.parse import urlsplit
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ModelRequest, ModelResponse, ModelSnapshot
@@ -45,7 +47,12 @@ class VertexCredentialError(ValueError):
 
 
 class VertexTokenProvider(Protocol):
-    """Returns a currently valid OAuth bearer token for one Vertex connection."""
+    """Returns a currently valid OAuth bearer token for one Vertex connection.
+
+    The runtime may call the provider more than once per request (an off-loop warm mint
+    followed by header construction), so implementations return a cached token until it
+    expires instead of minting on every call.
+    """
 
     def __call__(self) -> str:
         """Return a non-empty bearer token that authorizes the next request."""
@@ -176,6 +183,7 @@ class VertexClient(ProviderHttpClient):
             token_provider: Optional deterministic bearer-token seam for tests and callers
                 that own credential refresh themselves.
         """
+        _require_vertex_host(base_url)
         super().__init__(
             model=model,
             api_key=api_key,
@@ -185,6 +193,28 @@ class VertexClient(ProviderHttpClient):
             timeout_seconds=timeout_seconds,
         )
         self._token_provider = token_provider or ServiceAccountTokenProvider(api_key)
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Warm the bearer token off the event loop, then run the shared completion flow.
+
+        Args:
+            request: Visible messages, tool schemas, and sampling controls to send.
+            deadline: Optional request-wide deadline supplied by gateway execution.
+            idempotency_key: Optional stable caller or gateway attempt identity.
+
+        Returns:
+            The typed completed response with observed request economics.
+        """
+        await asyncio.to_thread(self._token_provider)
+        return await super().complete_async(
+            request, deadline=deadline, idempotency_key=idempotency_key
+        )
 
     async def stream(
         self,
@@ -205,10 +235,15 @@ class VertexClient(ProviderHttpClient):
         Returns:
             A cancellable provider-neutral event stream.
         """
+        # Token minting is one blocking HTTPS call; keep it off the gateway event loop.
+        bearer_token = await asyncio.to_thread(self._token_provider)
         return await start_gemini_generate_stream(
             self._transport,
             f"{self._base_url}/{self._stream_path()}",
-            headers=self._headers(),
+            headers={
+                "authorization": f"Bearer {bearer_token}",
+                "content-type": "application/json",
+            },
             payload=gemini_generate_request(
                 self._model.model_id,
                 gateway_model_request(request),
@@ -221,7 +256,11 @@ class VertexClient(ProviderHttpClient):
         )
 
     def _headers(self) -> dict[str, str]:
-        """Build native Vertex headers carrying a freshly validated OAuth bearer token."""
+        """Build native Vertex headers carrying the provider's current bearer token.
+
+        The async entry points warm the provider off the event loop first, so this call
+        returns the cached token without blocking in the ordinary case.
+        """
         return {
             "authorization": f"Bearer {self._token_provider()}",
             "content-type": "application/json",
@@ -244,6 +283,29 @@ class VertexClient(ProviderHttpClient):
         """Convert one completed generateContent payload into the shared response contract."""
         return gemini_generate_response(
             payload, configured_model=self._model, latency_seconds=latency_seconds
+        )
+
+
+def _require_vertex_host(base_url: str) -> None:
+    """Refuse endpoint roots that would receive the OAuth token on a non-Vertex host.
+
+    Catalog validation enforces the same rule with a configuration-time message; this
+    check makes the guarantee hold for every direct construction of the client.
+
+    Args:
+        base_url: Candidate project-and-location endpoint root.
+
+    Raises:
+        ValueError: The URL is not an HTTPS Vertex AI service host.
+    """
+    parts = urlsplit(base_url)
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or not (
+        host == "aiplatform.googleapis.com" or host.endswith("-aiplatform.googleapis.com")
+    ):
+        raise ValueError(
+            "Vertex clients only send OAuth tokens to HTTPS *.aiplatform.googleapis.com "
+            f"hosts; got {base_url!r}"
         )
 
 

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -1,0 +1,259 @@
+"""Native Vertex AI adapter for Google-published models over the Gemini wire protocol.
+
+Vertex serves the same ``generateContent`` and ``streamGenerateContent`` protocol as the
+Gemini API, so request and response conversion is shared with the Gemini adapter. What
+differs is identity: the endpoint root names one project and location, model routes live
+under ``publishers/google/models/``, and authentication uses short-lived OAuth bearer
+tokens minted from a service-account JSON credential instead of a static API key.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Protocol
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import ModelRequest, ModelResponse, ModelSnapshot
+from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.models.providers.async_transport import (
+    AsyncJsonHttpTransport,
+    RequestDeadline,
+)
+from exp.runtime.models.providers.base import (
+    DEFAULT_RETRY_POLICY,
+    DEFAULT_TIMEOUT_SECONDS,
+    ProviderHttpClient,
+)
+from exp.runtime.models.providers.gemini import (
+    gemini_generate_request,
+    gemini_generate_response,
+)
+from exp.runtime.models.providers.gemini_streaming import start_gemini_generate_stream
+from exp.runtime.models.providers.streaming import NormalizedProviderStream
+from exp.runtime.models.providers.transport import JsonHttpTransport, RetryPolicy
+from exp.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
+
+VERTEX_TOKEN_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+"""OAuth scope requested for every Vertex access token."""
+
+_MODEL_PATH_PREFIX = "publishers/google/models/"
+
+
+class VertexCredentialError(ValueError):
+    """A Vertex service-account credential could not mint a usable OAuth access token."""
+
+
+class VertexTokenProvider(Protocol):
+    """Returns a currently valid OAuth bearer token for one Vertex connection."""
+
+    def __call__(self) -> str:
+        """Return a non-empty bearer token that authorizes the next request."""
+        ...
+
+
+class VertexTokenProviderFactory(Protocol):
+    """Builds one connection-bound token provider from its service-account credential."""
+
+    def __call__(self, *, credentials_json: str) -> VertexTokenProvider:
+        """Return a token provider for one connection's already-read credential value."""
+        ...
+
+
+class _RefreshableCredentials(Protocol):
+    """Narrow google-auth credential surface used to mint and renew access tokens."""
+
+    valid: bool
+    token: str | None
+
+    def refresh(self, request: object) -> None:
+        """Mint or renew the access token through one blocking token-endpoint call."""
+
+
+class ServiceAccountTokenProvider:
+    """Mints short-lived Vertex bearer tokens from one service-account JSON credential.
+
+    Construction parses and validates the credential without any network call. Minting is
+    one blocking HTTPS call to Google's token endpoint roughly once per token lifetime
+    (about an hour); it runs under a lock so concurrent requests share a single mint and
+    every later call returns the cached token until it expires.
+    """
+
+    def __init__(
+        self,
+        credentials_json: str,
+        *,
+        credentials: _RefreshableCredentials | None = None,
+    ) -> None:
+        """Validate one service-account credential and prepare lazy token minting.
+
+        Args:
+            credentials_json: Full service-account JSON credential value, normally read from
+                the connection's named environment variable.
+            credentials: Optional deterministic credential object used by tests to observe
+                refresh behavior without contacting Google.
+
+        Raises:
+            VertexCredentialError: The value is not a service-account JSON credential.
+        """
+        self._lock = threading.Lock()
+        if credentials is not None:
+            self._credentials: _RefreshableCredentials = credentials
+            return
+        try:
+            info = json.loads(credentials_json)
+        except ValueError as exc:
+            raise VertexCredentialError(
+                "the Vertex credential is not valid JSON; set the connection's environment "
+                "variable to the full service-account JSON key file contents"
+            ) from exc
+        if not isinstance(info, dict):
+            raise VertexCredentialError(
+                "the Vertex credential must be a service-account JSON object, not a bare value"
+            )
+        # Official credential construction, kept lazy like the Bedrock boto3 boundary so the
+        # SDK never loads for catalogs that hold no Vertex connection.
+        from google.oauth2.service_account import Credentials
+
+        try:
+            self._credentials = Credentials.from_service_account_info(
+                info, scopes=[VERTEX_TOKEN_SCOPE]
+            )
+        except ValueError as exc:
+            raise VertexCredentialError(
+                f"the Vertex service-account credential is incomplete: {exc}; paste the full "
+                "JSON key file for a service account with Vertex AI access"
+            ) from exc
+
+    def __call__(self) -> str:
+        """Return a currently valid bearer token, minting or renewing it when needed.
+
+        Returns:
+            A non-empty OAuth access token.
+
+        Raises:
+            VertexCredentialError: Google's token endpoint returned no usable token.
+        """
+        with self._lock:
+            if not self._credentials.valid:
+                from google.auth.transport.requests import Request
+
+                self._credentials.refresh(Request())
+            token = self._credentials.token
+            if not token:
+                raise VertexCredentialError(
+                    "Google's token endpoint returned no access token; verify the service "
+                    "account exists and has Vertex AI permission on the project"
+                )
+            return token
+
+
+class VertexClient(ProviderHttpClient):
+    """Calls one explicit Google-published Vertex model through its native REST protocol."""
+
+    def __init__(
+        self,
+        *,
+        model: ModelSnapshot,
+        api_key: str,
+        base_url: str,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
+        retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        token_provider: VertexTokenProvider | None = None,
+    ) -> None:
+        """Create a client for one project-and-location Vertex endpoint root.
+
+        Args:
+            model: Resolved configured model identity.
+            api_key: Service-account JSON credential read from the connection's environment
+                variable. It never travels on the wire; it mints each request's bearer token.
+            base_url: Project-and-location endpoint root, such as
+                ``https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/locations/us-central1``.
+            transport: Optional deterministic transport used by tests.
+            retry_policy: Bounded same-endpoint retry policy.
+            timeout_seconds: Per-attempt timeout floor.
+            token_provider: Optional deterministic bearer-token seam for tests and callers
+                that own credential refresh themselves.
+        """
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            transport=transport,
+            retry_policy=retry_policy,
+            timeout_seconds=timeout_seconds,
+        )
+        self._token_provider = token_provider or ServiceAccountTokenProvider(api_key)
+
+    async def stream(
+        self,
+        request: GatewayRequest,
+        *,
+        deadline: RequestDeadline,
+        idempotency_key: str,
+        retry_policy: RetryPolicy | None = None,
+    ) -> NormalizedProviderStream:
+        """Start one native Vertex SSE stream under the gateway deadline.
+
+        Args:
+            request: Canonical streaming gateway request.
+            deadline: Immutable request-wide deadline.
+            idempotency_key: Stable identity for this deployment operation.
+            retry_policy: Optional caller-owned physical dispatch limit.
+
+        Returns:
+            A cancellable provider-neutral event stream.
+        """
+        return await start_gemini_generate_stream(
+            self._transport,
+            f"{self._base_url}/{self._stream_path()}",
+            headers=self._headers(),
+            payload=gemini_generate_request(
+                self._model.model_id,
+                gateway_model_request(request),
+            ),
+            request=request,
+            deadline=deadline,
+            idempotency_key=idempotency_key,
+            retry_policy=retry_policy or self._retry_policy,
+            timeout_seconds=self._timeout_seconds,
+        )
+
+    def _headers(self) -> dict[str, str]:
+        """Build native Vertex headers carrying a freshly validated OAuth bearer token."""
+        return {
+            "authorization": f"Bearer {self._token_provider()}",
+            "content-type": "application/json",
+        }
+
+    def _completion_path(self) -> str:
+        """Return the publisher-scoped native generateContent route."""
+        return f"{_MODEL_PATH_PREFIX}{_vertex_model_id(self._model.model_id)}:generateContent"
+
+    def _stream_path(self) -> str:
+        """Return the publisher-scoped native SSE streaming route."""
+        model_id = _vertex_model_id(self._model.model_id)
+        return f"{_MODEL_PATH_PREFIX}{model_id}:streamGenerateContent?alt=sse"
+
+    def _build_request(self, request: ModelRequest) -> JsonObject:
+        """Convert one typed request into a native generateContent payload."""
+        return gemini_generate_request(self._model.model_id, request)
+
+    def _parse_response(self, payload: JsonObject, *, latency_seconds: float) -> ModelResponse:
+        """Convert one completed generateContent payload into the shared response contract."""
+        return gemini_generate_response(
+            payload, configured_model=self._model, latency_seconds=latency_seconds
+        )
+
+
+def _vertex_model_id(model_id: str) -> str:
+    """Remove optional catalog spellings before placing a model in a Vertex route.
+
+    Args:
+        model_id: Catalog model identifier, with or without a resource-path prefix.
+
+    Returns:
+        The bare publisher model identifier.
+    """
+    return model_id.removeprefix(_MODEL_PATH_PREFIX).removeprefix("models/")

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -21,12 +21,14 @@ from exp.common.models import ModelRequest, ModelResponse, ModelSnapshot
 from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.async_transport import (
     AsyncJsonHttpTransport,
+    ProviderDeadlineExceeded,
     RequestDeadline,
 )
 from exp.runtime.models.providers.base import (
     DEFAULT_RETRY_POLICY,
     DEFAULT_TIMEOUT_SECONDS,
     ProviderHttpClient,
+    completion_timeout_seconds,
 )
 from exp.runtime.models.providers.gemini import (
     gemini_generate_request,
@@ -213,9 +215,12 @@ class VertexClient(ProviderHttpClient):
         Returns:
             The typed completed response with observed request economics.
         """
-        await asyncio.to_thread(self._token_provider)
+        request_deadline = deadline or RequestDeadline.after(
+            completion_timeout_seconds(self._timeout_seconds, request.maximum_output_tokens)
+        )
+        await self._warm_bearer_token(request_deadline)
         return await super().complete_async(
-            request, deadline=deadline, idempotency_key=idempotency_key
+            request, deadline=request_deadline, idempotency_key=idempotency_key
         )
 
     async def stream(
@@ -237,8 +242,7 @@ class VertexClient(ProviderHttpClient):
         Returns:
             A cancellable provider-neutral event stream.
         """
-        # Token minting is one blocking HTTPS call; keep it off the gateway event loop.
-        bearer_token = await asyncio.to_thread(self._token_provider)
+        bearer_token = await self._warm_bearer_token(deadline)
         return await start_gemini_generate_stream(
             self._transport,
             f"{self._base_url}/{self._stream_path()}",
@@ -256,6 +260,31 @@ class VertexClient(ProviderHttpClient):
             retry_policy=retry_policy or self._retry_policy,
             timeout_seconds=self._timeout_seconds,
         )
+
+    async def _warm_bearer_token(self, deadline: RequestDeadline) -> str:
+        """Mint or read the bearer token off the event loop, bounded by the request deadline.
+
+        Token minting is one blocking HTTPS call to Google's token endpoint. It runs on a
+        worker thread so the gateway event loop stays responsive, and the wait is bounded by
+        the smaller of the remaining request budget and the per-attempt timeout floor.
+
+        Args:
+            deadline: Immutable request-wide deadline shared with the provider dispatch.
+
+        Returns:
+            A currently valid bearer token.
+
+        Raises:
+            ProviderDeadlineExceeded: The deadline expired before a token was available.
+        """
+        timeout_seconds = deadline.attempt_timeout(self._timeout_seconds)
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                return await asyncio.to_thread(self._token_provider)
+        except TimeoutError as exc:
+            raise ProviderDeadlineExceeded(
+                "Vertex token refresh exhausted the provider request deadline"
+            ) from exc
 
     def _headers(self) -> dict[str, str]:
         """Build native Vertex headers carrying the provider's current bearer token.

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -1,0 +1,292 @@
+"""Vertex adapter routing, OAuth header, token-provider, and catalog resolution tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import (
+    BillingSource,
+    ConnectionConfig,
+    EmbeddingClient,
+    ModelCapabilities,
+    ModelCatalog,
+    ModelClient,
+    ModelFinishReason,
+    ModelRecord,
+)
+from exp.common.models.setup import ProviderConnection
+from exp.runtime.models.providers.openai_compatible_test import _request, _snapshot
+from exp.runtime.models.providers.transport import JsonHttpResponse, ScriptedJsonTransport
+from exp.runtime.models.providers.vertex import (
+    ServiceAccountTokenProvider,
+    VertexClient,
+    VertexCredentialError,
+    VertexTokenProvider,
+    _vertex_model_id,
+)
+from exp.runtime.models.registry import RuntimeModelCatalog
+
+_BASE_URL = (
+    "https://us-central1-aiplatform.googleapis.com/v1"
+    "/projects/fixture-project/locations/us-central1"
+)
+
+
+def _generate_response() -> JsonObject:
+    """Return one minimal completed generateContent payload."""
+    return {
+        "modelVersion": "gemini-2.5-pro-001",
+        "candidates": [{"content": {"parts": [{"text": "Working."}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 12,
+            "candidatesTokenCount": 6,
+            "cachedContentTokenCount": 0,
+        },
+    }
+
+
+class _FakeCredentials:
+    """Deterministic refreshable credential recording every mint."""
+
+    def __init__(self, tokens: list[str | None]) -> None:
+        """Store the token values handed out by successive refresh calls.
+
+        Args:
+            tokens: Token values consumed in order, one per refresh.
+        """
+        self.valid = False
+        self.token: str | None = None
+        self.refresh_calls = 0
+        self._tokens = tokens
+
+    def refresh(self, request: object) -> None:
+        """Consume the next scripted token and mark the credential valid.
+
+        Args:
+            request: Transport object supplied by the provider; unused by the fake.
+        """
+        self.refresh_calls += 1
+        self.token = self._tokens.pop(0)
+        self.valid = True
+
+
+def test_vertex_routes_publisher_models_with_a_bearer_token() -> None:
+    """Completion posts to the publisher route with OAuth auth and Gemini payload shape."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_generate_response())]
+    )
+    client = VertexClient(
+        model=_snapshot("vertex", "gemini-2.5-pro"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=transport,
+        token_provider=lambda: "fixture-bearer-token",
+    )
+
+    response = client.complete(_request())
+
+    assert isinstance(client, ModelClient)
+    assert not isinstance(client, EmbeddingClient)
+    assert response.model.model_id == "gemini-2.5-pro-001"
+    assert response.output.content == "Working."
+    url, headers, payload = transport.requests[0]
+    assert url == f"{_BASE_URL}/publishers/google/models/gemini-2.5-pro:generateContent"
+    assert headers["authorization"] == "Bearer fixture-bearer-token"
+    assert "x-goog-api-key" not in headers
+    assert payload["contents"]
+    assert payload["systemInstruction"] == {"parts": [{"text": "You are precise."}]}
+
+
+def test_vertex_reads_the_token_provider_on_every_request() -> None:
+    """A renewed bearer token reaches the wire without rebuilding the client."""
+    transport = ScriptedJsonTransport(
+        [
+            JsonHttpResponse(status_code=200, body=_generate_response()),
+            JsonHttpResponse(status_code=200, body=_generate_response()),
+        ]
+    )
+    tokens = iter(("token-first", "token-second"))
+    client = VertexClient(
+        model=_snapshot("vertex", "gemini-2.5-pro"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=transport,
+        token_provider=lambda: next(tokens),
+    )
+
+    client.complete(_request())
+    client.complete(_request())
+
+    assert transport.requests[0][1]["authorization"] == "Bearer token-first"
+    assert transport.requests[1][1]["authorization"] == "Bearer token-second"
+
+
+def test_vertex_stream_path_targets_the_sse_route() -> None:
+    """Streaming reuses the Gemini SSE protocol on the publisher-scoped route."""
+    client = VertexClient(
+        model=_snapshot("vertex", "publishers/google/models/gemini-2.5-flash"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=lambda: "fixture-bearer-token",
+    )
+
+    path = client._stream_path()
+
+    assert path == "publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+
+
+def test_vertex_model_id_strips_resource_path_spellings() -> None:
+    """Catalog spellings with resource prefixes collapse onto the bare publisher model."""
+    assert _vertex_model_id("gemini-2.5-pro") == "gemini-2.5-pro"
+    assert _vertex_model_id("models/gemini-2.5-pro") == "gemini-2.5-pro"
+    assert _vertex_model_id("publishers/google/models/gemini-2.5-pro") == "gemini-2.5-pro"
+
+
+def test_service_account_provider_mints_once_and_serves_the_cached_token() -> None:
+    """A valid cached token is reused; the credential refreshes only when invalid."""
+    credentials = _FakeCredentials(tokens=["minted-token"])
+    provider = ServiceAccountTokenProvider("{}", credentials=credentials)
+
+    first = provider()
+    second = provider()
+
+    assert first == "minted-token"
+    assert second == "minted-token"
+    assert credentials.refresh_calls == 1
+
+
+def test_service_account_provider_renews_an_expired_token() -> None:
+    """An invalidated credential mints again instead of serving the stale token."""
+    credentials = _FakeCredentials(tokens=["minted-token", "renewed-token"])
+    provider = ServiceAccountTokenProvider("{}", credentials=credentials)
+
+    provider()
+    credentials.valid = False
+
+    assert provider() == "renewed-token"
+    assert credentials.refresh_calls == 2
+
+
+def test_service_account_provider_rejects_an_empty_minted_token() -> None:
+    """A refresh that yields no token fails with an actionable credential error."""
+    credentials = _FakeCredentials(tokens=[None])
+    provider = ServiceAccountTokenProvider("{}", credentials=credentials)
+
+    with pytest.raises(VertexCredentialError, match="no access token"):
+        provider()
+
+
+def test_service_account_provider_rejects_non_json_credentials() -> None:
+    """A pasted API key or other non-JSON value fails before any network use."""
+    with pytest.raises(VertexCredentialError, match="not valid JSON"):
+        ServiceAccountTokenProvider("AIzaSyFixtureNotAServiceAccount")
+
+
+def test_service_account_provider_rejects_a_non_object_credential() -> None:
+    """A bare JSON scalar cannot stand in for a service-account object."""
+    with pytest.raises(VertexCredentialError, match="JSON object"):
+        ServiceAccountTokenProvider('"just-a-string"')
+
+
+def test_catalog_resolution_builds_a_vertex_client_through_the_token_seam() -> None:
+    """RuntimeModelCatalog constructs Vertex clients without contacting Google."""
+    seen_credentials: list[str] = []
+
+    def factory(*, credentials_json: str) -> VertexTokenProvider:
+        """Record the routed credential and hand back a deterministic token provider."""
+        seen_credentials.append(credentials_json)
+        return lambda: "factory-token"
+
+    catalog = RuntimeModelCatalog(
+        ModelCatalog(
+            connections={
+                "vertex": ConnectionConfig(
+                    provider="vertex",
+                    base_url=_BASE_URL,
+                    api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+                )
+            },
+            models={
+                "gemini-pro": ModelRecord(
+                    billing_source=BillingSource.CUSTOMER_MANAGED,
+                    connection="vertex",
+                    model="gemini-2.5-pro",
+                    capabilities=ModelCapabilities(
+                        supports_tools=True,
+                        supports_completions=True,
+                        supports_embeddings=False,
+                    ),
+                )
+            },
+        ),
+        environment={"VERTEX_SERVICE_ACCOUNT_JSON": '{"type": "service_account"}'},
+        transport_factory=lambda: ScriptedJsonTransport(
+            [JsonHttpResponse(status_code=200, body=_generate_response())]
+        ),
+        vertex_token_provider_factory=factory,
+    )
+
+    snapshot, _capabilities = catalog.snapshot("gemini-pro")
+    resolved = catalog.resolve("gemini-pro")
+    response = resolved.client.complete(_request())
+
+    assert snapshot.provider == "vertex"
+    assert isinstance(resolved.client, VertexClient)
+    assert resolved.embedding_client is None
+    assert response.finish_reason == ModelFinishReason.COMPLETED
+    assert seen_credentials == ['{"type": "service_account"}']
+
+
+def test_catalog_rejects_vertex_connections_missing_their_endpoint_or_credential() -> None:
+    """Vertex connection metadata fails closed with actionable endpoint and credential errors."""
+    with pytest.raises(ValueError, match="vertex requires base_url"):
+        ConnectionConfig(provider="vertex", api_key_env="VERTEX_SERVICE_ACCOUNT_JSON")
+    with pytest.raises(ValueError, match="vertex requires api_key_env"):
+        ConnectionConfig(provider="vertex", base_url=_BASE_URL)
+    with pytest.raises(ValueError, match="region is only accepted"):
+        ConnectionConfig(
+            provider="vertex",
+            base_url=_BASE_URL,
+            api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+            region="us-central1",
+        )
+
+
+def test_setup_accepts_a_complete_vertex_connection() -> None:
+    """Programmatic setup collects Vertex with an endpoint root and a credential name."""
+    connection = ProviderConnection(
+        name="vertex-primary",
+        provider="vertex",
+        base_url=_BASE_URL,
+        api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+    )
+
+    config = connection.catalog_config()
+
+    assert config.provider == "vertex"
+    assert config.base_url == _BASE_URL
+    with pytest.raises(ValueError, match="vertex requires an explicit project-and-location"):
+        ProviderConnection(
+            name="vertex-primary",
+            provider="vertex",
+            api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+        )
+
+
+def test_vertex_error_status_surfaces_after_bounded_retries() -> None:
+    """Non-2xx provider answers raise instead of parsing a partial body."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=403, body={"error": {"status": "PERMISSION_DENIED"}})]
+    )
+    client = VertexClient(
+        model=_snapshot("vertex", "gemini-2.5-pro"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=transport,
+        token_provider=lambda: "fixture-bearer-token",
+    )
+
+    with pytest.raises(Exception, match="403"):
+        client.complete(_request())

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -98,6 +98,24 @@ def test_vertex_routes_publisher_models_with_a_bearer_token() -> None:
     assert payload["systemInstruction"] == {"parts": [{"text": "You are precise."}]}
 
 
+class _StatefulTokenProvider:
+    """Cached-token fake matching the provider contract of repeatable per-request calls."""
+
+    def __init__(self, token: str) -> None:
+        """Start with one current token value.
+
+        Args:
+            token: Bearer token served until the test replaces it.
+        """
+        self.token = token
+        self.calls = 0
+
+    def __call__(self) -> str:
+        """Count the read and return the current cached token."""
+        self.calls += 1
+        return self.token
+
+
 def test_vertex_reads_the_token_provider_on_every_request() -> None:
     """A renewed bearer token reaches the wire without rebuilding the client."""
     transport = ScriptedJsonTransport(
@@ -106,20 +124,45 @@ def test_vertex_reads_the_token_provider_on_every_request() -> None:
             JsonHttpResponse(status_code=200, body=_generate_response()),
         ]
     )
-    tokens = iter(("token-first", "token-second"))
+    provider = _StatefulTokenProvider("token-first")
     client = VertexClient(
         model=_snapshot("vertex", "gemini-2.5-pro"),
         api_key='{"placeholder": true}',
         base_url=_BASE_URL,
         transport=transport,
-        token_provider=lambda: next(tokens),
+        token_provider=provider,
     )
 
     client.complete(_request())
+    provider.token = "token-second"
     client.complete(_request())
 
     assert transport.requests[0][1]["authorization"] == "Bearer token-first"
     assert transport.requests[1][1]["authorization"] == "Bearer token-second"
+    assert provider.calls >= 2
+
+
+def test_vertex_refuses_to_send_tokens_to_non_google_hosts() -> None:
+    """Construction fails closed before any bearer token could leave for a foreign host."""
+    for base_url in (
+        "https://attacker.example.com/v1/projects/p/locations/us-central1",
+        "https://aiplatform.googleapis.com.evil.example/v1/projects/p/locations/us",
+        "http://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1",
+    ):
+        with pytest.raises(ValueError, match="aiplatform.googleapis.com"):
+            VertexClient(
+                model=_snapshot("vertex", "gemini-2.5-pro"),
+                api_key='{"placeholder": true}',
+                base_url=base_url,
+                transport=ScriptedJsonTransport(),
+                token_provider=lambda: "fixture-bearer-token",
+            )
+    with pytest.raises(ValueError, match="HTTPS Vertex AI host"):
+        ConnectionConfig(
+            provider="vertex",
+            base_url="https://attacker.example.com/v1/projects/p/locations/us-central1",
+            api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+        )
 
 
 def test_vertex_stream_path_targets_the_sse_route() -> None:

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 from exp.common.core.artifacts import JsonObject
@@ -16,6 +19,10 @@ from exp.common.models import (
     ModelRecord,
 )
 from exp.common.models.setup import ProviderConnection
+from exp.runtime.models.providers.async_transport import (
+    ProviderDeadlineExceeded,
+    RequestDeadline,
+)
 from exp.runtime.models.providers.openai_compatible_test import _request, _snapshot
 from exp.runtime.models.providers.transport import JsonHttpResponse, ScriptedJsonTransport
 from exp.runtime.models.providers.vertex import (
@@ -316,6 +323,52 @@ def test_setup_accepts_a_complete_vertex_connection() -> None:
             provider="vertex",
             api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
         )
+
+
+def test_vertex_token_refresh_is_bounded_by_the_request_deadline() -> None:
+    """A hung token mint surfaces the runtime's deadline error instead of outliving it."""
+
+    def stalled_provider() -> str:
+        """Simulate a token endpoint that answers far too late."""
+        time.sleep(0.5)
+        return "too-late-token"
+
+    client = VertexClient(
+        model=_snapshot("vertex", "gemini-2.5-pro"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=stalled_provider,
+    )
+
+    async def scenario() -> float:
+        """Time how quickly the deadline error reaches the caller inside the loop."""
+        started = time.monotonic()
+        with pytest.raises(ProviderDeadlineExceeded, match="token refresh"):
+            await client.complete_async(_request(), deadline=RequestDeadline.after(0.05))
+        return time.monotonic() - started
+
+    # asyncio.run itself may wait for the orphaned worker thread at loop shutdown; the
+    # bound under test is how quickly the caller inside the loop sees the deadline error.
+    assert asyncio.run(scenario()) < 0.4
+
+
+def test_vertex_token_refresh_fails_fast_on_an_already_spent_deadline() -> None:
+    """No token mint starts once the request-wide budget is exhausted."""
+    provider = _StatefulTokenProvider("unused-token")
+    client = VertexClient(
+        model=_snapshot("vertex", "gemini-2.5-pro"),
+        api_key='{"placeholder": true}',
+        base_url=_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=provider,
+    )
+    spent = RequestDeadline.after(10.0, now_monotonic=0.0)
+
+    with pytest.raises(ProviderDeadlineExceeded):
+        asyncio.run(client.complete_async(_request(), deadline=spent))
+
+    assert provider.calls == 0
 
 
 def test_vertex_error_status_surfaces_after_bounded_retries() -> None:

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -43,6 +43,7 @@ from exp.runtime.models.providers.tinker_sampling import (
     create_tinker_sampler,
 )
 from exp.runtime.models.providers.transport import JsonHttpTransport
+from exp.runtime.models.providers.vertex import VertexClient, VertexTokenProviderFactory
 
 ProviderTransport = AsyncJsonHttpTransport | JsonHttpTransport
 
@@ -124,6 +125,7 @@ class RuntimeModelCatalog:
         transport_factory: Callable[[], ProviderTransport] = HttpxAsyncJsonTransport,
         tinker_sampler_factory: TinkerSamplerFactory | None = None,
         bedrock_runtime_factory: BedrockRuntimeFactory | None = None,
+        vertex_token_provider_factory: VertexTokenProviderFactory | None = None,
     ) -> None:
         """Create a local resolver without importing SDK registries or contacting providers.
 
@@ -134,12 +136,15 @@ class RuntimeModelCatalog:
             tinker_sampler_factory: Optional deterministic test override for completed-handle
                 sampling. Omit it to use the runtime-owned Tinker SDK construction seam.
             bedrock_runtime_factory: Optional deterministic Bedrock runtime factory used by tests.
+            vertex_token_provider_factory: Optional deterministic Vertex bearer-token seam used
+                by tests. Omit it to mint tokens from the connection's service-account JSON.
         """
         self._catalog = catalog
         self._environment = os.environ if environment is None else environment
         self._transport_factory = transport_factory
         self._tinker_sampler_factory = tinker_sampler_factory
         self._bedrock_runtime_factory = bedrock_runtime_factory
+        self._vertex_token_provider_factory = vertex_token_provider_factory
 
     def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
         """Resolve static identity and exact capability evidence without provider access.
@@ -239,6 +244,33 @@ class RuntimeModelCatalog:
             connection_id=record.connection,
             environment=self._environment,
         )
+        if provider == "vertex":
+            if connection.base_url is None:
+                raise ModelConnectionError(
+                    f"Vertex alias {alias!r} needs connection.base_url naming the "
+                    "project-and-location root, such as https://us-central1-aiplatform."
+                    "googleapis.com/v1/projects/PROJECT/locations/us-central1"
+                )
+            token_provider = (
+                None
+                if self._vertex_token_provider_factory is None
+                else self._vertex_token_provider_factory(credentials_json=api_key)
+            )
+            vertex_client = VertexClient(
+                model=snapshot,
+                api_key=api_key,
+                base_url=connection.base_url,
+                transport=self._transport_factory(),
+                token_provider=token_provider,
+            )
+            return ResolvedModel(
+                alias,
+                snapshot,
+                capabilities,
+                vertex_client,
+                None,
+                served_model_id=record.served_model_id,
+            )
         if provider == "openai":
             openai_client = OpenAIClient(
                 model=snapshot,
@@ -397,6 +429,7 @@ class RuntimeModelCatalog:
             transport_factory=self._transport_factory,
             tinker_sampler_factory=self._tinker_sampler_factory,
             bedrock_runtime_factory=self._bedrock_runtime_factory,
+            vertex_token_provider_factory=self._vertex_token_provider_factory,
         )
 
 
@@ -407,7 +440,13 @@ _HTTP_PROVIDERS: Mapping[str, tuple[_HttpClientFactory, str | None]] = {
     "openrouter": (OpenRouterClient, OPENROUTER_BASE_URL),
 }
 
-SUPPORTED_PROVIDERS = frozenset(_HTTP_PROVIDERS) | {"azure", "bedrock", "openai", "tinker"}
+SUPPORTED_PROVIDERS = frozenset(_HTTP_PROVIDERS) | {
+    "azure",
+    "bedrock",
+    "openai",
+    "tinker",
+    "vertex",
+}
 """Every provider identifier the runtime registry can construct a client for."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     # Bedrock uses the official AWS runtime client. Imports stay lazy inside the Bedrock adapter.
     "boto3>=1.35,<2",
     "botocore>=1.35,<2",
+    # Vertex mints OAuth tokens from service-account JSON through Google's official credential
+    # library. Imports stay lazy inside the Vertex adapter, mirroring the Bedrock boundary.
+    "google-auth>=2.35,<3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,91 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -347,11 +432,61 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -382,43 +517,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -489,6 +624,7 @@ dependencies = [
     { name = "exp-gateway-native" },
     { name = "fastapi" },
     { name = "filelock" },
+    { name = "google-auth" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "openai" },
@@ -524,6 +660,7 @@ requires-dist = [
     { name = "experiential", extras = ["sft"], marker = "extra == 'dev'" },
     { name = "fastapi", specifier = ">=0.128" },
     { name = "filelock", specifier = ">=3.12" },
+    { name = "google-auth", specifier = ">=2.35,<3" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.7,<2" },
     { name = "numpy", specifier = ">=1.26" },
@@ -669,6 +806,19 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
 ]
 
 [[package]]
@@ -1317,7 +1467,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1356,7 +1506,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1368,7 +1518,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1398,9 +1548,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1412,7 +1562,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1847,6 +1997,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
     { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
     { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a `vertex` provider to the runtime: Google-published Vertex AI models served from a customer Google Cloud project, over the same `generateContent`/`streamGenerateContent` wire protocol as the Gemini provider.

## Design

- **Shared protocol, distinct identity.** `VertexClient` reuses `gemini_generate_request`, `gemini_generate_response`, and `start_gemini_generate_stream` wholesale. Only the route shape (`publishers/google/models/{model}` under a project-and-location `base_url` root) and authentication differ, so request shaping, response parsing, refusal mapping, and SSE normalization stay single-sourced in the Gemini modules.
- **Credential seam mirrors Bedrock.** Vertex authenticates with short-lived OAuth bearer tokens minted from a service-account JSON credential (the value of the connection's `api_key_env`; it never travels on the wire). `VertexTokenProvider` is the runtime-owned seam; `ServiceAccountTokenProvider` is the default implementation (google-auth, lazy-imported exactly like the Bedrock boto3 boundary, refresh-under-lock, roughly one blocking token mint per hour shared across concurrent requests). `RuntimeModelCatalog` accepts an optional `vertex_token_provider_factory` for deterministic tests, mirroring `bedrock_runtime_factory`.
- **Explicit capabilities required.** `vertex` joins `_EXPLICIT_CAPABILITY_PROVIDERS`: publisher names do not imply protocol support or prices, same as azure/bedrock/openai-compatible.
- **Catalog-and-API only for now.** `SETUP_PROVIDERS` accepts vertex for programmatic setup; the interactive `exp config providers` picker deliberately does not offer it (no half-flow), documented in `docs/reference/providers.md`. Embeddings are not supported on vertex connections (Vertex embeddings use a different `:predict` shape); the doc points at the `gemini` provider for that.

## Dependency

`google-auth>=2.35,<3`, the official Google credential library, used only inside the Vertex adapter with lazy imports, mirroring the boto3 comment and boundary in `pyproject.toml`.

## Platform integration surface

```python
RuntimeModelCatalog(catalog, vertex_token_provider_factory=...)  # optional test/DI seam

class VertexTokenProviderFactory(Protocol):
    def __call__(self, *, credentials_json: str) -> VertexTokenProvider: ...

# Catalog contract:
# connection: provider="vertex", base_url=project-and-location root, api_key_env=SA JSON env
# model record: bare publisher id such as "gemini-2.5-pro", explicit capabilities required
```

## Tests

13 new tests beside the module: publisher routing + bearer header + Gemini payload shape, per-request token reads (renewed token reaches the wire), stream route, model-id normalization, mint-once/renew-on-expiry/empty-token/malformed-credential paths on the token provider, non-2xx surfacing, `RuntimeModelCatalog` resolution through the injected factory, and catalog/setup validation (missing endpoint, missing credential, rejected region).

Gates: full `ruff check`, `ruff format --check`, `ty check`, and `pytest` (2354 passed; one clean-room wheel test failed once during a machine-wide network outage and passes in isolation).

Live verification note: a read-only publisher-models probe against real Vertex was blocked in this environment (`aiplatform.googleapis.com` not enabled on any accessible quota project; enabling APIs was out of bounds for this change). Wire shape follows the published Vertex `generateContent` contract and is pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
