### PR TITLE
gateway: enforce capability-aware waterfall admission

### DIFF
--- a/exp/cli/gateway/alias.py
+++ b/exp/cli/gateway/alias.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import typer
 
+from exp.cli.gateway.capability_authority import retained_streaming_tool_arguments
 from exp.cli.gateway.receipts import GatewayReceipt, emit_items, emit_receipt
 from exp.cli.shared.options import ROOT_OPTION, usage_error
 from exp.common.core.artifacts import sha256_json
@@ -17,7 +18,6 @@ from exp.common.models import (
     GatewayTokenPrices,
     ModelCapabilities,
     ModelCatalog,
-    load_model_catalog,
 )
 from exp.optimize.router.activation import load_project_router
 from exp.runtime.gateway.catalog_authority import (
@@ -282,17 +282,12 @@ def _activate(
         provider = serving_connections[connection].provider
         declared_streaming_tool_arguments = supports_streaming_tool_arguments
         if declared_streaming_tool_arguments is None and replace:
-            catalog_path = root / "models.toml"
-            if catalog_path.exists():
-                existing = load_model_catalog(catalog_path).models.get(alias)
-                if (
-                    existing is not None
-                    and existing.connection == connection
-                    and existing.gateway is not None
-                ):
-                    declared_streaming_tool_arguments = (
-                        existing.gateway.capabilities.supports_streaming_tool_arguments
-                    )
+            declared_streaming_tool_arguments = retained_streaming_tool_arguments(
+                manager,
+                alias_id=alias,
+                connection_id=connection,
+                connection=serving_connections[connection],
+            )
         if declared_streaming_tool_arguments is None:
             declared_streaming_tool_arguments = provider_has_certified_capability(
                 provider,

--- a/exp/cli/gateway/alias.py
+++ b/exp/cli/gateway/alias.py
@@ -26,6 +26,10 @@ from exp.runtime.gateway.catalog_authority import (
     upsert_singleton_deployment,
 )
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.provider_certification import (
+    ProviderCapability,
+    provider_has_certified_capability,
+)
 
 alias_app = typer.Typer(help="Manage public gateway model aliases.", no_args_is_help=True)
 _JSON_OPTION = typer.Option(False, "--json")
@@ -263,6 +267,7 @@ def _activate(
         if exact_model is None:
             raise ValueError("direct aliases require --exact-model")
         connection, provider_model = parse_deployment(deployment)
+        provider = serving_connections[connection].provider
         normalized, snapshot, _catalog_changed = upsert_singleton_deployment(
             root,
             deployment_alias=alias,
@@ -277,7 +282,13 @@ def _activate(
             ),
             gateway_capabilities=GatewayDeploymentCapabilities(
                 supports_streaming=True,
-                supports_streaming_tool_arguments=supports_tools,
+                supports_streaming_tool_arguments=(
+                    supports_tools
+                    and provider_has_certified_capability(
+                        provider,
+                        ProviderCapability.TOOL_ARGUMENT_STREAM,
+                    )
+                ),
                 supports_developer_messages=supports_developer_messages,
                 supports_strict_tools=supports_strict_tools,
                 supports_parallel_tool_calls=supports_parallel_tool_calls,

--- a/exp/cli/gateway/alias.py
+++ b/exp/cli/gateway/alias.py
@@ -17,6 +17,7 @@ from exp.common.models import (
     GatewayTokenPrices,
     ModelCapabilities,
     ModelCatalog,
+    load_model_catalog,
 )
 from exp.optimize.router.activation import load_project_router
 from exp.runtime.gateway.catalog_authority import (
@@ -44,6 +45,10 @@ _PRICING_SOURCE_OPTION = typer.Option(None, "--pricing-source")
 _MAXIMUM_OUTPUT_OPTION = typer.Option(None, "--maximum-output-tokens", min=1)
 _REFUSAL_FAILOVER_OPTION = typer.Option(False, "--refusal-failover")
 _BILLING_SOURCE_OPTION = typer.Option(None, "--billing-source")
+_STREAMING_TOOL_ARGUMENTS_OPTION = typer.Option(
+    None,
+    "--supports-streaming-tool-arguments/--no-supports-streaming-tool-arguments",
+)
 
 
 @alias_app.command("list")
@@ -67,6 +72,7 @@ def alias_create(
     supports_developer_messages: bool = typer.Option(False, "--supports-developer-messages"),
     supports_strict_tools: bool = typer.Option(False, "--supports-strict-tools"),
     supports_parallel_tool_calls: bool = typer.Option(False, "--supports-parallel-tool-calls"),
+    supports_streaming_tool_arguments: bool | None = _STREAMING_TOOL_ARGUMENTS_OPTION,
     maximum_output_tokens: int | None = _MAXIMUM_OUTPUT_OPTION,
     input_price: int | None = typer.Option(None, "--input-price", min=0),
     cached_input_price: int | None = typer.Option(None, "--cached-input-price", min=0),
@@ -95,6 +101,7 @@ def alias_create(
             supports_developer_messages=supports_developer_messages,
             supports_strict_tools=supports_strict_tools,
             supports_parallel_tool_calls=supports_parallel_tool_calls,
+            supports_streaming_tool_arguments=supports_streaming_tool_arguments,
             maximum_output_tokens=maximum_output_tokens,
             prices=GatewayTokenPrices(
                 input_micro_usd_per_million_tokens=input_price,
@@ -144,6 +151,7 @@ def alias_update(
     supports_developer_messages: bool = typer.Option(False, "--supports-developer-messages"),
     supports_strict_tools: bool = typer.Option(False, "--supports-strict-tools"),
     supports_parallel_tool_calls: bool = typer.Option(False, "--supports-parallel-tool-calls"),
+    supports_streaming_tool_arguments: bool | None = _STREAMING_TOOL_ARGUMENTS_OPTION,
     maximum_output_tokens: int | None = _MAXIMUM_OUTPUT_OPTION,
     input_price: int | None = typer.Option(None, "--input-price", min=0),
     cached_input_price: int | None = typer.Option(None, "--cached-input-price", min=0),
@@ -172,6 +180,7 @@ def alias_update(
             supports_developer_messages=supports_developer_messages,
             supports_strict_tools=supports_strict_tools,
             supports_parallel_tool_calls=supports_parallel_tool_calls,
+            supports_streaming_tool_arguments=supports_streaming_tool_arguments,
             maximum_output_tokens=maximum_output_tokens,
             prices=GatewayTokenPrices(
                 input_micro_usd_per_million_tokens=input_price,
@@ -244,6 +253,7 @@ def _activate(
     supports_developer_messages: bool,
     supports_strict_tools: bool,
     supports_parallel_tool_calls: bool,
+    supports_streaming_tool_arguments: bool | None,
     maximum_output_tokens: int | None,
     prices: GatewayTokenPrices,
     pricing_source: str | None,
@@ -267,7 +277,27 @@ def _activate(
         if exact_model is None:
             raise ValueError("direct aliases require --exact-model")
         connection, provider_model = parse_deployment(deployment)
+        if connection not in serving_connections:
+            raise ValueError(f"deployment names unknown provider connection {connection!r}")
         provider = serving_connections[connection].provider
+        declared_streaming_tool_arguments = supports_streaming_tool_arguments
+        if declared_streaming_tool_arguments is None and replace:
+            catalog_path = root / "models.toml"
+            if catalog_path.exists():
+                existing = load_model_catalog(catalog_path).models.get(alias)
+                if (
+                    existing is not None
+                    and existing.connection == connection
+                    and existing.gateway is not None
+                ):
+                    declared_streaming_tool_arguments = (
+                        existing.gateway.capabilities.supports_streaming_tool_arguments
+                    )
+        if declared_streaming_tool_arguments is None:
+            declared_streaming_tool_arguments = provider_has_certified_capability(
+                provider,
+                ProviderCapability.TOOL_ARGUMENT_STREAM,
+            )
         normalized, snapshot, _catalog_changed = upsert_singleton_deployment(
             root,
             deployment_alias=alias,
@@ -282,13 +312,7 @@ def _activate(
             ),
             gateway_capabilities=GatewayDeploymentCapabilities(
                 supports_streaming=True,
-                supports_streaming_tool_arguments=(
-                    supports_tools
-                    and provider_has_certified_capability(
-                        provider,
-                        ProviderCapability.TOOL_ARGUMENT_STREAM,
-                    )
-                ),
+                supports_streaming_tool_arguments=declared_streaming_tool_arguments,
                 supports_developer_messages=supports_developer_messages,
                 supports_strict_tools=supports_strict_tools,
                 supports_parallel_tool_calls=supports_parallel_tool_calls,

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -365,6 +365,101 @@ def test_direct_alias_uses_provider_certification_for_tool_streaming(
     assert not replaced_custom.gateway.capabilities.supports_streaming_tool_arguments
 
 
+def test_direct_alias_preserves_tool_streaming_across_credential_env_rotation(
+    tmp_path: Path,
+) -> None:
+    """Credential locator rotation retains the same endpoint's explicit declaration."""
+    runner = CliRunner()
+    commands = (
+        ["config", "gateway", "init", "--root", str(tmp_path), "--json"],
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "custom",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://custom.example.test/v1",
+            "--credential-env",
+            "OLD_CUSTOM_API_KEY",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            "custom-tools",
+            "--deployment",
+            "custom:custom-fixture",
+            "--exact-model",
+            "custom-tools",
+            "--supports-tools",
+            "--supports-streaming-tool-arguments",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    for command in commands:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0, result.output
+
+    rotated = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "custom",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://custom.example.test/v1",
+            "--credential-env",
+            "NEW_CUSTOM_API_KEY",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert rotated.exit_code == 0, rotated.output
+    updated = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "alias",
+            "update",
+            "custom-tools",
+            "--deployment",
+            "custom:custom-fixture-v2",
+            "--exact-model",
+            "custom-tools",
+            "--supports-tools",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert updated.exit_code == 0, updated.output
+
+    catalog = load_model_catalog(tmp_path / "models.toml")
+    custom = catalog.models["custom-tools"]
+    assert catalog.connections["custom"].api_key_env == "NEW_CUSTOM_API_KEY"
+    assert custom.gateway is not None
+    assert custom.gateway.capabilities.supports_streaming_tool_arguments
+
+
 def test_direct_alias_rejects_an_unknown_provider_connection_cleanly(tmp_path: Path) -> None:
     """A deployment typo is a stable CLI usage error, never an unhandled mapping failure."""
     runner = CliRunner()

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -190,6 +190,79 @@ def test_noninteractive_management_story_emits_stable_secret_safe_json(
     assert raw_key.encode() not in durable
 
 
+def test_direct_alias_uses_provider_certification_for_tool_streaming(
+    tmp_path: Path,
+) -> None:
+    """Alias authoring never infers raw argument streaming from model tool support alone."""
+    runner = CliRunner()
+    commands = (
+        ["config", "gateway", "init", "--root", str(tmp_path), "--json"],
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "oai",
+            "--provider",
+            "openai",
+            "--credential-env",
+            "OPENAI_API_KEY",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "google",
+            "--provider",
+            "gemini",
+            "--credential-env",
+            "GEMINI_API_KEY",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    for command in commands:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0, result.output
+    for alias, deployment in (
+        ("oai-tools", "oai:gpt-fixture"),
+        ("gemini-tools", "google:gemini-fixture"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "gateway",
+                "alias",
+                "create",
+                alias,
+                "--deployment",
+                deployment,
+                "--exact-model",
+                alias,
+                "--supports-tools",
+                "--root",
+                str(tmp_path),
+                "--non-interactive",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    catalog = load_model_catalog(tmp_path / "models.toml")
+    assert catalog.models["oai-tools"].gateway is not None
+    assert catalog.models["gemini-tools"].gateway is not None
+    assert catalog.models["oai-tools"].gateway.capabilities.supports_streaming_tool_arguments
+    assert not catalog.models["gemini-tools"].gateway.capabilities.supports_streaming_tool_arguments
+
+
 def test_noninteractive_pool_certification_activates_ordered_alias_with_receipt(
     tmp_path: Path,
 ) -> None:

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -217,6 +217,21 @@ def test_direct_alias_uses_provider_certification_for_tool_streaming(
             "gateway",
             "provider",
             "add",
+            "custom",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://custom.example.test/v1",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
             "google",
             "--provider",
             "gemini",
@@ -255,12 +270,87 @@ def test_direct_alias_uses_provider_certification_for_tool_streaming(
             ],
         )
         assert result.exit_code == 0, result.output
+    custom = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            "custom-tools",
+            "--deployment",
+            "custom:custom-fixture",
+            "--exact-model",
+            "custom-tools",
+            "--supports-tools",
+            "--supports-streaming-tool-arguments",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert custom.exit_code == 0, custom.output
+    updated = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "alias",
+            "update",
+            "custom-tools",
+            "--deployment",
+            "custom:custom-fixture",
+            "--exact-model",
+            "custom-tools",
+            "--supports-tools",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert updated.exit_code == 0, updated.output
 
     catalog = load_model_catalog(tmp_path / "models.toml")
     assert catalog.models["oai-tools"].gateway is not None
     assert catalog.models["gemini-tools"].gateway is not None
+    assert catalog.models["custom-tools"].gateway is not None
     assert catalog.models["oai-tools"].gateway.capabilities.supports_streaming_tool_arguments
     assert not catalog.models["gemini-tools"].gateway.capabilities.supports_streaming_tool_arguments
+    assert catalog.models["custom-tools"].gateway.capabilities.supports_streaming_tool_arguments
+
+
+def test_direct_alias_rejects_an_unknown_provider_connection_cleanly(tmp_path: Path) -> None:
+    """A deployment typo is a stable CLI usage error, never an unhandled mapping failure."""
+    runner = CliRunner()
+    initialized = runner.invoke(
+        app,
+        ["config", "gateway", "init", "--root", str(tmp_path), "--json"],
+    )
+    assert initialized.exit_code == 0, initialized.output
+
+    result = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "alias",
+            "create",
+            "typo",
+            "--deployment",
+            "missing:model",
+            "--exact-model",
+            "model",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "unknown provider connection 'missing'" in result.output
 
 
 def test_noninteractive_pool_certification_activates_ordered_alias_with_receipt(

--- a/exp/cli/gateway/app_test.py
+++ b/exp/cli/gateway/app_test.py
@@ -320,6 +320,50 @@ def test_direct_alias_uses_provider_certification_for_tool_streaming(
     assert not catalog.models["gemini-tools"].gateway.capabilities.supports_streaming_tool_arguments
     assert catalog.models["custom-tools"].gateway.capabilities.supports_streaming_tool_arguments
 
+    replaced = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "custom",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://replacement.example.test/v1",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert replaced.exit_code == 0, replaced.output
+    recertified = runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "alias",
+            "update",
+            "custom-tools",
+            "--deployment",
+            "custom:custom-fixture",
+            "--exact-model",
+            "custom-tools",
+            "--supports-tools",
+            "--root",
+            str(tmp_path),
+            "--non-interactive",
+            "--json",
+        ],
+    )
+    assert recertified.exit_code == 0, recertified.output
+    replaced_catalog = load_model_catalog(tmp_path / "models.toml")
+    replaced_custom = replaced_catalog.models["custom-tools"]
+    assert replaced_custom.gateway is not None
+    assert not replaced_custom.gateway.capabilities.supports_streaming_tool_arguments
+
 
 def test_direct_alias_rejects_an_unknown_provider_connection_cleanly(tmp_path: Path) -> None:
     """A deployment typo is a stable CLI usage error, never an unhandled mapping failure."""

--- a/exp/cli/gateway/capability_authority.py
+++ b/exp/cli/gateway/capability_authority.py
@@ -49,7 +49,7 @@ def retained_streaming_tool_arguments(
         record is None
         or record.connection != connection_id
         or record.gateway is None
-        or snapshot.connections.get(connection_id) != connection
+        or snapshot.connections.get(connection_id) != bound.config
     ):
         return None
     return record.gateway.capabilities.supports_streaming_tool_arguments

--- a/exp/cli/gateway/capability_authority.py
+++ b/exp/cli/gateway/capability_authority.py
@@ -1,0 +1,55 @@
+"""Read exact prior endpoint capability declarations during CLI reconfiguration."""
+
+from __future__ import annotations
+
+from exp.common.models import ConnectionConfig, ModelCatalog
+from exp.runtime.gateway.catalog_authority import authored_snapshot_path
+from exp.runtime.gateway.management import GatewayManagement
+
+
+def retained_streaming_tool_arguments(
+    manager: GatewayManagement,
+    *,
+    alias_id: str,
+    connection_id: str,
+    connection: ConnectionConfig,
+) -> bool | None:
+    """Return a prior declaration only for the same frozen endpoint identity.
+
+    The mutable connection name is insufficient authority: an operator may
+    replace its endpoint while retaining the name. The active alias revision's
+    immutable snapshot and provider binding must both match the candidate
+    connection before its endpoint-specific declaration can be reused.
+    """
+    active = next(
+        (item for item in manager.aliases() if item.alias_id == alias_id and item.active),
+        None,
+    )
+    if active is None or active.revision_id is None or active.snapshot_ref is None:
+        return None
+    bound = next(
+        (
+            item
+            for item in manager.alias_provider_connections(
+                alias_id=alias_id,
+                alias_revision_id=active.revision_id,
+            )
+            if item.connection_id == connection_id
+        ),
+        None,
+    )
+    if bound is None or bound.config.identity_sha256() != connection.identity_sha256():
+        return None
+    normalized_snapshot = manager.root / "gateway" / active.snapshot_ref
+    snapshot = ModelCatalog.model_validate_json(
+        authored_snapshot_path(normalized_snapshot).read_bytes()
+    )
+    record = snapshot.models.get(alias_id)
+    if (
+        record is None
+        or record.connection != connection_id
+        or record.gateway is None
+        or snapshot.connections.get(connection_id) != connection
+    ):
+        return None
+    return record.gateway.capabilities.supports_streaming_tool_arguments

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.prompt import Confirm
 from rich.table import Table
 from rich.text import Text
 
@@ -203,6 +204,28 @@ def interactive_gateway_setup(
                 "reasoning_effort": model_selection.reasoning_effort,
             }
         )
+    selected_connections = {
+        item.connection_id: item.config
+        for item in (manager.provider_connections() if manager.initialized else ())
+    }
+    for endpoint in session.endpoints:
+        selected_connections[endpoint.connection.name] = endpoint.connection.catalog_config()
+    selected_provider = selected_connections[selected.connection].provider
+    supports_streaming_tool_arguments = provider_has_certified_capability(
+        selected_provider,
+        ProviderCapability.TOOL_ARGUMENT_STREAM,
+    )
+    if selected.connection == HOSTED_SETUP_PICKER:
+        supports_streaming_tool_arguments = True
+    elif selected_provider == "openai-compatible" and capabilities.supports_tools:
+        try:
+            supports_streaming_tool_arguments = Confirm.ask(
+                "Does this custom endpoint stream tool-call arguments?",
+                default=False,
+                console=console,
+            )
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise typer.Abort from exc
     total_steps = len(session.endpoints) + 8
     completed_steps = 0
 
@@ -249,13 +272,7 @@ def interactive_gateway_setup(
                         capabilities=capabilities,
                         gateway_capabilities=GatewayDeploymentCapabilities(
                             supports_streaming=True,
-                            supports_streaming_tool_arguments=(
-                                bool(capabilities.supports_tools)
-                                and provider_has_certified_capability(
-                                    serving_connections[selected.connection].provider,
-                                    ProviderCapability.TOOL_ARGUMENT_STREAM,
-                                )
-                            ),
+                            supports_streaming_tool_arguments=supports_streaming_tool_arguments,
                         ),
                         prices=GatewayTokenPrices(),
                         pricing_source=None,

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -55,6 +55,10 @@ from exp.runtime.gateway.catalog_authority import (
     rollback_singleton_deployment_update,
 )
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.provider_certification import (
+    ProviderCapability,
+    provider_has_certified_capability,
+)
 from exp.runtime.gateway.sqlite.alias_activation import AliasActivationOutcomeUnknownError
 from exp.runtime.models.providers import HttpProviderModelLister, ProviderModelLister
 
@@ -243,7 +247,16 @@ def interactive_gateway_setup(
                         exact_model_id=_gateway_exact_model_id(selected),
                         revision=None,
                         capabilities=capabilities,
-                        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                        gateway_capabilities=GatewayDeploymentCapabilities(
+                            supports_streaming=True,
+                            supports_streaming_tool_arguments=(
+                                bool(capabilities.supports_tools)
+                                and provider_has_certified_capability(
+                                    serving_connections[selected.connection].provider,
+                                    ProviderCapability.TOOL_ARGUMENT_STREAM,
+                                )
+                            ),
+                        ),
                         prices=GatewayTokenPrices(),
                         pricing_source=None,
                         billing_source=(

--- a/exp/cli/gateway/setup.py
+++ b/exp/cli/gateway/setup.py
@@ -15,6 +15,7 @@ from rich.prompt import Confirm
 from rich.table import Table
 from rich.text import Text
 
+from exp.cli.gateway.capability_authority import retained_streaming_tool_arguments
 from exp.cli.gateway.guardrail_setup import (
     GUARDRAILS_OFF,
     GuardrailSetupPlan,
@@ -217,11 +218,21 @@ def interactive_gateway_setup(
     )
     if selected.connection == HOSTED_SETUP_PICKER:
         supports_streaming_tool_arguments = True
-    elif selected_provider == "openai-compatible" and capabilities.supports_tools:
+    elif selected_provider == "openai-compatible" and capabilities.supports_tools is not False:
+        existing_declaration = (
+            retained_streaming_tool_arguments(
+                manager,
+                alias_id=values.alias,
+                connection_id=selected.connection,
+                connection=selected_connections[selected.connection],
+            )
+            if reconfigure
+            else None
+        )
         try:
             supports_streaming_tool_arguments = Confirm.ask(
                 "Does this custom endpoint stream tool-call arguments?",
-                default=False,
+                default=existing_declaration or False,
                 console=console,
             )
         except (EOFError, KeyboardInterrupt) as exc:

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -191,11 +191,66 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     assert load_settings(tmp_path).commands.maximum_cost_usd == 50.0
 
 
+@pytest.mark.parametrize("supports_tools", (True, None))
 def test_gateway_setup_collects_custom_endpoint_tool_streaming_capability(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    supports_tools: bool | None,
 ) -> None:
-    """Interactive custom setup records endpoint truth instead of provider-family inference."""
+    """Custom setup asks for endpoint truth unless model tool support is explicitly false."""
+    connection = ProviderConnection(
+        name="custom",
+        provider="openai-compatible",
+        base_url="https://custom.example.test/v1",
+        api_key_env="CUSTOM_API_KEY",
+    )
+    endpoint = provider_picker.PreparedEndpoint(
+        connection=connection,
+        api_key="secret",
+        configured=True,
+    )
+    model = provider_picker.AvailableModel(
+        alias="custom-tools",
+        connection="custom",
+        provider="openai-compatible",
+        model="custom-tools",
+        capabilities=ModelCapabilities(
+            supports_completions=True,
+            supports_tools=supports_tools,
+        ),
+        pricing_source=PricingSource.UNKNOWN,
+        configured=True,
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai-compatible",), False),
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((endpoint,), (model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(model, None),
+    )
+    console = ScriptedConsole("\ny\n")
+
+    setup.interactive_gateway_setup(tmp_path, console=console)
+
+    authored = load_model_catalog(tmp_path / "models.toml").models["custom-tools"]
+    assert authored.gateway is not None
+    assert authored.gateway.capabilities.supports_streaming_tool_arguments
+    assert "Does this custom endpoint stream tool-call arguments?" in console.output
+
+
+def test_gateway_setup_reconfigure_preserves_same_custom_endpoint_declaration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting defaults retains explicit transport truth for the same frozen endpoint."""
     connection = ProviderConnection(
         name="custom",
         provider="openai-compatible",
@@ -231,9 +286,14 @@ def test_gateway_setup_collects_custom_endpoint_tool_streaming_capability(
         "select_gateway_model",
         lambda *_args, **_kwargs: model_picker.GatewayModelSelection(model, None),
     )
-    console = ScriptedConsole("\ny\n")
+    first = setup.interactive_gateway_setup(tmp_path, console=ScriptedConsole("\ny\n"))
 
-    setup.interactive_gateway_setup(tmp_path, console=console)
+    console = ScriptedConsole(f"edit\n{first.alias}\ndefault\n50\noff\n\n")
+    setup.interactive_gateway_setup(
+        tmp_path,
+        console=console,
+        allow_reconfigure=True,
+    )
 
     authored = load_model_catalog(tmp_path / "models.toml").models["custom-tools"]
     assert authored.gateway is not None

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -53,6 +53,7 @@ def _prepared_gateway_models() -> tuple[
         model="gpt-5.6-luna",
         capabilities=ModelCapabilities(
             supports_completions=True,
+            supports_tools=True,
             supports_reasoning=True,
             reasoning_effort="medium",
         ),
@@ -184,6 +185,9 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
         "anthropic",
     }
     assert {item.alias_id for item in manager.aliases()} == {"gpt-5-6-luna"}
+    authored = load_model_catalog(tmp_path / "models.toml").models["gpt-5-6-luna"]
+    assert authored.gateway is not None
+    assert authored.gateway.capabilities.supports_streaming_tool_arguments
     assert load_settings(tmp_path).commands.maximum_cost_usd == 50.0
 
 

--- a/exp/cli/gateway/setup_test.py
+++ b/exp/cli/gateway/setup_test.py
@@ -191,6 +191,56 @@ def test_gateway_setup_persists_selected_connections_and_one_initial_alias(
     assert load_settings(tmp_path).commands.maximum_cost_usd == 50.0
 
 
+def test_gateway_setup_collects_custom_endpoint_tool_streaming_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive custom setup records endpoint truth instead of provider-family inference."""
+    connection = ProviderConnection(
+        name="custom",
+        provider="openai-compatible",
+        base_url="https://custom.example.test/v1",
+        api_key_env="CUSTOM_API_KEY",
+    )
+    endpoint = provider_picker.PreparedEndpoint(
+        connection=connection,
+        api_key="secret",
+        configured=True,
+    )
+    model = provider_picker.AvailableModel(
+        alias="custom-tools",
+        connection="custom",
+        provider="openai-compatible",
+        model="custom-tools",
+        capabilities=ModelCapabilities(supports_completions=True, supports_tools=True),
+        pricing_source=PricingSource.UNKNOWN,
+        configured=True,
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_providers",
+        lambda *_args, **_kwargs: (("openai-compatible",), False),
+    )
+    monkeypatch.setattr(
+        setup,
+        "prepare_providers",
+        lambda *_args, **_kwargs: ((endpoint,), (model,)),
+    )
+    monkeypatch.setattr(
+        setup,
+        "select_gateway_model",
+        lambda *_args, **_kwargs: model_picker.GatewayModelSelection(model, None),
+    )
+    console = ScriptedConsole("\ny\n")
+
+    setup.interactive_gateway_setup(tmp_path, console=console)
+
+    authored = load_model_catalog(tmp_path / "models.toml").models["custom-tools"]
+    assert authored.gateway is not None
+    assert authored.gateway.capabilities.supports_streaming_tool_arguments
+    assert "Does this custom endpoint stream tool-call arguments?" in console.output
+
+
 def test_gateway_setup_marks_experiential_deployment_as_host_managed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -774,7 +774,10 @@ def _configured_gateway(
         exact_model_id="model-revision-exact",
         revision=None,
         capabilities=capabilities or ModelCapabilities(),
-        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+        gateway_capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        ),
         prices=GatewayTokenPrices(),
         pricing_source=None,
         replace=False,

--- a/exp/runtime/gateway/management.py
+++ b/exp/runtime/gateway/management.py
@@ -310,6 +310,21 @@ class GatewayManagement:
             organization_id=self.organization_id,
         )
 
+    def alias_provider_connections(
+        self,
+        *,
+        alias_id: str,
+        alias_revision_id: str,
+    ) -> tuple[ProviderConnectionAuthority, ...]:
+        """Return the exact provider revisions frozen into one alias revision."""
+        if not self.initialized:
+            return ()
+        return self.require_initialized().alias_provider_connections(
+            organization_id=self.organization_id,
+            alias_id=alias_id,
+            alias_revision_id=alias_revision_id,
+        )
+
     def disable_provider_connection(self, *, connection_id: str) -> bool:
         """Disable one provider connection not used by an active alias revision."""
         return self.require_initialized().disable_provider_connection(

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -114,26 +114,42 @@ from exp.runtime.openai_protocol.state import (
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
 _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
-    "developer_messages": "messages",
-    "function_tools": "tools",
-    "parallel_tool_calls": "parallel_tool_calls",
-    "stop_sequences": "stop",
-    "streaming": "stream",
-    "strict_tools": "tools",
-    "structured_output": "response_format",
-    "structured_text": "response_format",
+    GatewayApiSurface.CHAT_COMPLETIONS: {
+        "developer_messages": "messages",
+        "function_tools": "tools",
+        "parallel_tool_calls": "parallel_tool_calls",
+        "stop_sequences": "stop",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+        "structured_output": "response_format",
+        "structured_text": "response_format",
+    },
+    GatewayApiSurface.RESPONSES: {
+        "developer_messages": "instructions",
+        "function_tools": "tools",
+        "parallel_tool_calls": "parallel_tool_calls",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+        "structured_output": "text.format",
+        "structured_text": "text.format",
+    },
+    GatewayApiSurface.MESSAGES: {
+        "developer_messages": "system",
+        "function_tools": "tools",
+        "parallel_tool_calls": "tool_choice.disable_parallel_tool_use",
+        "stop_sequences": "stop_sequences",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+    },
 }
 
 
 def _public_capability_param(capability: str, surface: GatewayApiSurface) -> str | None:
     """Translate an internal capability label to the caller's request field."""
-    parameter = _PUBLIC_REQUEST_CAPABILITY_PARAMS.get(capability)
-    if surface == GatewayApiSurface.RESPONSES:
-        if parameter == "messages":
-            return "input"
-        if parameter == "response_format":
-            return "text.format"
-    return parameter
+    return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
 
 
 _logger = logging.getLogger(__name__)
@@ -486,12 +502,12 @@ class NativeControlPlane(NativeObservabilityMixin):
             # request feature the route cannot preserve.
             failure = normalized_provider_failure(exc)
             self._accounting.finish_request_quietly(authorization, failure)
-            capability_param = (
+            failure_param = (
                 _public_capability_param(exc.capability, provider_request.surface)
                 if isinstance(exc, ProviderCapabilityError)
-                else None
+                else exc.param
             )
-            raise NativeBridgeError(public_failure_error(failure, param=capability_param)) from exc
+            raise NativeBridgeError(public_failure_error(failure, param=failure_param)) from exc
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             error = _authority_error(exc)
             failure = GatewayFailure(

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -448,7 +448,6 @@ class NativeControlPlane(NativeObservabilityMixin):
                         provider_request,
                         deployment.gateway.capabilities,
                         model_capabilities=deployment.capabilities,
-                        requested_stream=public_request.stream,
                     )
                     dialect_stream_payload(profile, provider_request)
                 except (ProviderParameterError, ProviderCapabilityError) as exc:
@@ -482,7 +481,6 @@ class NativeControlPlane(NativeObservabilityMixin):
                     provider_request,
                     deployment.gateway.capabilities,
                     model_capabilities=deployment.capabilities,
-                    requested_stream=public_request.stream,
                 )
                 upstream_payload = dialect_stream_payload(profile, provider_request)
                 upstream_body, dispatch_signer = frozen_dispatch(profile, client, upstream_payload)

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -118,8 +118,10 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = frozenset(
         "developer_messages",
         "function_tools",
         "parallel_tool_calls",
+        "stop_sequences",
         "streaming",
         "strict_tools",
+        "structured_output",
         "structured_text",
     }
 )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -159,10 +159,10 @@ def _public_capability_param(
     public_tools: bool = False,
 ) -> str | None:
     """Translate an internal capability label to the caller's request field."""
-    if capability == "streaming_tool_arguments" and not public_stream:
+    if capability == "streaming_tool_arguments":
         return "tools"
     if capability == "streaming" and not public_stream:
-        return "tools" if public_tools else None
+        return None
     return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
 
 

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -113,18 +113,28 @@ from exp.runtime.openai_protocol.state import (
 )
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
-_PUBLIC_REQUEST_CAPABILITY_PARAMS = frozenset(
-    {
-        "developer_messages",
-        "function_tools",
-        "parallel_tool_calls",
-        "stop_sequences",
-        "streaming",
-        "strict_tools",
-        "structured_output",
-        "structured_text",
-    }
-)
+_PUBLIC_REQUEST_CAPABILITY_PARAMS = {
+    "developer_messages": "messages",
+    "function_tools": "tools",
+    "parallel_tool_calls": "parallel_tool_calls",
+    "stop_sequences": "stop",
+    "streaming": "stream",
+    "strict_tools": "tools",
+    "structured_output": "response_format",
+    "structured_text": "response_format",
+}
+
+
+def _public_capability_param(capability: str, surface: GatewayApiSurface) -> str | None:
+    """Translate an internal capability label to the caller's request field."""
+    parameter = _PUBLIC_REQUEST_CAPABILITY_PARAMS.get(capability)
+    if surface == GatewayApiSurface.RESPONSES:
+        if parameter == "messages":
+            return "input"
+        if parameter == "response_format":
+            return "text.format"
+    return parameter
+
 
 _logger = logging.getLogger(__name__)
 
@@ -477,9 +487,8 @@ class NativeControlPlane(NativeObservabilityMixin):
             failure = normalized_provider_failure(exc)
             self._accounting.finish_request_quietly(authorization, failure)
             capability_param = (
-                exc.capability
+                _public_capability_param(exc.capability, provider_request.surface)
                 if isinstance(exc, ProviderCapabilityError)
-                and exc.capability in _PUBLIC_REQUEST_CAPABILITY_PARAMS
                 else None
             )
             raise NativeBridgeError(public_failure_error(failure, param=capability_param)) from exc

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -162,7 +162,7 @@ def _public_capability_param(
     if capability == "streaming_tool_arguments" and not public_stream:
         return "tools"
     if capability == "streaming" and not public_stream:
-        return "tools" if public_tools else "model"
+        return "tools" if public_tools else None
     return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
 
 

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -152,10 +152,13 @@ def _public_capability_param(
     surface: GatewayApiSurface,
     *,
     public_stream: bool = True,
+    public_tools: bool = False,
 ) -> str | None:
     """Translate an internal capability label to the caller's request field."""
     if capability == "streaming_tool_arguments" and not public_stream:
         return "tools"
+    if capability == "streaming" and not public_stream:
+        return "tools" if public_tools else "model"
     return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
 
 
@@ -514,6 +517,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                     exc.capability,
                     provider_request.surface,
                     public_stream=public_request.stream,
+                    public_tools=bool(public_request.tools),
                 )
                 if isinstance(exc, ProviderCapabilityError)
                 else exc.param

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -113,6 +113,16 @@ from exp.runtime.openai_protocol.state import (
 )
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
+_PUBLIC_REQUEST_CAPABILITY_PARAMS = frozenset(
+    {
+        "developer_messages",
+        "function_tools",
+        "parallel_tool_calls",
+        "streaming",
+        "strict_tools",
+        "structured_text",
+    }
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -464,7 +474,13 @@ class NativeControlPlane(NativeObservabilityMixin):
             # request feature the route cannot preserve.
             failure = normalized_provider_failure(exc)
             self._accounting.finish_request_quietly(authorization, failure)
-            raise NativeBridgeError(public_failure_error(failure)) from exc
+            capability_param = (
+                exc.capability
+                if isinstance(exc, ProviderCapabilityError)
+                and exc.capability in _PUBLIC_REQUEST_CAPABILITY_PARAMS
+                else None
+            )
+            raise NativeBridgeError(public_failure_error(failure, param=capability_param)) from exc
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             error = _authority_error(exc)
             failure = GatewayFailure(

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -493,6 +493,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                         provider_request,
                         deployment.gateway.capabilities,
                         model_capabilities=deployment.capabilities,
+                        public_stream=public_request.stream,
                     )
                     dialect_stream_payload(profile, provider_request)
                 except (ProviderParameterError, ProviderCapabilityError) as exc:
@@ -526,6 +527,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                     provider_request,
                     deployment.gateway.capabilities,
                     model_capabilities=deployment.capabilities,
+                    public_stream=public_request.stream,
                 )
                 upstream_payload = dialect_stream_payload(profile, provider_request)
                 upstream_body, dispatch_signer = frozen_dispatch(profile, client, upstream_payload)

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -448,6 +448,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                         provider_request,
                         deployment.gateway.capabilities,
                         model_capabilities=deployment.capabilities,
+                        requested_stream=public_request.stream,
                     )
                     dialect_stream_payload(profile, provider_request)
                 except (ProviderParameterError, ProviderCapabilityError) as exc:
@@ -481,6 +482,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                     provider_request,
                     deployment.gateway.capabilities,
                     model_capabilities=deployment.capabilities,
+                    requested_stream=public_request.stream,
                 )
                 upstream_payload = dialect_stream_payload(profile, provider_request)
                 upstream_body, dispatch_signer = frozen_dispatch(profile, client, upstream_payload)

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -172,6 +172,7 @@ def _public_capability_error(
     *,
     public_stream: bool,
     public_tools: bool,
+    developer_messages_param: str | None = None,
 ) -> OpenAIProtocolError:
     """Translate one internal admission label into a stable public 400.
 
@@ -180,11 +181,15 @@ def _public_capability_error(
     the field that activated them. Internal route requirements fail against
     ``model`` without exposing implementation details.
     """
-    param = _public_capability_param(
-        error.capability,
-        surface,
-        public_stream=public_stream,
-        public_tools=public_tools,
+    param = (
+        developer_messages_param
+        if error.capability == "developer_messages" and developer_messages_param is not None
+        else _public_capability_param(
+            error.capability,
+            surface,
+            public_stream=public_stream,
+            public_tools=public_tools,
+        )
     )
     if param is not None:
         return unsupported_field(param, capability=True)
@@ -555,6 +560,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                     provider_request.surface,
                     public_stream=public_request.stream,
                     public_tools=bool(public_request.tools),
+                    developer_messages_param=decoded.developer_messages_param,
                 )
                 if isinstance(exc, ProviderCapabilityError)
                 else public_failure_error(failure, param=exc.param)

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -147,8 +147,15 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
 }
 
 
-def _public_capability_param(capability: str, surface: GatewayApiSurface) -> str | None:
+def _public_capability_param(
+    capability: str,
+    surface: GatewayApiSurface,
+    *,
+    public_stream: bool = True,
+) -> str | None:
     """Translate an internal capability label to the caller's request field."""
+    if capability == "streaming_tool_arguments" and not public_stream:
+        return "tools"
     return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
 
 
@@ -503,7 +510,11 @@ class NativeControlPlane(NativeObservabilityMixin):
             failure = normalized_provider_failure(exc)
             self._accounting.finish_request_quietly(authorization, failure)
             failure_param = (
-                _public_capability_param(exc.capability, provider_request.surface)
+                _public_capability_param(
+                    exc.capability,
+                    provider_request.surface,
+                    public_stream=public_request.stream,
+                )
                 if isinstance(exc, ProviderCapabilityError)
                 else exc.param
             )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -103,7 +103,11 @@ from exp.runtime.models.providers.streaming_requests import (
     dialect_stream_payload,
     route_generation_parameter_requests,
 )
-from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
+from exp.runtime.openai_protocol.errors import (
+    OpenAIProtocolError,
+    public_failure_error,
+    unsupported_field,
+)
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 from exp.runtime.openai_protocol.state import (
     BoundedContinuationStore,
@@ -160,6 +164,39 @@ def _public_capability_param(
     if capability == "streaming" and not public_stream:
         return "tools" if public_tools else "model"
     return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
+
+
+def _public_capability_error(
+    error: ProviderCapabilityError,
+    surface: GatewayApiSurface,
+    *,
+    public_stream: bool,
+    public_tools: bool,
+) -> OpenAIProtocolError:
+    """Translate one internal admission label into a stable public 400.
+
+    Provider capability literals are useful for internal accounting but are
+    not part of the public request contract. Known request requirements name
+    the field that activated them. Internal route requirements fail against
+    ``model`` without exposing implementation details.
+    """
+    param = _public_capability_param(
+        error.capability,
+        surface,
+        public_stream=public_stream,
+        public_tools=public_tools,
+    )
+    if param is not None:
+        return unsupported_field(param, capability=True)
+    return OpenAIProtocolError(
+        status_code=400,
+        code="unsupported_capability",
+        message=(
+            "The selected model route cannot serve this request. "
+            "Choose a different model alias and resend the request."
+        ),
+        param="model",
+    )
 
 
 _logger = logging.getLogger(__name__)
@@ -512,17 +549,17 @@ class NativeControlPlane(NativeObservabilityMixin):
             # request feature the route cannot preserve.
             failure = normalized_provider_failure(exc)
             self._accounting.finish_request_quietly(authorization, failure)
-            failure_param = (
-                _public_capability_param(
-                    exc.capability,
+            public_error = (
+                _public_capability_error(
+                    exc,
                     provider_request.surface,
                     public_stream=public_request.stream,
                     public_tools=bool(public_request.tools),
                 )
                 if isinstance(exc, ProviderCapabilityError)
-                else exc.param
+                else public_failure_error(failure, param=exc.param)
             )
-            raise NativeBridgeError(public_failure_error(failure, param=failure_param)) from exc
+            raise NativeBridgeError(public_error) from exc
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             error = _authority_error(exc)
             failure = GatewayFailure(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3627,8 +3627,14 @@ def test_capability_rejection_names_the_public_request_field(tmp_path: Path) -> 
     body = json.dumps(
         {
             "model": "coding",
-            "instructions": "Follow the sync-lane policy canary-instructions.",
-            "input": "hello canary-input",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": "Follow the sync-lane policy canary-instructions.",
+                },
+                {"type": "message", "role": "user", "content": "hello canary-input"},
+            ],
         }
     )
     with pytest.raises(NativeBridgeError) as raised:
@@ -3637,8 +3643,8 @@ def test_capability_rejection_names_the_public_request_field(tmp_path: Path) -> 
     assert payload["status_code"] == 400
     assert payload["code"] == "unsupported_capability"
     assert payload["error_type"] == "invalid_request_error"
-    assert payload["param"] == "instructions"
-    assert "'instructions'" in payload["message"]
+    assert payload["param"] == "input.0.role"
+    assert "'input.0.role'" in payload["message"]
     assert "developer_messages" not in payload["message"]
     assert "canary" not in json.dumps(payload)
 

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -42,9 +42,11 @@ from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.gateway.native_bridge import (
     NativeBridgeError,
     NativeControlPlane,
+    _public_capability_error,
     _public_capability_param,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.models.providers.errors import ProviderCapabilityError
 from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
 from exp.runtime.openai_protocol.requests import decode_chat, decode_responses
@@ -118,6 +120,34 @@ def test_internal_text_streaming_failure_names_the_public_model_field() -> None:
             )
             == "model"
         )
+
+
+def test_public_capability_error_never_exposes_internal_labels() -> None:
+    """Internal route requirements fail against model without leaking their names."""
+    error = _public_capability_error(
+        ProviderCapabilityError(capability="tinker_gateway_execution"),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+        public_stream=False,
+        public_tools=False,
+    )
+
+    assert error.detail.param == "model"
+    assert error.detail.code == "unsupported_capability"
+    assert "tinker_gateway_execution" not in error.detail.message
+
+
+def test_public_capability_error_attributes_forced_streaming_to_tools() -> None:
+    """An internal streaming requirement identifies the tools field that activated it."""
+    error = _public_capability_error(
+        ProviderCapabilityError(capability="streaming"),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+        public_stream=False,
+        public_tools=True,
+    )
+
+    assert error.detail.param == "tools"
+    assert "'tools'" in error.detail.message
+    assert "streaming" not in error.detail.message
 
 
 def _parity_golden(name: str) -> object:
@@ -3591,15 +3621,8 @@ def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:
     assert json.loads(repeated.value.public_error_json)["code"] != "idempotency_conflict"
 
 
-def test_capability_rejection_names_the_unsupported_capability(tmp_path: Path) -> None:
-    """A pre-dispatch capability rejection names the exact capability.
-
-    A Responses request with instructions decodes to a developer message; a
-    route that cannot preserve developer messages must say so by name, not
-    with a flattened generic sentence, so a production 400 is triageable.
-    The message carries only the stable internal capability literal, never
-    request content.
-    """
+def test_capability_rejection_names_the_public_request_field(tmp_path: Path) -> None:
+    """A pre-dispatch capability rejection names the exact public field."""
     control, raw_key = _control_plane(tmp_path)
     body = json.dumps(
         {
@@ -3614,7 +3637,9 @@ def test_capability_rejection_names_the_unsupported_capability(tmp_path: Path) -
     assert payload["status_code"] == 400
     assert payload["code"] == "unsupported_capability"
     assert payload["error_type"] == "invalid_request_error"
-    assert "developer_messages" in payload["message"]
+    assert payload["param"] == "instructions"
+    assert "'instructions'" in payload["message"]
+    assert "developer_messages" not in payload["message"]
     assert "canary" not in json.dumps(payload)
 
 

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -76,7 +76,7 @@ _PublicErrorType = Literal[
         ),
         ("stop_sequences", "stop", None, "stop_sequences"),
         ("streaming", "stream", "stream", "stream"),
-        ("streaming_tool_arguments", "stream", "stream", "stream"),
+        ("streaming_tool_arguments", "tools", "tools", "tools"),
         ("strict_tools", "tools", "tools", "tools"),
         ("structured_output", "response_format", "text.format", None),
         ("structured_text", "response_format", "text.format", None),
@@ -94,19 +94,18 @@ def test_public_capability_params_name_real_surface_fields(
     assert _public_capability_param(capability, GatewayApiSurface.MESSAGES) == messages_param
 
 
-def test_internal_tool_streaming_failure_names_the_public_tools_field() -> None:
-    """A transport detail never blames stream when the caller requested non-streaming tools."""
+def test_tool_argument_streaming_failure_names_the_public_tools_field() -> None:
+    """Tool argument transport failures identify the tool request that activated them."""
     for surface in GatewayApiSurface:
-        for capability in ("streaming", "streaming_tool_arguments"):
-            assert (
-                _public_capability_param(
-                    capability,
-                    surface,
-                    public_stream=False,
-                    public_tools=True,
-                )
-                == "tools"
+        assert (
+            _public_capability_param(
+                "streaming_tool_arguments",
+                surface,
+                public_stream=False,
+                public_tools=True,
             )
+            == "tools"
+        )
 
 
 def test_internal_text_streaming_failure_has_no_fake_public_field() -> None:
@@ -145,8 +144,8 @@ def test_public_capability_error_never_exposes_internal_labels() -> None:
     assert "tinker_gateway_execution" not in error.detail.message
 
 
-def test_public_capability_error_attributes_forced_streaming_to_tools() -> None:
-    """An internal streaming requirement identifies the tools field that activated it."""
+def test_forced_streaming_deficit_names_the_model_route() -> None:
+    """Removing caller fields cannot cure a route that lacks required transport streaming."""
     error = _public_capability_error(
         ProviderCapabilityError(capability="streaming"),
         GatewayApiSurface.CHAT_COMPLETIONS,
@@ -154,8 +153,8 @@ def test_public_capability_error_attributes_forced_streaming_to_tools() -> None:
         public_tools=True,
     )
 
-    assert error.detail.param == "tools"
-    assert "'tools'" in error.detail.message
+    assert error.detail.param == "model"
+    assert "different model alias" in error.detail.message
     assert "streaming" not in error.detail.message
 
 
@@ -1221,8 +1220,8 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert "internal" not in error["code"]
 
 
-def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: Path) -> None:
-    """Internally forced streaming attributes incompatibility to the declared tools field."""
+def test_non_streaming_transport_failure_names_the_model_route(tmp_path: Path) -> None:
+    """A retry cannot remove the gateway's internally required streaming transport."""
     unsupported = GatewayDeploymentCapabilities(supports_strict_tools=True)
     control, raw_key = _pool_control_plane(
         tmp_path,
@@ -1253,7 +1252,8 @@ def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: P
 
     error = json.loads(raised.value.public_error_json)
     assert error["code"] == "unsupported_capability"
-    assert error["param"] == "tools"
+    assert error["param"] == "model"
+    assert "different model alias" in error["message"]
 
 
 def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -792,6 +792,7 @@ def _configured_pool_gateway(
     base_urls: tuple[str, str] = ("http://127.0.0.1:9/v1", "http://127.0.0.1:10/v1"),
     gateway_capabilities: tuple[GatewayDeploymentCapabilities, GatewayDeploymentCapabilities]
     | None = None,
+    model_capabilities: tuple[ModelCapabilities, ModelCapabilities] | None = None,
     api_key_envs: tuple[str, str] = ("TEST_PROVIDER_KEY", "TEST_PROVIDER_KEY"),
 ) -> tuple[GatewayManagement, str]:
     """Create one certified two-deployment pool alias, grant, and key.
@@ -801,6 +802,7 @@ def _configured_pool_gateway(
         refusal_failover: Whether the alias revision opts into refusal failover.
         base_urls: One provider endpoint per ordered deployment.
         gateway_capabilities: Optional protocol contract for each deployment.
+        model_capabilities: Optional semantic model contract for each deployment.
         api_key_envs: One credential environment-variable name per ordered
             deployment, so a test can make one rung's credential resolvable
             while another is absent.
@@ -826,8 +828,17 @@ def _configured_pool_gateway(
         GatewayDeploymentCapabilities(supports_streaming=True),
         GatewayDeploymentCapabilities(supports_streaming=True),
     )
-    for alias, base_url, gateway_capability, api_key_env in zip(
-        ("alpha", "beta"), base_urls, declared_gateway_capabilities, api_key_envs, strict=True
+    declared_model_capabilities = model_capabilities or (
+        ModelCapabilities(),
+        ModelCapabilities(),
+    )
+    for alias, base_url, gateway_capability, model_capability, api_key_env in zip(
+        ("alpha", "beta"),
+        base_urls,
+        declared_gateway_capabilities,
+        declared_model_capabilities,
+        api_key_envs,
+        strict=True,
     ):
         upsert_connection(
             root,
@@ -846,7 +857,7 @@ def _configured_pool_gateway(
             provider_model=f"{alias}-model-exact",
             exact_model_id="model-revision-exact",
             revision=None,
-            capabilities=ModelCapabilities(),
+            capabilities=model_capability,
             gateway_capabilities=gateway_capability,
             prices=GatewayTokenPrices(),
             pricing_source=None,
@@ -889,12 +900,14 @@ def _pool_control_plane(
     refusal_failover: bool = False,
     gateway_capabilities: tuple[GatewayDeploymentCapabilities, GatewayDeploymentCapabilities]
     | None = None,
+    model_capabilities: tuple[ModelCapabilities, ModelCapabilities] | None = None,
 ) -> tuple[NativeControlPlane, str]:
     """Load the native control plane over one certified two-deployment pool."""
     _manager, raw_key = _configured_pool_gateway(
         root,
         refusal_failover=refusal_failover,
         gateway_capabilities=gateway_capabilities,
+        model_capabilities=model_capabilities,
     )
     components = load_gateway_components(
         root,
@@ -967,6 +980,123 @@ def test_admit_removes_protocol_incompatible_fallbacks(tmp_path: Path) -> None:
     assert [item["model_id"] for item in route] == ["beta-model-exact"]
     upstream = cast("JsonObject", route[0]["upstream_payload"])
     assert upstream["stop"] == ["DONE"]
+
+
+@pytest.mark.parametrize(
+    ("body_update", "lead", "fallback", "model_capabilities"),
+    (
+        (
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                            "strict": True,
+                        },
+                    }
+                ]
+            },
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            GatewayDeploymentCapabilities(
+                supports_streaming=True,
+                supports_strict_tools=True,
+            ),
+            (ModelCapabilities(supports_tools=True), ModelCapabilities(supports_tools=True)),
+        ),
+        (
+            {
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {"type": "object"},
+                        "strict": True,
+                    },
+                }
+            },
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            GatewayDeploymentCapabilities(
+                supports_streaming=True,
+                supports_structured_text=True,
+            ),
+            (
+                ModelCapabilities(supports_structured_output=True),
+                ModelCapabilities(supports_structured_output=True),
+            ),
+        ),
+        (
+            {"stream": True},
+            GatewayDeploymentCapabilities(),
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            (ModelCapabilities(), ModelCapabilities()),
+        ),
+    ),
+)
+def test_admit_filters_each_protocol_capability_before_selection(
+    tmp_path: Path,
+    body_update: JsonObject,
+    lead: GatewayDeploymentCapabilities,
+    fallback: GatewayDeploymentCapabilities,
+    model_capabilities: tuple[ModelCapabilities, ModelCapabilities],
+) -> None:
+    """Tools, structured output, and streaming retain only a capable rung."""
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(lead, fallback),
+        model_capabilities=model_capabilities,
+    )
+    body: JsonObject = {
+        "model": "coding",
+        "messages": [{"role": "user", "content": "hi"}],
+        **body_update,
+    }
+
+    admission = _admit(control, raw_key, json.dumps(body))
+
+    route = cast("list[JsonObject]", admission["route"])
+    assert [item["model_id"] for item in route] == ["beta-model-exact"]
+
+
+def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
+    tmp_path: Path,
+) -> None:
+    """An all-incompatible tool route names strict_tools and never reports internal."""
+    unsupported = GatewayDeploymentCapabilities(supports_streaming=True)
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(unsupported, unsupported),
+        model_capabilities=(
+            ModelCapabilities(supports_tools=True),
+            ModelCapabilities(supports_tools=True),
+        ),
+    )
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                        "strict": True,
+                    },
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, body)
+
+    error = json.loads(raised.value.public_error_json)
+    assert error["status_code"] == 400
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "strict_tools"
+    assert "internal" not in error["code"]
 
 
 def _partial_pool_control_plane(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -92,6 +92,19 @@ def test_public_capability_params_name_real_surface_fields(
     assert _public_capability_param(capability, GatewayApiSurface.MESSAGES) == messages_param
 
 
+def test_internal_tool_streaming_failure_names_the_public_tools_field() -> None:
+    """A transport detail never blames stream when the caller requested non-streaming tools."""
+    for surface in GatewayApiSurface:
+        assert (
+            _public_capability_param(
+                "streaming_tool_arguments",
+                surface,
+                public_stream=False,
+            )
+            == "tools"
+        )
+
+
 def _parity_golden(name: str) -> object:
     """Load one committed golden fixture the Rust encoders must reproduce.
 
@@ -1132,6 +1145,44 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert error["code"] == "unsupported_capability"
     assert error["param"] == "tools"
     assert "internal" not in error["code"]
+
+
+def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: Path) -> None:
+    """Internally forced streaming attributes incompatibility to the declared tools field."""
+    unsupported = GatewayDeploymentCapabilities(
+        supports_streaming=True,
+        supports_strict_tools=True,
+    )
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(unsupported, unsupported),
+        model_capabilities=(
+            ModelCapabilities(supports_tools=True),
+            ModelCapabilities(supports_tools=True),
+        ),
+    )
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, body)
+
+    error = json.loads(raised.value.public_error_json)
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "tools"
 
 
 def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1099,6 +1099,63 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert "internal" not in error["code"]
 
 
+@pytest.mark.parametrize(
+    ("body_update", "gateway_capabilities", "model_capabilities", "param"),
+    (
+        (
+            {"stop": ["DONE"]},
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            ModelCapabilities(),
+            "stop_sequences",
+        ),
+        (
+            {
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {"type": "object"},
+                        "strict": True,
+                    },
+                }
+            },
+            GatewayDeploymentCapabilities(
+                supports_streaming=True,
+                supports_structured_text=True,
+            ),
+            ModelCapabilities(),
+            "structured_output",
+        ),
+    ),
+)
+def test_admit_scopes_each_public_capability_failure_to_its_request_field(
+    tmp_path: Path,
+    body_update: JsonObject,
+    gateway_capabilities: GatewayDeploymentCapabilities,
+    model_capabilities: ModelCapabilities,
+    param: str,
+) -> None:
+    """Public admission failures never degrade to an unscoped internal error."""
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(gateway_capabilities, gateway_capabilities),
+        model_capabilities=(model_capabilities, model_capabilities),
+    )
+    body: JsonObject = {
+        "model": "coding",
+        "messages": [{"role": "user", "content": "hi"}],
+        **body_update,
+    }
+
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, json.dumps(body))
+
+    error = json.loads(raised.value.public_error_json)
+    assert error["status_code"] == 400
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == param
+
+
 def _partial_pool_control_plane(
     root: Path,
     environment: dict[str, str],

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1167,8 +1167,8 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert "internal" not in error["code"]
 
 
-def test_non_streaming_tools_do_not_require_public_streaming_transport(tmp_path: Path) -> None:
-    """Internally forced streaming does not invent a caller transport requirement."""
+def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: Path) -> None:
+    """Internally forced streaming attributes incompatibility to the declared tools field."""
     unsupported = GatewayDeploymentCapabilities(
         supports_streaming=True,
         supports_strict_tools=True,
@@ -1197,13 +1197,12 @@ def test_non_streaming_tools_do_not_require_public_streaming_transport(tmp_path:
         }
     )
 
-    admission = _admit(control, raw_key, body)
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, body)
 
-    route = cast("list[JsonObject]", admission["route"])
-    assert [item["model_id"] for item in route] == [
-        "alpha-model-exact",
-        "beta-model-exact",
-    ]
+    error = json.loads(raised.value.public_error_json)
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "tools"
 
 
 def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -109,17 +109,23 @@ def test_internal_tool_streaming_failure_names_the_public_tools_field() -> None:
             )
 
 
-def test_internal_text_streaming_failure_names_the_public_model_field() -> None:
-    """An internal text transport deficit is attributed to route selection, not stream."""
+def test_internal_text_streaming_failure_has_no_fake_public_field() -> None:
+    """An internal text transport deficit has no caller-removable request field."""
     for surface in GatewayApiSurface:
-        assert (
-            _public_capability_param(
-                "streaming",
-                surface,
-                public_stream=False,
-            )
-            == "model"
+        assert _public_capability_param(
+            "streaming",
+            surface,
+            public_stream=False,
+        ) is None
+
+        error = _public_capability_error(
+            ProviderCapabilityError(capability="streaming"),
+            surface,
+            public_stream=False,
+            public_tools=False,
         )
+        assert error.detail.param == "model"
+        assert "Choose a different model alias" in error.detail.message
 
 
 def test_public_capability_error_never_exposes_internal_labels() -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1080,6 +1080,26 @@ def test_admit_removes_protocol_incompatible_fallbacks(tmp_path: Path) -> None:
             GatewayDeploymentCapabilities(supports_streaming=True),
             (ModelCapabilities(), ModelCapabilities()),
         ),
+        (
+            {
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            GatewayDeploymentCapabilities(
+                supports_streaming=True,
+                supports_streaming_tool_arguments=True,
+            ),
+            (ModelCapabilities(supports_tools=True), ModelCapabilities(supports_tools=True)),
+        ),
     ),
 )
 def test_admit_filters_each_protocol_capability_before_selection(
@@ -1147,8 +1167,8 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert "internal" not in error["code"]
 
 
-def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: Path) -> None:
-    """Internally forced streaming attributes incompatibility to the declared tools field."""
+def test_non_streaming_tools_do_not_require_public_streaming_transport(tmp_path: Path) -> None:
+    """Internally forced streaming does not invent a caller transport requirement."""
     unsupported = GatewayDeploymentCapabilities(
         supports_streaming=True,
         supports_strict_tools=True,
@@ -1177,12 +1197,13 @@ def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: P
         }
     )
 
-    with pytest.raises(NativeBridgeError) as raised:
-        _admit(control, raw_key, body)
+    admission = _admit(control, raw_key, body)
 
-    error = json.loads(raised.value.public_error_json)
-    assert error["code"] == "unsupported_capability"
-    assert error["param"] == "tools"
+    route = cast("list[JsonObject]", admission["route"])
+    assert [item["model_id"] for item in route] == [
+        "alpha-model-exact",
+        "beta-model-exact",
+    ]
 
 
 def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -23,6 +23,7 @@ from exp.runtime.gateway.budgets import BudgetReservationRejected, BudgetScopeKi
 from exp.runtime.gateway.catalog_authority import upsert_singleton_deployment
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
+    GatewayApiSurface,
     GatewayEvent,
     GatewayEventKind,
     GatewayFailure,
@@ -41,6 +42,7 @@ from exp.runtime.gateway.management import GatewayManagement
 from exp.runtime.gateway.native_bridge import (
     NativeBridgeError,
     NativeControlPlane,
+    _public_capability_param,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
@@ -57,6 +59,28 @@ _PublicErrorType = Literal[
     "insufficient_quota",
     "api_error",
 ]
+
+
+@pytest.mark.parametrize(
+    ("capability", "chat_param", "responses_param"),
+    (
+        ("developer_messages", "messages", "input"),
+        ("function_tools", "tools", "tools"),
+        ("stop_sequences", "stop", "stop"),
+        ("streaming", "stream", "stream"),
+        ("strict_tools", "tools", "tools"),
+        ("structured_output", "response_format", "text.format"),
+        ("structured_text", "response_format", "text.format"),
+    ),
+)
+def test_public_capability_params_name_real_surface_fields(
+    capability: str,
+    chat_param: str,
+    responses_param: str,
+) -> None:
+    """Internal admission labels never leak as nonexistent public fields."""
+    assert _public_capability_param(capability, GatewayApiSurface.CHAT_COMPLETIONS) == chat_param
+    assert _public_capability_param(capability, GatewayApiSurface.RESPONSES) == responses_param
 
 
 def _parity_golden(name: str) -> object:
@@ -1095,7 +1119,7 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     error = json.loads(raised.value.public_error_json)
     assert error["status_code"] == 400
     assert error["code"] == "unsupported_capability"
-    assert error["param"] == "strict_tools"
+    assert error["param"] == "tools"
     assert "internal" not in error["code"]
 
 
@@ -1106,7 +1130,7 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
             {"stop": ["DONE"]},
             GatewayDeploymentCapabilities(supports_streaming=True),
             ModelCapabilities(),
-            "stop_sequences",
+            "stop",
         ),
         (
             {
@@ -1124,7 +1148,7 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
                 supports_structured_text=True,
             ),
             ModelCapabilities(),
-            "structured_output",
+            "response_format",
         ),
     ),
 )

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -144,18 +144,16 @@ def test_public_capability_error_never_exposes_internal_labels() -> None:
     assert "tinker_gateway_execution" not in error.detail.message
 
 
-def test_forced_streaming_deficit_names_the_model_route() -> None:
-    """Removing caller fields cannot cure a route that lacks required transport streaming."""
+def test_forced_streaming_tool_deficit_names_the_public_tools_field() -> None:
+    """An internally streamed tool deficit names the tool request that caused it."""
     error = _public_capability_error(
-        ProviderCapabilityError(capability="streaming"),
+        ProviderCapabilityError(capability="streaming_tool_arguments"),
         GatewayApiSurface.CHAT_COMPLETIONS,
         public_stream=False,
         public_tools=True,
     )
 
-    assert error.detail.param == "model"
-    assert "different model alias" in error.detail.message
-    assert "streaming" not in error.detail.message
+    assert error.detail.param == "tools"
 
 
 def _parity_golden(name: str) -> object:
@@ -1220,8 +1218,8 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert "internal" not in error["code"]
 
 
-def test_non_streaming_transport_failure_names_the_model_route(tmp_path: Path) -> None:
-    """A retry cannot remove the gateway's internally required streaming transport."""
+def test_non_streaming_tool_transport_failure_names_tools(tmp_path: Path) -> None:
+    """A buffered tool request identifies the feature that requires streaming."""
     unsupported = GatewayDeploymentCapabilities(supports_strict_tools=True)
     control, raw_key = _pool_control_plane(
         tmp_path,
@@ -1252,8 +1250,8 @@ def test_non_streaming_transport_failure_names_the_model_route(tmp_path: Path) -
 
     error = json.loads(raised.value.public_error_json)
     assert error["code"] == "unsupported_capability"
-    assert error["param"] == "model"
-    assert "different model alias" in error["message"]
+    assert error["param"] == "tools"
+    assert "Remove the field" in error["message"]
 
 
 def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -62,25 +62,34 @@ _PublicErrorType = Literal[
 
 
 @pytest.mark.parametrize(
-    ("capability", "chat_param", "responses_param"),
+    ("capability", "chat_param", "responses_param", "messages_param"),
     (
-        ("developer_messages", "messages", "input"),
-        ("function_tools", "tools", "tools"),
-        ("stop_sequences", "stop", "stop"),
-        ("streaming", "stream", "stream"),
-        ("strict_tools", "tools", "tools"),
-        ("structured_output", "response_format", "text.format"),
-        ("structured_text", "response_format", "text.format"),
+        ("developer_messages", "messages", "instructions", "system"),
+        ("function_tools", "tools", "tools", "tools"),
+        (
+            "parallel_tool_calls",
+            "parallel_tool_calls",
+            "parallel_tool_calls",
+            "tool_choice.disable_parallel_tool_use",
+        ),
+        ("stop_sequences", "stop", None, "stop_sequences"),
+        ("streaming", "stream", "stream", "stream"),
+        ("streaming_tool_arguments", "stream", "stream", "stream"),
+        ("strict_tools", "tools", "tools", "tools"),
+        ("structured_output", "response_format", "text.format", None),
+        ("structured_text", "response_format", "text.format", None),
     ),
 )
 def test_public_capability_params_name_real_surface_fields(
     capability: str,
-    chat_param: str,
-    responses_param: str,
+    chat_param: str | None,
+    responses_param: str | None,
+    messages_param: str | None,
 ) -> None:
     """Internal admission labels never leak as nonexistent public fields."""
     assert _public_capability_param(capability, GatewayApiSurface.CHAT_COMPLETIONS) == chat_param
     assert _public_capability_param(capability, GatewayApiSurface.RESPONSES) == responses_param
+    assert _public_capability_param(capability, GatewayApiSurface.MESSAGES) == messages_param
 
 
 def _parity_golden(name: str) -> object:
@@ -540,6 +549,7 @@ def test_admit_serves_bedrock_natively_with_a_signed_frozen_body(
         ),
         gateway_capabilities=GatewayDeploymentCapabilities(
             supports_streaming=True,
+            supports_streaming_tool_arguments=True,
             supports_stop_sequences=True,
             supports_strict_tools=True,
             supports_structured_text=True,
@@ -1025,6 +1035,7 @@ def test_admit_removes_protocol_incompatible_fallbacks(tmp_path: Path) -> None:
             GatewayDeploymentCapabilities(supports_streaming=True),
             GatewayDeploymentCapabilities(
                 supports_streaming=True,
+                supports_streaming_tool_arguments=True,
                 supports_strict_tools=True,
             ),
             (ModelCapabilities(supports_tools=True), ModelCapabilities(supports_tools=True)),
@@ -1121,6 +1132,34 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
     assert error["code"] == "unsupported_capability"
     assert error["param"] == "tools"
     assert "internal" not in error["code"]
+
+
+def test_admit_preserves_parameter_path_for_an_over_limit_stop_list(tmp_path: Path) -> None:
+    """A parameter validator reaches the public 400 with its exact field path intact."""
+    capabilities = GatewayDeploymentCapabilities(
+        supports_streaming=True,
+        supports_stop_sequences=True,
+        maximum_stop_sequences=5,
+    )
+    control, raw_key = _pool_control_plane(
+        tmp_path,
+        gateway_capabilities=(capabilities, capabilities),
+    )
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": ["a", "b", "c", "d", "e", "f"],
+        }
+    )
+
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, body)
+
+    error = json.loads(raised.value.public_error_json)
+    assert error["status_code"] == 400
+    assert error["code"] == "invalid_parameter"
+    assert error["param"] == "stop"
 
 
 @pytest.mark.parametrize(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -112,11 +112,14 @@ def test_internal_tool_streaming_failure_names_the_public_tools_field() -> None:
 def test_internal_text_streaming_failure_has_no_fake_public_field() -> None:
     """An internal text transport deficit has no caller-removable request field."""
     for surface in GatewayApiSurface:
-        assert _public_capability_param(
-            "streaming",
-            surface,
-            public_stream=False,
-        ) is None
+        assert (
+            _public_capability_param(
+                "streaming",
+                surface,
+                public_stream=False,
+            )
+            is None
+        )
 
         error = _public_capability_error(
             ProviderCapabilityError(capability="streaming"),

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -95,13 +95,28 @@ def test_public_capability_params_name_real_surface_fields(
 def test_internal_tool_streaming_failure_names_the_public_tools_field() -> None:
     """A transport detail never blames stream when the caller requested non-streaming tools."""
     for surface in GatewayApiSurface:
+        for capability in ("streaming", "streaming_tool_arguments"):
+            assert (
+                _public_capability_param(
+                    capability,
+                    surface,
+                    public_stream=False,
+                    public_tools=True,
+                )
+                == "tools"
+            )
+
+
+def test_internal_text_streaming_failure_names_the_public_model_field() -> None:
+    """An internal text transport deficit is attributed to route selection, not stream."""
+    for surface in GatewayApiSurface:
         assert (
             _public_capability_param(
-                "streaming_tool_arguments",
+                "streaming",
                 surface,
                 public_stream=False,
             )
-            == "tools"
+            == "model"
         )
 
 
@@ -1169,10 +1184,7 @@ def test_admit_returns_a_field_specific_400_when_no_rung_supports_tools(
 
 def test_non_streaming_tool_transport_failure_names_tools_not_stream(tmp_path: Path) -> None:
     """Internally forced streaming attributes incompatibility to the declared tools field."""
-    unsupported = GatewayDeploymentCapabilities(
-        supports_streaming=True,
-        supports_strict_tools=True,
-    )
+    unsupported = GatewayDeploymentCapabilities(supports_strict_tools=True)
     control, raw_key = _pool_control_plane(
         tmp_path,
         gateway_capabilities=(unsupported, unsupported),

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -165,29 +165,9 @@ def _migrate_legacy_project_gateway_metadata(
             ProviderCapability.TOOL_ARGUMENT_STREAM,
         )
         if record.gateway is not None:
-            if provider == "openai-compatible":
-                # Generic endpoint families have no transport-wide truth. Preserve an explicit
-                # deployment declaration and otherwise leave the conservative default intact.
-                continue
-            existing = record.gateway.capabilities
-            if existing.supports_streaming_tool_arguments == supports_streaming_tool_arguments:
-                continue
-            models[alias] = record.model_copy(
-                update={
-                    "gateway": record.gateway.model_copy(
-                        update={
-                            "capabilities": existing.model_copy(
-                                update={
-                                    "supports_streaming_tool_arguments": (
-                                        supports_streaming_tool_arguments
-                                    )
-                                }
-                            )
-                        }
-                    )
-                }
-            )
-            changed = True
+            # Any gateway metadata is already an endpoint-specific declaration. The schema's
+            # conservative false default is indistinguishable from an explicit false, so a
+            # provider-family certification must never overwrite it during legacy migration.
             continue
         models[alias] = record.model_copy(
             update={

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -158,7 +158,12 @@ def _migrate_legacy_project_gateway_metadata(
         models[alias] = record.model_copy(
             update={
                 "gateway": GatewayDeploymentMetadata(
-                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+                    capabilities=GatewayDeploymentCapabilities(
+                        supports_streaming=True,
+                        supports_streaming_tool_arguments=bool(
+                            record.capabilities and record.capabilities.supports_tools
+                        ),
+                    )
                 )
             }
         )

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -166,6 +166,10 @@ def _migrate_legacy_project_gateway_metadata(
             and provider_has_certified_capability(provider, ProviderCapability.TOOL_ARGUMENT_STREAM)
         )
         if record.gateway is not None:
+            if provider == "openai-compatible":
+                # Generic endpoint families have no transport-wide truth. Preserve an explicit
+                # deployment declaration and otherwise leave the conservative default intact.
+                continue
             existing = record.gateway.capabilities
             if existing.supports_streaming_tool_arguments == supports_streaming_tool_arguments:
                 continue

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -19,6 +19,11 @@ from exp.runtime.gateway.project_activation import (
     ProjectActivationRepository,
     require_project_activation_authority,
 )
+from exp.runtime.gateway.provider_certification import (
+    PROVIDER_CERTIFICATION_MATRIX,
+    ProviderCapability,
+    ProviderCertificationResult,
+)
 from exp.runtime.models import RuntimeModelCatalog
 
 
@@ -31,6 +36,18 @@ class ProjectGatewayAlias:
     identity_id: str
     policy_id: str
     changed: bool
+
+
+_CERTIFIED_STREAMING_TOOL_PROVIDERS = frozenset(
+    cell.provider
+    for cell in PROVIDER_CERTIFICATION_MATRIX.cells
+    if cell.capability == ProviderCapability.TOOL_ARGUMENT_STREAM
+    and cell.result
+    in {
+        ProviderCertificationResult.PROVIDER_FIXTURE_PASS,
+        ProviderCertificationResult.INHERITED_COMPATIBLE_FIXTURE_PASS,
+    }
+)
 
 
 def prepare_project_gateway_alias(
@@ -158,7 +175,13 @@ def _migrate_legacy_project_gateway_metadata(
         models[alias] = record.model_copy(
             update={
                 "gateway": GatewayDeploymentMetadata(
-                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+                    capabilities=GatewayDeploymentCapabilities(
+                        supports_streaming=True,
+                        supports_streaming_tool_arguments=(
+                            catalog.connections[record.connection].provider
+                            in _CERTIFIED_STREAMING_TOOL_PROVIDERS
+                        ),
+                    )
                 )
             }
         )

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -160,10 +160,9 @@ def _migrate_legacy_project_gateway_metadata(
         if record is None:
             continue
         provider = catalog.connections[record.connection].provider
-        supports_streaming_tool_arguments = (
-            record.capabilities is not None
-            and bool(record.capabilities.supports_tools)
-            and provider_has_certified_capability(provider, ProviderCapability.TOOL_ARGUMENT_STREAM)
+        supports_streaming_tool_arguments = provider_has_certified_capability(
+            provider,
+            ProviderCapability.TOOL_ARGUMENT_STREAM,
         )
         if record.gateway is not None:
             if provider == "openai-compatible":

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -158,12 +158,7 @@ def _migrate_legacy_project_gateway_metadata(
         models[alias] = record.model_copy(
             update={
                 "gateway": GatewayDeploymentMetadata(
-                    capabilities=GatewayDeploymentCapabilities(
-                        supports_streaming=True,
-                        supports_streaming_tool_arguments=bool(
-                            record.capabilities and record.capabilities.supports_tools
-                        ),
-                    )
+                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
                 )
             }
         )

--- a/exp/runtime/gateway/project_alias.py
+++ b/exp/runtime/gateway/project_alias.py
@@ -20,9 +20,8 @@ from exp.runtime.gateway.project_activation import (
     require_project_activation_authority,
 )
 from exp.runtime.gateway.provider_certification import (
-    PROVIDER_CERTIFICATION_MATRIX,
     ProviderCapability,
-    ProviderCertificationResult,
+    provider_has_certified_capability,
 )
 from exp.runtime.models import RuntimeModelCatalog
 
@@ -36,18 +35,6 @@ class ProjectGatewayAlias:
     identity_id: str
     policy_id: str
     changed: bool
-
-
-_CERTIFIED_STREAMING_TOOL_PROVIDERS = frozenset(
-    cell.provider
-    for cell in PROVIDER_CERTIFICATION_MATRIX.cells
-    if cell.capability == ProviderCapability.TOOL_ARGUMENT_STREAM
-    and cell.result
-    in {
-        ProviderCertificationResult.PROVIDER_FIXTURE_PASS,
-        ProviderCertificationResult.INHERITED_COMPATIBLE_FIXTURE_PASS,
-    }
-)
 
 
 def prepare_project_gateway_alias(
@@ -170,17 +157,41 @@ def _migrate_legacy_project_gateway_metadata(
     changed = False
     for alias in aliases:
         record = models.get(alias)
-        if record is None or record.gateway is not None:
+        if record is None:
+            continue
+        provider = catalog.connections[record.connection].provider
+        supports_streaming_tool_arguments = (
+            record.capabilities is not None
+            and bool(record.capabilities.supports_tools)
+            and provider_has_certified_capability(provider, ProviderCapability.TOOL_ARGUMENT_STREAM)
+        )
+        if record.gateway is not None:
+            existing = record.gateway.capabilities
+            if existing.supports_streaming_tool_arguments == supports_streaming_tool_arguments:
+                continue
+            models[alias] = record.model_copy(
+                update={
+                    "gateway": record.gateway.model_copy(
+                        update={
+                            "capabilities": existing.model_copy(
+                                update={
+                                    "supports_streaming_tool_arguments": (
+                                        supports_streaming_tool_arguments
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+            changed = True
             continue
         models[alias] = record.model_copy(
             update={
                 "gateway": GatewayDeploymentMetadata(
                     capabilities=GatewayDeploymentCapabilities(
                         supports_streaming=True,
-                        supports_streaming_tool_arguments=(
-                            catalog.connections[record.connection].provider
-                            in _CERTIFIED_STREAMING_TOOL_PROVIDERS
-                        ),
+                        supports_streaming_tool_arguments=supports_streaming_tool_arguments,
                     )
                 )
             }

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -96,6 +96,11 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
                 billing_source=BillingSource.CUSTOMER_MANAGED,
                 capabilities=ModelCapabilities(supports_tools=True),
             ),
+            "legacy-unknown": ModelRecord(
+                connection="provider",
+                model="legacy-unknown-model",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+            ),
             "explicit": ModelRecord(
                 connection="provider",
                 model="explicit-model",
@@ -136,6 +141,7 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
         tmp_path,
         aliases=(
             "legacy",
+            "legacy-unknown",
             "legacy-gemini",
             "legacy-custom",
             "explicit",
@@ -146,6 +152,12 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
 
     assert changed is True
     assert migrated.models["legacy"].gateway == GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        )
+    )
+    assert migrated.models["legacy-unknown"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(
             supports_streaming=True,
             supports_streaming_tool_arguments=True,
@@ -171,6 +183,7 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
             tmp_path,
             aliases=(
                 "legacy",
+                "legacy-unknown",
                 "legacy-gemini",
                 "legacy-custom",
                 "explicit",

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -175,7 +175,6 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
     assert migrated.models["explicit"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(
             supports_strict_tools=True,
-            supports_streaming_tool_arguments=True,
         )
     )
     assert (

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -11,6 +11,7 @@ from exp.common.models import (
     ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
+    ModelCapabilities,
     ModelCatalog,
     ModelRecord,
     PricingSnapshot,
@@ -74,8 +75,8 @@ def _activation(*, project_ref: str, activation_ref: str) -> ProjectActivation:
     )
 
 
-def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path: Path) -> None:
-    """Upgrade absent gateway metadata without overriding explicit declarations."""
+def test_legacy_project_candidates_gain_their_known_streaming_transport(tmp_path: Path) -> None:
+    """Upgrade known tool streaming without overriding explicit declarations."""
     catalog = ModelCatalog(
         schema_version=2,
         connections={"provider": ConnectionConfig(provider="openai")},
@@ -84,6 +85,7 @@ def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path
                 connection="provider",
                 model="legacy-model",
                 billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
             ),
             "explicit": ModelRecord(
                 connection="provider",
@@ -105,7 +107,10 @@ def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path
 
     assert changed is True
     assert migrated.models["legacy"].gateway == GatewayDeploymentMetadata(
-        capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        )
     )
     assert migrated.models["explicit"].gateway == catalog.models["explicit"].gateway
     assert (

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -11,7 +11,6 @@ from exp.common.models import (
     ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
-    ModelCapabilities,
     ModelCatalog,
     ModelRecord,
     PricingSnapshot,
@@ -75,8 +74,8 @@ def _activation(*, project_ref: str, activation_ref: str) -> ProjectActivation:
     )
 
 
-def test_legacy_project_candidates_gain_their_known_streaming_transport(tmp_path: Path) -> None:
-    """Upgrade known tool streaming without overriding explicit declarations."""
+def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path: Path) -> None:
+    """Upgrade absent gateway metadata without overriding explicit declarations."""
     catalog = ModelCatalog(
         schema_version=2,
         connections={"provider": ConnectionConfig(provider="openai")},
@@ -85,7 +84,6 @@ def test_legacy_project_candidates_gain_their_known_streaming_transport(tmp_path
                 connection="provider",
                 model="legacy-model",
                 billing_source=BillingSource.CUSTOMER_MANAGED,
-                capabilities=ModelCapabilities(supports_tools=True),
             ),
             "explicit": ModelRecord(
                 connection="provider",
@@ -107,10 +105,7 @@ def test_legacy_project_candidates_gain_their_known_streaming_transport(tmp_path
 
     assert changed is True
     assert migrated.models["legacy"].gateway == GatewayDeploymentMetadata(
-        capabilities=GatewayDeploymentCapabilities(
-            supports_streaming=True,
-            supports_streaming_tool_arguments=True,
-        )
+        capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
     )
     assert migrated.models["explicit"].gateway == catalog.models["explicit"].gateway
     assert (

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -84,6 +84,10 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
         connections={
             "provider": ConnectionConfig(provider="openai"),
             "gemini": ConnectionConfig(provider="gemini", api_key_env="GEMINI_API_KEY"),
+            "custom": ConnectionConfig(
+                provider="openai-compatible",
+                base_url="https://custom.example.test/v1",
+            ),
         },
         models={
             "legacy": ModelRecord(
@@ -107,13 +111,36 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
                 billing_source=BillingSource.CUSTOMER_MANAGED,
                 capabilities=ModelCapabilities(supports_tools=True),
             ),
+            "legacy-custom": ModelRecord(
+                connection="custom",
+                model="custom-legacy-model",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
+            ),
+            "explicit-custom": ModelRecord(
+                connection="custom",
+                model="custom-explicit-model",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
+                gateway=GatewayDeploymentMetadata(
+                    capabilities=GatewayDeploymentCapabilities(
+                        supports_streaming_tool_arguments=True
+                    )
+                ),
+            ),
         },
     )
     write_model_catalog(tmp_path / "models.toml", catalog)
 
     changed = _migrate_legacy_project_gateway_metadata(
         tmp_path,
-        aliases=("legacy", "legacy-gemini", "explicit"),
+        aliases=(
+            "legacy",
+            "legacy-gemini",
+            "legacy-custom",
+            "explicit",
+            "explicit-custom",
+        ),
     )
     migrated = load_model_catalog(tmp_path / "models.toml")
 
@@ -127,6 +154,12 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
     assert migrated.models["legacy-gemini"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
     )
+    assert migrated.models["legacy-custom"].gateway == GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+    )
+    assert migrated.models["explicit-custom"].gateway == GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(supports_streaming_tool_arguments=True)
+    )
     assert migrated.models["explicit"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(
             supports_strict_tools=True,
@@ -136,7 +169,13 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
     assert (
         _migrate_legacy_project_gateway_metadata(
             tmp_path,
-            aliases=("legacy", "legacy-gemini", "explicit"),
+            aliases=(
+                "legacy",
+                "legacy-gemini",
+                "legacy-custom",
+                "explicit",
+                "explicit-custom",
+            ),
         )
         is False
     )

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -74,11 +74,16 @@ def _activation(*, project_ref: str, activation_ref: str) -> ProjectActivation:
     )
 
 
-def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path: Path) -> None:
-    """Upgrade absent gateway metadata without overriding explicit declarations."""
+def test_legacy_project_candidates_gain_only_certified_streaming_transport(
+    tmp_path: Path,
+) -> None:
+    """Upgrade transport facts from adapter certification, never model tool support."""
     catalog = ModelCatalog(
         schema_version=2,
-        connections={"provider": ConnectionConfig(provider="openai")},
+        connections={
+            "provider": ConnectionConfig(provider="openai"),
+            "gemini": ConnectionConfig(provider="gemini", api_key_env="GEMINI_API_KEY"),
+        },
         models={
             "legacy": ModelRecord(
                 connection="provider",
@@ -93,25 +98,36 @@ def test_legacy_project_candidates_gain_only_shared_streaming_transport(tmp_path
                     capabilities=GatewayDeploymentCapabilities(supports_strict_tools=True)
                 ),
             ),
+            "legacy-gemini": ModelRecord(
+                connection="gemini",
+                model="gemini-legacy-model",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+            ),
         },
     )
     write_model_catalog(tmp_path / "models.toml", catalog)
 
     changed = _migrate_legacy_project_gateway_metadata(
         tmp_path,
-        aliases=("legacy", "explicit"),
+        aliases=("legacy", "legacy-gemini", "explicit"),
     )
     migrated = load_model_catalog(tmp_path / "models.toml")
 
     assert changed is True
     assert migrated.models["legacy"].gateway == GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        )
+    )
+    assert migrated.models["legacy-gemini"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
     )
     assert migrated.models["explicit"].gateway == catalog.models["explicit"].gateway
     assert (
         _migrate_legacy_project_gateway_metadata(
             tmp_path,
-            aliases=("legacy", "explicit"),
+            aliases=("legacy", "legacy-gemini", "explicit"),
         )
         is False
     )

--- a/exp/runtime/gateway/project_alias_test.py
+++ b/exp/runtime/gateway/project_alias_test.py
@@ -11,6 +11,7 @@ from exp.common.models import (
     ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
+    ModelCapabilities,
     ModelCatalog,
     ModelRecord,
     PricingSnapshot,
@@ -89,11 +90,13 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
                 connection="provider",
                 model="legacy-model",
                 billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
             ),
             "explicit": ModelRecord(
                 connection="provider",
                 model="explicit-model",
                 billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
                 gateway=GatewayDeploymentMetadata(
                     capabilities=GatewayDeploymentCapabilities(supports_strict_tools=True)
                 ),
@@ -102,6 +105,7 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
                 connection="gemini",
                 model="gemini-legacy-model",
                 billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=ModelCapabilities(supports_tools=True),
             ),
         },
     )
@@ -123,7 +127,12 @@ def test_legacy_project_candidates_gain_only_certified_streaming_transport(
     assert migrated.models["legacy-gemini"].gateway == GatewayDeploymentMetadata(
         capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
     )
-    assert migrated.models["explicit"].gateway == catalog.models["explicit"].gateway
+    assert migrated.models["explicit"].gateway == GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_strict_tools=True,
+            supports_streaming_tool_arguments=True,
+        )
+    )
     assert (
         _migrate_legacy_project_gateway_metadata(
             tmp_path,

--- a/exp/runtime/gateway/provider_certification.py
+++ b/exp/runtime/gateway/provider_certification.py
@@ -85,6 +85,14 @@ class ProviderCertificationMatrix(ContractModel):
         return sha256_json(self)
 
 
+_CERTIFIED_RESULTS = frozenset(
+    {
+        ProviderCertificationResult.PROVIDER_FIXTURE_PASS,
+        ProviderCertificationResult.INHERITED_COMPATIBLE_FIXTURE_PASS,
+    }
+)
+
+
 _EVALUATED_AT = datetime(2026, 8, 25, tzinfo=UTC)
 _CLIENT_SDK = "openai==3.0.0"
 _GATEWAY_API_SURFACES = ("chat.completions", "responses")
@@ -281,3 +289,16 @@ PROVIDER_CERTIFICATION_MATRIX = ProviderCertificationMatrix(
         )
     )
 )
+
+
+def provider_has_certified_capability(
+    provider: str,
+    capability: ProviderCapability,
+) -> bool:
+    """Return whether deterministic evidence certifies one provider behavior."""
+    return any(
+        cell.provider == provider
+        and cell.capability is capability
+        and cell.result in _CERTIFIED_RESULTS
+        for cell in PROVIDER_CERTIFICATION_MATRIX.cells
+    )

--- a/exp/runtime/gateway/provider_certification.py
+++ b/exp/runtime/gateway/provider_certification.py
@@ -262,6 +262,15 @@ def _launch_provider_cells(
         if capability is ProviderCapability.CREDENTIAL_GATED_LIVE:
             result = ProviderCertificationResult.NOT_RUN_REQUIRES_CREDENTIALS
             limitation = "No provider credential was available in the deterministic lane."
+        elif (
+            provider == "openai-compatible"
+            and capability is ProviderCapability.TOOL_ARGUMENT_STREAM
+        ):
+            result = ProviderCertificationResult.UNSUPPORTED
+            limitation = (
+                "A generic adapter fixture cannot certify streamed tool arguments for an "
+                "arbitrary custom endpoint; deployments must declare that endpoint fact."
+            )
         else:
             result = ProviderCertificationResult.PROVIDER_FIXTURE_PASS
             limitation = None

--- a/exp/runtime/gateway/provider_certification_test.py
+++ b/exp/runtime/gateway/provider_certification_test.py
@@ -90,6 +90,9 @@ def test_google_raw_argument_limit_is_explicit_while_bedrock_is_certified() -> N
         is ProviderCertificationResult.PROVIDER_FIXTURE_PASS
     )
     assert provider_has_certified_capability("openai", ProviderCapability.TOOL_ARGUMENT_STREAM)
+    assert not provider_has_certified_capability(
+        "openai-compatible", ProviderCapability.TOOL_ARGUMENT_STREAM
+    )
     assert not provider_has_certified_capability("gemini", ProviderCapability.TOOL_ARGUMENT_STREAM)
 
 

--- a/exp/runtime/gateway/provider_certification_test.py
+++ b/exp/runtime/gateway/provider_certification_test.py
@@ -11,6 +11,7 @@ from exp.runtime.gateway.provider_certification import (
     ProviderCapability,
     ProviderCertificationMatrix,
     ProviderCertificationResult,
+    provider_has_certified_capability,
 )
 from exp.runtime.models import SUPPORTED_PROVIDERS
 
@@ -88,6 +89,8 @@ def test_google_raw_argument_limit_is_explicit_while_bedrock_is_certified() -> N
         cells[("bedrock", ProviderCapability.TOOL_ARGUMENT_STREAM)].result
         is ProviderCertificationResult.PROVIDER_FIXTURE_PASS
     )
+    assert provider_has_certified_capability("openai", ProviderCapability.TOOL_ARGUMENT_STREAM)
+    assert not provider_has_certified_capability("gemini", ProviderCapability.TOOL_ARGUMENT_STREAM)
 
 
 def test_anthropic_text_stream_cell_names_exact_native_fixture() -> None:

--- a/exp/runtime/models/providers/errors.py
+++ b/exp/runtime/models/providers/errors.py
@@ -148,14 +148,15 @@ def normalized_provider_failure(exception: BaseException) -> GatewayFailure:
             },
         )
     if isinstance(exception, ProviderCapabilityError):
-        # The capability is a stable internal literal (never request content),
-        # and naming it is what makes the 400 triageable for the caller.
+        # Keep the internal literal for operator diagnostics, but never put it in
+        # the public-safe message. Protocol boundaries translate known literals
+        # to real request fields when they have the API-surface context required
+        # to do so.
         return GatewayFailure(
             failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
             safe_message=(
-                "provider deployment cannot preserve the requested capability: "
-                f"{exception.capability}. Remove the unsupported field or request "
-                "a different model alias"
+                "provider deployment cannot preserve a requested capability; "
+                "remove the unsupported field or request a different model alias"
             ),
             safe_details={"capability": exception.capability},
         )

--- a/exp/runtime/models/providers/errors_test.py
+++ b/exp/runtime/models/providers/errors_test.py
@@ -119,13 +119,13 @@ def test_refusal_and_capability_failures_keep_only_safe_signals() -> None:
     assert refusal.safe_details == {"signal": "safety"}
     assert capability.failure_class is GatewayFailureClass.UNSUPPORTED_CAPABILITY
     assert capability.safe_details == {"capability": "strict_tools"}
-    # The message names the capability literal and nothing else, so a 400 is
-    # triageable without ever carrying request content.
+    # Internal capability literals remain operator metadata and never cross the
+    # public-safe message boundary.
     assert capability.safe_message == (
-        "provider deployment cannot preserve the requested capability: "
-        "strict_tools. Remove the unsupported field or request "
-        "a different model alias"
+        "provider deployment cannot preserve a requested capability; "
+        "remove the unsupported field or request a different model alias"
     )
+    assert "strict_tools" not in capability.safe_message
 
 
 def test_parameter_failure_preserves_only_public_code_and_path() -> None:

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -186,6 +186,7 @@ def preflight_gateway_request(
     capabilities: GatewayDeploymentCapabilities,
     *,
     model_capabilities: ModelCapabilities | None = None,
+    requested_stream: bool | None = None,
 ) -> None:
     """Reject gateway semantics a deployment cannot preserve before provider dispatch.
 
@@ -195,6 +196,8 @@ def preflight_gateway_request(
         model_capabilities: Exact model-level semantic capabilities. Production
             routes supply this value; ``None`` preserves compatibility for
             standalone callers that only validate deployment protocol fields.
+        requested_stream: Caller-visible streaming intent when the gateway has
+            forced the provider request into streaming mode internally.
 
     Raises:
         ProviderCapabilityError: A present request feature is unsupported.
@@ -233,7 +236,8 @@ def preflight_gateway_request(
             "structured_text",
         ),
         (
-            request.stream and bool(request.tools),
+            (request.stream if requested_stream is None else requested_stream)
+            and bool(request.tools),
             capabilities.supports_streaming_tool_arguments,
             "streaming_tool_arguments",
         ),

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -186,6 +186,7 @@ def preflight_gateway_request(
     capabilities: GatewayDeploymentCapabilities,
     *,
     model_capabilities: ModelCapabilities | None = None,
+    public_stream: bool | None = None,
 ) -> None:
     """Reject gateway semantics a deployment cannot preserve before provider dispatch.
 
@@ -195,6 +196,9 @@ def preflight_gateway_request(
         model_capabilities: Exact model-level semantic capabilities. Production
             routes supply this value; ``None`` preserves compatibility for
             standalone callers that only validate deployment protocol fields.
+        public_stream: Whether the caller requested streaming. ``None`` uses
+            ``request.stream`` for standalone callers. Hosted execution passes
+            this explicitly because its provider request is always streamed.
 
     Raises:
         ProviderCapabilityError: A present request feature is unsupported.
@@ -209,8 +213,10 @@ def preflight_gateway_request(
                 "structured_output",
             ),
         )
+    caller_stream = request.stream if public_stream is None else public_stream
+    if caller_stream:
+        requirements += ((request.stream, capabilities.supports_streaming, "streaming"),)
     requirements += (
-        (request.stream, capabilities.supports_streaming, "streaming"),
         (
             any(message.role == "developer" for message in request.messages),
             capabilities.supports_developer_messages,
@@ -238,6 +244,8 @@ def preflight_gateway_request(
             "streaming_tool_arguments",
         ),
     )
+    if request.stream and not caller_stream:
+        requirements += ((True, capabilities.supports_streaming, "streaming"),)
     for requested, supported, capability in requirements:
         if requested and not supported:
             raise ProviderCapabilityError(capability=capability)

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -186,7 +186,6 @@ def preflight_gateway_request(
     capabilities: GatewayDeploymentCapabilities,
     *,
     model_capabilities: ModelCapabilities | None = None,
-    requested_stream: bool | None = None,
 ) -> None:
     """Reject gateway semantics a deployment cannot preserve before provider dispatch.
 
@@ -196,8 +195,6 @@ def preflight_gateway_request(
         model_capabilities: Exact model-level semantic capabilities. Production
             routes supply this value; ``None`` preserves compatibility for
             standalone callers that only validate deployment protocol fields.
-        requested_stream: Caller-visible streaming intent when the gateway has
-            forced the provider request into streaming mode internally.
 
     Raises:
         ProviderCapabilityError: A present request feature is unsupported.
@@ -236,8 +233,7 @@ def preflight_gateway_request(
             "structured_text",
         ),
         (
-            (request.stream if requested_stream is None else requested_stream)
-            and bool(request.tools),
+            request.stream and bool(request.tools),
             capabilities.supports_streaming_tool_arguments,
             "streaming_tool_arguments",
         ),

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -8,7 +8,7 @@ from typing import Protocol, runtime_checkable
 
 from exp.common.models import ModelCapabilities, ModelClient, ModelRequest, ModelResponse
 from exp.common.models.catalog import GatewayDeploymentCapabilities
-from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayRequest
 from exp.runtime.models.providers.async_transport import (
     RequestDeadline,
     run_then_close_pooled_client,
@@ -199,7 +199,17 @@ def preflight_gateway_request(
     Raises:
         ProviderCapabilityError: A present request feature is unsupported.
     """
-    requirements = (
+    requirements: tuple[tuple[bool, bool, str], ...] = ()
+    if model_capabilities is not None:
+        requirements += (
+            (bool(request.tools), model_capabilities.supports_tools is not False, "function_tools"),
+            (
+                request.structured_text is not None,
+                model_capabilities.supports_structured_output,
+                "structured_output",
+            ),
+        )
+    requirements += (
         (request.stream, capabilities.supports_streaming, "streaming"),
         (
             any(message.role == "developer" for message in request.messages),
@@ -222,17 +232,12 @@ def preflight_gateway_request(
             capabilities.supports_structured_text,
             "structured_text",
         ),
+        (
+            request.stream and bool(request.tools),
+            capabilities.supports_streaming_tool_arguments,
+            "streaming_tool_arguments",
+        ),
     )
-    if model_capabilities is not None:
-        model_requirements = (
-            (bool(request.tools), model_capabilities.supports_tools is not False, "function_tools"),
-            (
-                request.structured_text is not None,
-                model_capabilities.supports_structured_output,
-                "structured_output",
-            ),
-        )
-        requirements += model_requirements
     for requested, supported, capability in requirements:
         if requested and not supported:
             raise ProviderCapabilityError(capability=capability)
@@ -243,8 +248,8 @@ def preflight_gateway_request(
                 f"This model route accepts at most {stop_limit} stop "
                 f"sequences; the request supplied {len(request.stop)}."
             ),
-            param="stop",
-            code="too_many_stop_sequences",
+            param=("stop_sequences" if request.surface == GatewayApiSurface.MESSAGES else "stop"),
+            code="invalid_parameter",
         )
 
 

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -210,6 +210,24 @@ def test_preflight_requires_streaming_tool_argument_support() -> None:
     )
 
 
+def test_preflight_attributes_forced_streaming_to_tool_arguments_first() -> None:
+    """Internally streamed tool requests report the tool transport deficit first."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
+        stream=True,
+    )
+
+    with pytest.raises(ProviderCapabilityError, match="streaming_tool_arguments"):
+        preflight_gateway_request(
+            request,
+            GatewayDeploymentCapabilities(),
+            model_capabilities=ModelCapabilities(supports_tools=True),
+            public_stream=False,
+        )
+
+
 def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -> None:
     """An over-cap stop list fails locally instead of surfacing the provider's opaque 4xx."""
     request = GatewayRequest(

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -184,7 +184,7 @@ def test_preflight_treats_false_parallel_control_as_semantic() -> None:
 
 
 def test_preflight_requires_streaming_tool_argument_support() -> None:
-    """Internally streamed tool calls only select deployments that can frame arguments."""
+    """Caller-streamed tool calls only select deployments that can frame arguments."""
     request = GatewayRequest(
         surface=GatewayApiSurface.CHAT_COMPLETIONS,
         messages=(GatewayMessage(role="user", content="hi"),),
@@ -207,6 +207,13 @@ def test_preflight_requires_streaming_tool_argument_support() -> None:
             supports_streaming_tool_arguments=True,
         ),
         model_capabilities=model_capabilities,
+    )
+
+    preflight_gateway_request(
+        request,
+        GatewayDeploymentCapabilities(supports_streaming=True),
+        model_capabilities=model_capabilities,
+        requested_stream=False,
     )
 
 

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -183,6 +183,33 @@ def test_preflight_treats_false_parallel_control_as_semantic() -> None:
         preflight_gateway_request(request, GatewayDeploymentCapabilities())
 
 
+def test_preflight_requires_streaming_tool_argument_support() -> None:
+    """Internally streamed tool calls only select deployments that can frame arguments."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
+        stream=True,
+    )
+    model_capabilities = ModelCapabilities(supports_tools=True)
+
+    with pytest.raises(ProviderCapabilityError, match="streaming_tool_arguments"):
+        preflight_gateway_request(
+            request,
+            GatewayDeploymentCapabilities(supports_streaming=True),
+            model_capabilities=model_capabilities,
+        )
+
+    preflight_gateway_request(
+        request,
+        GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        ),
+        model_capabilities=model_capabilities,
+    )
+
+
 def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -> None:
     """An over-cap stop list fails locally instead of surfacing the provider's opaque 4xx."""
     request = GatewayRequest(
@@ -198,7 +225,7 @@ def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -
     with pytest.raises(ProviderParameterError) as caught:
         preflight_gateway_request(request, capabilities)
     assert caught.value.param == "stop"
-    assert caught.value.code == "too_many_stop_sequences"
+    assert caught.value.code == "invalid_parameter"
 
     # At the limit passes, and an unbounded route (default None) never counts.
     at_limit = request.model_copy(update={"stop": ("a", "b", "c", "d", "e")})

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -209,13 +209,6 @@ def test_preflight_requires_streaming_tool_argument_support() -> None:
         model_capabilities=model_capabilities,
     )
 
-    preflight_gateway_request(
-        request,
-        GatewayDeploymentCapabilities(supports_streaming=True),
-        model_capabilities=model_capabilities,
-        requested_stream=False,
-    )
-
 
 def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -> None:
     """An over-cap stop list fails locally instead of surfacing the provider's opaque 4xx."""

--- a/exp/runtime/openai_protocol/errors.py
+++ b/exp/runtime/openai_protocol/errors.py
@@ -195,6 +195,19 @@ def public_failure_error(
         if param is None and isinstance(detail_param, str):
             param = detail_param
     message = failure.safe_message
+    if failure.failure_class is GatewayFailureClass.UNSUPPORTED_CAPABILITY and isinstance(
+        failure.safe_details.get("capability"), str
+    ):
+        if param is None:
+            message = (
+                "The requested capability is not supported by this model route. "
+                "Remove the unsupported field or choose a different model."
+            )
+        else:
+            message = (
+                f"The capability '{param}' is not supported by this model route. "
+                "Remove the field or choose a different model."
+            )
     retry_after_seconds: int | None = None
     if failure.failure_class is GatewayFailureClass.THROTTLED:
         retry_after_seconds = THROTTLED_RETRY_AFTER_SECONDS

--- a/exp/runtime/openai_protocol/errors_test.py
+++ b/exp/runtime/openai_protocol/errors_test.py
@@ -140,6 +140,29 @@ def test_invalid_route_parameter_preserves_field_specific_error() -> None:
     assert error.detail.param == "max_completion_tokens"
 
 
+@pytest.mark.parametrize("param", (None, "tools"))
+def test_unsupported_capability_never_exposes_internal_identifiers(
+    param: str | None,
+) -> None:
+    """Generic public mapping ignores internal capability names and messages."""
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
+            safe_message="internal tinker_gateway_execution capability failed",
+            safe_details={"capability": "tinker_gateway_execution"},
+        ),
+        param=param,
+    )
+
+    assert error.status_code == 400
+    assert error.detail.code == "unsupported_capability"
+    assert error.detail.param == param
+    assert "tinker_gateway_execution" not in error.detail.message
+    assert "internal" not in error.detail.message
+    if param is not None:
+        assert param in error.detail.message
+
+
 def test_retry_after_must_be_positive() -> None:
     """A non-positive advertised wait is a programming error, not a response."""
     with pytest.raises(ValueError, match="retry_after_seconds must be positive"):

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -52,6 +52,7 @@ class DecodedGatewayRequest(ContractModel):
 
     alias: str = Field(min_length=1, max_length=256)
     request: GatewayRequest
+    developer_messages_param: str | None = None
 
 
 class _WireModel(BaseModel):
@@ -540,7 +541,25 @@ def decode_responses(
         )
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
-    return DecodedGatewayRequest(alias=request.model, request=canonical)
+    developer_messages_param = None
+    if request.instructions is not None:
+        developer_messages_param = "instructions"
+    elif not isinstance(request.input, str):
+        developer_index = next(
+            (
+                index
+                for index, item in enumerate(request.input)
+                if isinstance(item, _ResponseMessage) and item.role == "developer"
+            ),
+            None,
+        )
+        if developer_index is not None:
+            developer_messages_param = f"input.{developer_index}.role"
+    return DecodedGatewayRequest(
+        alias=request.model,
+        request=canonical,
+        developer_messages_param=developer_messages_param,
+    )
 
 
 def _validate_manifest(payload: JsonObject, manifest: CompatibilityManifest) -> None:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -178,6 +178,7 @@ def test_responses_decoder_preserves_continuation_and_distinct_wire_shapes() -> 
     )
 
     request = decoded.request
+    assert decoded.developer_messages_param == "instructions"
     assert request.surface == GatewayApiSurface.RESPONSES
     assert tuple(message.role for message in request.messages) == (
         "developer",
@@ -199,6 +200,21 @@ def test_responses_decoder_preserves_continuation_and_distinct_wire_shapes() -> 
     assert request.maximum_output_tokens_parameter == "max_output_tokens"
     assert request.structured_text is not None
     assert request.client_request_id == "operation-two"
+
+
+def test_responses_decoder_tracks_developer_input_origin() -> None:
+    """Capability errors can identify an input developer role without inventing instructions."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "message", "role": "user", "content": "hello"},
+                {"type": "message", "role": "developer", "content": "follow policy"},
+            ],
+        }
+    )
+
+    assert decoded.developer_messages_param == "input.1.role"
 
 
 def test_responses_decoder_rejects_conflicting_reasoning_summary_aliases() -> None:

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -1533,6 +1533,7 @@ def _installed_release_driver() -> None:
             "--supports-developer-messages",
             "--supports-strict-tools",
             "--supports-parallel-tool-calls",
+            "--supports-streaming-tool-arguments",
             "--maximum-output-tokens",
             "4096",
             "--input-price",


### PR DESCRIPTION
## Scope

Adds exact regression coverage for per-deployment tools, structured-output, streaming, reasoning, and sampling admission. When no rung qualifies, the public 400 now names the rejected capability instead of returning internal or an unscoped error.

## Validation

- Focused gateway/error tests: 6 passed
- Non-live suite excluding existing macOS picker renderer failures: 2560 passed, 1 skipped
- Ruff, format, ty: passed
- Cargo fmt, clippy no-default-features, test no-default-features: 75 passed

## Supersedes from #639

No #639 production commit: capability filtering was already on main from #643/#649. This PR supplies the missing exact failure regressions and field-specific public parameter behavior in native_bridge_test.py and openai_protocol/errors.py.

No production verification is claimed. Do not merge or enqueue without explicit approval.