### PR TITLE
gateway: opaque provider-reasoning carrier (Claude Code thinking + Codex encrypted reasoning)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -188,9 +188,10 @@ configuration is forwarded verbatim, overriding the catalog's adaptive default),
 `max_tokens`, validates and drops `cache_control` (the gateway has no prompt-caching channel),
 and rejects image and document blocks loudly because the surface is text-only. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
-`anthropic_messages` dialect; on OpenAI-shaped surfaces over Anthropic routes, thinking text is
+`anthropic_messages` dialect; on the Responses surface over Anthropic routes, thinking text is
 projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive
-the reasoning they pay for. Streaming emits the Anthropic
+the reasoning they pay for, while the Chat surface has no reasoning representation and drops it
+like summary deltas. Streaming emits the Anthropic
 lifecycle (`message_start`, `ping`, content blocks, `message_delta` with the mapped stop reason
 and usage, `message_stop`, or one terminal `error` event); the non-streaming body is the
 Anthropic message object. Completed streams stop with `end_turn` (`tool_use` when tool calls are

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -181,10 +181,16 @@ are accumulated in original order and validated only at the complete-call bounda
 `POST /v1/messages` for Anthropic SDK callers over the same canonical gateway request. Callers
 authenticate with `x-api-key` (the Anthropic SDK default) or a standard Bearer header; both carry
 the same virtual key, and every failure on this surface is rendered in the Anthropic error
-envelope `{"type": "error", "error": {...}}`. The decoder translates text, `tool_use`, and
-`tool_result` blocks faithfully, requires `max_tokens`, validates and drops `thinking` and
-`cache_control` (the gateway has no extended-thinking or prompt-caching channel), and rejects
-image and document blocks loudly because the surface is text-only. Streaming emits the Anthropic
+envelope `{"type": "error", "error": {...}}`. The decoder translates text, `tool_use`,
+`tool_result`, `thinking`, and `redacted_thinking` blocks faithfully (thinking history rides an
+opaque provider-reasoning carrier with byte-exact signatures, and a caller `thinking`
+configuration is forwarded verbatim, overriding the catalog's adaptive default), requires
+`max_tokens`, validates and drops `cache_control` (the gateway has no prompt-caching channel),
+and rejects image and document blocks loudly because the surface is text-only. Thinking carriers
+replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
+`anthropic_messages` dialect; on OpenAI-shaped surfaces over Anthropic routes, thinking text is
+projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive
+the reasoning they pay for. Streaming emits the Anthropic
 lifecycle (`message_start`, `ping`, content blocks, `message_delta` with the mapped stop reason
 and usage, `message_stop`, or one terminal `error` event); the non-streaming body is the
 Anthropic message object. Completed streams stop with `end_turn` (`tool_use` when tool calls are
@@ -210,7 +216,10 @@ calendar-month reset boundary in the error message.
 OpenAI `3.0.0` `OpenAI` and `AsyncOpenAI` clients are release-certified for Chat Completions and
 Responses in synchronous and asynchronous, streaming and non-streaming forms. Responses
 continuation and duplicate replay retain content only in bounded, process-local, tenant and
-alias-revision-scoped stores. Replay is opt-in through an idempotency or client request key. Restart
+alias-revision-scoped stores. A `store: false` request skips continuation retention entirely
+(continuing from its ID answers `continuation_unavailable`), and
+`include: ["reasoning.encrypted_content"]` forwards the encrypted reasoning request to native
+OpenAI Responses routes, whose opaque payloads replay verbatim from the caller's input. Replay is opt-in through an idempotency or client request key. Restart
 or eviction returns an explicit unavailable error and never reconstructs content from SQLite.
 
 ## Content-free observability and lifecycle

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -257,7 +257,7 @@ class GatewayDeploymentCapabilities(ContractModel):
     @model_validator(mode="after")
     def _require_valid_reasoning_contract(self) -> GatewayDeploymentCapabilities:
         """Reject ambiguous or non-canonical reasoning declarations."""
-        order = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+        order = ("none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max")
         indexes = tuple(order.index(effort) for effort in self.supported_reasoning_efforts)
         if len(set(self.supported_reasoning_efforts)) != len(self.supported_reasoning_efforts):
             raise ValueError("supported_reasoning_efforts cannot repeat values")

--- a/exp/common/models/known_models.py
+++ b/exp/common/models/known_models.py
@@ -34,9 +34,9 @@ class KnownModel:
     supports_top_k: bool | None = None
     supports_logprobs: bool | None = None
     supports_reasoning_effort: bool = False
-    reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"] | None = (
-        None
-    )
+    reasoning_effort: (
+        Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"] | None
+    ) = None
     sampling_requires_reasoning_none: bool = False
     chat_max_tokens_field: Literal["max_tokens", "max_completion_tokens"] | None = None
     minimum_temperature: float | None = None
@@ -67,7 +67,7 @@ def _chat(
     supports_logprobs: bool = False,
     supports_structured_output: bool = True,
     supports_reasoning_effort: bool = False,
-    reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+    reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"]
     | None = None,
     sampling_requires_reasoning_none: bool = False,
     chat_max_tokens_field: Literal["max_tokens", "max_completion_tokens"] | None = None,

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -23,7 +23,7 @@ from exp.common.tasks import ToolSchema
 ModelAlias = ArtifactId
 _JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
 
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"]
 ChatMaxTokensField = Literal["max_tokens", "max_completion_tokens"]
 
 DEFAULT_REASONING_EFFORT: Final[ReasoningEffort] = "medium"

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -39,6 +39,7 @@ MESSAGES_MANIFEST = CompatibilityManifest(
         ),
         _field("tools", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field("tool_choice", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
+        _field("thinking", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "extended_thinking"),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
         *(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
@@ -48,7 +49,6 @@ MESSAGES_MANIFEST = CompatibilityManifest(
                 "mcp_servers",
                 "output_config",
                 "service_tier",
-                "thinking",
             )
         ),
     ),

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -19,6 +19,6 @@ def test_required_protocol_and_sampling_fields_are_supported() -> None:
     for path in ("model", "messages", "max_tokens", "system", "stream", "stop_sequences"):
         assert decisions[path] == CompatibilityDisposition.SUPPORTED
     assert decisions["tools"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
-    assert decisions["thinking"] == CompatibilityDisposition.UNSUPPORTED
+    assert decisions["thinking"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert decisions["output_config"] == CompatibilityDisposition.UNSUPPORTED
     assert decisions["top_k"] == CompatibilityDisposition.SUPPORTED

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -1,12 +1,13 @@
 """Decode Anthropic Messages bodies into canonical serving requests.
 
 The decoder is strict and lossless for supported content: text, ``tool_use``,
-and ``tool_result`` blocks translate faithfully; ``cache_control`` annotations
-are validated and dropped because they do not change model semantics;
-``thinking``, ``redacted_thinking``, ``image``, and ``document`` blocks are
-rejected loudly because the serving surface cannot preserve them. Unknown or
-unsupported fields are rejected with a field-specific error, never silently
-dropped. Errors raise
+``tool_result``, ``thinking``, and ``redacted_thinking`` blocks translate
+faithfully (thinking history rides the opaque provider-reasoning carrier with
+byte-exact signatures); ``cache_control`` annotations are validated and
+dropped because they do not change model semantics; ``image`` and
+``document`` blocks are rejected loudly because the serving surface cannot
+preserve them. Unknown or unsupported fields are rejected with a
+field-specific error, never silently dropped. Errors raise
 :class:`OpenAIProtocolError` so the shared boundary stays single-authority;
 the HTTP layer renders them in the Anthropic envelope.
 """
@@ -16,7 +17,7 @@ from __future__ import annotations
 import json
 from typing import Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import JsonObject
@@ -29,6 +30,9 @@ from exp.runtime.gateway.contracts import (
     GatewayNamedToolChoice,
     GatewayRequest,
     GatewayToolDefinition,
+    ProviderReasoningBlock,
+    RedactedThinkingBlock,
+    ThinkingBlock,
 )
 from exp.runtime.openai_protocol.errors import (
     OpenAIProtocolError,
@@ -39,8 +43,6 @@ from exp.runtime.openai_protocol.manifest import disposition_map
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 
 _REJECTED_BLOCK_HINTS = {
-    "thinking": "thinking history blocks are not supported by this gateway",
-    "redacted_thinking": "redacted thinking blocks are not supported by this gateway",
     "image": "image blocks are not supported: this gateway surface is text-only",
     "document": "document blocks are not supported: this gateway surface is text-only",
     "server_tool_use": "server tools are not supported by this gateway",
@@ -70,7 +72,7 @@ class _TextBlock(_WireModel):
 
 
 class _ThinkingBlock(_WireModel):
-    """Extended-thinking history block recognized for a targeted rejection."""
+    """Extended-thinking assistant history block, carried verbatim."""
 
     type: Literal["thinking"]
     thinking: str = ""
@@ -78,7 +80,7 @@ class _ThinkingBlock(_WireModel):
 
 
 class _RedactedThinkingBlock(_WireModel):
-    """Redacted-thinking history block recognized for a targeted rejection."""
+    """Redacted-thinking assistant history block, carried verbatim."""
 
     type: Literal["redacted_thinking"]
     data: str = ""
@@ -149,10 +151,19 @@ class _Metadata(_WireModel):
 
 
 class _ThinkingConfig(_WireModel):
-    """Extended-thinking configuration retained only for closed wire validation."""
+    """Extended-thinking configuration validated closed, then forwarded verbatim."""
 
-    type: Literal["enabled", "disabled"]
+    type: Literal["enabled", "disabled", "adaptive"]
     budget_tokens: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _require_budget_only_when_enabled(self) -> _ThinkingConfig:
+        """Bind the token budget to the one mode Anthropic defines it for."""
+        if self.type == "enabled" and self.budget_tokens is None:
+            raise ValueError("thinking.budget_tokens is required when thinking is enabled")
+        if self.type != "enabled" and self.budget_tokens is not None:
+            raise ValueError("thinking.budget_tokens is valid only when thinking is enabled")
+        return self
 
 
 class _MessagesRequest(_WireModel):
@@ -216,6 +227,11 @@ def decode_messages(payload: JsonObject) -> DecodedGatewayRequest:
             stream=request.stream,
             include_usage=request.stream,
             metadata=_gateway_metadata(request.metadata),
+            # The raw payload value, not the re-serialized wire model, so the
+            # provider receives the caller's thinking config byte-for-byte.
+            provider_thinking_config=(
+                cast(JsonObject, payload["thinking"]) if request.thinking is not None else None
+            ),
         )
     except ValidationError as exc:
         raise _validation_error(exc.errors(include_url=False)[0]) from exc
@@ -361,23 +377,38 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
     out: list[GatewayMessage] = []
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
+    reasoning: list[ProviderReasoningBlock] = []
 
     def flush() -> None:
-        """Emit the pending text and tool calls as one canonical message."""
+        """Emit the pending text, tool calls, and reasoning as one canonical message."""
         content = "".join(text_parts) if text_parts else None
-        if content is None and not tool_calls:
+        if content is None and not tool_calls and not reasoning:
             return
-        out.append(GatewayMessage(role=message.role, content=content, tool_calls=tuple(tool_calls)))
+        out.append(
+            GatewayMessage(
+                role=message.role,
+                content=content,
+                tool_calls=tuple(tool_calls),
+                provider_reasoning=tuple(reasoning),
+            )
+        )
         text_parts.clear()
         tool_calls.clear()
+        reasoning.clear()
 
     for block_index, block in enumerate(message.content):
         if isinstance(block, _TextBlock):
             text_parts.append(block.text)
         elif isinstance(block, (_ThinkingBlock, _RedactedThinkingBlock)):
-            raise invalid_field(
-                f"{param}.content.{block_index}",
-                "thinking history blocks are not supported by this gateway.",
+            if message.role != "assistant":
+                raise invalid_field(
+                    f"{param}.content.{block_index}",
+                    "thinking blocks are only valid in assistant messages.",
+                )
+            reasoning.append(
+                ThinkingBlock(text=block.thinking, signature=block.signature)
+                if isinstance(block, _ThinkingBlock)
+                else RedactedThinkingBlock(data=block.data)
             )
         elif isinstance(block, _ToolUseBlock):
             if message.role != "assistant":
@@ -414,7 +445,8 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
     if not out:
         raise invalid_field(
             f"{param}.content",
-            f"{message.role} message must contain text, tool_use, or tool_result content.",
+            f"{message.role} message must contain text, thinking, tool_use, "
+            "or tool_result content.",
         )
     return out
 

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -7,7 +7,12 @@ from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.anthropic_protocol.requests import decode_messages
-from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayNamedToolChoice
+from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayNamedToolChoice,
+    RedactedThinkingBlock,
+    ThinkingBlock,
+)
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 
 
@@ -129,28 +134,83 @@ def test_decode_drops_only_nonsemantic_cache_control() -> None:
     assert decoded.request.metadata == {}
 
 
-@pytest.mark.parametrize(
-    "field",
-    [
-        {"thinking": {"type": "enabled", "budget_tokens": 1024}},
-        {"output_config": {"effort": "high"}},
-    ],
-)
-def test_reasoning_controls_are_rejected_instead_of_silently_dropped(field: JsonObject) -> None:
-    """Native Messages reasoning controls fail until their semantics can be preserved."""
+def test_output_config_is_rejected_instead_of_silently_dropped() -> None:
+    """The Anthropic output_config control fails until its semantics can be preserved."""
     with pytest.raises(OpenAIProtocolError) as excinfo:
-        decode_messages(_body(**field))
-    assert excinfo.value.detail.param in field
+        decode_messages(_body(output_config={"effort": "high"}))
+    assert excinfo.value.detail.param == "output_config"
 
 
-def test_thinking_history_blocks_are_rejected_instead_of_dropped() -> None:
-    """Assistant reasoning history cannot disappear during canonical translation."""
-    with pytest.raises(OpenAIProtocolError, match="thinking history blocks are not supported"):
+def test_thinking_config_is_carried_verbatim() -> None:
+    """The caller's thinking object survives byte-for-byte on the canonical request."""
+    config: JsonObject = {"type": "enabled", "budget_tokens": 1024}
+    decoded = decode_messages(_body(thinking=config))
+    assert decoded.request.provider_thinking_config == config
+    assert decode_messages(_body()).request.provider_thinking_config is None
+
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(_body(thinking={"type": "enabled"}))
+    assert excinfo.value.detail.param == "thinking"
+    with pytest.raises(OpenAIProtocolError):
+        decode_messages(_body(thinking={"type": "adaptive", "budget_tokens": 64}))
+
+
+def test_thinking_history_blocks_ride_the_opaque_carrier_in_order() -> None:
+    """Assistant reasoning history translates losslessly with byte-exact signatures."""
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "private", "signature": "sig=="},
+                        {"type": "redacted_thinking", "data": "opaque=="},
+                        {"type": "text", "text": "done"},
+                        {
+                            "type": "tool_use",
+                            "id": "call-1",
+                            "name": "search",
+                            "input": {},
+                        },
+                    ],
+                },
+            ]
+        )
+    )
+    assistant = decoded.request.messages[1]
+    assert assistant.content == "done"
+    assert assistant.tool_calls[0].call_id == "call-1"
+    blocks = assistant.provider_reasoning
+    assert [block.kind for block in blocks] == ["thinking", "redacted_thinking"]
+    thinking, redacted = blocks
+    assert isinstance(thinking, ThinkingBlock)
+    assert thinking.text == "private"
+    assert thinking.signature == "sig=="
+    assert isinstance(redacted, RedactedThinkingBlock)
+    assert redacted.data == "opaque=="
+
+    # A thinking-only assistant turn (cut off mid-thinking) is legal history.
+    only = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "thinking", "thinking": "partial"}],
+                },
+                {"role": "user", "content": "continue"},
+            ]
+        )
+    )
+    assert only.request.messages[1].provider_reasoning[0].kind == "thinking"
+
+    with pytest.raises(OpenAIProtocolError, match="only valid in assistant messages"):
         decode_messages(
             _body(
                 messages=[
                     {
-                        "role": "assistant",
+                        "role": "user",
                         "content": [{"type": "thinking", "thinking": "private"}],
                     }
                 ]

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256
+from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256, sha256_json
 from exp.common.models.gateway_catalog import (
     DeploymentId,
     ExactModelId,
@@ -141,8 +141,11 @@ class GatewayMessage(ContractModel):
     encrypted reasoning items exist only on the OpenAI Responses wire. Route
     admission therefore requires every waterfall rung to speak the one
     dialect that can replay them, mirroring ``tool_is_error``. Like that
-    flag, the carrier is excluded from model serialization so request
-    digests, replay identity, and immutable artifacts are unaffected by it.
+    flag, the carrier is excluded from model serialization so immutable
+    artifacts and carrier-free request digests are unperturbed; requests that
+    do carry it join replay identity through
+    :func:`canonical_request_sha256`, so a caller operation key reused with
+    different reasoning is a rejected conflict, never a silent replay.
     """
 
     @model_validator(mode="after")
@@ -202,8 +205,9 @@ class GatewayRequest(ContractModel):
     The object is opaque to the gateway: it is validated against the closed
     wire profile at decode time and then forwarded byte-for-byte to the
     Anthropic upstream, overriding the catalog's adaptive default. Excluded
-    from serialization like the other Anthropic-only carriers so digests and
-    replay identity are unperturbed.
+    from serialization like the other Anthropic-only carriers so
+    config-free digests are unperturbed; a present config joins replay
+    identity through :func:`canonical_request_sha256`.
     """
     response_store: bool | None = None
     """Caller ``store`` selector from the Responses surface.
@@ -299,6 +303,42 @@ class GatewayRequest(ContractModel):
         if len(set(self.reasoning_summary_parameters)) != len(self.reasoning_summary_parameters):
             raise ValueError("reasoning summary parameter paths must not repeat")
         return self
+
+
+def canonical_request_sha256(request: GatewayRequest) -> Sha256:
+    """Digest one canonical request including its opaque reasoning carriers.
+
+    The carriers are excluded from model serialization so immutable artifacts
+    and pre-existing request digests stay byte-identical, but they are
+    provider-significant input: a caller operation key reused with different
+    replayed reasoning must be a rejected conflict, never a silent replay of
+    the earlier response. A request with no carrier digests exactly as its
+    plain serialization, so every request decoded before the carriers existed
+    keeps its identity.
+
+    Args:
+        request: Canonical gateway request as decoded from the public wire.
+
+    Returns:
+        The stable canonical request digest.
+    """
+    carriers: list[JsonObject] = [
+        {
+            "message_index": index,
+            "blocks": [block.model_dump(mode="json") for block in message.provider_reasoning],
+        }
+        for index, message in enumerate(request.messages)
+        if message.provider_reasoning
+    ]
+    if not carriers and request.provider_thinking_config is None:
+        return sha256_json(request)
+    return sha256_json(
+        {
+            "request_sha256": sha256_json(request),
+            "provider_reasoning": carriers,
+            "provider_thinking_config": request.provider_thinking_config,
+        }
+    )
 
 
 class GatewayUsage(ContractModel):

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -77,6 +77,45 @@ class GatewayNamedToolChoice(ContractModel):
     name: str = Field(min_length=1, max_length=256)
 
 
+class ThinkingBlock(ContractModel):
+    """One verbatim Anthropic extended-thinking block from assistant history.
+
+    ``signature`` is an opaque cryptographic value the provider issued with
+    the block; it must round-trip byte-exact or the provider rejects the
+    replayed turn, so it is never normalized or re-encoded.
+    """
+
+    kind: Literal["thinking"] = "thinking"
+    text: str = ""
+    signature: str | None = None
+
+
+class RedactedThinkingBlock(ContractModel):
+    """One opaque Anthropic redacted-thinking block from assistant history."""
+
+    kind: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
+class EncryptedReasoningBlock(ContractModel):
+    """One opaque OpenAI Responses reasoning item replayed with the input.
+
+    ``encrypted_content`` is the provider-issued opaque payload a stateless
+    caller (``store: false``) replays so the model can resume its own prior
+    reasoning; it must reach the provider byte-exact.
+    """
+
+    kind: Literal["encrypted_reasoning"] = "encrypted_reasoning"
+    id: str | None = Field(default=None, min_length=1, max_length=256)
+    encrypted_content: str = Field(min_length=1)
+
+
+ProviderReasoningBlock = Annotated[
+    ThinkingBlock | RedactedThinkingBlock | EncryptedReasoningBlock,
+    Field(discriminator="kind"),
+]
+
+
 class GatewayMessage(ContractModel):
     """One canonical gateway message preserving developer and tool-call identity."""
 
@@ -95,6 +134,16 @@ class GatewayMessage(ContractModel):
     serialization so request digests, replay identity, and immutable
     artifacts are unaffected by it.
     """
+    provider_reasoning: tuple[ProviderReasoningBlock, ...] = Field(default=(), exclude=True)
+    """Ordered opaque provider-reasoning blocks carried on assistant turns.
+
+    Thinking and redacted-thinking blocks exist only on the Anthropic wire;
+    encrypted reasoning items exist only on the OpenAI Responses wire. Route
+    admission therefore requires every waterfall rung to speak the one
+    dialect that can replay them, mirroring ``tool_is_error``. Like that
+    flag, the carrier is excluded from model serialization so request
+    digests, replay identity, and immutable artifacts are unaffected by it.
+    """
 
     @model_validator(mode="after")
     def _require_role_coherence(self) -> GatewayMessage:
@@ -106,10 +155,12 @@ class GatewayMessage(ContractModel):
         Raises:
             ValueError: Content, tool linkage, or assistant calls are incoherent.
         """
-        if self.content is None and not self.tool_calls:
-            raise ValueError("gateway messages need content or assistant tool calls")
+        if self.content is None and not self.tool_calls and not self.provider_reasoning:
+            raise ValueError("gateway messages need content, tool calls, or reasoning blocks")
         if self.role != "assistant" and self.tool_calls:
             raise ValueError("tool_calls are valid only for assistant messages")
+        if self.role != "assistant" and self.provider_reasoning:
+            raise ValueError("provider reasoning blocks are valid only for assistant messages")
         if self.role == "tool" and self.tool_call_id is None:
             raise ValueError("tool messages require tool_call_id")
         if self.role != "tool" and self.tool_call_id is not None:
@@ -145,6 +196,23 @@ class GatewayRequest(ContractModel):
         Literal["reasoning.generate_summary", "reasoning.summary"], ...
     ] = Field(default=(), exclude=True)
     """Exact caller selector paths normalized into ``reasoning_summary``."""
+    provider_thinking_config: JsonObject | None = Field(default=None, exclude=True)
+    """Verbatim caller ``thinking`` configuration from the Messages surface.
+
+    The object is opaque to the gateway: it is validated against the closed
+    wire profile at decode time and then forwarded byte-for-byte to the
+    Anthropic upstream, overriding the catalog's adaptive default. Excluded
+    from serialization like the other Anthropic-only carriers so digests and
+    replay identity are unperturbed.
+    """
+    response_store: bool | None = None
+    """Caller ``store`` selector from the Responses surface.
+
+    ``False`` skips gateway-side continuation retention for the produced
+    response; ``True`` and absent keep the default retention behavior.
+    """
+    include_encrypted_reasoning: bool = False
+    """Whether the caller asked for ``include=["reasoning.encrypted_content"]``."""
     stream: bool = False
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
@@ -218,6 +286,12 @@ class GatewayRequest(ContractModel):
             raise ValueError("include_usage is valid only for streaming requests")
         if self.reasoning_summary is not None and self.surface != GatewayApiSurface.RESPONSES:
             raise ValueError("reasoning_summary is valid only for Responses requests")
+        if self.response_store is not None and self.surface != GatewayApiSurface.RESPONSES:
+            raise ValueError("response_store is valid only for Responses requests")
+        if self.include_encrypted_reasoning and self.surface != GatewayApiSurface.RESPONSES:
+            raise ValueError("include_encrypted_reasoning is valid only for Responses requests")
+        if self.provider_thinking_config is not None and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("provider_thinking_config is valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
             raise ValueError("maximum output parameter requires a maximum output value")
         if self.reasoning_summary_parameters and self.reasoning_summary is None:
@@ -270,6 +344,10 @@ class GatewayEventKind(StrEnum):
     TEXT_DELTA = "text_delta"
     REFUSAL_DELTA = "refusal_delta"
     REASONING_SUMMARY_DELTA = "reasoning_summary_delta"
+    THINKING_DELTA = "thinking_delta"
+    THINKING_SIGNATURE = "thinking_signature"
+    REDACTED_THINKING = "redacted_thinking"
+    ENCRYPTED_REASONING = "encrypted_reasoning"
     TOOL_CALL_STARTED = "tool_call_started"
     TOOL_ARGUMENTS_DELTA = "tool_arguments_delta"
     TOOL_CALL_COMPLETED = "tool_call_completed"
@@ -287,6 +365,11 @@ class GatewayEvent(ContractModel):
     text_delta: str | None = None
     reasoning_summary_output_index: int | None = Field(default=None, ge=0)
     reasoning_summary_index: int | None = Field(default=None, ge=0)
+    reasoning_block_index: int | None = Field(default=None, ge=0)
+    """Provider content-block (or output-item) index grouping reasoning events."""
+    thinking_signature: str | None = None
+    redacted_thinking_data: str | None = None
+    encrypted_content: str | None = None
     tool_call_index: int | None = Field(default=None, ge=0)
     tool_call_id: str | None = Field(default=None, min_length=1, max_length=256)
     tool_name: str | None = Field(default=None, min_length=1, max_length=256)
@@ -315,6 +398,18 @@ class GatewayEvent(ContractModel):
                 or self.reasoning_summary_index is None
             ):
                 raise ValueError("reasoning summary deltas require output, summary, and text")
+        elif self.kind == GatewayEventKind.THINKING_DELTA:
+            if self.text_delta is None or self.reasoning_block_index is None:
+                raise ValueError("thinking deltas require block index and text")
+        elif self.kind == GatewayEventKind.THINKING_SIGNATURE:
+            if self.thinking_signature is None or self.reasoning_block_index is None:
+                raise ValueError("thinking signatures require block index and signature")
+        elif self.kind == GatewayEventKind.REDACTED_THINKING:
+            if self.redacted_thinking_data is None or self.reasoning_block_index is None:
+                raise ValueError("redacted thinking requires block index and data")
+        elif self.kind == GatewayEventKind.ENCRYPTED_REASONING:
+            if self.encrypted_content is None or self.reasoning_block_index is None:
+                raise ValueError("encrypted reasoning requires block index and content")
         elif self.kind == GatewayEventKind.TOOL_CALL_STARTED:
             if self.tool_call_index is None or self.tool_call_id is None or self.tool_name is None:
                 raise ValueError("tool-call start requires index, ID, and name")

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -228,6 +228,29 @@ def test_provider_reasoning_carrier_is_ordered_assistant_only_and_digest_free() 
     assert carried.messages[0].provider_reasoning == blocks
     assert carried.model_dump(mode="json") == bare.model_dump(mode="json")
     assert sha256_json(carried) == sha256_json(bare)
+    # Plain digests stay byte-identical (immutable artifacts, pre-carrier
+    # requests), but replay identity distinguishes reasoning content so a
+    # reused caller operation key with different reasoning conflicts.
+    from exp.runtime.gateway.contracts import canonical_request_sha256
+
+    assert canonical_request_sha256(bare) == sha256_json(bare)
+    assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
+    recarried = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="assistant", content="done", provider_reasoning=blocks),),
+    )
+    assert canonical_request_sha256(recarried) == canonical_request_sha256(carried)
+    changed = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(
+                role="assistant",
+                content="done",
+                provider_reasoning=(ThinkingBlock(text="step one", signature="sig-2"),),
+            ),
+        ),
+    )
+    assert canonical_request_sha256(changed) != canonical_request_sha256(carried)
 
     # A thinking-only assistant turn is legal history (e.g. a turn cut off
     # mid-thinking), so the carrier alone satisfies message coherence.

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -202,3 +202,138 @@ def test_tool_error_marker_never_reaches_serialization_or_request_digests() -> N
 
     with pytest.raises(ValidationError, match="tool_is_error is valid only for tool messages"):
         GatewayMessage(role="user", content="hi", tool_is_error=True)
+
+
+def test_provider_reasoning_carrier_is_ordered_assistant_only_and_digest_free() -> None:
+    """Opaque reasoning blocks ride assistant turns without perturbing digests."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.contracts import (
+        EncryptedReasoningBlock,
+        RedactedThinkingBlock,
+        ThinkingBlock,
+    )
+
+    blocks = (
+        ThinkingBlock(text="step one", signature="sig-1"),
+        RedactedThinkingBlock(data="opaque"),
+    )
+    carried = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="assistant", content="done", provider_reasoning=blocks),),
+    )
+    bare = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="assistant", content="done"),),
+    )
+    assert carried.messages[0].provider_reasoning == blocks
+    assert carried.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(carried) == sha256_json(bare)
+
+    # A thinking-only assistant turn is legal history (e.g. a turn cut off
+    # mid-thinking), so the carrier alone satisfies message coherence.
+    reasoning_only = GatewayMessage(
+        role="assistant",
+        provider_reasoning=(EncryptedReasoningBlock(id="rs_1", encrypted_content="blob"),),
+    )
+    assert reasoning_only.content is None
+
+    with pytest.raises(ValidationError, match="valid only for assistant messages"):
+        GatewayMessage(
+            role="user",
+            content="hi",
+            provider_reasoning=(ThinkingBlock(text="x", signature=None),),
+        )
+
+
+def test_reasoning_carrier_request_fields_are_surface_scoped() -> None:
+    """store, include, and verbatim thinking config bind to their one surface."""
+    messages = (GatewayMessage(role="user", content="hi"),)
+    stored = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=messages,
+        response_store=False,
+        include_encrypted_reasoning=True,
+    )
+    assert stored.response_store is False
+    assert stored.include_encrypted_reasoning is True
+
+    thinking = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        provider_thinking_config={"type": "enabled", "budget_tokens": 2048},
+    )
+    assert thinking.provider_thinking_config == {"type": "enabled", "budget_tokens": 2048}
+    # The verbatim config is authority-visible only, never in digests.
+    assert "provider_thinking_config" not in thinking.model_dump(mode="json")
+
+    with pytest.raises(ValidationError, match="response_store is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=messages,
+            response_store=True,
+        )
+    with pytest.raises(ValidationError, match="include_encrypted_reasoning is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=messages,
+            include_encrypted_reasoning=True,
+        )
+    with pytest.raises(ValidationError, match="provider_thinking_config is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=messages,
+            provider_thinking_config={"type": "enabled"},
+        )
+
+
+def test_reasoning_stream_events_require_their_payloads() -> None:
+    """Each new reasoning event kind carries its block index and payload."""
+    thinking = GatewayEvent(
+        kind=GatewayEventKind.THINKING_DELTA,
+        sequence_number=0,
+        reasoning_block_index=0,
+        text_delta="because",
+    )
+    assert thinking.reasoning_block_index == 0
+    signature = GatewayEvent(
+        kind=GatewayEventKind.THINKING_SIGNATURE,
+        sequence_number=1,
+        reasoning_block_index=0,
+        thinking_signature="sig",
+    )
+    assert signature.thinking_signature == "sig"
+    redacted = GatewayEvent(
+        kind=GatewayEventKind.REDACTED_THINKING,
+        sequence_number=2,
+        reasoning_block_index=1,
+        redacted_thinking_data="opaque",
+    )
+    assert redacted.redacted_thinking_data == "opaque"
+    encrypted = GatewayEvent(
+        kind=GatewayEventKind.ENCRYPTED_REASONING,
+        sequence_number=3,
+        reasoning_block_index=0,
+        encrypted_content="blob",
+    )
+    assert encrypted.encrypted_content == "blob"
+
+    with pytest.raises(ValidationError, match="thinking deltas require"):
+        GatewayEvent(kind=GatewayEventKind.THINKING_DELTA, sequence_number=0, text_delta="x")
+    with pytest.raises(ValidationError, match="thinking signatures require"):
+        GatewayEvent(
+            kind=GatewayEventKind.THINKING_SIGNATURE,
+            sequence_number=0,
+            reasoning_block_index=0,
+        )
+    with pytest.raises(ValidationError, match="redacted thinking requires"):
+        GatewayEvent(
+            kind=GatewayEventKind.REDACTED_THINKING,
+            sequence_number=0,
+            reasoning_block_index=0,
+        )
+    with pytest.raises(ValidationError, match="encrypted reasoning requires"):
+        GatewayEvent(
+            kind=GatewayEventKind.ENCRYPTED_REASONING,
+            sequence_number=0,
+            encrypted_content="blob",
+        )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.2.3"
+version = "0.3.0"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -1,7 +1,7 @@
-//! Anthropic Messages frame mapping, mirroring the python event mapper:
-//! usage legs accumulate across the message lifecycle and fold at
-//! `message_stop`, refusal blocks and refusal stop reasons mark the stream,
-//! and extended-thinking blocks are skipped rather than rejected.
+//! Anthropic Messages frame mapping: usage legs accumulate across the
+//! message lifecycle and fold at `message_stop`, refusal blocks and refusal
+//! stop reasons mark the stream, and extended-thinking blocks normalize to
+//! dedicated thinking events so callers receive the reasoning they pay for.
 
 use serde_json::Value;
 
