### PR TITLE
fireworks: allow Responses tool_choice none

### DIFF
--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -63,8 +63,6 @@ def _fireworks_continuation_required(
     return (
         request.surface == GatewayApiSurface.RESPONSES
         and _is_fireworks_profile(profile)
-        and request.response_store is False
-        and not request.include_encrypted_reasoning
         and bool(request.tools)
         and request.tool_choice != "none"
     )
@@ -208,9 +206,8 @@ def route_generation_parameter_requests(
     if any(_fireworks_continuation_required(profile, request) for profile in profiles):
         raise ProviderParameterError(
             message=(
-                "Fireworks Responses tool continuations require gateway storage or encrypted "
-                "reasoning. Enable one continuation channel, set tool_choice to 'none', or "
-                "choose another provider route."
+                "Fireworks Responses tool continuations are unavailable on this route. Set "
+                "tool_choice to 'none' or choose another provider route."
             ),
             param="tool_choice",
             code="unsupported_parameter",

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ChatMaxTokensField
 from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
     GatewayNamedToolChoice,
     GatewayRequest,
 )
@@ -53,6 +55,26 @@ _NO_PARALLEL_TOOL_CONTROL_DIALECTS = frozenset(
 )
 
 
+def _fireworks_continuation_required(
+    profile: GatewayWireProfile,
+    request: GatewayRequest,
+) -> bool:
+    """Return whether a Fireworks Responses turn can emit an unretained tool call."""
+    return (
+        request.surface == GatewayApiSurface.RESPONSES
+        and _is_fireworks_profile(profile)
+        and request.response_store is False
+        and not request.include_encrypted_reasoning
+        and bool(request.tools)
+        and request.tool_choice != "none"
+    )
+
+
+def _is_fireworks_profile(profile: GatewayWireProfile) -> bool:
+    """Return whether one wire profile targets the public Fireworks API."""
+    return (urlsplit(profile.url).hostname or "").lower() == "api.fireworks.ai"
+
+
 def dialect_stream_payload(
     profile: GatewayWireProfile,
     provider_request: GatewayRequest,
@@ -70,6 +92,8 @@ def dialect_stream_payload(
         ProviderCapabilityError: The request uses a capability this dialect
             cannot preserve.
     """
+    if _fireworks_continuation_required(profile, provider_request):
+        raise ProviderCapabilityError(capability="responses_fireworks_reasoning_continuation")
     required_reasoning_effort = (
         profile.reasoning_effort if profile.reasoning_effort_required else None
     )
@@ -181,6 +205,16 @@ def route_generation_parameter_requests(
     """
     if not profiles:
         raise ValueError("generation parameter shaping requires at least one wire profile")
+    if any(_fireworks_continuation_required(profile, request) for profile in profiles):
+        raise ProviderParameterError(
+            message=(
+                "Fireworks Responses tool continuations require gateway storage or encrypted "
+                "reasoning. Enable one continuation channel, set tool_choice to 'none', or "
+                "choose another provider route."
+            ),
+            param="tool_choice",
+            code="unsupported_parameter",
+        )
 
     ignored = list(request.ignored_parameters)
     provider_updates: dict[str, object] = {}

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1,6 +1,6 @@
 """Tests for launch-provider streaming request payload translation."""
 
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 
@@ -17,6 +17,7 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
 from exp.runtime.models.providers.errors import (
+    ProviderCapabilityError,
     ProviderParameterError,
     UnsupportedReasoningEffortError,
 )
@@ -58,6 +59,84 @@ def _chat_request(
         stream=True,
         include_usage=True,
     )
+
+
+def _fireworks_responses_request(
+    *,
+    tool_choice: Literal["auto", "none", "required"] | GatewayNamedToolChoice | None = None,
+) -> GatewayRequest:
+    """Build a store-disabled Fireworks Responses request that declares one tool."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
+        tool_choice=tool_choice,
+        response_store=False,
+        stream=True,
+        include_usage=True,
+    )
+
+
+def _fireworks_profile() -> GatewayWireProfile:
+    """Return the exact public Fireworks Chat endpoint profile."""
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://api.fireworks.ai/inference/v1/chat/completions",
+        model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
+    )
+
+
+def test_fireworks_tools_disabled_needs_no_continuation_channel() -> None:
+    """Declared tools plus tool_choice none remains a guaranteed text-only turn."""
+    profile = _fireworks_profile()
+    request = _fireworks_responses_request(tool_choice="none")
+
+    route_generation_parameter_requests((profile,), request)
+    payload = dialect_stream_payload(profile, request)
+
+    assert payload["tool_choice"] == "none"
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    (None, "auto", "required", GatewayNamedToolChoice(name="lookup")),
+)
+def test_fireworks_tools_that_can_run_require_continuation(
+    tool_choice: Literal["auto", "none", "required"] | GatewayNamedToolChoice | None,
+) -> None:
+    """Every selector able to emit a tool call still fails closed without retention."""
+    profile = _fireworks_profile()
+    request = _fireworks_responses_request(tool_choice=tool_choice)
+
+    with pytest.raises(ProviderParameterError, match="continuation"):
+        route_generation_parameter_requests((profile,), request)
+    with pytest.raises(ProviderCapabilityError, match="reasoning_continuation"):
+        dialect_stream_payload(profile, request)
+
+
+def test_fireworks_continuation_gate_accepts_safe_alternatives() -> None:
+    """No tools or gateway storage each provide a safe route."""
+    profile = _fireworks_profile()
+    request = _fireworks_responses_request()
+
+    for safe in (
+        request.model_copy(update={"tools": ()}),
+        request.model_copy(update={"response_store": True}),
+    ):
+        route_generation_parameter_requests((profile,), safe)
+        assert dialect_stream_payload(profile, safe)["stream"] is True
+
+
+def test_fireworks_encrypted_reasoning_waits_for_the_authenticated_carrier() -> None:
+    """This small gate never claims the incompatible Chat wire preserves encrypted state."""
+    profile = _fireworks_profile()
+    request = _fireworks_responses_request().model_copy(
+        update={"include_encrypted_reasoning": True}
+    )
+
+    with pytest.raises(ProviderParameterError, match="encrypted reasoning") as raised:
+        route_generation_parameter_requests((profile,), request)
+    assert raised.value.param == "include"
 
 
 def test_openai_compatible_stream_payload_forwards_top_p_and_usage() -> None:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -114,17 +114,29 @@ def test_fireworks_tools_that_can_run_require_continuation(
         dialect_stream_payload(profile, request)
 
 
-def test_fireworks_continuation_gate_accepts_safe_alternatives() -> None:
-    """No tools or gateway storage each provide a safe route."""
+def test_fireworks_continuation_gate_accepts_no_tools() -> None:
+    """A request without tools needs no continuation channel."""
     profile = _fireworks_profile()
     request = _fireworks_responses_request()
 
-    for safe in (
-        request.model_copy(update={"tools": ()}),
-        request.model_copy(update={"response_store": True}),
-    ):
-        route_generation_parameter_requests((profile,), safe)
-        assert dialect_stream_payload(profile, safe)["stream"] is True
+    safe = request.model_copy(update={"tools": ()})
+    route_generation_parameter_requests((profile,), safe)
+    assert dialect_stream_payload(profile, safe)["stream"] is True
+
+
+@pytest.mark.parametrize(
+    "update",
+    ({"response_store": True}, {"include_encrypted_reasoning": True}),
+)
+def test_fireworks_unimplemented_continuation_channels_still_fail_closed(
+    update: dict[str, bool],
+) -> None:
+    """Storage flags cannot claim retention before the carrier PR lands."""
+    profile = _fireworks_profile()
+    request = _fireworks_responses_request().model_copy(update=update)
+
+    with pytest.raises(ProviderParameterError, match="unavailable"):
+        route_generation_parameter_requests((profile,), request)
 
 
 def test_fireworks_encrypted_reasoning_waits_for_the_authenticated_carrier() -> None:
@@ -134,9 +146,9 @@ def test_fireworks_encrypted_reasoning_waits_for_the_authenticated_carrier() -> 
         update={"include_encrypted_reasoning": True}
     )
 
-    with pytest.raises(ProviderParameterError, match="encrypted reasoning") as raised:
+    with pytest.raises(ProviderParameterError, match="unavailable") as raised:
         route_generation_parameter_requests((profile,), request)
-    assert raised.value.param == "include"
+    assert raised.value.param == "tool_choice"
 
 
 def test_openai_compatible_stream_payload_forwards_top_p_and_usage() -> None:


### PR DESCRIPTION
## Scope

Allows Fireworks Responses requests that declare tools but explicitly disable them with tool_choice none. Tool-capable selectors still fail closed when neither gateway storage nor encrypted continuation is available.

## Validation

- Focused Fireworks route and direct-payload tests: 6 passed
- Non-live suite excluding existing macOS picker renderer failures: 2562 passed, 1 skipped
- Ruff, format, ty: passed
- Cargo fmt, clippy no-default-features, test no-default-features: 75 passed

## Supersedes from #639

Supersedes only the Fireworks tool_choice none hunks from 8afd08d3. Files: providers/streaming_requests.py and streaming_requests_test.py.

No production verification is claimed. Do not merge or enqueue without explicit approval.