### PR TITLE
Accept OpenAI end-user attribution fields (safety_identifier / user / prompt_cache_key)

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -137,8 +137,28 @@ class GatewayRequest(ContractModel):
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: JsonObject = Field(default_factory=dict)
+    # End-user attribution / cache hints from the OpenAI request. Captured for
+    # gateway-side attribution and never forwarded to the model. `safety_identifier`
+    # is the current stable end-user identifier; `user` its deprecated predecessor;
+    # `prompt_cache_key` a same-prefix cache-routing hint (never an identity).
+    safety_identifier: str | None = Field(default=None, max_length=1024)
+    user: str | None = Field(default=None, max_length=1024)
+    prompt_cache_key: str | None = Field(default=None, max_length=1024)
     idempotency_key: str | None = Field(default=None, min_length=1, max_length=512)
     client_request_id: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @property
+    def attribution_label(self) -> str | None:
+        """The end-user attribution label for this request, per the OpenAI spec.
+
+        Prefers the current `safety_identifier`; falls back to the deprecated
+        `user` field for older clients. `prompt_cache_key` is deliberately never
+        used here — it is a cache-routing hint, not an end-user identity.
+
+        Returns:
+            The attribution label, or None when the caller sent neither field.
+        """
+        return self.safety_identifier or self.user
 
     @field_validator("stop")
     @classmethod
@@ -335,6 +355,9 @@ class AuthorizationSnapshot(ContractModel):
     """Caller-supplied ``HTTP-Referer`` app identity, content-free and never a credential."""
     app_title: str | None = Field(default=None, max_length=256)
     """Caller-supplied ``X-Title`` app label used only for content-free app attribution."""
+    attribution_label: str | None = Field(default=None, max_length=1024)
+    """End-user attribution from the OpenAI ``safety_identifier`` (or deprecated
+    ``user``) request field: content-free and never a credential."""
 
 
 class ExecutionSnapshot(ContractModel):

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -50,6 +50,13 @@ CHAT_MANIFEST = CompatibilityManifest(
             "structured_output",
         ),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