@@ -95,8 +95,19 @@ impl Normalizer {
                             "Anthropic refusal",
                         )?));
                     }
-                    // Blocks with no gateway-visible output (extended thinking)
-                    // are skipped rather than rejected.
+                    Some("thinking") => {
+                        let text = optional_text(block, "thinking", "Anthropic initial thinking")?;
+                        if !text.is_empty() {
+                            events.push(Event::ThinkingDelta { index, delta: text });
+                        }
+                    }
+                    Some("redacted_thinking") => {
+                        // Redacted thinking arrives whole in the start frame.
+                        let data = optional_text(block, "data", "Anthropic redacted thinking")?;
+                        events.push(Event::RedactedThinking { index, data });
+                    }
+                    // Unknown block kinds with no gateway-visible output are
+                    // skipped rather than rejected.
                     _ => {}
                 }
             }
@@ -135,7 +146,19 @@ impl Normalizer {
                             "Anthropic refusal delta",
                         )?));
                     }
-                    // thinking_delta and signature_delta are skipped.
+                    Some("thinking_delta") => {
+                        let text = optional_text(delta, "thinking", "Anthropic thinking delta")?;
+                        if !text.is_empty() {
+                            events.push(Event::ThinkingDelta { index, delta: text });
+                        }
+                    }
+                    Some("signature_delta") => {
+                        let signature =
+                            optional_text(delta, "signature", "Anthropic signature delta")?;
+                        if !signature.is_empty() {
+                            events.push(Event::ThinkingSignature { index, signature });
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -187,6 +210,9 @@ impl Normalizer {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(self.output_tokens),
                     cached_input_tokens: Some(self.cache_read),
+                    // Anthropic reports thinking inside output_tokens and
+                    // publishes no separate count, so the reasoning subset
+                    // stays unknown instead of being invented.
                     reasoning_tokens: None,
                 }));
                 if self.refusal_seen || self.stop_reason.as_deref() == Some("refusal") {
@@ -206,5 +232,63 @@ impl Normalizer {
             }
         }
         Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dialects::{Dialect, Normalizer};
