### PR TITLE
models: restore Azure Foundry API surfaces

### DIFF
--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -125,7 +125,7 @@ def provider_update(
         ),
         None,
     )
-    if azure_api_surface is None and existing is not None:
+    if azure_api_surface is None and existing is not None and provider == "azure":
         azure_api_surface = existing.azure_api_surface
     provider_add(
         name=name,

--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import typer
 
@@ -21,6 +22,7 @@ _NON_INTERACTIVE_OPTION = typer.Option(False, "--non-interactive")
 _BASE_URL_OPTION = typer.Option(None, "--base-url")
 _CREDENTIAL_ENV_OPTION = typer.Option(None, "--credential-env")
 _API_VERSION_OPTION = typer.Option(None, "--api-version")
+_AZURE_API_SURFACE_OPTION = typer.Option(None, "--azure-api-surface")
 _REGION_OPTION = typer.Option(None, "--region")
 
 
@@ -32,6 +34,7 @@ class GatewayProviderView(ContractModel):
     credential_env: str | None = None
     base_url: str | None = None
     api_version: str | None = None
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = None
 
 
@@ -45,6 +48,7 @@ def provider_list(root: Path = ROOT_OPTION, json_output: bool = _JSON_OPTION) ->
             credential_env=connection.api_key_env,
             base_url=connection.base_url,
             api_version=connection.api_version,
+            azure_api_surface=connection.azure_api_surface,
             region=connection.region,
         )
         for authority in GatewayManagement(root).provider_connections()
