### PR TITLE
Health-aware routing: fail-fast timeouts, skip dead lanes, admit past disabled rungs

### DIFF
--- a/exp/runtime/gateway/health.py
+++ b/exp/runtime/gateway/health.py
@@ -1,4 +1,24 @@
-"""Bounded per-deployment circuit and throttle state for exact-model waterfalls."""
+"""Bounded per-deployment circuit and throttle state for exact-model waterfalls.
+
+This registry is per-process: each gateway pod keeps its own circuit state, so a
+lane that one pod has proven dead is still probed by every other pod. Two things
+keep that probe cheap rather than a 35-second stall: the data plane's fail-fast
+connect and time-to-first-byte bounds detect the dead lane in seconds, and a
+first-byte stall is classified failover-eligible but not same-deployment
+retryable, so the pod advances to the next live rung instead of redialing the
+stalled lane.
+
+Follow-up (fleet-shared health): to route the *whole* fleet around a dead lane
+without every pod paying its own probe, this in-memory state should be backed by
+a small shared, TTL'd health signal the control plane reads at route time and
+writes on failure (keyed by the same ``DeploymentHealthKey`` tuple). That
+cross-pod state change is deliberately kept out of this change: the OSS engine's
+store is per-pod SQLite, so a true fleet-shared signal needs a shared store and
+is a fragile distributed-state change to force into one PR. It layers onto the
+same ``claim``/``failed`` seam without changing the waterfall contract, so the
+per-pod fast-fail-and-skip above is the conservative first step and the shared
+signal is the follow-up.
+"""
 
 from __future__ import annotations
 
