### PR TITLE
gateway: name unsupported capabilities, accept reasoning.context, gate the SDK surface

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -217,6 +217,17 @@ class GatewayRequest(ContractModel):
     """
     include_encrypted_reasoning: bool = False
     """Whether the caller asked for ``include=["reasoning.encrypted_content"]``."""
+    reasoning_context: Literal["auto", "current_turn", "all_turns"] | None = Field(
+        default=None, exclude=True
+    )
+    """Caller ``reasoning.context`` selector from the Responses surface.
+
+    Controls whether the model re-renders prior turns' reasoning. Forwarded
+    verbatim to native Responses rungs. Excluded from model serialization so
+    context-free request digests stay byte-identical to pre-field traffic; a
+    present value joins replay identity through
+    :func:`canonical_request_sha256`.
+    """
     stream: bool = False
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
@@ -294,6 +305,8 @@ class GatewayRequest(ContractModel):
             raise ValueError("response_store is valid only for Responses requests")
         if self.include_encrypted_reasoning and self.surface != GatewayApiSurface.RESPONSES:
             raise ValueError("include_encrypted_reasoning is valid only for Responses requests")
+        if self.reasoning_context is not None and self.surface != GatewayApiSurface.RESPONSES:
+            raise ValueError("reasoning_context is valid only for Responses requests")
         if self.provider_thinking_config is not None and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("provider_thinking_config is valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
@@ -330,13 +343,18 @@ def canonical_request_sha256(request: GatewayRequest) -> Sha256:
         for index, message in enumerate(request.messages)
         if message.provider_reasoning
     ]
-    if not carriers and request.provider_thinking_config is None:
+    if (
+        not carriers
+        and request.provider_thinking_config is None
+        and request.reasoning_context is None
+    ):
         return sha256_json(request)
     return sha256_json(
         {
             "request_sha256": sha256_json(request),
             "provider_reasoning": carriers,
             "provider_thinking_config": request.provider_thinking_config,
+            "reasoning_context": request.reasoning_context,
         }
     )
 

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -360,3 +360,40 @@ def test_reasoning_stream_events_require_their_payloads() -> None:
             sequence_number=0,
             encrypted_content="blob",
         )
+
+
+def test_reasoning_context_is_digest_excluded_but_joins_replay_identity() -> None:
+    """Context-free requests digest byte-identically to pre-field traffic.
+
+    The field is excluded from model serialization so this release does not
+    move canonical digests for context-free traffic; a present value folds
+    into replay identity so a reused caller operation key with a different
+    context is a conflict, never a silent replay.
+    """
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.contracts import canonical_request_sha256
+
+    messages = (GatewayMessage(role="user", content="hi"),)
+    bare = GatewayRequest(surface=GatewayApiSurface.RESPONSES, messages=messages)
+    carried = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=messages,
+        reasoning_context="all_turns",
+    )
+    assert carried.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(carried) == sha256_json(bare)
+    assert canonical_request_sha256(bare) == sha256_json(bare)
+    assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
+    other = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=messages,
+        reasoning_context="current_turn",
+    )
+    assert canonical_request_sha256(other) != canonical_request_sha256(carried)
+
+    with pytest.raises(ValidationError, match="reasoning_context is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=messages,
+            reasoning_context="all_turns",
+        )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -447,15 +447,12 @@ class NativeControlPlane(NativeObservabilityMixin):
                     )
                 )
                 signers.append(dispatch_signer)
-        except ProviderParameterError as exc:
+        except (ProviderParameterError, ProviderCapabilityError) as exc:
+            # One shared normalizer keeps both pre-dispatch rejections
+            # field-specific: the parameter path names the parameter and the
+            # capability path names the capability, so a triager sees which
+            # request feature the route cannot preserve.
             failure = normalized_provider_failure(exc)
-            self._accounting.finish_request_quietly(authorization, failure)
-            raise NativeBridgeError(public_failure_error(failure)) from exc
-        except ProviderCapabilityError as exc:
-            failure = GatewayFailure(
-                failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
-                safe_message="the resolved deployment does not support the requested capability",
-            )
             self._accounting.finish_request_quietly(authorization, failure)
             raise NativeBridgeError(public_failure_error(failure)) from exc
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3197,3 +3197,24 @@ def test_capability_rejection_names_the_unsupported_capability(tmp_path: Path) -
     assert payload["error_type"] == "invalid_request_error"
     assert "developer_messages" in payload["message"]
     assert "canary" not in json.dumps(payload)
+
+
+def test_reasoning_context_reflects_in_the_envelope_only_when_sent() -> None:
+    """The response envelope echoes reasoning.context, and only when present,
+    so context-free bodies stay byte-identical to the committed goldens."""
+    from exp.runtime.gateway.native_responses import responses_envelope
+
+    with_context = decode_responses(
+        {
+            "model": "coding",
+            "input": "hi",
+            "reasoning": {"effort": "high", "context": "all_turns"},
+        }
+    ).request
+    assert responses_envelope(with_context)["reasoning"] == {
+        "effort": "high",
+        "summary": None,
+        "context": "all_turns",
+    }
+    without = decode_responses({"model": "coding", "input": "hi"}).request
+    assert responses_envelope(without)["reasoning"] == {"effort": None, "summary": None}

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3170,3 +3170,30 @@ def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:
     with pytest.raises(NativeBridgeError) as repeated:
         admit_keyed(reasoning_body("blob-one=="))
     assert json.loads(repeated.value.public_error_json)["code"] != "idempotency_conflict"
+
+
+def test_capability_rejection_names_the_unsupported_capability(tmp_path: Path) -> None:
+    """A pre-dispatch capability rejection names the exact capability.
+
+    A Responses request with instructions decodes to a developer message; a
+    route that cannot preserve developer messages must say so by name, not
+    with a flattened generic sentence, so a production 400 is triageable.
+    The message carries only the stable internal capability literal, never
+    request content.
+    """
+    control, raw_key = _control_plane(tmp_path)
+    body = json.dumps(
+        {
+            "model": "coding",
+            "instructions": "Follow the sync-lane policy canary-instructions.",
+            "input": "hello canary-input",
+        }
+    )
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit_responses(control, raw_key, body)
+    payload = json.loads(raised.value.public_error_json)
+    assert payload["status_code"] == 400
+    assert payload["code"] == "unsupported_capability"
+    assert payload["error_type"] == "invalid_request_error"
+    assert "developer_messages" in payload["message"]
+    assert "canary" not in json.dumps(payload)

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -185,15 +185,20 @@ def responses_envelope(request: GatewayRequest) -> JsonObject:
     Returns:
         JSON envelope fields keyed exactly as the public response object.
     """