@@ -61,6 +65,9 @@ def provider_add(
     credential_env: str | None = _CREDENTIAL_ENV_OPTION,
     base_url: str | None = _BASE_URL_OPTION,
     api_version: str | None = _API_VERSION_OPTION,
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = (
+        _AZURE_API_SURFACE_OPTION
+    ),
     region: str | None = _REGION_OPTION,
     replace: bool = typer.Option(False, "--replace"),
     non_interactive: bool = _NON_INTERACTIVE_OPTION,
@@ -76,6 +83,7 @@ def provider_add(
                 base_url=base_url,
                 api_key_env=credential_env,
                 api_version=api_version,
+                azure_api_surface=azure_api_surface,
                 region=region,
             ),
             replace=replace,
@@ -101,11 +109,24 @@ def provider_update(
     credential_env: str | None = _CREDENTIAL_ENV_OPTION,
     base_url: str | None = _BASE_URL_OPTION,
     api_version: str | None = _API_VERSION_OPTION,
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = (
+        _AZURE_API_SURFACE_OPTION
+    ),
     region: str | None = _REGION_OPTION,
     non_interactive: bool = _NON_INTERACTIVE_OPTION,
     json_output: bool = _JSON_OPTION,
 ) -> None:
     """Replace one provider connection and force active snapshot revalidation."""
+    existing = next(
+        (
+            authority.config
+            for authority in GatewayManagement(root).provider_connections()
+            if authority.connection_id == name
+        ),
+        None,
+    )
+    if azure_api_surface is None and existing is not None:
+        azure_api_surface = existing.azure_api_surface
     provider_add(
         name=name,
         provider=provider,
@@ -113,6 +134,7 @@ def provider_update(
         credential_env=credential_env,
         base_url=base_url,
         api_version=api_version,
+        azure_api_surface=azure_api_surface,
         region=region,
         replace=True,
         non_interactive=non_interactive,

--- a/exp/cli/gateway/provider_test.py
+++ b/exp/cli/gateway/provider_test.py
@@ -143,3 +143,49 @@ def test_provider_add_accepts_a_supported_provider_identifier(tmp_path: Path) ->
     assert listing["resource_kind"] == "providers"
     (item,) = listing["items"]
     assert item["provider"] == "openai-compatible"
+
+
+def test_azure_update_preserves_model_inference_surface_when_omitted(tmp_path: Path) -> None:
+    """An endpoint-only update cannot silently switch Foundry back to classic Azure."""
+    root = _initialized_root(tmp_path)
+    common = [
+        "--provider",
+        "azure",
+        "--base-url",
+        "https://resource.services.ai.azure.com/models",
+        "--credential-env",
+        "AZURE_FOUNDRY_API_KEY",
+        "--api-version",
+        "2024-05-01-preview",
+        "--non-interactive",
+        "--json",
+        "--root",
+        str(root),
+    ]
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "foundry",
+            *common,
+            "--azure-api-surface",
+            "model_inference",
+        ],
+    )
+    updated = _runner.invoke(
+        app,
+        ["config", "gateway", "provider", "update", "foundry", *common],
+    )
+    listed = _runner.invoke(
+        app,
+        ["config", "gateway", "provider", "list", "--json", "--root", str(root)],
+    )
+
+    assert added.exit_code == 0
+    assert updated.exit_code == 0
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.azure_api_surface == "model_inference"
+    assert json.loads(listed.output)["items"][0]["azure_api_surface"] == "model_inference"

--- a/exp/cli/gateway/provider_test.py
+++ b/exp/cli/gateway/provider_test.py
@@ -189,3 +189,58 @@ def test_azure_update_preserves_model_inference_surface_when_omitted(tmp_path: P
     (authority,) = GatewayManagement(root).provider_connections()
     assert authority.config.azure_api_surface == "model_inference"
     assert json.loads(listed.output)["items"][0]["azure_api_surface"] == "model_inference"
+
+
+def test_provider_update_drops_azure_surface_when_changing_provider(tmp_path: Path) -> None:
+    """A cross-provider update cannot carry an Azure-only discriminator forward."""
+    root = _initialized_root(tmp_path)
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "foundry",
+            "--provider",
+            "azure",
+            "--base-url",
+            "https://resource.services.ai.azure.com",
+            "--credential-env",
+            "AZURE_FOUNDRY_API_KEY",
+            "--api-version",
+            "2024-05-01-preview",
+            "--azure-api-surface",
+            "model_inference",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    updated = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "foundry",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://gateway.example.test/v1",
+            "--credential-env",
+            "CUSTOM_API_KEY",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert added.exit_code == 0, added.output
+    assert updated.exit_code == 0, updated.output
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.provider == "openai-compatible"
+    assert authority.config.azure_api_surface is None

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -836,7 +836,7 @@ def test_azure_provider_connection_collects_required_endpoint_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Azure setup collects the resource endpoint and defaults its API version to v1."""
-    answers = iter(("https://resource.openai.azure.com", "v1"))
+    answers = iter(("https://resource.openai.azure.com", "v1", "openai_deployments"))
 
     def _prompt(_text: str, **_kwargs: object) -> str:
         """Return the next scripted Azure connection field."""
@@ -851,6 +851,7 @@ def test_azure_provider_connection_collects_required_endpoint_fields(
         base_url="https://resource.openai.azure.com",
         api_key_env="AZURE_OPENAI_API_KEY",
         api_version="v1",
+        azure_api_surface="openai_deployments",
     )
 
 

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from functools import partial
 from getpass import getpass
+from typing import Literal, cast
 
 from rich.console import Console
 from rich.prompt import Prompt
@@ -351,6 +352,7 @@ def collect_provider_connection(
         return hosted_connection(environment).catalog_config()
     base_url = None
     api_version = None
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region = None
     if provider in ("openai-compatible", "azure"):
         base_url = ask_text(f"{SETUP_PROVIDER_LABELS[provider]} base URL", console=console)
@@ -360,6 +362,16 @@ def collect_provider_connection(
         api_version = ask_text("Azure OpenAI API version", console=console, default="v1")
         if not api_version:
             return None
+        selected_surface = ask_text(
+            "Azure API surface",
+            console=console,
+            default="openai_deployments",
+        )
+        if not selected_surface:
+            return None
+        if selected_surface not in ("openai_deployments", "model_inference"):
+            raise ValueError(f"unsupported Azure API surface {selected_surface!r}")
+        azure_api_surface = cast(Literal["openai_deployments", "model_inference"], selected_surface)
     if provider == "bedrock":
         region = (
             ask_text(
@@ -376,6 +388,7 @@ def collect_provider_connection(
         base_url=base_url,
         api_key_env=api_key_env,
         api_version=api_version,
+        azure_api_surface=azure_api_surface,
         region=region,
     )
 
@@ -501,6 +514,7 @@ def _resolve_endpoint(
         api_key_env=config.api_key_env,
         base_url=config.base_url,
         api_version=config.api_version,
+        azure_api_surface=config.azure_api_surface,
         region=config.region,
     )
     configured = connection is not None
@@ -512,6 +526,7 @@ def _resolve_endpoint(
             api_key_env=config.api_key_env or derived_api_key_env(config.provider, name),
             base_url=config.base_url,
             api_version=config.api_version,
+            azure_api_surface=config.azure_api_surface,
             region=config.region,
         )
     if provider == "bedrock":
@@ -536,6 +551,7 @@ def _reused_connection(
     api_key_env: str | None,
     base_url: str | None,
     api_version: str | None,
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None,
     region: str | None,
 ) -> ProviderConnection | None:
     """Return the configured connection that already describes this exact endpoint.
@@ -546,6 +562,7 @@ def _reused_connection(
         api_key_env: Canonical or collected environment override name, if any.
         base_url: Optional collected endpoint.
         api_version: Optional Azure API version.
+        azure_api_surface: Optional Azure API surface discriminator.
         region: Optional Bedrock region.
 
     Returns:
@@ -557,6 +574,7 @@ def _reused_connection(
             connection.provider != provider
             or connection.base_url != base_url
             or connection.api_version != api_version
+            or connection.azure_api_surface != azure_api_surface
             or connection.region != region
         ):
             continue

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -568,15 +568,18 @@ def _reused_connection(
     Returns:
         The matching configured connection when exactly one exists, otherwise ``None``.
     """
+    candidate = ConnectionConfig(
+        provider=provider,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_version=api_version,
+        azure_api_surface=azure_api_surface,
+        region=region,
+    )
     matches: list[ProviderConnection] = []
     for connection in existing_connections:
-        if (
-            connection.provider != provider
-            or connection.base_url != base_url
-            or connection.api_version != api_version
-            or connection.azure_api_surface != azure_api_surface
-            or connection.region != region
-        ):
+        configured = connection.catalog_config()
+        if configured.identity_sha256() != candidate.identity_sha256():
             continue
         if api_key_env is not None and connection.api_key_env != api_key_env:
             continue

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -1040,7 +1040,7 @@ def test_openai_compatible_does_not_reuse_when_multiple_accounts_share_an_endpoi
 
 def test_azure_prepares_exact_connection_for_manual_deployment_declaration() -> None:
     """Azure preserves endpoint and API version without inventing deployment metadata."""
-    console = ScriptedConsole("https://resource.openai.azure.com\n\n")
+    console = ScriptedConsole("https://resource.openai.azure.com\n\n\n")
     lister = _FakeLister({})
 
     prepared = _prepare(
@@ -1060,8 +1060,21 @@ def test_azure_prepares_exact_connection_for_manual_deployment_declaration() -> 
         api_key_env="AZURE_OPENAI_API_KEY",
         base_url="https://resource.openai.azure.com",
         api_version="v1",
+        azure_api_surface="openai_deployments",
     )
     assert "declare deployment model IDs" in console.output
+
+
+def test_azure_prepares_explicit_model_inference_surface() -> None:
+    """Interactive setup can author Foundry model inference without losing its discriminator."""
+    console = ScriptedConsole(
+        "https://resource.services.ai.azure.com/models\n2024-05-01-preview\nmodel_inference\n"
+    )
+
+    connection = provider_picker.collect_provider_connection("azure", console=console)
+
+    assert connection is not None
+    assert connection.azure_api_surface == "model_inference"
 
 
 def test_bedrock_prepares_credential_chain_without_listing_or_identity_invention() -> None:

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -1107,9 +1107,7 @@ def test_azure_reuses_identity_equivalent_connection_spellings(
         provider="azure",
         api_key_env="AZURE_EXISTING_KEY",
         base_url=configured_base_url,
-        api_version=(
-            "2024-05-01-preview" if collected_surface == "model_inference" else "v1"
-        ),
+        api_version=("2024-05-01-preview" if collected_surface == "model_inference" else "v1"),
         azure_api_surface=configured_surface,
     )
 

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
@@ -1075,6 +1076,54 @@ def test_azure_prepares_explicit_model_inference_surface() -> None:
 
     assert connection is not None
     assert connection.azure_api_surface == "model_inference"
+
+
+@pytest.mark.parametrize(
+    ("configured_base_url", "configured_surface", "collected_base_url", "collected_surface"),
+    [
+        (
+            "https://resource.openai.azure.com",
+            None,
+            "https://resource.openai.azure.com/",
+            "openai_deployments",
+        ),
+        (
+            "https://resource.services.ai.azure.com",
+            "model_inference",
+            "https://resource.services.ai.azure.com/MODELS",
+            "model_inference",
+        ),
+    ],
+)
+def test_azure_reuses_identity_equivalent_connection_spellings(
+    configured_base_url: str,
+    configured_surface: Literal["openai_deployments", "model_inference"] | None,
+    collected_base_url: str,
+    collected_surface: Literal["openai_deployments", "model_inference"],
+) -> None:
+    """Setup reuses one credential locator across equivalent Azure endpoint spellings."""
+    existing = ProviderConnection(
+        name="azure-existing",
+        provider="azure",
+        api_key_env="AZURE_EXISTING_KEY",
+        base_url=configured_base_url,
+        api_version=(
+            "2024-05-01-preview" if collected_surface == "model_inference" else "v1"
+        ),
+        azure_api_surface=configured_surface,
+    )
+
+    reused = provider_picker._reused_connection(
+        (existing,),
+        provider="azure",
+        api_key_env="AZURE_EXISTING_KEY",
+        base_url=collected_base_url,
+        api_version=existing.api_version,
+        azure_api_surface=collected_surface,
+        region=None,
+    )
+
+    assert reused == existing
 
 
 def test_bedrock_prepares_credential_chain_without_listing_or_identity_invention() -> None:

--- a/exp/cli/providers/setup.py
+++ b/exp/cli/providers/setup.py
@@ -633,6 +633,7 @@ def existing_setup_connections(existing: ModelCatalog | None) -> tuple[ProviderC
             api_key_env=connection.api_key_env,
             base_url=connection.base_url,
             api_version=connection.api_version,
+            azure_api_surface=connection.azure_api_surface,
             region=connection.region,
         )
         for name, connection in sorted(existing.connections.items())

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -117,6 +117,11 @@ class ConnectionConfig(ContractModel):
                     "azure api_version must be 'v1' or a dated Azure OpenAI version such as "
                     "2024-10-21"
                 )
+            if self.azure_api_surface == "model_inference" and self.api_version == "v1":
+                raise ValueError(
+                    "azure model_inference requires a dated api_version for the mandatory "
+                    "api-version query parameter"
+                )
             if self.region is not None:
                 raise ValueError("region is only accepted for provider='bedrock'")
         elif self.provider == "bedrock":

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -57,6 +57,20 @@ def _normalize_base_url(value: str) -> str:
     return urlunsplit((scheme, netloc, parsed.path.rstrip("/"), "", ""))
 
 
+def _normalize_connection_base_url(connection: ConnectionConfig) -> str | None:
+    """Normalize one endpoint while preserving provider-surface equivalence."""
+    if connection.base_url is None:
+        return None
+    normalized = _normalize_base_url(connection.base_url)
+    if (
+        connection.provider == "azure"
+        and connection.azure_api_surface == "model_inference"
+        and normalized.lower().endswith("/models")
+    ):
+        return normalized[:-7].rstrip("/")
+    return normalized
+
+
 class ModelCatalogError(ValueError):
     """A local model catalog was malformed or named a credential value."""
 
@@ -192,7 +206,7 @@ class ConnectionConfig(ContractModel):
         """
         identity: JsonObject = {
             "provider": self.provider,
-            "base_url": None if self.base_url is None else _normalize_base_url(self.base_url),
+            "base_url": _normalize_connection_base_url(self),
         }
         if self.api_version is not None:
             identity["api_version"] = self.api_version

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -68,6 +68,7 @@ class ConnectionConfig(ContractModel):
     base_url: str | None = Field(default=None, max_length=2_048)
     api_key_env: str | None = Field(default=None, max_length=256)
     api_version: str | None = Field(default=None, max_length=64)
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
 
     @field_validator("api_key_env")
@@ -94,6 +95,8 @@ class ConnectionConfig(ContractModel):
 
     @model_validator(mode="after")
     def _require_secret_free_connection_metadata(self) -> ConnectionConfig:
+        if self.provider != "azure" and self.azure_api_surface is not None:
+            raise ValueError("azure_api_surface is only accepted for provider='azure'")
         if self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
             raise ValueError(
                 f"native provider {self.provider!r} uses its built-in official endpoint; "
@@ -167,6 +170,7 @@ class ConnectionConfig(ContractModel):
                     "provider": self.provider,
                     "base_url": self.base_url,
                     "api_version": self.api_version,
+                    "azure_api_surface": self.azure_api_surface,
                     "region": self.region,
                 }
             )
@@ -187,6 +191,11 @@ class ConnectionConfig(ContractModel):
         }
         if self.api_version is not None:
             identity["api_version"] = self.api_version
+        if self.provider == "azure" and self.azure_api_surface == "model_inference":
+            # Keep classic Azure revisions byte-compatible with the identity
+            # contract that predates this discriminator. Only the genuinely
+            # different Foundry surface needs a new credential binding.
+            identity["azure_api_surface"] = "model_inference"
         if self.region is not None:
             identity["region"] = self.region
         return sha256_json(identity)

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -495,6 +495,10 @@ def test_azure_connection_requires_endpoint_key_and_api_version() -> None:
         api_version="2024-05-01-preview",
         azure_api_surface="model_inference",
     )
+    inference_root = inference.model_copy(
+        update={"base_url": "https://resource.services.ai.azure.com"}
+    )
+    assert inference.identity_sha256() == inference_root.identity_sha256()
     assert inference.identity_sha256() != connection.identity_sha256()
     explicit_classic = connection.model_copy(update={"azure_api_surface": "openai_deployments"})
     assert explicit_classic.identity_sha256() == connection.identity_sha256()

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -499,6 +499,20 @@ def test_azure_connection_requires_endpoint_key_and_api_version() -> None:
         update={"base_url": "https://resource.services.ai.azure.com"}
     )
     assert inference.identity_sha256() == inference_root.identity_sha256()