+    use crate::events::Event;
+    use crate::sse::SseEvent;
+
+    fn frame(payload: serde_json::Value) -> SseEvent {
+        SseEvent {
+            event: None,
+            data: payload.to_string(),
+        }
+    }
+
+    #[test]
+    fn thinking_blocks_normalize_to_dedicated_events() {
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let start = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        }));
+        assert!(normalizer.feed(&start).expect("start").is_empty());
+
+        let delta = frame(serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "step one"},
+        }));
+        let events = normalizer.feed(&delta).expect("thinking delta");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ThinkingDelta { index: 0, delta }] if delta == "step one"
+        ));
+
+        let signature = frame(serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "sig=="},
+        }));
+        let events = normalizer.feed(&signature).expect("signature delta");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ThinkingSignature { index: 0, signature }] if signature == "sig=="
+        ));
+
+        let redacted = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "redacted_thinking", "data": "opaque=="},
+        }));
+        let events = normalizer.feed(&redacted).expect("redacted block");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::RedactedThinking { index: 1, data }] if data == "opaque=="
+        ));
     }
 }

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -157,6 +157,24 @@ impl Normalizer {
             "response.function_call_arguments.done" | "response.output_item.done" => {
                 let index = require_u64(&payload, "output_index", "OpenAI output_index")
                     .map_err(|message| malformed(&message))? as u32;
+                if event_type == "response.output_item.done" {
+                    if let Some(item) = payload.get("item").and_then(Value::as_object) {
+                        // Requested encrypted reasoning arrives whole on the
+                        // completed reasoning item; pass the opaque payload
+                        // through under the shared retained-output budget.
+                        if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+                            if let Some(Value::String(encrypted)) = item.get("encrypted_content") {
+                                if !encrypted.is_empty() {
+                                    self.reserve_summary_bytes(encrypted.len())?;
+                                    events.push(Event::EncryptedReasoning {
+                                        output_index: index,
+                                        encrypted_content: encrypted.clone(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
                 let pending = self.tools.get(&index).is_some_and(|tool| !tool.completed);
                 if pending {
                     let mut final_arguments = payload
@@ -481,5 +499,45 @@ mod tests {
             .expect_err("entry above ceiling must fail");
         assert_eq!(failure.failure_class, FailureClass::ProviderInternal);
         assert_eq!(failure.safe_message, OUTPUT_OVERFLOW_MESSAGE);
+    }
+
+    #[test]
+    fn completed_reasoning_items_pass_encrypted_content_through() {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+        let done = SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "id": "rs_provider",
+                    "type": "reasoning",
+                    "summary": [],
+                    "encrypted_content": "blob==",
+                    "status": "completed",
+                },
+            })
+            .to_string(),
+        };
+        let events = normalizer.feed(&done).expect("reasoning item completes");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::EncryptedReasoning {
+                output_index: 0,
+                encrypted_content,
+            }] if encrypted_content == "blob=="
+        ));
+
+        // A reasoning item without the requested include stays silent.
+        let bare = SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "type": "response.output_item.done",
+                "output_index": 1,
+                "item": {"id": "rs_2", "type": "reasoning", "summary": []},
+            })
+            .to_string(),
+        };
+        assert!(normalizer.feed(&bare).expect("bare item").is_empty());
     }
 }

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -84,7 +84,13 @@ impl ChatSseEncoder {
         match event {
             Event::TextDelta(text) => Ok(vec![self.chunk(json!({"content": text}), None)]),
             Event::RefusalDelta(text) => Ok(vec![self.chunk(json!({"refusal": text}), None)]),
-            Event::ReasoningSummaryDelta { .. } => Ok(Vec::new()),
+            // The Chat wire has no reasoning representation, so provider
+            // reasoning follows the summary path and is deliberately dropped.
+            Event::ReasoningSummaryDelta { .. }
+            | Event::ThinkingDelta { .. }
+            | Event::ThinkingSignature { .. }
+            | Event::RedactedThinking { .. }
+            | Event::EncryptedReasoning { .. } => Ok(Vec::new()),
             Event::ToolCallStarted {
                 index,
                 call_id,

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -94,6 +94,16 @@ fn error_frame(failure: &Failure) -> String {
     event_frame("error", &anthropic_error_body(&failure.public_error()))
 }
 
+/// The block families one Messages stream schedules, with their provider
+/// grouping index where content arrives incrementally.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BlockKind {
+    Text,
+    Tool(u32),
+    Thinking(u32),
+    Redacted,
+}
+
 /// One scheduled content block, buffered until it can stream in order.
 ///
 /// Anthropic SSE streams content blocks strictly sequentially and a closed
@@ -102,10 +112,26 @@ fn error_frame(failure: &Failure) -> String {
 /// start order: the earliest block streams live, later blocks accumulate
 /// their content in `pending` until every earlier block has closed.
 struct PendingBlock {
-    /// `None` for a text block, or the gateway tool-call index.
-    tool_index: Option<u32>,
+    kind: BlockKind,
     pending: String,
+    /// Thinking only: the opaque signature flushes as one `signature_delta`
+    /// immediately before the block closes.
+    pending_signature: String,
+    /// Redacted only: the whole opaque payload travels in the start frame.
+    redacted_data: Option<String>,
     anthropic_index: Option<u32>,
+}
+
+impl PendingBlock {
+    fn new(kind: BlockKind) -> Self {
+        Self {
+            kind,
+            pending: String::new(),
+            pending_signature: String::new(),
+            redacted_data: None,
+            anthropic_index: None,
+        }
+    }
 }
 
 /// Stateful Anthropic Messages SSE encoder with one open block and one
@@ -209,7 +235,15 @@ impl MessagesSseEncoder {
                 self.refusal_seen = true;
                 Ok(Vec::new())
             }
-            Event::ReasoningSummaryDelta { .. } => Ok(Vec::new()),
+            // OpenAI-only reasoning shapes have no Messages representation.
+            Event::ReasoningSummaryDelta { .. } | Event::EncryptedReasoning { .. } => {
+                Ok(Vec::new())
+            }
+            Event::ThinkingDelta { index, delta } => self.thinking_delta(*index, delta),
+            Event::ThinkingSignature { index, signature } => {
+                self.thinking_signature(*index, signature)
+            }
+            Event::RedactedThinking { data, .. } => self.redacted_thinking(data),
             Event::ToolCallStarted {
                 index,
                 call_id,
@@ -282,21 +316,71 @@ impl MessagesSseEncoder {
     /// Schedule one text delta on the last text block, buffering as needed.
     fn text_delta(&mut self, delta: &str) -> Result<Vec<String>, PublicError> {
         let needs_new_block = match self.blocks.last() {
-            Some(block) => block.tool_index.is_some(),
+            Some(block) => block.kind != BlockKind::Text,
             None => true,
         };
         if needs_new_block {
-            self.blocks.push(PendingBlock {
-                tool_index: None,
-                pending: String::new(),
-                anthropic_index: None,
-            });
+            self.blocks.push(PendingBlock::new(BlockKind::Text));
         }
         let position = self.blocks.len() - 1;
         self.buffer(position, delta)?;
         let mut frames = self.advance();
         self.flush_open(&mut frames);
         Ok(frames)
+    }
+
+    /// Schedule one thinking text delta on its provider-indexed block.
+    fn thinking_delta(&mut self, index: u32, delta: &str) -> Result<Vec<String>, PublicError> {
+        let position = self.thinking_position(index);
+        self.buffer(position, delta)?;
+        let mut frames = self.advance();
+        self.flush_open(&mut frames);
+        Ok(frames)
+    }
+
+    /// Retain one opaque signature fragment; it flushes at block close.
+    fn thinking_signature(
+        &mut self,
+        index: u32,
+        signature: &str,
+    ) -> Result<Vec<String>, PublicError> {
+        let position = self.thinking_position(index);
+        self.buffered_bytes = self.buffered_bytes.saturating_add(signature.len());
+        if self.buffered_bytes > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(invalid_provider_stream(
+                "Messages stream buffered blocks exceeded the gateway response limit.",
+            ));
+        }
+        self.blocks[position].pending_signature.push_str(signature);
+        Ok(self.advance())
+    }
+
+    /// Schedule one complete redacted-thinking block at its arrival position.
+    fn redacted_thinking(&mut self, data: &str) -> Result<Vec<String>, PublicError> {
+        self.buffered_bytes = self.buffered_bytes.saturating_add(data.len());
+        if self.buffered_bytes > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(invalid_provider_stream(
+                "Messages stream buffered blocks exceeded the gateway response limit.",
+            ));
+        }
+        let mut block = PendingBlock::new(BlockKind::Redacted);
+        block.redacted_data = Some(data.to_string());
+        self.blocks.push(block);
+        Ok(self.advance())
+    }
+
+    /// Find or schedule the thinking block for one provider index.
+    fn thinking_position(&mut self, index: u32) -> usize {
+        if let Some(position) = self
+            .blocks
+            .iter()
+            .position(|block| block.kind == BlockKind::Thinking(index))
+        {
+            return position;
+        }
+        self.blocks
+            .push(PendingBlock::new(BlockKind::Thinking(index)));
+        self.blocks.len() - 1
     }
 
     /// Schedule one tool_use block at its start position.
@@ -315,11 +399,8 @@ impl MessagesSseEncoder {
             .insert(tool_index, (call_id.to_string(), name.to_string()));
         self.tool_arguments.insert(tool_index, String::new());
         self.saw_tool_use = true;
-        self.blocks.push(PendingBlock {
-            tool_index: Some(tool_index),
-            pending: String::new(),
-            anthropic_index: None,
-        });
+        self.blocks
+            .push(PendingBlock::new(BlockKind::Tool(tool_index)));
         Ok(self.advance())
     }
 
@@ -346,7 +427,7 @@ impl MessagesSseEncoder {
         let position = self
             .blocks
             .iter()
-            .position(|block| block.tool_index == Some(tool_index))
+            .position(|block| block.kind == BlockKind::Tool(tool_index))
             .expect("started tool has a scheduled block");
         self.buffer(position, delta)?;
         let mut frames = self.advance();
@@ -379,13 +460,15 @@ impl MessagesSseEncoder {
                 let block = &self.blocks[position];
                 let last = position == self.blocks.len() - 1;
                 let closable = self.draining
-                    || match block.tool_index {
-                        None => !last,
-                        Some(tool_index) => self.tool_completed.contains(&tool_index),
+                    || match block.kind {
+                        BlockKind::Text | BlockKind::Thinking(_) | BlockKind::Redacted => !last,
+                        BlockKind::Tool(tool_index) => self.tool_completed.contains(&tool_index),
                     };
                 if !closable {
                     return frames;
                 }
+                self.flush_signature(position, &mut frames);
+                let block = &self.blocks[position];
                 frames.push(event_frame(
                     "content_block_stop",
                     &json!({"type": "content_block_stop", "index": block.anthropic_index}),
@@ -403,9 +486,19 @@ impl MessagesSseEncoder {
             self.next_block_index += 1;
             let block = &mut self.blocks[position];
             block.anthropic_index = Some(anthropic_index);
-            let content_block = match block.tool_index {
-                None => json!({"type": "text", "text": ""}),
-                Some(tool_index) => {
+            let content_block = match block.kind {
+                BlockKind::Text => json!({"type": "text", "text": ""}),
+                // The SDK thinking block type requires both fields, so the
+                // start frame carries their empty forms like the provider.
+                BlockKind::Thinking(_) => {
+                    json!({"type": "thinking", "thinking": "", "signature": ""})
+                }
+                BlockKind::Redacted => {
+                    let data = block.redacted_data.take().unwrap_or_default();
+                    self.buffered_bytes = self.buffered_bytes.saturating_sub(data.len());
+                    json!({"type": "redacted_thinking", "data": data})
+                }
+                BlockKind::Tool(tool_index) => {
                     let identity = self
                         .tool_identities
                         .get(&tool_index)
@@ -430,6 +523,26 @@ impl MessagesSseEncoder {
         }
     }
 
+    /// Emit one closing `signature_delta` for a thinking block, if retained.
+    fn flush_signature(&mut self, position: usize, frames: &mut Vec<String>) {
+        let block = &mut self.blocks[position];
+        if !matches!(block.kind, BlockKind::Thinking(_)) || block.pending_signature.is_empty() {
+            return;
+        }
+        frames.push(event_frame(
+            "content_block_delta",
+            &json!({
+                "type": "content_block_delta",
+                "index": block.anthropic_index,
+                "delta": {"type": "signature_delta", "signature": block.pending_signature},
+            }),
+        ));
+        self.buffered_bytes = self
+            .buffered_bytes
+            .saturating_sub(block.pending_signature.len());
+        block.pending_signature.clear();
+    }
+
     /// Emit the open block's buffered content as one delta, if any.
     fn flush_open(&mut self, frames: &mut Vec<String>) {
         let Some(position) = self.open_position else {
@@ -439,9 +552,15 @@ impl MessagesSseEncoder {
         if block.pending.is_empty() {
             return;
         }
-        let delta = match block.tool_index {
-            None => json!({"type": "text_delta", "text": block.pending}),
-            Some(_) => json!({"type": "input_json_delta", "partial_json": block.pending}),
+        let delta = match block.kind {
+            BlockKind::Text => json!({"type": "text_delta", "text": block.pending}),
+            BlockKind::Thinking(_) => json!({"type": "thinking_delta", "thinking": block.pending}),
+            // Redacted blocks carry their payload in the start frame and
+            // never buffer deltas.
+            BlockKind::Redacted => return,
+            BlockKind::Tool(_) => {
+                json!({"type": "input_json_delta", "partial_json": block.pending})
+            }
         };
         frames.push(event_frame(
             "content_block_delta",
@@ -531,7 +650,23 @@ pub fn completed_messages_body(
     // sentinel, after later text.
     let mut slots: Vec<Option<Value>> = Vec::new();
     let mut tool_positions: HashMap<u32, usize> = HashMap::new();
+    let mut thinking_positions: HashMap<u32, usize> = HashMap::new();
     let mut saw_tool_use = false;
+    // Resolve one thinking slot per provider index, creating the block with
+    // the SDK-required empty fields on first use.
+    fn thinking_slot<'a>(
+        slots: &'a mut Vec<Option<Value>>,
+        positions: &mut HashMap<u32, usize>,
+        index: u32,
+    ) -> &'a mut Value {
+        let position = *positions.entry(index).or_insert_with(|| {
+            slots.push(Some(
+                json!({"type": "thinking", "thinking": "", "signature": ""}),
+            ));
+            slots.len() - 1
+        });
+        slots[position].as_mut().expect("thinking slot is filled")
+    }
     for event in events {
         match event {
             Event::TextDelta(delta) if !delta.is_empty() => {
@@ -549,6 +684,21 @@ pub fn completed_messages_body(
                 if !appended {
                     slots.push(Some(json!({"type": "text", "text": delta})));
                 }
+            }
+            Event::ThinkingDelta { index, delta } if !delta.is_empty() => {
+                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
+                if let Some(Value::String(text)) = block.get_mut("thinking") {
+                    text.push_str(delta);
+                }
+            }
+            Event::ThinkingSignature { index, signature } => {
+                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
+                if let Some(Value::String(text)) = block.get_mut("signature") {
+                    text.push_str(signature);
+                }
+            }
+            Event::RedactedThinking { data, .. } => {
+                slots.push(Some(json!({"type": "redacted_thinking", "data": data})));
             }
             Event::ToolCallStarted { index, .. } => {
                 tool_positions.insert(*index, slots.len());
@@ -595,255 +745,4 @@ pub fn completed_messages_body(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::events::CompletedToolCall;
-
-    #[test]
-    fn usage_reports_cached_reads_out_of_the_input_total() {
-        let usage = Usage {
-            input_tokens: Some(10),
-            output_tokens: Some(4),
-            cached_input_tokens: Some(3),
-            reasoning_tokens: None,
-        };
-        assert_eq!(
-            messages_usage(Some(&usage)),
-            json!({"input_tokens": 7, "output_tokens": 4, "cache_read_input_tokens": 3})
-        );
-        assert_eq!(
-            messages_usage(None),
-            json!({"input_tokens": 0, "output_tokens": 0})
-        );
-    }
-
-    #[test]
-    fn error_body_folds_param_and_maps_status_first() {
-        let mut error = PublicError::new(
-            400,
-            "invalid_parameter",
-            "Invalid value.",
-            "invalid_request_error",
-        );
-        error.param = Some("top_k".to_string());
-        assert_eq!(
-            anthropic_error_body(&error),
-            json!({
-                "type": "error",
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": "Invalid value. (param: top_k)",
-                },
-            })
-        );
-        let throttled = PublicError::new(429, "unavailable_route", "Throttled.", "api_error");
-        assert_eq!(
-            anthropic_error_body(&throttled)["error"]["type"],
-            json!("rate_limit_error")
-        );
-    }
-
-    #[test]
-    fn completed_body_orders_text_before_tool_use_blocks() {
-        let events = vec![
-            Event::TextDelta("hi".to_string()),
-            Event::ToolCallStarted {
-                index: 0,
-                call_id: "call-1".to_string(),
-                name: "search".to_string(),
-            },
-            Event::ToolArgumentsDelta {
-                index: 0,
-                delta: "{\"b\":1,\"a\":2}".to_string(),
-            },
-            Event::ToolCallCompleted {
-                index: 0,
-                call: CompletedToolCall {
-                    call_id: "call-1".to_string(),
-                    name: "search".to_string(),
-                    raw_arguments: "{\"b\":1,\"a\":2}".to_string(),
-                },
-            },
-            Event::Completed,
-        ];
-        let aggregated =
-            completed_messages_body("request-abc", "coding", &events).expect("aggregates");
-        assert!(aggregated.failure.is_none());
-        assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
-        assert_eq!(aggregated.body["content"][0]["type"], json!("text"));
-        // preserve_order keeps the provider's key order in the parsed input.
-        assert_eq!(
-            compact_json(&aggregated.body["content"][1]["input"]),
-            "{\"b\":1,\"a\":2}"
-        );
-        assert_eq!(aggregated.tool_names, vec!["search".to_string()]);
-    }
-
-    #[test]
-    fn completed_body_preserves_interleaved_block_order() {
-        let events = vec![
-            Event::ToolCallStarted {
-                index: 0,
-                call_id: "call-1".to_string(),
-                name: "search".to_string(),
-            },
-            Event::ToolCallCompleted {
-                index: 0,
-                call: CompletedToolCall {
-                    call_id: "call-1".to_string(),
-                    name: "search".to_string(),
-                    raw_arguments: "{}".to_string(),
-                },
-            },
-            Event::TextDelta("after ".to_string()),
-            Event::TextDelta("the tool".to_string()),
-            Event::Completed,
-        ];
-        let aggregated =
-            completed_messages_body("request-abc", "coding", &events).expect("aggregates");
-        assert_eq!(aggregated.body["content"][0]["type"], json!("tool_use"));
-        assert_eq!(
-            aggregated.body["content"][1],
-            json!({"type": "text", "text": "after the tool"})
-        );
-    }
-
-    #[test]
-    fn deferred_tool_completion_keeps_the_started_block_position() {
-        // OpenAI-compatible streams complete every tool only at [DONE], so
-        // text may arrive between the tool's arguments and its completion.
-        let events = vec![
-            Event::ToolCallStarted {
-                index: 0,
-                call_id: "call-1".to_string(),
-                name: "search".to_string(),
-            },
-            Event::ToolArgumentsDelta {
-                index: 0,
-                delta: "{}".to_string(),
-            },
-            Event::TextDelta("after".to_string()),
-            Event::ToolCallCompleted {
-                index: 0,
-                call: CompletedToolCall {
-                    call_id: "call-1".to_string(),
-                    name: "search".to_string(),
-                    raw_arguments: "{}".to_string(),
-                },
-            },
-            Event::Completed,
-        ];
-        let aggregated =
-            completed_messages_body("request-abc", "coding", &events).expect("aggregates");
-        assert_eq!(aggregated.body["content"][0]["type"], json!("tool_use"));
-        assert_eq!(
-            aggregated.body["content"][1],
-            json!({"type": "text", "text": "after"})
-        );
-        let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
-        let mut frames = encoder.start().expect("starts");
-        for event in &events {
-            frames.extend(
-                encoder
-                    .feed(event)
-                    .expect("streams the deferred completion"),
-            );
-        }
-        assert!(frames.last().expect("terminal").contains("message_stop"));
-    }
-
-    #[test]
-    fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
-        // Tool A streams live through the interleaving; tool B's fragment
-        // buffers and flushes as one delta after A's block closes.
-        let events = vec![
-            Event::ToolCallStarted {
-                index: 0,
-                call_id: "call-a".to_string(),
-                name: "alpha".to_string(),
-            },
-            Event::ToolArgumentsDelta {
-                index: 0,
-                delta: "{\"a\": ".to_string(),
-            },
-            Event::ToolCallStarted {
-                index: 1,
-                call_id: "call-b".to_string(),
-                name: "beta".to_string(),
-            },
-            Event::ToolArgumentsDelta {
-                index: 1,
-                delta: "{\"b\": 2}".to_string(),
-            },
-            Event::ToolArgumentsDelta {
-                index: 0,
-                delta: "1}".to_string(),
-            },
-            Event::ToolCallCompleted {
-                index: 0,
-                call: CompletedToolCall {
-                    call_id: "call-a".to_string(),
-                    name: "alpha".to_string(),
-                    raw_arguments: "{\"a\": 1}".to_string(),
-                },
-            },
-            Event::ToolCallCompleted {
-                index: 1,
-                call: CompletedToolCall {
-                    call_id: "call-b".to_string(),
-                    name: "beta".to_string(),
-                    raw_arguments: "{\"b\": 2}".to_string(),
-                },
-            },
-            Event::Completed,
-        ];
-        let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
-        let mut frames = encoder.start().expect("starts");
-        for event in &events {
-            frames.extend(encoder.feed(event).expect("streams the interleaving"));
-        }
-        let names: Vec<&str> = frames
-            .iter()
-            .map(|frame| {
-                frame
-                    .lines()
-                    .next()
-                    .and_then(|line| line.strip_prefix("event: "))
-                    .expect("named frame")
-            })
-            .collect();
-        assert_eq!(
-            names,
-            vec![
-                "message_start",
-                "ping",
-                "content_block_start",
-                "content_block_delta",
-                "content_block_delta",
-                "content_block_stop",
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop",
-                "message_delta",
-                "message_stop",
-            ]
-        );
-        // The buffered tool-B fragment flushes as one input_json_delta on
-        // Anthropic block index 1 after block 0 closes.
-        assert!(frames[7].contains("\"index\":1"));
-        assert!(frames[7].contains("{\\\"b\\\": 2}"));
-        let aggregated =
-            completed_messages_body("request-abc", "coding", &events).expect("aggregates");
-        assert_eq!(aggregated.body["content"][0]["id"], json!("call-a"));
-        assert_eq!(aggregated.body["content"][1]["id"], json!("call-b"));
-    }
-
-    #[test]
-    fn refusal_content_aggregates_as_a_sanitized_failure() {
-        let events = vec![Event::RefusalDelta("no".to_string()), Event::Completed];
-        let aggregated =
-            completed_messages_body("request-abc", "coding", &events).expect("aggregates");
-        let failure = aggregated.failure.expect("refusal failure");
-        assert_eq!(failure.failure_class, FailureClass::Refusal);
-    }
-}
+mod tests;

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -1,0 +1,388 @@
+//! Inline tests for `encode_messages`, split into a submodule file so the
+//! implementation stays within the repository line budget.
+
+use super::*;
+use crate::events::CompletedToolCall;
+
+#[test]
+fn usage_reports_cached_reads_out_of_the_input_total() {
+    let usage = Usage {
+        input_tokens: Some(10),
+        output_tokens: Some(4),
+        cached_input_tokens: Some(3),
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({"input_tokens": 7, "output_tokens": 4, "cache_read_input_tokens": 3})
+    );
+    assert_eq!(
+        messages_usage(None),
+        json!({"input_tokens": 0, "output_tokens": 0})
+    );
+}
+
+#[test]
+fn error_body_folds_param_and_maps_status_first() {
+    let mut error = PublicError::new(
+        400,
+        "invalid_parameter",
+        "Invalid value.",
+        "invalid_request_error",
+    );
+    error.param = Some("top_k".to_string());
+    assert_eq!(
+        anthropic_error_body(&error),
+        json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Invalid value. (param: top_k)",
+            },
+        })
+    );
+    let throttled = PublicError::new(429, "unavailable_route", "Throttled.", "api_error");
+    assert_eq!(
+        anthropic_error_body(&throttled)["error"]["type"],
+        json!("rate_limit_error")
+    );
+}
+
+#[test]
+fn completed_body_orders_text_before_tool_use_blocks() {
+    let events = vec![
+        Event::TextDelta("hi".to_string()),
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-1".to_string(),
+            name: "search".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{\"b\":1,\"a\":2}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-1".to_string(),
+                name: "search".to_string(),
+                raw_arguments: "{\"b\":1,\"a\":2}".to_string(),
+            },
+        },
+        Event::Completed,
+    ];
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert!(aggregated.failure.is_none());
+    assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
+    assert_eq!(aggregated.body["content"][0]["type"], json!("text"));
+    // preserve_order keeps the provider's key order in the parsed input.
+    assert_eq!(
+        compact_json(&aggregated.body["content"][1]["input"]),
+        "{\"b\":1,\"a\":2}"
+    );
+    assert_eq!(aggregated.tool_names, vec!["search".to_string()]);
+}
+
+#[test]
+fn completed_body_preserves_interleaved_block_order() {
+    let events = vec![
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-1".to_string(),
+            name: "search".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-1".to_string(),
+                name: "search".to_string(),
+                raw_arguments: "{}".to_string(),
+            },
+        },
+        Event::TextDelta("after ".to_string()),
+        Event::TextDelta("the tool".to_string()),
+        Event::Completed,
+    ];
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert_eq!(aggregated.body["content"][0]["type"], json!("tool_use"));
+    assert_eq!(
+        aggregated.body["content"][1],
+        json!({"type": "text", "text": "after the tool"})
+    );
+}
+
+#[test]
+fn deferred_tool_completion_keeps_the_started_block_position() {
+    // OpenAI-compatible streams complete every tool only at [DONE], so
+    // text may arrive between the tool's arguments and its completion.
+    let events = vec![
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-1".to_string(),
+            name: "search".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::TextDelta("after".to_string()),
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-1".to_string(),
+                name: "search".to_string(),
+                raw_arguments: "{}".to_string(),
+            },
+        },
+        Event::Completed,
+    ];
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert_eq!(aggregated.body["content"][0]["type"], json!("tool_use"));
+    assert_eq!(
+        aggregated.body["content"][1],
+        json!({"type": "text", "text": "after"})
+    );
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(
+            encoder
+                .feed(event)
+                .expect("streams the deferred completion"),
+        );
+    }
+    assert!(frames.last().expect("terminal").contains("message_stop"));
+}
+
+#[test]
+fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
+    // Tool A streams live through the interleaving; tool B's fragment
+    // buffers and flushes as one delta after A's block closes.
+    let events = vec![
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-a".to_string(),
+            name: "alpha".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{\"a\": ".to_string(),
+        },
+        Event::ToolCallStarted {
+            index: 1,
+            call_id: "call-b".to_string(),
+            name: "beta".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 1,
+            delta: "{\"b\": 2}".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "1}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-a".to_string(),
+                name: "alpha".to_string(),
+                raw_arguments: "{\"a\": 1}".to_string(),
+            },
+        },
+        Event::ToolCallCompleted {
+            index: 1,
+            call: CompletedToolCall {
+                call_id: "call-b".to_string(),
+                name: "beta".to_string(),
+                raw_arguments: "{\"b\": 2}".to_string(),
+            },
+        },
+        Event::Completed,
+    ];
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams the interleaving"));
+    }
+    let names: Vec<&str> = frames
+        .iter()
+        .map(|frame| {
+            frame
+                .lines()
+                .next()
+                .and_then(|line| line.strip_prefix("event: "))
+                .expect("named frame")
+        })
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+    );
+    // The buffered tool-B fragment flushes as one input_json_delta on
+    // Anthropic block index 1 after block 0 closes.
+    assert!(frames[7].contains("\"index\":1"));
+    assert!(frames[7].contains("{\\\"b\\\": 2}"));
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert_eq!(aggregated.body["content"][0]["id"], json!("call-a"));
+    assert_eq!(aggregated.body["content"][1]["id"], json!("call-b"));
+}
+
+#[test]
+fn refusal_content_aggregates_as_a_sanitized_failure() {
+    let events = vec![Event::RefusalDelta("no".to_string()), Event::Completed];
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    let failure = aggregated.failure.expect("refusal failure");
+    assert_eq!(failure.failure_class, FailureClass::Refusal);
+}
+
+#[test]
+fn thinking_blocks_stream_in_valid_anthropic_order() {
+    let events = vec![
+        Event::ThinkingDelta {
+            index: 0,
+            delta: "step ".to_string(),
+        },
+        Event::ThinkingDelta {
+            index: 0,
+            delta: "one".to_string(),
+        },
+        Event::ThinkingSignature {
+            index: 0,
+            signature: "sig==".to_string(),
+        },
+        Event::RedactedThinking {
+            index: 1,
+            data: "opaque==".to_string(),
+        },
+        Event::TextDelta("answer".to_string()),
+        Event::Completed,
+    ];
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams thinking"));
+    }
+    let names: Vec<&str> = frames
+        .iter()
+        .map(|frame| {
+            frame
+                .lines()
+                .next()
+                .and_then(|line| line.strip_prefix("event: "))
+                .expect("named frame")
+        })
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+    );
+    // The thinking block opens with the SDK-required empty fields, streams
+    // its text, and closes with one signature_delta before its stop.
+    assert!(frames[2].contains("{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}"));
+    assert!(frames[3].contains("{\"type\":\"thinking_delta\",\"thinking\":\"step \"}"));
+    assert!(frames[5].contains("{\"type\":\"signature_delta\",\"signature\":\"sig==\"}"));
+    assert!(frames[7].contains("{\"type\":\"redacted_thinking\",\"data\":\"opaque==\"}"));
+    assert!(frames[10].contains("{\"type\":\"text_delta\",\"text\":\"answer\"}"));
+}
+
+#[test]
+fn completed_body_carries_thinking_blocks_verbatim_and_in_order() {
+    let events = vec![
+        Event::ThinkingDelta {
+            index: 0,
+            delta: "step one".to_string(),
+        },
+        Event::ThinkingSignature {
+            index: 0,
+            signature: "sig==".to_string(),
+        },
+        Event::RedactedThinking {
+            index: 1,
+            data: "opaque==".to_string(),
+        },
+        Event::TextDelta("answer".to_string()),
+        Event::Completed,
+    ];
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert!(aggregated.failure.is_none());
+    assert_eq!(
+        aggregated.body["content"],
+        json!([
+            {"type": "thinking", "thinking": "step one", "signature": "sig=="},
+            {"type": "redacted_thinking", "data": "opaque=="},
+            {"type": "text", "text": "answer"},
+        ])
+    );
+    assert_eq!(aggregated.body["stop_reason"], json!("end_turn"));
+}
+
+#[test]
+fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
+    // Interleaved thinking may arrive between tool calls; blocks stay
+    // strictly sequential in start order.
+    let events = vec![
+        Event::ThinkingDelta {
+            index: 0,
+            delta: "plan".to_string(),
+        },
+        Event::ThinkingSignature {
+            index: 0,
+            signature: "sig-a".to_string(),
+        },
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-1".to_string(),
+            name: "search".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-1".to_string(),
+                name: "search".to_string(),
+                raw_arguments: "{}".to_string(),
+            },
+        },
+        Event::Completed,
+    ];
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams interleaving"));
+    }
+    assert!(frames.last().expect("terminal").contains("message_stop"));
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert_eq!(aggregated.body["content"][0]["type"], json!("thinking"));
+    assert_eq!(aggregated.body["content"][1]["type"], json!("tool_use"));
+    assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
+}

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -97,11 +97,13 @@ impl ToolState {
     }
 }
 
