### PR TITLE
Add TrustedRouter as a native OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ OPENAI_API_KEY=
 # OpenRouter (serves pool candidates like GLM-5.2 / Kimi, priced from its own catalog)
 OPENROUTER_API_KEY=
 
+# TrustedRouter (attested OpenAI-compatible router; catalog publishes roles, context, prices)
+TRUSTEDROUTER_API_KEY=
+
 # Tinker (distillation: student sampling, training, and serving trained adapters)
 TINKER_API_KEY=
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -77,10 +77,11 @@ with the same vocabulary. Setup keeps the completion and embedding roles from
 
 `supported_parameters` is read the way OpenRouter's is when a model publishes it. The array is
 optional: a model that omits it keeps tool, structured-output, sampling, and reasoning support
-**unknown** rather than reporting them as unsupported, and the operator declares the minimum
-fields for a selected role the same way an identity-only OpenAI-compatible model does. A model
-that reports a non-positive `context_length` keeps an unknown context window rather than borrowing
-one from a neighboring field.
+**unknown** rather than reporting them as unsupported. Because that listing can return an unproven
+model, `trustedrouter` joins `openai-compatible` in the operator-declaration path, so such a model
+stays visible and the operator declares the minimum fields a selected role needs instead of the
+model being dropped from the role choices. A model that reports a non-positive `context_length`
+keeps an unknown context window rather than borrowing one from a neighboring field.
 
 ## OpenAI-compatible listing metadata
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -70,14 +70,17 @@ third-party OpenAI-compatible host.
 
 ## TrustedRouter listing metadata
 
-`trustedrouter` lists an OpenRouter-shaped catalog from its own origin. Setup keeps the fields it
-publishes: the completion and embedding roles from `trustedrouter.supports_chat` and
-`trustedrouter.supports_embeddings`, `context_length`, and the `pricing.prompt` and
-`pricing.completion` per-token prices. The catalog publishes no `supported_parameters` array, so
-tool, structured-output, sampling, and reasoning support stay unknown and the operator declares the
-minimum fields for a selected role, the same way an identity-only OpenAI-compatible model does. A
-model that reports a non-positive `context_length` keeps an unknown context window rather than
-borrowing one from a neighboring field.
+`trustedrouter` lists an OpenRouter-shaped catalog from its own origin and names its parameters
+with the same vocabulary. Setup keeps the completion and embedding roles from
+`trustedrouter.supports_chat` and `trustedrouter.supports_embeddings`, `context_length`,
+`top_provider.max_completion_tokens`, and the `pricing` per-token prices.
+
+`supported_parameters` is read the way OpenRouter's is when a model publishes it. The array is
+optional: a model that omits it keeps tool, structured-output, sampling, and reasoning support
+**unknown** rather than reporting them as unsupported, and the operator declares the minimum
+fields for a selected role the same way an identity-only OpenAI-compatible model does. A model
+that reports a non-positive `context_length` keeps an unknown context window rather than borrowing
+one from a neighboring field.
 
 ## OpenAI-compatible listing metadata
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -8,7 +8,7 @@ Configure connections with `exp config providers` or the first `exp build` on a 
 An interactive terminal opens a provider list: Up and Down move focus, Enter selects or deselects
 the focused provider, and the Complete row submits the selection. Agents skip that list with
 repeatable `--provider` flags (`experiential-cloud`, `openai`, `anthropic`, `gemini`, `openrouter`,
-`openai-compatible`, `azure`, `bedrock`). Unsupported or duplicate values
+`trustedrouter`, `openai-compatible`, `azure`, `bedrock`). Unsupported or duplicate values
 fail before any catalog write. Azure and Bedrock still require manual model IDs. Other selected
 providers use account model discovery when credentials are available.
 
@@ -55,6 +55,7 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 |---|---|---|---|
 | OpenAI | `openai` | `api_key_env` (suggested `OPENAI_API_KEY`) | Official OpenAI origin |
 | OpenRouter | `openrouter` | `api_key_env` (suggested `OPENROUTER_API_KEY`) | Official OpenRouter origin |
+| TrustedRouter | `trustedrouter` | `api_key_env` (suggested `TRUSTEDROUTER_API_KEY`) | Official TrustedRouter origin |
 | Anthropic | `anthropic` | `api_key_env` (suggested `ANTHROPIC_API_KEY`) | Official Anthropic origin |
 | Gemini | `gemini` | `api_key_env` (suggested `GEMINI_API_KEY`) | Official Gemini origin |
 | OpenAI-compatible | `openai-compatible` | `api_key_env` plus explicit `base_url` | Catalog `base_url` |
@@ -66,6 +67,17 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 
 Native fixed-origin providers reject a custom `base_url`. Use `openai-compatible` for a trusted
 third-party OpenAI-compatible host.
