### PR TITLE
Gateway error clarity: local stop-limit rejection + output-ceiling clamp

### DIFF
--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -223,6 +223,13 @@ class GatewayDeploymentCapabilities(ContractModel):
     supports_parallel_tool_calls: bool = False
     supports_structured_text: bool = False
     supports_stop_sequences: bool = False
+    maximum_stop_sequences: int | None = Field(default=None, ge=1)
+    """Largest stop-sequence count this route accepts, when the provider caps it.
+
+    ``None`` leaves the count unbounded (only ``supports_stop_sequences`` gates the
+    field). A concrete value lets admission reject an over-limit list locally with a
+    named parameter error instead of forwarding it and surfacing the provider's
+    opaque 4xx (e.g. Gemini caps ``stopSequences`` at 5)."""
     reports_refusals: bool = False
     reports_cached_input_tokens: bool = False
     reports_reasoning_tokens: bool = False

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -532,8 +532,20 @@ def maximum_attempt_cost_micro_usd(
     """
     input_tokens = len(canonical_json_bytes(request))
     output_tokens = request.maximum_output_tokens
-    if output_tokens is None and deployment.capabilities is not None:
-        output_tokens = deployment.capabilities.maximum_output_tokens
+    deployment_ceiling = (
+        deployment.capabilities.maximum_output_tokens
+        if deployment.capabilities is not None
+        else None
+    )
+    # The physical call can never emit more than the deployment's own ceiling,
+    # so clamp the caller's requested output to it before the worst case. A huge
+    # or unbounded caller value would otherwise inflate the estimate past
+    # MAXIMUM_MICRO_USD, return None, and mis-terminalize a fundable request as
+    # a quota refusal. Settlement still charges actual tokens, not this bound.
+    if output_tokens is None:
+        output_tokens = deployment_ceiling
+    elif deployment_ceiling is not None:
+        output_tokens = min(output_tokens, deployment_ceiling)
     if output_tokens is None:
         return None
     prices = deployment.gateway.prices

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -228,6 +228,30 @@ def test_maximum_attempt_cost_is_integer_conservative_and_unknown_prices_fail_cl
     )
 
 
+def test_huge_caller_output_ceiling_clamps_to_deployment_instead_of_failing_closed() -> None:
+    """A caller output ceiling above the deployment's own is clamped, not None.
+
+    Without the clamp a very large caller ``maximum_output_tokens`` inflates the
+    worst case past ``MAXIMUM_MICRO_USD`` and returns ``None``, which fails a
+    perfectly fundable request closed and mis-terminalizes it as a quota refusal.
+    The deployment can never emit more than its own ceiling, so the output term
+    clamps to it: the huge request stays a small bounded int, differing from the
+    at-ceiling request only by the extra JSON bytes of the larger literal.
+    """
+    deployment = _deployment()  # ModelCapabilities(maximum_output_tokens=16)
+    bounded = maximum_attempt_cost_micro_usd(_request("four bytes"), deployment)
+    huge = maximum_attempt_cost_micro_usd(
+        _request("four bytes").model_copy(update={"maximum_output_tokens": 10**12}),
+        deployment,
+    )
+
+    assert bounded is not None
+    assert huge is not None and isinstance(huge, int)
+    # Output is clamped to the ceiling; only the input-byte count of the larger
+    # literal differs, so the two stay within a handful of micro-USD of each other.
+    assert abs(huge - bounded) < 100
+
+
 def test_concurrent_identity_reservations_never_exceed_hard_limit(tmp_path: Path) -> None:
     """BEGIN IMMEDIATE serializes competing reservations before attempt insertion."""
     clock = _Clock()

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -14,7 +14,10 @@ from exp.runtime.models.providers.async_transport import (
     run_then_close_pooled_client,
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
-from exp.runtime.models.providers.errors import ProviderCapabilityError
+from exp.runtime.models.providers.errors import (
+    ProviderCapabilityError,
+    ProviderParameterError,
+)
 
 
 class AsyncCompletedModelClient(Protocol):
@@ -233,6 +236,16 @@ def preflight_gateway_request(
     for requested, supported, capability in requirements:
         if requested and not supported:
             raise ProviderCapabilityError(capability=capability)
+    stop_limit = capabilities.maximum_stop_sequences
+    if stop_limit is not None and len(request.stop) > stop_limit:
+        raise ProviderParameterError(
+            message=(
+                f"This model route accepts at most {stop_limit} stop "
+                f"sequences; the request supplied {len(request.stop)}."
+            ),
+            param="stop",
+            code="too_many_stop_sequences",
+        )
 
 
 def require_gateway_provider(provider: str) -> None:

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -24,7 +24,10 @@ from exp.runtime.gateway.contracts import (
     GatewayToolDefinition,
 )
 from exp.runtime.models.providers.async_transport import RequestDeadline
-from exp.runtime.models.providers.errors import ProviderCapabilityError
+from exp.runtime.models.providers.errors import (
+    ProviderCapabilityError,
+    ProviderParameterError,
+)
 from exp.runtime.models.providers.protocol import (
     BoundedSyncModelClientAdapter,
     SyncModelClientAdapter,
@@ -178,6 +181,29 @@ def test_preflight_treats_false_parallel_control_as_semantic() -> None:
 
     with pytest.raises(ProviderCapabilityError, match="parallel_tool_calls"):
         preflight_gateway_request(request, GatewayDeploymentCapabilities())
+
+
+def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -> None:
+    """An over-cap stop list fails locally instead of surfacing the provider's opaque 4xx."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        stop=("a", "b", "c", "d", "e", "f"),
+    )
+    capabilities = GatewayDeploymentCapabilities(
+        supports_stop_sequences=True,
+        maximum_stop_sequences=5,
+    )
+
+    with pytest.raises(ProviderParameterError) as caught:
+        preflight_gateway_request(request, capabilities)
+    assert caught.value.param == "stop"
+    assert caught.value.code == "too_many_stop_sequences"
+
+    # At the limit passes, and an unbounded route (default None) never counts.
+    at_limit = request.model_copy(update={"stop": ("a", "b", "c", "d", "e")})
+    preflight_gateway_request(at_limit, capabilities)
+    preflight_gateway_request(request, GatewayDeploymentCapabilities(supports_stop_sequences=True))
 
 
 def test_tinker_is_explicitly_excluded_from_gateway_execution() -> None:


