### PR TITLE
Release 0.5.4: crate 0.1.4 plus a crate-bump CI guard

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -24,6 +24,21 @@ jobs:
           workspaces: exp/runtime/gateway/native
       - name: Install the project and its dev extras
         run: uv sync --extra dev
+      - name: Crate changes require a crate version bump
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          if git diff --quiet "origin/$GITHUB_BASE_REF"...HEAD -- exp/runtime/gateway/native/; then
+            echo "crate untouched"
+          elif git diff "origin/$GITHUB_BASE_REF"...HEAD -- exp/runtime/gateway/native/Cargo.toml | grep -q '^+version = '; then
+            echo "crate changed and version bumped"
+          else
+            echo "exp/runtime/gateway/native/ changed without bumping the crate version;" >&2
+            echo "published wheels are immutable per version, so bump Cargo.toml and the" >&2
+            echo "crate pyproject together (the lockstep test keeps them and the" >&2
+            echo "dependency floor aligned)." >&2
+            exit 1
+          fi
       - name: cargo fmt
         run: cargo fmt --check --manifest-path exp/runtime/gateway/native/Cargo.toml
       - name: cargo clippy

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -33,8 +33,12 @@ jobs:
           # Published wheels are immutable per version, so any change under the
           # crate must move the crate version. GitHub's merge-base file list is
           # authoritative and needs no local history (the checkout is shallow).
-          changed="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-            --paginate -q '.[].filename' | grep -c '^exp/runtime/gateway/native/' || true)"
+          files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --paginate -q '.[].filename')" || {
+            echo "could not list the pull request's files; failing closed" >&2
+            exit 1
+          }
+          changed="$(printf '%s\n' "${files}" | grep -c '^exp/runtime/gateway/native/' || true)"
           if [ "${changed}" = "0" ]; then
             echo "crate untouched"
             exit 0

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -26,19 +26,31 @@ jobs:
         run: uv sync --extra dev
       - name: Crate changes require a crate version bump
         if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
-          if git diff --quiet "origin/$GITHUB_BASE_REF"...HEAD -- exp/runtime/gateway/native/; then
+          # Published wheels are immutable per version, so any change under the
+          # crate must move the crate version. GitHub's merge-base file list is
+          # authoritative and needs no local history (the checkout is shallow).
+          changed="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --paginate -q '.[].filename' | grep -c '^exp/runtime/gateway/native/' || true)"
+          if [ "${changed}" = "0" ]; then
             echo "crate untouched"
-          elif git diff "origin/$GITHUB_BASE_REF"...HEAD -- exp/runtime/gateway/native/Cargo.toml | grep -q '^+version = '; then
-            echo "crate changed and version bumped"
-          else
-            echo "exp/runtime/gateway/native/ changed without bumping the crate version;" >&2
-            echo "published wheels are immutable per version, so bump Cargo.toml and the" >&2
-            echo "crate pyproject together (the lockstep test keeps them and the" >&2
-            echo "dependency floor aligned)." >&2
-            exit 1
+            exit 0
           fi
+          head_version="$(grep -m1 '^version = ' exp/runtime/gateway/native/Cargo.toml)"
+          base_version="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/exp/runtime/gateway/native/Cargo.toml?ref=${GITHUB_BASE_REF}" \
+            -q .content | base64 -d | grep -m1 '^version = ')"
+          if [ "${head_version}" != "${base_version}" ]; then
+            echo "crate changed and version moved: ${base_version} -> ${head_version}"
+            exit 0
+          fi
+          echo "exp/runtime/gateway/native/ changed without moving the crate version" >&2
+          echo "(${head_version}); bump Cargo.toml and the crate pyproject together" >&2
+          echo "so the release can publish fresh wheels." >&2
+          exit 1
       - name: cargo fmt
         run: cargo fmt --check --manifest-path exp/runtime/gateway/native/Cargo.toml
       - name: cargo clippy

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.1.3"
+version = "0.1.4"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.5.3"
+version = "0.5.4"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.1.3,<0.2",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.1.4,<0.2",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -475,12 +475,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.1.3"
+version = "0.1.4"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Cuts 0.5.4 with exp-gateway-native 0.1.4: the published 0.1.3 wheels predate #617's `/metrics` route, so no release currently contains it and the crate content has drifted from its published version for the second time.

Beyond the bumps, the gate gains a guard that fails any PR touching `exp/runtime/gateway/native/` without a crate version bump, since published wheels are immutable per version. Together with the existing lockstep test (manifests and dependency floor agree), version drift against PyPI is now structurally impossible.

This release also unblocks the platform released-only pinning rule: it will pin `experiential==0.5.4` from PyPI and drop its git sources and Rust builder stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)