### PR TITLE
release: 0.5.6 (Vertex runtime)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.5.5"
+version = "0.5.6"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only: 0.5.5 -> 0.5.6 (pyproject + lock).

0.5.5 was published at 04:57 UTC today, before #618 (Vertex AI runtime, dc719775) merged, so no released wheel carries the vertex provider. The platform consumes experiential as exact-pinned PyPI releases only (its deploy guard forbids git pins), so adopting Vertex serving requires this release.

After merge: publish GitHub release v0.5.6 to trigger the PyPI publish per python-package.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)