### PR TITLE
Gateway: enforce exact generation parameter contracts

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -195,16 +195,13 @@ Commit-independent headers are available before streaming begins. Route-dependen
 emitted only after an execution snapshot exists. Stable public IDs do not expose raw key,
 idempotency, request, or provider values.
 
-`GET /v1/models` lists only the aliases granted to the presented key, as OpenAI model objects
-enriched with an `exp` object carrying the alias revision and catalog digest of the granted
-authority. When that alias revision targets exactly one direct singleton pool, the same object
-also carries optional extension fields copied from that pool's deployment: `supports_completions`,
-`supports_tools`, `supports_structured_output`, `maximum_output_tokens`, `context_window_tokens`
-when the catalog declares a window, and a `pricing` object of configured micro-USD-per-million-token
-rates. The gateway never invents a context window or a cache-write price, and it never hard-codes
-hosted alias names. Its list envelope carries `exp.authority_schema_version`, including when `data` is
-empty, so caller-side key validation can distinguish this gateway from a generic OpenAI proxy.
-`GET /v1/models/{model_id}` describes one granted alias with the same object and
+`GET /v1/models` lists only the aliases granted to the presented key. The envelope contains
+only the OpenAI `object` and `data` fields, and every entry contains only `id`, `object`,
+`created`, and `owned_by`. Capability, pricing, revision, and catalog-digest metadata never
+ride this compatibility endpoint. Platform's separate `/api/models` catalog owns rich route
+metadata, including configured micro-USD-per-million-token prices.
+`GET /v1/models/{model_id}` describes one granted alias with
+the same exact OpenAI Model object and
 returns the identical `model_not_found` 404 for every other model ID, so the route never confirms
 whether an ungranted alias exists. Quota-exhausted and throttled 429 responses and the draining
 503 advertise a `Retry-After` wait, and monthly quota exhaustion reports its exact UTC

--- a/docs/reference/openai-compatible-recipes.md
+++ b/docs/reference/openai-compatible-recipes.md
@@ -35,7 +35,7 @@ exp config gateway provider add fireworks \
 
 Then bind one exact model as a direct alias. The capability flags are the template for a
 current Fireworks chat model: most support tools and structured output, and none require
-developer messages. Confirm the flags and the micro-USD-per-million-token prices against
+developer messages. Confirm the flags and the micro-USD prices per million tokens against
 the Fireworks model page before authoring, because the gateway treats both as frozen
 authority for routing and accounting.
 