+
+## TrustedRouter listing metadata
+
+`trustedrouter` lists an OpenRouter-shaped catalog from its own origin. Setup keeps the fields it
+publishes: the completion and embedding roles from `trustedrouter.supports_chat` and
+`trustedrouter.supports_embeddings`, `context_length`, and the `pricing.prompt` and
+`pricing.completion` per-token prices. The catalog publishes no `supported_parameters` array, so
+tool, structured-output, sampling, and reasoning support stay unknown and the operator declares the
+minimum fields for a selected role, the same way an identity-only OpenAI-compatible model does. A
+model that reports a non-positive `context_length` keeps an unknown context window rather than
+borrowing one from a neighboring field.
 
 ## OpenAI-compatible listing metadata
 

--- a/exp/cli/build/app.py
+++ b/exp/cli/build/app.py
@@ -88,7 +88,7 @@ _PROVIDER_OPTION = typer.Option(
     help=(
         "Repeatable provider to configure during first-build setup. "
         "Supported values: experiential-cloud, openai, anthropic, gemini, openrouter, "
-        "openai-compatible, azure, bedrock."
+        "trustedrouter, openai-compatible, azure, bedrock."
     ),
 )
 

--- a/exp/cli/config/app.py
+++ b/exp/cli/config/app.py
@@ -55,7 +55,7 @@ _PROVIDER_OPTION = typer.Option(
     help=(
         "Repeatable provider that skips the opening list during interactive setup. "
         "Supported values: experiential-cloud, openai, anthropic, gemini, openrouter, "
-        "openai-compatible, azure, bedrock."
+        "trustedrouter, openai-compatible, azure, bedrock."
     ),
 )
 

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -75,9 +75,9 @@ def test_gateway_setup_uses_the_shared_provider_setup_seams() -> None:
         ("1", "experiential-cloud"),
         ("2", "openai"),
         ("3", "anthropic"),
-        ("6", "openai-compatible"),
-        ("7", "azure"),
-        ("8", "bedrock"),
+        ("7", "openai-compatible"),
+        ("8", "azure"),
+        ("9", "bedrock"),
     ),
 )
 def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