+    reasoning: JsonObject = {
+        "effort": request.reasoning_effort,
+        "summary": request.reasoning_summary,
+    }
+    if request.reasoning_context is not None:
+        # Reflected only when the caller sent it, so context-free response
+        # bodies stay byte-identical to the committed goldens.
+        reasoning["context"] = request.reasoning_context
     return {
         "metadata": request.metadata or None,
         "parallel_tool_calls": request.parallel_tool_calls is not False,
         "temperature": request.temperature,
         "top_p": request.top_p,
-        "reasoning": {
-            "effort": request.reasoning_effort,
-            "summary": request.reasoning_summary,
-        },
+        "reasoning": reasoning,
         "ignored_parameters": list(request.ignored_parameters),
         "tool_choice": _responses_tool_choice(request),
         "tools": [

--- a/exp/runtime/models/providers/errors.py
+++ b/exp/runtime/models/providers/errors.py
@@ -148,11 +148,14 @@ def normalized_provider_failure(exception: BaseException) -> GatewayFailure:
             },
         )
     if isinstance(exception, ProviderCapabilityError):
+        # The capability is a stable internal literal (never request content),
+        # and naming it is what makes the 400 triageable for the caller.
         return GatewayFailure(
             failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
             safe_message=(
-                "provider deployment cannot preserve the requested capability; remove the "
-                "unsupported field or request a different model alias"
+                "provider deployment cannot preserve the requested capability: "
+                f"{exception.capability}. Remove the unsupported field or request "
+                "a different model alias"
             ),
             safe_details={"capability": exception.capability},
         )

