### PR TITLE
providers: give the derived-timeout transport assertion real tolerance

### DIFF
--- a/exp/runtime/models/providers/base_test.py
+++ b/exp/runtime/models/providers/base_test.py
@@ -314,7 +314,12 @@ def test_complete_passes_the_derived_timeout_to_the_transport() -> None:
     client.complete(ModelRequest(messages=(message,), maximum_output_tokens=16_000))
     client.complete(ModelRequest(messages=(message,)))
 
-    assert transport.timeouts == [
-        pytest.approx(480.0),
-        pytest.approx(DEFAULT_TIMEOUT_SECONDS),
-    ]
+    # Each attempt is bounded by the derived timeout minus the wall time
+    # already spent under the request deadline, so scheduling jitter legally
+    # lands the observed value slightly below the exact derivation. The
+    # contract under test is WHICH timeout reached the transport (the
+    # token-scaled one, then the configured default), so a whole second of
+    # slack still distinguishes 480.0 from 60.0 unambiguously.
+    assert len(transport.timeouts) == 2
+    for observed, derived in zip(transport.timeouts, (480.0, DEFAULT_TIMEOUT_SECONDS), strict=True):
+        assert derived - 1.0 < observed <= derived


### PR DESCRIPTION
## What

`test_complete_passes_the_derived_timeout_to_the_transport` failed the gate on #650 with `59.99993378 != approx(60.0)` (default relative tolerance 1e-6 = +/-6e-05 s). The value the transport receives is the derived timeout minus wall time already spent under the request deadline (`RequestDeadline.after(completion_timeout)` is minted before the attempt, and `run_with_retry_async` bounds each attempt by the remaining time), so any CI scheduling hiccup legally lands outside that window. Exact equality was never the code's contract.

## How

The assertion now accepts `derived - 1.0 < observed <= derived`, which matches the test's actual intent: proving WHICH timeout reached the transport (the token-scaled 480.0, then the configured default 60.0). One second of slack still distinguishes those unambiguously, and the upper bound stays exact (elapsed time can only subtract). One test file, no behavior change.

## Gates

`uv run pytest -q exp/runtime/models/providers/base_test.py`: 11 passed. `ruff check .`, `ruff format --check .`, `ty check`: clean.

Does not block 0.7.2; rides after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)