### PR TITLE
Release 0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.5.4"
+version = "0.5.5"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for 0.5.5: the complete native engine — multi-attempt certified waterfall with per-attempt accounting (#623), rust-only engine mode with the python engine deprecated (#625), the native Anthropic Messages surface (#621), and native Gemini (#622) and Bedrock (#624) dialects with dispatch-time SigV4 signing. exp-gateway-native ships as 0.1.12 (already bumped per-change by the CI guard; published latest is 0.1.4, so all wheel filenames are fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)