--- a/exp/runtime/models/providers/errors_test.py
+++ b/exp/runtime/models/providers/errors_test.py
@@ -119,6 +119,13 @@ def test_refusal_and_capability_failures_keep_only_safe_signals() -> None:
     assert refusal.safe_details == {"signal": "safety"}
     assert capability.failure_class is GatewayFailureClass.UNSUPPORTED_CAPABILITY
     assert capability.safe_details == {"capability": "strict_tools"}
+    # The message names the capability literal and nothing else, so a 400 is
+    # triageable without ever carrying request content.
+    assert capability.safe_message == (
+        "provider deployment cannot preserve the requested capability: "
+        "strict_tools. Remove the unsupported field or request "
+        "a different model alias"
+    )
 
 
 def test_parameter_failure_preserves_only_public_code_and_path() -> None:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -310,6 +310,17 @@ def route_generation_parameter_requests(
             param=path,
             code="unsupported_parameter",
         )
+    if request.reasoning_context is not None and not all(
+        profile.dialect == "openai_responses" and profile.supports_reasoning for profile in profiles
+    ):
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'reasoning.context' is not supported by this model route. "
+                "Remove the field or choose a different model."
+            ),
+            param="reasoning.context",
+            code="unsupported_parameter",
+        )
 
     if (
         request.structured_text is not None
@@ -609,6 +620,10 @@ def openai_responses_stream_payload(
         reasoning["effort"] = openai_reasoning_effort(model_id, effective_reasoning_effort)
     if supports_reasoning and request.reasoning_summary is not None:
         reasoning["summary"] = request.reasoning_summary
+    if supports_reasoning and request.reasoning_context is not None:
+        # Forwarded verbatim: the value controls provider-side re-rendering
+        # of prior turns' reasoning and has no gateway semantics.
+        reasoning["context"] = request.reasoning_context
     if reasoning:
         payload["reasoning"] = reasoning
     return payload

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1419,3 +1419,44 @@ def test_ultra_effort_is_admitted_only_where_the_family_documents_it() -> None:
     )
     with pytest.raises(UnsupportedReasoningEffortError):
         route_generation_parameter_requests((older,), request)
+
+
+def test_reasoning_context_passes_through_verbatim_and_narrows_per_rung() -> None:
+    """reasoning.context forwards untouched and admits only native Responses rungs."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        reasoning_effort="high",
+        reasoning_context="all_turns",
+    )
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-luna",
+        request,
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+    assert payload["reasoning"] == {"effort": "high", "context": "all_turns"}
+
+    responses = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://openai.test",
+        model_id="gpt-5.6-luna",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+    )
+    # The fallback accepts the effort, so context is the one blocker.
+    fallback = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://fallback.test",
+        model_id="gpt-5.2",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+    )
+    route_generation_parameter_requests((responses,), request)
+    # Per-rung narrowing keeps the compatible rung; the whole-route error
+    # names the field only when no rung qualifies.
+    assert compatible_generation_parameter_profile_indexes((responses, fallback), request) == (0,)
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((fallback,), request)
+    assert raised.value.param == "reasoning.context"
+    assert raised.value.code == "unsupported_parameter"

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -70,9 +70,12 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "functions",
                 "logit_bias",
                 "modalities",
+                "moderation",
                 "n",
                 "prediction",
                 "presence_penalty",
+                "prompt_cache_options",
+                "prompt_cache_retention",
                 "seed",
                 "service_tier",
                 "store",
@@ -123,9 +126,13 @@ RESPONSES_MANIFEST = CompatibilityManifest(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
             for path in (
                 "background",
+                "context_management",
                 "conversation",
                 "max_tool_calls",
+                "moderation",
                 "prompt",
+                "prompt_cache_options",
+                "prompt_cache_retention",
                 "service_tier",
                 "stream_options",
                 "truncation",
@@ -133,6 +140,49 @@ RESPONSES_MANIFEST = CompatibilityManifest(
         ),
     ),
 )
+
+
+RESPONSES_REASONING_FIELDS_ACCEPTED = frozenset(
+    {"effort", "summary", "generate_summary", "context"}
+)
+"""Nested ``reasoning`` object fields the Responses decoder models."""
+
+RESPONSES_REASONING_FIELDS_REJECTED = frozenset({"mode"})
+"""Nested ``reasoning`` fields consciously rejected with a named 400.
+
+``mode`` selects provider-priced reasoning tiers ("standard"/"pro"); pricing
+authority lives in the catalog, so the gateway rejects the field until a
+priced route contract exists for it.
+"""
+
+RESPONSES_REASONING_EFFORTS_ACCEPTED = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"}
+)
+"""``reasoning.effort`` values the decoders accept (route support still applies)."""
+
+RESPONSES_REASONING_CONTEXTS_ACCEPTED = frozenset({"auto", "current_turn", "all_turns"})
+"""``reasoning.context`` values the Responses decoder accepts verbatim."""
+
+RESPONSES_REASONING_SUMMARIES_ACCEPTED = frozenset({"auto", "concise", "detailed"})
+"""``reasoning.summary`` and ``generate_summary`` values the decoder accepts."""
+
+RESPONSES_INCLUDE_PATHS_ACCEPTED = frozenset({"reasoning.encrypted_content"})
+"""``include`` selectors the gateway honors."""
+
+RESPONSES_INCLUDE_PATHS_REJECTED = frozenset(
+    {
+        "code_interpreter_call.outputs",
+        "computer_call_output.output.image_url",
+        "file_search_call.results",
+        "message.input_image.image_url",
+        "message.output_text.logprobs",
+        "web_search_call.action.sources",
+        "web_search_call.results",
+    }
+)
+"""``include`` selectors consciously rejected: each names a server-tool or
+multimodal surface this gateway does not serve, so honoring the selector is
+impossible and accepting it would be silent."""
 
 
 def disposition_map(manifest: CompatibilityManifest) -> dict[str, CompatibilityDisposition]:

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+import typing
+
 import pytest
 
+from exp.common.models.model import ReasoningEffort
 from exp.runtime.gateway.contracts import CompatibilityDisposition, CompatibilityManifest
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
+    RESPONSES_INCLUDE_PATHS_ACCEPTED,
+    RESPONSES_INCLUDE_PATHS_REJECTED,
     RESPONSES_MANIFEST,
+    RESPONSES_REASONING_CONTEXTS_ACCEPTED,
+    RESPONSES_REASONING_EFFORTS_ACCEPTED,
+    RESPONSES_REASONING_FIELDS_ACCEPTED,
+    RESPONSES_REASONING_FIELDS_REJECTED,
+    RESPONSES_REASONING_SUMMARIES_ACCEPTED,
     disposition_map,
 )
 
@@ -45,3 +55,89 @@ def test_manifests_classify_explicit_exclusions() -> None:
     assert responses["top_p"] == CompatibilityDisposition.SUPPORTED
     assert responses["top_k"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert responses["top_logprobs"] == CompatibilityDisposition.UNSUPPORTED
+
+
+def _sdk_literal_values(annotation: object) -> frozenset[str]:
+    """Collect every string literal reachable inside one SDK type annotation."""
+    values: set[str] = set()
+
+    def walk(node: object) -> None:
+        """Accumulate string literals depth-first across unions and wrappers."""
+        origin = typing.get_origin(node)
+        if origin is typing.Literal:
+            values.update(arg for arg in typing.get_args(node) if isinstance(arg, str))
+            return
+        for argument in typing.get_args(node):
+            walk(argument)
+
+    walk(annotation)
+    return frozenset(values)
+
+
+def _decided(new_fields: frozenset[str] | set[str], surface: str) -> str:
+    """Render the drift-gate failure text naming exactly what must be decided."""
+    listed = ", ".join(sorted(new_fields))
+    return (
+        f"The installed openai SDK carries {surface} fields this gateway has never "
+        f"classified: {listed}. Decide each one now: add it to the manifest (or the "
+        "reasoning/include decision tables in exp/runtime/openai_protocol/manifest.py) as "
+        "SUPPORTED, CONDITIONALLY_SUPPORTED, or UNSUPPORTED with a written rationale. "
+        "Silent drift here is how paying customers become the first detector."
+    )
+
+
+def test_every_official_sdk_request_field_is_consciously_classified() -> None:
+    """The SDK-surface drift gate: an ``openai`` bump may add request fields.
+
+    Every top-level field the official request types carry must appear in the
+    matching manifest, in exactly one disposition bucket, so a dependency bump
+    turns new OpenAI surface into a loud decision instead of a silent
+    customer-facing 400.
+    """
+    from openai.types.chat.completion_create_params import CompletionCreateParamsBase
+    from openai.types.responses.response_create_params import ResponseCreateParamsBase
+
+    responses_fields = set(ResponseCreateParamsBase.__annotations__) | {"stream"}
+    chat_fields = set(CompletionCreateParamsBase.__annotations__) | {"stream"}
+    responses_decided = set(disposition_map(RESPONSES_MANIFEST))
+    chat_decided = set(disposition_map(CHAT_MANIFEST))
+
+    undecided_responses = responses_fields - responses_decided
+    assert not undecided_responses, _decided(undecided_responses, "Responses")
+    undecided_chat = chat_fields - chat_decided
+    assert not undecided_chat, _decided(undecided_chat, "Chat Completions")
+
+
+def test_every_official_sdk_reasoning_field_and_value_is_decided() -> None:
+    """Nested ``reasoning`` fields and enum values are part of the drift gate."""
+    from openai.types.shared_params.reasoning import Reasoning
+
+    hints = typing.get_type_hints(Reasoning)
+    undecided = (
+        set(hints) - RESPONSES_REASONING_FIELDS_ACCEPTED - RESPONSES_REASONING_FIELDS_REJECTED
+    )
+    assert not undecided, _decided(undecided, "reasoning.*")
+    # Accepted and rejected buckets must stay disjoint decisions.
+    assert not RESPONSES_REASONING_FIELDS_ACCEPTED & RESPONSES_REASONING_FIELDS_REJECTED
+
+    new_efforts = _sdk_literal_values(hints["effort"]) - RESPONSES_REASONING_EFFORTS_ACCEPTED
+    assert not new_efforts, _decided(new_efforts, "reasoning.effort value")
+    new_contexts = _sdk_literal_values(hints["context"]) - RESPONSES_REASONING_CONTEXTS_ACCEPTED
+    assert not new_contexts, _decided(new_contexts, "reasoning.context value")
+    for field in ("summary", "generate_summary"):
+        new_summaries = _sdk_literal_values(hints[field]) - RESPONSES_REASONING_SUMMARIES_ACCEPTED
+        assert not new_summaries, _decided(new_summaries, f"reasoning.{field} value")
+
+    # The engine ladder must cover every SDK effort so decode never narrows it.
+    engine_efforts = set(typing.get_args(ReasoningEffort))
+    assert _sdk_literal_values(hints["effort"]) <= engine_efforts
+
+
+def test_every_official_sdk_include_selector_is_decided() -> None:
+    """``include[]`` members are decided: honored or rejected by name."""
+    from openai.types.responses.response_includable import ResponseIncludable
+
+    sdk_selectors = _sdk_literal_values(ResponseIncludable)
+    undecided = sdk_selectors - RESPONSES_INCLUDE_PATHS_ACCEPTED - RESPONSES_INCLUDE_PATHS_REJECTED
+    assert not undecided, _decided(undecided, "include selector")
+    assert not RESPONSES_INCLUDE_PATHS_ACCEPTED & RESPONSES_INCLUDE_PATHS_REJECTED

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -303,6 +303,7 @@ class _ResponseReasoning(_WireModel):
     """
 
     effort: ReasoningEffort | None = None
+    context: Literal["auto", "current_turn", "all_turns"] | None = None
     generate_summary: Literal["auto", "concise", "detailed"] | None = None
     summary: Literal["auto", "concise", "detailed"] | None = None
 
@@ -475,6 +476,9 @@ def decode_responses(
             logprobs=(True if request.top_logprobs is not None else None),
             top_logprobs=request.top_logprobs,
             reasoning_effort=(request.reasoning.effort if request.reasoning is not None else None),
+            reasoning_context=(
+                request.reasoning.context if request.reasoning is not None else None
+            ),
             reasoning_summary=(
                 request.reasoning.summary or request.reasoning.generate_summary
                 if request.reasoning is not None

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -765,3 +765,43 @@ def test_chat_decoder_accepts_the_ultra_reasoning_effort() -> None:
             }
         )
     assert raised.value.detail.param == "reasoning_effort"
+
+
+def test_responses_decoder_accepts_reasoning_context_and_names_rejections() -> None:
+    """reasoning.context decodes verbatim; unknown values and fields 400 by name.
+
+    Customer repro: pydantic_ai's OpenAIResponsesModel sends
+    reasoning={"effort": ..., "context": "all_turns"} on the gpt-5.6 family
+    and OpenAI-direct accepts it, so the gateway must too.
+    """
+    for value in ("auto", "current_turn", "all_turns"):
+        decoded = decode_responses(
+            {
+                "model": "coding",
+                "input": "hi",
+                "reasoning": {"effort": "high", "context": value},
+            }
+        )
+        assert decoded.request.reasoning_context == value
+    assert decode_responses({"model": "coding", "input": "hi"}).request.reasoning_context is None
+
+    with pytest.raises(OpenAIProtocolError) as invalid_value:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": "hi",
+                "reasoning": {"context": "every_turn"},
+            }
+        )
+    assert invalid_value.value.detail.param == "reasoning.context"
+
+    # The consciously rejected reasoning.mode field keeps its named 400.
+    with pytest.raises(OpenAIProtocolError) as rejected_field:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": "hi",
+                "reasoning": {"mode": "pro"},
+            }
+        )
+    assert rejected_field.value.detail.param == "reasoning.mode"