-/// One accumulated reasoning item with provider-indexed summary parts.
+/// One accumulated reasoning item with provider-indexed summary parts and
+/// an optional opaque encrypted payload the caller replays verbatim.
 struct ReasoningState {
     item_id: String,
     output_index: usize,
     parts: BTreeMap<u32, String>,
+    encrypted_content: Option<String>,
 }
 
 impl ReasoningState {
@@ -114,12 +116,18 @@ impl ReasoningState {
         } else {
             Vec::new()
         };
-        json!({
+        let mut item = json!({
             "id": self.item_id,
             "type": "reasoning",
             "summary": summary,
             "status": if completed { "completed" } else { "in_progress" },
-        })
+        });
+        if let Some(encrypted) = &self.encrypted_content {
+            item.as_object_mut()
+                .expect("reasoning item is an object")
+                .insert("encrypted_content".to_string(), json!(encrypted));
+        }
+        item
     }
 }
 
@@ -219,6 +227,16 @@ impl ResponsesSseEncoder {
                 summary_index,
                 delta,
             } => self.reasoning_summary_delta(*output_index, *summary_index, delta),
+            // Lossy projection: Anthropic thinking text streams as a summary
+            // part so callers receive what they pay for. Signatures and
+            // redacted payloads are dropped deliberately, since this surface
+            // cannot round-trip them.
+            Event::ThinkingDelta { index, delta } => self.reasoning_summary_delta(*index, 0, delta),
+            Event::ThinkingSignature { .. } | Event::RedactedThinking { .. } => Ok(Vec::new()),
+            Event::EncryptedReasoning {
+                output_index,
+                encrypted_content,
+            } => self.encrypted_reasoning(*output_index, encrypted_content),
             Event::ToolCallStarted {
                 index,
                 call_id,
@@ -326,6 +344,50 @@ impl ResponsesSseEncoder {
         index
     }
 
+    /// Create one stable reasoning output item on first use.
+    fn ensure_reasoning(&mut self, provider_output_index: u32, frames: &mut Vec<String>) {
+        if self.reasoning.contains_key(&provider_output_index) {
+            return;
+        }
+        let state = ReasoningState {
+            item_id: stable_public_id(
+                "rs",
+                &format!("{}:{}", self.response_id, provider_output_index),
+            ),
+            output_index: self.output_order.len(),
+            parts: BTreeMap::new(),
+            encrypted_content: None,
+        };
+        let frame = self.event(
+            "response.output_item.added",
+            json!({
+                "output_index": state.output_index,
+                "item": state.item(false),
+            }),
+        );
+        self.reasoning.insert(provider_output_index, state);
+        self.output_order
+            .push(OutputSlot::Reasoning(provider_output_index));
+        frames.push(frame);
+    }
+
+    /// Retain one opaque encrypted reasoning payload on its output item; the
+    /// payload surfaces on the item's completion frames rather than a delta.
+    fn encrypted_reasoning(
+        &mut self,
+        provider_output_index: u32,
+        encrypted_content: &str,
+    ) -> Result<Vec<String>, PublicError> {
+        let mut frames = Vec::new();
+        self.ensure_reasoning(provider_output_index, &mut frames);
+        let state = self
+            .reasoning
+            .get_mut(&provider_output_index)
+            .expect("reasoning state just ensured");
+        state.encrypted_content = Some(encrypted_content.to_string());
+        Ok(frames)
+    }
+
     /// Start one reasoning item/summary part as needed and emit its text delta.
     fn reasoning_summary_delta(
         &mut self,
@@ -334,27 +396,7 @@ impl ResponsesSseEncoder {
         delta: &str,
     ) -> Result<Vec<String>, PublicError> {
         let mut frames = Vec::new();
-        if !self.reasoning.contains_key(&provider_output_index) {
-            let state = ReasoningState {
-                item_id: stable_public_id(
-                    "rs",
-                    &format!("{}:{}", self.response_id, provider_output_index),
-                ),
-                output_index: self.output_order.len(),
-                parts: BTreeMap::new(),
-            };
-            let frame = self.event(
-                "response.output_item.added",
-                json!({
-                    "output_index": state.output_index,
-                    "item": state.item(false),
-                }),
-            );
-            self.reasoning.insert(provider_output_index, state);
-            self.output_order
-                .push(OutputSlot::Reasoning(provider_output_index));
-            frames.push(frame);
-        }
+        self.ensure_reasoning(provider_output_index, &mut frames);
         let (item_id, output_index, new_part) = {
             let state = self
                 .reasoning
@@ -866,31 +908,4 @@ pub fn completed_responses_body(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn ignored_generation_controls_are_disclosed_by_responses_encoder() {
-        let envelope = ResponsesEnvelope {
-            ignored_parameters: vec!["top_k".to_string()],
-            ..ResponsesEnvelope::default()
-        };
-        let mut encoder =
-            ResponsesSseEncoder::new("request-1", "coding", 1_700_000_000.0, envelope.clone());
-        let frames = encoder.start().expect("stream start must encode");
-        assert!(frames[0].contains("\"x-experiential-ignored-parameters\":[\"top_k\"]"));
-
-        let completed = completed_responses_body(
-            "request-1",
-            "coding",
-            1_700_000_000.0,
-            envelope,
-            &[Event::Completed],
-        )
-        .expect("completed body must encode");
-        assert_eq!(
-            completed.body["x-experiential-ignored-parameters"],
-            json!(["top_k"])
-        );
-    }
-}
+mod tests;

--- a/exp/runtime/gateway/native/src/encode_responses/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tests.rs
@@ -1,0 +1,110 @@
+//! Inline tests for `encode_responses`, split into a submodule file so the
+//! implementation stays within the repository line budget.
+
+use super::*;
+#[test]
+fn ignored_generation_controls_are_disclosed_by_responses_encoder() {
+    let envelope = ResponsesEnvelope {
+        ignored_parameters: vec!["top_k".to_string()],
+        ..ResponsesEnvelope::default()
+    };
+    let mut encoder =
+        ResponsesSseEncoder::new("request-1", "coding", 1_700_000_000.0, envelope.clone());
+    let frames = encoder.start().expect("stream start must encode");
+    assert!(frames[0].contains("\"x-experiential-ignored-parameters\":[\"top_k\"]"));
+
+    let completed = completed_responses_body(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        envelope,
+        &[Event::Completed],
+    )
+    .expect("completed body must encode");
+    assert_eq!(
+        completed.body["x-experiential-ignored-parameters"],
+        json!(["top_k"])
+    );
+}
+
+#[test]
+fn thinking_deltas_project_onto_reasoning_summary_parts() {
+    let mut encoder = ResponsesSseEncoder::new(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+    );
+    encoder.start().expect("stream start must encode");
+    let frames = encoder
+        .feed(&Event::ThinkingDelta {
+            index: 0,
+            delta: "step one".to_string(),
+        })
+        .expect("thinking delta projects");
+    assert!(frames[0].contains("response.output_item.added"));
+    assert!(frames.iter().any(
+        |frame| frame.contains("response.reasoning_summary_text.delta")
+            && frame.contains("\"delta\":\"step one\"")
+    ));
+    // Signatures cannot round-trip on this surface and stay silent.
+    assert!(encoder
+        .feed(&Event::ThinkingSignature {
+            index: 0,
+            signature: "sig==".to_string(),
+        })
+        .expect("signature is dropped")
+        .is_empty());
+}
+
+#[test]
+fn encrypted_reasoning_lands_on_the_completed_reasoning_item() {
+    let completed = completed_responses_body(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &[
+            Event::ReasoningSummaryDelta {
+                output_index: 0,
+                summary_index: 0,
+                delta: "planned".to_string(),
+            },
+            Event::EncryptedReasoning {
+                output_index: 0,
+                encrypted_content: "blob==".to_string(),
+            },
+            Event::TextDelta("answer".to_string()),
+            Event::Completed,
+        ],
+    )
+    .expect("completed body must encode");
+    let reasoning = &completed.body["output"][0];
+    assert_eq!(reasoning["type"], json!("reasoning"));
+    assert_eq!(reasoning["encrypted_content"], json!("blob=="));
+    assert_eq!(
+        reasoning["summary"],
+        json!([{"type": "summary_text", "text": "planned"}])
+    );
+    assert_eq!(completed.body["output"][1]["type"], json!("message"));
+
+    // An encrypted payload with no summary still creates its output item.
+    let bare = completed_responses_body(
+        "request-2",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &[
+            Event::EncryptedReasoning {
+                output_index: 0,
+                encrypted_content: "blob==".to_string(),
+            },
+            Event::TextDelta("answer".to_string()),
+            Event::Completed,
+        ],
+    )
+    .expect("completed body must encode");
+    assert_eq!(bare.body["output"][0]["type"], json!("reasoning"));
+    assert_eq!(bare.body["output"][0]["encrypted_content"], json!("blob=="));
+    assert_eq!(bare.body["output"][0]["summary"], json!([]));
+}

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -39,6 +39,28 @@ pub enum Event {
         summary_index: u32,
         delta: String,
     },
+    /// Verbatim Anthropic extended-thinking text for one provider block.
+    ThinkingDelta {
+        index: u32,
+        delta: String,
+    },
+    /// Opaque cryptographic signature closing one Anthropic thinking block;
+    /// it must round-trip byte-exact or the provider rejects the replay.
+    ThinkingSignature {
+        index: u32,
+        signature: String,
+    },
+    /// One complete opaque Anthropic redacted-thinking block.
+    RedactedThinking {
+        index: u32,
+        data: String,
+    },
+    /// One opaque OpenAI Responses encrypted reasoning payload, keyed by its
+    /// provider output-item index.
+    EncryptedReasoning {
+        output_index: u32,
+        encrypted_content: String,
+    },
     ToolCallStarted {
         index: u32,
         call_id: String,
@@ -83,6 +105,29 @@ pub fn simplified_event(event: &Event) -> Value {
             "output_index": output_index,
             "summary_index": summary_index,
             "text": delta,
+        }),
+        Event::ThinkingDelta { index, delta } => serde_json::json!({
+            "kind": "thinking_delta",
+            "index": index,
+            "text": delta,
+        }),
+        Event::ThinkingSignature { index, signature } => serde_json::json!({
+            "kind": "thinking_signature",
+            "index": index,
+            "signature": signature,
+        }),
+        Event::RedactedThinking { index, data } => serde_json::json!({
+            "kind": "redacted_thinking",
+            "index": index,
+            "data": data,
+        }),
+        Event::EncryptedReasoning {
+            output_index,
+            encrypted_content,
+        } => serde_json::json!({
+            "kind": "encrypted_reasoning",
+            "output_index": output_index,
+            "encrypted_content": encrypted_content,
         }),
         Event::ToolCallStarted {
             index,

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -67,13 +67,20 @@ pub fn output_argument(request_id: &str, events: &[Event]) -> String {
     }))
 }
 
-/// Replace text deltas with one rewritten delta. Refusal deltas are dropped.
+/// Replace text deltas with one rewritten delta. Refusal deltas are dropped,
+/// and so is every provider-reasoning event: rewritten output must not leak
+/// the redacted content through the model's own reasoning channel.
 pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event> {
     let mut rewritten = Vec::with_capacity(events.len());
     let mut inserted = false;
     for event in events {
         match event {
-            Event::RefusalDelta(_) => {}
+            Event::RefusalDelta(_)
+            | Event::ReasoningSummaryDelta { .. }
+            | Event::ThinkingDelta { .. }
+            | Event::ThinkingSignature { .. }
+            | Event::RedactedThinking { .. }
+            | Event::EncryptedReasoning { .. } => {}
             Event::TextDelta(_) => {
                 if inserted {
                     continue;
@@ -152,6 +159,37 @@ mod tests {
         assert_eq!(payload["refusal"], false);
         assert_eq!(payload["tool_calls"][0]["name"], "lookup");
         assert_eq!(payload["tool_calls"][0]["arguments"], "{\"q\":\"x\"}");
+    }
+
+    #[test]
+    fn text_replacement_drops_every_reasoning_channel() {
+        // A rewritten output must not leak the redacted content through the
+        // model's own reasoning stream.
+        let events = vec![
+            Event::ThinkingDelta {
+                index: 0,
+                delta: "secret plan".to_string(),
+            },
+            Event::ThinkingSignature {
+                index: 0,
+                signature: "sig==".to_string(),
+            },
+            Event::RedactedThinking {
+                index: 1,
+                data: "opaque==".to_string(),
+            },
+            Event::EncryptedReasoning {
+                output_index: 0,
+                encrypted_content: "blob==".to_string(),
+            },
+            Event::TextDelta("disallowed".to_string()),
+            Event::Completed,
+        ];
+        let rewritten = apply_text_replacement(&events, "[redacted]");
+        assert!(matches!(
+            rewritten.as_slice(),
+            [Event::TextDelta(text), Event::Completed] if text == "[redacted]"
+        ));
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -337,6 +337,34 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                     .unwrap_or(0) as u32,
                 delta: text,
             },
+            "thinking_delta" => events::Event::ThinkingDelta { index, delta: text },
+            "thinking_signature" => events::Event::ThinkingSignature {
+                index,
+                signature: object
+                    .get("signature")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "redacted_thinking" => events::Event::RedactedThinking {
+                index,
+                data: object
+                    .get("data")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "encrypted_reasoning" => events::Event::EncryptedReasoning {
+                output_index: object
+                    .get("output_index")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0) as u32,
+                encrypted_content: object
+                    .get("encrypted_content")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
             "tool_call_started" => events::Event::ToolCallStarted {
                 index,
                 call_id: object

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -35,6 +35,12 @@ pub fn event_retained_bytes(event: &Event) -> usize {
     match event {
         Event::TextDelta(text) | Event::RefusalDelta(text) => text.len(),
         Event::ReasoningSummaryDelta { delta, .. } => delta.len(),
+        Event::ThinkingDelta { delta, .. } => delta.len(),
+        Event::ThinkingSignature { signature, .. } => signature.len(),
+        Event::RedactedThinking { data, .. } => data.len(),
+        Event::EncryptedReasoning {
+            encrypted_content, ..
+        } => encrypted_content.len(),
         Event::ToolArgumentsDelta { delta, .. } => delta.len(),
         Event::ToolCallCompleted { call, .. } => call.raw_arguments.len().max(64),
         _ => 64,

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -132,6 +132,10 @@ fn is_semantic(event: &Event) -> bool {
         Event::TextDelta(_)
             | Event::RefusalDelta(_)
             | Event::ReasoningSummaryDelta { .. }
+            | Event::ThinkingDelta { .. }
+            | Event::ThinkingSignature { .. }
+            | Event::RedactedThinking { .. }
+            | Event::EncryptedReasoning { .. }
             | Event::ToolCallStarted { .. }
             | Event::ToolArgumentsDelta { .. }
             | Event::ToolCallCompleted { .. }

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -2921,6 +2921,201 @@ def test_rust_responses_encrypted_reasoning_matches_the_hand_authored_golden() -
     assert body == _parity_golden("responses_encrypted_reasoning_body")
 
 
+def test_thinking_bytes_round_trip_the_native_pipeline_exactly() -> None:
+    """Non-ASCII thinking text and a multi-kilobyte signature survive the full
+    provider-frames-to-public-frames pipeline byte-identically.
+
+    The signature is an opaque cryptographic value the provider verifies on
+    replay, so any re-encoding drift (Unicode escaping, truncation, split
+    handling) would break every continued Claude Code conversation.
+    """
+    native = pytest.importorskip("exp_gateway_native")
+
+    thinking_one = "Grüß 事實 مرحبا  "
+    thinking_two = "🤔🧠 σκέψη ⇒ done"
+    signature = "Eq" + "A0b/+=" * 700  # ~4.2 KB, base64-shaped.
+    redacted = "R3" * 1500
+    provider_chunks = [
+        json.dumps({"type": "message_start", "message": {"usage": {"input_tokens": 3}}}),
+        json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": thinking_one},
+            },
+            ensure_ascii=False,
+        ),
+        json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": thinking_two},
+            },
+            ensure_ascii=False,
+        ),
+        json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": signature},
+            }
+        ),
+        json.dumps({"type": "content_block_stop", "index": 0}),
+        json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "redacted_thinking", "data": redacted},
+            }
+        ),
+        json.dumps({"type": "content_block_stop", "index": 1}),
+        json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 9},
+            }
+        ),
+        json.dumps({"type": "message_stop"}),
+    ]
+    # The fixture boundary carries raw stream bytes as latin-1 code points.
+    frames_json = json.dumps(
+        [f"data: {chunk}\n\n".encode().decode("latin-1") for chunk in provider_chunks]
+    )
+    normalized = json.loads(native.normalize_stream_fixture("anthropic_messages", frames_json))
+    assert normalized["failure"] is None
+    events = normalized["events"]
+    streamed_thinking = "".join(
+        event["text"] for event in events if event["kind"] == "thinking_delta"
+    )
+    assert streamed_thinking.encode() == (thinking_one + thinking_two).encode()
+    assert [event["signature"] for event in events if event["kind"] == "thinking_signature"] == [
+        signature
+    ]
+
+    fixture = json.dumps(events, ensure_ascii=False)
+    public_frames = native.encode_messages_fixture("request-abc", "coding", fixture)
+    payloads = [json.loads(frame.split("data: ", 1)[1].strip()) for frame in public_frames if frame]
+    out_thinking = "".join(
+        payload["delta"]["thinking"]
+        for payload in payloads
+        if payload["type"] == "content_block_delta" and payload["delta"]["type"] == "thinking_delta"
+    )
+    out_signature = "".join(
+        payload["delta"]["signature"]
+        for payload in payloads
+        if payload["type"] == "content_block_delta"
+        and payload["delta"]["type"] == "signature_delta"
+    )
+    assert out_thinking.encode() == (thinking_one + thinking_two).encode()
+    assert out_signature.encode() == signature.encode()
+
+    body = json.loads(native.completed_messages_fixture("request-abc", "coding", fixture))
+    assert body["content"][0]["thinking"].encode() == (thinking_one + thinking_two).encode()
+    assert body["content"][0]["signature"].encode() == signature.encode()
+    assert body["content"][1]["data"].encode() == redacted.encode()
+
+
+def test_encrypted_content_bytes_survive_the_responses_encoder_exactly() -> None:
+    """A large opaque encrypted payload lands byte-identical on the public item."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    encrypted = "gAAAA" + "Zm9vYmFy+/=" * 1200  # ~13 KB, base64-shaped.
+    fixture = json.dumps(
+        [
+            {"kind": "encrypted_reasoning", "output_index": 0, "encrypted_content": encrypted},
+            {"kind": "text_delta", "text": "done ✓"},
+            {"kind": "completed"},
+        ],
+        ensure_ascii=False,
+    )
+    body = json.loads(
+        native.completed_responses_fixture("request-abc", "coding", 1_700_000_000.0, "{}", fixture)
+    )
+    assert body["output"][0]["encrypted_content"].encode() == encrypted.encode()
+
+    frames = native.encode_responses_fixture(
+        "request-abc", "coding", 1_700_000_000.0, "{}", fixture
+    )
+    done_items = [
+        json.loads(frame.split("data: ", 1)[1].strip())
+        for frame in frames
+        if "response.output_item.done" in frame
+    ]
+    reasoning_items = [item["item"] for item in done_items if item["item"]["type"] == "reasoning"]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["encrypted_content"].encode() == encrypted.encode()
+
+
+def test_keyed_store_false_never_reaches_the_continuation_store(tmp_path: Path) -> None:
+    """An Idempotency-Key on a store:false request opens no side door into
+    continuation state: the retention callback stays a no-op, the response ID
+    resolves to continuation_unavailable in its own namespace, and keyed
+    admission replays the operation without manufacturing stored history."""
+    control, raw_key = _control_plane(tmp_path)
+    body = _responses_body(store=False)
+    admission = json.loads(
+        control.admit(
+            json.dumps(
+                {
+                    "raw_key": raw_key,
+                    "body": body,
+                    "surface": "responses",
+                    "idempotency_key": "codex-op",
+                }
+            )
+        )
+    )
+    assert (
+        control.remember(
+            json.dumps(
+                {
+                    "request_id": admission["request_id"],
+                    "text": "The answer is 42.",
+                    "refusal": False,
+                    "tool_calls": [],
+                }
+            )
+        )
+        == "{}"
+    )
+    response_id = stable_public_id("resp", _admitted_request_id(admission))
+    # Direct store probe in the exact tenant namespace: nothing was retained.
+    entry = control._accounting.entry(  # noqa: SLF001 - namespace extraction for the probe.
+        _admitted_request_id(admission)
+    )
+    assert entry is not None and entry.continuation is not None
+    assert entry.continuation.retain is False
+    with pytest.raises(OpenAIProtocolError) as direct:
+        control._continuations.resolve_now(  # noqa: SLF001 - retention isolation assertion.
+            namespace=entry.continuation.namespace,
+            previous_response_id=response_id,
+        )
+    assert direct.value.detail.code == "continuation_unavailable"
+    # Continuing from the ID through the public path fails closed too, with
+    # or without the original caller operation key.
+    for key in (None, "codex-op-next"):
+        with pytest.raises(NativeBridgeError) as continued:
+            control.admit(
+                json.dumps(
+                    {
+                        "raw_key": raw_key,
+                        "body": _responses_body(previous_response_id=response_id),
+                        "surface": "responses",
+                        "idempotency_key": key,
+                    }
+                )
+            )
+        assert json.loads(continued.value.public_error_json)["code"] == "continuation_unavailable"
+
+
 def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:
     """A caller operation key reused with different replayed reasoning is a
     conflict: opaque carriers are digest-excluded for artifact stability, so

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -2857,3 +2857,65 @@ def test_store_false_skips_continuation_retention(tmp_path: Path) -> None:
         "assistant",
         "user",
     ]