@@ -47,6 +67,13 @@ class DeploymentHealthRegistry:
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         """Initialize finite in-process deployment health policy.
+
+        The default opens a circuit after two consecutive operational failures,
+        which preserves the bounded same-deployment redial: a single transient
+        blip still redials the lane, and only a lane that fails twice is
+        suppressed for the cooldown. A stalled (dead) lane is skipped before it
+        reaches this threshold because a first-byte timeout is classified
+        failover-not-redial in the data plane.
 
         Args:
             failure_threshold: Consecutive operational failures that open one circuit.

--- a/exp/runtime/gateway/health_test.py
+++ b/exp/runtime/gateway/health_test.py
@@ -68,6 +68,36 @@ def test_operational_failures_still_open_the_circuit() -> None:
         assert not registry.claim(_KEY)
 
 
+def test_default_threshold_preserves_one_transient_redial_before_opening() -> None:
+    """The default keeps a lane admissible after a single transient failure.
+
+    A stalled lane is skipped by the data plane's failover-not-redial timeout
+    classification, so the circuit deliberately tolerates one blip here rather
+    than suppressing a lane that a bounded redial could still recover.
+    """
+    registry = DeploymentHealthRegistry(clock=lambda: 100.0)
+
+    registry.failed(_KEY, _failure(GatewayFailureClass.PROVIDER_INTERNAL))
+    assert registry.claim(_KEY)
+
+    registry.failed(_KEY, _failure(GatewayFailureClass.PROVIDER_INTERNAL))
+    assert not registry.claim(_KEY)
+
+
+def test_a_suppressed_lane_recovers_after_the_cooldown_window() -> None:
+    """A circuit reopens for a probe once the cooldown window elapses."""
+    now = [100.0]
+    registry = DeploymentHealthRegistry(
+        failure_threshold=1, open_seconds=30.0, clock=lambda: now[0]
+    )
+
+    registry.failed(_KEY, _failure(GatewayFailureClass.TRANSPORT))
+    assert not registry.claim(_KEY)
+
+    now[0] += 31
+    assert registry.claim(_KEY)
+
+
 def test_throttle_storms_still_suppress_the_deployment() -> None:
     """Provider throttling keeps its authoritative suppression window."""
     registry = DeploymentHealthRegistry(throttle_seconds=30.0, clock=lambda: 100.0)

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -56,6 +56,24 @@ pub fn stream_timeout_failure(deadline: Instant) -> Failure {
     }
 }
 
+/// Classify a provider that accepted the connection but did not stream its
+/// first byte within the fail-fast time-to-first-byte bound. A stalled lead
+/// deployment must not hold the request for its full per-chunk timeout, so
+/// this is a transient, capacity-shaped failure that is failover-eligible.
+///
+/// It is deliberately *not* same-deployment retryable: a lane that accepted
+/// the connection but never answered is the clearest dead-lane signal, and
+/// redialing it would only stall again for another window. Skipping the redial
+/// and advancing straight to the next certified deployment is what keeps a
+/// fresh pod's cost on a dead lane near one fail-fast window instead of several.
+pub fn first_byte_timeout_failure() -> Failure {
+    Failure::new(
+        FailureClass::Timeout,
+        "provider did not send the first token in time; failing over to the next deployment",
+    )
+    .with_retry(false, true)
+}
+
 /// The synthesized failure for a provider stream that closed without a
 /// terminal event, matching the python executor's classification.
 pub(crate) fn ended_without_terminal() -> Failure {
@@ -93,17 +111,39 @@ pub struct UpstreamRelay {
     pending: VecDeque<Event>,
     eof: bool,
     first_byte_recorded: bool,
+    /// Fail-fast bound for the very first provider byte. Once the first byte
+    /// arrives (`first_byte_recorded`), subsequent reads use the deployment's
+    /// per-chunk timeout instead, so a slow reasoning model can stream for a
+    /// long time after it has started answering.
+    first_byte_deadline: Instant,
 }
 
 impl UpstreamRelay {
-    pub fn new(response: reqwest::Response, dialect: Dialect) -> Self {
+    pub fn new(
+        response: reqwest::Response,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+    ) -> Self {
+        Self::from_stream(
+            response.bytes_stream().boxed(),
+            dialect,
+            first_byte_deadline,
+        )
+    }
+
+    fn from_stream(
+        stream: BoxStream<'static, reqwest::Result<Bytes>>,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+    ) -> Self {
         Self {
-            stream: response.bytes_stream().boxed(),
+            stream,
             decoder: FrameDecoder::new(dialect),
             normalizer: Normalizer::new(dialect),
             pending: VecDeque::new(),
             eof: false,
             first_byte_recorded: false,
+            first_byte_deadline,
         }
     }
 
@@ -124,7 +164,15 @@ impl UpstreamRelay {
             if self.eof {
                 return Ok(None);
             }
-            let bound = remaining(deadline).min(phase_timeout);
+            // Before the first byte the fail-fast time-to-first-byte bound
+            // applies; after it, each chunk is paced by the deployment's own
+            // per-chunk timeout so long-running generation is never capped.
+            let waiting_for_first_byte = !self.first_byte_recorded;
+            let bound = if waiting_for_first_byte {
+                remaining(deadline).min(remaining(self.first_byte_deadline))
+            } else {
+                remaining(deadline).min(phase_timeout)
+            };
             let chunk = match tokio::time::timeout(bound, self.stream.next()).await {
                 Ok(Some(Ok(chunk))) => chunk,
                 Ok(Some(Err(_))) => {
@@ -149,7 +197,17 @@ impl UpstreamRelay {
                     }
                     continue;
                 }
-                Err(_) => return Err(stream_timeout_failure(deadline)),
+                Err(_) => {
+                    // A first-byte stall while the request deadline still has
+                    // budget is the fail-fast case: classify it as a
+                    // failover-eligible transient so the next rung is tried at
+                    // once. A later chunk stall, or an exhausted request
+                    // deadline, keeps the existing transport/deadline mapping.
+                    if waiting_for_first_byte && !remaining(deadline).is_zero() {
+                        return Err(first_byte_timeout_failure());
+                    }
+                    return Err(stream_timeout_failure(deadline));
+                }
             };
             if !self.first_byte_recorded {
                 METRICS
@@ -211,5 +269,54 @@ pub async fn collect_committed(
             }
             None => return Err(ended_without_terminal()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+
+    #[test]
+    fn a_first_byte_stall_fails_over_without_redialing_the_dead_lane() {
+        let failure = first_byte_timeout_failure();
+        assert_eq!(failure.failure_class, FailureClass::Timeout);
+        assert!(failure.failover_eligible);
+        // A stalled lane is skipped, not redialed: redialing it would only
+        // stall again for another window.
+        assert!(!failure.retryable_same_deployment);
+    }
+
+    #[tokio::test]
+    async fn a_stalled_first_byte_trips_the_ttft_bound_not_the_chunk_timeout() {
+        // A provider that opened the stream but never sends a byte must fail
+        // over in about the time-to-first-byte window, not the (far larger)
+        // per-chunk deployment timeout.
+        let never = stream::pending::<reqwest::Result<Bytes>>().boxed();
+        let time_to_first_byte = Duration::from_millis(80);
+        let mut relay = UpstreamRelay::from_stream(
+            never,
+            Dialect::OpenAiCompatible,
+            Instant::now() + time_to_first_byte,
+        );
+        let request_deadline = Instant::now() + Duration::from_secs(120);
+        let per_chunk_timeout = Duration::from_secs(35);
+
+        let started = Instant::now();
+        let outcome = relay
+            .next_event(request_deadline, per_chunk_timeout, started)
+            .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "expected a fail-fast time-to-first-byte trip, waited {elapsed:?}"
+        );
+        let failure = outcome.expect_err("a never-yielding stream must not succeed");
+        assert_eq!(failure.failure_class, FailureClass::Timeout);
+        assert!(
+            failure.failover_eligible,
+            "a first-byte stall must advance to the next deployment"
+        );
     }
 }

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -199,6 +199,7 @@ pub(crate) async fn chat(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -160,6 +160,7 @@ pub(crate) async fn messages(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -196,6 +196,7 @@ pub(crate) async fn responses(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -38,6 +38,14 @@ pub struct ServeConfig {
     pub max_active_requests: usize,
     #[serde(default = "default_request_timeout_seconds")]
     pub request_timeout_seconds: f64,
+    /// Fail-fast bound on the TCP+TLS connect phase of every provider call.
+    #[serde(default = "default_connect_timeout_seconds")]
+    pub connect_timeout_seconds: f64,
+    /// Fail-fast bound on the wait for a provider's first streamed byte. This
+    /// never caps total generation time: once the first byte arrives, reads
+    /// are paced by the deployment's own per-chunk timeout.
+    #[serde(default = "default_time_to_first_byte_seconds")]
+    pub time_to_first_byte_seconds: f64,
     #[serde(default = "default_callback_permits")]
     pub callback_permits: usize,
     #[serde(default = "default_native_usage_enabled")]
@@ -48,6 +56,14 @@ pub struct ServeConfig {
 
 fn default_graceful_timeout_seconds() -> f64 {
     10.0
+}
+
+fn default_connect_timeout_seconds() -> f64 {
+    5.0
+}
+
+fn default_time_to_first_byte_seconds() -> f64 {
+    15.0
 }
 
 fn default_max_active_requests() -> usize {
@@ -73,6 +89,8 @@ pub(crate) struct AppState {
     pub(crate) http: reqwest::Client,
     pub(crate) permits: Arc<Semaphore>,
     pub(crate) request_timeout: Duration,
+    /// Fail-fast bound on the wait for the first provider byte per attempt.
+    pub(crate) time_to_first_byte: Duration,
     /// Settlement writes still in flight, held open through graceful shutdown.
     pub(crate) pending_settlements: Arc<AtomicUsize>,
     /// Requests handled since start; the idle reclaim loop trims the
@@ -93,7 +111,8 @@ pub async fn run(
     shutdown: Option<tokio::sync::watch::Receiver<bool>>,
     on_listening: Option<Py<PyAny>>,
 ) -> Result<(), String> {
-    let http = crate::upstream::build_client()?;
+    let connect_timeout = Duration::from_secs_f64(config.connect_timeout_seconds.max(0.001));
+    let http = crate::upstream::build_client(connect_timeout)?;
     let pending_settlements = Arc::new(AtomicUsize::new(0));
     let max_active_requests = config.max_active_requests.max(1);
     let handled_requests = Arc::new(AtomicUsize::new(0));
@@ -102,6 +121,7 @@ pub async fn run(
         http,
         permits: Arc::new(Semaphore::new(max_active_requests)),
         request_timeout: Duration::from_secs_f64(config.request_timeout_seconds),
+        time_to_first_byte: Duration::from_secs_f64(config.time_to_first_byte_seconds.max(0.001)),
         pending_settlements: pending_settlements.clone(),
         handled_requests: handled_requests.clone(),
         replays: Arc::new(ReplayStore::new()),

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -10,10 +10,14 @@ use crate::errors::{Failure, FailureClass};
 /// Build the shared pooled upstream client, mirroring the pooling constants in
 /// `providers.async_transport` (64 keep-alive) and its no-redirect policy so a
 /// provider 3xx can never re-send credentials to an attacker-chosen location.
-pub fn build_client() -> Result<reqwest::Client, String> {
+///
+/// `connect_timeout` bounds only the TCP+TLS connect phase; a dead lane whose
+/// host never accepts the connection fails over after this window instead of
+/// hanging on the per-deployment request timeout.
+pub fn build_client(connect_timeout: Duration) -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .pool_max_idle_per_host(64)
-        .connect_timeout(Duration::from_secs(10))
+        .connect_timeout(connect_timeout)
         .redirect(reqwest::redirect::Policy::none())
         .use_rustls_tls()
         .build()

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -88,6 +88,11 @@ pub struct WaterfallContext<'a> {
     pub route: &'a [DeploymentWire],
     pub policy: RoutePolicy,
     pub deadline: Instant,
+    /// Fail-fast bound on the wait for each physical attempt's first provider
+    /// byte. Applied per attempt (each redial and each failover advance gets a
+    /// fresh window); it bounds the connect/header/first-byte phase only and
+    /// never caps generation once the provider has started answering.
+    pub time_to_first_byte: Duration,
 }
 
 /// The winning outcome of one waterfall run.
@@ -405,10 +410,16 @@ async fn run_attempt(
             };
         }
     };
-    // The connection's raw timeout bounds each transport phase (open, then
-    // every chunk read), exactly like the python streaming path.
+    // The connection's raw timeout bounds each chunk read, exactly like the
+    // python streaming path. The open phase is additionally bounded by the
+    // fail-fast time-to-first-byte window (fresh per attempt) so a dead lane
+    // that never answers is abandoned in seconds, not after the full
+    // per-deployment timeout.
     let phase_timeout = Duration::from_secs_f64(wire.timeout_seconds.max(0.001));
-    let open_bound = remaining(ctx.deadline).min(phase_timeout);
+    let first_byte_deadline = Instant::now() + ctx.time_to_first_byte;
+    let open_bound = remaining(ctx.deadline)
+        .min(phase_timeout)
+        .min(remaining(first_byte_deadline));
     let response = match open_stream(
         ctx.http,
         &wire.url,
@@ -433,7 +444,7 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
-    let mut relay = UpstreamRelay::new(response, dialect);
+    let mut relay = UpstreamRelay::new(response, dialect, first_byte_deadline);
     let mut usage: Option<Usage> = None;
     let mut tool_names: Vec<String> = Vec::new();
     let mut withheld: Vec<Event> = Vec::new();

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -73,8 +73,10 @@ from exp.runtime.gateway.native_execution import (
     MAXIMUM_TOTAL_ATTEMPTS,
     InflightRequest,
     NativeDialectUnavailableError,
+    NoDispatchableDeploymentError,
     deployment_wire_entry,
-    resolve_route_profiles,
+    resolve_dispatchable_wires,
+    route_with_dispatchable_deployments,
 )
 from exp.runtime.gateway.native_metrics_text import render_metrics_text
 from exp.runtime.gateway.native_responses import (
@@ -338,9 +340,27 @@ class NativeControlPlane:
                 request,
                 continuation=continuation_context,
             )
-            resolved_wires = resolve_route_profiles(self._components.runtime_catalogs, route)
+            # Skip any disabled or un-dispatchable rung so a dead lead rung
+            # never fails admission when a live fallback rung can still serve.
+            dispatchable = resolve_dispatchable_wires(self._components.runtime_catalogs, route)
+            route = route_with_dispatchable_deployments(
+                route, tuple(deployment for deployment, _profile, _client in dispatchable)
+            )
+            resolved_wires = tuple(
+                (profile, client) for _deployment, profile, client in dispatchable
+            )
         except NativeDialectUnavailableError as exc:
             return self._escalate_accepted(authorization, str(exc))
+        except NoDispatchableDeploymentError as exc:
+            # Every certified rung is disabled or unavailable: finish the
+            # accepted request with an honest provider-unavailable terminal
+            # rather than a mislabeled internal error or a hang.
+            failure = GatewayFailure(
+                failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+                safe_message="all certified deployments for this model are currently unavailable",
+            )
+            self._accounting.finish_request_quietly(authorization, failure)
+            raise NativeBridgeError(public_failure_error(failure)) from exc
         except Exception as exc:  # noqa: BLE001 - raised after route packaging below.
             probe_failure = exc
         if route is not None and self._native_route_eligible is not None:
@@ -606,7 +626,10 @@ class NativeControlPlane:
         if isinstance(authorization.target, DirectTarget):
             try:
                 route = self._components.routes.resolve_direct(authorization)
-                resolve_route_profiles(self._components.runtime_catalogs, route)
+                # Servability mirrors admission: a route with at least one
+                # dispatchable rung is servable even if its lead rung is
+                # disabled, so only a fully dialectless route escalates here.
+                resolve_dispatchable_wires(self._components.runtime_catalogs, route)
             except NativeDialectUnavailableError as exc:
                 return _escalation(str(exc))
             except Exception:  # noqa: BLE001 - the owner's admission records this failure.

--- a/exp/runtime/gateway/native_dispatch.py
+++ b/exp/runtime/gateway/native_dispatch.py
@@ -5,7 +5,7 @@ the upstream payload itself. Body-signing dialects (Bedrock SigV4) compute
 their headers over the exact serialized body bytes, so the control plane
 freezes one canonical serialization at admission (:func:`frozen_dispatch`,
 called per route deployment alongside
-``native_execution.resolve_route_profiles``) and retains the resolved
+``native_execution.resolve_dispatchable_wires``) and retains the resolved
 signer. The data plane must send the frozen bytes verbatim: re-serializing
 JSON on the other side of the boundary could reorder or reformat bytes and
 invalidate the signature. Signing itself happens at dispatch time, through

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -50,6 +50,17 @@ class NativeDialectUnavailableError(RuntimeError):
     """The resolved provider has no native dialect, so the route cannot serve."""
 
 
+class NoDispatchableDeploymentError(RuntimeError):
+    """Every certified deployment in the route is currently un-dispatchable.
+
+    Raised only when no rung resolves to a usable wire profile for a reason
+    other than a missing native dialect (a disabled or drifted connection).
+    A route with no native dialect anywhere raises
+    :class:`NativeDialectUnavailableError` instead, preserving the launch-time
+    servability escalation contract.
+    """
+
+
 @dataclass
 class InflightRequest:
     """One admitted request awaiting its terminal settlement.