@@ -109,13 +109,12 @@ interactive screens, or authors the same configured metadata with `--non-interac
 `--connection-json` / `--model-json` (or a hand-written `.exp/models.toml` record). Setup never
 infers tools, structured output, token limits, or prices.
 
-A hosted Experiential gateway is the same provider family and an optional richer listing. Point
-`base_url` at its `/v1` origin and present a granted virtual key. `GET /v1/models` keeps the
-OpenAI list shape and may publish per-alias completion capabilities, limits, and configured
-micro-USD prices from the active catalog. `exp config providers --provider openai-compatible`
-reads those optional fields, converts micro-USD prices to USD per million tokens, and leaves
-unknown any field the catalog did not declare. It does not treat official OpenAI listing
-metadata the same way.
+A hosted Experiential gateway is the same provider family. Point `base_url` at its `/v1` origin
+and present a granted virtual key. `GET /v1/models` is identity-only and contains no capability,
+limit, pricing, revision, or catalog extension fields. Hosted catalog metadata is available from
+the Platform `/api/models` surface. Other compatible providers may expose optional model-list
+extensions; setup can read those declarations but leaves unknown anything the provider omits.
+The hosted gateway never relies on such extensions in the OpenAI discovery response.
 
 ## Experiential Cloud
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -98,17 +98,16 @@ required price or limit remains unknown.
 | `pricing.output_micro_usd_per_million_tokens` | integer `>= 0` | Configured output price in micro-USD per million tokens |
 | `pricing.cached_input_micro_usd_per_million_tokens` | integer `>= 0` | Configured cached-input price in micro-USD per million tokens |
 
-Micro-USD prices convert to catalog USD-per-million-token prices by dividing by `1_000_000`. A
-hosted Experiential gateway publishes these fields from the granted alias revision's direct
-singleton pool. Project aliases and multi-deployment pools stay identity-only. Published
-completion, tool, structured-output, and input/output price fields are enough to assign
-world-model and judge roles without a questionnaire. Router-candidate setup still requires a
-published or operator-declared context window and both cache prices. The gateway never invents
-those values, and setup never infers them.
+Micro-USD prices convert to catalog USD-per-million-token prices by dividing by `1_000_000`.
+When a trusted third-party compatible host publishes these fields, completion, tool,
+structured-output, and input/output price declarations can assign world-model and judge roles
+without a questionnaire. Router-candidate setup still requires a published or
+operator-declared context window and both cache prices. Setup never invents missing values.
 
-The hosted gateway `/v1/models` response keeps the standard OpenAI list shape (`object`, `data`,
-and the four OpenAI model keys) and only adds these extension fields plus the existing `exp`
-authority marker.
+The hosted gateway `/v1/models` response is the strict OpenAI discovery surface. Its list
+envelope contains only `object` and `data`; each model contains only `id`, `object`,
+`created`, and `owned_by`. Hosted capability and price discovery belongs to the platform
+catalog API, not to additive fields on the OpenAI endpoint.
 
 ## Azure
 

--- a/exp/cli/gateway/caller.py
+++ b/exp/cli/gateway/caller.py
@@ -100,12 +100,7 @@ def caller_models(
         typer.echo(response.text)
         return
     for model in _listed_models(response):
-        identity = str(model.get("id", ""))
-        authority = model.get("exp")
-        if isinstance(authority, dict) and "alias_revision_id" in authority:
-            typer.echo(f"{identity} (revision {authority['alias_revision_id']})")
-        else:
-            typer.echo(identity)
+        typer.echo(str(model.get("id", "")))
 
 
 def caller_key_check(
@@ -130,7 +125,7 @@ def caller_key_check(
     with _gateway_client(url, timeout=timeout) as client:
         response = _gateway_request(client, "GET", "/models", raw_key=raw_key, url=url)
     if response.status_code == 200:
-        models = _listed_authority_models(response)
+        models = _listed_gateway_models(response)
         if models is not None:
             aliases = [str(model["id"]) for model in models]
             if json_output:
@@ -154,7 +149,7 @@ def caller_key_check(
                 )
             return
         code = "invalid_gateway_response"
-        message = "HTTP 200 did not contain the EXP gateway model-authority response shape."
+        message = "HTTP 200 did not contain the gateway's exact OpenAI model-list shape."
     else:
         code, message = _error_detail(response)
     if json_output:
@@ -400,26 +395,24 @@ def _listed_models(response: httpx.Response) -> list[JsonObject]:
     return [cast(JsonObject, item) for item in payload["data"] if isinstance(item, dict)]
 
 
-def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | None:
-    """Return a validated EXP gateway model-authority list.
+def _listed_gateway_models(response: httpx.Response) -> list[JsonObject] | None:
+    """Return a validated exact OpenAI model list from this gateway.
 
     Args:
         response: Successful response from the caller's ``GET /v1/models`` request.
 
     Returns:
-        Validated model objects, including an empty list when the authority marker is present,
-        or ``None`` when the response is not the EXP gateway authority shape.
+        Validated model objects, including an empty list, or ``None`` when the
+        response does not match the gateway's exact public discovery contract.
     """
     try:
         payload = response.json()
     except (json.JSONDecodeError, UnicodeDecodeError):
         return None
-    if not isinstance(payload, dict) or payload.get("object") != "list":
-        return None
-    authority_marker = payload.get("exp")
     if (
-        not isinstance(authority_marker, dict)
-        or authority_marker.get("authority_schema_version") != 1
+        not isinstance(payload, dict)
+        or set(payload) != {"object", "data"}
+        or payload.get("object") != "list"
     ):
         return None
     data = payload.get("data")
@@ -430,34 +423,31 @@ def _listed_authority_models(response: httpx.Response) -> list[JsonObject] | Non
         if not isinstance(item, dict):
             return None
         model = cast(JsonObject, item)
-        if not _is_authority_model(model):
+        if not _is_gateway_model(model):
             return None
         models.append(model)
     return models
 
 
-def _is_authority_model(model: JsonObject) -> bool:
-    """Check the stable wire fields that identify an EXP authority model object.
+def _is_gateway_model(model: JsonObject) -> bool:
+    """Check one exact gateway-owned OpenAI Model object.
 
     Args:
         model: One decoded model object from a models-list response.
 
     Returns:
-        ``True`` only when the object carries the gateway authority metadata.
+        ``True`` only when the object has the four public Model fields and no
+        gateway-specific extensions.
     """
     if (
-        model.get("object") != "model"
+        set(model) != {"id", "object", "created", "owned_by"}
+        or model.get("object") != "model"
         or model.get("created") != 0
         or model.get("owned_by") != "exp"
     ):
         return False
     model_id = model.get("id")
-    authority = model.get("exp")
-    if not isinstance(model_id, str) or not model_id or not isinstance(authority, dict):
-        return False
-    revision = authority.get("alias_revision_id")
-    digest = authority.get("catalog_sha256")
-    return isinstance(revision, str) and bool(revision) and isinstance(digest, str) and bool(digest)
+    return isinstance(model_id, str) and bool(model_id)
 
 
 def _authorization(raw_key: str) -> dict[str, str]:

--- a/exp/cli/gateway/caller_test.py
+++ b/exp/cli/gateway/caller_test.py
@@ -240,10 +240,10 @@ def test_unreachable_gateway_is_a_usage_error_naming_the_url(
     assert "start one with 'exp'" in normalized
 
 
-def test_models_prints_the_caller_view_with_granted_revisions(
+def test_models_prints_the_exact_openai_caller_view(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The live caller view lists each granted alias with its active revision."""
+    """The live caller view lists each granted alias without private metadata."""
     envelope = {
         "object": "list",
         "data": [
@@ -252,14 +252,12 @@ def test_models_prints_the_caller_view_with_granted_revisions(
                 "object": "model",
                 "created": 0,
                 "owned_by": "exp",
-                "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
             }
         ],
-        "exp": {"authority_schema_version": 1},
     }
 
     def respond(request: httpx.Request) -> httpx.Response:
-        """Serve the enriched discovery list for the authenticated caller."""
+        """Serve the exact discovery list for the authenticated caller."""
         assert request.url.path == "/v1/models"
         assert request.headers["Authorization"] == f"Bearer {_RAW_KEY}"
         return httpx.Response(200, json=envelope)
@@ -269,7 +267,7 @@ def test_models_prints_the_caller_view_with_granted_revisions(
     raw = CliRunner().invoke(app, ["config", "gateway", "models", "--key", _RAW_KEY, "--json"])
 
     assert human.exit_code == 0, human.output
-    assert human.output == "coding (revision revision-one)\n"
+    assert human.output == "coding\n"
     assert raw.exit_code == 0, raw.output
     assert json.loads(raw.stdout) == envelope
     assert len(seen) == 2
@@ -293,13 +291,8 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
                         "object": "model",
                         "created": 0,
                         "owned_by": "exp",
-                        "exp": {
-                            "alias_revision_id": "revision-one",
-                            "catalog_sha256": "a" * 64,
-                        },
                     }
                 ],
-                "exp": {"authority_schema_version": 1},
             },
         )
 
@@ -327,15 +320,27 @@ def test_key_check_reports_granted_aliases_without_echoing_the_key(
     "envelope",
     (
         {"object": "list"},
-        {"object": "list", "data": []},
         {"object": "list", "data": [{"id": "generic-model", "object": "model"}]},
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": "coding",
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "exp",
+                    "exp": {"alias_revision_id": "revision-one"},
+                }
+            ],
+        },
+        {"object": "list", "data": [], "exp": {"authority_schema_version": 1}},
     ),
 )
-def test_key_check_rejects_http_200_without_gateway_authority_shape(
+def test_key_check_rejects_http_200_without_exact_gateway_model_shape(
     monkeypatch: pytest.MonkeyPatch,
     envelope: dict[str, object],
 ) -> None:
-    """An unrelated HTTP 200 model list cannot validate a gateway key."""
+    """Malformed or extended model lists cannot validate a gateway key."""
 
     def respond(request: httpx.Request) -> httpx.Response:
         """Serve a malformed or generic OpenAI model-list response."""
@@ -354,15 +359,15 @@ def test_key_check_rejects_http_200_without_gateway_authority_shape(
         "operation": "key.check",
         "valid": False,
         "error_code": "invalid_gateway_response",
-        "message": "HTTP 200 did not contain the EXP gateway model-authority response shape.",
+        "message": "HTTP 200 did not contain the gateway's exact OpenAI model-list shape.",
     }
     assert _RAW_KEY not in result.output
 
 
-def test_key_check_accepts_a_gateway_authority_envelope_with_no_grants(
+def test_key_check_accepts_an_exact_empty_gateway_model_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A marked empty gateway list proves authentication without inventing grants."""
+    """A successful exact empty list proves authentication without inventing grants."""
 
     def respond(request: httpx.Request) -> httpx.Response:
         """Serve the gateway's authenticated no-grants envelope."""
@@ -372,7 +377,6 @@ def test_key_check_accepts_a_gateway_authority_envelope_with_no_grants(
             json={
                 "object": "list",
                 "data": [],
-                "exp": {"authority_schema_version": 1},
             },
         )
 

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -245,6 +245,15 @@ class GatewayDeploymentCapabilities(ContractModel):
     reports_cached_input_tokens: bool = False
     reports_reasoning_tokens: bool = False
 
+    @property
+    def declares_reasoning_contract(self) -> bool:
+        """Whether this metadata overrides provider-family reasoning behavior."""
+        return bool(
+            self.supported_reasoning_efforts
+            or self.reasoning_default_effort is not None
+            or self.reasoning_effort_required
+        )
+
     @model_validator(mode="after")
     def _require_valid_reasoning_contract(self) -> GatewayDeploymentCapabilities:
         """Reject ambiguous or non-canonical reasoning declarations."""
@@ -355,6 +364,15 @@ class ModelRecord(ContractModel):
 
     @model_validator(mode="after")
     def _require_secret_free_model_identity(self) -> ModelRecord:
+        """Reject contradictory reasoning metadata and credential-bearing identity fields."""
+        if (
+            self.gateway is not None
+            and self.gateway.capabilities.declares_reasoning_contract
+            and (self.capabilities is None or not self.capabilities.supports_reasoning)
+        ):
+            raise ValueError(
+                "gateway reasoning metadata requires model capabilities.supports_reasoning=true"
+            )
         if (
             self.sft_provenance is not None
             and self.sft_provenance.sampling_handle_sha256

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -237,6 +237,8 @@ class GatewayDeploymentCapabilities(ContractModel):
     contract. OpenRouter and other catalog-driven providers declare the exact
     ordered set here because their supported values vary by model.
     """
+    reasoning_default_effort: ReasoningEffort | None = None
+    """Explicit provider default used only when the wire requires this field."""
     reasoning_effort_required: bool = False
     """Whether this deployment requires an explicit reasoning effort on its wire."""
     reports_refusals: bool = False
@@ -252,10 +254,19 @@ class GatewayDeploymentCapabilities(ContractModel):
             raise ValueError("supported_reasoning_efforts cannot repeat values")
         if indexes != tuple(sorted(indexes)):
             raise ValueError("supported_reasoning_efforts must use canonical order")
+        if (
+            self.reasoning_default_effort is not None
+            and self.reasoning_default_effort not in self.supported_reasoning_efforts
+        ):
+            raise ValueError(
+                "reasoning_default_effort must be one of the supported reasoning efforts"
+            )
         if self.reasoning_effort_required and not self.supported_reasoning_efforts:
             raise ValueError(
                 "reasoning_effort_required needs at least one supported reasoning effort"
             )
+        if self.reasoning_effort_required and self.reasoning_default_effort is None:
+            raise ValueError("reasoning_effort_required needs reasoning_default_effort")
         return self
 
 

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -230,9 +230,33 @@ class GatewayDeploymentCapabilities(ContractModel):
     field). A concrete value lets admission reject an over-limit list locally with a
     named parameter error instead of forwarding it and surfacing the provider's
     opaque 4xx (e.g. Gemini caps ``stopSequences`` at 5)."""
+    supported_reasoning_efforts: tuple[ReasoningEffort, ...] = ()
+    """Exact caller values this deployment can preserve without normalization.
+
+    An empty tuple means the gateway should use its maintained provider-family
+    contract. OpenRouter and other catalog-driven providers declare the exact
+    ordered set here because their supported values vary by model.
+    """
+    reasoning_effort_required: bool = False
+    """Whether this deployment requires an explicit reasoning effort on its wire."""
     reports_refusals: bool = False
     reports_cached_input_tokens: bool = False
     reports_reasoning_tokens: bool = False
+
+    @model_validator(mode="after")
+    def _require_valid_reasoning_contract(self) -> GatewayDeploymentCapabilities:
+        """Reject ambiguous or non-canonical reasoning declarations."""
+        order = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+        indexes = tuple(order.index(effort) for effort in self.supported_reasoning_efforts)
+        if len(set(self.supported_reasoning_efforts)) != len(self.supported_reasoning_efforts):
+            raise ValueError("supported_reasoning_efforts cannot repeat values")
+        if indexes != tuple(sorted(indexes)):
+            raise ValueError("supported_reasoning_efforts must use canonical order")
+        if self.reasoning_effort_required and not self.supported_reasoning_efforts:
+            raise ValueError(
+                "reasoning_effort_required needs at least one supported reasoning effort"
+            )
+        return self
 
 
 class GatewayTokenPrices(ContractModel):

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -282,7 +282,7 @@ def test_connections_only_catalog_round_trips_without_optimizer_roles(tmp_path: 
 def test_gateway_metadata_is_deployment_local_and_secret_free(tmp_path: Path) -> None:
     """Gateway protocol and integer pricing metadata persist outside frozen capabilities."""
     path = tmp_path / "models.toml"
-    capabilities = ModelCapabilities(supports_tools=True)
+    capabilities = ModelCapabilities(supports_tools=True, supports_reasoning=True)
     original_identity = capabilities.identity_sha256()
     catalog = ModelCatalog(
         connections={"openai": ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")},
@@ -358,6 +358,25 @@ def test_gateway_reasoning_default_must_be_supported() -> None:
         GatewayDeploymentCapabilities(
             supported_reasoning_efforts=("low", "high"),
             reasoning_default_effort="max",
+        )
+
+
+@pytest.mark.parametrize("capabilities", (None, ModelCapabilities()))
+def test_gateway_reasoning_metadata_requires_model_reasoning_support(
+    capabilities: ModelCapabilities | None,
+) -> None:
+    """Authored reasoning metadata cannot contradict the model capability contract."""
+    with pytest.raises(ValueError, match="supports_reasoning=true"):
+        ModelRecord(
+            connection="openai",
+            model="gpt-coding",
+            billing_source=BillingSource.CUSTOMER_MANAGED,
+            capabilities=capabilities,
+            gateway=GatewayDeploymentMetadata(
+                capabilities=GatewayDeploymentCapabilities(
+                    supported_reasoning_efforts=("medium",),
+                )
+            ),
         )
 
 

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -20,6 +20,7 @@ from exp.common.models import (
     ModelRecord,
     ModelRoles,
     ModelSnapshot,
+    ReasoningEffort,
     SFTModelProvenance,
     load_model_catalog,
     write_model_catalog,
@@ -296,6 +297,8 @@ def test_gateway_metadata_is_deployment_local_and_secret_free(tmp_path: Path) ->
                     capabilities=GatewayDeploymentCapabilities(
                         supports_streaming=True,
                         supports_streaming_tool_arguments=True,
+                        supported_reasoning_efforts=("low", "high", "max"),
+                        reasoning_effort_required=True,
                     ),
                     prices=GatewayTokenPrices(
                         input_micro_usd_per_million_tokens=1_250_000,
@@ -312,7 +315,31 @@ def test_gateway_metadata_is_deployment_local_and_secret_free(tmp_path: Path) ->
     assert loaded == catalog
     assert loaded.models["coding"].capabilities is not None
     assert loaded.models["coding"].capabilities.identity_sha256() == original_identity
+    assert loaded.models["coding"].gateway is not None
+    assert loaded.models["coding"].gateway.capabilities.supported_reasoning_efforts == (
+        "low",
+        "high",
+        "max",
+    )
     assert "input_micro_usd_per_million_tokens = 1250000" in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "values",
+    (("high", "low"), ("high", "high")),
+)
+def test_gateway_reasoning_efforts_require_unique_canonical_order(
+    values: tuple[ReasoningEffort, ...],
+) -> None:
+    """Ambiguous provider effort sets fail when the catalog is authored."""
+    with pytest.raises(ValueError):
+        GatewayDeploymentCapabilities(supported_reasoning_efforts=values)
+
+
+def test_required_gateway_reasoning_effort_needs_supported_values() -> None:
+    """A mandatory wire parameter cannot omit its provider value domain."""
+    with pytest.raises(ValueError, match="at least one supported reasoning effort"):
+        GatewayDeploymentCapabilities(reasoning_effort_required=True)
 
 
 def test_model_catalog_rejects_credential_values_and_embedded_url_credentials(

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -298,6 +298,7 @@ def test_gateway_metadata_is_deployment_local_and_secret_free(tmp_path: Path) ->
                         supports_streaming=True,
                         supports_streaming_tool_arguments=True,
                         supported_reasoning_efforts=("low", "high", "max"),
+                        reasoning_default_effort="max",
                         reasoning_effort_required=True,
                     ),
                     prices=GatewayTokenPrices(
@@ -340,6 +341,24 @@ def test_required_gateway_reasoning_effort_needs_supported_values() -> None:
     """A mandatory wire parameter cannot omit its provider value domain."""
     with pytest.raises(ValueError, match="at least one supported reasoning effort"):
         GatewayDeploymentCapabilities(reasoning_effort_required=True)
+
+
+def test_required_gateway_reasoning_effort_needs_an_explicit_default() -> None:
+    """A mandatory wire parameter cannot force admission to guess its value."""
+    with pytest.raises(ValueError, match="needs reasoning_default_effort"):
+        GatewayDeploymentCapabilities(
+            supported_reasoning_efforts=("low", "high"),
+            reasoning_effort_required=True,
+        )
+
+
+def test_gateway_reasoning_default_must_be_supported() -> None:
+    """A provider default outside the exact domain fails catalog loading."""
+    with pytest.raises(ValueError, match="must be one of the supported"):
+        GatewayDeploymentCapabilities(
+            supported_reasoning_efforts=("low", "high"),
+            reasoning_default_effort="max",
+        )
 
 
 def test_model_catalog_rejects_credential_values_and_embedded_url_credentials(

--- a/exp/common/models/gateway_catalog.py
+++ b/exp/common/models/gateway_catalog.py
@@ -37,6 +37,17 @@ class ExactModelDeployment(ContractModel):
     capabilities: ModelCapabilities | None = None
     gateway: GatewayDeploymentMetadata = Field(default_factory=GatewayDeploymentMetadata)
 
+    @model_validator(mode="after")
+    def _require_consistent_reasoning_contract(self) -> ExactModelDeployment:
+        """Reject a gateway reasoning override that the frozen model cannot support."""
+        if self.gateway.capabilities.declares_reasoning_contract and (
+            self.capabilities is None or not self.capabilities.supports_reasoning
+        ):
+            raise ValueError(
+                "gateway reasoning metadata requires model capabilities.supports_reasoning=true"
+            )
+        return self
+
 
 class ExactModelPool(ContractModel):
     """An ordered set of deployments certified as one exact logical model."""

--- a/exp/common/models/gateway_catalog_test.py
+++ b/exp/common/models/gateway_catalog_test.py
@@ -11,6 +11,7 @@ from exp.common.core.artifacts import ArtifactInput, sha256_json
 from exp.common.models.catalog import (
     BillingSource,
     ConnectionConfig,
+    GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
     GatewayEquivalenceCertification,
     GatewayPoolRecord,
@@ -154,6 +155,29 @@ def test_legacy_normalized_deployment_defaults_to_customer_managed_billing() -> 
     )
 
     assert deployment.billing_source == BillingSource.CUSTOMER_MANAGED
+
+
+def test_normalized_deployment_rejects_inconsistent_reasoning_metadata() -> None:
+    """Persisted snapshots cannot combine required reasoning with unsupported models."""
+    with pytest.raises(ValidationError, match="supports_reasoning=true"):
+        ExactModelDeployment(
+            deployment_id="coding",
+            source_alias="coding",
+            exact_model_id="exact-coding",
+            connection="openai",
+            provider="openai",
+            provider_model="gpt-coding",
+            connection_sha256="a" * 64,
+            capabilities_sha256="b" * 64,
+            capabilities=ModelCapabilities(),
+            gateway=GatewayDeploymentMetadata(
+                capabilities=GatewayDeploymentCapabilities(
+                    supported_reasoning_efforts=("medium",),
+                    reasoning_default_effort="medium",
+                    reasoning_effort_required=True,
+                )
+            ),
+        )
 
 
 def test_tinker_and_sft_records_are_not_gateway_deployments() -> None:

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -408,6 +408,8 @@ class ModelCapabilities(ContractModel):
         for name, minimum, maximum in ranges:
             if minimum is not None and maximum is not None and minimum > maximum:
                 raise ValueError(f"minimum_{name} cannot exceed maximum_{name}")
+        if self.reasoning_effort is not None and not self.supports_reasoning:
+            raise ValueError("reasoning_effort requires reasoning support")
         if self.sampling_requires_reasoning_none and not self.supports_reasoning:
             raise ValueError("conditional sampling requires reasoning support")
         return self

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -163,6 +163,12 @@ def test_completion_support_preserves_provider_identity_for_existing_traces() ->
         )
 
 
+def test_reasoning_effort_requires_explicit_reasoning_support() -> None:
+    """A pinned effort cannot create reasoning support by implication."""
+    with pytest.raises(ValidationError, match="reasoning_effort requires reasoning support"):
+        ModelCapabilities(reasoning_effort="high")
+
+
 def test_routed_candidate_payload_serializes_explicit_billing_source() -> None:
     """Automatic capability freezing retains the model billing source byte for byte."""
     payload = {

--- a/exp/runtime/gateway/discovery.py
+++ b/exp/runtime/gateway/discovery.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -13,9 +12,6 @@ from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 AliasAuthority = tuple[str, str, str]
 """Granted alias name, active revision, and catalog digest."""
-
-MODEL_AUTHORITY_SCHEMA_VERSION = 1
-"""Version of the gateway-specific model-list authority envelope."""
 
 
 class AliasMetadataLookup(Protocol):
@@ -187,56 +183,38 @@ def listing_metadata_by_alias(
 
 def public_model_object(
     authority: AliasAuthority,
-    metadata: PublishedAliasMetadata | None = None,
 ) -> JsonObject:
-    """Build one OpenAI model object enriched with granted authority and catalog fields.
-
-    The four OpenAI keys keep their exact meaning for official clients. The ``exp``
-    object carries only authority metadata the gateway already exposes to callers
-    through response headers and grants, never provider or credential detail.
-    Optional capability, limit, and price fields are catalog copies, never guesses.
+    """Build one exact OpenAI Model object for a granted public alias.
 
     Args:
         authority: Granted alias, active revision, and catalog digest triple.
-        metadata: Catalog-backed extension fields for the granted alias, when unique.
 
     Returns:
-        JSON-compatible public model object.
+        JSON-compatible Model object with only fields defined by OpenAI.
     """
-    alias, revision, digest = authority
-    payload: JsonObject = {
+    alias, _revision, _digest = authority
+    return {
         "id": alias,
         "object": "model",
         "created": 0,
         "owned_by": "exp",
-        "exp": {"alias_revision_id": revision, "catalog_sha256": digest},
     }
-    if metadata is not None:
-        payload.update(metadata.extension_fields())
-    return payload
 
 
 def public_model_list(
     authorities: tuple[AliasAuthority, ...],
-    metadata_by_alias: Mapping[str, PublishedAliasMetadata] | None = None,
 ) -> JsonObject:
-    """Build a caller model list with an authority marker even when it is empty.
+    """Build an exact OpenAI model-list envelope for granted aliases.
 
     Args:
         authorities: Granted alias, revision, and catalog digest triples.
-        metadata_by_alias: Catalog-backed extension fields keyed by granted alias.
 
     Returns:
-        OpenAI-compatible model-list envelope with the gateway authority marker.
+        OpenAI model-list object with no gateway-specific response fields.
     """
-    published = {} if metadata_by_alias is None else metadata_by_alias
     return {
         "object": "list",
-        "data": [
-            public_model_object(authority, metadata=published.get(authority[0]))
-            for authority in authorities
-        ],
-        "exp": {"authority_schema_version": MODEL_AUTHORITY_SCHEMA_VERSION},
+        "data": [public_model_object(authority) for authority in authorities],
     }
 
 

--- a/exp/runtime/gateway/discovery_test.py
+++ b/exp/runtime/gateway/discovery_test.py
@@ -1,101 +1,37 @@
-"""Tests for caller-facing model discovery objects."""
+"""Tests for caller-facing OpenAI model discovery objects."""
 
 from __future__ import annotations
 
 import pytest
 
-from exp.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
-from exp.common.models.gateway_catalog import ExactModelDeployment
-from exp.common.models.model import ModelCapabilities
 from exp.runtime.gateway.discovery import (
-    PublishedAliasMetadata,
-    listing_metadata_by_alias,
     public_model_list,
     public_model_object,
-    published_alias_metadata,
     require_granted_authority,
 )
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 _AUTHORITY = ("coding", "revision-one", "a" * 64)
-_EXP_LISTING_CONTRACT = {
+_MODEL_OBJECT = {
     "id": "coding",
     "object": "model",
     "created": 0,
     "owned_by": "exp",
-    "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
-    "supports_completions": True,
-    "supports_tools": True,
-    "supports_structured_output": True,
-    "supports_temperature": True,
-    "supports_top_p": True,
-    "supports_top_k": True,
-    "supports_logprobs": False,
-    "supports_reasoning": True,
-    "reasoning_effort": "low",
-    "sampling_requires_reasoning_none": False,
-    "chat_max_tokens_field": "max_completion_tokens",
-    "minimum_temperature": 0.0,
-    "maximum_temperature": 2.0,
-    "minimum_top_p": 0.0,
-    "maximum_top_p": 1.0,
-    "minimum_top_k": 1,
-    "maximum_top_k": 100,
-    "maximum_output_tokens": 16_000,
-    "pricing": {
-        "input_micro_usd_per_million_tokens": 1_250_000,
-        "output_micro_usd_per_million_tokens": 10_000_000,
-        "cached_input_micro_usd_per_million_tokens": 125_000,
-    },
 }
 
 
-def _deployment(
-    *,
-    capabilities: ModelCapabilities | None,
-    prices: GatewayTokenPrices | None = None,
-) -> ExactModelDeployment:
-    """Build one catalog deployment used only for public listing projection.
-
-    Args:
-        capabilities: Authored capability snapshot, or ``None`` when undeclared.
-        prices: Configured gateway prices, or defaults when omitted.
-
-    Returns:
-        A secret-free deployment whose public alias is ``coding``.
-    """
-    return ExactModelDeployment(
-        deployment_id="coding",
-        source_alias="coding",
-        exact_model_id="exact-coding",
-        connection="hosted",
-        provider="openai-compatible",
-        provider_model="hosted-coding",
-        connection_sha256="b" * 64,
-        capabilities_sha256="c" * 64,
-        capabilities=capabilities,
-        gateway=GatewayDeploymentMetadata(prices=prices or GatewayTokenPrices()),
-    )
+def test_public_model_object_has_only_openai_model_fields() -> None:
+    """The detail endpoint never leaks gateway-specific extension fields."""
+    assert public_model_object(_AUTHORITY) == _MODEL_OBJECT
 
 
-def test_public_model_object_keeps_the_openai_keys_and_adds_authority() -> None:
-    """The enriched object stays a valid OpenAI model for official clients."""
-    assert public_model_object(_AUTHORITY) == {
-        "id": "coding",
-        "object": "model",
-        "created": 0,
-        "owned_by": "exp",
-        "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
-    }
-
-
-def test_public_model_list_marks_even_an_empty_authority_envelope() -> None:
-    """The caller can identify an authenticated gateway with no granted aliases."""
-    assert public_model_list(()) == {
+def test_public_model_list_has_only_the_openai_list_shape() -> None:
+    """List entries and their envelope contain no gateway-specific fields."""
+    assert public_model_list((_AUTHORITY,)) == {
         "object": "list",
-        "data": [],
-        "exp": {"authority_schema_version": 1},
+        "data": [_MODEL_OBJECT],
     }
+    assert public_model_list(()) == {"object": "list", "data": []}
 
 
 def test_require_granted_authority_returns_the_exact_granted_triple() -> None:
@@ -104,7 +40,7 @@ def test_require_granted_authority_returns_the_exact_granted_triple() -> None:
 
 
 def test_unknown_and_ungranted_aliases_raise_the_identical_404() -> None:
-    """The 404 never distinguishes an unknown alias from an ungranted one."""
+    """The detail route never confirms whether an ungranted alias exists."""
     with pytest.raises(OpenAIProtocolError) as ungranted:
         require_granted_authority((_AUTHORITY,), "other-model")
     with pytest.raises(OpenAIProtocolError) as unknown:
@@ -118,145 +54,3 @@ def test_unknown_and_ungranted_aliases_raise_the_identical_404() -> None:
         "GET /v1/models lists the model aliases available to this key."
         in ungranted.value.detail.message
     )
-
-
-def test_public_model_object_copies_catalog_capabilities_limits_and_prices() -> None:
-    """A unique catalog deployment publishes its declared fields and no invented ones."""
-    metadata = published_alias_metadata(
-        _deployment(
-            capabilities=ModelCapabilities(
-                supports_tools=True,
-                supports_structured_output=True,
-                supports_top_p=True,
-                supports_top_k=True,
-                supports_logprobs=False,
-                supports_reasoning=True,
-                reasoning_effort="low",
-                chat_max_tokens_field="max_completion_tokens",
-                minimum_temperature=0.0,
-                maximum_temperature=2.0,
-                minimum_top_p=0.0,
-                maximum_top_p=1.0,
-                minimum_top_k=1,
-                maximum_top_k=100,
-                maximum_output_tokens=16_000,
-            ),
-            prices=GatewayTokenPrices(
-                input_micro_usd_per_million_tokens=1_250_000,
-                output_micro_usd_per_million_tokens=10_000_000,
-                cached_input_micro_usd_per_million_tokens=125_000,
-            ),
-        )
-    )
-
-    payload = public_model_object(_AUTHORITY, metadata=metadata)
-
-    assert payload == _EXP_LISTING_CONTRACT
-    assert "context_window_tokens" not in payload
-    assert "cache_write" not in str(payload)
-
-
-def test_public_model_object_omits_undeclared_catalog_fields() -> None:
-    """An undeclared snapshot still marks completion support and invents nothing else."""
-    payload = public_model_object(
-        _AUTHORITY, metadata=published_alias_metadata(_deployment(capabilities=None))
-    )
-
-    assert payload["supports_completions"] is True
-    assert "supports_tools" not in payload
-    assert "supports_structured_output" not in payload
-    assert "maximum_output_tokens" not in payload
-    assert "pricing" not in payload
-    assert "context_window_tokens" not in payload
-
-
-def test_explicit_completion_denial_is_published() -> None:
-    """A catalog ``supports_completions=False`` is copied instead of being overridden."""
-    metadata = published_alias_metadata(
-        _deployment(capabilities=ModelCapabilities(supports_completions=False))
-    )
-
-    assert metadata is not None
-    assert metadata.supports_completions is False
-    assert public_model_object(_AUTHORITY, metadata=metadata)["supports_completions"] is False
-
-
-def test_missing_deployment_publishes_no_extension_fields() -> None:
-    """A granted alias without a unique catalog deployment stays identity-only."""
-    assert published_alias_metadata(None) is None
-    assert public_model_object(_AUTHORITY) == {
-        "id": "coding",
-        "object": "model",
-        "created": 0,
-        "owned_by": "exp",
-        "exp": {"alias_revision_id": "revision-one", "catalog_sha256": "a" * 64},
-    }
-
-
-def test_public_model_list_attaches_per_alias_catalog_metadata() -> None:
-    """List entries receive only the metadata keyed to that granted alias."""
-    metadata = published_alias_metadata(
-        _deployment(
-            capabilities=ModelCapabilities(
-                supports_tools=True,
-                supports_structured_output=True,
-                supports_top_p=True,
-                supports_top_k=True,
-                supports_logprobs=False,
-                supports_reasoning=True,
-                reasoning_effort="low",
-                chat_max_tokens_field="max_completion_tokens",
-                minimum_temperature=0.0,
-                maximum_temperature=2.0,
-                minimum_top_p=0.0,
-                maximum_top_p=1.0,
-                minimum_top_k=1,
-                maximum_top_k=100,
-                maximum_output_tokens=16_000,
-            ),
-            prices=GatewayTokenPrices(
-                input_micro_usd_per_million_tokens=1_250_000,
-                output_micro_usd_per_million_tokens=10_000_000,
-                cached_input_micro_usd_per_million_tokens=125_000,
-            ),
-        )
-    )
-    assert metadata is not None
-
-    assert public_model_list((_AUTHORITY,), metadata_by_alias={"coding": metadata}) == {
-        "object": "list",
-        "data": [_EXP_LISTING_CONTRACT],
-        "exp": {"authority_schema_version": 1},
-    }
-
-
-def test_listing_metadata_by_alias_keeps_only_successful_lookups() -> None:
-    """Failed catalog lookups are omitted so unmatched aliases stay identity-only."""
-
-    def lookup(
-        *, alias: str, revision_id: str, catalog_sha256: str
-    ) -> PublishedAliasMetadata | None:
-        """Return metadata only for the coding alias.
-
-        Args:
-            alias: Granted public alias.
-            revision_id: Active revision.
-            catalog_sha256: Frozen catalog digest.
-
-        Returns:
-            Catalog metadata for ``coding``, otherwise ``None``.
-        """
-        del revision_id, catalog_sha256
-        if alias != "coding":
-            return None
-        return published_alias_metadata(
-            _deployment(capabilities=ModelCapabilities(supports_tools=True))
-        )
-
-    published = listing_metadata_by_alias(
-        (_AUTHORITY, ("other", "revision-two", "b" * 64)),
-        lookup,
-    )
-
-    assert set(published) == {"coding"}
-    assert published["coding"].supports_tools is True

--- a/exp/runtime/gateway/execution_resolution.py
+++ b/exp/runtime/gateway/execution_resolution.py
@@ -28,6 +28,7 @@ def _resolved_wire_profile(
         TypeError: The resolved client exposes no native wire profile.
     """
     capabilities = runtime_model.capabilities
+    gateway_capabilities = deployment.gateway.capabilities
     if isinstance(runtime_model.client, NativeWireClient):
         profile = runtime_model.client.gateway_wire_profile()
         output_limits = tuple(
@@ -74,6 +75,13 @@ def _resolved_wire_profile(
                 else profile.maximum_top_k
             ),
             sampling_requires_reasoning_none=capabilities.sampling_requires_reasoning_none,
+            supported_reasoning_efforts=(
+                gateway_capabilities.supported_reasoning_efforts
+                or profile.supported_reasoning_efforts
+            ),
+            reasoning_effort_required=(
+                gateway_capabilities.reasoning_effort_required or profile.reasoning_effort_required
+            ),
             token_limit_key=capabilities.chat_max_tokens_field or profile.token_limit_key,
             maximum_output_tokens=min(output_limits) if output_limits else None,
         )

--- a/exp/runtime/gateway/execution_resolution.py
+++ b/exp/runtime/gateway/execution_resolution.py
@@ -79,6 +79,9 @@ def _resolved_wire_profile(
                 gateway_capabilities.supported_reasoning_efforts
                 or profile.supported_reasoning_efforts
             ),
+            reasoning_effort=(
+                gateway_capabilities.reasoning_default_effort or profile.reasoning_effort
+            ),
             reasoning_effort_required=(
                 gateway_capabilities.reasoning_effort_required or profile.reasoning_effort_required
             ),

--- a/exp/runtime/gateway/execution_resolution.py
+++ b/exp/runtime/gateway/execution_resolution.py
@@ -10,6 +10,10 @@ from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.protocol import NativeWireClient
 
 
+class GatewayWireContractError(ValueError):
+    """A resolved provider profile contradicts the frozen gateway contract."""
+
+
 def _resolved_wire_profile(
     deployment: ExactModelDeployment,
     runtime_model: ResolvedModel,
@@ -25,12 +29,20 @@ def _resolved_wire_profile(
         intersected against the deployment's catalog capabilities.
 
     Raises:
+        GatewayWireContractError: Catalog reasoning metadata contradicts the
+            resolved model or provider wire profile.
         TypeError: The resolved client exposes no native wire profile.
     """
     capabilities = runtime_model.capabilities
     gateway_capabilities = deployment.gateway.capabilities
     if isinstance(runtime_model.client, NativeWireClient):
         profile = runtime_model.client.gateway_wire_profile()
+        if gateway_capabilities.declares_reasoning_contract and (
+            not capabilities.supports_reasoning or not profile.supports_reasoning
+        ):
+            raise GatewayWireContractError(
+                "gateway reasoning metadata conflicts with the resolved provider wire profile"
+            )
         output_limits = tuple(
             limit
             for limit in (

--- a/exp/runtime/gateway/execution_resolution_test.py
+++ b/exp/runtime/gateway/execution_resolution_test.py
@@ -7,7 +7,11 @@ from typing import cast
 import pytest
 
 from exp.common.models import BillingSource, ModelCapabilities, ModelSnapshot
-from exp.common.models.catalog import GatewayDeploymentMetadata, GatewayTokenPrices
+from exp.common.models.catalog import (
+    GatewayDeploymentCapabilities,
+    GatewayDeploymentMetadata,
+    GatewayTokenPrices,
+)
 from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.execution_resolution import (
     _require_deployment_identity,
@@ -29,7 +33,10 @@ def _snapshot() -> ModelSnapshot:
     )
 
 
-def _deployment(capabilities: ModelCapabilities | None) -> ExactModelDeployment:
+def _deployment(
+    capabilities: ModelCapabilities | None,
+    gateway_capabilities: GatewayDeploymentCapabilities | None = None,
+) -> ExactModelDeployment:
     """Build one exact deployment carrying the given catalog capability contract."""
     return ExactModelDeployment(
         deployment_id="primary",
@@ -42,6 +49,7 @@ def _deployment(capabilities: ModelCapabilities | None) -> ExactModelDeployment:
         capabilities_sha256="a" * 64,
         capabilities=capabilities,
         gateway=GatewayDeploymentMetadata(
+            capabilities=gateway_capabilities or GatewayDeploymentCapabilities(),
             prices=GatewayTokenPrices(),
             pricing_source="test",
         ),
@@ -102,6 +110,33 @@ def test_profile_ranges_intersect_with_the_catalog_contract() -> None:
     assert resolved.maximum_output_tokens == 128
     assert resolved.token_limit_key == "max_completion_tokens"
     assert resolved.model_id == "provider-model"
+
+
+def test_profile_resolution_applies_exact_gateway_reasoning_values() -> None:
+    """Deployment metadata replaces a family guess with provider-published values."""
+    capabilities = ModelCapabilities(
+        supports_reasoning=True,
+        reasoning_effort="max",
+    )
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://example.test/v1/chat/completions",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="max",
+    )
+    gateway_capabilities = GatewayDeploymentCapabilities(
+        supported_reasoning_efforts=("low", "high", "max"),
+        reasoning_effort_required=True,
+    )
+
+    resolved = _resolved_wire_profile(
+        _deployment(capabilities, gateway_capabilities),
+        _resolved(_NativeClient(profile), capabilities),
+    )
+
+    assert resolved.supported_reasoning_efforts == ("low", "high", "max")
+    assert resolved.reasoning_effort_required is True
 
 
 def test_profile_resolution_requires_a_native_wire_client() -> None:

--- a/exp/runtime/gateway/execution_resolution_test.py
+++ b/exp/runtime/gateway/execution_resolution_test.py
@@ -127,6 +127,7 @@ def test_profile_resolution_applies_exact_gateway_reasoning_values() -> None:
     )
     gateway_capabilities = GatewayDeploymentCapabilities(
         supported_reasoning_efforts=("low", "high", "max"),
+        reasoning_default_effort="high",
         reasoning_effort_required=True,
     )
 
@@ -136,6 +137,7 @@ def test_profile_resolution_applies_exact_gateway_reasoning_values() -> None:
     )
 
     assert resolved.supported_reasoning_efforts == ("low", "high", "max")
+    assert resolved.reasoning_effort == "high"
     assert resolved.reasoning_effort_required is True
 
 

--- a/exp/runtime/gateway/execution_resolution_test.py
+++ b/exp/runtime/gateway/execution_resolution_test.py
@@ -14,6 +14,7 @@ from exp.common.models.catalog import (
 )
 from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.execution_resolution import (
+    GatewayWireContractError,
     _require_deployment_identity,
     _resolved_wire_profile,
 )
@@ -139,6 +140,26 @@ def test_profile_resolution_applies_exact_gateway_reasoning_values() -> None:
     assert resolved.supported_reasoning_efforts == ("low", "high", "max")
     assert resolved.reasoning_effort == "high"
     assert resolved.reasoning_effort_required is True
+
+
+def test_profile_resolution_rejects_provider_reasoning_contract_conflict() -> None:
+    """A provider profile cannot silently weaken frozen gateway reasoning metadata."""
+    capabilities = ModelCapabilities(supports_reasoning=True)
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://example.test/v1/chat/completions",
+    )
+    gateway_capabilities = GatewayDeploymentCapabilities(
+        supported_reasoning_efforts=("medium",),
+        reasoning_default_effort="medium",
+        reasoning_effort_required=True,
+    )
+
+    with pytest.raises(GatewayWireContractError, match="reasoning metadata conflicts"):
+        _resolved_wire_profile(
+            _deployment(capabilities, gateway_capabilities),
+            _resolved(_NativeClient(profile), capabilities),
+        )
 
 
 def test_profile_resolution_requires_a_native_wire_client() -> None:

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -47,7 +47,6 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
 )
 from exp.runtime.gateway.discovery import (
-    listing_metadata_by_alias,
     public_model_list,
     public_model_object,
     require_granted_authority,
@@ -75,6 +74,7 @@ from exp.runtime.gateway.native_execution import (
     NativeDialectUnavailableError,
     deployment_wire_entry,
     resolve_route_profiles,
+    select_route_deployments,
 )
 from exp.runtime.gateway.native_metrics_text import render_metrics_text
 from exp.runtime.gateway.native_responses import (
@@ -98,6 +98,9 @@ from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
     normalized_provider_failure,
+)
+from exp.runtime.models.providers.generation_route_compat import (
+    compatible_generation_parameter_profile_indexes,
 )
 from exp.runtime.models.providers.protocol import GatewayDispatchSigner, NativeWireClient
 from exp.runtime.models.providers.streaming_requests import (
@@ -361,6 +364,12 @@ class NativeControlPlane:
         try:
             if probe_failure is not None or route is None or resolved_wires is None:
                 raise probe_failure or GatewayRoutingError("authorized route did not resolve")
+            compatible_indexes = compatible_generation_parameter_profile_indexes(
+                tuple(profile for profile, _client in resolved_wires),
+                request,
+            )
+            route = select_route_deployments(route, compatible_indexes)
+            resolved_wires = tuple(resolved_wires[index] for index in compatible_indexes)
             public_request, provider_request = route_generation_parameter_requests(
                 tuple(profile for profile, _client in resolved_wires),
                 request,
@@ -368,6 +377,38 @@ class NativeControlPlane:
             provider_request = provider_request.model_copy(
                 update={"stream": True, "include_usage": True}
             )
+            protocol_indexes: list[int] = []
+            first_protocol_error: ProviderParameterError | ProviderCapabilityError | None = None
+            for index, (deployment, (profile, _client)) in enumerate(
+                zip(route.deployments, resolved_wires, strict=True)
+            ):
+                try:
+                    preflight_gateway_request(
+                        provider_request,
+                        deployment.gateway.capabilities,
+                        model_capabilities=deployment.capabilities,
+                    )
+                    dialect_stream_payload(profile, provider_request)
+                except (ProviderParameterError, ProviderCapabilityError) as exc:
+                    if first_protocol_error is None:
+                        first_protocol_error = exc
+                    continue
+                protocol_indexes.append(index)
+            if not protocol_indexes:
+                if first_protocol_error is None:
+                    raise GatewayRoutingError("authorized route has no compatible deployment")
+                raise first_protocol_error
+            if len(protocol_indexes) != len(route.deployments):
+                selected_indexes = tuple(protocol_indexes)
+                route = select_route_deployments(route, selected_indexes)
+                resolved_wires = tuple(resolved_wires[index] for index in selected_indexes)
+                public_request, provider_request = route_generation_parameter_requests(
+                    tuple(profile for profile, _client in resolved_wires),
+                    request,
+                )
+                provider_request = provider_request.model_copy(
+                    update={"stream": True, "include_usage": True}
+                )
             wire_route: list[JsonObject] = []
             signers: list[GatewayDispatchSigner | None] = []
             for deployment, (profile, client) in zip(
@@ -673,12 +714,7 @@ class NativeControlPlane:
         data = json.loads(argument)
         try:
             authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
-            body = public_model_list(
-                authorities,
-                metadata_by_alias=listing_metadata_by_alias(
-                    authorities, self._components.routes.published_metadata
-                ),
-            )
+            body = public_model_list(authorities)
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             raise _authority_error(exc) from exc
         return json.dumps(body, separators=(",", ":"))
@@ -689,12 +725,7 @@ class NativeControlPlane:
         try:
             authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
             authority = require_granted_authority(authorities, data["model_id"])
-            body = public_model_object(
-                authority,
-                metadata=listing_metadata_by_alias(
-                    (authority,), self._components.routes.published_metadata
-                ).get(authority[0]),
-            )
+            body = public_model_object(authority)
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             raise _authority_error(exc) from exc
         return json.dumps(body, separators=(",", ":"))

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -30,7 +30,6 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayUsage,
 )
-from exp.runtime.gateway.discovery import listing_metadata_by_alias
 from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.lifecycle import (
     LocalGatewayComponents,
@@ -705,6 +704,8 @@ def _configured_pool_gateway(
     *,
     refusal_failover: bool = False,
     base_urls: tuple[str, str] = ("http://127.0.0.1:9/v1", "http://127.0.0.1:10/v1"),
+    gateway_capabilities: tuple[GatewayDeploymentCapabilities, GatewayDeploymentCapabilities]
+    | None = None,
 ) -> tuple[GatewayManagement, str]:
     """Create one certified two-deployment pool alias, grant, and key.
 
@@ -712,18 +713,14 @@ def _configured_pool_gateway(
         root: Gateway root to initialize.
         refusal_failover: Whether the alias revision opts into refusal failover.
         base_urls: One provider endpoint per ordered deployment.
+        gateway_capabilities: Optional protocol contract for each deployment.
 
     Returns:
         The management handle and the issued raw key.
     """
     from datetime import UTC, datetime
 
-    from exp.common.models import (
-        GatewayDeploymentCapabilities,
-        GatewayEquivalenceCertification,
-        GatewayTokenPrices,
-        ModelCapabilities,
-    )
+    from exp.common.models import GatewayEquivalenceCertification
     from exp.runtime.gateway.catalog_authority import (
         ConnectionConfig,
         upsert_certified_pool,
@@ -735,7 +732,13 @@ def _configured_pool_gateway(
     manager.initialize()
     normalized = None
     snapshot = None
-    for alias, base_url in zip(("alpha", "beta"), base_urls, strict=True):
+    declared_gateway_capabilities = gateway_capabilities or (
+        GatewayDeploymentCapabilities(supports_streaming=True),
+        GatewayDeploymentCapabilities(supports_streaming=True),
+    )
+    for alias, base_url, gateway_capability in zip(
+        ("alpha", "beta"), base_urls, declared_gateway_capabilities, strict=True
+    ):
         upsert_connection(
             root,
             name=f"{alias}-provider",
@@ -754,7 +757,7 @@ def _configured_pool_gateway(
             exact_model_id="model-revision-exact",
             revision=None,
             capabilities=ModelCapabilities(),
-            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+            gateway_capabilities=gateway_capability,
             prices=GatewayTokenPrices(),
             pricing_source=None,
             replace=False,
@@ -794,9 +797,15 @@ def _pool_control_plane(
     root: Path,
     *,
     refusal_failover: bool = False,
+    gateway_capabilities: tuple[GatewayDeploymentCapabilities, GatewayDeploymentCapabilities]
+    | None = None,
 ) -> tuple[NativeControlPlane, str]:
     """Load the native control plane over one certified two-deployment pool."""
-    _manager, raw_key = _configured_pool_gateway(root, refusal_failover=refusal_failover)
+    _manager, raw_key = _configured_pool_gateway(
+        root,
+        refusal_failover=refusal_failover,
+        gateway_capabilities=gateway_capabilities,
+    )
     components = load_gateway_components(
         root,
         environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
@@ -840,6 +849,34 @@ def test_admit_returns_the_full_ordered_route_without_starting_attempts(
             "select attempt_ordinal, route_depth, state from gateway_attempts"
         ).fetchall()
     assert rows == [(0, 0, "dispatched")]
+
+
+def test_admit_removes_protocol_incompatible_fallbacks(tmp_path: Path) -> None:
+    """A supported stop request keeps the compatible rung instead of failing the pool."""
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            GatewayDeploymentCapabilities(
+                supports_streaming=True,
+                supports_stop_sequences=True,
+            ),
+        ),
+    )
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": ["DONE"],
+        }
+    )
+
+    admission = _admit(control, raw_key, body)
+
+    route = cast("list[JsonObject]", admission["route"])
+    assert [item["model_id"] for item in route] == ["beta-model-exact"]
+    upstream = cast("JsonObject", route[0]["upstream_payload"])
+    assert upstream["stop"] == ["DONE"]
 
 
 def test_pool_failover_records_ordinals_depths_and_one_finalize(tmp_path: Path) -> None:
@@ -1106,20 +1143,18 @@ def test_authenticate_rejects_an_invalid_key(tmp_path: Path) -> None:
     assert payload["code"] == "invalid_key"
 
 
-def test_models_and_detail_mirror_the_python_discovery_bodies(tmp_path: Path) -> None:
-    """Model discovery bodies match the shared discovery encoding with metadata."""
+def test_models_and_detail_are_exact_openai_discovery_bodies(tmp_path: Path) -> None:
+    """Model discovery emits no gateway-specific response fields."""
     control, raw_key = _control_plane(tmp_path)
-    components = control._components  # noqa: SLF001 - expected-body construction.
-    authorities = components.store.granted_alias_authorities(raw_key=raw_key)
-    metadata = listing_metadata_by_alias(authorities, components.routes.published_metadata)
-    assert "coding" in metadata
 
     models = json.loads(control.models(json.dumps({"raw_key": raw_key})))
-    assert [item["id"] for item in models["data"]] == ["coding"]
-    assert models["exp"]["authority_schema_version"] == 1
-    listed = models["data"][0]
-    for key, value in metadata["coding"].extension_fields().items():
-        assert listed[key] == value
+    listed = {
+        "id": "coding",
+        "object": "model",
+        "created": 0,
+        "owned_by": "exp",
+    }
+    assert models == {"object": "list", "data": [listed]}
     detail = json.loads(
         control.model_detail(json.dumps({"raw_key": raw_key, "model_id": "coding"}))
     )

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -25,6 +25,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
 )
 from exp.runtime.gateway.execution_resolution import (
+    GatewayWireContractError,
     _require_deployment_identity,
     _resolved_wire_profile,
 )
@@ -347,12 +348,17 @@ def native_serving_blockers(components: LocalGatewayComponents) -> tuple[str, ..
                 reasons.append(f"provider {deployment.provider!r} has no native wire profile")
                 continue
             try:
-                client.gateway_wire_profile()
+                _resolved_wire_profile(deployment, resolved)
             except ProviderCapabilityError as exc:
                 if exc.capability != "native_data_plane":
                     raise
                 reasons.append(
                     f"provider {deployment.provider!r} has no native dialect implementation"
+                )
+            except GatewayWireContractError:
+                reasons.append(
+                    f"deployment {deployment.deployment_id!r} has an invalid "
+                    "reasoning wire contract"
                 )
         if reasons:
             unique = ", ".join(dict.fromkeys(reasons))

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -236,6 +236,44 @@ def resolve_route_profiles(
     return tuple(resolved_wires)
 
 
+def select_route_deployments(
+    route: GatewayRoute,
+    indexes: tuple[int, ...],
+) -> GatewayRoute:
+    """Return a route narrowed to ordered compatible deployment indexes.
+
+    Args:
+        route: Frozen ordered deployment route selected for the request.
+        indexes: Strictly increasing indexes into the route deployments.
+
+    Returns:
+        The original route when every deployment remains, otherwise a new
+        execution snapshot naming exactly the compatible deployments.
+
+    Raises:
+        ValueError: The selection is empty, unordered, repeated, or out of range.
+    """
+    deployments = route.deployments
+    if not indexes:
+        raise ValueError("a narrowed route requires at least one deployment")
+    if indexes != tuple(sorted(set(indexes))):
+        raise ValueError("route deployment indexes must be unique and ordered")
+    if indexes[0] < 0 or indexes[-1] >= len(deployments):
+        raise ValueError("route deployment index is out of range")
+    if indexes == tuple(range(len(deployments))):
+        return route
+    selected = tuple(deployments[index] for index in indexes)
+    return GatewayRoute(
+        snapshot=route.snapshot.model_copy(
+            update={"deployment_ids": tuple(item.deployment_id for item in selected)}
+        ),
+        deployment=selected[0],
+        fallback_deployments=selected[1:],
+        route_reason=route.route_reason,
+        fallback_reason=route.fallback_reason,
+    )
+
+
 def deployment_wire_entry(
     route: GatewayRoute,
     deployment: ExactModelDeployment,

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -314,3 +314,84 @@ def test_native_serving_blockers_name_dialectless_providers(
     assert blockers[0].startswith("escalated: ")
     assert "gemini" in blockers[0]
     assert "native dialect" in blockers[0]
+
+
+def test_native_serving_blockers_name_reasoning_wire_contract_conflicts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rust startup rejects catalog reasoning metadata the provider profile cannot carry."""
+    from dataclasses import replace
+
+    from exp.common.models import (
+        GatewayDeploymentCapabilities,
+        GatewayTokenPrices,
+        ModelCapabilities,
+    )
+    from exp.runtime.gateway.catalog_authority import (
+        ConnectionConfig,
+        upsert_connection,
+        upsert_singleton_deployment,
+    )
+    from exp.runtime.gateway.lifecycle import load_gateway_components
+    from exp.runtime.gateway.lifecycle_test import _configured_gateway
+    from exp.runtime.gateway.native_execution import native_serving_blockers
+    from exp.runtime.models.providers.base import GatewayWireProfile
+    from exp.runtime.models.providers.gemini import GeminiClient
+
+    original_wire_profile = GeminiClient.gateway_wire_profile
+
+    def _profile_without_reasoning(self: GeminiClient) -> GatewayWireProfile:
+        """Return a valid profile that contradicts the authored reasoning contract."""
+        return replace(
+            original_wire_profile(self),
+            supports_reasoning=False,
+            reasoning_wire_format="none",
+        )
+
+    monkeypatch.setattr(GeminiClient, "gateway_wire_profile", _profile_without_reasoning)
+
+    manager, _raw_key = _configured_gateway(tmp_path)
+    upsert_connection(
+        tmp_path,
+        name="gemini-main",
+        connection=ConnectionConfig(provider="gemini", api_key_env="TEST_GEMINI_KEY"),
+        replace=False,
+    )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        tmp_path,
+        deployment_alias="reasoning",
+        connection_name="gemini-main",
+        provider_model="gemini-model-exact",
+        exact_model_id="gemini-revision-exact",
+        revision=None,
+        capabilities=ModelCapabilities(supports_reasoning=True),
+        gateway_capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supported_reasoning_efforts=("medium",),
+            reasoning_default_effort="medium",
+            reasoning_effort_required=True,
+        ),
+        prices=GatewayTokenPrices(),
+        pricing_source=None,
+        replace=False,
+    )
+    manager.activate_direct_alias(
+        alias_id="reasoning",
+        alias_name="reasoning",
+        revision_id="revision-reasoning",
+        pool_id="reasoning",
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+    )
+    manager.add_grant(identity_id="default", alias_id="reasoning")
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_GEMINI_KEY": "gemini-secret-canary"},
+    )
+
+    blockers = native_serving_blockers(components)
+
+    assert len(blockers) == 1
+    assert blockers[0].startswith("reasoning: ")
+    assert "invalid reasoning wire contract" in blockers[0]

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -6,17 +6,72 @@ from pathlib import Path
 
 import pytest
 
-from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.common.models.catalog import GatewayDeploymentMetadata
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayFailure,
+    GatewayFailureClass,
+)
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_execution import (
     claim_route_from,
     next_route_candidate,
+    select_route_deployments,
 )
+from exp.runtime.gateway.routing import GatewayRoute
 
 _KEYS: tuple[DeploymentHealthKey, ...] = (
     ("catalog" + "0" * 57, "deployment-a", "connection-a"),
     ("catalog" + "0" * 57, "deployment-b", "connection-b"),
 )
+
+
+def _deployment(deployment_id: str) -> ExactModelDeployment:
+    """Build one exact deployment for route-narrowing tests."""
+    return ExactModelDeployment(
+        deployment_id=deployment_id,
+        source_alias=deployment_id,
+        exact_model_id="exact-one",
+        connection=f"connection-{deployment_id}",
+        provider="openai-compatible",
+        provider_model="provider-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(),
+    )
+
+
+def _route() -> GatewayRoute:
+    """Build a three-rung exact-model route."""
+    deployments = tuple(_deployment(name) for name in ("one", "two", "three"))
+    authorization = AuthorizationSnapshot(
+        request_id="request-one",
+        organization_id="organization-one",
+        identity_id="identity-one",
+        virtual_key_id="key-one",
+        alias="public-model",
+        alias_revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256="a" * 64,
+        canonical_request_sha256="d" * 64,
+        deadline_monotonic=1.0,
+    )
+    return GatewayRoute(
+        snapshot=ExecutionSnapshot(
+            authorization=authorization,
+            exact_model_id="exact-one",
+            pool_id="pool-one",
+            deployment_ids=tuple(item.deployment_id for item in deployments),
+        ),
+        deployment=deployments[0],
+        fallback_deployments=deployments[1:],
+        route_reason="direct",
+    )
 
 
 def _retryable() -> GatewayFailure:
@@ -36,6 +91,21 @@ def _failover_only() -> GatewayFailure:
         safe_message="provider throttled the request",
         failover_eligible=True,
     )
+
+
+def test_select_route_deployments_rebinds_the_execution_snapshot() -> None:
+    """Accounting and wire order name exactly the compatible deployment subset."""
+    selected = select_route_deployments(_route(), (1, 2))
+
+    assert tuple(item.deployment_id for item in selected.deployments) == ("two", "three")
+    assert selected.snapshot.deployment_ids == ("two", "three")
+
+
+@pytest.mark.parametrize("indexes", ((), (1, 0), (0, 0), (3,)))
+def test_select_route_deployments_rejects_invalid_indexes(indexes: tuple[int, ...]) -> None:
+    """An invalid compatibility selection cannot corrupt waterfall accounting."""
+    with pytest.raises(ValueError):
+        select_route_deployments(_route(), indexes)
 
 
 def test_claim_ladder_prefers_healthy_then_probe_then_forced() -> None:

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -12,7 +12,13 @@ from typing import ClassVar, Literal
 from uuid import uuid4
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models import ChatMaxTokensField, ModelRequest, ModelResponse, ModelSnapshot
+from exp.common.models import (
+    ChatMaxTokensField,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    ReasoningEffort,
+)
 from exp.runtime.models.providers.async_transport import (
     AsyncJsonHttpTransport,
     RequestDeadline,
@@ -138,7 +144,13 @@ class GatewayWireProfile:
     """Exact provider field used to carry normalized reasoning effort."""
 
     reasoning_effort: str | None = None
-    """Optional catalog-pinned reasoning effort."""
+    """Optional provider default used when the wire requires an explicit effort."""
+
+    supported_reasoning_efforts: tuple[ReasoningEffort, ...] = ()
+    """Exact caller values declared by this deployment, in canonical order."""
+
+    reasoning_effort_required: bool = False
+    """Whether dispatch must put an explicit reasoning effort on this wire."""
 
     sampling_requires_reasoning_none: bool = False
     """Whether sampling controls require an exact ``none`` reasoning effort."""
@@ -178,6 +190,26 @@ class GatewayWireProfile:
             raise ValueError("reasoning support requires a concrete wire format")
         if self.reasoning_effort is not None and not self.supports_reasoning:
             raise ValueError("a configured reasoning effort requires reasoning support")
+        if self.supported_reasoning_efforts and not self.supports_reasoning:
+            raise ValueError("supported reasoning efforts require reasoning support")
+        effort_order = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+        effort_indexes = tuple(
+            effort_order.index(effort) for effort in self.supported_reasoning_efforts
+        )
+        if len(set(self.supported_reasoning_efforts)) != len(self.supported_reasoning_efforts):
+            raise ValueError("supported reasoning efforts cannot repeat values")
+        if effort_indexes != tuple(sorted(effort_indexes)):
+            raise ValueError("supported reasoning efforts must use canonical order")
+        if (
+            self.reasoning_effort is not None
+            and self.supported_reasoning_efforts
+            and self.reasoning_effort not in self.supported_reasoning_efforts
+        ):
+            raise ValueError("the configured reasoning effort is not supported by this route")
+        if self.reasoning_effort_required and self.reasoning_effort is None:
+            raise ValueError("a required reasoning effort needs a configured provider default")
+        if self.reasoning_effort_required and not self.supports_reasoning:
+            raise ValueError("a required reasoning effort needs reasoning support")
         if self.sampling_requires_reasoning_none and not self.supports_reasoning:
             raise ValueError("conditional sampling requires reasoning support")
         if not math.isfinite(self.timeout_seconds) or self.timeout_seconds <= 0:

--- a/exp/runtime/models/providers/base_test.py
+++ b/exp/runtime/models/providers/base_test.py
@@ -205,10 +205,48 @@ def test_gateway_wire_profile_rejects_malformed_generation_contracts() -> None:
             url="https://provider.test/v1/chat/completions",
             sampling_requires_reasoning_none=True,
         ),
+        lambda: GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://provider.test/v1/chat/completions",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            supported_reasoning_efforts=("high", "low"),
+        ),
+        lambda: GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://provider.test/v1/chat/completions",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            supported_reasoning_efforts=("high",),
+            reasoning_effort="medium",
+        ),
+        lambda: GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://provider.test/v1/chat/completions",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            supported_reasoning_efforts=("high",),
+            reasoning_effort_required=True,
+        ),
     )
     for constructor in constructors:
         with pytest.raises(ValueError):
             constructor()
+
+
+def test_gateway_wire_profile_accepts_an_exact_required_reasoning_contract() -> None:
+    """A required provider default must be one member of its exact allowed set."""
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://provider.test/v1/chat/completions",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="max",
+        supported_reasoning_efforts=("low", "high", "max"),
+        reasoning_effort_required=True,
+    )
+
+    assert profile.reasoning_effort == "max"
 
 
 def test_complete_posts_bearer_headers_and_class_defaults_to_the_completion_route() -> None:

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -1,0 +1,73 @@
+"""Per-deployment generation-parameter compatibility for gateway routes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.models.providers.base import GatewayWireProfile
+from exp.runtime.models.providers.errors import ProviderParameterError
+from exp.runtime.models.providers.streaming_requests import route_generation_parameter_requests
+
+
+def compatible_generation_parameter_profile_indexes(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+) -> tuple[int, ...]:
+    """Return route rungs that can preserve every caller semantic exactly.
+
+    Each deployment is checked independently. A caller value may therefore
+    narrow a waterfall to compatible providers instead of being rejected
+    merely because an unused fallback has a different wire contract.
+
+    Args:
+        profiles: Ordered wire profiles for the certified deployment route.
+        request: Decoded public request before provider streaming is forced.
+
+    Returns:
+        Ordered indexes of every compatible route profile.
+
+    Raises:
+        ProviderParameterError: No deployment can preserve the request, or
+            required provider defaults disagree.
+        ValueError: The route has no wire profiles.
+    """
+    if not profiles:
+        raise ValueError("generation parameter selection requires at least one wire profile")
+    compatibility_request = _request_with_required_route_effort(profiles, request)
+    compatible: list[int] = []
+    for index, profile in enumerate(profiles):
+        try:
+            route_generation_parameter_requests((profile,), compatibility_request)
+        except ProviderParameterError:
+            continue
+        compatible.append(index)
+    if compatible:
+        return tuple(compatible)
+    route_generation_parameter_requests(profiles, compatibility_request)
+    raise AssertionError("an incompatible route returned without a parameter error")
+
+
+def _request_with_required_route_effort(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+) -> GatewayRequest:
+    """Insert one unanimous required provider effort for compatibility checks."""
+    if request.reasoning_effort is not None:
+        return request
+    required = {
+        profile.reasoning_effort for profile in profiles if profile.reasoning_effort_required
+    }
+    if not required:
+        return request
+    if None in required or len(required) != 1:
+        param = "reasoning.effort" if request.surface.value == "responses" else "reasoning_effort"
+        raise ProviderParameterError(
+            message=(
+                "The model route has inconsistent required reasoning efforts. "
+                "The gateway operator must align every waterfall deployment before retrying."
+            ),
+            param=param,
+            code="invalid_parameter",
+        )
+    return request.model_copy(update={"reasoning_effort": next(iter(required))})

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -28,46 +28,19 @@ def compatible_generation_parameter_profile_indexes(
         Ordered indexes of every compatible route profile.
 
     Raises:
-        ProviderParameterError: No deployment can preserve the request, or
-            required provider defaults disagree.
+        ProviderParameterError: No deployment can preserve the request.
         ValueError: The route has no wire profiles.
     """
     if not profiles:
         raise ValueError("generation parameter selection requires at least one wire profile")
-    compatibility_request = _request_with_required_route_effort(profiles, request)
     compatible: list[int] = []
     for index, profile in enumerate(profiles):
         try:
-            route_generation_parameter_requests((profile,), compatibility_request)
+            route_generation_parameter_requests((profile,), request)
         except ProviderParameterError:
             continue
         compatible.append(index)
     if compatible:
         return tuple(compatible)
-    route_generation_parameter_requests(profiles, compatibility_request)
+    route_generation_parameter_requests(profiles, request)
     raise AssertionError("an incompatible route returned without a parameter error")
-
-
-def _request_with_required_route_effort(
-    profiles: Sequence[GatewayWireProfile],
-    request: GatewayRequest,
-) -> GatewayRequest:
-    """Insert one unanimous required provider effort for compatibility checks."""
-    if request.reasoning_effort is not None:
-        return request
-    required = {
-        profile.reasoning_effort for profile in profiles if profile.reasoning_effort_required
-    }
-    if not required:
-        return request
-    if None in required or len(required) != 1:
-        param = "reasoning.effort" if request.surface.value == "responses" else "reasoning_effort"
-        raise ProviderParameterError(
-            message=(
-                "The model route has inconsistent required reasoning efforts. "
-                "The gateway operator must align every waterfall deployment before retrying."
-            ),
-            param=param,
-            code="invalid_parameter",
-        )
-    return request.model_copy(update={"reasoning_effort": next(iter(required))})

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -72,6 +72,7 @@ def supported_reasoning_efforts(
     wire_format: str,
     *,
     configured_effort: str | None = None,
+    explicit_efforts: Collection[str] | None = None,
 ) -> tuple[str, ...]:
     """Return efforts a route can send without provider-side normalization.
 
@@ -84,10 +85,13 @@ def supported_reasoning_efforts(
         model_id: Exact provider model identifier.
         wire_format: Provider field used to carry reasoning effort.
         configured_effort: Optional operator-pinned effort proven by the catalog.
+        explicit_efforts: Exact provider-published values for this deployment.
 
     Returns:
         Canonically ordered efforts that preserve the caller's exact value.
     """
+    if explicit_efforts is not None:
+        return tuple(effort for effort in _EFFORT_ORDER if effort in explicit_efforts)
     supported: Collection[str] | None
     if wire_format in {"openai_responses", "reasoning_effort"}:
         supported = _openai_supported_efforts(model_id)

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -212,19 +212,17 @@ def route_generation_parameter_requests(
             (_ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT, *route_limits)
         )
     effort_path = "reasoning.effort" if request.surface.value == "responses" else "reasoning_effort"
-    effective_reasoning_effort = _effective_route_reasoning_effort(
-        profiles,
-        request.reasoning_effort,
-        param=effort_path,
-    )
-    if request.reasoning_effort is None and effective_reasoning_effort is not None:
-        provider_updates["reasoning_effort"] = effective_reasoning_effort
+
+    def profile_reasoning_effort(profile: GatewayWireProfile) -> str | None:
+        """Return the caller effort or this wire's required provider default."""
+        return _effective_profile_reasoning_effort(profile, request.reasoning_effort)
 
     def sampling_supported(profile: GatewayWireProfile, *, top_p: bool = False) -> bool:
         """Return whether one rung accepts this request's sampling mode."""
         declared = profile.supports_top_p is True if top_p else profile.supports_temperature
         return declared and (
-            not profile.sampling_requires_reasoning_none or effective_reasoning_effort == "none"
+            not profile.sampling_requires_reasoning_none
+            or profile_reasoning_effort(profile) == "none"
         )
 
     if request.temperature is not None:
@@ -256,28 +254,33 @@ def route_generation_parameter_requests(
             minimum=lambda profile: profile.minimum_top_k,
             maximum=lambda profile: profile.maximum_top_k,
         )
-    if effective_reasoning_effort is not None:
+    if request.reasoning_effort is not None:
         portable_efforts = set(REASONING_EFFORTS)
         for profile in profiles:
-            if not profile.supports_reasoning or profile.reasoning_wire_format == "none":
-                portable_efforts.clear()
-                break
-            portable_efforts.intersection_update(
-                supported_reasoning_efforts(
-                    profile.model_id,
-                    profile.reasoning_wire_format,
-                    configured_effort=profile.reasoning_effort,
-                    explicit_efforts=profile.supported_reasoning_efforts or None,
-                )
-            )
-        if effective_reasoning_effort not in portable_efforts:
+            portable_efforts.intersection_update(_profile_reasoning_efforts(profile))
+        if request.reasoning_effort not in portable_efforts:
             raise UnsupportedReasoningEffortError(
-                effort=effective_reasoning_effort,
+                effort=request.reasoning_effort,
                 supported_efforts=tuple(
                     effort for effort in REASONING_EFFORTS if effort in portable_efforts
                 ),
                 param=effort_path,
             )
+    else:
+        # An omitted caller value remains omitted on the shared request. Each
+        # dialect payload injects only its own provider-required default, so a
+        # fallback never forces that default onto a wire where it is optional.
+        for profile in profiles:
+            required_effort = profile_reasoning_effort(profile)
+            if required_effort is None:
+                continue
+            profile_efforts = _profile_reasoning_efforts(profile)
+            if required_effort not in profile_efforts:
+                raise UnsupportedReasoningEffortError(
+                    effort=required_effort,
+                    supported_efforts=profile_efforts,
+                    param=effort_path,
+                )
     if request.stop and any(profile.dialect == "openai_responses" for profile in profiles):
         raise ProviderParameterError(
             message=(
@@ -413,30 +416,26 @@ def route_generation_parameter_requests(
     return public_request, provider_request
 
 
-def _effective_route_reasoning_effort(
-    profiles: Sequence[GatewayWireProfile],
+def _effective_profile_reasoning_effort(
+    profile: GatewayWireProfile,
     requested_effort: str | None,
-    *,
-    param: str,
 ) -> str | None:
-    """Return an explicit effort or one consistent required provider default."""
+    """Return an explicit caller effort or one wire's required default."""
     if requested_effort is not None:
         return requested_effort
-    configured = {
-        profile.reasoning_effort for profile in profiles if profile.reasoning_effort_required
-    }
-    if not configured:
-        return None
-    if None in configured or len(configured) != 1:
-        raise ProviderParameterError(
-            message=(
-                "The model route has inconsistent required reasoning efforts. "
-                "The gateway operator must align every waterfall deployment before retrying."
-            ),
-            param=param,
-            code="invalid_parameter",
-        )
-    return next(iter(configured))
+    return profile.reasoning_effort if profile.reasoning_effort_required else None
+
+
+def _profile_reasoning_efforts(profile: GatewayWireProfile) -> tuple[str, ...]:
+    """Return exact accepted efforts for one deployment wire profile."""
+    if not profile.supports_reasoning or profile.reasoning_wire_format == "none":
+        return ()
+    return supported_reasoning_efforts(
+        profile.model_id,
+        profile.reasoning_wire_format,
+        configured_effort=profile.reasoning_effort,
+        explicit_efforts=profile.supported_reasoning_efforts or None,
+    )
 
 
 def _require_route_numeric_parameter(

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -61,6 +61,9 @@ def dialect_stream_payload(
         ProviderCapabilityError: The request uses a capability this dialect
             cannot preserve.
     """
+    required_reasoning_effort = (
+        profile.reasoning_effort if profile.reasoning_effort_required else None
+    )
     if profile.dialect == "openai_responses":
         return openai_responses_stream_payload(
             profile.model_id,
@@ -74,7 +77,7 @@ def dialect_stream_payload(
             supports_top_k=profile.supports_top_k,
             supports_logprobs=profile.supports_logprobs,
             supports_reasoning=profile.supports_reasoning,
-            reasoning_effort=profile.reasoning_effort,
+            reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
         )
     if profile.dialect == "anthropic_messages":
@@ -90,7 +93,7 @@ def dialect_stream_payload(
             supports_top_k=profile.supports_top_k,
             supports_logprobs=profile.supports_logprobs,
             supports_reasoning=profile.supports_reasoning,
-            reasoning_effort=profile.reasoning_effort,
+            reasoning_effort=required_reasoning_effort,
         )
     if profile.dialect == "gemini_generate_content":
         return gemini_generate_content_stream_payload(
@@ -105,7 +108,7 @@ def dialect_stream_payload(
             supports_top_k=profile.supports_top_k,
             supports_logprobs=profile.supports_logprobs,
             supports_reasoning=profile.supports_reasoning,
-            reasoning_effort=profile.reasoning_effort,
+            reasoning_effort=required_reasoning_effort,
         )
     if profile.dialect == "bedrock_converse_stream":
         return bedrock_converse_stream_payload(
@@ -135,7 +138,7 @@ def dialect_stream_payload(
             supports_logprobs=profile.supports_logprobs,
             supports_reasoning=profile.supports_reasoning,
             reasoning_wire_format=profile.reasoning_wire_format,
-            reasoning_effort=profile.reasoning_effort,
+            reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")
@@ -214,6 +217,8 @@ def route_generation_parameter_requests(
         request.reasoning_effort,
         param=effort_path,
     )
+    if request.reasoning_effort is None and effective_reasoning_effort is not None:
+        provider_updates["reasoning_effort"] = effective_reasoning_effort
 
     def sampling_supported(profile: GatewayWireProfile, *, top_p: bool = False) -> bool:
         """Return whether one rung accepts this request's sampling mode."""
@@ -262,6 +267,7 @@ def route_generation_parameter_requests(
                     profile.model_id,
                     profile.reasoning_wire_format,
                     configured_effort=profile.reasoning_effort,
+                    explicit_efforts=profile.supported_reasoning_efforts or None,
                 )
             )
         if effective_reasoning_effort not in portable_efforts:
@@ -413,16 +419,18 @@ def _effective_route_reasoning_effort(
     *,
     param: str,
 ) -> str | None:
-    """Return an explicit effort or one consistent route pin without changing it."""
+    """Return an explicit effort or one consistent required provider default."""
     if requested_effort is not None:
         return requested_effort
-    configured = {profile.reasoning_effort for profile in profiles}
-    if configured == {None}:
+    configured = {
+        profile.reasoning_effort for profile in profiles if profile.reasoning_effort_required
+    }
+    if not configured:
         return None
     if None in configured or len(configured) != 1:
         raise ProviderParameterError(
             message=(
-                "The model route has inconsistent configured reasoning efforts. "
+                "The model route has inconsistent required reasoning efforts. "
                 "The gateway operator must align every waterfall deployment before retrying."
             ),
             param=param,

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -391,34 +391,37 @@ def test_route_rejects_an_unsupported_configured_effort_without_clamping() -> No
     assert "Supported values: 'low', 'medium', 'high', 'xhigh'" in str(raised.value)
 
 
-def test_route_rejects_inconsistent_configured_efforts_across_fallbacks() -> None:
-    """A fallback cannot silently change an operator-pinned reasoning level."""
+def test_route_preserves_each_required_reasoning_default_across_fallbacks() -> None:
+    """An omitted caller effort is injected independently on each required wire."""
     profiles = (
         GatewayWireProfile(
-            dialect="anthropic_messages",
+            dialect="openai_compatible",
             url="https://first.test",
-            model_id="claude-opus-5",
+            model_id="provider/first",
             supports_reasoning=True,
-            reasoning_wire_format="anthropic_adaptive",
+            reasoning_wire_format="reasoning",
             reasoning_effort="high",
+            supported_reasoning_efforts=("medium", "high"),
             reasoning_effort_required=True,
         ),
         GatewayWireProfile(
-            dialect="anthropic_messages",
+            dialect="openai_compatible",
             url="https://fallback.test",
-            model_id="claude-opus-5",
+            model_id="provider/fallback",
             supports_reasoning=True,
-            reasoning_wire_format="anthropic_adaptive",
+            reasoning_wire_format="reasoning",
             reasoning_effort="medium",
+            supported_reasoning_efforts=("medium", "high"),
             reasoning_effort_required=True,
         ),
     )
 
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests(profiles, _chat_request())
+    public, provider = route_generation_parameter_requests(profiles, _chat_request())
 
-    assert raised.value.code == "invalid_parameter"
-    assert "gateway operator must align" in str(raised.value)
+    assert public.reasoning_effort is None
+    assert provider.reasoning_effort is None
+    assert dialect_stream_payload(profiles[0], provider)["reasoning"] == {"effort": "high"}
+    assert dialect_stream_payload(profiles[1], provider)["reasoning"] == {"effort": "medium"}
 
 
 def test_explicit_provider_effort_set_accepts_exact_values_and_rejects_others() -> None:
@@ -472,7 +475,7 @@ def test_required_reasoning_default_is_sent_but_optional_default_is_not() -> Non
 
     public, provider = route_generation_parameter_requests((required,), _chat_request())
     assert public.reasoning_effort is None
-    assert provider.reasoning_effort == "max"
+    assert provider.reasoning_effort is None
     assert dialect_stream_payload(required, provider)["reasoning"] == {"effort": "max"}
     optional_public, optional_provider = route_generation_parameter_requests(
         (optional,), _chat_request()
@@ -480,6 +483,14 @@ def test_required_reasoning_default_is_sent_but_optional_default_is_not() -> Non
     assert optional_public.reasoning_effort is None
     assert optional_provider.reasoning_effort is None
     assert "reasoning" not in dialect_stream_payload(optional, optional_provider)
+
+    mixed_public, mixed_provider = route_generation_parameter_requests(
+        (required, optional), _chat_request()
+    )
+    assert mixed_public.reasoning_effort is None
+    assert mixed_provider.reasoning_effort is None
+    assert dialect_stream_payload(required, mixed_provider)["reasoning"] == {"effort": "max"}
+    assert "reasoning" not in dialect_stream_payload(optional, mixed_provider)
 
 
 def test_generation_parameter_selection_skips_incompatible_fallbacks() -> None:
@@ -500,6 +511,65 @@ def test_generation_parameter_selection_skips_incompatible_fallbacks() -> None:
         ),
     )
     request = _chat_request().model_copy(update={"reasoning_effort": "high"})
+
+    assert compatible_generation_parameter_profile_indexes(profiles, request) == (1,)
+
+
+def test_generation_parameter_selection_accepts_different_required_defaults() -> None:
+    """Omitted effort keeps independently valid rungs with different wire defaults."""
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://first.test",
+            model_id="provider/first",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            reasoning_effort="high",
+            supported_reasoning_efforts=("medium", "high"),
+            reasoning_effort_required=True,
+        ),
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://fallback.test",
+            model_id="provider/fallback",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            reasoning_effort="medium",
+            supported_reasoning_efforts=("medium", "high"),
+            reasoning_effort_required=True,
+        ),
+    )
+
+    assert compatible_generation_parameter_profile_indexes(profiles, _chat_request()) == (0, 1)
+
+
+def test_generation_parameter_selection_uses_each_default_for_sampling() -> None:
+    """Conditional sampling narrows against each required default independently."""
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://reasoning.test",
+            model_id="provider/reasoning",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            reasoning_effort="high",
+            supported_reasoning_efforts=("none", "high"),
+            reasoning_effort_required=True,
+            sampling_requires_reasoning_none=True,
+        ),
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://sampling.test",
+            model_id="provider/sampling",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            reasoning_effort="none",
+            supported_reasoning_efforts=("none", "high"),
+            reasoning_effort_required=True,
+            sampling_requires_reasoning_none=True,
+        ),
+    )
+    request = _chat_request().model_copy(update={"temperature": 0.5})
 
     assert compatible_generation_parameter_profile_indexes(profiles, request) == (1,)
 

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -20,6 +20,9 @@ from exp.runtime.models.providers.errors import (
     UnsupportedReasoningEffortError,
 )
 from exp.runtime.models.providers.gemini_requests import gemini_generate_request
+from exp.runtime.models.providers.generation_route_compat import (
+    compatible_generation_parameter_profile_indexes,
+)
 from exp.runtime.models.providers.streaming_requests import (
     anthropic_messages_stream_payload,
     bedrock_converse_stream_payload,
@@ -378,6 +381,7 @@ def test_route_rejects_an_unsupported_configured_effort_without_clamping() -> No
                     supports_reasoning=True,
                     reasoning_wire_format="openai_responses",
                     reasoning_effort="minimal",
+                    reasoning_effort_required=True,
                 ),
             ),
             _chat_request(),
@@ -397,6 +401,7 @@ def test_route_rejects_inconsistent_configured_efforts_across_fallbacks() -> Non
             supports_reasoning=True,
             reasoning_wire_format="anthropic_adaptive",
             reasoning_effort="high",
+            reasoning_effort_required=True,
         ),
         GatewayWireProfile(
             dialect="anthropic_messages",
@@ -405,6 +410,7 @@ def test_route_rejects_inconsistent_configured_efforts_across_fallbacks() -> Non
             supports_reasoning=True,
             reasoning_wire_format="anthropic_adaptive",
             reasoning_effort="medium",
+            reasoning_effort_required=True,
         ),
     )
 
@@ -413,6 +419,89 @@ def test_route_rejects_inconsistent_configured_efforts_across_fallbacks() -> Non
 
     assert raised.value.code == "invalid_parameter"
     assert "gateway operator must align" in str(raised.value)
+
+
+def test_explicit_provider_effort_set_accepts_exact_values_and_rejects_others() -> None:
+    """Catalog-published OpenRouter values replace the unknown-family singleton."""
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://openrouter.test",
+        model_id="z-ai/glm-5.3",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="max",
+        supported_reasoning_efforts=("low", "high", "max"),
+        reasoning_effort_required=True,
+    )
+
+    _public, provider = route_generation_parameter_requests(
+        (profile,),
+        _chat_request().model_copy(update={"reasoning_effort": "high"}),
+    )
+    assert provider.reasoning_effort == "high"
+
+    with pytest.raises(UnsupportedReasoningEffortError) as raised:
+        route_generation_parameter_requests(
+            (profile,),
+            _chat_request().model_copy(update={"reasoning_effort": "medium"}),
+        )
+    assert "Supported values: 'low', 'high', 'max'." in str(raised.value)
+
+
+def test_required_reasoning_default_is_sent_but_optional_default_is_not() -> None:
+    """Only a provider-mandated default may add an omitted reasoning field."""
+    required = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://required.test",
+        model_id="z-ai/glm-5.3",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="max",
+        supported_reasoning_efforts=("low", "high", "max"),
+        reasoning_effort_required=True,
+    )
+    optional = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://optional.test",
+        model_id="deepseek/deepseek-v4-flash",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="high",
+        supported_reasoning_efforts=("high", "xhigh"),
+    )
+
+    public, provider = route_generation_parameter_requests((required,), _chat_request())
+    assert public.reasoning_effort is None
+    assert provider.reasoning_effort == "max"
+    assert dialect_stream_payload(required, provider)["reasoning"] == {"effort": "max"}
+    optional_public, optional_provider = route_generation_parameter_requests(
+        (optional,), _chat_request()
+    )
+    assert optional_public.reasoning_effort is None
+    assert optional_provider.reasoning_effort is None
+    assert "reasoning" not in dialect_stream_payload(optional, optional_provider)
+
+
+def test_generation_parameter_selection_skips_incompatible_fallbacks() -> None:
+    """An exact caller value keeps usable rungs instead of poisoning the waterfall."""
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://azure.test",
+            model_id="DeepSeek-V4-Flash",
+        ),
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://openrouter.test",
+            model_id="deepseek/deepseek-v4-flash",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            supported_reasoning_efforts=("high", "xhigh"),
+        ),
+    )
+    request = _chat_request().model_copy(update={"reasoning_effort": "high"})
+
+    assert compatible_generation_parameter_profile_indexes(profiles, request) == (1,)
 
 
 def test_route_accepts_anthropic_max_effort_without_translation() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.6.0"
+version = "0.6.1"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Add exact per-deployment reasoning-effort contracts and narrow waterfalls to deployments that preserve every explicit caller value.
- Apply route-aware validation for temperature, top_p, top_k, output-token limits, stop sequences, tools, structured output, and provider wire dialect requirements before dispatch.
- Preserve provider defaults when callers omit reasoning effort; inject an effort only when the provider wire explicitly requires one.
- Return OpenAI-spec model discovery objects from `/v1/models` with only `id`, `object`, `created`, and `owned_by`. Rich capabilities and pricing stay on Platform `/api/models`.

## Behavior

Unsupported explicit values return a typed invalid request before provider dispatch. Values are never clamped or silently changed. A mixed waterfall stays callable when at least one deployment supports the complete requested parameter combination.

## Validation

- Focused gateway and release-revision suite: 202 passed
- Full pytest: 2,611 passed, 2 skipped; 11 unrelated pseudo-terminal rendering failures reproduce on clean main in this local sandbox
- Ruff, format, and ty: passed
- Rust: 64 tests passed, cargo fmt passed, clippy with warnings denied passed
- Version-bump release checks: 17 passed, 1 skipped

## Release coordination

This PR versions the release pair as `experiential 0.6.1` and `exp-gateway-native 0.2.1`. After merge, publish both from the same exact release tag before Platform updates its exact PyPI pins. No package is published by this PR.