+
+
+def _thinking_fixture_json() -> str:
+    """Return the Rust fixture-event JSON for the thinking Messages stream."""
+    return json.dumps(
+        [
+            {"kind": "thinking_delta", "index": 0, "text": "Let me "},
+            {"kind": "thinking_delta", "index": 0, "text": "check."},
+            {"kind": "thinking_signature", "index": 0, "signature": "c2lnbmF0dXJl"},
+            {"kind": "redacted_thinking", "index": 1, "data": "b3BhcXVl"},
+            {"kind": "text_delta", "text": "Hello"},
+            {"kind": "usage", "input_tokens": 12, "output_tokens": 7, "cached_input_tokens": 2},
+            {"kind": "completed"},
+        ]
+    )
+
+
+def test_rust_messages_thinking_stream_matches_the_hand_authored_goldens() -> None:
+    """Thinking blocks stream and aggregate exactly as the Anthropic spec fixes.
+
+    The golden frames were hand-authored against the public Messages
+    streaming contract: the thinking block opens with empty fields, streams
+    thinking_delta fragments, closes with one signature_delta, redacted
+    thinking travels whole in its start frame, and the non-streaming body
+    carries the same blocks in order with the byte-exact signature.
+    """
+    native = pytest.importorskip("exp_gateway_native")
+
+    frames = native.encode_messages_fixture("request-abc", "coding", _thinking_fixture_json())
+    assert list(frames) == _parity_golden("messages_thinking_frames")
+    body = native.completed_messages_fixture("request-abc", "coding", _thinking_fixture_json())
+    assert body == _parity_golden("messages_thinking_body")
+
+
+def test_rust_responses_encrypted_reasoning_matches_the_hand_authored_golden() -> None:
+    """Requested encrypted reasoning lands verbatim on the reasoning item."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    fixture = json.dumps(
+        [
+            {
+                "kind": "reasoning_summary_delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "text": "planned",
+            },
+            {"kind": "encrypted_reasoning", "output_index": 0, "encrypted_content": "ZW5jcnlwdGVk"},
+            {"kind": "text_delta", "text": "Hello"},
+            {
+                "kind": "usage",
+                "input_tokens": 12,
+                "output_tokens": 9,
+                "cached_input_tokens": 0,
+                "reasoning_tokens": 4,
+            },
+            {"kind": "completed"},
+        ]
+    )
+    body = native.completed_responses_fixture(
+        "request-abc", "coding", 1_700_000_000.0, "{}", fixture
+    )
+    assert body == _parity_golden("responses_encrypted_reasoning_body")

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -2919,3 +2919,59 @@ def test_rust_responses_encrypted_reasoning_matches_the_hand_authored_golden() -
         "request-abc", "coding", 1_700_000_000.0, "{}", fixture
     )
     assert body == _parity_golden("responses_encrypted_reasoning_body")
+
+
+def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:
+    """A caller operation key reused with different replayed reasoning is a
+    conflict: opaque carriers are digest-excluded for artifact stability, so
+    replay identity must fold them back in through canonical_request_sha256."""
+    control, raw_key = _control_plane(tmp_path)
+
+    def reasoning_body(encrypted_content: str) -> str:
+        """Return one Responses body replaying encrypted reasoning."""
+        return json.dumps(
+            {
+                "model": "coding",
+                "input": [
+                    {"type": "message", "role": "user", "content": "go"},
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [],
+                        "encrypted_content": encrypted_content,
+                    },
+                    {"type": "message", "role": "assistant", "content": "done"},
+                    {"type": "message", "role": "user", "content": "continue"},
+                ],
+            }
+        )
+
+    def admit_keyed(body: str) -> JsonObject:
+        """Admit one keyed Responses request."""
+        return json.loads(
+            control.admit(
+                json.dumps(
+                    {
+                        "raw_key": raw_key,
+                        "body": body,
+                        "surface": "responses",
+                        "idempotency_key": "reasoning-op",
+                    }
+                )
+            )
+        )
+
+    # The seeded route is OpenAI-compatible, so the carrier is rejected at
+    # parameter admission; the accepted request still lands a durable keyed
+    # terminal, which is exactly what replay identity is checked against.
+    with pytest.raises(NativeBridgeError) as first:
+        admit_keyed(reasoning_body("blob-one=="))
+    assert json.loads(first.value.public_error_json)["code"] == "unsupported_parameter"
+
+    with pytest.raises(NativeBridgeError) as changed:
+        admit_keyed(reasoning_body("blob-two=="))
+    assert json.loads(changed.value.public_error_json)["code"] == "idempotency_conflict"
+
+    with pytest.raises(NativeBridgeError) as repeated:
+        admit_keyed(reasoning_body("blob-one=="))
+    assert json.loads(repeated.value.public_error_json)["code"] != "idempotency_conflict"

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1744,11 +1744,14 @@ def _responses_body(
     previous_response_id: str | None = None,
     with_tools: bool = False,
     reasoning_summary: str | None = None,
+    store: bool | None = None,
 ) -> str:
     """Return one raw Responses API request body."""
     payload: JsonObject = {"model": model, "input": [{"role": "user", "content": "hi"}]}
     if stream:
         payload["stream"] = True
+    if store is not None:
+        payload["store"] = store
     if previous_response_id is not None:
         payload["previous_response_id"] = previous_response_id
     if reasoning_summary is not None:
@@ -2804,3 +2807,53 @@ def test_rust_messages_interleaved_parallel_tools_match_the_goldens() -> None:
     assert list(actual_frames) == _parity_golden("messages_interleaved_frames")
     actual_body = native.completed_messages_fixture("request-abc", "coding", fixture)
     assert actual_body == _parity_golden("messages_interleaved_body")
+
+
+def test_store_false_skips_continuation_retention(tmp_path: Path) -> None:
+    """A store:false response is never remembered, so continuing from it fails
+    closed with the shared continuation_unavailable error."""
+    control, raw_key = _control_plane(tmp_path)
+    first = _admit_responses(control, raw_key, _responses_body(store=False))
+    assert (
+        control.remember(
+            json.dumps(
+                {
+                    "request_id": first["request_id"],
+                    "text": "The answer is 42.",
+                    "refusal": False,
+                    "tool_calls": [],
+                }
+            )
+        )
+        == "{}"
+    )
+    response_id = stable_public_id("resp", _admitted_request_id(first))
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit_responses(control, raw_key, _responses_body(previous_response_id=response_id))
+    payload = json.loads(raised.value.public_error_json)
+    assert payload["code"] == "continuation_unavailable"
+
+    # An explicit store:true keeps the default retention behavior.
+    stored = _admit_responses(control, raw_key, _responses_body(store=True))
+    control.remember(
+        json.dumps(
+            {
+                "request_id": stored["request_id"],
+                "text": "kept",
+                "refusal": False,
+                "tool_calls": [],
+            }
+        )
+    )
+    continued = _admit_responses(
+        control,
+        raw_key,
+        _responses_body(
+            previous_response_id=stable_public_id("resp", _admitted_request_id(stored))
+        ),
+    )
+    assert [message["role"] for message in _payload_messages(continued)] == [
+        "user",
+        "assistant",
+        "user",
+    ]

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -42,6 +42,13 @@ class ContinuationContext:
     episode_key: str
     response_id: str
     messages: tuple[GatewayMessage, ...]
+    retain: bool = True
+    """Whether the completed turn may be remembered for later continuation.
+
+    ``store: false`` callers keep episode identity (a continued request still
+    joins its original selection episode) but the produced response is never
+    retained, so its ID can never be continued from.
+    """
 
 
 def continued_request(
@@ -70,6 +77,7 @@ def continued_request(
         identity_id=authorization.identity_id,
         alias_revision_id=authorization.alias_revision_id,
     )
+    retain = request.response_store is not False
     if request.previous_response_id is None:
         episode = episode_namespace(
             namespace=namespace,
@@ -83,6 +91,7 @@ def continued_request(
                 episode_key=episode[-1],
                 response_id=stable_public_id("resp", authorization.request_id),
                 messages=request.messages,
+                retain=retain,
             ),
         )
     continuation = continuations.resolve_now(
@@ -99,6 +108,7 @@ def continued_request(
             episode_key=continuation.episode_key,
             response_id=stable_public_id("resp", authorization.request_id),
             messages=execution_request.messages,
+            retain=retain,
         ),
     )
 
@@ -127,6 +137,11 @@ def remember_turn(
         ValueError: A completed tool call carried malformed fields.
         KeyError: A completed tool call omitted a required field.
     """
