### PR TITLE
fix(cli): make Run Gateway the first home option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,9 @@ uv run pytest -q
   World-model fidelity testing is a separately invoked common-evaluation mode with no authority
   over router fitting or runtime activation. Its reports contain measurements only and never carry
   an approval, denial, gate, threshold, or decision.
-- `exp` opens the branded home screen. Its `Default Gateway` choice starts the initialized
-  authenticated multi-alias gateway on loopback, while `exp --project PROJECT --root ROOT --port
+- `exp` opens the branded home screen. Its `Run Gateway` choice starts the initialized
+  authenticated multi-alias gateway on loopback, running first-time setup when no gateway exists,
+  while `exp --project PROJECT --root ROOT --port
   PORT [--ghost]` retains the single-project compatibility server. Both expose OpenAI Chat
   Completions, Responses, and Models routes. Public request and
   response types come

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -2,7 +2,7 @@
 
 ## Supported surface
 
-`exp` opens the default gateway home screen. Its `Default Gateway` choice starts an authenticated
+`exp` opens the gateway home screen. Its `Run Gateway` choice starts an authenticated
 multi-alias gateway on `127.0.0.1`.
 It serves:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@ The root surface is deliberately small:
 
 | Command | Purpose | Local result |
 |---|---|---|
-| `exp` | Open the branded home screen. `Default Gateway` is the recommended setup-and-start path. | Interactive gateway menu, or the default gateway in a non-interactive terminal. |
+| `exp` | Open the branded home screen. `Run Gateway` is the first option and runs setup when needed. | Interactive gateway menu, or the default gateway in a non-interactive terminal. |
 | `exp login [--root ROOT]` | Sign in to Experiential Cloud through the Platform browser approval flow, save the returned organization key, and synchronize the authenticated account's model identities. | User-local credential plus secret-free hosted provider/model records in `.exp/models.toml`. |
 | `exp run [PROJECT] [--root ROOT] [--check] [--engine auto\|rust\|python]` | Start the local gateway directly, optionally with one project-backed alias. | OpenAI-compatible endpoint, readiness routes, and content-free usage view. |
 | `exp build PROJECT [-t PATH] --source SOURCE --root ROOT [--provider NAME ...]` | Launch the guided end-to-end build when traces are omitted, or use one explicit local source for automation. | Simulation, serving RAG, fit RAG, syllabus, evaluation evidence, and a runnable automatic router. |

--- a/exp/cli/gateway/home.py
+++ b/exp/cli/gateway/home.py
@@ -1,4 +1,4 @@
-"""Interactive home screen for the default Experiential gateway flow."""
+"""Interactive home screen for the Experiential gateway flow."""
 
 from __future__ import annotations
 
@@ -24,24 +24,14 @@ from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUn
 
 _MENU_OPTIONS = (
     PickerOption(
-        value="default",
-        label="Default Gateway",
-        detail="recommended happy path: setup if needed, then start",
-    ),
-    PickerOption(
         value="run",
         label="Run Gateway",
-        detail="start an already configured local gateway",
+        detail="set up if needed, then start",
     ),
     PickerOption(
         value="setup",
         label="Setup Gateway",
         detail="choose providers, a model, an alias, and a key",
-    ),
-    PickerOption(
-        value="status",
-        label="Gateway Status",
-        detail="show content-free local gateway counts",
     ),
     PickerOption(value="exit", label="Exit"),
 )
@@ -118,7 +108,7 @@ def default_gateway(
             output,
             title="What would you like to do?",
             options=_MENU_OPTIONS,
-            default="default",
+            default="run",
         )
         if selection.action in {PickerAction.BACK, PickerAction.CANCEL}:
             _render_exit(output)
@@ -127,22 +117,11 @@ def default_gateway(
             _render_exit(output)
             return
         choice = selection.values[0]
-        if choice == "default":
+        if choice == "run":
             if _start_from_menu(
                 output,
                 root=root,
                 port=port,
-                graceful_timeout=graceful_timeout,
-                engine=engine,
-                max_active_requests=max_active_requests,
-            ):
-                return
-        elif choice == "run":
-            if _start_from_menu(
-                output,
-                root=root,
-                port=port,
-                non_interactive=True,
                 graceful_timeout=graceful_timeout,
                 engine=engine,
                 max_active_requests=max_active_requests,
@@ -150,8 +129,6 @@ def default_gateway(
                 return
         elif choice == "setup":
             _setup_from_menu(output, root=root, port=port)
-        elif choice == "status":
-            _show_status(output, root=root)
         else:
             _render_exit(output)
             return
@@ -201,7 +178,6 @@ def _start_from_menu(
     *,
     root: Path,
     port: int,
-    non_interactive: bool = False,
     graceful_timeout: float,
     engine: str,
     max_active_requests: int,
@@ -215,7 +191,7 @@ def _start_from_menu(
         start_gateway(
             root=root,
             port=port,
-            non_interactive=non_interactive,
+            non_interactive=False,
             graceful_timeout=graceful_timeout,
             engine=engine,
             max_active_requests=max_active_requests,
@@ -279,24 +255,7 @@ def _setup_from_menu(console: Console, *, root: Path, port: int) -> None:
         return
     emit_setup_credentials(port=port, setup=setup, console=console)
     outcome = "reconfigured" if reconfigure else "configured"
-    console.print(f"[green]✓ Gateway {outcome}[/green] Choose Default Gateway to start it.")
-
-
-def _show_status(console: Console, *, root: Path) -> None:
-    """Render content-free gateway counts without creating local state."""
-    status = GatewayManagement(root).status()
-    if not status.initialized:
-        console.print("[yellow]Gateway not configured[/yellow]")
-        console.print("[dim]Choose Setup Gateway to create the default local gateway.[/dim]")
-        return
-    console.print("[green]✓ Gateway configured[/green]")
-    console.print(
-        "[dim]"
-        f"identities={status.active_identities} keys={status.active_keys} "
-        f"aliases={status.active_aliases} providers={status.active_provider_connections} "
-        f"grants={status.grants}"
-        "[/dim]"
-    )
+    console.print(f"[green]✓ Gateway {outcome}[/green] Choose Run Gateway to start it.")
 
 
 def _render_exit(console: Console) -> None:

--- a/exp/cli/gateway/home_test.py
+++ b/exp/cli/gateway/home_test.py
@@ -1,4 +1,4 @@
-"""Tests for the branded default gateway home screen."""
+"""Tests for the branded gateway home screen."""
 
 from __future__ import annotations
 
@@ -17,25 +17,26 @@ from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 
 
-def test_home_screen_starts_with_brand_and_recommends_default_gateway(tmp_path: Path) -> None:
-    """The first interactive screen presents the green EXP brand and happy path first."""
-    console = ScriptedConsole("5\n")
+def test_home_screen_starts_with_brand_and_puts_run_gateway_first(tmp_path: Path) -> None:
+    """The first interactive screen puts the setup-aware run path first."""
+    console = ScriptedConsole("3\n")
 
     home.default_gateway(root=tmp_path, console=console)
 
     assert "exp" in console.output
     assert "Experiential gateway" in console.output
-    assert "Default Gateway" in console.output
-    assert "recommended happy path" in console.output
     assert "Run Gateway" in console.output
     assert "Setup Gateway" in console.output
+    assert "Gateway Status" not in console.output
+    assert "Default Gateway" not in console.output
+    assert console.output.index("Run Gateway") < console.output.index("Setup Gateway")
 
 
-def test_default_gateway_menu_starts_the_recommended_path(
+def test_run_gateway_menu_starts_with_setup_allowed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The focused default row starts an ordinary gateway with interactive setup allowed."""
+    """The first menu row starts an ordinary gateway with setup allowed."""
     calls: list[dict[str, object]] = []
 
     def start(**kwargs: object) -> None:
@@ -57,26 +58,6 @@ def test_default_gateway_menu_starts_the_recommended_path(
     ]
 
 
-def test_run_gateway_menu_uses_the_existing_configuration_only(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The explicit run row never opens first-run setup prompts."""
-    calls: list[dict[str, object]] = []
-
-    def start(**kwargs: object) -> None:
-        """Capture the gateway launch selected by the home screen."""
-        calls.append(kwargs)
-
-    monkeypatch.setattr(home, "start_gateway", start)
-    home.default_gateway(root=tmp_path, console=ScriptedConsole("2\n"))
-
-    assert calls[0]["root"] == tmp_path
-    assert calls[0]["non_interactive"] is True
-    assert calls[0]["engine"] == "auto"
-    assert calls[0]["max_active_requests"] == DEFAULT_MAX_ACTIVE_REQUESTS
-
-
 @pytest.mark.parametrize(
     ("policy", "ghost"),
     [("policy-a", False), (None, True)],
@@ -92,7 +73,7 @@ def test_project_only_gateway_options_validate_before_home_menu(
             root=tmp_path,
             policy=policy,
             ghost=ghost,
-            console=ScriptedConsole("5\n"),
+            console=ScriptedConsole("3\n"),
         )
 
 
@@ -109,13 +90,13 @@ def test_setup_gateway_returns_to_home_with_one_time_credentials(
             raw_key="exp_vk_test",
         ),
     )
-    console = ScriptedConsole("3\n5\n")
+    console = ScriptedConsole("2\n3\n")
 
     home.default_gateway(root=tmp_path, console=console)
 
     assert "export EXP_GATEWAY_URL=http://127.0.0.1:8000/v1" in console.output
     assert "export EXP_GATEWAY_KEY=exp_vk_test" in console.output
-    assert "Choose Default Gateway to start it." in console.output
+    assert "Choose Run Gateway to start it." in console.output
 
 
 def test_setup_gateway_warns_and_reconfigures_an_initialized_gateway(
@@ -136,7 +117,7 @@ def test_setup_gateway_warns_and_reconfigures_an_initialized_gateway(
         )
 
     monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
-    console = ScriptedConsole("3\ny\n5\n")
+    console = ScriptedConsole("2\ny\n3\n")
 
     home.default_gateway(root=tmp_path, console=console)
 
@@ -173,7 +154,7 @@ def test_setup_gateway_preserves_a_key_when_reconfiguration_outcome_is_unknown(
         )
 
     monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
-    console = ScriptedConsole("3\ny\n5\n")
+    console = ScriptedConsole("2\ny\n3\n")
 
     home.default_gateway(root=tmp_path, console=console)
 
@@ -197,7 +178,7 @@ def test_setup_gateway_declines_initialized_gateway_reconfiguration(
         raise AssertionError("setup should not run after a declined reconfiguration")
 
     monkeypatch.setattr("exp.cli.gateway.setup.interactive_gateway_setup", setup_gateway)
-    console = ScriptedConsole("3\n\n5\n")
+    console = ScriptedConsole("2\n\n3\n")
 
     home.default_gateway(root=tmp_path, console=console)
 


### PR DESCRIPTION
## Summary
- make Run Gateway the first home-screen option
- run first-time setup automatically when the gateway is uninitialized
- remove Default Gateway and Gateway Status from the home menu
- update focused tests and gateway documentation

## Verification
- exp/cli/gateway: 95 passed
- exp/cli/gateway/home_test.py: 8 passed
- Ruff check and format check passed
- ty check exp passed

Ready for review.