### PR DESCRIPTION
## Gateway error clarity: two shipped fixes, three scoped follow-ups

Each fix is independent (drop either commit). Both trace to failure modes reproduced end to end against the live gateway this week, and both are Python on the admission/reservation path that survives the Rust data-plane migration (#629). No provider content, secrets, or free-text bodies enter any error, ledger, or log.

### Shipped

**1. Reject over-limit stop lists locally with a named parameter error** (`3c40b4c3`)
A route can support stop sequences yet cap the count — Gemini's direct lane accepts at most 5. `preflight_gateway_request` only checked the boolean `supports_stop_sequences`, so a longer list was forwarded to Google and returned the opaque `provider rejected the request; verify the request fields` 4xx.
- Reproduced in production: `stop` with 6 sequences 400s on the gemini direct lane; 5 passes (byte-identical to the incident rows).
- Adds `maximum_stop_sequences` to `GatewayDeploymentCapabilities` (default `None` = unbounded, non-breaking) and enforces it in preflight with `ProviderParameterError(param="stop", code="too_many_stop_sequences")` naming the limit — matching every other pre-dispatch parameter rejection.
- Before: forwarded → provider 400 → opaque `invalid_request`. After: local named rejection an agent can self-correct from.
- Follow-up: populating the per-lane value (gemini = 5) is a catalog-authoring step (set `maximum_stop_sequences` on the gemini deployment capability in the launch catalog).

**3. Clamp the caller output ceiling to the deployment before the cost worst case** (`c44f052b`)
`maximum_attempt_cost_micro_usd` used the raw caller `maximum_output_tokens`, so an unbounded/huge value inflated the worst case past `MAXIMUM_MICRO_USD`, returned `None`, and failed a fundable request closed — mis-terminalized as a quota refusal (the caller-driven twin of the catalog-capability `None` source fixed in platform #877).
- The physical call can never emit more than the deployment ceiling, so clamp to it before the estimate. Settlement still charges actual tokens; this only tightens a conservative bound.

### Validation
`ruff format`/`check` clean, `ty check` clean, and 826 passed across `exp/common/models`, `exp/runtime/gateway`, `exp/runtime/models/providers` (incl. the two added regression tests). Nothing merged.

### Scoped follow-ups (Rust data plane — not in this PR)
These are engine-owned in the native gateway and need the Rust build/parity-golden cycle; documented with exact targets rather than shipped unverified:

- **Admission/internal cause tags** (`exp/runtime/gateway/native/src/admission.rs`): the admit and reserve seams both surface `PublicError::internal()` ("gateway admission failed before provider dispatch") with no way to tell authority vs accounting vs wire-resolution apart. Add a coarse content-free cause tag. (M4, reproduced exactly via bounded fault injection.)
- **Fail-fast on unresponsive routes** (`exp/runtime/gateway/native/src/upstream.rs`): dead lanes hang ~25s to the prod ceiling before failing (glm-5-turbo, qwen3.8-27b, others). Add a bounded connect/first-byte timeout — scoped to connect/first-byte, not total generation, so slow reasoning models are unaffected. This is genuinely a tuning knob: recommend a config value with a conservative default rather than a hardcode.
- **Generic 4xx carries the provider machine code** (`upstream.rs`, mirrored in `exp/runtime/models/providers/errors.py`): the generic `invalid_request` mapping discards the provider's sanitized status/machine code that's already available — include the code/param (still no free-text body) so agents self-correct. (Same family as fix #1; the live 4xx for direct lanes is emitted in Rust.)

### Note on scope vs. the original request
The brief named Python symbols (`gemini_requests.py`, the transport classifier) as the serving encoders. Post-#629 the live data plane is Rust: `GatewayWireProfile`'s own docstring confirms the native plane builds provider payloads and parses streams, so the outbound stop-sequence emission and generic 4xx mapping live in Rust (`native/src/`), while the Python provider modules serve the resolved-client/offline path. Fix #1 is therefore placed in `preflight_gateway_request` — the Python admission guard that runs before dispatch regardless of encoder — which is both correct and encoder-independent. Fixes #2/#4/#5 are Rust and listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