+        # End-user attribution / cache hints (OpenAI spec). Accepted and recorded
+        # gateway-side, never forwarded to the model: `safety_identifier` is the
+        # current stable end-user identifier, `user` its deprecated predecessor,
+        # `prompt_cache_key` a same-prefix cache-routing hint (not identity).
+        _field("safety_identifier", CompatibilityDisposition.METADATA_ONLY),
+        _field("user", CompatibilityDisposition.METADATA_ONLY),
+        _field("prompt_cache_key", CompatibilityDisposition.METADATA_ONLY),
         *(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
             for path in (
@@ -68,7 +75,6 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "service_tier",
                 "store",
                 "top_logprobs",
-                "user",
                 "verbosity",
                 "web_search_options",
             )
@@ -101,6 +107,11 @@ RESPONSES_MANIFEST = CompatibilityManifest(
         ),
         _field("text", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "structured_output"),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
+        # End-user attribution / cache hints (OpenAI spec), same handling as the
+        # Chat surface: accepted and recorded gateway-side, never forwarded.
+        _field("safety_identifier", CompatibilityDisposition.METADATA_ONLY),
+        _field("user", CompatibilityDisposition.METADATA_ONLY),
+        _field("prompt_cache_key", CompatibilityDisposition.METADATA_ONLY),
         *(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
             for path in (
@@ -116,7 +127,6 @@ RESPONSES_MANIFEST = CompatibilityManifest(
                 "top_logprobs",
                 "top_p",
                 "truncation",
-                "user",
             )
         ),
     ),

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -202,6 +202,10 @@ class _ChatRequest(_WireModel):
     stream: bool = False
     stream_options: _ChatStreamOptions | None = None
     metadata: JsonObject = Field(default_factory=dict)
+    # End-user attribution / cache hints; captured, never forwarded to the model.
+    safety_identifier: str | None = Field(default=None, max_length=1024)
+    user: str | None = Field(default=None, max_length=1024)
+    prompt_cache_key: str | None = Field(default=None, max_length=1024)
 
     @model_validator(mode="after")
     def _require_coherent_options(self) -> _ChatRequest:
@@ -279,6 +283,10 @@ class _ResponsesRequest(_WireModel):
     text: _ResponseText | None = None
     stream: bool = False
     metadata: JsonObject = Field(default_factory=dict)
+    # End-user attribution / cache hints; captured, never forwarded to the model.
+    safety_identifier: str | None = Field(default=None, max_length=1024)
+    user: str | None = Field(default=None, max_length=1024)
+    prompt_cache_key: str | None = Field(default=None, max_length=1024)
 
 
 def decode_chat(
@@ -335,6 +343,9 @@ def decode_chat(
                 request.stream_options is not None and request.stream_options.include_usage
             ),
             metadata=request.metadata,
+            safety_identifier=request.safety_identifier,
+            user=request.user,
+            prompt_cache_key=request.prompt_cache_key,
             idempotency_key=operation if idempotency_key is not None else None,
             client_request_id=operation if client_request_id is not None else None,
         )
@@ -382,6 +393,9 @@ def decode_responses(
             stream=request.stream,
             previous_response_id=request.previous_response_id,
             metadata=request.metadata,
+            safety_identifier=request.safety_identifier,
+            user=request.user,
+            prompt_cache_key=request.prompt_cache_key,
             idempotency_key=operation if idempotency_key is not None else None,
             client_request_id=operation if client_request_id is not None else None,
         )

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -529,3 +529,60 @@ def test_empty_responses_input_is_a_public_protocol_error() -> None:
         decode_responses({"model": "coding", "input": []})
     assert captured.value.detail.code == "invalid_parameter"
     assert captured.value.detail.param == "messages"
+
+
+def test_chat_decoder_captures_end_user_attribution_and_cache_hint() -> None:
+    """safety_identifier/user/prompt_cache_key are captured; the label prefers safety_identifier."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "safety_identifier": "sha256:abc",
+            "user": "legacy-user",
+            "prompt_cache_key": "prompt_v1:sess",
+        }
+    )
+    request = decoded.request
+    assert request.safety_identifier == "sha256:abc"
+    assert request.user == "legacy-user"
+    assert request.prompt_cache_key == "prompt_v1:sess"
+    # The current safety_identifier wins over the deprecated user for attribution.
+    assert request.attribution_label == "sha256:abc"
+
+
+def test_chat_attribution_label_falls_back_to_deprecated_user() -> None:
+    """With no safety_identifier, the deprecated user field still labels the request."""
+    decoded = decode_chat(
+        {"model": "coding", "messages": [{"role": "user", "content": "hi"}], "user": "u-1"}
+    )
+    assert decoded.request.safety_identifier is None
+    assert decoded.request.attribution_label == "u-1"
+
+
+def test_prompt_cache_key_is_never_an_attribution_label() -> None:
+    """prompt_cache_key is a cache-routing hint, not an end-user identity."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt_cache_key": "pck",
+        }
+    )
+    assert decoded.request.prompt_cache_key == "pck"
+    assert decoded.request.attribution_label is None
+
+
+def test_responses_decoder_captures_end_user_attribution() -> None:
+    """The Responses surface captures the same attribution/cache fields as Chat."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": "hi",
+            "safety_identifier": "sid-9",
+            "prompt_cache_key": "pck-1",
+        }
+    )
+    request = decoded.request
+    assert request.safety_identifier == "sid-9"
+    assert request.prompt_cache_key == "pck-1"
+    assert request.attribution_label == "sid-9"


### PR DESCRIPTION
## Why
The gateway currently **400s** on the OpenAI end-user attribution fields — `safety_identifier`, `user`, and `prompt_cache_key` are marked `UNSUPPORTED` on both Chat Completions and Responses. Those are standard OpenAI request fields, so rejecting them breaks drop-in compatibility, and it blocks the platform from slicing usage/spend by end user.

Per the current OpenAI spec: **`user` is deprecated**, split into **`safety_identifier`** (the stable end-user identifier, recommended to be a hash of username/email, used for abuse monitoring) and **`prompt_cache_key`** (a same-prefix cache-routing hint — *not* an identity). Both are on Chat Completions and Responses; identifiers don't carry across APIs.

## What
- **manifest**: `safety_identifier`, `user`, `prompt_cache_key` move from `UNSUPPORTED` → `METADATA_ONLY` on both surfaces — accepted and recorded gateway-side, **never forwarded to the model**.
- **wire models + decode**: `_ChatRequest`/`_ResponsesRequest` carry the three fields into `GatewayRequest`.
- **`GatewayRequest.attribution_label`**: prefers the current `safety_identifier`, falls back to the deprecated `user`. `prompt_cache_key` is deliberately **never** used for attribution.
- **`AuthorizationSnapshot.attribution_label`**: so the platform ledger can persist + group by it (sits alongside the existing content-free `app_referer`/`app_title`).

All content-free, per-API, never a credential.

## Tests
- New coverage in `requests_test.py`: capture on both surfaces, `safety_identifier` preferred over `user`, `user` fallback, and `prompt_cache_key` never yielding a label.
- `uv run ruff check` + `uv run ty check` clean on the touched modules; `857 passed` across `exp/runtime/{gateway,openai_protocol,models}`.

## Follow-up
This is the engine half. A release (version bump + PyPI publish) is needed before the platform can pin it; the platform side then adds an `attribution_label` ledger column + a "By label" usage breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)