--- a/exp/runtime/openai_protocol/streaming.py
+++ b/exp/runtime/openai_protocol/streaming.py
@@ -764,10 +764,7 @@ class ResponsesSseEncoder:
             "parallel_tool_calls": self.request.parallel_tool_calls is not False,
             "temperature": self.request.temperature,
             "top_p": self.request.top_p,
-            "reasoning": {
-                "effort": self.request.reasoning_effort,
-                "summary": self.request.reasoning_summary,
-            },
+            "reasoning": _reasoning_envelope(self.request),
             "tool_choice": _responses_tool_choice(self.request),
             "tools": [
                 {
@@ -906,6 +903,21 @@ def _responses_usage(usage: GatewayUsage | None) -> JsonObject | None:
         "output_tokens_details": {"reasoning_tokens": usage.reasoning_tokens or 0},
         "total_tokens": usage.input_tokens + usage.output_tokens,
     }
+
+
+def _reasoning_envelope(request: GatewayRequest) -> JsonObject:
+    """Reflect the caller's reasoning controls in the response envelope.
+
+    ``context`` is included only when the caller sent it, so context-free
+    response bodies stay byte-identical to pre-field traffic and goldens.
+    """
+    reasoning: JsonObject = {
+        "effort": request.reasoning_effort,
+        "summary": request.reasoning_summary,
+    }
+    if request.reasoning_context is not None:
+        reasoning["context"] = request.reasoning_context
+    return reasoning
 
 
 def _responses_tool_choice(request: GatewayRequest) -> JsonObject | str:


### PR DESCRIPTION
## What

Production triage today (Responses + `instructions` 400ing on every sync-written lane) was blinded by the admission handler in `exp/runtime/gateway/native_bridge.py` flattening every capability rejection to one generic sentence: "the resolved deployment does not support the requested capability". `ProviderCapabilityError` already carries the stable internal capability literal (`developer_messages`, `strict_tools`, `stop_sequences`, ...), which is safe to expose and is exactly what a triager needs.

## How

- `normalized_provider_failure` now names the capability in the safe message: `provider deployment cannot preserve the requested capability: developer_messages. Remove the unsupported field or request a different model alias`. The literal was already in `safe_details`, but `public_failure_error` renders only the message, so the detail never reached callers.
- The bridge's separate `except ProviderCapabilityError` arm (which hand-rolled an even flatter `GatewayFailure`) is merged into the `ProviderParameterError` arm: both pre-dispatch rejections flow through the one shared normalizer, making the capability path consistent with the parameter path (which already names its parameter and code) and with the no-compatible-rung raise, whose `first_protocol_error` re-raises the original exception into these same two arms.
- Public shape is unchanged otherwise: 400, code `unsupported_capability`, `invalid_request_error`, content-free (the capability literal is constructor-provided, never request content).

## Tests

- `errors_test.py` pins the exact new message for `strict_tools` (proving the capability literal and nothing else is added).
- `native_bridge_test.py::test_capability_rejection_names_the_unsupported_capability` reproduces today's incident shape end to end at admission: a Responses request with `instructions` decodes to a developer message, the seeded route cannot preserve `developer_messages`, and the public 400 names it while canary request content stays absent from the whole error payload.

## Gates

`uv run pytest -q`: 2667 passed, 2 skipped, 0 failed. `ruff check .`, `ruff format --check .`, `ty check`: clean. Python-only diff; the native crate is untouched (no version bump required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Extension: accept `reasoning.context` (customer-verified)

`reasoning.context` is a real, current OpenAI Responses field (`"auto" | "current_turn" | "all_turns"`, controlling whether gpt-5.6-family models re-render prior turns' reasoning; gpt-5.6 defaults to `all_turns`). A paying customer hit the gateway 400 (`Invalid value for 'reasoning.context'.`) via pydantic_ai's `OpenAIResponsesModel` + Coder harness on gpt-5.6-luna; the identical request succeeds against OpenAI-direct, and production reproduces: any `reasoning.context` value 400s while effort-only returns 200.

Following the summary/encrypted-content patterns exactly:
- The Responses wire profile models `context` with the installed SDK's exact closed value set `{"auto","current_turn","all_turns"}` (the task named two values; the SDK also carries `"auto"`, and rejecting it would recreate the incident, so the full SDK set is accepted). Invalid values keep a NAMED 400 (`reasoning.context`).
- `GatewayRequest.reasoning_context` carries it Responses-only and is forwarded VERBATIM by `openai_responses_stream_payload`.
- Admission narrows per rung exactly like `reasoning.summary`: only `openai_responses` rungs with reasoning support qualify; the route-wide 400 names `reasoning.context` when none do.
- The response envelope reflects the caller's context, only when sent, so context-free response bodies stay byte-identical to the committed goldens. (Upstream *effective-mode* echo when the caller omitted context would require normalizer plumbing for the terminal response's `reasoning` object; deliberately deferred as a follow-up.)
- Digest stability: the field is excluded from model serialization and a PRESENT value folds into `canonical_request_sha256` (the 0.7.0 carrier mechanism), so context-free traffic keeps byte-identical canonical digests and this release does not repeat the 0.7.0 idempotency rollout cost. Pinned by test.

## Extension: SDK-surface drift gate (never-again mechanism)

Four incidents (effort `ultra`, store/include/summary, developer-role gating, `reasoning.context`) share one root: the official SDK accepts a field the closed manifest neither models nor consciously rejects, and a paying customer is the first detector. A table-driven gate in `manifest_test.py` now walks the official request types (`ResponseCreateParamsBase` + stream, `CompletionCreateParamsBase` + stream, the nested `reasoning` object, every reasoning enum, and the `include` selector literals) and fails the build with text naming exactly what must be decided whenever an `openai` bump introduces surface absent from the manifests or the new decision tables (`RESPONSES_REASONING_*`, `RESPONSES_INCLUDE_PATHS_*`, colocated in `manifest.py`).

Writing the gate immediately proved its value: it surfaced five SDK fields the gateway had never classified — `reasoning.mode` and top-level `context_management`, `moderation`, `prompt_cache_options`, `prompt_cache_retention` — all now recorded as conscious UNSUPPORTED rejections with named 400s (rationale for `reasoning.mode` documented next to the table: it selects provider-priced reasoning tiers and pricing authority lives in the catalog).

## Coordination note (#639)

Per its owner, #639 (8afd08d3) is non-overlapping with this PR; a file-level diff intersection run for confirmation found 10 shared files but ZERO semantic overlap (no `reasoning.context`, capability-message, or manifest-gate work in #639). The one adjacency: #639 inserts dispatch-binding lines in `native_bridge.py`'s admit loop directly above the pre-dispatch `except` arms this PR merges, so whichever lands second has a small mechanical rebase. Either merge order works.