+    inference_redundant_terminal = inference.model_copy(
+        update={"base_url": "https://resource.services.ai.azure.com//models"}
+    )
+    assert inference_redundant_terminal.identity_sha256() == inference_root.identity_sha256()
+    inference_internal_separator = inference.model_copy(
+        update={"base_url": "https://gateway.example.test/tenant-a//azure/models"}
+    )
+    inference_collapsed_separator = inference_internal_separator.model_copy(
+        update={"base_url": "https://gateway.example.test/tenant-a/azure/models"}
+    )
+    assert (
+        inference_internal_separator.identity_sha256()
+        != inference_collapsed_separator.identity_sha256()
+    )
     assert inference.identity_sha256() != connection.identity_sha256()
     explicit_classic = connection.model_copy(update={"azure_api_surface": "openai_deployments"})
     assert explicit_classic.identity_sha256() == connection.identity_sha256()

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -487,6 +487,26 @@ def test_azure_connection_requires_endpoint_key_and_api_version() -> None:
         api_key_env="AZURE_OPENAI_API_KEY",
         api_version="v1",
     )
+    assert connection.azure_api_surface is None
+    inference = ConnectionConfig(
+        provider="azure",
+        base_url="https://resource.services.ai.azure.com/models",
+        api_key_env="AZURE_FOUNDRY_API_KEY",
+        api_version="2024-05-01-preview",
+        azure_api_surface="model_inference",
+    )
+    assert inference.identity_sha256() != connection.identity_sha256()
+    explicit_classic = connection.model_copy(update={"azure_api_surface": "openai_deployments"})
+    assert explicit_classic.identity_sha256() == connection.identity_sha256()
+    assert connection.identity_sha256() == sha256_json(
+        {
+            "provider": "azure",
+            "base_url": "https://resource.openai.azure.com",
+            "api_version": "v1",
+        }
+    )
+    with pytest.raises(ValueError, match="azure_api_surface"):
+        ConnectionConfig(provider="openai", azure_api_surface="model_inference")
 
     assert (
         connection.identity_sha256()

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -507,6 +507,14 @@ def test_azure_connection_requires_endpoint_key_and_api_version() -> None:
     )
     with pytest.raises(ValueError, match="azure_api_surface"):
         ConnectionConfig(provider="openai", azure_api_surface="model_inference")
