### PR TITLE
gateway: admission-time skip-and-recover for a dead lead rung

### DIFF
--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -159,6 +159,11 @@ class NativeAttemptAccounting:
         self._accounting_healthy = True
         self._sweep_retained_replayed = 0
         self._sweep_abandoned_cancelled = 0
+        # Admission-time dead-rung skips: a request served off a fallback
+        # because a certified rung could not be resolved for dispatch, and the
+        # subset of those where the skipped rung was the lead.
+        self._admission_dead_rungs_skipped = 0
+        self._admission_lead_rungs_skipped = 0
         # The sweep also runs on a timer so retained settlements and abandoned
         # attempts are recovered even when no further requests arrive.
         self._sweeper = threading.Thread(
@@ -190,6 +195,23 @@ class NativeAttemptAccounting:
                 self._sweep_abandoned_cancelled,
                 len(self._inflight),
             )
+
+    def record_admission_rung_skips(self, dead_count: int, *, lead_skipped: bool) -> None:
+        """Count admission-time dead-rung skips for the metrics snapshot.
+
+        Args:
+            dead_count: Number of certified rungs skipped as dead at admission.
+            lead_skipped: Whether the skipped set included the lead rung.
+        """
+        with self._lock:
+            self._admission_dead_rungs_skipped += dead_count
+            if lead_skipped:
+                self._admission_lead_rungs_skipped += 1
+
+    def admission_rung_skips(self) -> tuple[int, int]:
+        """Return ``(lead_rungs_skipped, dead_rungs_skipped)`` for metrics."""
+        with self._lock:
+            return (self._admission_lead_rungs_skipped, self._admission_dead_rungs_skipped)
 
     def register(self, entry: InflightRequest) -> None:
         """Track one accepted request until its terminal settlement."""

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -36,7 +36,6 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from typing import cast
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import (
@@ -47,17 +46,11 @@ from exp.runtime.gateway.contracts import (
     GatewayFailureClass,
     GatewayRequest,
 )
-from exp.runtime.gateway.discovery import (
-    public_model_list,
-    public_model_object,
-    require_granted_authority,
-)
 from exp.runtime.gateway.group_commit import SyncGroupCommitLedger
 from exp.runtime.gateway.guardrails.client import assert_not_internal_classification
 from exp.runtime.gateway.guardrails.contracts import GuardrailRejected
 from exp.runtime.gateway.guardrails.enforcement import GuardrailEngine
 from exp.runtime.gateway.guardrails.native import enforce_native_input, enforce_native_output
-from exp.runtime.gateway.ledger import SQLiteAttemptLedger
 from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
@@ -80,7 +73,7 @@ from exp.runtime.gateway.native_execution import (
     resolve_route_profiles,
     select_route_deployments,
 )
-from exp.runtime.gateway.native_metrics_text import render_metrics_text
+from exp.runtime.gateway.native_observability import NativeObservabilityMixin
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
     continued_request,
@@ -91,8 +84,6 @@ from exp.runtime.gateway.native_settlement import (
     optional_text,
 )
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
-from exp.runtime.gateway.sqlite.migrations import close_idle_connections
-from exp.runtime.gateway.usage import GatewayUsageReport, read_usage_report, usage_html
 from exp.runtime.models.providers import (
     preflight_gateway_request,
     require_gateway_provider,
@@ -140,7 +131,7 @@ def _escalation(reason: str) -> str:
     return json.dumps({"escalate": reason}, separators=(",", ":"))
 
 
-class NativeControlPlane:
+class NativeControlPlane(NativeObservabilityMixin):
     """Authority and accounting callbacks for the native data plane.
 
     Methods are called from multiple Rust worker threads. Ledger writes block
@@ -728,168 +719,6 @@ class NativeControlPlane:
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             raise _authority_error(exc) from exc
         return "{}"
-
-    def models(self, argument: str) -> str:
-        """Return the granted model list body for one authenticated key."""
-        data = json.loads(argument)
-        try:
-            authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
-            body = public_model_list(authorities)
-        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
-            raise _authority_error(exc) from exc
-        return json.dumps(body, separators=(",", ":"))
-
-    def model_detail(self, argument: str) -> str:
-        """Return one granted model object or the shared no-oracle 404."""
-        data = json.loads(argument)
-        try:
-            authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
-            authority = require_granted_authority(authorities, data["model_id"])
-            body = public_model_object(authority)
-        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
-            raise _authority_error(exc) from exc
-        return json.dumps(body, separators=(",", ":"))
-
-    def usage_json(self, argument: str) -> str:
-        """Return the content-free usage report body.
-
-        Args:
-            argument: JSON object with an optional ``raw_key``. A presented
-                key scopes the report to its owning identity; an absent key
-                returns the organization-wide report.
-
-        Returns:
-            The schema-versioned usage report as one JSON object.
-
-        Raises:
-            NativeBridgeError: The presented key is invalid, expired, or revoked.
-        """
-        if self._usage_reporter is not None:
-            return json.dumps(self._usage_reporter(), separators=(",", ":"))
-        report = self._usage_report(argument)
-        return json.dumps(report.model_dump(mode="json"), separators=(",", ":"))
-
-    def usage_page(self, argument: str) -> str:
-        """Return the content-free usage page rendering.
-
-        Args:
-            argument: JSON object with an optional ``raw_key``, scoped exactly
-                like :meth:`usage_json`.
-
-        Returns:
-            JSON object with one ``html`` field holding the rendered page.
-
-        Raises:
-            NativeBridgeError: The presented key is invalid, expired, or revoked.
-        """
-        report = self._usage_report(argument)
-        return json.dumps({"html": usage_html(report)}, separators=(",", ":"))
-
-    def _usage_report(self, argument: str) -> GatewayUsageReport:
-        """Read the usage report for one optionally key-scoped callback.
-
-        Args:
-            argument: JSON object with an optional ``raw_key``.
-
-        Returns:
-            The organization-wide report, or the report scoped to the
-            presented key's identity.
-
-        Raises:
-            NativeBridgeError: The presented key is invalid, expired, or revoked.
-        """
-        data = json.loads(argument)
-        raw_key = data.get("raw_key")
-        identity_id: str | None = None
-        if raw_key is not None:
-            try:
-                _, identity_id = self._components.store.authenticated_identity(raw_key=str(raw_key))
-            except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
-                raise _authority_error(exc) from exc
-        # Only the local composition (SQLite ledger) serves native usage;
-        # hosted compositions disable it and own their own usage surface.
-        return read_usage_report(
-            cast("SQLiteAttemptLedger", self._components.ledger),
-            organization_id=self._components.organization_id,
-            identity_id=identity_id,
-        )
-
-    def metrics_snapshot(self) -> JsonObject:
-        """Compose the one content-free observability snapshot.
-
-        ``data_plane`` carries the native engine's registry when a provider
-        is bound, otherwise ``None``; ``control_plane`` carries this bridge's
-        own sweep recoveries, in-flight registry size, reconciliation counts,
-        and accounting health. The native ``/metrics.json`` route serves
-        exactly this body; ``/metrics`` serves its Prometheus text rendering.
-        """
-        data_plane: JsonObject | None = None
-        if self._data_plane_metrics is not None:
-            data_plane = json.loads(self._data_plane_metrics())
-        retained_replayed, abandoned_cancelled, inflight = self._accounting.counters()
-        lead_rungs_skipped, dead_rungs_skipped = self._accounting.admission_rung_skips()
-        control_plane: JsonObject = {
-            "sweep_retained_settlements_replayed": retained_replayed,
-            "sweep_abandoned_attempts_cancelled": abandoned_cancelled,
-            "admission_dead_rungs_skipped": dead_rungs_skipped,
-            "admission_lead_rungs_skipped": lead_rungs_skipped,
-            "inflight_attempts": inflight,
-            "reconciled_expired_requests": self._components.reconciled_expired_requests,
-            "reconciled_unknown_attempts": self._components.reconciled_unknown_attempts,
-            "accounting_healthy": self._accounting.accounting_healthy,
-        }
-        return {"data_plane": data_plane, "control_plane": control_plane}
-
-    def metrics_json(self, argument: str) -> str:
-        """Return the content-free metrics snapshot body for the data plane."""
-        del argument
-        return json.dumps(self.metrics_snapshot(), separators=(",", ":"))
-
-    def metrics_text(self, argument: str) -> str:
-        """Return ``{"text": ...}`` holding the snapshot's Prometheus exposition."""
-        del argument
-        text = render_metrics_text(self.metrics_snapshot())
-        return json.dumps({"text": text}, separators=(",", ":"))
-
-    def readiness(self, argument: str) -> str:
-        """Return whether bridge settlement and composition accounting stay healthy.
-
-        Readiness fails closed once the bridge's own settlement registry has
-        latched a durable-write loss, once the composition's accounting
-        surface reports unhealthy, or when an injected hosted lifecycle probe
-        answers false or raises.
-        """
-        del argument
-        if not self._accounting.accounting_healthy:
-            return "false"
-        try:
-            if not self._components.accounting_healthy:
-                return "false"
-        except Exception:  # noqa: BLE001 - readiness fails closed at the boundary.
-            return "false"
-        if self._readiness_probe is not None:
-            try:
-                return "true" if self._readiness_probe() else "false"
-            except Exception:  # noqa: BLE001 - readiness fails closed at the boundary.
-                return "false"
-        return "true"
-
-    def close_thread_resources(self, argument: str) -> str:
-        """Release the calling thread's cached resources before it exits.
-
-        The data plane pins control-plane callbacks to a fixed pool of worker
-        threads and calls this once per worker as the pool shuts down, so the
-        SQLite connections cached per thread by ``persistent_connection``
-        close with the worker instead of outliving it.
-
-        Args:
-            argument: Empty JSON object, matching the callback shape.
-
-        Returns:
-            JSON object reporting the number of connections closed.
-        """
-        del argument
-        return json.dumps({"closed_connections": close_idle_connections()}, separators=(",", ":"))
 
     def _decode_body(
         self,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -33,6 +33,7 @@ metrics and fails the request closed with the shared internal error.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections.abc import Callable
 from typing import cast
@@ -70,9 +71,12 @@ from exp.runtime.gateway.native_dispatch import dispatch_signature_headers, froz
 from exp.runtime.gateway.native_execution import (
     MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
     MAXIMUM_TOTAL_ATTEMPTS,
+    DeadRung,
     InflightRequest,
     NativeDialectUnavailableError,
+    deployment_health_key,
     deployment_wire_entry,
+    dispatchable_route_profiles,
     resolve_route_profiles,
     select_route_deployments,
 )
@@ -117,6 +121,8 @@ from exp.runtime.openai_protocol.state import (
 )
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
+
+_logger = logging.getLogger(__name__)
 
 
 def _escalation(reason: str) -> str:
@@ -341,7 +347,21 @@ class NativeControlPlane:
                 request,
                 continuation=continuation_context,
             )
-            resolved_wires = resolve_route_profiles(self._components.runtime_catalogs, route)
+            # A rung that is dead at admission (a lost credential, a drifted
+            # connection) is skipped so a live fallback still serves the
+            # request instead of the whole request failing on a dead lead.
+            dispatchable = dispatchable_route_profiles(self._components.runtime_catalogs, route)
+            self._record_dead_admission_rungs(authorization, dispatchable.dead)
+            if not dispatchable.indexes:
+                # Every certified rung was operationally dead at admission;
+                # there is nothing live to serve, so the accepted request is
+                # finished closed.
+                return self._escalate_accepted(
+                    authorization,
+                    "every certified deployment was unavailable at admission",
+                )
+            route = select_route_deployments(route, dispatchable.indexes)
+            resolved_wires = dispatchable.resolved_wires
         except NativeDialectUnavailableError as exc:
             return self._escalate_accepted(authorization, str(exc))
         except Exception as exc:  # noqa: BLE001 - raised after route packaging below.
@@ -807,9 +827,12 @@ class NativeControlPlane:
         if self._data_plane_metrics is not None:
             data_plane = json.loads(self._data_plane_metrics())
         retained_replayed, abandoned_cancelled, inflight = self._accounting.counters()
+        lead_rungs_skipped, dead_rungs_skipped = self._accounting.admission_rung_skips()
         control_plane: JsonObject = {
             "sweep_retained_settlements_replayed": retained_replayed,
             "sweep_abandoned_attempts_cancelled": abandoned_cancelled,
+            "admission_dead_rungs_skipped": dead_rungs_skipped,
+            "admission_lead_rungs_skipped": lead_rungs_skipped,
             "inflight_attempts": inflight,
             "reconciled_expired_requests": self._components.reconciled_expired_requests,
             "reconciled_unknown_attempts": self._components.reconciled_unknown_attempts,
@@ -886,6 +909,41 @@ class NativeControlPlane:
             )
         except NativeDecodeError as exc:
             raise NativeBridgeError(exc.error) from exc
+
+    def _record_dead_admission_rungs(
+        self,
+        authorization: AuthorizationSnapshot,
+        dead: tuple[DeadRung, ...],
+    ) -> None:
+        """Feed each admission-dead rung into its health circuit and surface it.
+
+        A rung skipped because it was operationally dead at admission is
+        recorded in the same deployment health circuit as a runtime failure,
+        so the existing cooldown and half-open probe bring it back
+        automatically when it heals; it is never permanently blacklisted. A
+        skipped lead rung is logged and counted so a persistently dead lead
+        reaches a human instead of being silently masked behind a healthy
+        fallback forever.
+
+        Args:
+            authorization: Frozen authority for the accepted request.
+            dead: Every rung skipped as operationally dead, in route order.
+        """
+        if not dead:
+            return
+        health = self._accounting.health
+        for rung in dead:
+            health.failed(deployment_health_key(authorization, rung.deployment), rung.failure)
+        lead = next((rung for rung in dead if rung.index == 0), None)
+        self._accounting.record_admission_rung_skips(len(dead), lead_skipped=lead is not None)
+        if lead is not None:
+            _logger.warning(
+                "gateway admission skipped the lead rung for alias %r: served off a "
+                "fallback because deployment %r (provider %r) was dead at admission",
+                authorization.alias,
+                lead.deployment.deployment_id,
+                lead.deployment.provider,
+            )
 
     def _escalate_accepted(self, authorization: AuthorizationSnapshot, reason: str) -> str:
         """Finish one accepted-but-unservable request and return its disposition.

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -342,7 +342,11 @@ class NativeControlPlane(NativeObservabilityMixin):
             # connection) is skipped so a live fallback still serves the
             # request instead of the whole request failing on a dead lead.
             dispatchable = dispatchable_route_profiles(self._components.runtime_catalogs, route)
-            self._record_dead_admission_rungs(authorization, dispatchable.dead)
+            self._record_dead_admission_rungs(
+                authorization,
+                dispatchable.dead,
+                fallback_available=bool(dispatchable.indexes),
+            )
             if not dispatchable.indexes:
                 # Every certified rung was operationally dead at admission;
                 # there is nothing live to serve, so the accepted request is
@@ -743,6 +747,8 @@ class NativeControlPlane(NativeObservabilityMixin):
         self,
         authorization: AuthorizationSnapshot,
         dead: tuple[DeadRung, ...],
+        *,
+        fallback_available: bool,
     ) -> None:
         """Feed each admission-dead rung into its health circuit and surface it.
 
@@ -752,11 +758,14 @@ class NativeControlPlane(NativeObservabilityMixin):
         automatically when it heals; it is never permanently blacklisted. A
         skipped lead rung is logged and counted so a persistently dead lead
         reaches a human instead of being silently masked behind a healthy
-        fallback forever.
+        fallback forever. That masking signal only exists when a live
+        fallback actually serves: a total route outage escalates loudly on
+        its own path and must not read as one more fallback-served request.
 
         Args:
             authorization: Frozen authority for the accepted request.
             dead: Every rung skipped as operationally dead, in route order.
+            fallback_available: Whether any live rung remains to serve.
         """
         if not dead:
             return
@@ -764,8 +773,9 @@ class NativeControlPlane(NativeObservabilityMixin):
         for rung in dead:
             health.failed(deployment_health_key(authorization, rung.deployment), rung.failure)
         lead = next((rung for rung in dead if rung.index == 0), None)
-        self._accounting.record_admission_rung_skips(len(dead), lead_skipped=lead is not None)
-        if lead is not None:
+        lead_masked = lead is not None and fallback_available
+        self._accounting.record_admission_rung_skips(len(dead), lead_skipped=lead_masked)
+        if lead is not None and fallback_available:
             _logger.warning(
                 "gateway admission skipped the lead rung for alias %r: served off a "
                 "fallback because deployment %r (provider %r) was dead at admission",

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -706,6 +706,7 @@ def _configured_pool_gateway(
     base_urls: tuple[str, str] = ("http://127.0.0.1:9/v1", "http://127.0.0.1:10/v1"),
     gateway_capabilities: tuple[GatewayDeploymentCapabilities, GatewayDeploymentCapabilities]
     | None = None,
+    api_key_envs: tuple[str, str] = ("TEST_PROVIDER_KEY", "TEST_PROVIDER_KEY"),
 ) -> tuple[GatewayManagement, str]:
     """Create one certified two-deployment pool alias, grant, and key.
 
@@ -714,6 +715,9 @@ def _configured_pool_gateway(
         refusal_failover: Whether the alias revision opts into refusal failover.
         base_urls: One provider endpoint per ordered deployment.
         gateway_capabilities: Optional protocol contract for each deployment.
+        api_key_envs: One credential environment-variable name per ordered
+            deployment, so a test can make one rung's credential resolvable
+            while another is absent.
 
     Returns:
         The management handle and the issued raw key.
@@ -736,8 +740,8 @@ def _configured_pool_gateway(
         GatewayDeploymentCapabilities(supports_streaming=True),
         GatewayDeploymentCapabilities(supports_streaming=True),
     )
-    for alias, base_url, gateway_capability in zip(
-        ("alpha", "beta"), base_urls, declared_gateway_capabilities, strict=True
+    for alias, base_url, gateway_capability, api_key_env in zip(
+        ("alpha", "beta"), base_urls, declared_gateway_capabilities, api_key_envs, strict=True
     ):
         upsert_connection(
             root,
@@ -745,7 +749,7 @@ def _configured_pool_gateway(
             connection=ConnectionConfig(
                 provider="openai-compatible",
                 base_url=base_url,
-                api_key_env="TEST_PROVIDER_KEY",
+                api_key_env=api_key_env,
             ),
             replace=False,
         )
@@ -877,6 +881,100 @@ def test_admit_removes_protocol_incompatible_fallbacks(tmp_path: Path) -> None:
     assert [item["model_id"] for item in route] == ["beta-model-exact"]
     upstream = cast("JsonObject", route[0]["upstream_payload"])
     assert upstream["stop"] == ["DONE"]
+
+
+def _partial_pool_control_plane(
+    root: Path,
+    environment: dict[str, str],
+) -> tuple[NativeControlPlane, str]:
+    """Load a two-rung pool whose lead reads a separately-toggled credential.
+
+    The lead (``alpha``) reads ``TEST_ALPHA_KEY`` and the fallback (``beta``)
+    reads ``TEST_PROVIDER_KEY``. Both must be present in ``environment`` at load
+    so readiness admits the alias; a test then mutates the shared ``environment``
+    mapping to make the lead dead or healthy at a later admission.
+    """
+    _manager, raw_key = _configured_pool_gateway(
+        root,
+        api_key_envs=("TEST_ALPHA_KEY", "TEST_PROVIDER_KEY"),
+    )
+    components = load_gateway_components(root, environment=environment)
+    return NativeControlPlane(components), raw_key
+
+
+def test_admit_skips_a_dead_lead_rung_and_serves_the_fallback(tmp_path: Path) -> None:
+    """A lead dead at admission fails over to the live fallback and feeds the circuit."""
+    environment = {"TEST_ALPHA_KEY": "alpha-secret", "TEST_PROVIDER_KEY": "beta-secret"}
+    control, raw_key = _partial_pool_control_plane(tmp_path, environment)
+
+    # The lead credential is lost after load, so its rung is dead at admission
+    # while the fallback stays healthy.
+    del environment["TEST_ALPHA_KEY"]
+    admission = _admit(control, raw_key, _chat_body())
+
+    assert "escalate" not in admission
+    route = cast("list[JsonObject]", admission["route"])
+    assert [item["model_id"] for item in route] == ["beta-model-exact"]
+
+    snapshot = control.metrics_snapshot()
+    control_plane = cast("JsonObject", snapshot["control_plane"])
+    assert control_plane["admission_lead_rungs_skipped"] == 1
+    assert control_plane["admission_dead_rungs_skipped"] == 1
+
+    # The skip fed the SAME deployment health circuit runtime failures feed:
+    # exactly the dead lead's circuit is open (a cooldown, never a blacklist),
+    # and admission never claims the fallback so no other circuit was touched.
+    states = control._accounting.health._states  # noqa: SLF001 - assert the circuit state.
+    assert len(states) == 1
+    (dead_state,) = states.values()
+    assert dead_state.open_until > time.monotonic()
+
+    # The narrowed route is what serves and anchors accounting.
+    started = _start_first(control, admission)
+    assert started["route_depth"] == 0
+
+
+def test_admit_recovers_a_dead_lead_when_its_credential_heals(tmp_path: Path) -> None:
+    """A healed lead is served again on a later admission; the skip is never permanent."""
+    environment = {"TEST_ALPHA_KEY": "alpha-secret", "TEST_PROVIDER_KEY": "beta-secret"}
+    control, raw_key = _partial_pool_control_plane(tmp_path, environment)
+
+    del environment["TEST_ALPHA_KEY"]
+    narrowed = cast("list[JsonObject]", _admit(control, raw_key, _chat_body())["route"])
+    assert [item["model_id"] for item in narrowed] == ["beta-model-exact"]
+
+    # The credential returns; admission re-resolves the frozen route and the
+    # lead is served again, proving the skip is not a permanent blacklist.
+    environment["TEST_ALPHA_KEY"] = "alpha-secret"
+    recovered = cast("list[JsonObject]", _admit(control, raw_key, _chat_body())["route"])
+    assert [item["model_id"] for item in recovered] == ["alpha-model-exact", "beta-model-exact"]
+
+
+def test_admit_escalates_when_every_rung_is_dead(tmp_path: Path) -> None:
+    """A route with no resolvable rung is finished closed, not served."""
+    environment = {"TEST_ALPHA_KEY": "alpha-secret", "TEST_PROVIDER_KEY": "beta-secret"}
+    control, raw_key = _partial_pool_control_plane(tmp_path, environment)
+
+    environment.clear()
+    admission = _admit(control, raw_key, _chat_body())
+
+    assert "escalate" in admission
+    control_plane = cast("JsonObject", control.metrics_snapshot()["control_plane"])
+    assert control_plane["admission_dead_rungs_skipped"] == 2
+    assert control_plane["admission_lead_rungs_skipped"] == 1
+
+
+def test_admit_keeps_a_fully_resolvable_route_and_never_skips(tmp_path: Path) -> None:
+    """A healthy route admits every rung; only resolve-time deadness narrows."""
+    control, raw_key = _pool_control_plane(tmp_path)
+
+    admission = _admit(control, raw_key, _chat_body())
+
+    route = cast("list[JsonObject]", admission["route"])
+    assert [item["model_id"] for item in route] == ["alpha-model-exact", "beta-model-exact"]
+    control_plane = cast("JsonObject", control.metrics_snapshot()["control_plane"])
+    assert control_plane["admission_dead_rungs_skipped"] == 0
+    assert control_plane["admission_lead_rungs_skipped"] == 0
 
 
 def test_pool_failover_records_ordinals_depths_and_one_finalize(tmp_path: Path) -> None:
@@ -1192,6 +1290,8 @@ def test_metrics_snapshot_reports_control_plane_state_without_a_data_plane(
     control_plane = snapshot["control_plane"]
     assert control_plane["sweep_retained_settlements_replayed"] == 0
     assert control_plane["sweep_abandoned_attempts_cancelled"] == 0
+    assert control_plane["admission_dead_rungs_skipped"] == 0
+    assert control_plane["admission_lead_rungs_skipped"] == 0
     assert control_plane["inflight_attempts"] == 1
     assert control_plane["reconciled_expired_requests"] == 0
     assert control_plane["reconciled_unknown_attempts"] == 0

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -961,7 +961,9 @@ def test_admit_escalates_when_every_rung_is_dead(tmp_path: Path) -> None:
     assert "escalate" in admission
     control_plane = cast("JsonObject", control.metrics_snapshot()["control_plane"])
     assert control_plane["admission_dead_rungs_skipped"] == 2
-    assert control_plane["admission_lead_rungs_skipped"] == 1
+    # A total outage escalates on its own path; the lead-skip counter means
+    # "a fallback served while the lead was dead" and must stay silent here.
+    assert control_plane["admission_lead_rungs_skipped"] == 0
 
 
 def test_admit_keeps_a_fully_resolvable_route_and_never_skips(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -34,7 +34,8 @@ from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegi
 from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.native_settlement import deployment_operation_key
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
-from exp.runtime.models import RuntimeModelCatalog
+from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
+from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderCapabilityError
 from exp.runtime.models.providers.protocol import GatewayDispatchSigner, NativeWireClient
@@ -181,6 +182,87 @@ def next_route_candidate(
     return claim_route_from(health, keys, current_depth + 1)
 
 
+# Resolve-time deadness that a frozen route narrows past at admission instead
+# of failing the whole request. A missing credential, connection drift, or
+# capability drift means the deployment cannot be dispatched right now; it is an
+# operational outage, not a request fault, so the route narrows past the rung
+# and the rung's health circuit is fed like any runtime failure so it recovers
+# automatically when it heals. Operator-*disabled* deployments never reach here:
+# the catalog drops a disabled deployment from the live route on its ~15s
+# refresh, so this path only ever sees operational deadness that should recover.
+_ADMISSION_DEAD_ERRORS = (ModelConnectionError, ModelCredentialError, ProviderCapabilityError)
+
+
+@dataclass(frozen=True)
+class DeadRung:
+    """One route deployment that could not be resolved for dispatch at admission."""
+
+    index: int
+    deployment: ExactModelDeployment
+    failure: GatewayFailure
+
+
+@dataclass(frozen=True)
+class DispatchableRoute:
+    """The dispatchable subset of a frozen route resolved at admission.
+
+    ``indexes`` and ``resolved_wires`` are aligned and hold only the rungs that
+    resolved; ``dead`` names every rung skipped because it was operationally
+    dead at admission, in route order, for the health circuit and metrics.
+    """
+
+    indexes: tuple[int, ...]
+    resolved_wires: tuple[tuple[GatewayWireProfile, NativeWireClient], ...]
+    dead: tuple[DeadRung, ...]
+
+
+def _authorized_runtime_catalog(
+    runtime_catalogs: Mapping[tuple[str, str], RuntimeModelCatalog],
+    route: GatewayRoute,
+) -> RuntimeModelCatalog:
+    """Return the frozen runtime catalog for the route's authorized revision."""
+    authorization = route.snapshot.authorization
+    catalog = runtime_catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
+    if catalog is None:
+        raise GatewayRoutingError("runtime catalog is not loaded for the authorized revision")
+    return catalog
+
+
+def _resolve_deployment_profile(
+    catalog: RuntimeModelCatalog,
+    deployment: ExactModelDeployment,
+) -> tuple[GatewayWireProfile, NativeWireClient]:
+    """Resolve one route deployment's identity-checked native wire profile.
+
+    Raises:
+        NativeDialectUnavailableError: The provider has no native-dialect
+            implementation, so no engine can serve it.
+        ModelConnectionError: The alias provider cannot be constructed in the
+            approved shape (drift, missing endpoint, unsupported provider).
+        ModelCredentialError: The connection's credential is absent.
+        ProviderCapabilityError: The client cannot carry a catalog-declared
+            capability.
+        ValueError: A resolved client drifts from the frozen deployment.
+    """
+    resolved = catalog.resolve(deployment.source_alias)
+    _require_deployment_identity(deployment, resolved)
+    client = resolved.client
+    if not isinstance(client, NativeWireClient):
+        raise NativeDialectUnavailableError(
+            f"provider {deployment.provider!r} has no native wire profile"
+        )
+    try:
+        # Intersect the client's wire profile with the frozen catalog
+        # capability contract before payload bytes are frozen.
+        return _resolved_wire_profile(deployment, resolved), client
+    except ProviderCapabilityError as exc:
+        if exc.capability != "native_data_plane":
+            raise
+        raise NativeDialectUnavailableError(
+            f"provider {deployment.provider!r} has no native dialect implementation"
+        ) from exc
+
+
 def resolve_route_profiles(
     runtime_catalogs: Mapping[tuple[str, str], RuntimeModelCatalog],
     route: GatewayRoute,
@@ -192,6 +274,11 @@ def resolve_route_profiles(
     a frozen route. The check is structural (``NativeWireClient``), not a concrete HTTP base
     class: a non-HTTP client such as the bounded Bedrock adapter satisfies it
     too as long as it implements ``gateway_wire_profile``.
+
+    This is the all-or-nothing resolver used off the request hot path (for
+    example the replay-scope probe); request admission uses
+    :func:`dispatchable_route_profiles`, which narrows past an operationally
+    dead rung instead of failing the whole route.
 
     Args:
         runtime_catalogs: Revision and catalog digests mapped to frozen
@@ -210,31 +297,86 @@ def resolve_route_profiles(
         GatewayRoutingError: The authorized catalog is not loaded.
         ValueError: A resolved client drifts from the frozen deployment.
     """
-    authorization = route.snapshot.authorization
-    catalog = runtime_catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
-    if catalog is None:
-        raise GatewayRoutingError("runtime catalog is not loaded for the authorized revision")
+    catalog = _authorized_runtime_catalog(runtime_catalogs, route)
+    return tuple(
+        _resolve_deployment_profile(catalog, deployment) for deployment in route.deployments
+    )
+
+
+def dispatchable_route_profiles(
+    runtime_catalogs: Mapping[tuple[str, str], RuntimeModelCatalog],
+    route: GatewayRoute,
+) -> DispatchableRoute:
+    """Resolve a frozen route, narrowing past any rung dead at admission.
+
+    A rung whose provider client cannot be constructed right now (a lost
+    credential, a drifted connection, or a capability drift) is skipped so a
+    live fallback still serves, instead of the whole request failing on a dead
+    lead. The caller feeds each skipped rung into the deployment health circuit
+    (so it recovers on its own when it heals) and narrows the served route with
+    :func:`select_route_deployments`, keeping accounting anchored to the rung
+    that actually serves.
+
+    A provider with no native dialect is a structural fault no engine can
+    serve, so it still raises ``NativeDialectUnavailableError`` (escalation)
+    rather than being narrowed past.
+
+    Args:
+        runtime_catalogs: Revision and catalog digests mapped to frozen
+            runtime catalogs.
+        route: Resolved ordered route.
+
+    Returns:
+        The dispatchable rung indexes with their resolved wires, plus every
+        rung skipped as operationally dead.
+
+    Raises:
+        NativeDialectUnavailableError: A route deployment's provider has no
+            native-dialect implementation.
+        GatewayRoutingError: The authorized catalog is not loaded.
+    """
+    catalog = _authorized_runtime_catalog(runtime_catalogs, route)
+    indexes: list[int] = []
     resolved_wires: list[tuple[GatewayWireProfile, NativeWireClient]] = []
-    for deployment in route.deployments:
-        resolved = catalog.resolve(deployment.source_alias)
-        _require_deployment_identity(deployment, resolved)
-        client = resolved.client
-        if not isinstance(client, NativeWireClient):
-            raise NativeDialectUnavailableError(
-                f"provider {deployment.provider!r} has no native wire profile"
-            )
+    dead: list[DeadRung] = []
+    for index, deployment in enumerate(route.deployments):
         try:
-            # Intersect the client's wire profile with the frozen catalog
-            # capability contract before payload bytes are frozen.
-            profile = _resolved_wire_profile(deployment, resolved)
-        except ProviderCapabilityError as exc:
-            if exc.capability != "native_data_plane":
-                raise
-            raise NativeDialectUnavailableError(
-                f"provider {deployment.provider!r} has no native dialect implementation"
-            ) from exc
-        resolved_wires.append((profile, client))
-    return tuple(resolved_wires)
+            resolved = _resolve_deployment_profile(catalog, deployment)
+        except _ADMISSION_DEAD_ERRORS as exc:
+            dead.append(DeadRung(index, deployment, _admission_dead_failure(exc)))
+            continue
+        indexes.append(index)
+        resolved_wires.append(resolved)
+    return DispatchableRoute(tuple(indexes), tuple(resolved_wires), tuple(dead))
+
+
+def _admission_dead_failure(exc: Exception) -> GatewayFailure:
+    """Classify one admission-time deadness into a health-circuit failure.
+
+    A missing credential mirrors a runtime auth rejection (a hard failure that
+    opens the circuit at once); a connection or capability drift mirrors a
+    runtime transport failure (an operational failure that opens after the
+    circuit threshold). Both stay honest by feeding the same circuit that
+    runtime failures do, so recovery is the existing cooldown plus half-open
+    probe and never a permanent blacklist.
+    """
+    match exc:
+        case ModelCredentialError():
+            return GatewayFailure(
+                failure_class=GatewayFailureClass.PROVIDER_AUTHENTICATION,
+                safe_message=(
+                    "the resolved deployment had no usable credential at admission; "
+                    "failing over to the next deployment"
+                ),
+            )
+        case _:
+            return GatewayFailure(
+                failure_class=GatewayFailureClass.TRANSPORT,
+                safe_message=(
+                    "the resolved deployment was unavailable at admission; "
+                    "failing over to the next deployment"
+                ),
+            )
 
 
 def select_route_deployments(

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -108,6 +108,32 @@ def test_select_route_deployments_rejects_invalid_indexes(indexes: tuple[int, ..
         select_route_deployments(_route(), indexes)
 
 
+def test_admission_dead_failure_mirrors_runtime_circuit_classes() -> None:
+    """A dead-at-admission rung feeds the circuit like the runtime failure it mirrors."""
+    from exp.runtime.gateway.native_execution import _admission_dead_failure
+    from exp.runtime.models import ModelConnectionError
+    from exp.runtime.models.credentials import MissingModelCredentialError, ModelCredentialError
+    from exp.runtime.models.providers.errors import ProviderCapabilityError
+
+    # A missing credential opens the circuit at once, like a runtime 401.
+    for credential_error in (
+        ModelCredentialError("no key"),
+        MissingModelCredentialError("TEST_KEY", connection_id="conn"),
+    ):
+        failure = _admission_dead_failure(credential_error)
+        assert failure.failure_class == GatewayFailureClass.PROVIDER_AUTHENTICATION
+
+    # A connection or capability drift is operational, like a runtime transport failure.
+    assert (
+        _admission_dead_failure(ModelConnectionError("drifted")).failure_class
+        == GatewayFailureClass.TRANSPORT
+    )
+    assert (
+        _admission_dead_failure(ProviderCapabilityError(capability="reasoning")).failure_class
+        == GatewayFailureClass.TRANSPORT
+    )
+
+
 def test_claim_ladder_prefers_healthy_then_probe_then_forced() -> None:
     """A suppressed route still admits through bounded probe and forced claims."""
     health = DeploymentHealthRegistry(failure_threshold=1, open_seconds=60.0)

--- a/exp/runtime/gateway/native_metrics_text.py
+++ b/exp/runtime/gateway/native_metrics_text.py
@@ -48,6 +48,14 @@ _CONTROL_PLANE_COUNTERS: tuple[tuple[str, str], ...] = (
         "Abandoned attempts the sweep cancelled.",
     ),
     (
+        "admission_dead_rungs_skipped",
+        "Certified rungs skipped as dead at admission.",
+    ),
+    (
+        "admission_lead_rungs_skipped",
+        "Fallbacks served for a dead lead rung.",
+    ),
+    (
         "reconciled_expired_requests",
         "Crashed requests reconciled at startup.",
     ),

--- a/exp/runtime/gateway/native_metrics_text_test.py
+++ b/exp/runtime/gateway/native_metrics_text_test.py
@@ -38,6 +38,8 @@ def _control_plane() -> JsonObject:
     return {
         "sweep_retained_settlements_replayed": 1,
         "sweep_abandoned_attempts_cancelled": 0,
+        "admission_dead_rungs_skipped": 0,
+        "admission_lead_rungs_skipped": 0,
         "inflight_attempts": 2,
         "reconciled_expired_requests": 0,
         "reconciled_unknown_attempts": 0,
@@ -95,6 +97,12 @@ exp_gateway_sweep_retained_settlements_replayed_total 1
 # HELP exp_gateway_sweep_abandoned_attempts_cancelled_total Abandoned attempts the sweep cancelled.
 # TYPE exp_gateway_sweep_abandoned_attempts_cancelled_total counter
 exp_gateway_sweep_abandoned_attempts_cancelled_total 0
+# HELP exp_gateway_admission_dead_rungs_skipped_total Certified rungs skipped as dead at admission.
+# TYPE exp_gateway_admission_dead_rungs_skipped_total counter
+exp_gateway_admission_dead_rungs_skipped_total 0
+# HELP exp_gateway_admission_lead_rungs_skipped_total Fallbacks served for a dead lead rung.
+# TYPE exp_gateway_admission_lead_rungs_skipped_total counter
+exp_gateway_admission_lead_rungs_skipped_total 0
 # HELP exp_gateway_reconciled_expired_requests_total Crashed requests reconciled at startup.
 # TYPE exp_gateway_reconciled_expired_requests_total counter
 exp_gateway_reconciled_expired_requests_total 0

--- a/exp/runtime/gateway/native_observability.py
+++ b/exp/runtime/gateway/native_observability.py
@@ -1,0 +1,205 @@
+"""Discovery, usage, metrics, and lifecycle callbacks for the native bridge.
+
+:class:`NativeObservabilityMixin` carries the content-free read-side
+callbacks of :class:`~exp.runtime.gateway.native_bridge.NativeControlPlane`:
+granted-model discovery, the usage report, the composed metrics snapshot,
+readiness, and per-worker resource release. The mixin owns no state; it reads
+the control plane's bound components and accounting registry, so the bridge
+module keeps only the request-serving authority path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import cast
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.discovery import (
+    public_model_list,
+    public_model_object,
+    require_granted_authority,
+)
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.native_accounting import (
+    NativeAttemptAccounting,
+)
+from exp.runtime.gateway.native_accounting import (
+    authority_error as _authority_error,
+)
+from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.gateway.native_metrics_text import render_metrics_text
+from exp.runtime.gateway.sqlite.migrations import close_idle_connections
+from exp.runtime.gateway.usage import GatewayUsageReport, read_usage_report, usage_html
+
+
+class NativeObservabilityMixin:
+    """Content-free read-side callbacks shared by the native control plane."""
+
+    _components: NativeGatewayComponents
+    _accounting: NativeAttemptAccounting
+    _data_plane_metrics: Callable[[], str] | None
+    _usage_reporter: Callable[[], JsonObject] | None
+    _readiness_probe: Callable[[], bool] | None
+
+    def models(self, argument: str) -> str:
+        """Return the granted model list body for one authenticated key."""
+        data = json.loads(argument)
+        try:
+            authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
+            body = public_model_list(authorities)
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise _authority_error(exc) from exc
+        return json.dumps(body, separators=(",", ":"))
+
+    def model_detail(self, argument: str) -> str:
+        """Return one granted model object or the shared no-oracle 404."""
+        data = json.loads(argument)
+        try:
+            authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
+            authority = require_granted_authority(authorities, data["model_id"])
+            body = public_model_object(authority)
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise _authority_error(exc) from exc
+        return json.dumps(body, separators=(",", ":"))
+
+    def usage_json(self, argument: str) -> str:
+        """Return the content-free usage report body.
+
+        Args:
+            argument: JSON object with an optional ``raw_key``. A presented
+                key scopes the report to its owning identity; an absent key
+                returns the organization-wide report.
+
+        Returns:
+            The schema-versioned usage report as one JSON object.
+
+        Raises:
+            NativeBridgeError: The presented key is invalid, expired, or revoked.
+        """
+        if self._usage_reporter is not None:
+            return json.dumps(self._usage_reporter(), separators=(",", ":"))
+        report = self._usage_report(argument)
+        return json.dumps(report.model_dump(mode="json"), separators=(",", ":"))
+
+    def usage_page(self, argument: str) -> str:
+        """Return the content-free usage page rendering.
+
+        Args:
+            argument: JSON object with an optional ``raw_key``, scoped exactly
+                like :meth:`usage_json`.
+
+        Returns:
+            JSON object with one ``html`` field holding the rendered page.
+
+        Raises:
+            NativeBridgeError: The presented key is invalid, expired, or revoked.
+        """
+        report = self._usage_report(argument)
+        return json.dumps({"html": usage_html(report)}, separators=(",", ":"))
+
+    def _usage_report(self, argument: str) -> GatewayUsageReport:
+        """Read the usage report for one optionally key-scoped callback.
+
+        Args:
+            argument: JSON object with an optional ``raw_key``.
+
+        Returns:
+            The organization-wide report, or the report scoped to the
+            presented key's identity.
+
+        Raises:
+            NativeBridgeError: The presented key is invalid, expired, or revoked.
+        """
+        data = json.loads(argument)
+        raw_key = data.get("raw_key")
+        identity_id: str | None = None
+        if raw_key is not None:
+            try:
+                _, identity_id = self._components.store.authenticated_identity(raw_key=str(raw_key))
+            except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+                raise _authority_error(exc) from exc
+        # Only the local composition (SQLite ledger) serves native usage;
+        # hosted compositions disable it and own their own usage surface.
+        return read_usage_report(
+            cast("SQLiteAttemptLedger", self._components.ledger),
+            organization_id=self._components.organization_id,
+            identity_id=identity_id,
+        )
+
+    def metrics_snapshot(self) -> JsonObject:
+        """Compose the one content-free observability snapshot.
+
+        ``data_plane`` carries the native engine's registry when a provider
+        is bound, otherwise ``None``; ``control_plane`` carries this bridge's
+        own sweep recoveries, in-flight registry size, reconciliation counts,
+        and accounting health. The native ``/metrics.json`` route serves
+        exactly this body; ``/metrics`` serves its Prometheus text rendering.
+        """
+        data_plane: JsonObject | None = None
+        if self._data_plane_metrics is not None:
+            data_plane = json.loads(self._data_plane_metrics())
+        retained_replayed, abandoned_cancelled, inflight = self._accounting.counters()
+        lead_rungs_skipped, dead_rungs_skipped = self._accounting.admission_rung_skips()
+        control_plane: JsonObject = {
+            "sweep_retained_settlements_replayed": retained_replayed,
+            "sweep_abandoned_attempts_cancelled": abandoned_cancelled,
+            "admission_dead_rungs_skipped": dead_rungs_skipped,
+            "admission_lead_rungs_skipped": lead_rungs_skipped,
+            "inflight_attempts": inflight,
+            "reconciled_expired_requests": self._components.reconciled_expired_requests,
+            "reconciled_unknown_attempts": self._components.reconciled_unknown_attempts,
+            "accounting_healthy": self._accounting.accounting_healthy,
+        }
+        return {"data_plane": data_plane, "control_plane": control_plane}
+
+    def metrics_json(self, argument: str) -> str:
+        """Return the content-free metrics snapshot body for the data plane."""
+        del argument
+        return json.dumps(self.metrics_snapshot(), separators=(",", ":"))
+
+    def metrics_text(self, argument: str) -> str:
+        """Return ``{"text": ...}`` holding the snapshot's Prometheus exposition."""
+        del argument
+        text = render_metrics_text(self.metrics_snapshot())
+        return json.dumps({"text": text}, separators=(",", ":"))
+
+    def readiness(self, argument: str) -> str:
+        """Return whether bridge settlement and composition accounting stay healthy.
+
+        Readiness fails closed once the bridge's own settlement registry has
+        latched a durable-write loss, once the composition's accounting
+        surface reports unhealthy, or when an injected hosted lifecycle probe
+        answers false or raises.
+        """
+        del argument
+        if not self._accounting.accounting_healthy:
+            return "false"
+        try:
+            if not self._components.accounting_healthy:
+                return "false"
+        except Exception:  # noqa: BLE001 - readiness fails closed at the boundary.
+            return "false"
+        if self._readiness_probe is not None:
+            try:
+                return "true" if self._readiness_probe() else "false"
+            except Exception:  # noqa: BLE001 - readiness fails closed at the boundary.
+                return "false"
+        return "true"
+
+    def close_thread_resources(self, argument: str) -> str:
+        """Release the calling thread's cached resources before it exits.
+
+        The data plane pins control-plane callbacks to a fixed pool of worker
+        threads and calls this once per worker as the pool shuts down, so the
+        SQLite connections cached per thread by ``persistent_connection``
+        close with the worker instead of outliving it.
+
+        Args:
+            argument: Empty JSON object, matching the callback shape.
+
+        Returns:
+            JSON object reporting the number of connections closed.
+        """
+        del argument
+        return json.dumps({"closed_connections": close_idle_connections()}, separators=(",", ":"))

--- a/exp/runtime/gateway/native_observability_test.py
+++ b/exp/runtime/gateway/native_observability_test.py
@@ -1,0 +1,1 @@
+"""Covered by exp/runtime/gateway/native_bridge_test.py through the bridge boundary."""


### PR DESCRIPTION
## What

A frozen route whose **lead rung is dead at admission** — the deployment lost its credential, its connection drifted, or a capability drifted before any dispatch — failed the **whole request** instead of serving a live fallback (the "dead lead rung" class from the qwen incident).

`health.py`'s circuits only catch **runtime** failures; an admission-time-dead lead was never skipped. And because the alias reloader only reloads on **revision drift** (not per request), a lead that dies *after* load stays in the frozen route indefinitely — so this was a durable outage, not just an inter-refresh window.

## Fix (design agreed with the product owner)

- **Narrow past the dead rung at admission.** New `dispatchable_route_profiles` resolves each rung and skips any that is operationally dead, then narrows the served route with the existing `select_route_deployments` idiom (the old `route_with_dispatchable_deployments` main replaced is **not** resurrected). Accounting stays anchored to the rung that actually serves, because narrowing happens before `register(InflightRequest)`.
- **Feed the same circuit runtime failures feed.** Each skipped rung is recorded in `health.py` via `health.failed(key, failure)`: a missing credential → `PROVIDER_AUTHENTICATION` (hard, opens at once, mirrors a runtime 401); a connection/capability drift → `TRANSPORT` (operational). Recovery is the **existing cooldown + half-open probe** — **never a permanent blacklist.** When the lead heals, admission re-resolves the frozen route and serves it again.
- **Operator-disabled is left to the catalog.** A deliberately-disabled deployment is dropped from the live route by the ~15s refresh; this path only ever sees operational deadness. A provider with no native dialect is still a structural escalation, not a narrow.
- **Loudly surfaced.** A skipped lead rung is logged (`_logger.warning`, server-side ops) and counted (`exp_gateway_admission_lead_rungs_skipped_total`, plus `exp_gateway_admission_dead_rungs_skipped_total`) so a *persistently* dead lead reaches a human instead of being silently masked behind a fallback forever.

## Files

- `native_execution.py`: `_resolve_deployment_profile` (factored), `dispatchable_route_profiles`, `DispatchableRoute`/`DeadRung`, `_admission_dead_failure` classifier.
- `native_bridge.py` `admit`: use the resilient resolver, feed the circuit + log/count via `_record_dead_admission_rungs`, narrow the route, escalate only when *every* rung is dead.
- `native_accounting.py`: `record_admission_rung_skips` / `admission_rung_skips` counters.
- `native_metrics_text.py`: two new control-plane counters.

## Tests

- `test_admit_skips_a_dead_lead_rung_and_serves_the_fallback`: lead dead at admission → route narrowed to the fallback, exactly the lead's circuit opened (a cooldown), counters moved, narrowed route serves.
- `test_admit_recovers_a_dead_lead_when_its_credential_heals`: after the credential returns, a later admission serves the lead again — the skip is never permanent.
- `test_admit_escalates_when_every_rung_is_dead`: no resolvable rung → finished closed.
- `test_admit_keeps_a_fully_resolvable_route_and_never_skips`: a healthy route admits every rung and never counts a skip (only resolve-time deadness narrows; a runtime 4xx is unchanged and handled at settle, never at admission).
- `test_admission_dead_failure_mirrors_runtime_circuit_classes`: credential → auth (hard), connection/capability → transport (operational).

## Verification

- `ruff format` / `ruff check` — clean
- `ty check` (whole repo) — All checks passed
- `pytest exp/runtime/gateway/` — 478 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)