@@ -108,7 +108,7 @@ def test_gateway_provider_selector_exposes_primary_and_legacy_providers(
 
 def test_gateway_provider_selector_accepts_multiple_providers() -> None:
     """The gateway uses the builder's multi-select semantics instead of forcing one provider."""
-    console = ScriptedConsole("1,2,6,7\n\n")
+    console = ScriptedConsole("1,2,7,8\n\n")
 
     selected = provider_picker.select_providers(
         provider_picker.SetupSession(),
@@ -123,7 +123,7 @@ def test_gateway_provider_selector_uses_the_builder_keyboard_picker() -> None:
     """The gateway selector accepts the same Up, Down, and Enter interaction as the builder."""
     keys = iter(
         (
-            *(PickerKey.DOWN for _ in range(5)),
+            *(PickerKey.DOWN for _ in range(6)),
             PickerKey.ENTER,
             *(PickerKey.DOWN for _ in range(3)),
             PickerKey.ENTER,

--- a/exp/cli/providers/declaration.py
+++ b/exp/cli/providers/declaration.py
@@ -1,7 +1,8 @@
 """Operator-declared capability and price metadata for discovered model identities.
 
-Discovery may list an OpenAI-compatible identity before any capability or price is proven.
-This module collects only the minimum fields a selected build role needs, confirms published
+Discovery may list an identity before any capability or price is proven, either from an
+OpenAI-compatible endpoint or from a router whose catalog omits the parameter array. This
+module collects only the minimum fields a selected build role needs, confirms published
 values when they exist, and never infers tools, structured output, token limits, or prices.
 """
 
@@ -13,6 +14,7 @@ from rich.console import Console
 from rich.prompt import Confirm, IntPrompt
 
 from exp.cli.providers.provider_picker import (
+    OPERATOR_DECLARED_PROVIDERS,
     UNKNOWN_METADATA_LABEL,
     AvailableModel,
     SetupCancelled,
@@ -64,9 +66,10 @@ def can_declare_role(item: AvailableModel, role: SetupRole) -> bool:
         role: Build role the operator selected.
 
     Returns:
-        ``True`` only for OpenAI-compatible identities that do not already prove the role.
+        ``True`` only for a provider whose listing can leave a model unknown, and only when
+        that model does not already prove the role.
     """
-    if item.provider != "openai-compatible":
+    if item.provider not in OPERATOR_DECLARED_PROVIDERS:
         return False
     return item.capabilities is None or not serves_role(item.capabilities, role)
 

--- a/exp/cli/providers/declaration_test.py
+++ b/exp/cli/providers/declaration_test.py
@@ -1,4 +1,4 @@
-"""Operator declaration tests for identity-only OpenAI-compatible models."""
+"""Operator declaration tests for identities a listing left unproven."""
 
 from __future__ import annotations
 
@@ -9,7 +9,11 @@ from exp.cli.providers.declaration import (
     merge_declared_models,
     role_row_detail,
 )
-from exp.cli.providers.provider_picker import UNKNOWN_METADATA_LABEL, AvailableModel
+from exp.cli.providers.provider_picker import (
+    OPERATOR_DECLARED_PROVIDERS,
+    UNKNOWN_METADATA_LABEL,
+    AvailableModel,
+)
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.models import (
     DiscoveredModel,
@@ -180,6 +184,29 @@ def test_official_models_are_not_declarable() -> None:
 
     assert not can_declare_role(item, SetupRole.WORLD_MODEL)
     assert not eligible_for_role(item, SetupRole.WORLD_MODEL)
+
+
+def test_router_identities_without_a_parameter_array_stay_declarable() -> None:
+    """A TrustedRouter model whose catalog omits its parameters is declarable, not excluded."""
+    item = AvailableModel(
+        alias="opus",
+        connection="trustedrouter",
+        provider="trustedrouter",
+        model="anthropic/claude-opus-4.5",
+        capabilities=None,
+        pricing_source=PricingSource.UNKNOWN,
+        configured=False,
+    )
+
+    assert role_row_detail(item) == UNKNOWN_METADATA_LABEL
+    assert can_declare_role(item, SetupRole.WORLD_MODEL)
+    assert can_declare_role(item, SetupRole.JUDGE)
+    assert eligible_for_role(item, SetupRole.ROUTER_CANDIDATE)
+
+
+def test_operator_declared_providers_are_exactly_the_unknown_capable_listings() -> None:
+    """Only listings that can return an unproven model open the declaration questionnaire."""
+    assert OPERATOR_DECLARED_PROVIDERS == {"openai-compatible", "trustedrouter"}
 
 
 def test_merge_declared_models_replaces_the_same_alias() -> None:

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -69,6 +69,7 @@ SETUP_PROVIDER_LABELS = {
     "anthropic": "anthropic",
     "gemini": "gemini",
     "openrouter": "openrouter",
+    "trustedrouter": "trustedrouter",
     "openai-compatible": "openai-compatible",
     "azure": "azure",
     "bedrock": "bedrock",

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -76,7 +76,8 @@ SETUP_PROVIDER_LABELS = {
 }
 CANONICAL_CREDENTIAL_ENV = CANONICAL_API_KEY_ENV
 _MANUAL_MODEL_PROVIDERS = frozenset({"azure", "bedrock"})
-_OPERATOR_DECLARED_PROVIDERS = frozenset({"openai-compatible"})
+OPERATOR_DECLARED_PROVIDERS = frozenset({"openai-compatible", "trustedrouter"})
+"""Providers whose listing can leave a model unknown for the operator to declare."""
 _CONFIGURED_ONLY = "configured-models-only"
 UNKNOWN_METADATA_LABEL = "unknown capabilities/prices"
 _RECOVERY_RETRY = "retry"
@@ -780,7 +781,7 @@ def _discover_models(
             tuple(model for model in resolved if not served_roles(model.capabilities)),
             provider=runtime_provider,
         )
-        if runtime_provider not in _OPERATOR_DECLARED_PROVIDERS:
+        if runtime_provider not in OPERATOR_DECLARED_PROVIDERS:
             unknown = ()
         if not verified and not unknown:
             console.print(f"[yellow]{label} published no model with verified metadata.[/yellow]")

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -187,7 +187,7 @@ def test_keyboard_provider_list_selects_without_typed_numbers() -> None:
             PickerKey.ENTER,
             PickerKey.DOWN,
             PickerKey.ENTER,
-            *(PickerKey.DOWN for _ in range(6)),
+            *(PickerKey.DOWN for _ in range(7)),
             PickerKey.ENTER,
         )
     )
@@ -1093,7 +1093,7 @@ def test_release_tty_walk_selects_azure_then_completes() -> None:
     """The installed-wheel provider walk still lands on Azure, then Complete."""
     keys = iter(
         (
-            *(PickerKey.DOWN for _ in range(6)),
+            *(PickerKey.DOWN for _ in range(7)),
             PickerKey.ENTER,
             *(PickerKey.DOWN for _ in range(2)),
             PickerKey.ENTER,
@@ -1114,7 +1114,7 @@ def test_release_tty_walk_selects_azure_then_completes() -> None:
 
 def test_azure_and_bedrock_force_explicit_manual_model_declaration() -> None:
     """Providers without a safe listing API make the manual model row available explicitly."""
-    console = ScriptedConsole("7,8\n\n")
+    console = ScriptedConsole("8,9\n\n")
 
     selection = select_providers(SetupSession(), console=console, environment={})
 

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -287,7 +287,7 @@ def test_noninteractive_provider_flags_validate_without_prompts_or_writes(tmp_pa
     assert "duplicate --provider value 'openai'" in output
     assert (
         "choose from: experiential-cloud, openai, anthropic, gemini, openrouter, "
-        "openai-compatible, azure, bedrock" in output
+        "trustedrouter, openai-compatible, azure, bedrock" in output
     )
     assert "Select the providers you want to use" not in output
     assert not (root / "models.toml").exists()

--- a/exp/common/auth/env_names.py
+++ b/exp/common/auth/env_names.py
@@ -14,6 +14,7 @@ CANONICAL_API_KEY_ENV = {
     "azure": "AZURE_OPENAI_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "trustedrouter": "TRUSTEDROUTER_API_KEY",
     "openai-compatible": "OPENAI_COMPATIBLE_API_KEY",
     "tinker": "TINKER_API_KEY",
 }

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -34,7 +34,9 @@ _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _AZURE_API_VERSION = re.compile(r"^(?:v1|\d{4}-\d{2}-\d{2}(?:-preview)?)$")
 _AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 _VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
-_FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
+_FIXED_ORIGIN_PROVIDERS = frozenset(
+    {"anthropic", "gemini", "openai", "openrouter", "trustedrouter", "tinker"}
+)
 _EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
 
 

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -28,6 +28,7 @@ SETUP_PROVIDERS = frozenset(
         "openai",
         "openai-compatible",
         "openrouter",
+        "trustedrouter",
         "vertex",
     }
 )

--- a/exp/runtime/gateway/provider_certification.py
+++ b/exp/runtime/gateway/provider_certification.py
@@ -68,6 +68,7 @@ class ProviderCertificationMatrix(ContractModel):
             "openai",
             "openai-compatible",
             "openrouter",
+            "trustedrouter",
             "vertex",
         }
         expected = {
@@ -96,6 +97,7 @@ _PROVIDER_API_SURFACES = {
     "openai": "responses SSE",
     "openai-compatible": "chat.completions SSE",
     "openrouter": "chat.completions SSE",
+    "trustedrouter": "chat.completions SSE",
     "vertex": "streamGenerateContent SSE",
 }
 _GEMINI_EVIDENCE = ("exp/runtime/gateway/tests/native_dialect_parity_test.py",)
@@ -211,7 +213,7 @@ def _compatible_provider_cells(provider: str) -> tuple[ProviderCertificationCell
     """Return inherited compatible-stream results without claiming a live run.
 
     Args:
-        provider: Azure or OpenRouter provider identifier.
+        provider: Identifier of a provider served by the generic compatible adapter.
 
     Returns:
         Complete capability cells for the compatible adapter.
@@ -276,6 +278,7 @@ PROVIDER_CERTIFICATION_MATRIX = ProviderCertificationMatrix(
                 *_native_provider_cells("bedrock", _BEDROCK_EVIDENCE),
                 *_compatible_provider_cells("azure"),
                 *_compatible_provider_cells("openrouter"),
+                *_compatible_provider_cells("trustedrouter"),
             ),
             key=lambda cell: (cell.provider, cell.capability.value),
         )

--- a/exp/runtime/gateway/provider_certification_test.py
+++ b/exp/runtime/gateway/provider_certification_test.py
@@ -19,7 +19,7 @@ def test_provider_matrix_is_complete_deterministic_and_secret_free() -> None:
     """Every launch-provider cell is labeled and the artifact round-trips exactly."""
     matrix = PROVIDER_CERTIFICATION_MATRIX
 
-    assert len(matrix.cells) == 8 * len(ProviderCapability)
+    assert len(matrix.cells) == 9 * len(ProviderCapability)
     assert {cell.provider for cell in matrix.cells} == {
         "anthropic",
         "azure",
@@ -28,6 +28,7 @@ def test_provider_matrix_is_complete_deterministic_and_secret_free() -> None:
         "openai",
         "openai-compatible",
         "openrouter",
+        "trustedrouter",
         "vertex",
     }
     assert {cell.client_sdk for cell in matrix.cells} == {"openai==3.0.0"}
@@ -64,6 +65,7 @@ def test_provider_matrix_does_not_claim_unperformed_live_credentials() -> None:
         "openai",
         "openai-compatible",
         "openrouter",
+        "trustedrouter",
         "vertex",
     }
     assert all(

--- a/exp/runtime/models/providers/listing.py
+++ b/exp/runtime/models/providers/listing.py
@@ -22,6 +22,7 @@ from exp.runtime.models.providers.openai_compatible import (
     OPENROUTER_BASE_URL,
     OPENROUTER_REFERER,
     OPENROUTER_TITLE,
+    TRUSTEDROUTER_BASE_URL,
 )
 from exp.runtime.models.providers.reasoning_compat import default_reasoning_effort
 from exp.runtime.models.providers.transport import (
@@ -112,6 +113,8 @@ class HttpProviderModelLister:
             models = self._anthropic_models(endpoint)
         elif endpoint.provider == "openrouter":
             models = self._openrouter_models(endpoint)
+        elif endpoint.provider == "trustedrouter":
+            models = self._trustedrouter_models(endpoint)
         elif endpoint.provider == "openai":
             models = self._openai_models(endpoint)
         elif endpoint.provider == "openai-compatible":
@@ -195,6 +198,22 @@ class HttpProviderModelLister:
             if identity is None:
                 continue
             models.append(_openrouter_model(endpoint.provider, identity, entry))
+        return models
+
+    def _trustedrouter_models(self, endpoint: ProviderEndpoint) -> list[DiscoveredModel]:
+        """List TrustedRouter models, which publish roles, context limits, and prices."""
+        base_url = _base_url(endpoint, default=TRUSTEDROUTER_BASE_URL)
+        body = self._read(
+            endpoint,
+            f"{base_url}/models",
+            {"Authorization": f"Bearer {endpoint.api_key}"},
+        )
+        models = []
+        for entry in _entries(endpoint.provider, body.get("data")):
+            identity = _text(entry.get("id"))
+            if identity is None:
+                continue
+            models.append(_trustedrouter_model(endpoint.provider, identity, entry))
         return models
 
     def _gemini_models(self, endpoint: ProviderEndpoint) -> list[DiscoveredModel]:
@@ -324,6 +343,41 @@ def _openrouter_model(provider: str, identity: str, entry: JsonObject) -> Discov
         cache_write_cost_per_million_tokens_usd=_million_token_price(
             prices.get("input_cache_write")
         ),
+    )
+
+
+def _trustedrouter_model(provider: str, identity: str, entry: JsonObject) -> DiscoveredModel:
+    """Build one discovered model from a TrustedRouter catalog entry.
+
+    The catalog is OpenRouter-shaped but publishes no ``supported_parameters`` array, so
+    sampling, tool, and reasoning support stay unknown rather than being inferred from a
+    neighboring field. Roles, context window, and token prices are published and are kept.
+
+    Args:
+        provider: Setup provider kind, always ``trustedrouter``.
+        identity: Provider-published model ID.
+        entry: One object from the ``data`` array.
+
+    Returns:
+        The identity plus the roles, limits, and prices TrustedRouter actually declares.
+    """
+    pricing = entry.get("pricing")
+    prices: JsonObject = cast(JsonObject, pricing) if isinstance(pricing, dict) else {}
+    routing = entry.get("trustedrouter")
+    route: JsonObject = cast(JsonObject, routing) if isinstance(routing, dict) else {}
+    supports_chat = route.get("supports_chat")
+    supports_embeddings = route.get("supports_embeddings")
+    return DiscoveredModel(
+        provider=provider,
+        model=identity,
+        supports_completions=supports_chat if isinstance(supports_chat, bool) else None,
+        supports_embeddings=(
+            supports_embeddings if isinstance(supports_embeddings, bool) else None
+        ),
+        chat_max_tokens_field="max_tokens",
+        context_window_tokens=_positive_int(entry.get("context_length")),
+        input_cost_per_million_tokens_usd=_million_token_price(prices.get("prompt")),
+        output_cost_per_million_tokens_usd=_million_token_price(prices.get("completion")),
     )
 
 

--- a/exp/runtime/models/providers/listing.py
+++ b/exp/runtime/models/providers/listing.py
@@ -349,9 +349,11 @@ def _openrouter_model(provider: str, identity: str, entry: JsonObject) -> Discov
 def _trustedrouter_model(provider: str, identity: str, entry: JsonObject) -> DiscoveredModel:
     """Build one discovered model from a TrustedRouter catalog entry.
 
-    The catalog is OpenRouter-shaped but publishes no ``supported_parameters`` array, so
-    sampling, tool, and reasoning support stay unknown rather than being inferred from a
-    neighboring field. Roles, context window, and token prices are published and are kept.
+    The catalog is OpenRouter-shaped and names its parameters with the same vocabulary, so
+    a published ``supported_parameters`` array is read the way OpenRouter's is. The array
+    is optional: when it is absent or wrongly typed, sampling, tool, and reasoning support
+    stay unknown rather than being reported as unsupported. Roles, context window, and
+    token prices are always published and are kept.
 
     Args:
         provider: Setup provider kind, always ``trustedrouter``.
@@ -359,7 +361,7 @@ def _trustedrouter_model(provider: str, identity: str, entry: JsonObject) -> Dis
         entry: One object from the ``data`` array.
 
     Returns:
-        The identity plus the roles, limits, and prices TrustedRouter actually declares.
+        The identity plus the roles, limits, prices, and any declared parameter support.
     """
     pricing = entry.get("pricing")
     prices: JsonObject = cast(JsonObject, pricing) if isinstance(pricing, dict) else {}
@@ -367,6 +369,23 @@ def _trustedrouter_model(provider: str, identity: str, entry: JsonObject) -> Dis
     route: JsonObject = cast(JsonObject, routing) if isinstance(routing, dict) else {}
     supports_chat = route.get("supports_chat")
     supports_embeddings = route.get("supports_embeddings")
+    parameters = entry.get("supported_parameters")
+    supported = (
+        frozenset(value.casefold() for value in parameters if isinstance(value, str))
+        if isinstance(parameters, list)
+        else None
+    )
+
+    def declared(*names: str) -> bool | None:
+        """Report a parameter only when the model published its parameter array."""
+        if supported is None:
+            return None
+        return any(name in supported for name in names)
+
+    temperature = declared("temperature")
+    top_p = declared("top_p")
+    top_k = declared("top_k")
+    reasoning = declared("reasoning", "reasoning_effort")
     return DiscoveredModel(
         provider=provider,
         model=identity,
@@ -374,11 +393,38 @@ def _trustedrouter_model(provider: str, identity: str, entry: JsonObject) -> Dis
         supports_embeddings=(
             supports_embeddings if isinstance(supports_embeddings, bool) else None
         ),
+        supports_tools=declared("tools", "tool_choice"),
+        supports_structured_output=declared("structured_outputs", "response_format"),
+        supports_temperature=temperature,
+        supports_top_p=top_p,
+        supports_top_k=top_k,
+        supports_logprobs=declared("logprobs", "top_logprobs"),
+        supports_reasoning=reasoning,
+        reasoning_effort=default_reasoning_effort(identity, "reasoning") if reasoning else None,
         chat_max_tokens_field="max_tokens",
+        minimum_temperature=0.0 if temperature else None,
+        maximum_temperature=2.0 if temperature else None,
+        minimum_top_p=0.0 if top_p else None,
+        maximum_top_p=1.0 if top_p else None,
+        minimum_top_k=1 if top_k else None,
         context_window_tokens=_positive_int(entry.get("context_length")),
+        maximum_output_tokens=_positive_int(
+            _mapping(entry.get("top_provider")).get("max_completion_tokens")
+        ),
         input_cost_per_million_tokens_usd=_million_token_price(prices.get("prompt")),
         output_cost_per_million_tokens_usd=_million_token_price(prices.get("completion")),
+        cached_input_cost_per_million_tokens_usd=_million_token_price(
+            prices.get("input_cache_read")
+        ),
+        cache_write_cost_per_million_tokens_usd=_million_token_price(
+            prices.get("input_cache_write")
+        ),
     )
+
+
+def _mapping(value: object) -> JsonObject:
+    """Return one nested catalog object, or an empty mapping when it is absent."""
+    return cast(JsonObject, value) if isinstance(value, dict) else {}
 
 
 def _gemini_model(provider: str, identity: str, entry: JsonObject) -> DiscoveredModel:

--- a/exp/runtime/models/providers/listing_test.py
+++ b/exp/runtime/models/providers/listing_test.py
@@ -319,6 +319,82 @@ def test_openrouter_listing_reads_capabilities_limits_and_prices() -> None:
     assert model.cache_write_cost_per_million_tokens_usd is None
 
 
+def test_trustedrouter_listing_reads_roles_limits_and_prices() -> None:
+    """TrustedRouter publishes roles, context length, and per-token prices."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "anthropic/claude-opus-4.5",
+                        "name": "Anthropic: Claude Opus 4.5",
+                        "context_length": 200000,
+                        "pricing": {
+                            "prompt": "0.000005275",
+                            "completion": "0.000026375",
+                        },
+                        "top_provider": {"max_completion_tokens": None},
+                        "trustedrouter": {
+                            "provider": "anthropic",
+                            "supports_chat": True,
+                            "supports_embeddings": False,
+                        },
+                    }
+                ]
+            }
+        )
+    )
+
+    models = _lister(transport).list_models(
+        ProviderEndpoint(provider="trustedrouter", api_key="secret-key")
+    )
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.model == "anthropic/claude-opus-4.5"
+    assert model.supports_completions is True
+    assert model.supports_embeddings is False
+    assert model.chat_max_tokens_field == "max_tokens"
+    assert model.context_window_tokens == 200000
+    assert model.input_cost_per_million_tokens_usd == pytest.approx(5.275)
+    assert model.output_cost_per_million_tokens_usd == pytest.approx(26.375)
+    request = transport.requests[0]
+    assert request.url == "https://api.trustedrouter.com/v1/models"
+    assert request.headers["Authorization"] == "Bearer secret-key"
+
+
+def test_trustedrouter_listing_leaves_undeclared_capabilities_unknown() -> None:
+    """The catalog publishes no ``supported_parameters``, so nothing is inferred for it."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "trustedrouter/auto",
+                        "name": "TrustedRouter Auto",
+                        "context_length": 200000,
+                        "pricing": {"prompt": "0.0000000844", "completion": "0.0000001899"},
+                        "trustedrouter": {"provider": "trustedrouter", "supports_chat": True},
+                    }
+                ]
+            }
+        )
+    )
+
+    model = _lister(transport).list_models(
+        ProviderEndpoint(provider="trustedrouter", api_key="secret-key")
+    )[0]
+
+    assert model.supports_tools is None
+    assert model.supports_structured_output is None
+    assert model.supports_temperature is None
+    assert model.supports_top_p is None
+    assert model.supports_reasoning is None
+    assert model.supports_embeddings is None
+    assert model.maximum_output_tokens is None
+    assert model.cached_input_cost_per_million_tokens_usd is None
+
+
 def test_gemini_listing_follows_pages_and_drops_the_resource_prefix() -> None:
     """Gemini paginates its model resources and prefixes each identity with ``models/``."""
     transport = _transport(

--- a/exp/runtime/models/providers/listing_test.py
+++ b/exp/runtime/models/providers/listing_test.py
@@ -363,8 +363,8 @@ def test_trustedrouter_listing_reads_roles_limits_and_prices() -> None:
     assert request.headers["Authorization"] == "Bearer secret-key"
 
 
-def test_trustedrouter_listing_leaves_undeclared_capabilities_unknown() -> None:
-    """The catalog publishes no ``supported_parameters``, so nothing is inferred for it."""
+def test_trustedrouter_listing_leaves_an_absent_parameter_array_unknown() -> None:
+    """A model that publishes no ``supported_parameters`` stays unknown, not unsupported."""
     transport = _transport(
         _ok(
             {
@@ -393,6 +393,57 @@ def test_trustedrouter_listing_leaves_undeclared_capabilities_unknown() -> None:
     assert model.supports_embeddings is None
     assert model.maximum_output_tokens is None
     assert model.cached_input_cost_per_million_tokens_usd is None
+
+
+def test_trustedrouter_listing_reads_a_published_parameter_array() -> None:
+    """TrustedRouter names parameters with the OpenRouter vocabulary, so they are read."""
+    transport = _transport(
+        _ok(
+            {
+                "data": [
+                    {
+                        "id": "openai/gpt-5.1",
+                        "name": "OpenAI: GPT-5.1",
+                        "context_length": 400000,
+                        "supported_parameters": [
+                            "tools",
+                            "structured_outputs",
+                            "temperature",
+                            "top_p",
+                            "top_k",
+                            "reasoning",
+                            "logprobs",
+                        ],
+                        "top_provider": {"max_completion_tokens": 128000},
+                        "pricing": {
+                            "prompt": "0.00000125",
+                            "completion": "0.00001",
+                            "input_cache_read": "0.000000125",
+                        },
+                        "trustedrouter": {"provider": "openai", "supports_chat": True},
+                    }
+                ]
+            }
+        )
+    )
+
+    model = _lister(transport).list_models(
+        ProviderEndpoint(provider="trustedrouter", api_key="secret-key")
+    )[0]
+
+    assert model.supports_tools is True
+    assert model.supports_structured_output is True
+    assert model.supports_temperature is True
+    assert model.supports_top_p is True
+    assert model.supports_top_k is True
+    assert model.supports_reasoning is True
+    assert model.supports_logprobs is True
+    assert model.maximum_temperature == 2.0
+    assert model.maximum_top_p == 1.0
+    assert model.minimum_top_k == 1
+    assert model.maximum_output_tokens == 128000
+    assert model.cached_input_cost_per_million_tokens_usd == pytest.approx(0.125)
+    assert model.cache_write_cost_per_million_tokens_usd is None
 
 
 def test_gemini_listing_follows_pages_and_drops_the_resource_prefix() -> None:

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -47,6 +47,7 @@ from exp.runtime.models.providers.reasoning_compat import (
 from exp.runtime.models.providers.transport import JsonHttpTransport, RetryPolicy
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+TRUSTEDROUTER_BASE_URL = "https://api.trustedrouter.com/v1"
 OPENROUTER_REFERER = "https://github.com/experientiallabs/experiential"
 OPENROUTER_TITLE = "experiential"
 

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -33,6 +33,7 @@ from exp.runtime.models.providers.gemini import GEMINI_BASE_URL, GeminiClient
 from exp.runtime.models.providers.openai import OPENAI_BASE_URL, OpenAIClient
 from exp.runtime.models.providers.openai_compatible import (
     OPENROUTER_BASE_URL,
+    TRUSTEDROUTER_BASE_URL,
     OpenAICompatibleClient,
     OpenRouterClient,
 )
@@ -374,7 +375,7 @@ class RuntimeModelCatalog:
             "base_url": base_url,
             "transport": self._transport_factory(),
         }
-        if provider in {"anthropic", "gemini", "openrouter", "openai-compatible"}:
+        if provider in {"anthropic", "gemini", "openrouter", "trustedrouter", "openai-compatible"}:
             http_kwargs.update(
                 {
                     "supports_temperature": capabilities.supports_temperature,
@@ -383,16 +384,16 @@ class RuntimeModelCatalog:
                     "supports_logprobs": _supports_flag(capabilities, "supports_logprobs"),
                 }
             )
-        if provider in {"openrouter", "openai-compatible"}:
+        if provider in {"openrouter", "trustedrouter", "openai-compatible"}:
             http_kwargs["chat_max_tokens_field"] = capabilities.chat_max_tokens_field
-        if provider in {"anthropic", "gemini", "openrouter", "openai-compatible"}:
+        if provider in {"anthropic", "gemini", "openrouter", "trustedrouter", "openai-compatible"}:
             http_kwargs.update(
                 {
                     "supports_reasoning": capabilities.supports_reasoning,
                     "reasoning_effort": capabilities.reasoning_effort,
                 }
             )
-        if provider in {"openrouter", "openai-compatible"}:
+        if provider in {"openrouter", "trustedrouter", "openai-compatible"}:
             http_kwargs["sampling_requires_reasoning_none"] = (
                 capabilities.sampling_requires_reasoning_none
             )
@@ -484,6 +485,7 @@ _HTTP_PROVIDERS: Mapping[str, tuple[_HttpClientFactory, str | None]] = {
     "gemini": (GeminiClient, GEMINI_BASE_URL),
     "openai-compatible": (OpenAICompatibleClient, None),
     "openrouter": (OpenRouterClient, OPENROUTER_BASE_URL),
+    "trustedrouter": (OpenAICompatibleClient, TRUSTEDROUTER_BASE_URL),
 }
 
 SUPPORTED_PROVIDERS = frozenset(_HTTP_PROVIDERS) | {

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -250,6 +250,7 @@ def test_resolution_rejects_unsupported_connection_and_incomplete_compatible_url
         ("anthropic", None),
         ("gemini", None),
         ("openrouter", None),
+        ("trustedrouter", None),
         ("openai-compatible", "https://models.example.test/v1"),
         ("azure", "https://resource.example.test"),
     ],

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -2491,7 +2491,7 @@ def _installed_release_driver() -> None:
             "Providers",
             # Experiential Cloud is first, then openai through openai-compatible and Azure;
             # Complete is after Bedrock.
-            (down * 6) + enter + (down * 2) + enter,
+            (down * 7) + enter + (down * 2) + enter,
         ),
         ("azure base URL", azure_endpoint),
         ("Azure OpenAI API version", ""),


### PR DESCRIPTION
Reopens #637 with the review finding fixed. [TrustedRouter](https://trustedrouter.com) is an attested OpenAI-compatible router; it serves the standard Chat Completions surface from a fixed origin, so it fits the native provider path rather than requiring every operator to hand-declare an `openai-compatible` connection and its capabilities.

```bash
exp config providers --provider trustedrouter   # TRUSTEDROUTER_API_KEY
```

Execution routes through the existing `OpenAICompatibleClient` — no new adapter.

### What changed since #637

The review on that PR was right: a TrustedRouter model whose capabilities were unknown could not be assigned a judge or router-candidate role, and there was no way to declare the missing metadata. Two gates caused it — `prepare_providers` dropped unknown rows for any provider outside `_OPERATOR_DECLARED_PROVIDERS`, and `can_declare_role` separately hardcoded `"openai-compatible"`.

Those were two spellings of one rule, so this gives it a single owner, `OPERATOR_DECLARED_PROVIDERS`, which `declaration.py` now reads instead of its own string literal. `trustedrouter` joins it, so an unproven TrustedRouter model stays visible and the operator declares the minimum fields the selected role needs — the same flow an identity-only OpenAI-compatible model already gets. Covered by a test that fails against the old gate.

### Listing

The catalog is OpenRouter-shaped and names its parameters with the same vocabulary, so `supported_parameters` is read the way OpenRouter's is: tools, structured outputs, sampling bounds, logprobs, and reasoning.

The array is treated as **optional**. A model that omits it keeps those capabilities *unknown* rather than reported as unsupported. That matters because the currently published catalog omits it on every entry — reusing `_openrouter_model` unchanged would have read the missing array and silently marked all 638 models as supporting no tools, no sampling, and no reasoning. Roles, context window, and prices are published today and are always kept.

I ran the live catalog body through the parser. All 638 entries parse — 574 chat, 28 embedding, 638 priced, 596 with a context window; the other 42 report `context_length: 0`, which `_positive_int` already turns into an unknown window rather than a bogus one. There are tests for the published-array case, the absent-array case, and the zero-context case.

### Certification

`trustedrouter` uses `_compatible_provider_cells`, the same shape as `azure` and `openrouter`: non-live capabilities are `INHERITED_COMPATIBLE_FIXTURE_PASS`, since it genuinely runs on the generic compatible adapter whose fixtures those cells cite, and `CREDENTIAL_GATED_LIVE` stays `NOT_RUN_REQUIRES_CREDENTIALS`. No live run is claimed. I left `_EVALUATED_AT` at its existing date since the inherited evidence is unchanged — happy to re-date the artifact if you would rather.

### Test updates

Adding a provider row shifts the setup picker, so the positional walks in `provider_picker_test.py`, `cli/gateway/setup_test.py`, and the installed-wheel walk in `release_test.py` move by one. Those are index updates only; each still selects the same provider it did before.

`just gate` is green: `ruff check`, `ruff format --check`, `ty check`, and `pytest` (2620 passed, 2 skipped).