@@ -180,17 +191,70 @@ def next_route_candidate(
     return claim_route_from(health, keys, current_depth + 1)
 
 
-def resolve_route_profiles(
+def _resolve_one_wire(
+    catalog: RuntimeModelCatalog,
+    deployment: ExactModelDeployment,
+) -> tuple[GatewayWireProfile, NativeWireClient]:
+    """Resolve one deployment's public wire profile, or fail deployment-scoped.
+
+    The deployment is resolved and identity-checked before any ledger write or
+    billable dispatch, so a drifted runtime catalog can never bill against a
+    frozen route. The client check is structural (``NativeWireClient``), not a
+    concrete HTTP base class: a non-HTTP client such as the bounded Bedrock
+    adapter satisfies it too as long as it implements ``gateway_wire_profile``.
+
+    Args:
+        catalog: The authorized revision's frozen runtime catalog.
+        deployment: The certified deployment to resolve.
+
+    Returns:
+        The ``(profile, client)`` pair, with the model identity filled from
+        the resolved snapshot when the profile leaves it empty.
+
+    Raises:
+        NativeDialectUnavailableError: The deployment's provider has no
+            native-dialect implementation.
+        ProviderCapabilityError: The resolved wire profile rejects a
+            non-dialect capability.
+        ModelConnectionError: The connection cannot be constructed (a disabled
+            or absent provider credential); a subclass of ``ValueError``.
+        ValueError: The resolved client drifts from the frozen deployment.
+    """
+    resolved = catalog.resolve(deployment.source_alias)
+    _require_deployment_identity(deployment, resolved)
+    client = resolved.client
+    if not isinstance(client, NativeWireClient):
+        raise NativeDialectUnavailableError(
+            f"provider {deployment.provider!r} has no native wire profile"
+        )
+    try:
+        # Intersect the client's wire profile with the frozen catalog
+        # capability contract before payload bytes are frozen.
+        profile = _resolved_wire_profile(deployment, resolved)
+    except ProviderCapabilityError as exc:
+        if exc.capability != "native_data_plane":
+            raise
+        raise NativeDialectUnavailableError(
+            f"provider {deployment.provider!r} has no native dialect implementation"
+        ) from exc
+    return profile, client
+
+
+def resolve_dispatchable_wires(
     runtime_catalogs: Mapping[tuple[str, str], RuntimeModelCatalog],
     route: GatewayRoute,
-) -> tuple[tuple[GatewayWireProfile, NativeWireClient], ...]:
-    """Resolve every route deployment's public wire profile for the data plane.
+) -> tuple[tuple[ExactModelDeployment, GatewayWireProfile, NativeWireClient], ...]:
+    """Resolve the route's dispatchable rungs, skipping the un-dispatchable ones.
 
-    Every deployment is resolved and identity-checked before any ledger write
-    or billable dispatch, so a drifted runtime catalog can never bill against
-    a frozen route. The check is structural (``NativeWireClient``), not a concrete HTTP base
-    class: a non-HTTP client such as the bounded Bedrock adapter satisfies it
-    too as long as it implements ``gateway_wire_profile``.
+    A certified waterfall can lead with a rung whose connection is disabled,
+    drifted, or otherwise not currently dispatchable. Resolving the whole route
+    all-or-nothing turns that dead lead rung into a failed admission ("gateway
+    admission failed before provider dispatch") even when a live fallback rung
+    could still serve. This resolves each rung independently and keeps only the
+    ones that produce a usable wire profile, in route order, so a disabled lead
+    rung is skipped to the next live rung. Only deployment-scoped resolution
+    faults are skipped; a request-scoped fault (raised later while the surviving
+    wires are built) still fails the whole admission.
 
     Args:
         runtime_catalogs: Revision and catalog digests mapped to frozen
@@ -198,42 +262,70 @@ def resolve_route_profiles(
         route: Resolved ordered route.
 
     Returns:
-        One ``(profile, client)`` pair per deployment, in route order, with
-        the model identity filled from the resolved snapshot when the
-        profile leaves it empty. The client rides alongside its profile so
-        body-signing dialects can freeze their dispatch signer at admission.
+        One ``(deployment, profile, client)`` triple per dispatchable rung, in
+        route order. The client rides alongside its profile so body-signing
+        dialects can freeze their dispatch signer at admission.
 
     Raises:
-        NativeDialectUnavailableError: A route deployment's provider has no
-            native-dialect implementation.
-        GatewayRoutingError: The authorized catalog is not loaded.
-        ValueError: A resolved client drifts from the frozen deployment.
+        GatewayRoutingError: The authorized catalog is not loaded (whole route).
+        NativeDialectUnavailableError: No rung is dispatchable and every skipped
+            rung lacked a native dialect, preserving the servability escalation.
+        NoDispatchableDeploymentError: No rung is dispatchable and at least one
+            was skipped for a non-dialect reason (a disabled connection).
     """
     authorization = route.snapshot.authorization
     catalog = runtime_catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
     if catalog is None:
         raise GatewayRoutingError("runtime catalog is not loaded for the authorized revision")
-    resolved_wires: list[tuple[GatewayWireProfile, NativeWireClient]] = []
+    dispatchable: list[tuple[ExactModelDeployment, GatewayWireProfile, NativeWireClient]] = []
+    only_dialect_gaps = True
     for deployment in route.deployments:
-        resolved = catalog.resolve(deployment.source_alias)
-        _require_deployment_identity(deployment, resolved)
-        client = resolved.client
-        if not isinstance(client, NativeWireClient):
-            raise NativeDialectUnavailableError(
-                f"provider {deployment.provider!r} has no native wire profile"
-            )
         try:
-            # Intersect the client's wire profile with the frozen catalog
-            # capability contract before payload bytes are frozen.
-            profile = _resolved_wire_profile(deployment, resolved)
-        except ProviderCapabilityError as exc:
-            if exc.capability != "native_data_plane":
-                raise
-            raise NativeDialectUnavailableError(
-                f"provider {deployment.provider!r} has no native dialect implementation"
-            ) from exc
-        resolved_wires.append((profile, client))
-    return tuple(resolved_wires)
+            profile, client = _resolve_one_wire(catalog, deployment)
+        except NativeDialectUnavailableError:
+            continue
+        except (ProviderCapabilityError, ValueError):
+            # A disabled or drifted connection, a runtime-identity mismatch, or
+            # a non-dialect capability rejection: this rung cannot dispatch now,
+            # but a later live rung still can.
+            only_dialect_gaps = False
+            continue
+        dispatchable.append((deployment, profile, client))
+    if dispatchable:
+        return tuple(dispatchable)
+    if only_dialect_gaps:
+        raise NativeDialectUnavailableError(
+            "no certified deployment for the resolved model has a native dialect"
+        )
+    raise NoDispatchableDeploymentError(
+        "all certified deployments for the resolved model are currently unavailable"
+    )
+
+
+def route_with_dispatchable_deployments(
+    route: GatewayRoute,
+    deployments: tuple[ExactModelDeployment, ...],
+) -> GatewayRoute:
+    """Narrow a route to only its dispatchable rungs, preserving order.
+
+    The frozen execution snapshot keeps the full certified pool identity; only
+    the executable lead deployment and its fallbacks are narrowed, so per-rung
+    health keys, idempotency keys, and route-depth headers stay aligned with
+    the rungs the data plane will actually dispatch.
+
+    Args:
+        route: The originally resolved route.
+        deployments: The dispatchable subset, in route order (non-empty).
+
+    Returns:
+        A route whose lead and fallback deployments are exactly ``deployments``.
+    """
+    return route.model_copy(
+        update={
+            "deployment": deployments[0],
+            "fallback_deployments": tuple(deployments[1:]),
+        }
+    )
 
 
 def deployment_wire_entry(

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -2,16 +2,46 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayFailure,
+    GatewayFailureClass,
+)
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_execution import (
+    NativeDialectUnavailableError,
+    NoDispatchableDeploymentError,
     claim_route_from,
     next_route_candidate,
+    resolve_dispatchable_wires,
 )
+from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models import RuntimeModelCatalog
+from exp.runtime.models.registry import ModelConnectionError
+
+_SHA = "a" * 64
+_CATALOG_KEY = ("revision-1", _SHA)
+
+
+def _fake_catalogs() -> Mapping[tuple[str, str], RuntimeModelCatalog]:
+    """Return a catalog mapping whose value is unused once resolution is patched.
+
+    ``resolve_dispatchable_wires`` only forwards the catalog to the patched
+    ``_resolve_one_wire`` seam, so a placeholder standing in for the frozen
+    runtime catalog exercises the filtering without a full lifecycle build.
+    """
+    return cast("Mapping[tuple[str, str], RuntimeModelCatalog]", {_CATALOG_KEY: object()})
+
 
 _KEYS: tuple[DeploymentHealthKey, ...] = (
     ("catalog" + "0" * 57, "deployment-a", "connection-a"),
@@ -167,6 +197,103 @@ def test_caller_invalid_request_never_advances() -> None:
         refusal_failover=False,
     )
     assert candidate is None
+
+
+def _deployment(alias: str) -> ExactModelDeployment:
+    """Build one minimal certified deployment for route-filtering tests."""
+    return ExactModelDeployment(
+        deployment_id=alias,
+        source_alias=alias,
+        exact_model_id="exact-model",
+        connection=f"connection-{alias}",
+        provider="openai",
+        provider_model="gpt-x",
+        connection_sha256=_SHA,
+        capabilities_sha256=_SHA,
+    )
+
+
+def _two_rung_route(*aliases: str) -> GatewayRoute:
+    """Build a resolved two-rung direct route over the given deployment aliases."""
+    deployments = tuple(_deployment(alias) for alias in aliases)
+    authorization = AuthorizationSnapshot(
+        request_id="request-1",
+        organization_id="org-1",
+        identity_id="identity-1",
+        virtual_key_id="key-1",
+        alias="alias-1",
+        alias_revision_id=_CATALOG_KEY[0],
+        target=DirectTarget(pool_id="pool-1"),
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256=_SHA,
+        canonical_request_sha256=_SHA,
+        deadline_monotonic=1.0,
+    )
+    return GatewayRoute(
+        snapshot=ExecutionSnapshot(
+            authorization=authorization,
+            exact_model_id="exact-model",
+            pool_id="pool-1",
+            deployment_ids=tuple(d.deployment_id for d in deployments),
+        ),
+        deployment=deployments[0],
+        fallback_deployments=deployments[1:],
+        route_reason="direct",
+    )
+
+
+def test_a_disabled_lead_rung_resolves_to_the_next_live_rung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled position-0 deployment is skipped to the next dispatchable rung."""
+    route = _two_rung_route("deployment-a", "deployment-b")
+    live = object()
+
+    def _resolve_one(catalog: object, deployment: ExactModelDeployment) -> tuple[object, object]:
+        del catalog
+        if deployment.source_alias == "deployment-a":
+            raise ModelConnectionError("connection is disabled")
+        return (f"profile-{deployment.source_alias}", live)
+
+    monkeypatch.setattr("exp.runtime.gateway.native_execution._resolve_one_wire", _resolve_one)
+
+    dispatchable = resolve_dispatchable_wires(_fake_catalogs(), route)
+
+    assert [deployment.source_alias for deployment, _p, _c in dispatchable] == ["deployment-b"]
+    assert dispatchable[0][1] == "profile-deployment-b"
+    assert dispatchable[0][2] is live
+
+
+def test_every_rung_disabled_raises_the_unavailable_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No dispatchable rung for a non-dialect reason is an honest terminal, not a hang."""
+    route = _two_rung_route("deployment-a", "deployment-b")
+
+    def _resolve_one(catalog: object, deployment: ExactModelDeployment) -> tuple[object, object]:
+        del catalog, deployment
+        raise ModelConnectionError("connection is disabled")
+
+    monkeypatch.setattr("exp.runtime.gateway.native_execution._resolve_one_wire", _resolve_one)
+
+    with pytest.raises(NoDispatchableDeploymentError):
+        resolve_dispatchable_wires(_fake_catalogs(), route)
+
+
+def test_every_rung_dialectless_preserves_the_escalation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A route with no native dialect anywhere still escalates, not terminates."""
+    route = _two_rung_route("deployment-a", "deployment-b")
+
+    def _resolve_one(catalog: object, deployment: ExactModelDeployment) -> tuple[object, object]:
+        del catalog, deployment
+        raise NativeDialectUnavailableError("no native dialect")
+
+    monkeypatch.setattr("exp.runtime.gateway.native_execution._resolve_one_wire", _resolve_one)
+
+    with pytest.raises(NativeDialectUnavailableError):
+        resolve_dispatchable_wires(_fake_catalogs(), route)
 
 
 def test_native_serving_blockers_name_dialectless_providers(

--- a/exp/runtime/gateway/native_server.py
+++ b/exp/runtime/gateway/native_server.py
@@ -33,6 +33,8 @@ def serve_native_gateway(
     port: int,
     max_active_requests: int = 64,
     graceful_timeout_seconds: float = 10.0,
+    connect_timeout_seconds: float = 5.0,
+    time_to_first_byte_seconds: float = 15.0,
     native_usage_enabled: bool = True,
     shutdown: ShutdownHandle | None = None,
     on_listening: Callable[[], None] | None = None,
@@ -45,6 +47,15 @@ def serve_native_gateway(
         port: Public listener port.
         max_active_requests: Native concurrent-admission bound.
         graceful_timeout_seconds: Bound for graceful shutdown.
+        connect_timeout_seconds: Fail-fast bound on the TCP+TLS connect phase
+            of every provider call, so a lane whose host never accepts the
+            connection fails over in seconds instead of hanging on the
+            per-deployment request timeout.
+        time_to_first_byte_seconds: Fail-fast bound on the wait for a
+            provider's first streamed byte per attempt. It never caps total
+            generation time: once the first byte arrives, reads are paced by
+            the deployment's own per-chunk timeout, so slow reasoning models
+            keep streaming for as long as they need.
         native_usage_enabled: Whether Rust owns ``/usage.json``. Hosted,
             multi-tenant callers should disable it so their own surface owns
             usage.
@@ -73,6 +84,8 @@ def serve_native_gateway(
         "max_active_requests": max_active_requests,
         "request_timeout_seconds": control_plane.request_timeout_seconds,
         "graceful_timeout_seconds": graceful_timeout_seconds,
+        "connect_timeout_seconds": connect_timeout_seconds,
+        "time_to_first_byte_seconds": time_to_first_byte_seconds,
         "native_usage_enabled": native_usage_enabled,
     }
     try:

--- a/exp/runtime/gateway/native_server_test.py
+++ b/exp/runtime/gateway/native_server_test.py
@@ -42,6 +42,8 @@ def test_host_passes_the_serve_configuration(monkeypatch: pytest.MonkeyPatch) ->
         port=8080,
         max_active_requests=23,
         graceful_timeout_seconds=45.0,
+        connect_timeout_seconds=4.0,
+        time_to_first_byte_seconds=12.0,
         native_usage_enabled=False,
     )
 
@@ -53,6 +55,8 @@ def test_host_passes_the_serve_configuration(monkeypatch: pytest.MonkeyPatch) ->
     assert config["max_active_requests"] == 23
     assert config["request_timeout_seconds"] == 37.0
     assert config["graceful_timeout_seconds"] == 45.0
+    assert config["connect_timeout_seconds"] == 4.0
+    assert config["time_to_first_byte_seconds"] == 12.0
     assert config["native_usage_enabled"] is False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.2.1,<0.3",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.2.2,<0.3",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Health-aware routing for the native gateway

Production evidence (live, this session): models fall over ~35s per dead
deployment rung because there is no fast timeout; the per-pod in-memory circuit
breaker doesn't share state, so fresh pods keep re-trying dead lanes; and
admission throws on a disabled lead rung instead of skipping it. Concretely,
`qwen3.8-27b` 35s-times-out on both its lanes, and 187 models have a default
waterfall that leads with a disabled deployment.

Three independent, additive fixes, each behind a clear boundary so review can
accept them separately. The gateway data plane is Rust; candidate selection and
admission stay in the Python control plane.

### 1. Fail-fast timeouts on the upstream call
The native client hard-coded a 10s connect timeout and used the deployment's
own (~35s) timeout as the bound for both the open phase and every chunk read,
so a lane that accepted the connection but never streamed a byte held the
request for the full ~35s before failing over.

- New `ServeConfig` knobs `connect_timeout_seconds` (**default 5.0**) and
  `time_to_first_byte_seconds` (**default 15.0**), plumbed through
  `serve_native_gateway`.
- `build_client` now takes the connect timeout (`upstream.rs`).
- `UpstreamRelay` owns a per-attempt first-byte deadline; `next_event` bounds
  the wait for the first byte by it and, on a genuine first-byte stall,
  classifies a `Timeout` (`relay.rs`). `run_attempt` bounds the open phase by
  the same window (`waterfall.rs`).
- **Does not cap generation**: once the first byte arrives, reads revert to the
  deployment's per-chunk timeout, so slow reasoning models stream as long as
  they need.

Before: a stalled lane blocks ~35s. After: it fails over in ~≤15s (first-byte)
or ~5s (connect). Test: `relay::tests::a_stalled_first_byte_trips_the_ttft_bound_not_the_chunk_timeout`.

### 2. Skip a dead lane instead of redialing it (health memory)
A first-byte stall is now **failover-eligible but not same-deployment
retryable** (`relay.rs::first_byte_timeout_failure`), so the waterfall advances
straight to the next live rung rather than wasting a redial on a lane that
never answered. Combined with fix 1, a fresh pod's cost on a dead lane is ~one
fail-fast window instead of several.

Design choice — option (b) with a documented follow-up. Option (a), a
fleet-shared TTL'd health signal read at route time, is the real cross-pod fix,
but the OSS engine's store is per-pod SQLite, so a true fleet-shared signal
needs a shared store and is a fragile distributed-state change to force into one
PR. The per-pod circuit is left at its **two-failure default** deliberately:
lowering it to one failure breaks the frozen bounded same-deployment redial (a
single transient blip should still redial), removes transient retries for
singleton pools, and destabilizes the module-scoped waterfall scenario suite in
an order-dependent way. The fleet-shared design is documented as the follow-up
in `health.py`, layering onto the same `claim`/`failed` seam. Test:
`test_default_threshold_preserves_one_transient_redial_before_opening`.

### 3. Admission skips disabled/unavailable rungs
`resolve_route_profiles` resolved the whole route all-or-nothing, so one
disabled lead rung raised out of the per-deployment wire build and surfaced as
the mislabeled `INTERNAL` "gateway admission failed before provider dispatch".

- Replaced with `resolve_dispatchable_wires` (`native_execution.py`): resolves
  each rung independently and keeps only the dispatchable ones, in route order.
  A disabled/drifted connection (`ModelConnectionError`), an identity mismatch,
  or a non-dialect capability rejection skips that rung; a request-scoped fault
  still fails the whole admission when the surviving wires are built.
- `route_with_dispatchable_deployments` narrows the executable route to the
  survivors; per-rung health keys, idempotency keys, and route-depth headers
  stay aligned (they are per-deployment, not order-dependent).
- If **every** rung is unavailable for a non-dialect reason, admission finishes
  the accepted request with an honest `PROVIDER_INTERNAL` terminal ("all
  certified deployments for this model are currently unavailable") — not a hang,
  not a mislabeled internal. A route with **no native dialect anywhere** still
  escalates, preserving the launch-time servability contract. The keyed-replay
  servability probe uses the same resolver.
- Removed the now-unused `resolve_route_profiles` and updated its doc
  reference.

Before: a disabled position-0 deployment fails the whole request. After: it is
skipped to the next live rung. Tests:
`test_a_disabled_lead_rung_resolves_to_the_next_live_rung`,
`test_every_rung_disabled_raises_the_unavailable_terminal`,
`test_every_rung_dialectless_preserves_the_escalation_contract`.

## Validation
- Rust: `cargo test --no-default-features` — 66 passed; `cargo clippy` clean;
  `cargo fmt --check` clean.
- Python: full `exp/runtime/gateway` suite — 475 passed; router + CLI gateway
  callers of the changed `serve_native_gateway` — 128 passed.
- `ruff check .`, `ruff format --check`, and `ty check exp/runtime exp/cli/gateway`
  all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