+    with pytest.raises(ValueError, match="dated api_version"):
+        ConnectionConfig(
+            provider="azure",
+            base_url="https://resource.services.ai.azure.com",
+            api_key_env="AZURE_FOUNDRY_API_KEY",
+            api_version="v1",
+            azure_api_surface="model_inference",
+        )
 
     assert (
         connection.identity_sha256()

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field, model_validator
 
@@ -45,6 +46,7 @@ class ProviderConnection(ContractModel):
     api_key_env: str | None = Field(default=None, max_length=256)
     base_url: str | None = Field(default=None, max_length=2_048)
     api_version: str | None = Field(default=None, max_length=64)
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
 
     @model_validator(mode="after")
@@ -98,6 +100,7 @@ class ProviderConnection(ContractModel):
             base_url=self.base_url,
             api_key_env=self.api_key_env,
             api_version=self.api_version,
+            azure_api_surface=self.azure_api_surface,
             region=self.region,
         )
         return self
@@ -109,6 +112,7 @@ class ProviderConnection(ContractModel):
             base_url=self.base_url,
             api_key_env=self.api_key_env,
             api_version=self.api_version,
+            azure_api_surface=self.azure_api_surface,
             region=self.region,
         )
 

--- a/exp/runtime/gateway/management_test.py
+++ b/exp/runtime/gateway/management_test.py
@@ -90,3 +90,27 @@ def test_upsert_provider_connection_accepts_registry_supported_providers(
     assert native_authority.config.provider == "anthropic"
     assert "anthropic" in SUPPORTED_PROVIDERS
     assert "openai-compatible" in SUPPORTED_PROVIDERS
+
+
+def test_azure_model_inference_surface_survives_management_restart(tmp_path: Path) -> None:
+    """SQLite replay retains the Foundry surface that participates in connection identity."""
+    manager = GatewayManagement(tmp_path)
+    manager.initialize()
+    config = ConnectionConfig(
+        provider="azure",
+        base_url="https://resource.services.ai.azure.com",
+        api_key_env="AZURE_FOUNDRY_API_KEY",
+        api_version="2024-05-01-preview",
+        azure_api_surface="model_inference",
+    )
+
+    changed, authority = manager.upsert_provider_connection(
+        connection_id="foundry",
+        config=config,
+    )
+    (reloaded,) = GatewayManagement(tmp_path).provider_connections()
+
+    assert changed
+    assert authority.config == config
+    assert reloaded.config == config
+    assert reloaded.connection_sha256 == config.identity_sha256()

--- a/exp/runtime/gateway/platform.py
+++ b/exp/runtime/gateway/platform.py
@@ -143,6 +143,7 @@ class ProviderConnectionRevision(ContractModel):
     provider: str = Field(min_length=1, max_length=128)
     base_url: str | None = Field(default=None, max_length=2_048)
     api_version: str | None = Field(default=None, max_length=256)
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=256)
     secret_reference: OpaqueSecretReference | None = None
     connection_sha256: Sha256
@@ -558,6 +559,7 @@ class UpsertProviderConnectionCommand(ContractModel):
     provider: str = Field(min_length=1, max_length=128)
     base_url: str | None = Field(default=None, max_length=2_048)
     api_version: str | None = Field(default=None, max_length=256)
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=256)
     secret_reference: OpaqueSecretReference | None = None
     replace: bool = False

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 
 class GatewaySchemaError(RuntimeError):
@@ -586,6 +586,12 @@ _MIGRATION_10 = (
     "DROP TABLE gateway_schema_refresh_v10",
 )
 
