### PR TITLE
fix gateway reservation pricing for token subsets

### DIFF
--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -526,9 +526,11 @@ def maximum_attempt_cost_micro_usd(
     """Return a conservative integer micro-USD ceiling for one physical call.
 
     Canonical UTF-8 bytes conservatively upper-bound input tokens. The caller's output ceiling
-    wins when present, otherwise the frozen deployment limit is required. Optional cache and
-    reasoning dimensions participate only when the deployment declares that it reports them.
-    Unknown required prices produce ``None`` so an applicable hard limit fails closed.
+    wins when present, otherwise the frozen deployment limit is required. Cached-input and
+    reasoning counts are subsets of the total input and output counts, so the worst case uses
+    the highest applicable rate in each direction rather than adding subset rates to the same
+    token ceiling. Unknown required prices produce ``None`` so an applicable hard limit fails
+    closed.
     """
     input_tokens = len(canonical_json_bytes(request))
     output_tokens = request.maximum_output_tokens
@@ -560,16 +562,24 @@ def maximum_attempt_cost_micro_usd(
         required_rates.append(prices.reasoning_micro_usd_per_million_tokens)
     if any(rate is None for rate in required_rates):
         return None
-    input_rates = (
-        prices.input_micro_usd_per_million_tokens,
-        prices.cached_input_micro_usd_per_million_tokens,
+    input_rate = max(
+        rate
+        for rate in (
+            prices.input_micro_usd_per_million_tokens,
+            prices.cached_input_micro_usd_per_million_tokens,
+        )
+        if rate is not None
     )
-    output_rates = (
-        prices.output_micro_usd_per_million_tokens,
-        prices.reasoning_micro_usd_per_million_tokens,
+    output_rate = max(
+        rate
+        for rate in (
+            prices.output_micro_usd_per_million_tokens,
+            prices.reasoning_micro_usd_per_million_tokens,
+        )
+        if rate is not None
     )
-    numerator = input_tokens * sum(rate or 0 for rate in input_rates)
-    numerator += output_tokens * sum(rate or 0 for rate in output_rates)
+    numerator = input_tokens * input_rate
+    numerator += output_tokens * output_rate
     maximum = (numerator + 999_999) // 1_000_000
     return maximum if maximum <= MAXIMUM_MICRO_USD else None
 

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -230,6 +230,10 @@ class GatewayRequest(ContractModel):
 class GatewayUsage(ContractModel):
     """Normalized token counts and invoked tool names from one provider attempt.
 
+    Cached-input and reasoning counts are subsets of the total input and output counts when
+    present. They identify differently priced portions of those totals and must not be added a
+    second time by callers.
+
     A terminal event may carry only ``tool_names`` when the provider omits token usage. In that
     case both token totals remain unknown instead of being represented as zero.
     """

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -924,8 +924,9 @@ def _estimated_cost(
     """Compute attributed integer micro-USD or preserve unknown pricing.
 
     Cached-input and reasoning counts are subsets of their total token counts. Price the
-    differently priced subsets at their effective rates and the fresh remainders at the base
-    rates, clamping malformed detail counts to the corresponding total.
+    differently priced subsets at their configured rates and the fresh remainders at the base
+    rates, clamping malformed detail counts to the corresponding total. A missing rate for a
+    reported subset preserves unknown pricing rather than silently falling back to the base rate.
     """
     if usage is None or not usage.has_token_counts:
         return None
@@ -935,9 +936,9 @@ def _estimated_cost(
     reasoning_tokens = min(usage.reasoning_tokens or 0, usage.output_tokens)
     dimensions = (
         (usage.input_tokens - cached_input_tokens, input_rate),
-        (cached_input_tokens, cached_input_rate if cached_input_rate is not None else input_rate),
+        (cached_input_tokens, cached_input_rate),
         (usage.output_tokens - reasoning_tokens, output_rate),
-        (reasoning_tokens, reasoning_rate if reasoning_rate is not None else output_rate),
+        (reasoning_tokens, reasoning_rate),
     )
     if any(tokens > 0 and rate is None for tokens, rate in dimensions):
         return None

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -921,16 +921,23 @@ def _estimated_cost(
     output_rate: int | None,
     reasoning_rate: int | None,
 ) -> int | None:
-    """Compute attributed integer micro-USD or preserve unknown pricing."""
+    """Compute attributed integer micro-USD or preserve unknown pricing.
+
+    Cached-input and reasoning counts are subsets of their total token counts. Price the
+    differently priced subsets at their effective rates and the fresh remainders at the base
+    rates, clamping malformed detail counts to the corresponding total.
+    """
     if usage is None or not usage.has_token_counts:
         return None
     assert usage.input_tokens is not None
     assert usage.output_tokens is not None
+    cached_input_tokens = min(usage.cached_input_tokens or 0, usage.input_tokens)
+    reasoning_tokens = min(usage.reasoning_tokens or 0, usage.output_tokens)
     dimensions = (
-        (usage.input_tokens, input_rate),
-        (usage.cached_input_tokens or 0, cached_input_rate),
-        (usage.output_tokens, output_rate),
-        (usage.reasoning_tokens or 0, reasoning_rate),
+        (usage.input_tokens - cached_input_tokens, input_rate),
+        (cached_input_tokens, cached_input_rate if cached_input_rate is not None else input_rate),
+        (usage.output_tokens - reasoning_tokens, output_rate),
+        (reasoning_tokens, reasoning_rate if reasoning_rate is not None else output_rate),
     )
     if any(tokens > 0 and rate is None for tokens, rate in dimensions):
         return None

--- a/exp/runtime/gateway/ledger_test.py
+++ b/exp/runtime/gateway/ledger_test.py
@@ -189,7 +189,7 @@ def test_attempt_usage_and_integer_cost_are_content_free(tmp_path: Path) -> None
     assert len(usage) == 1
     assert usage[0].requests == 1
     assert usage[0].attempts == 1
-    assert usage[0].known_estimated_cost_micro_usd == 4_350
+    assert usage[0].known_estimated_cost_micro_usd == 3_950
     assert usage[0].unknown_cost_attempts == 0
     assert 124 <= usage[0].total_latency_ms <= 126
     assert usage[0].average_latency_ms is not None


### PR DESCRIPTION
## Summary

- price cached-input and reasoning subsets at the highest applicable rate instead of adding subset rates to the same total token ceiling
- align local SQLite settlement with Platform subset pricing and clamp malformed detail counts
- preserve unknown-cost accounting when a reported subset has no configured rate
- update one existing cost expectation; no new regression test added

This keeps the hard caller or deployment output ceiling unchanged. It only removes the double-counting that inflated worst-case reservations and could make local settlement exceed the reservation.

## Validation

- gateway budgets and ledger tests: 34 passed
- Ruff check and format: passed
- ty: passed
- full non-live run: 2,561 passed, 1 skipped; 11 unrelated macOS terminal-rendering failures in `exp/cli/shared/picker*_test.py`