### PR TITLE
gateway/native: fail-fast connect + time-to-first-byte timeouts (extracted residual of #635)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -56,6 +56,24 @@ pub fn stream_timeout_failure(deadline: Instant) -> Failure {
     }
 }
 
+/// Classify a provider that accepted the connection but did not stream its
+/// first byte within the fail-fast time-to-first-byte bound. A stalled lead
+/// deployment must not hold the request for its full per-chunk timeout, so
+/// this is a transient, capacity-shaped failure that is failover-eligible.
+///
+/// It is deliberately *not* same-deployment retryable: a lane that accepted
+/// the connection but never answered is the clearest dead-lane signal, and
+/// redialing it would only stall again for another window. Skipping the redial
+/// and advancing straight to the next certified deployment is what keeps a
+/// fresh pod's cost on a dead lane near one fail-fast window instead of several.
+pub fn first_byte_timeout_failure() -> Failure {
+    Failure::new(
+        FailureClass::Timeout,
+        "provider did not send the first token in time; failing over to the next deployment",
+    )
+    .with_retry(false, true)
+}
+
 /// The synthesized failure for a provider stream that closed without a
 /// terminal event, matching the python executor's classification.
 pub(crate) fn ended_without_terminal() -> Failure {
@@ -93,17 +111,39 @@ pub struct UpstreamRelay {
     pending: VecDeque<Event>,
     eof: bool,
     first_byte_recorded: bool,
+    /// Fail-fast bound for the very first provider byte. Once the first byte
+    /// arrives (`first_byte_recorded`), subsequent reads use the deployment's
+    /// per-chunk timeout instead, so a slow reasoning model can stream for a
+    /// long time after it has started answering.
+    first_byte_deadline: Instant,
 }
 
 impl UpstreamRelay {
-    pub fn new(response: reqwest::Response, dialect: Dialect) -> Self {
+    pub fn new(
+        response: reqwest::Response,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+    ) -> Self {
+        Self::from_stream(
+            response.bytes_stream().boxed(),
+            dialect,
+            first_byte_deadline,
+        )
+    }
+
+    fn from_stream(
+        stream: BoxStream<'static, reqwest::Result<Bytes>>,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+    ) -> Self {
         Self {
-            stream: response.bytes_stream().boxed(),
+            stream,
             decoder: FrameDecoder::new(dialect),
             normalizer: Normalizer::new(dialect),
             pending: VecDeque::new(),
             eof: false,
             first_byte_recorded: false,
+            first_byte_deadline,
         }
     }
 
@@ -124,7 +164,15 @@ impl UpstreamRelay {
             if self.eof {
                 return Ok(None);
             }
-            let bound = remaining(deadline).min(phase_timeout);
+            // Before the first byte the fail-fast time-to-first-byte bound
+            // applies; after it, each chunk is paced by the deployment's own
+            // per-chunk timeout so long-running generation is never capped.
+            let waiting_for_first_byte = !self.first_byte_recorded;
+            let bound = if waiting_for_first_byte {
+                remaining(deadline).min(remaining(self.first_byte_deadline))
+            } else {
+                remaining(deadline).min(phase_timeout)
+            };
             let chunk = match tokio::time::timeout(bound, self.stream.next()).await {
                 Ok(Some(Ok(chunk))) => chunk,
                 Ok(Some(Err(_))) => {
@@ -149,7 +197,17 @@ impl UpstreamRelay {
                     }
                     continue;
                 }
-                Err(_) => return Err(stream_timeout_failure(deadline)),
+                Err(_) => {
+                    // A first-byte stall while the request deadline still has
+                    // budget is the fail-fast case: classify it as a
+                    // failover-eligible transient so the next rung is tried at
+                    // once. A later chunk stall, or an exhausted request
+                    // deadline, keeps the existing transport/deadline mapping.
+                    if waiting_for_first_byte && !remaining(deadline).is_zero() {
+                        return Err(first_byte_timeout_failure());
+                    }
+                    return Err(stream_timeout_failure(deadline));
+                }
             };
             if !self.first_byte_recorded {
                 METRICS
@@ -211,5 +269,54 @@ pub async fn collect_committed(
             }
             None => return Err(ended_without_terminal()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+
+    #[test]
+    fn a_first_byte_stall_fails_over_without_redialing_the_dead_lane() {
+        let failure = first_byte_timeout_failure();
+        assert_eq!(failure.failure_class, FailureClass::Timeout);
+        assert!(failure.failover_eligible);
+        // A stalled lane is skipped, not redialed: redialing it would only
+        // stall again for another window.
+        assert!(!failure.retryable_same_deployment);
+    }
+
+    #[tokio::test]
+    async fn a_stalled_first_byte_trips_the_ttft_bound_not_the_chunk_timeout() {
+        // A provider that opened the stream but never sends a byte must fail
+        // over in about the time-to-first-byte window, not the (far larger)
+        // per-chunk deployment timeout.
+        let never = stream::pending::<reqwest::Result<Bytes>>().boxed();
+        let time_to_first_byte = Duration::from_millis(80);
+        let mut relay = UpstreamRelay::from_stream(
+            never,
+            Dialect::OpenAiCompatible,
+            Instant::now() + time_to_first_byte,
+        );
+        let request_deadline = Instant::now() + Duration::from_secs(120);
+        let per_chunk_timeout = Duration::from_secs(35);
+
+        let started = Instant::now();
+        let outcome = relay
+            .next_event(request_deadline, per_chunk_timeout, started)
+            .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "expected a fail-fast time-to-first-byte trip, waited {elapsed:?}"
+        );
+        let failure = outcome.expect_err("a never-yielding stream must not succeed");
+        assert_eq!(failure.failure_class, FailureClass::Timeout);
+        assert!(
+            failure.failover_eligible,
+            "a first-byte stall must advance to the next deployment"
+        );
     }
 }

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -199,6 +199,7 @@ pub(crate) async fn chat(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -160,6 +160,7 @@ pub(crate) async fn messages(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -196,6 +196,7 @@ pub(crate) async fn responses(
         route: &admission.route,
         policy: admission.policy(),
         deadline,
+        time_to_first_byte: state.time_to_first_byte,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -38,6 +38,14 @@ pub struct ServeConfig {
     pub max_active_requests: usize,
     #[serde(default = "default_request_timeout_seconds")]
     pub request_timeout_seconds: f64,
+    /// Fail-fast bound on the TCP+TLS connect phase of every provider call.
+    #[serde(default = "default_connect_timeout_seconds")]
+    pub connect_timeout_seconds: f64,
+    /// Fail-fast bound on the wait for a provider's first streamed byte. This
+    /// never caps total generation time: once the first byte arrives, reads
+    /// are paced by the deployment's own per-chunk timeout.
+    #[serde(default = "default_time_to_first_byte_seconds")]
+    pub time_to_first_byte_seconds: f64,
     #[serde(default = "default_callback_permits")]
     pub callback_permits: usize,
     #[serde(default = "default_native_usage_enabled")]
@@ -48,6 +56,14 @@ pub struct ServeConfig {
 
 fn default_graceful_timeout_seconds() -> f64 {
     10.0
+}
+
+fn default_connect_timeout_seconds() -> f64 {
+    5.0
+}
+
+fn default_time_to_first_byte_seconds() -> f64 {
+    15.0
 }
 
 fn default_max_active_requests() -> usize {
@@ -73,6 +89,8 @@ pub(crate) struct AppState {
     pub(crate) http: reqwest::Client,
     pub(crate) permits: Arc<Semaphore>,
     pub(crate) request_timeout: Duration,
+    /// Fail-fast bound on the wait for the first provider byte per attempt.
+    pub(crate) time_to_first_byte: Duration,
     /// Settlement writes still in flight, held open through graceful shutdown.
     pub(crate) pending_settlements: Arc<AtomicUsize>,
     /// Requests handled since start; the idle reclaim loop trims the
@@ -93,7 +111,8 @@ pub async fn run(
     shutdown: Option<tokio::sync::watch::Receiver<bool>>,
     on_listening: Option<Py<PyAny>>,
 ) -> Result<(), String> {
-    let http = crate::upstream::build_client()?;
+    let connect_timeout = Duration::from_secs_f64(config.connect_timeout_seconds.max(0.001));
+    let http = crate::upstream::build_client(connect_timeout)?;
     let pending_settlements = Arc::new(AtomicUsize::new(0));
     let max_active_requests = config.max_active_requests.max(1);
     let handled_requests = Arc::new(AtomicUsize::new(0));
@@ -102,6 +121,7 @@ pub async fn run(
         http,
         permits: Arc::new(Semaphore::new(max_active_requests)),
         request_timeout: Duration::from_secs_f64(config.request_timeout_seconds),
+        time_to_first_byte: Duration::from_secs_f64(config.time_to_first_byte_seconds.max(0.001)),
         pending_settlements: pending_settlements.clone(),
         handled_requests: handled_requests.clone(),
         replays: Arc::new(ReplayStore::new()),

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -10,10 +10,14 @@ use crate::errors::{Failure, FailureClass};
 /// Build the shared pooled upstream client, mirroring the pooling constants in
 /// `providers.async_transport` (64 keep-alive) and its no-redirect policy so a
 /// provider 3xx can never re-send credentials to an attacker-chosen location.
-pub fn build_client() -> Result<reqwest::Client, String> {
+///
+/// `connect_timeout` bounds only the TCP+TLS connect phase; a dead lane whose
+/// host never accepts the connection fails over after this window instead of
+/// hanging on the per-deployment request timeout.
+pub fn build_client(connect_timeout: Duration) -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .pool_max_idle_per_host(64)
-        .connect_timeout(Duration::from_secs(10))
+        .connect_timeout(connect_timeout)
         .redirect(reqwest::redirect::Policy::none())
         .use_rustls_tls()
         .build()

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -88,6 +88,11 @@ pub struct WaterfallContext<'a> {
     pub route: &'a [DeploymentWire],
     pub policy: RoutePolicy,
     pub deadline: Instant,
+    /// Fail-fast bound on the wait for each physical attempt's first provider
+    /// byte. Applied per attempt (each redial and each failover advance gets a
+    /// fresh window); it bounds the connect/header/first-byte phase only and
+    /// never caps generation once the provider has started answering.
+    pub time_to_first_byte: Duration,
 }
 
 /// The winning outcome of one waterfall run.
@@ -405,10 +410,16 @@ async fn run_attempt(
             };
         }
     };
-    // The connection's raw timeout bounds each transport phase (open, then
-    // every chunk read), exactly like the python streaming path.
+    // The connection's raw timeout bounds each chunk read, exactly like the
+    // python streaming path. The open phase is additionally bounded by the
+    // fail-fast time-to-first-byte window (fresh per attempt) so a dead lane
+    // that never answers is abandoned in seconds, not after the full
+    // per-deployment timeout.
     let phase_timeout = Duration::from_secs_f64(wire.timeout_seconds.max(0.001));
-    let open_bound = remaining(ctx.deadline).min(phase_timeout);
+    let first_byte_deadline = Instant::now() + ctx.time_to_first_byte;
+    let open_bound = remaining(ctx.deadline)
+        .min(phase_timeout)
+        .min(remaining(first_byte_deadline));
     let response = match open_stream(
         ctx.http,
         &wire.url,
@@ -433,7 +444,7 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
-    let mut relay = UpstreamRelay::new(response, dialect);
+    let mut relay = UpstreamRelay::new(response, dialect, first_byte_deadline);
     let mut usage: Option<Usage> = None;
     let mut tool_names: Vec<String> = Vec::new();
     let mut withheld: Vec<Event> = Vec::new();

--- a/exp/runtime/gateway/native_server.py
+++ b/exp/runtime/gateway/native_server.py
@@ -33,6 +33,8 @@ def serve_native_gateway(
     port: int,
     max_active_requests: int = 64,
     graceful_timeout_seconds: float = 10.0,
+    connect_timeout_seconds: float = 5.0,
+    time_to_first_byte_seconds: float = 15.0,
     native_usage_enabled: bool = True,
     shutdown: ShutdownHandle | None = None,
     on_listening: Callable[[], None] | None = None,
@@ -45,6 +47,15 @@ def serve_native_gateway(
         port: Public listener port.
         max_active_requests: Native concurrent-admission bound.
         graceful_timeout_seconds: Bound for graceful shutdown.
+        connect_timeout_seconds: Fail-fast bound on the TCP+TLS connect phase
+            of every provider call, so a lane whose host never accepts the
+            connection fails over in seconds instead of hanging on the
+            per-deployment request timeout.
+        time_to_first_byte_seconds: Fail-fast bound on the wait for a
+            provider's first streamed byte per attempt. It never caps total
+            generation time: once the first byte arrives, reads are paced by
+            the deployment's own per-chunk timeout, so slow reasoning models
+            keep streaming for as long as they need.
         native_usage_enabled: Whether Rust owns ``/usage.json``. Hosted,
             multi-tenant callers should disable it so their own surface owns
             usage.
@@ -73,6 +84,8 @@ def serve_native_gateway(
         "max_active_requests": max_active_requests,
         "request_timeout_seconds": control_plane.request_timeout_seconds,
         "graceful_timeout_seconds": graceful_timeout_seconds,
+        "connect_timeout_seconds": connect_timeout_seconds,
+        "time_to_first_byte_seconds": time_to_first_byte_seconds,
         "native_usage_enabled": native_usage_enabled,
     }
     try:

--- a/exp/runtime/gateway/native_server_test.py
+++ b/exp/runtime/gateway/native_server_test.py
@@ -42,6 +42,8 @@ def test_host_passes_the_serve_configuration(monkeypatch: pytest.MonkeyPatch) ->
         port=8080,
         max_active_requests=23,
         graceful_timeout_seconds=45.0,
+        connect_timeout_seconds=4.0,
+        time_to_first_byte_seconds=12.0,
         native_usage_enabled=False,
     )
 
@@ -53,6 +55,8 @@ def test_host_passes_the_serve_configuration(monkeypatch: pytest.MonkeyPatch) ->
     assert config["max_active_requests"] == 23
     assert config["request_timeout_seconds"] == 37.0
     assert config["graceful_timeout_seconds"] == 45.0
+    assert config["connect_timeout_seconds"] == 4.0
+    assert config["time_to_first_byte_seconds"] == 12.0
     assert config["native_usage_enabled"] is False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.2.1,<0.3",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.2.2,<0.3",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.1"
+version = "0.2.2"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What

Extracts the one genuinely-missing piece of #635 (`fix/health-aware-routing`) as a small, clean change on top of current `main`.

#635 is now mostly superseded: `main` independently shipped health-aware routing — `exp/runtime/gateway/health.py` (per-deployment circuit breakers, throttle, failover, admit-past-open-circuit) and the routing refactor to `resolve_route_profiles` / `select_route_deployments`. The residual value #635 still carried was **general fail-fast connect / time-to-first-byte (TTFB) timeouts** on the native data plane. That is what this PR adds, and nothing else.

Before this, a provider lane that accepts the TCP/TLS connection but never streams a byte held the request for the full per-deployment timeout (~35s) before failing over.

## Changes

- `ServeConfig` gains `connect_timeout_seconds` (default 5.0) and `time_to_first_byte_seconds` (default 15.0), plumbed through `serve_native_gateway` into the Rust data plane config.
- `connect_timeout` now bounds only the TCP+TLS connect phase of `build_client` (previously a hard 10s).
- A per-attempt TTFB deadline (fresh per redial and per failover advance) bounds the wait for the first provider byte. **Once the first byte arrives, reads revert to the deployment's own per-chunk timeout**, so long-running/reasoning generation is never capped.
- A first-byte stall is classified `FailureClass::Timeout`, `failover_eligible = true`, `retryable_same_deployment = false`.

## Reuses main's health.py — does not reimplement circuits

A first-byte-timeout `FailureClass::Timeout` serializes to `"timeout"`, is parsed back into `GatewayFailureClass.TIMEOUT` in `native_accounting._failure_from_payload`, and fed to `DeploymentHealthRegistry.failed()` via `_apply_settlement`. `TIMEOUT` is already in health.py's `_OPERATIONAL_FAILURES`, so the stall trips main's existing per-deployment circuit and fails over. **No changes to `health.py`.**

## Deliberately NOT ported from #635

The `resolve_dispatchable_wires` / `route_with_dispatchable_deployments` routing-skip changes. They refactor the same function `main` evolved differently (`select_route_deployments`) and are a separate admission-semantics concern (skipping a *statically* disabled/drifted lead rung at admission). Left for a human product-owner decision — see the note recommending #635 be closed as superseded.

## Verification

- `cargo test --no-default-features` (crate): **66 passed**, including the new `relay::tests::a_stalled_first_byte_trips_the_ttft_bound_not_the_chunk_timeout` (a never-streaming lane trips the TTFB bound in <2s, not the 35s per-chunk timeout, and is classified failover-eligible) and `a_first_byte_stall_fails_over_without_redialing_the_dead_lane`.
- `cargo fmt --check` and `cargo clippy --no-default-features -- -D warnings`: clean.
- `pytest` on `native_server_test.py`, `health_test.py`, `native_bridge_test.py`: **73 passed**.
- `ruff format`, `ruff check`, `ty check`: clean.

Crate bumped 0.2.1 → 0.2.2 (gate.yml requires a version move when `native/` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)