+    if not context.retain:
+        # A store:false caller opted out of server-side continuation state;
+        # a later previous_response_id naming this response answers the
+        # shared continuation_unavailable error because it was never stored.
+        return
     if bool(data.get("refusal")):
         return
     text = str(data.get("text") or "")

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -28,6 +28,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayTarget,
     ProjectTarget,
+    canonical_request_sha256,
 )
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.sqlite import key_delivery
@@ -709,7 +710,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             alias_revision_id=str(row["active_revision_id"]),
             target=target,
             catalog_sha256=str(row["catalog_sha256"]),
-            canonical_request_sha256=sha256_json(request),
+            canonical_request_sha256=canonical_request_sha256(request),
             deadline_monotonic=deadline_monotonic,
             surface=request.surface,
             caller_operation_sha256=caller_operation,

--- a/exp/runtime/gateway/testdata/parity_goldens.json
+++ b/exp/runtime/gateway/testdata/parity_goldens.json
@@ -369,5 +369,23 @@
   "data: {\"id\":\"chatcmpl_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"coding\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null,\"logprobs\":null}],\"x-experiential-ignored-parameters\":[\"logprobs\",\"reasoning.summary\"]}\n\n",
   "data: {\"id\":\"chatcmpl_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"coding\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\",\"logprobs\":null}],\"x-experiential-ignored-parameters\":[\"logprobs\",\"reasoning.summary\"]}\n\n",
   "data: [DONE]\n\n"
- ]
+ ],
+ "messages_thinking_frames": [
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: ping\ndata: {\"type\":\"ping\"}\n\n",
+  "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n",
+  "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me \"}}\n\n",
+  "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"check.\"}}\n\n",
+  "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"c2lnbmF0dXJl\"}}\n\n",
+  "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+  "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"b3BhcXVl\"}}\n\n",
+  "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+  "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+  "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+  "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":2}\n\n",
+  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":7,\"cache_read_input_tokens\":2}}\n\n",
+  "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+ ],
+ "messages_thinking_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"Let me check.\",\"signature\":\"c2lnbmF0dXJl\"},{\"type\":\"redacted_thinking\",\"data\":\"b3BhcXVl\"},{\"type\":\"text\",\"text\":\"Hello\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":7,\"cache_read_input_tokens\":2}}",
+ "responses_encrypted_reasoning_body": "{\"id\":\"resp_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"response\",\"created_at\":1700000000.0,\"completed_at\":1700000000.0,\"status\":\"completed\",\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"metadata\":null,\"model\":\"coding\",\"output\":[{\"id\":\"rs_01161eec6982f41bdc4271a8fceb6c60\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"planned\"}],\"status\":\"completed\",\"encrypted_content\":\"ZW5jcnlwdGVk\"},{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\",\"annotations\":[]}]}],\"parallel_tool_calls\":true,\"temperature\":null,\"top_p\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"tool_choice\":\"auto\",\"tools\":[],\"max_output_tokens\":null,\"previous_response_id\":null,\"usage\":{\"input_tokens\":12,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":9,\"output_tokens_details\":{\"reasoning_tokens\":4},\"total_tokens\":21}}"
 }

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -374,3 +374,90 @@ def test_native_bedrock_normalizer_fails_corrupt_and_truncated_frames() -> None:
     failure = truncated["failure"]
     assert isinstance(failure, dict)
     assert failure["failure_class"] == "malformed_response"
+
+
+ANTHROPIC_THINKING_CHUNKS: tuple[bytes, ...] = (
+    _sse(
+        {
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 6, "cache_read_input_tokens": 2}},
+        }
+    ),
+    _sse(
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        }
+    ),
+    _sse(
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "step one"},
+        }
+    ),
+    _sse(
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "c2ln"},
+        }
+    ),
+    _sse({"type": "content_block_stop", "index": 0}),
+    _sse(
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "redacted_thinking", "data": "b3BhcXVl"},
+        }
+    ),
+    _sse({"type": "content_block_stop", "index": 1}),
+    _sse(
+        {
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {"type": "text", "text": ""},
+        }
+    ),
+    _sse(
+        {
+            "type": "content_block_delta",
+            "index": 2,
+            "delta": {"type": "text_delta", "text": "Hi"},
+        }
+    ),
+    _sse({"type": "content_block_stop", "index": 2}),
+    _sse(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 9},
+        }
+    ),
+    _sse({"type": "message_stop"}),
+)
+
+ANTHROPIC_THINKING_EVENTS: tuple[JsonObject, ...] = (
+    {"kind": "thinking_delta", "index": 0, "text": "step one"},
+    {"kind": "thinking_signature", "index": 0, "signature": "c2ln"},
+    {"kind": "redacted_thinking", "index": 1, "data": "b3BhcXVl"},
+    {"kind": "text_delta", "text": "Hi"},
+    {
+        "kind": "usage",
+        "input_tokens": 8,
+        "output_tokens": 9,
+        "cached_input_tokens": 2,
+        # Anthropic reports thinking inside output_tokens with no separate
+        # count, so the reasoning subset stays unknown.
+        "reasoning_tokens": None,
+    },
+    {"kind": "completed"},
+)
+
+
+def test_native_anthropic_normalizer_emits_thinking_events() -> None:
+    """Extended-thinking frames normalize to dedicated events, never silence."""
+    result = _native_normalized("anthropic_messages", ANTHROPIC_THINKING_CHUNKS)
+    assert result["failure"] is None
+    assert result["events"] == list(ANTHROPIC_THINKING_EVENTS)

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -778,3 +778,97 @@ def test_messages_stream_zero_output_keeps_real_input_tokens(
         "output_tokens": 0,
         "cache_read_input_tokens": 2,
     }
+
+
+def test_thinking_carriers_reject_non_anthropic_routes_before_dispatch(
+    engine: _ServingEngine,
+) -> None:
+    """Thinking config and history need an Anthropic-only route; the seeded
+    OpenAI-compatible route rejects both in the Anthropic envelope with no
+    upstream dispatch."""
+    with _SseUpstream.payloads_lock:
+        dispatched_before = len(_SseUpstream.payloads)
+
+    config = httpx.post(
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json={
+            **_messages_body("must-not-dispatch"),
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+        },
+        timeout=10.0,
+    )
+    assert config.status_code == 400
+    assert config.json()["error"]["type"] == "invalid_request_error"
+    assert "thinking" in config.json()["error"]["message"]
+
+    history = httpx.post(
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json={
+            **_messages_body("must-not-dispatch"),
+            "messages": [
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "private", "signature": "sig=="},
+                        {"type": "text", "text": "done"},
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ],
+        },
+        timeout=10.0,
+    )
+    assert history.status_code == 400
+    assert "thinking" in history.json()["error"]["message"]
+
+    with _SseUpstream.payloads_lock:
+        assert len(_SseUpstream.payloads) == dispatched_before
+
+
+def test_encrypted_reasoning_include_rejects_non_responses_routes(
+    engine: _ServingEngine,
+) -> None:
+    """The encrypted reasoning include selector needs a native Responses route."""
+    response = httpx.post(
+        f"{engine.base}/v1/responses",
+        headers={"authorization": f"Bearer {engine.raw_key}"},
+        json={
+            "model": "coding",
+            "input": "fast-token",
+            "include": ["reasoning.encrypted_content"],
+        },
+        timeout=10.0,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["param"] == "include"
+    assert body["error"]["code"] == "unsupported_parameter"
+
+
+def test_store_false_responses_cannot_be_continued(engine: _ServingEngine) -> None:
+    """store:false answers normally but its response ID is never retained."""
+    first = httpx.post(
+        f"{engine.base}/v1/responses",
+        headers={"authorization": f"Bearer {engine.raw_key}"},
+        json={"model": "coding", "input": "fast-token", "store": False},
+        timeout=30.0,
+    )
+    assert first.status_code == 200
+    body = first.json()
+    assert body["status"] == "completed"
+
+    continued = httpx.post(
+        f"{engine.base}/v1/responses",
+        headers={"authorization": f"Bearer {engine.raw_key}"},
+        json={
+            "model": "coding",
+            "input": "fast-token",
+            "previous_response_id": body["id"],
+        },
+        timeout=30.0,
+    )
+    assert continued.status_code == 400
+    assert continued.json()["error"]["code"] == "continuation_unavailable"

--- a/exp/runtime/models/providers/anthropic.py
+++ b/exp/runtime/models/providers/anthropic.py
@@ -145,6 +145,13 @@ def anthropic_messages_response(
             )
         elif block_type == "tool_use":
             tool_calls.append(_anthropic_tool_call(block, index))
+        elif block_type in {"thinking", "redacted_thinking"}:
+            # Extended-thinking blocks are expected whenever the route pins a
+            # reasoning effort. The typed client contract carries final
+            # content and tool calls only, and thinking tokens are already a
+            # priced subset of the reported output usage, so the blocks are
+            # accepted and not surfaced here.
+            continue
         else:
             raise ProviderResponseError(
                 f"Anthropic content[{index}] has unsupported type {block_type!r}"

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -192,7 +192,7 @@ class GatewayWireProfile:
             raise ValueError("a configured reasoning effort requires reasoning support")
         if self.supported_reasoning_efforts and not self.supports_reasoning:
             raise ValueError("supported reasoning efforts require reasoning support")
-        effort_order = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+        effort_order = ("none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max")
         effort_indexes = tuple(
             effort_order.index(effort) for effort in self.supported_reasoning_efforts
         )

--- a/exp/runtime/models/providers/listing.py
+++ b/exp/runtime/models/providers/listing.py
@@ -442,6 +442,8 @@ def _reasoning_effort(value: object) -> ReasoningEffort | None:
         return "high"
     if value == "xhigh":
         return "xhigh"
+    if value == "ultra":
+        return "ultra"
     if value == "max":
         return "max"
     return None

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -19,6 +19,7 @@ REASONING_EFFORTS = (
     "medium",
     "high",
     "xhigh",
+    "ultra",
     "max",
 )
 _EFFORT_ORDER = REASONING_EFFORTS
@@ -181,7 +182,9 @@ def _openai_supported_efforts(model_id: str) -> Collection[str] | None:
     elif identity in {"gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro"}:
         supported = ("medium", "high", "xhigh")
     elif identity.startswith("gpt-5.6-"):
-        supported = ("low", "medium", "high", "xhigh")
+        # The gpt-5.6 family is the first to document the "ultra" tier
+        # (Codex sends it by default at its highest setting).
+        supported = ("low", "medium", "high", "xhigh", "ultra")
     elif identity in {
         "gpt-5.2",
         "gpt-5.4",

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ChatMaxTokensField
 from exp.runtime.gateway.contracts import (
-    GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
 )
@@ -26,6 +25,12 @@ from exp.runtime.models.providers.reasoning_compat import (
     openai_reasoning_effort,
     require_sampling_reasoning_compatibility,
     supported_reasoning_efforts,
+)
+from exp.runtime.models.providers.wire_messages import (
+    add_openai_tools,
+    anthropic_blocks,
+    openai_chat_message,
+    responses_items,
 )
 from exp.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
 
@@ -338,6 +343,42 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
 
+    # Opaque provider-reasoning carriers replay only on the one wire that
+    # issued them, so a mixed waterfall is rejected instead of dropping them.
+    anthropic_reasoning_present = request.provider_thinking_config is not None or any(
+        block.kind in {"thinking", "redacted_thinking"}
+        for message in request.messages
+        for block in message.provider_reasoning
+    )
+    if anthropic_reasoning_present and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'thinking' is not supported by this model route. "
+                "Remove extended-thinking content or choose a native Anthropic-only route."
+            ),
+            param="thinking",
+            code="unsupported_parameter",
+        )
+    encrypted_reasoning_present = request.include_encrypted_reasoning or any(
+        block.kind == "encrypted_reasoning"
+        for message in request.messages
+        for block in message.provider_reasoning
+    )
+    if encrypted_reasoning_present and not all(
+        profile.dialect == "openai_responses" for profile in profiles
+    ):
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'reasoning.encrypted_content' is not supported by this "
+                "model route. Remove encrypted reasoning or choose a native OpenAI "
+                "Responses-only route."
+            ),
+            param="include",
+            code="unsupported_parameter",
+        )
+
     # Tool-selection controls have no semantics without tool definitions and
     # several provider APIs reject the otherwise harmless combination.
     if not request.tools:
@@ -515,16 +556,22 @@ def openai_responses_stream_payload(
                 raise ProviderResponseError("instruction messages require text")
             instructions.append(message.content)
         else:
-            items.extend(_responses_items(message))
+            items.extend(responses_items(message))
+    # Upstream storage stays disabled regardless of the caller's `store`
+    # selector: continuation state is gateway-owned, the gateway never
+    # references a provider-stored response, and disabled storage is what
+    # makes the provider return encrypted reasoning content.
     payload: JsonObject = {
         "model": model_id,
         "input": items,
         "store": False,
         "stream": True,
     }
+    if request.include_encrypted_reasoning:
+        payload["include"] = ["reasoning.encrypted_content"]
     if instructions:
         payload["instructions"] = "\n\n".join(instructions)
-    _add_openai_tools(payload, request, responses=True)
+    add_openai_tools(payload, request, responses=True)
     if request.parallel_tool_calls is not None:
         payload["parallel_tool_calls"] = request.parallel_tool_calls
     if request.structured_text is not None:
@@ -602,7 +649,7 @@ def anthropic_messages_stream_payload(
                 raise ProviderResponseError("instruction messages require text")
             system_parts.append(message.content)
             continue
-        role, blocks = _anthropic_blocks(message)
+        role, blocks = anthropic_blocks(message)
         if messages and messages[-1].get("role") == role:
             existing = messages[-1].get("content")
             if not isinstance(existing, list):
@@ -650,7 +697,12 @@ def anthropic_messages_stream_payload(
         payload["top_k"] = request.top_k
     effective_reasoning_effort = request.reasoning_effort or reasoning_effort
     output_config: JsonObject = {}
-    if supports_reasoning and effective_reasoning_effort is not None:
+    if request.provider_thinking_config is not None:
+        # The caller's exact thinking configuration wins over the catalog's
+        # adaptive default and travels verbatim, so budget semantics are
+        # never reinterpreted by the gateway.
+        payload["thinking"] = request.provider_thinking_config
+    elif supports_reasoning and effective_reasoning_effort is not None:
         payload["thinking"] = {"type": "adaptive"}
         output_config["effort"] = anthropic_reasoning_effort(model_id, effective_reasoning_effort)
     if request.structured_text is not None:
@@ -801,11 +853,11 @@ def openai_compatible_stream_payload(
     """
     payload: JsonObject = {
         "model": model_id,
-        "messages": [_openai_message(message) for message in request.messages],
+        "messages": [openai_chat_message(message) for message in request.messages],
         "stream": True,
         "stream_options": {"include_usage": True},
     }
-    _add_openai_tools(payload, request, responses=False)
+    add_openai_tools(payload, request, responses=False)
     if request.parallel_tool_calls is not None:
         payload["parallel_tool_calls"] = request.parallel_tool_calls
     if request.structured_text is not None:
@@ -846,131 +898,3 @@ def openai_compatible_stream_payload(
                 model_id, effective_reasoning_effort
             )
     return payload
-
-
-def _responses_items(message: GatewayMessage) -> list[JsonObject]:
-    """Translate one non-instruction gateway message to Responses input items."""
-    if message.role == "tool":
-        return [
-            {
-                "type": "function_call_output",
-                "call_id": message.tool_call_id or "",
-                "output": message.content or "",
-            }
-        ]
-    if message.role == "user":
-        return [{"role": "user", "content": message.content or ""}]
-    if message.role != "assistant":
-        raise ProviderResponseError("unsupported Responses message role")
-    items: list[JsonObject] = []
-    if message.content is not None:
-        items.append({"role": "assistant", "content": message.content})
-    items.extend(
-        {
-            "type": "function_call",
-            "call_id": call.call_id,
-            "name": call.name,
-            "arguments": call.arguments_json(),
-        }
-        for call in message.tool_calls
-    )
-    return items
-
-
-def _anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
-    """Translate one non-instruction gateway message to Anthropic content blocks."""
-    if message.role == "tool":
-        result: JsonObject = {
-            "type": "tool_result",
-            "tool_use_id": message.tool_call_id or "",
-            "content": message.content or "",
-        }
-        # Only the Anthropic wire can express a failed tool invocation; the
-        # marker is emitted solely when set so existing payloads are unchanged.
-        if message.tool_is_error:
-            result["is_error"] = True
-        return ("user", [result])
-    if message.role == "user":
-        return "user", [{"type": "text", "text": message.content or ""}]
-    if message.role != "assistant":
-        raise ProviderResponseError("unsupported Anthropic message role")
-    blocks: list[JsonObject] = []
-    if message.content is not None:
-        blocks.append({"type": "text", "text": message.content})
-    blocks.extend(
-        {
-            "type": "tool_use",
-            "id": call.call_id,
-            "name": call.name,
-            "input": call.arguments,
-        }
-        for call in message.tool_calls
-    )
-    return "assistant", blocks
-
-
-def _openai_message(message: GatewayMessage) -> JsonObject:
-    """Translate one gateway message to OpenAI Chat wire JSON."""
-    if message.role == "tool":
-        return {
-            "role": "tool",
-            "content": message.content or "",
-            "tool_call_id": message.tool_call_id or "",
-        }
-    payload: JsonObject = {"role": message.role, "content": message.content or ""}
-    if message.tool_calls:
-        payload["tool_calls"] = [
-            {
-                "id": call.call_id,
-                "type": "function",
-                "function": {"name": call.name, "arguments": call.arguments_json()},
-            }
-            for call in message.tool_calls
-        ]
-    return payload
-
-
-def _add_openai_tools(
-    payload: JsonObject,
-    request: GatewayRequest,
-    *,
-    responses: bool,
-) -> None:
-    """Add Responses-native or Chat-native tools and tool choice in place."""
-    if request.tools:
-        if responses:
-            payload["tools"] = [
-                {
-                    "type": "function",
-                    "name": tool.name,
-                    "description": tool.description,
-                    "parameters": tool.parameters,
-                    "strict": tool.strict,
-                }
-                for tool in request.tools
-            ]
-        else:
-            payload["tools"] = [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters,
-                        "strict": tool.strict,
-                    },
-                }
-                for tool in request.tools
-            ]
-    if request.tool_choice is not None:
-        if isinstance(request.tool_choice, GatewayNamedToolChoice):
-            payload["tool_choice"] = (
-                {"type": "function", "name": request.tool_choice.name}
-                if responses
-                else {
-                    "type": "function",
-                    "function": {"name": request.tool_choice.name},
-                }
-            )
-        else:
-            payload["tool_choice"] = request.tool_choice

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1235,3 +1235,187 @@ def test_dialect_dispatch_builds_the_bedrock_payload() -> None:
 
     assert "modelId" not in payload
     assert payload["messages"] == [{"role": "user", "content": [{"text": "hello"}]}]
+
+
+def _thinking_history_request(**overrides: object) -> GatewayRequest:
+    """Build one Messages request replaying thinking history blocks."""
+    from exp.runtime.gateway.contracts import RedactedThinkingBlock, ThinkingBlock
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(
+                role="assistant",
+                content="done",
+                provider_reasoning=(
+                    ThinkingBlock(text="private", signature="sig=="),
+                    RedactedThinkingBlock(data="opaque=="),
+                ),
+            ),
+            GatewayMessage(role="user", content="continue"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    return request.model_copy(update=dict(overrides)) if overrides else request
+
+
+def test_anthropic_payload_carries_verbatim_thinking_config_over_adaptive() -> None:
+    """The caller's exact thinking object wins over the catalog effort default."""
+    config: JsonObject = {"type": "enabled", "budget_tokens": 2048}
+    request = _thinking_history_request(provider_thinking_config=config)
+    payload = anthropic_messages_stream_payload(
+        "claude-fable-5",
+        request,
+        supports_reasoning=True,
+        reasoning_effort="high",
+    )
+    assert payload["thinking"] == config
+    # The adaptive default and its effort stay off the wire under an
+    # explicit caller configuration.
+    assert "output_config" not in payload
+
+    adaptive = anthropic_messages_stream_payload(
+        "claude-fable-5",
+        _thinking_history_request(),
+        supports_reasoning=True,
+        reasoning_effort="high",
+    )
+    assert adaptive["thinking"] == {"type": "adaptive"}
+    assert adaptive["output_config"] == {"effort": "high"}
+
+
+def test_anthropic_payload_replays_thinking_blocks_first_and_verbatim() -> None:
+    """Thinking history leads the assistant turn with byte-exact signatures."""
+    payload = anthropic_messages_stream_payload("claude-fable-5", _thinking_history_request())
+    messages = cast(list[JsonObject], payload["messages"])
+    assistant_blocks = cast(list[JsonObject], messages[1]["content"])
+    assert assistant_blocks[0] == {
+        "type": "thinking",
+        "thinking": "private",
+        "signature": "sig==",
+    }
+    assert assistant_blocks[1] == {"type": "redacted_thinking", "data": "opaque=="}
+    assert assistant_blocks[2] == {"type": "text", "text": "done"}
+
+
+def test_route_rejects_thinking_outside_native_anthropic() -> None:
+    """Thinking carriers require every waterfall rung to speak the Anthropic wire."""
+    anthropic = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        reasoning_wire_format="anthropic_adaptive",
+    )
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+
+    for request in (
+        _thinking_history_request(),
+        _chat_request().model_copy(
+            update={
+                "surface": GatewayApiSurface.MESSAGES,
+                "provider_thinking_config": {"type": "enabled", "budget_tokens": 1024},
+            }
+        ),
+    ):
+        route_generation_parameter_requests((anthropic,), request)
+        with pytest.raises(ProviderParameterError) as raised:
+            route_generation_parameter_requests((anthropic, fallback), request)
+        assert raised.value.param == "thinking"
+        assert raised.value.code == "unsupported_parameter"
+
+
+def _encrypted_reasoning_request() -> GatewayRequest:
+    """Build one Codex-shaped Responses request with encrypted reasoning replay."""
+    from exp.runtime.gateway.contracts import EncryptedReasoningBlock
+
+    return GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(
+                role="assistant",
+                content="done",
+                provider_reasoning=(
+                    EncryptedReasoningBlock(id="rs_1", encrypted_content="blob=="),
+                ),
+            ),
+            GatewayMessage(role="user", content="continue"),
+        ),
+        response_store=False,
+        include_encrypted_reasoning=True,
+        stream=True,
+        include_usage=True,
+    )
+
+
+def test_responses_payload_forwards_include_and_replays_reasoning_items() -> None:
+    """Encrypted reasoning replays ahead of its assistant message, store stays false."""
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-sol",
+        _encrypted_reasoning_request(),
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+    assert payload["store"] is False
+    assert payload["include"] == ["reasoning.encrypted_content"]
+    items = cast(list[JsonObject], payload["input"])
+    assert items[1] == {
+        "type": "reasoning",
+        "summary": [],
+        "encrypted_content": "blob==",
+        "id": "rs_1",
+    }
+    assert items[2] == {"role": "assistant", "content": "done"}
+
+
+def test_route_rejects_encrypted_reasoning_outside_native_responses() -> None:
+    """Encrypted reasoning requires every waterfall rung to speak native Responses."""
+    responses = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://openai.test",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+    )
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+    request = _encrypted_reasoning_request()
+
+    route_generation_parameter_requests((responses,), request)
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((responses, fallback), request)
+    assert raised.value.param == "include"
+    assert raised.value.code == "unsupported_parameter"
+
+
+def test_ultra_effort_is_admitted_only_where_the_family_documents_it() -> None:
+    """The gpt-5.6 family accepts ultra; other routes reject it before dispatch."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        reasoning_effort="ultra",
+    )
+    codex = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://openai.test",
+        model_id="gpt-5.6-sol",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+    )
+    route_generation_parameter_requests((codex,), request)
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-sol",
+        request,
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+    assert payload["reasoning"] == {"effort": "ultra"}
+
+    older = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://openai.test",
+        model_id="gpt-5.2",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+    )
+    with pytest.raises(UnsupportedReasoningEffortError):
+        route_generation_parameter_requests((older,), request)

--- a/exp/runtime/models/providers/tests/native_test.py
+++ b/exp/runtime/models/providers/tests/native_test.py
@@ -631,3 +631,24 @@ def test_native_provider_refusals_are_typed_without_exposing_refusal_text() -> N
         )
     assert gemini_error.value.signal is ProviderRefusalSignal.SAFETY
     assert "gemini-refusal-canary" not in str(gemini_error.value)
+
+
+def test_anthropic_completed_thinking_blocks_are_accepted() -> None:
+    """A pinned-effort route returns thinking blocks; the typed client keeps
+    final content and tool calls without raising."""
+    response = anthropic_messages_response(
+        {
+            "content": [
+                {"type": "thinking", "thinking": "private", "signature": "sig=="},
+                {"type": "redacted_thinking", "data": "opaque=="},
+                {"type": "text", "text": "final answer"},
+            ],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 9},
+        },
+        configured_model=_snapshot("anthropic", "claude-fable-5"),
+        latency_seconds=0.1,
+    )
+    assert response.output is not None
+    assert response.output.content == "final answer"
+    assert response.output.tool_calls == ()

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -1,0 +1,175 @@
+"""Canonical gateway message translation to each provider wire vocabulary.
+
+These translators are the one place a canonical :class:`GatewayMessage`
+(including its opaque provider-reasoning carrier) becomes provider content
+items or blocks; every streaming payload builder composes them so the two
+engines cannot drift at the message boundary.
+"""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import (
+    GatewayMessage,
+    GatewayNamedToolChoice,
+    GatewayRequest,
+)
+from exp.runtime.models.providers.errors import ProviderResponseError
+
+
+def responses_items(message: GatewayMessage) -> list[JsonObject]:
+    """Translate one non-instruction gateway message to Responses input items."""
+    if message.role == "tool":
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": message.tool_call_id or "",
+                "output": message.content or "",
+            }
+        ]
+    if message.role == "user":
+        return [{"role": "user", "content": message.content or ""}]
+    if message.role != "assistant":
+        raise ProviderResponseError("unsupported Responses message role")
+    items: list[JsonObject] = []
+    for block in message.provider_reasoning:
+        if block.kind != "encrypted_reasoning":
+            # Anthropic thinking cannot replay on the OpenAI wire; route
+            # admission rejects the combination before dispatch.
+            raise ProviderResponseError("thinking blocks cannot replay on the Responses wire")
+        # Reasoning items precede the assistant action they belong to, and
+        # the encrypted payload is the round-trip authority; the display-only
+        # summary is deliberately empty on replay.
+        item: JsonObject = {
+            "type": "reasoning",
+            "summary": [],
+            "encrypted_content": block.encrypted_content,
+        }
+        if block.id is not None:
+            item["id"] = block.id
+        items.append(item)
+    if message.content is not None:
+        items.append({"role": "assistant", "content": message.content})
+    items.extend(
+        {
+            "type": "function_call",
+            "call_id": call.call_id,
+            "name": call.name,
+            "arguments": call.arguments_json(),
+        }
+        for call in message.tool_calls
+    )
+    return items
+
+
+def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
+    """Translate one non-instruction gateway message to Anthropic content blocks."""
+    if message.role == "tool":
+        result: JsonObject = {
+            "type": "tool_result",
+            "tool_use_id": message.tool_call_id or "",
+            "content": message.content or "",
+        }
+        # Only the Anthropic wire can express a failed tool invocation; the
+        # marker is emitted solely when set so existing payloads are unchanged.
+        if message.tool_is_error:
+            result["is_error"] = True
+        return ("user", [result])
+    if message.role == "user":
+        return "user", [{"type": "text", "text": message.content or ""}]
+    if message.role != "assistant":
+        raise ProviderResponseError("unsupported Anthropic message role")
+    blocks: list[JsonObject] = []
+    for reasoning in message.provider_reasoning:
+        # Thinking blocks lead the assistant turn (the Anthropic contract)
+        # and re-emit verbatim: the signature must round-trip byte-exact.
+        if reasoning.kind == "thinking":
+            thinking: JsonObject = {"type": "thinking", "thinking": reasoning.text}
+            if reasoning.signature is not None:
+                thinking["signature"] = reasoning.signature
+            blocks.append(thinking)
+        elif reasoning.kind == "redacted_thinking":
+            blocks.append({"type": "redacted_thinking", "data": reasoning.data})
+        else:
+            # OpenAI encrypted reasoning cannot replay on the Anthropic wire;
+            # route admission rejects the combination before dispatch.
+            raise ProviderResponseError("encrypted reasoning cannot replay on the Anthropic wire")
+    if message.content is not None:
+        blocks.append({"type": "text", "text": message.content})
+    blocks.extend(
+        {
+            "type": "tool_use",
+            "id": call.call_id,
+            "name": call.name,
+            "input": call.arguments,
+        }
+        for call in message.tool_calls
+    )
+    return "assistant", blocks
+
+
+def openai_chat_message(message: GatewayMessage) -> JsonObject:
+    """Translate one gateway message to OpenAI Chat wire JSON."""
+    if message.role == "tool":
+        return {
+            "role": "tool",
+            "content": message.content or "",
+            "tool_call_id": message.tool_call_id or "",
+        }
+    payload: JsonObject = {"role": message.role, "content": message.content or ""}
+    if message.tool_calls:
+        payload["tool_calls"] = [
+            {
+                "id": call.call_id,
+                "type": "function",
+                "function": {"name": call.name, "arguments": call.arguments_json()},
+            }
+            for call in message.tool_calls
+        ]
+    return payload
+
+
+def add_openai_tools(
+    payload: JsonObject,
+    request: GatewayRequest,
+    *,
+    responses: bool,
+) -> None:
+    """Add Responses-native or Chat-native tools and tool choice in place."""
+    if request.tools:
+        if responses:
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                    "strict": tool.strict,
+                }
+                for tool in request.tools
+            ]
+        else:
+            payload["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                        "strict": tool.strict,
+                    },
+                }
+                for tool in request.tools
+            ]
+    if request.tool_choice is not None:
+        if isinstance(request.tool_choice, GatewayNamedToolChoice):
+            payload["tool_choice"] = (
+                {"type": "function", "name": request.tool_choice.name}
+                if responses
+                else {
+                    "type": "function",
+                    "function": {"name": request.tool_choice.name},
+                }
+            )
+        else:
+            payload["tool_choice"] = request.tool_choice

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -110,6 +110,10 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
 
 def openai_chat_message(message: GatewayMessage) -> JsonObject:
     """Translate one gateway message to OpenAI Chat wire JSON."""
+    if message.provider_reasoning:
+        # No Chat wire field can replay any reasoning carrier; route
+        # admission rejects the combination before dispatch.
+        raise ProviderResponseError("reasoning carriers cannot replay on the Chat wire")
     if message.role == "tool":
         return {
             "role": "tool",

--- a/exp/runtime/models/providers/wire_messages_test.py
+++ b/exp/runtime/models/providers/wire_messages_test.py
@@ -1,0 +1,2 @@
+"""Wire-message translation is covered through the payload builders in
+:mod:`exp.runtime.models.providers.streaming_requests_test`."""

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -98,9 +98,11 @@ RESPONSES_MANIFEST = CompatibilityManifest(
                 "temperature",
                 "top_p",
                 "stream",
+                "store",
             )
         ),
         _field("tools", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
+        _field("include", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "encrypted_reasoning"),
         _field("tool_choice", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field(
             "parallel_tool_calls",
@@ -122,11 +124,9 @@ RESPONSES_MANIFEST = CompatibilityManifest(
             for path in (
                 "background",
                 "conversation",
-                "include",
                 "max_tool_calls",
                 "prompt",
                 "service_tier",
-                "store",
                 "stream_options",
                 "truncation",
             )

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -40,7 +40,8 @@ def test_manifests_classify_explicit_exclusions() -> None:
     assert chat["top_p"] == CompatibilityDisposition.SUPPORTED
     assert responses["background"] == CompatibilityDisposition.UNSUPPORTED
     assert responses["conversation"] == CompatibilityDisposition.UNSUPPORTED
-    assert responses["include"] == CompatibilityDisposition.UNSUPPORTED
+    assert responses["include"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
+    assert responses["store"] == CompatibilityDisposition.SUPPORTED
     assert responses["top_p"] == CompatibilityDisposition.SUPPORTED
     assert responses["top_k"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert responses["top_logprobs"] == CompatibilityDisposition.UNSUPPORTED

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -24,6 +24,7 @@ from exp.common.models.model import ReasoningEffort, ToolCall
 from exp.runtime.gateway.contracts import (
     CompatibilityDisposition,
     CompatibilityManifest,
+    EncryptedReasoningBlock,
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
@@ -249,6 +250,27 @@ class _ResponseFunctionOutput(_WireModel):
     output: str
 
 
+class _ReasoningSummaryPart(_WireModel):
+    """One display-only summary part replayed inside a reasoning input item."""
+
+    type: Literal["summary_text"]
+    text: str
+
+
+class _ResponseReasoningItem(_WireModel):
+    """One opaque reasoning item a stateless caller replays with its input.
+
+    ``encrypted_content`` is the round-trip payload; the display-only
+    ``summary`` parts are validated and dropped because the provider derives
+    the model-visible reasoning from the encrypted payload alone.
+    """
+
+    type: Literal["reasoning"]
+    id: str | None = Field(default=None, min_length=1, max_length=256)
+    encrypted_content: str = Field(min_length=1)
+    summary: tuple[_ReasoningSummaryPart, ...] = ()
+
+
 class _ResponseFormat(_WireModel):
     """Supported Responses text format."""
 
@@ -296,13 +318,20 @@ class _ResponseReasoning(_WireModel):
         return self
 
 
+_ResponsesInputItem = (
+    _ResponseMessage | _ResponseFunctionCall | _ResponseFunctionOutput | _ResponseReasoningItem
+)
+
+
 class _ResponsesRequest(_WireModel):
     """Closed gateway Responses request profile."""
 
     model: str = Field(min_length=1, max_length=256)
-    input: str | tuple[_ResponseMessage | _ResponseFunctionCall | _ResponseFunctionOutput, ...]
+    input: str | tuple[_ResponsesInputItem, ...]
     instructions: str | None = None
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
+    store: bool | None = None
+    include: tuple[str, ...] | None = None
     tools: tuple[_ResponseTool, ...] = ()
     tool_choice: JsonValue = None
     parallel_tool_calls: bool | None = None
@@ -417,8 +446,11 @@ def decode_responses(
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
     """
     _validate_manifest(payload, RESPONSES_MANIFEST)
-    _validate_official(_RESPONSES_OFFICIAL, payload, extension_fields={"top_k"})
+    # The installed SDK's effort literal lags the newest provider tier
+    # ("ultra"), so the strict wire model owns reasoning validation.
+    _validate_official(_RESPONSES_OFFICIAL, payload, extension_fields={"top_k", "reasoning"})
     request = _validate_wire(_ResponsesRequest, payload)
+    include_encrypted_reasoning = _include_encrypted_reasoning(request.include)
     operation = _caller_operation(idempotency_key, client_request_id)
     messages = list(_response_input_messages(request.input))
     if request.instructions is not None:
@@ -458,6 +490,8 @@ def decode_responses(
                 if request.reasoning is not None
                 else ()
             ),
+            response_store=request.store,
+            include_encrypted_reasoning=include_encrypted_reasoning,
             stream=request.stream,
             previous_response_id=request.previous_response_id,
             metadata=request.metadata,
@@ -781,16 +815,77 @@ def _responses_structured_text(value: _ResponseText | None) -> StructuredTextFor
     )
 
 
+def _include_encrypted_reasoning(include: tuple[str, ...] | None) -> bool:
+    """Validate the closed ``include`` selector list.
+
+    Args:
+        include: Raw caller include paths.
+
+    Returns:
+        Whether the caller asked for ``reasoning.encrypted_content``.
+
+    Raises:
+        OpenAIProtocolError: An include path is not supported by this gateway.
+    """
+    if include is None:
+        return False
+    for path in include:
+        if path != "reasoning.encrypted_content":
+            raise invalid_field(
+                "include",
+                f"The include path {path!r} is not supported by this gateway. "
+                "Only 'reasoning.encrypted_content' is available.",
+            )
+    return bool(include)
+
+
 def _response_input_messages(
-    value: str | tuple[_ResponseMessage | _ResponseFunctionCall | _ResponseFunctionOutput, ...],
+    value: str | tuple[_ResponsesInputItem, ...],
 ) -> tuple[GatewayMessage, ...]:
-    """Convert Responses input items into ordered canonical history."""
+    """Convert Responses input items into ordered canonical history.
+
+    A replayed reasoning item precedes the assistant action it belongs to on
+    the official wire, so pending reasoning blocks attach to the next
+    assistant message or function call; trailing or orphaned reasoning stays
+    a standalone assistant turn carrying only the opaque blocks.
+    """
     if isinstance(value, str):
         return (GatewayMessage(role="user", content=value),)
     messages: list[GatewayMessage] = []
+    pending_reasoning: list[EncryptedReasoningBlock] = []
+
+    def take_reasoning(role: str) -> tuple[EncryptedReasoningBlock, ...]:
+        """Hand pending reasoning blocks to one assistant successor."""
+        if role != "assistant" or not pending_reasoning:
+            return ()
+        taken = tuple(pending_reasoning)
+        pending_reasoning.clear()
+        return taken
+
+    def flush_orphaned_reasoning() -> None:
+        """Emit reasoning that has no assistant successor as its own turn."""
+        if pending_reasoning:
+            messages.append(
+                GatewayMessage(role="assistant", provider_reasoning=take_reasoning("assistant"))
+            )
+
     for index, item in enumerate(value):