+_MIGRATION_11 = (
+    "ALTER TABLE provider_connection_revisions ADD COLUMN azure_api_surface TEXT "
+    "CHECK (azure_api_surface IS NULL OR azure_api_surface IN "
+    "('openai_deployments', 'model_inference'))",
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -597,6 +603,7 @@ _MIGRATIONS = {
     8: _MIGRATION_8,
     9: _MIGRATION_9,
     10: _MIGRATION_10,
+    11: _MIGRATION_11,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from exp.common.models import ConnectionConfig
 from exp.runtime.gateway.sqlite import migrations
 from exp.runtime.gateway.sqlite.migrations import (
     _MIGRATION_1,
@@ -847,5 +848,72 @@ def test_v10_migration_widens_api_surface_and_preserves_rows(tmp_path: Path) -> 
         # The child attempt still resolves its rewritten parent's foreign key.
         migrated.execute("DELETE FROM gateway_attempts WHERE attempt_id = 'att-1'")
         migrated.execute("DELETE FROM gateway_requests WHERE request_id = 'req-1'")
+    finally:
+        migrated.close()
+
+
+def test_v11_migration_adds_azure_surface_without_rewriting_existing_authority(
+    tmp_path: Path,
+) -> None:
+    """Existing v10 provider revisions migrate with the classic Azure default intact."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    config = ConnectionConfig(
+        provider="azure",
+        base_url="https://resource.openai.azure.com",
+        api_key_env="AZURE_OPENAI_API_KEY",
+        api_version="v1",
+    )
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for version in range(1, 11):
+            for statement in migrations._MIGRATIONS[version]:
+                connection.execute(statement)
+        connection.execute("PRAGMA user_version = 10")
+        connection.execute("INSERT INTO organizations VALUES ('org', 'org', 'Org', 1, 't', 't')")
+        connection.execute(
+            """
+            INSERT INTO provider_connections (
+                connection_id, organization_id, active, created_at, updated_at
+            ) VALUES ('azure', 'org', 1, 't', 't')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_connection_revisions (
+                revision_id, organization_id, connection_id, revision_number,
+                provider, base_url, api_key_env, api_version, region,
+                connection_sha256, created_at
+            ) VALUES ('rev', 'org', 'azure', 1, 'azure', ?, ?, 'v1', NULL, ?, 't')
+            """,
+            (config.base_url, config.api_key_env, config.identity_sha256()),
+        )
+        connection.execute(
+            "UPDATE provider_connections SET active_revision_id = 'rev' "
+            "WHERE connection_id = 'azure'"
+        )
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None and backup.exists()
+    migrated = connect_database(path)
+    try:
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        row = migrated.execute(
+            "SELECT azure_api_surface, connection_sha256 "
+            "FROM provider_connection_revisions WHERE revision_id = 'rev'"
+        ).fetchone()
+        assert row["azure_api_surface"] is None
+        assert row["connection_sha256"] == config.identity_sha256()
+        with pytest.raises(sqlite3.IntegrityError):
+            migrated.execute(
+                "UPDATE provider_connection_revisions SET azure_api_surface = 'bogus' "
+                "WHERE revision_id = 'rev'"
+            )
     finally:
         migrated.close()

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, cast
 
 from exp.common.core.artifacts import stable_id
 from exp.common.models import ConnectionConfig
@@ -426,10 +425,7 @@ class SQLiteGatewayPlatform:
                 provider=str(row["provider"]),
                 base_url=None if row["base_url"] is None else str(row["base_url"]),
                 api_version=None if row["api_version"] is None else str(row["api_version"]),
-                azure_api_surface=cast(
-                    Literal["openai_deployments", "model_inference"] | None,
-                    None if row["azure_api_surface"] is None else str(row["azure_api_surface"]),
-                ),
+                azure_api_surface=row["azure_api_surface"],
                 region=None if row["region"] is None else str(row["region"]),
                 secret_reference=(
                     None

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import Literal, cast
 
 from exp.common.core.artifacts import stable_id
 from exp.common.models import ConnectionConfig
@@ -207,6 +208,7 @@ class SQLiteGatewayPlatform:
                     base_url=command.base_url,
                     api_key_env=(None if secret_reference is None else secret_reference.reference),
                     api_version=command.api_version,
+                    azure_api_surface=command.azure_api_surface,
                     region=command.region,
                 ),
                 replace=command.replace,
@@ -424,6 +426,10 @@ class SQLiteGatewayPlatform:
                 provider=str(row["provider"]),
                 base_url=None if row["base_url"] is None else str(row["base_url"]),
                 api_version=None if row["api_version"] is None else str(row["api_version"]),
+                azure_api_surface=cast(
+                    Literal["openai_deployments", "model_inference"] | None,
+                    None if row["azure_api_surface"] is None else str(row["azure_api_surface"]),
+                ),
                 region=None if row["region"] is None else str(row["region"]),
                 secret_reference=(
                     None

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -488,6 +488,29 @@ def test_revision_reads_forward_existing_sqlite_authority(tmp_path: Path) -> Non
         )[0].remaining_micro_usd
         == 1_000
     )
+
+
+def test_natural_provider_replay_preserves_azure_api_surface(tmp_path: Path) -> None:
+    """The storage-neutral command and revision view round-trip the Foundry selector."""
+    platform = _platform(tmp_path)
+    command = UpsertProviderConnectionCommand(
+        organization_id="org-one",
+        connection_id="foundry",
+        revision_id="foundry-revision-one",
+        provider="azure",
+        base_url="https://resource.services.ai.azure.com",
+        api_version="2024-05-01-preview",
+        azure_api_surface="model_inference",
+        secret_reference=OpaqueSecretReference(
+            scheme=OpaqueSecretScheme.ENVIRONMENT,
+            reference="AZURE_FOUNDRY_API_KEY",
+        ),
+    )
+
+    assert platform.mutate_provider_connection(command).changed
+    assert not platform.mutate_provider_connection(command).changed
+    (revision,) = platform.provider_connection_revisions(organization_id="org-one")
+    assert revision.azure_api_surface == "model_inference"
     assert platform.alias_revisions(organization_id="org-two") == ()
 
 

--- a/exp/runtime/gateway/sqlite/provider_authority.py
+++ b/exp/runtime/gateway/sqlite/provider_authority.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from typing import Literal, cast
 
 from exp.common.core.artifacts import ContractModel, Sha256
 from exp.common.models import ConnectionConfig
@@ -113,9 +114,9 @@ def upsert_provider_connection(
         """
         INSERT INTO provider_connection_revisions (
             revision_id, organization_id, connection_id, revision_number,
-            provider, base_url, api_key_env, api_version, region,
+            provider, base_url, api_key_env, api_version, azure_api_surface, region,
             connection_sha256, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             revision_id,
@@ -126,6 +127,7 @@ def upsert_provider_connection(
             config.base_url,
             config.api_key_env,
             config.api_version,
+            config.azure_api_surface,
             config.region,
             digest,
             now,
@@ -179,7 +181,8 @@ def bound_provider_connections(
     rows = connection.execute(
         """
         SELECT c.connection_id, r.revision_id, r.revision_number,
-               r.provider, r.base_url, r.api_key_env, r.api_version, r.region,
+               r.provider, r.base_url, r.api_key_env, r.api_version,
+               r.azure_api_surface, r.region,
                r.connection_sha256, c.active
         FROM alias_revision_provider_connections AS b
         JOIN provider_connections AS c
@@ -308,6 +311,10 @@ def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
         base_url=None if row["base_url"] is None else str(row["base_url"]),
         api_key_env=None if row["api_key_env"] is None else str(row["api_key_env"]),
         api_version=None if row["api_version"] is None else str(row["api_version"]),
+        azure_api_surface=cast(
+            Literal["openai_deployments", "model_inference"] | None,
+            None if row["azure_api_surface"] is None else str(row["azure_api_surface"]),
+        ),
         region=None if row["region"] is None else str(row["region"]),
     )
     digest = str(row["connection_sha256"])
@@ -325,7 +332,8 @@ def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
 
 _SELECT_AUTHORITY = """
 SELECT c.connection_id, r.revision_id, r.revision_number,
-       r.provider, r.base_url, r.api_key_env, r.api_version, r.region,
+       r.provider, r.base_url, r.api_key_env, r.api_version,
+       r.azure_api_surface, r.region,
        r.connection_sha256, c.active
 FROM provider_connections AS c
 JOIN provider_connection_revisions AS r

--- a/exp/runtime/models/credentials_test.py
+++ b/exp/runtime/models/credentials_test.py
@@ -101,6 +101,33 @@ def test_fresh_resolver_reads_the_store_written_by_another_instance(tmp_path: Pa
     assert api_key == _SECRET
 
 
+def test_azure_model_inference_root_and_models_path_share_stored_credential(
+    tmp_path: Path,
+) -> None:
+    """Equivalent Foundry endpoint spellings retain the same bound credential."""
+    resource_root = ConnectionConfig(
+        provider="azure",
+        base_url="https://resource.services.ai.azure.com",
+        api_key_env="AZURE_FOUNDRY_API_KEY",
+        api_version="2024-05-01-preview",
+        azure_api_surface="model_inference",
+    )
+    explicit_models = resource_root.model_copy(
+        update={"base_url": "https://resource.services.ai.azure.com/MODELS"}
+    )
+    store = ProviderAuthStore(tmp_path / "auth.json")
+    store.put("foundry", _SECRET, binding=_binding(resource_root))
+
+    api_key = read_connection_api_key(
+        explicit_models,
+        connection_id="foundry",
+        environment={},
+        store=store,
+    )
+
+    assert api_key == _SECRET
+
+
 def test_store_resolves_when_the_connection_omits_an_env_name(tmp_path: Path) -> None:
     """A stored key is enough when the catalog has no environment override name."""
     store = ProviderAuthStore(tmp_path / "auth.json")

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -19,7 +19,12 @@ _V1_API_VERSION = "v1"
 _V1_ROOT_SUFFIX = "/openai/v1"
 
 
-def same_azure_endpoint(left: str, right: str | None) -> bool:
+def same_azure_endpoint(
+    left: str,
+    right: str | None,
+    *,
+    api_surface: str = "openai_deployments",
+) -> bool:
     """Compare two Azure resource endpoints after canonical host and path normalization.
 
     Scheme and hostname are compared case-insensitively. Default HTTPS and HTTP ports are
@@ -30,13 +35,17 @@ def same_azure_endpoint(left: str, right: str | None) -> bool:
     Args:
         left: Catalog or request endpoint.
         right: Endpoint to compare, often ``AZURE_OPENAI_ENDPOINT``.
+        api_surface: Azure wire surface whose equivalent root spellings are accepted.
 
     Returns:
         ``True`` when both values name the same Azure resource after canonicalization.
     """
     if right is None:
         return False
-    return _canonical_azure_endpoint(left) == _canonical_azure_endpoint(right)
+    return _canonical_azure_endpoint(
+        left,
+        api_surface=api_surface,
+    ) == _canonical_azure_endpoint(right, api_surface=api_surface)
 
 
 def bind_azure_api_key(
@@ -45,6 +54,7 @@ def bind_azure_api_key(
     api_key_env: str,
     api_key: str,
     environment: Mapping[str, str],
+    api_surface: str = "openai_deployments",
 ) -> str:
     """Return the connection key only when it is paired with this exact Azure endpoint.
 
@@ -56,6 +66,7 @@ def bind_azure_api_key(
         api_key_env: Environment-variable name configured on the connection.
         api_key: Credential already read from ``api_key_env``.
         environment: Process or injected environment mapping.
+        api_surface: Azure wire surface used to normalize equivalent endpoint roots.
 
     Returns:
         The same non-empty API key when the pairing is valid.
@@ -68,7 +79,11 @@ def bind_azure_api_key(
         raise ValueError("Azure clients require a non-empty API key")
     if api_key_env == AZURE_OPENAI_API_KEY_ENV:
         trusted_endpoint = environment.get(AZURE_OPENAI_ENDPOINT_ENV)
-        if trusted_endpoint and not same_azure_endpoint(endpoint, trusted_endpoint):
+        if trusted_endpoint and not same_azure_endpoint(
+            endpoint,
+            trusted_endpoint,
+            api_surface=api_surface,
+        ):
             raise ModelCredentialError(
                 "AZURE_OPENAI_API_KEY is bound to AZURE_OPENAI_ENDPOINT and cannot be sent to a "
                 "different Azure resource"
@@ -206,11 +221,16 @@ class AzureClient(OpenAICompatibleClient):
         return path
 
 
-def _canonical_azure_endpoint(value: str) -> tuple[str, str, int | None, str]:
+def _canonical_azure_endpoint(
+    value: str,
+    *,
+    api_surface: str,
+) -> tuple[str, str, int | None, str]:
     """Return the comparable scheme, host, port, and path for one Azure endpoint.
 
     Default HTTPS port 443 and HTTP port 80 are treated as omitted so catalog identity and key
-    pairing stay aligned. A non-default port is part of the resource identity.
+    pairing stay aligned. A non-default port is part of the resource identity. Model-inference
+    resource roots and their terminal ``/models`` form share one authority.
     """
     parsed = urlsplit(value)
     hostname = (parsed.hostname or "").lower()
@@ -221,4 +241,7 @@ def _canonical_azure_endpoint(value: str) -> tuple[str, str, int | None, str]:
     scheme = parsed.scheme.lower()
     default_port = 443 if scheme == "https" else 80
     comparable_port = None if port in {None, default_port} else port
-    return (scheme, hostname, comparable_port, parsed.path.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    if api_surface == "model_inference" and path.lower().endswith("/models"):
+        path = path[:-7].rstrip("/")
+    return (scheme, hostname, comparable_port, path)

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -114,7 +114,7 @@ def _azure_base_url(
     root = endpoint.rstrip("/")
     if api_surface == "model_inference":
         if root.lower().endswith("/models"):
-            return root
+            return f"{root[:-7]}/models"
         return f"{root}/models"
     if api_version == _V1_API_VERSION:
         if root.lower().endswith(_V1_ROOT_SUFFIX):

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -114,12 +114,11 @@ def _azure_base_url(
     root = endpoint.rstrip("/")
     if api_surface == "model_inference":
         parsed = urlsplit(endpoint)
-        path = "/".join(part for part in parsed.path.split("/") if part)
-        normalized_path = f"/{path}" if path else ""
-        root = urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", ""))
-        if root.lower().endswith("/models"):
-            return f"{root[:-7]}/models"
-        return f"{root}/models"
+        path = parsed.path.rstrip("/")
+        if path.lower().endswith("/models"):
+            path = path[:-7].rstrip("/")
+        model_path = f"{path}/models" if path else "/models"
+        return urlunsplit((parsed.scheme, parsed.netloc, model_path, "", ""))
     if api_version == _V1_API_VERSION:
         if root.lower().endswith(_V1_ROOT_SUFFIX):
             return root

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -76,7 +76,13 @@ def bind_azure_api_key(
     return api_key
 
 
-def _azure_base_url(endpoint: str, *, deployment: str, api_version: str) -> str:
+def _azure_base_url(
+    endpoint: str,
+    *,
+    deployment: str,
+    api_version: str,
+    api_surface: str,
+) -> str:
     """Build the Azure request root for the configured API surface.
 
     ``v1`` uses the Foundry and Azure OpenAI ``/openai/v1`` root and places the deployment in
@@ -91,6 +97,10 @@ def _azure_base_url(endpoint: str, *, deployment: str, api_version: str) -> str:
         Absolute request root. The root never includes a credential or query string.
     """
     root = endpoint.rstrip("/")
+    if api_surface == "model_inference":
+        if root.lower().endswith("/models"):
+            return root
+        return f"{root}/models"
     if api_version == _V1_API_VERSION:
         if root.lower().endswith(_V1_ROOT_SUFFIX):
             return root
@@ -114,6 +124,7 @@ class AzureClient(OpenAICompatibleClient):
         endpoint: str,
         api_key: str,
         api_version: str,
+        api_surface: str = "openai_deployments",
         transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
@@ -132,7 +143,8 @@ class AzureClient(OpenAICompatibleClient):
             model: Resolved identity whose ``model_id`` is the exact Azure deployment name.
             endpoint: Explicit Azure resource endpoint from the catalog.
             api_key: Credential already paired with ``endpoint``.
-            api_version: ``v1`` or a dated Azure OpenAI API version.
+            api_version: ``v1`` or a dated Azure API version.
+            api_surface: Azure ``openai_deployments`` or Foundry ``model_inference`` wire API.
             transport: Optional deterministic transport used by tests.
             retry_policy: Bounded same-endpoint retry policy.
             timeout_seconds: Per-attempt timeout floor. Completion calls scale above it from the
@@ -145,10 +157,17 @@ class AzureClient(OpenAICompatibleClient):
             raise ValueError("Azure clients require an explicit resource endpoint")
         if not api_version:
             raise ValueError("Azure clients require an explicit api_version")
+        if api_surface not in {"openai_deployments", "model_inference"}:
+            raise ValueError("Azure clients require a supported api_surface")
         super().__init__(
             model=model,
             api_key=api_key,
-            base_url=_azure_base_url(endpoint, deployment=model.model_id, api_version=api_version),
+            base_url=_azure_base_url(
+                endpoint,
+                deployment=model.model_id,
+                api_version=api_version,
+                api_surface=api_surface,
+            ),
             transport=transport,
             retry_policy=retry_policy,
             timeout_seconds=timeout_seconds,

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import ClassVar
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from exp.common.models import ChatMaxTokensField, ModelSnapshot
 from exp.runtime.models.credentials import ModelCredentialError
@@ -111,7 +111,10 @@ def _azure_base_url(
     Returns:
         Absolute request root. The root never includes a credential or query string.
     """
-    root = endpoint.rstrip("/")
+    parsed = urlsplit(endpoint)
+    path = "/".join(part for part in parsed.path.split("/") if part)
+    normalized_path = f"/{path}" if path else ""
+    root = urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", ""))
     if api_surface == "model_inference":
         if root.lower().endswith("/models"):
             return f"{root[:-7]}/models"
@@ -176,6 +179,8 @@ class AzureClient(OpenAICompatibleClient):
             raise ValueError("Azure clients require a supported api_surface")
         if api_surface == "model_inference" and api_version == _V1_API_VERSION:
             raise ValueError("Azure model_inference requires a dated api_version")
+        if api_surface == "model_inference":
+            chat_max_tokens_field = "max_tokens"
         super().__init__(
             model=model,
             api_key=api_key,

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -159,6 +159,8 @@ class AzureClient(OpenAICompatibleClient):
             raise ValueError("Azure clients require an explicit api_version")
         if api_surface not in {"openai_deployments", "model_inference"}:
             raise ValueError("Azure clients require a supported api_surface")
+        if api_surface == "model_inference" and api_version == _V1_API_VERSION:
+            raise ValueError("Azure model_inference requires a dated api_version")
         super().__init__(
             model=model,
             api_key=api_key,
@@ -181,6 +183,7 @@ class AzureClient(OpenAICompatibleClient):
             sampling_requires_reasoning_none=sampling_requires_reasoning_none,
         )
         self._api_version = api_version
+        self._api_surface = api_surface
 
     def _headers(self) -> dict[str, str]:
         """Return Azure ``api-key`` authentication headers without a Bearer token."""
@@ -198,7 +201,7 @@ class AzureClient(OpenAICompatibleClient):
         Returns:
             Wire path with the configured API version when required.
         """
-        if self._api_version != _V1_API_VERSION:
+        if self._api_surface == "model_inference" or self._api_version != _V1_API_VERSION:
             path = f"{path}?api-version={self._api_version}"
         return path
 

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -111,11 +111,12 @@ def _azure_base_url(
     Returns:
         Absolute request root. The root never includes a credential or query string.
     """
-    parsed = urlsplit(endpoint)
-    path = "/".join(part for part in parsed.path.split("/") if part)
-    normalized_path = f"/{path}" if path else ""
-    root = urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", ""))
+    root = endpoint.rstrip("/")
     if api_surface == "model_inference":
+        parsed = urlsplit(endpoint)
+        path = "/".join(part for part in parsed.path.split("/") if part)
+        normalized_path = f"/{path}" if path else ""
+        root = urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", ""))
         if root.lower().endswith("/models"):
             return f"{root[:-7]}/models"
         return f"{root}/models"

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -142,7 +142,6 @@ def test_model_inference_route_keeps_deployment_in_body() -> None:
         api_version="2024-05-01-preview",
         api_surface="model_inference",
         transport=transport,
-        chat_max_tokens_field="max_tokens",
     )
 
     client.complete(_request())
@@ -155,6 +154,7 @@ def test_model_inference_route_keeps_deployment_in_body() -> None:
     assert headers["api-key"] == _SECRET
     assert payload["model"] == "DeepSeek-V4-Flash"
     assert payload["max_tokens"] == 128
+    assert "max_completion_tokens" not in payload
 
 
 def test_model_inference_appends_models_to_a_resource_root() -> None:
@@ -186,6 +186,27 @@ def test_model_inference_canonicalizes_terminal_models_path_case() -> None:
     client = AzureClient(
         model=_snapshot("azure", "DeepSeek-V4-Flash"),
         endpoint="https://resource.services.ai.azure.com/MODELS",
+        api_key=_SECRET,
+        api_version="2024-05-01-preview",
+        api_surface="model_inference",
+        transport=transport,
+    )
+
+    client.complete(_request())
+
+    assert transport.requests[0][0].startswith(
+        "https://resource.services.ai.azure.com/models/chat/completions?"
+    )
+
+
+def test_model_inference_canonicalizes_redundant_resource_path_separators() -> None:
+    """An identity-equivalent root cannot emit a divergent double-slash wire path."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "DeepSeek-V4-Flash"),
+        endpoint="https://resource.services.ai.azure.com//models",
         api_key=_SECRET,
         api_version="2024-05-01-preview",
         api_surface="model_inference",

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -238,6 +238,16 @@ def test_trusted_azure_key_is_not_sent_to_a_different_endpoint() -> None:
     )
     assert (
         bind_azure_api_key(
+            endpoint="https://resource.services.ai.azure.com/models",
+            api_key_env=AZURE_OPENAI_API_KEY_ENV,
+            api_key=_SECRET,
+            environment={AZURE_OPENAI_ENDPOINT_ENV: "https://resource.services.ai.azure.com"},
+            api_surface="model_inference",
+        )
+        == _SECRET
+    )
+    assert (
+        bind_azure_api_key(
             endpoint=_OTHER_ENDPOINT,
             api_key_env="AZURE_FOUNDRY_API_KEY",
             api_key=_SECRET,

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -130,6 +130,54 @@ def test_classic_route_puts_the_exact_deployment_in_the_path() -> None:
     assert payload["model"] == "exact-deployment"
 
 
+def test_model_inference_route_keeps_deployment_in_body() -> None:
+    """Azure AI Model Inference uses the shared /models route, not deployment-in-path."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "DeepSeek-V4-Flash"),
+        endpoint="https://resource.services.ai.azure.com/models",
+        api_key=_SECRET,
+        api_version="2024-05-01-preview",
+        api_surface="model_inference",
+        transport=transport,
+        chat_max_tokens_field="max_tokens",
+    )
+
+    client.complete(_request())
+
+    url, headers, payload = transport.requests[0]
+    assert url == (
+        "https://resource.services.ai.azure.com/models/chat/completions"
+        "?api-version=2024-05-01-preview"
+    )
+    assert headers["api-key"] == _SECRET
+    assert payload["model"] == "DeepSeek-V4-Flash"
+    assert payload["max_tokens"] == 128
+
+
+def test_model_inference_appends_models_to_a_resource_root() -> None:
+    """A Foundry resource root and its explicit /models root resolve identically."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "FW-GLM-5.2"),
+        endpoint="https://resource.services.ai.azure.com",
+        api_key=_SECRET,
+        api_version="2024-05-01-preview",
+        api_surface="model_inference",
+        transport=transport,
+    )
+
+    client.complete(_request())
+
+    assert transport.requests[0][0].startswith(
+        "https://resource.services.ai.azure.com/models/chat/completions?"
+    )
+
+
 def test_embeddings_use_the_configured_deployment_alias() -> None:
     """Embedding aliases send their own deployment ID rather than a guessed base model."""
     transport = ScriptedJsonTransport(

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -178,6 +178,27 @@ def test_model_inference_appends_models_to_a_resource_root() -> None:
     )
 
 
+def test_model_inference_canonicalizes_terminal_models_path_case() -> None:
+    """Equivalent endpoint spelling emits one lowercase provider wire path."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "DeepSeek-V4-Flash"),
+        endpoint="https://resource.services.ai.azure.com/MODELS",
+        api_key=_SECRET,
+        api_version="2024-05-01-preview",
+        api_surface="model_inference",
+        transport=transport,
+    )
+
+    client.complete(_request())
+
+    assert transport.requests[0][0].startswith(
+        "https://resource.services.ai.azure.com/models/chat/completions?"
+    )
+
+
 def test_model_inference_rejects_v1_without_a_supported_api_version_query() -> None:
     """The model-inference surface never silently omits its required api-version query."""
     with pytest.raises(ValueError, match="dated api_version"):

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -178,6 +178,18 @@ def test_model_inference_appends_models_to_a_resource_root() -> None:
     )
 
 
+def test_model_inference_rejects_v1_without_a_supported_api_version_query() -> None:
+    """The model-inference surface never silently omits its required api-version query."""
+    with pytest.raises(ValueError, match="dated api_version"):
+        AzureClient(
+            model=_snapshot("azure", "DeepSeek-V4-Flash"),
+            endpoint="https://resource.services.ai.azure.com",
+            api_key=_SECRET,
+            api_version="v1",
+            api_surface="model_inference",
+        )
+
+
 def test_embeddings_use_the_configured_deployment_alias() -> None:
     """Embedding aliases send their own deployment ID rather than a guessed base model."""
     transport = ScriptedJsonTransport(

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -220,6 +220,27 @@ def test_model_inference_canonicalizes_redundant_resource_path_separators() -> N
     )
 
 
+def test_model_inference_preserves_identity_distinct_internal_separators() -> None:
+    """Only separators adjacent to the equivalent terminal models suffix collapse."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "DeepSeek-V4-Flash"),
+        endpoint="https://gateway.example.test/tenant-a//azure/models",
+        api_key=_SECRET,
+        api_version="2024-05-01-preview",
+        api_surface="model_inference",
+        transport=transport,
+    )
+
+    client.complete(_request())
+
+    assert transport.requests[0][0].startswith(
+        "https://gateway.example.test/tenant-a//azure/models/chat/completions?"
+    )
+
+
 def test_classic_surface_preserves_endpoint_path_authority() -> None:
     """Classic custom endpoint paths remain byte-distinct from collapsed credentials."""
     transport = ScriptedJsonTransport(

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -220,6 +220,27 @@ def test_model_inference_canonicalizes_redundant_resource_path_separators() -> N
     )
 
 
+def test_classic_surface_preserves_endpoint_path_authority() -> None:
+    """Classic custom endpoint paths remain byte-distinct from collapsed credentials."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_completion_response())]
+    )
+    client = AzureClient(
+        model=_snapshot("azure", "deployment-name"),
+        endpoint="https://gateway.example.test/tenant-a//azure",
+        api_key=_SECRET,
+        api_version="v1",
+        api_surface="openai_deployments",
+        transport=transport,
+    )
+
+    client.complete(_request())
+
+    assert transport.requests[0][0] == (
+        "https://gateway.example.test/tenant-a//azure/openai/v1/chat/completions"
+    )
+
+
 def test_model_inference_rejects_v1_without_a_supported_api_version_query() -> None:
     """The model-inference surface never silently omits its required api-version query."""
     with pytest.raises(ValueError, match="dated api_version"):

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -214,6 +214,8 @@ class RuntimeModelCatalog:
             }
             if connection.api_version is not None:
                 current_connection["api_version"] = connection.api_version
+            if connection.azure_api_surface is not None:
+                current_connection["azure_api_surface"] = connection.azure_api_surface
             if connection.region is not None:
                 current_connection["region"] = connection.region
             current_connection_sha256 = sha256_json(current_connection)
@@ -321,6 +323,7 @@ class RuntimeModelCatalog:
                 endpoint=connection.base_url,
                 api_key=api_key,
                 api_version=connection.api_version,
+                api_surface=connection.azure_api_surface or "openai_deployments",
                 transport=self._transport_factory(),
                 supports_temperature=capabilities.supports_temperature,
                 supports_top_p=_supports_top_p(capabilities),

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -317,6 +317,7 @@ class RuntimeModelCatalog:
                 api_key_env=connection.api_key_env,
                 api_key=api_key,
                 environment=self._environment,
+                api_surface=connection.azure_api_surface or "openai_deployments",
             )
             client = AzureClient(
                 model=snapshot,

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 from exp.common.core.artifacts import sha256_json
@@ -20,6 +22,7 @@ from exp.common.models import (
 )
 from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.preflight import CapabilityRequirement, ModelCapabilityError
+from exp.runtime.models.providers.azure import AzureClient
 from exp.runtime.models.providers.tinker_sampling import (
     TinkerOptionalDependencyError,
     TinkerSample,
@@ -54,6 +57,7 @@ def _catalog(
     base_url: str | None = None,
     api_key_env: str | None = "FIXTURE_API_KEY",
     api_version: str | None = None,
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None,
     region: str | None = None,
     capabilities: ModelCapabilities | None = _DEFAULT_CAPABILITIES,
     served_model_id: str | None = None,
@@ -67,6 +71,7 @@ def _catalog(
                 base_url=base_url,
                 api_key_env=api_key_env,
                 api_version=api_version,
+                azure_api_surface=azure_api_surface,
                 region=region,
             )
         },
@@ -104,6 +109,26 @@ def test_snapshot_is_credential_free_and_records_capability_digest() -> None:
         maximum_output_tokens=16_000,
     )
     assert snapshot.capabilities_sha256 == capabilities.identity_sha256()
+
+
+def test_foundry_catalog_resolution_uses_model_inference_token_field() -> None:
+    """A setup-shaped Foundry connection emits the API surface's max_tokens contract."""
+    catalog = RuntimeModelCatalog(
+        _catalog(
+            provider="azure",
+            base_url="https://resource.services.ai.azure.com",
+            api_version="2024-05-01-preview",
+            azure_api_surface="model_inference",
+            capabilities=ModelCapabilities(supports_completions=True),
+        ),
+        environment={"FIXTURE_API_KEY": "azure-secret"},
+        transport_factory=ScriptedJsonTransport,
+    )
+
+    resolved = catalog.resolve("fixture-model")
+
+    assert isinstance(resolved.client, AzureClient)
+    assert resolved.client.gateway_wire_profile().token_limit_key == "max_tokens"
 
 
 def test_snapshots_preserve_per_model_billing_source_on_one_connection() -> None:

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -2495,6 +2495,7 @@ def _installed_release_driver() -> None:
         ),
         ("azure base URL", azure_endpoint),
         ("Azure OpenAI API version", ""),
+        ("Azure API surface", ""),
         ("Models to configure", space + down + enter),
         ("Connection for the declared model", enter),
         ("Provider model ID", "core-model"),


### PR DESCRIPTION
## Scope

Restores explicit Azure openai_deployments and model_inference surfaces. DeepSeek and GLM model-inference routes use /models/chat/completions and keep the provider model ID in the body.

## Validation

- Focused Azure/catalog/registry tests: 57 passed
- Non-live suite excluding existing macOS picker renderer failures: 2558 passed, 1 skipped
- Ruff, format, ty: passed
- Cargo fmt, clippy no-default-features, test no-default-features: 75 passed

## Supersedes from #639

Supersedes Azure commit a35d32a3, reverted by the Azure hunks of 823df1ce. Files: catalog.py, catalog_test.py, providers/azure.py, providers/azure_test.py, registry.py.

No production verification is claimed. Do not merge or enqueue without explicit approval.