-        if isinstance(item, _ResponseMessage):
-            messages.extend(_messages((item,), f"input.{index}"))
+        if isinstance(item, _ResponseReasoningItem):
+            pending_reasoning.append(
+                EncryptedReasoningBlock(id=item.id, encrypted_content=item.encrypted_content)
+            )
+        elif isinstance(item, _ResponseMessage):
+            if item.role != "assistant":
+                flush_orphaned_reasoning()
+            converted = _messages((item,), f"input.{index}")
+            if converted and item.role == "assistant":
+                converted = (
+                    converted[0].model_copy(
+                        update={"provider_reasoning": take_reasoning("assistant")}
+                    ),
+                    *converted[1:],
+                )
+            messages.extend(converted)
         elif isinstance(item, _ResponseFunctionCall):
             wire_call = _AssistantToolCall(
                 id=item.call_id,
@@ -800,10 +895,13 @@ def _response_input_messages(
                 GatewayMessage(
                     role="assistant",
                     tool_calls=(_tool_call(wire_call, f"input.{index}.arguments"),),
+                    provider_reasoning=take_reasoning("assistant"),
                 )
             )
         else:
+            flush_orphaned_reasoning()
             messages.append(
                 GatewayMessage(role="tool", content=item.output, tool_call_id=item.call_id)
             )
+    flush_orphaned_reasoning()
     return tuple(messages)

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -376,7 +376,9 @@ def decode_chat(
     """
     payload = _drop_opencode_cache_control(payload)
     _validate_manifest(payload, CHAT_MANIFEST)
-    _validate_official(_CHAT_OFFICIAL, payload, extension_fields={"top_k"})
+    # The installed SDK's effort literal lags the newest provider tier
+    # ("ultra"), so the strict wire model owns reasoning validation.
+    _validate_official(_CHAT_OFFICIAL, payload, extension_fields={"top_k", "reasoning_effort"})
     request = _validate_wire(_ChatRequest, payload)
     operation = _caller_operation(idempotency_key, client_request_id)
     maximum = request.max_completion_tokens or request.max_tokens

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -743,3 +743,25 @@ def test_responses_decoder_rejects_unknown_include_paths() -> None:
                 "input": [{"type": "reasoning", "id": "rs_1", "summary": []}],
             }
         )
+
+
+def test_chat_decoder_accepts_the_ultra_reasoning_effort() -> None:
+    """The wire model owns effort validation ahead of the installed SDK literal."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "ultra",
+        }
+    )
+    assert decoded.request.reasoning_effort == "ultra"
+
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_effort": "extreme",
+            }
+        )
+    assert raised.value.detail.param == "reasoning_effort"

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -655,3 +655,91 @@ def test_responses_decoder_captures_end_user_attribution() -> None:
     assert request.safety_identifier == "sid-9"
     assert request.prompt_cache_key == "pck-1"
     assert request.attribution_label == "sid-9"
+
+
+def test_responses_decoder_accepts_the_codex_request_shape() -> None:
+    """store:false, include, ultra effort, and replayed reasoning all decode."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "store": False,
+            "include": ["reasoning.encrypted_content"],
+            "reasoning": {"effort": "ultra", "summary": "auto"},
+            "prompt_cache_key": "codex-session-1",
+            "input": [
+                {"type": "message", "role": "user", "content": "run the tool"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "planned"}],
+                    "encrypted_content": "blob==",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "search",
+                    "arguments": "{}",
+                },
+                {"type": "function_call_output", "call_id": "call-1", "output": "found"},
+            ],
+        }
+    )
+    request = decoded.request
+    assert request.response_store is False
+    assert request.include_encrypted_reasoning is True
+    assert request.reasoning_effort == "ultra"
+    assert request.reasoning_summary == "auto"
+    assert request.prompt_cache_key == "codex-session-1"
+    assistant = request.messages[1]
+    assert assistant.role == "assistant"
+    assert assistant.tool_calls[0].call_id == "call-1"
+    blocks = assistant.provider_reasoning
+    assert len(blocks) == 1
+    assert blocks[0].kind == "encrypted_reasoning"
+    assert blocks[0].id == "rs_1"
+    assert blocks[0].encrypted_content == "blob=="
+
+
+def test_responses_decoder_keeps_orphaned_reasoning_as_its_own_turn() -> None:
+    """Trailing reasoning with no assistant successor stays a standalone turn."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "message", "role": "user", "content": "go"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [],
+                    "encrypted_content": "blob==",
+                },
+            ],
+        }
+    )
+    trailing = decoded.request.messages[-1]
+    assert trailing.role == "assistant"
+    assert trailing.content is None
+    block = trailing.provider_reasoning[0]
+    assert block.kind == "encrypted_reasoning"
+    assert block.encrypted_content == "blob=="
+
+
+def test_responses_decoder_rejects_unknown_include_paths() -> None:
+    """Only the encrypted reasoning include selector is honored."""
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_responses(
+            {
+                "model": "coding",
+                "include": ["message.output_text.logprobs"],
+                "input": "hi",
+            }
+        )
+    assert raised.value.detail.param == "include"
+
+    with pytest.raises(OpenAIProtocolError):
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [{"type": "reasoning", "id": "rs_1", "summary": []}],
+            }
+        )

--- a/exp/runtime/openai_protocol/streaming.py
+++ b/exp/runtime/openai_protocol/streaming.py
@@ -83,7 +83,15 @@ class ChatSseEncoder:
             return (self._chunk(delta={"content": event.text_delta}),)
         if event.kind == GatewayEventKind.REFUSAL_DELTA:
             return (self._chunk(delta={"refusal": event.text_delta}),)
-        if event.kind == GatewayEventKind.REASONING_SUMMARY_DELTA:
+        if event.kind in {
+            GatewayEventKind.REASONING_SUMMARY_DELTA,
+            # The Chat wire has no reasoning representation, so provider
+            # reasoning is deliberately dropped here like summary deltas.
+            GatewayEventKind.THINKING_DELTA,
+            GatewayEventKind.THINKING_SIGNATURE,
+            GatewayEventKind.REDACTED_THINKING,
+            GatewayEventKind.ENCRYPTED_REASONING,
+        }:
             return ()
         if event.kind == GatewayEventKind.TOOL_CALL_STARTED:
             index = _required_index(event)
@@ -251,10 +259,11 @@ class _ResponseReasoningState:
         self.item_id = item_id
         self.output_index = output_index
         self.parts: dict[int, str] = {}
+        self.encrypted_content: str | None = None
 
     def item(self, *, completed: bool) -> JsonObject:
         """Return the current official Responses reasoning item."""
-        return {
+        item: JsonObject = {
             "id": self.item_id,
             "type": "reasoning",
             "summary": (
@@ -264,6 +273,9 @@ class _ResponseReasoningState:
             ),
             "status": "completed" if completed else "in_progress",
         }
+        if self.encrypted_content is not None:
+            item["encrypted_content"] = self.encrypted_content
+        return item
 
 
 class ResponsesSseEncoder:
@@ -319,6 +331,22 @@ class ResponsesSseEncoder:
             return self._content_delta("refusal", _required_text(event.text_delta))
         if event.kind == GatewayEventKind.REASONING_SUMMARY_DELTA:
             return self._reasoning_summary_delta(event)
+        if event.kind == GatewayEventKind.THINKING_DELTA:
+            # Lossy projection: Anthropic thinking text streams as a summary
+            # part so callers receive what they pay for. Signatures are
+            # dropped deliberately, since this surface cannot round-trip them.
+            if event.reasoning_block_index is None:
+                raise self._state_error("Responses thinking delta omitted its block index.")
+            return self._reasoning_summary_text(
+                event.reasoning_block_index, 0, _required_text(event.text_delta)
+            )
+        if event.kind in {
+            GatewayEventKind.THINKING_SIGNATURE,
+            GatewayEventKind.REDACTED_THINKING,
+        }:
+            return ()
+        if event.kind == GatewayEventKind.ENCRYPTED_REASONING:
+            return self._encrypted_reasoning(event)
         if event.kind == GatewayEventKind.TOOL_CALL_STARTED:
             return self._tool_started(event)
         if event.kind == GatewayEventKind.TOOL_ARGUMENTS_DELTA:
@@ -437,7 +465,14 @@ class ResponsesSseEncoder:
         summary_index = event.reasoning_summary_index
         if provider_output_index is None or summary_index is None:
             raise self._state_error("Responses reasoning delta omitted its indices.")
-        frames: list[str] = []
+        return self._reasoning_summary_text(
+            provider_output_index, summary_index, _required_text(event.text_delta)
+        )
+
+    def _ensure_reasoning_state(
+        self, provider_output_index: int, frames: list[str]
+    ) -> _ResponseReasoningState:
+        """Create one stable reasoning output item on first use."""
         state = self._reasoning.get(provider_output_index)
         if state is None:
             state = _ResponseReasoningState(
@@ -455,6 +490,23 @@ class ResponsesSseEncoder:
                     },
                 )
             )
+        return state
+
+    def _encrypted_reasoning(self, event: GatewayEvent) -> tuple[str, ...]:
+        """Retain one opaque encrypted reasoning payload on its output item."""
+        if event.reasoning_block_index is None or event.encrypted_content is None:
+            raise self._state_error("Responses encrypted reasoning omitted its payload.")
+        frames: list[str] = []
+        state = self._ensure_reasoning_state(event.reasoning_block_index, frames)
+        state.encrypted_content = event.encrypted_content
+        return tuple(frames)
+
+    def _reasoning_summary_text(
+        self, provider_output_index: int, summary_index: int, delta: str
+    ) -> tuple[str, ...]:
+        """Emit one summary text delta, opening its item and part as needed."""
+        frames: list[str] = []
+        state = self._ensure_reasoning_state(provider_output_index, frames)
         if summary_index not in state.parts:
             state.parts[summary_index] = ""
             frames.append(
@@ -468,7 +520,6 @@ class ResponsesSseEncoder:
                     },
                 )
             )
-        delta = _required_text(event.text_delta)
         state.parts[summary_index] += delta
         frames.append(
             self._event(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.6.1"
+version = "0.7.0"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.2.3,<0.3",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.0,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,12 +610,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.2.3"
+version = "0.3.0"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

One generic opaque provider-reasoning carrier so the hosted gateway fully serves Claude Code (Anthropic Messages with extended thinking) and OpenAI Codex (Responses with `store: false`, `include: ["reasoning.encrypted_content"]`, `reasoning.summary`, effort `ultra`), plus the live thinking-discard bug fix.

### Canonical contracts (`exp/runtime/gateway/contracts.py`)

- `GatewayMessage.provider_reasoning`: an ordered, assistant-only tuple of `ThinkingBlock {text, signature}`, `RedactedThinkingBlock {data}`, and `EncryptedReasoningBlock {id?, encrypted_content}`. `Field(exclude=True)` like `tool_is_error`, so request digests, replay identity, and immutable artifacts are unperturbed (tested by sha256 equality).
- `GatewayRequest` gains `provider_thinking_config` (the caller's verbatim Anthropic `thinking` object, excluded from digests), `response_store`, and `include_encrypted_reasoning` (both serialized: they are public wire fields with behavioral meaning). All three are surface-scoped by the model validator.
- New `GatewayEventKind` members mirrored by Rust `Event` variants: `thinking_delta`, `thinking_signature`, `redacted_thinking`, `encrypted_reasoning`.

### Anthropic Messages lane (Claude Code)

- Manifest: `thinking` moves to CONDITIONALLY_SUPPORTED (`extended_thinking`).
- Decoder accepts `thinking` configs (`enabled` with a required budget, `disabled`, `adaptive`) and forwards the raw caller object byte-for-byte; thinking and redacted-thinking history blocks ride the carrier in order with byte-exact signatures; a thinking-only assistant turn is legal history.
- Outbound payloads emit the caller's verbatim thinking config, overriding the catalog's adaptive-effort default, and re-emit thinking blocks first in the assistant turn.
- Bug fix: the Rust Anthropic normalizer no longer discards `thinking_delta`/`signature_delta`/`redacted_thinking` frames (customers were billed for thinking the gateway threw away on pinned-effort routes). The Messages encoder schedules thinking blocks through the valid Anthropic SSE lifecycle and includes them in non-streaming bodies; on OpenAI-shaped surfaces the thinking text projects onto the reasoning-summary channel (a deliberate lossy projection, signatures dropped, since those surfaces cannot round-trip them); Chat keeps dropping reasoning like summary deltas.
- Non-streaming `AnthropicClient` accepts thinking blocks instead of raising. (Deviation from the spec letter: `ModelResponse`/`AssistantAction` is a frozen artifact contract with no carrier slot and no consumer for reasoning, so the typed client tolerates and skips the blocks rather than widening that contract.)
- Cost accounting unchanged: Anthropic reports thinking inside `output_tokens`; `reasoning_tokens` stays `None` with a comment saying why.

### OpenAI Responses lane (Codex)

- Manifest: `store` SUPPORTED, `include` CONDITIONALLY_SUPPORTED (`encrypted_reasoning`); only `reasoning.encrypted_content` is accepted as an include path.
- Replayed input `reasoning` items decode onto the carrier (attached to the following assistant item, standalone when trailing) and re-emit upstream ahead of their assistant action with `summary: []`; the display-only replayed summary parts are validated and dropped because the encrypted payload is the round-trip authority.
- `store: false` skips gateway continuation retention (`ContinuationContext.retain`); continuing from a never-stored ID answers the existing `continuation_unavailable` error. Episode identity is preserved so continued store:false requests still join their original selection episode. Upstream `store` deliberately stays `false` in all cases: continuation state is gateway-owned, the gateway never references a provider-stored response, and disabled storage is what makes providers return encrypted reasoning (deviation from the spec letter, flagged at design checkpoint).
- The Rust Responses normalizer passes `encrypted_content` from completed reasoning items through under the shared retained-output budget; the encoder lands it verbatim on the public reasoning item (streaming `output_item.done` and non-streaming body).
- `ReasoningEffort` gains `ultra` (ordered between `xhigh` and `max`) everywhere the ladder is spelled; the gpt-5.6 family table documents it. The installed OpenAI SDK literal lags `ultra`, so both OpenAI decoders exempt the reasoning field from official-schema validation and own it in the strict wire models.

### Route admission

Mirroring the `tool_is_error` gate: thinking configs/blocks require every waterfall rung to be `anthropic_messages`; encrypted reasoning and the include selector require every rung to be `openai_responses`. Per-rung narrowing still applies, so a mixed waterfall narrows to compatible rungs before rejecting.

### Guardrail hardening

`apply_text_replacement` now drops every reasoning channel (summary, thinking, signature, redacted, encrypted) alongside refusal deltas: a guardrail-rewritten output must not leak redacted content through the model's own reasoning stream.

### Replay identity for carried reasoning (review finding, fixed in-branch)

The carriers are digest-excluded so immutable artifacts and carrier-free request digests stay byte-identical, which originally left keyed Responses requests that differ only in replayed encrypted reasoning colliding under one idempotency key. `exp.runtime.gateway.contracts.canonical_request_sha256` now folds present carriers (and a verbatim thinking config) into replay identity: key reuse with changed reasoning answers `idempotency_conflict`, requests without carriers keep their exact prior identity. Hosted stores that compute their own `AuthorizationSnapshot.canonical_request_sha256` (the platform control plane) should adopt the same helper when they bump to 0.7.0.

### reasoning.summary investigation (production rejection on gpt-5.6-sol)

The strict gate (`every rung openai_responses AND supports_reasoning`) is CORRECT and stays. The production route rejected `reasoning.summary` because Azure deployments serve through `AzureClient`, a subclass of `OpenAICompatibleClient`: dialect `openai_compatible` (Chat Completions wire), which has no reasoning-summary representation. Widening the gate would silently send `summary` to a wire that cannot honor it.

**Platform-side change needed for Codex models:** route them through deployments served by the native OpenAI client (`OpenAIClient`, dialect `openai_responses`, `supports_reasoning` true with `reasoning_wire_format="openai_responses"`), i.e. bind an OpenAI (or OpenAI-compatible Responses-capable) connection for gpt-5.6-codex/gpt-5.6-sol in the platform catalog instead of (or ahead of, as the only rungs of a Codex-facing alias) Azure Chat deployments. Alternatively, an Azure `/openai/v1` Responses adapter would be a new wire dialect in this repo; that is a separate feature, not silently widened here. Note also the encrypted-reasoning and summary gates mean a Codex alias must be a pure `openai_responses` waterfall.

**Platform pin bump:** `exp-gateway-native` 0.3.0 and `experiential` 0.7.0 (dependency range `exp-gateway-native>=0.3.0,<0.4`). The platform must bump its `experiential` pin to 0.7.0 to pick up `store`/`include`/`thinking`/`ultra` admission.

### Structural notes

- `streaming_requests.py` crossed the 999-line cap; the message-to-wire translators moved to `exp/runtime/models/providers/wire_messages.py` (one coherent seam, covered through the payload-builder tests).
- The inline test mods of `encode_messages.rs`/`encode_responses.rs` moved to `src/<module>/tests.rs` submodules for the same cap.
- New goldens in `testdata/parity_goldens.json` (`messages_thinking_frames`, `messages_thinking_body`, `responses_encrypted_reasoning_body`) were hand-authored against the public wire specs, not generated from the encoders.

### Effort snap audit (release-notes citation)

Audited for the 0.7.0 train: zero silent reasoning-effort snaps exist in the engine. Every caller-effort path is exact passthrough or a loud rejection listing the supported values; nothing maps a requested effort to a different effective level. Recorded as platform-side follow-ups: disclosure of route-pinned default efforts (the `ignored_parameters` mechanism is the natural carrier if wanted) and one canonical effort-ordering export that both repos consume in place of today's duplicated ladders.

### Rebase note

Rebased onto main past v0.6.1, #640, #641, and #643 (native crate base 0.2.3 -> 0.3.0). The admission gates were designed against the v0.6.1 per-rung model from the start: they mirror the `tool_is_error` gate, so `compatible_generation_parameter_profile_indexes` checks each rung independently, a mixed waterfall narrows to the rungs that can replay the carrier, and the route-wide error surfaces only when no rung qualifies.

## Test evidence

- `uv run ruff check .` / `ruff format --check .` / `ty check`: all pass, zero diagnostics.
- `uv run pytest -q`: 2656 passed, 2 skipped (full suite, clean tree).
- `cargo test --no-default-features` in `exp/runtime/gateway/native`: 72 passed; `cargo fmt --check` and `cargo clippy --no-default-features -- -D warnings` clean.
- New coverage: carrier digest-invariance and surface scoping; Messages decode round-trips (config verbatim, blocks in order, user-role rejection); Responses Codex-shape decode (store/include/ultra/replayed reasoning, orphaned reasoning, unknown include paths); route-admission mixed-waterfall rejections for both carriers; verbatim thinking-config payload override; ultra family gating; store:false retention skip at the bridge and over the live served engine; hand-authored golden byte parity for thinking SSE frames, thinking body, and encrypted-reasoning body; Rust normalizer/encoder/guardrail unit tests; live-engine admission rejections with zero upstream dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
