### PR TITLE
feat: support explicit Bedrock credentials

### DIFF
--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -26,6 +26,8 @@ _BEDROCK_AUTH_MODE_OPTION = typer.Option(None, "--bedrock-auth-mode")
 _API_VERSION_OPTION = typer.Option(None, "--api-version")
 _AZURE_API_SURFACE_OPTION = typer.Option(None, "--azure-api-surface")
 _REGION_OPTION = typer.Option(None, "--region")
+_CLEAR_CREDENTIALS_OPTION = typer.Option(False, "--clear-credentials")
+_CLEAR_REGION_OPTION = typer.Option(False, "--clear-region")
 
 
 class GatewayProviderView(ContractModel):
@@ -40,6 +42,50 @@ class GatewayProviderView(ContractModel):
     api_version: str | None = None
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = None
+
+
+def _updated_credentials(
+    *,
+    current: ConnectionConfig,
+    provider: str,
+    credential_env: str | None,
+    access_key_id_env: str | None,
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None,
+    clear_credentials: bool,
+) -> tuple[str | None, str | None, Literal["access_key_pair", "api_key"] | None]:
+    """Resolve update credential metadata without changing an old locator's meaning."""
+    supplied = (credential_env, access_key_id_env, bedrock_auth_mode)
+    if clear_credentials:
+        if any(value is not None for value in supplied):
+            raise ValueError(
+                "--clear-credentials cannot be combined with credential or auth-mode options"
+            )
+        return None, None, None
+    if current.provider != provider:
+        return credential_env, access_key_id_env, bedrock_auth_mode
+    mode_changed = bedrock_auth_mode is not None and bedrock_auth_mode != current.bedrock_auth_mode
+    if mode_changed:
+        if credential_env is None:
+            raise ValueError("changing Bedrock auth mode requires --credential-env")
+        if bedrock_auth_mode == "api_key":
+            if access_key_id_env is not None:
+                raise ValueError("Bedrock api_key auth forbids --access-key-id-env")
+            return credential_env, None, bedrock_auth_mode
+        if access_key_id_env is None:
+            raise ValueError(
+                "changing to Bedrock access_key_pair auth requires --access-key-id-env"
+            )
+        return credential_env, access_key_id_env, bedrock_auth_mode
+    effective_mode = current.bedrock_auth_mode if bedrock_auth_mode is None else bedrock_auth_mode
+    effective_credential = current.api_key_env if credential_env is None else credential_env
+    effective_access_key_id = (
+        current.aws_access_key_id_env if access_key_id_env is None else access_key_id_env
+    )
+    if effective_mode == "api_key":
+        if access_key_id_env is not None:
+            raise ValueError("Bedrock api_key auth forbids --access-key-id-env")
+        effective_access_key_id = None
+    return effective_credential, effective_access_key_id, effective_mode
 
 
 @provider_app.command("list")
@@ -125,6 +171,8 @@ def provider_update(
         _AZURE_API_SURFACE_OPTION
     ),
     region: str | None = _REGION_OPTION,
+    clear_credentials: bool = _CLEAR_CREDENTIALS_OPTION,
+    clear_region: bool = _CLEAR_REGION_OPTION,
     non_interactive: bool = _NON_INTERACTIVE_OPTION,
     json_output: bool = _JSON_OPTION,
 ) -> None:
@@ -138,23 +186,26 @@ def provider_update(
             raise ValueError(f"provider connection {name!r} does not exist")
     current = authorities[name].config
     same_provider = current.provider == provider
+    with usage_error(ValueError):
+        if clear_region and region is not None:
+            raise ValueError("--clear-region cannot be combined with --region")
+        updated_credential_env, updated_access_key_id_env, updated_bedrock_auth_mode = (
+            _updated_credentials(
+                current=current,
+                provider=provider,
+                credential_env=credential_env,
+                access_key_id_env=access_key_id_env,
+                bedrock_auth_mode=bedrock_auth_mode,
+                clear_credentials=clear_credentials,
+            )
+        )
     provider_add(
         name=name,
         provider=provider,
         root=root,
-        credential_env=(
-            current.api_key_env if credential_env is None and same_provider else credential_env
-        ),
-        access_key_id_env=(
-            current.aws_access_key_id_env
-            if access_key_id_env is None and same_provider and provider == "bedrock"
-            else access_key_id_env
-        ),
-        bedrock_auth_mode=(
-            current.bedrock_auth_mode
-            if bedrock_auth_mode is None and same_provider and provider == "bedrock"
-            else bedrock_auth_mode
-        ),
+        credential_env=updated_credential_env,
+        access_key_id_env=updated_access_key_id_env,
+        bedrock_auth_mode=updated_bedrock_auth_mode,
         base_url=current.base_url if base_url is None and same_provider else base_url,
         api_version=current.api_version if api_version is None and same_provider else api_version,
         azure_api_surface=(
@@ -162,7 +213,13 @@ def provider_update(
             if azure_api_surface is None and same_provider and provider == "azure"
             else azure_api_surface
         ),
-        region=current.region if region is None and same_provider else region,
+        region=(
+            None
+            if clear_region
+            else current.region
+            if region is None and same_provider
+            else region
+        ),
         replace=True,
         non_interactive=non_interactive,
         json_output=json_output,

--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -214,11 +214,7 @@ def provider_update(
             else azure_api_surface
         ),
         region=(
-            None
-            if clear_region
-            else current.region
-            if region is None and same_provider
-            else region
+            None if clear_region else current.region if region is None and same_provider else region
         ),
         replace=True,
         non_interactive=non_interactive,

--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -21,6 +21,8 @@ _JSON_OPTION = typer.Option(False, "--json")
 _NON_INTERACTIVE_OPTION = typer.Option(False, "--non-interactive")
 _BASE_URL_OPTION = typer.Option(None, "--base-url")
 _CREDENTIAL_ENV_OPTION = typer.Option(None, "--credential-env")
+_ACCESS_KEY_ID_ENV_OPTION = typer.Option(None, "--access-key-id-env")
+_BEDROCK_AUTH_MODE_OPTION = typer.Option(None, "--bedrock-auth-mode")
 _API_VERSION_OPTION = typer.Option(None, "--api-version")
 _AZURE_API_SURFACE_OPTION = typer.Option(None, "--azure-api-surface")
 _REGION_OPTION = typer.Option(None, "--region")
@@ -32,6 +34,8 @@ class GatewayProviderView(ContractModel):
     name: str
     provider: str
     credential_env: str | None = None
+    access_key_id_env: str | None = None
+    bedrock_auth_mode: str | None = None
     base_url: str | None = None
     api_version: str | None = None
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
@@ -46,6 +50,8 @@ def provider_list(root: Path = ROOT_OPTION, json_output: bool = _JSON_OPTION) ->
             name=name,
             provider=connection.provider,
             credential_env=connection.api_key_env,
+            access_key_id_env=connection.aws_access_key_id_env,
+            bedrock_auth_mode=connection.bedrock_auth_mode,
             base_url=connection.base_url,
             api_version=connection.api_version,
             azure_api_surface=connection.azure_api_surface,
@@ -63,6 +69,8 @@ def provider_add(
     provider: str = typer.Option(..., "--provider"),
     root: Path = ROOT_OPTION,
     credential_env: str | None = _CREDENTIAL_ENV_OPTION,
+    access_key_id_env: str | None = _ACCESS_KEY_ID_ENV_OPTION,
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = (_BEDROCK_AUTH_MODE_OPTION),
     base_url: str | None = _BASE_URL_OPTION,
     api_version: str | None = _API_VERSION_OPTION,
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = (
@@ -82,6 +90,8 @@ def provider_add(
                 provider=provider,
                 base_url=base_url,
                 api_key_env=credential_env,
+                aws_access_key_id_env=access_key_id_env,
+                bedrock_auth_mode=bedrock_auth_mode,
                 api_version=api_version,
                 azure_api_surface=azure_api_surface,
                 region=region,
@@ -107,6 +117,8 @@ def provider_update(
     provider: str = typer.Option(..., "--provider"),
     root: Path = ROOT_OPTION,
     credential_env: str | None = _CREDENTIAL_ENV_OPTION,
+    access_key_id_env: str | None = _ACCESS_KEY_ID_ENV_OPTION,
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = (_BEDROCK_AUTH_MODE_OPTION),
     base_url: str | None = _BASE_URL_OPTION,
     api_version: str | None = _API_VERSION_OPTION,
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = (
@@ -117,25 +129,40 @@ def provider_update(
     json_output: bool = _JSON_OPTION,
 ) -> None:
     """Replace one provider connection and force active snapshot revalidation."""
-    existing = next(
-        (
-            authority.config
-            for authority in GatewayManagement(root).provider_connections()
-            if authority.connection_id == name
-        ),
-        None,
-    )
-    if azure_api_surface is None and existing is not None and provider == "azure":
-        azure_api_surface = existing.azure_api_surface
+    authorities = {
+        authority.connection_id: authority
+        for authority in GatewayManagement(root).provider_connections()
+    }
+    if name not in authorities:
+        with usage_error(ValueError):
+            raise ValueError(f"provider connection {name!r} does not exist")
+    current = authorities[name].config
+    same_provider = current.provider == provider
     provider_add(
         name=name,
         provider=provider,
         root=root,
-        credential_env=credential_env,
-        base_url=base_url,
-        api_version=api_version,
-        azure_api_surface=azure_api_surface,
-        region=region,
+        credential_env=(
+            current.api_key_env if credential_env is None and same_provider else credential_env
+        ),
+        access_key_id_env=(
+            current.aws_access_key_id_env
+            if access_key_id_env is None and same_provider and provider == "bedrock"
+            else access_key_id_env
+        ),
+        bedrock_auth_mode=(
+            current.bedrock_auth_mode
+            if bedrock_auth_mode is None and same_provider and provider == "bedrock"
+            else bedrock_auth_mode
+        ),
+        base_url=current.base_url if base_url is None and same_provider else base_url,
+        api_version=current.api_version if api_version is None and same_provider else api_version,
+        azure_api_surface=(
+            current.azure_api_surface
+            if azure_api_surface is None and same_provider and provider == "azure"
+            else azure_api_surface
+        ),
+        region=current.region if region is None and same_provider else region,
         replace=True,
         non_interactive=non_interactive,
         json_output=json_output,

--- a/exp/cli/gateway/provider_test.py
+++ b/exp/cli/gateway/provider_test.py
@@ -244,3 +244,66 @@ def test_provider_update_drops_azure_surface_when_changing_provider(tmp_path: Pa
     (authority,) = GatewayManagement(root).provider_connections()
     assert authority.config.provider == "openai-compatible"
     assert authority.config.azure_api_surface is None
+
+
+def test_provider_update_preserves_explicit_bedrock_credentials(tmp_path: Path) -> None:
+    """A metadata-only update does not downgrade an explicit Bedrock pair to ambient auth."""
+    root = _initialized_root(tmp_path)
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--credential-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--access-key-id-env",
+            "AWS_ACCESS_KEY_ID",
+            "--bedrock-auth-mode",
+            "access_key_pair",
+            "--region",
+            "us-west-2",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    updated = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--region",
+            "us-east-1",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    listed = _runner.invoke(
+        app,
+        ["config", "gateway", "provider", "list", "--json", "--root", str(root)],
+    )
+
+    assert added.exit_code == 0
+    assert updated.exit_code == 0
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.api_key_env == "AWS_SECRET_ACCESS_KEY"
+    assert authority.config.aws_access_key_id_env == "AWS_ACCESS_KEY_ID"
+    assert authority.config.bedrock_auth_mode == "access_key_pair"
+    assert authority.config.region == "us-east-1"
+    (item,) = json.loads(listed.output)["items"]
+    assert item["credential_env"] == "AWS_SECRET_ACCESS_KEY"
+    assert item["access_key_id_env"] == "AWS_ACCESS_KEY_ID"
+    assert item["bedrock_auth_mode"] == "access_key_pair"

--- a/exp/cli/gateway/provider_test.py
+++ b/exp/cli/gateway/provider_test.py
@@ -307,3 +307,172 @@ def test_provider_update_preserves_explicit_bedrock_credentials(tmp_path: Path) 
     assert item["credential_env"] == "AWS_SECRET_ACCESS_KEY"
     assert item["access_key_id_env"] == "AWS_ACCESS_KEY_ID"
     assert item["bedrock_auth_mode"] == "access_key_pair"
+
+
+def test_provider_update_switches_bedrock_pair_to_api_key_without_stale_access_key(
+    tmp_path: Path,
+) -> None:
+    """Changing auth mode drops the access-key locator from bearer configuration."""
+    root = _initialized_root(tmp_path)
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--credential-env",
+            "BEDROCK_SECRET_ACCESS_KEY",
+            "--access-key-id-env",
+            "BEDROCK_ACCESS_KEY_ID",
+            "--bedrock-auth-mode",
+            "access_key_pair",
+            "--region",
+            "us-west-2",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    updated = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--credential-env",
+            "BEDROCK_API_KEY",
+            "--bedrock-auth-mode",
+            "api_key",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert added.exit_code == 0
+    assert updated.exit_code == 0, updated.output
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.api_key_env == "BEDROCK_API_KEY"
+    assert authority.config.aws_access_key_id_env is None
+    assert authority.config.bedrock_auth_mode == "api_key"
+    assert authority.config.region == "us-west-2"
+
+
+def test_provider_update_does_not_reinterpret_a_stale_secret_locator_as_an_api_key(
+    tmp_path: Path,
+) -> None:
+    """A mode switch requires a fresh credential locator instead of changing its meaning."""
+    root = _initialized_root(tmp_path)
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--credential-env",
+            "BEDROCK_SECRET_ACCESS_KEY",
+            "--access-key-id-env",
+            "BEDROCK_ACCESS_KEY_ID",
+            "--bedrock-auth-mode",
+            "access_key_pair",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    rejected = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--bedrock-auth-mode",
+            "api_key",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert added.exit_code == 0
+    assert rejected.exit_code != 0
+    assert "requires --credential-env" in _plain_output(rejected.output)
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.api_key_env == "BEDROCK_SECRET_ACCESS_KEY"
+    assert authority.config.aws_access_key_id_env == "BEDROCK_ACCESS_KEY_ID"
+    assert authority.config.bedrock_auth_mode == "access_key_pair"
+
+
+def test_provider_update_can_clear_bedrock_auth_and_region_to_ambient(tmp_path: Path) -> None:
+    """Explicit clear flags remove every credential locator and the pinned region."""
+    root = _initialized_root(tmp_path)
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--credential-env",
+            "BEDROCK_SECRET_ACCESS_KEY",
+            "--access-key-id-env",
+            "BEDROCK_ACCESS_KEY_ID",
+            "--bedrock-auth-mode",
+            "access_key_pair",
+            "--region",
+            "us-west-2",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    updated = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "bedrock-production",
+            "--provider",
+            "bedrock",
+            "--clear-credentials",
+            "--clear-region",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert added.exit_code == 0
+    assert updated.exit_code == 0, updated.output
+    (authority,) = GatewayManagement(root).provider_connections()
+    assert authority.config.api_key_env is None
+    assert authority.config.aws_access_key_id_env is None
+    assert authority.config.bedrock_auth_mode is None
+    assert authority.config.region is None

--- a/exp/cli/providers/bedrock_credentials.py
+++ b/exp/cli/providers/bedrock_credentials.py
@@ -1,0 +1,46 @@
+"""Bedrock credential-mode inference for interactive provider setup."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal
+
+_BEDROCK_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK"
+_AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID"
+_AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY"
+_AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
+_AWS_SECURITY_TOKEN_ENV = "AWS_SECURITY_TOKEN"
+
+
+def infer_bedrock_auth(
+    environment: Mapping[str, str] | None,
+) -> tuple[str | None, str | None, Literal["access_key_pair", "api_key"] | None]:
+    """Return secret locator, access-ID locator, and mode from standard AWS variables."""
+    if environment is None:
+        return None, None, None
+    if environment.get(_BEDROCK_BEARER_ENV, "").strip():
+        return _BEDROCK_BEARER_ENV, None, "api_key"
+    if any(
+        environment.get(name, "").strip()
+        for name in (_AWS_SESSION_TOKEN_ENV, _AWS_SECURITY_TOKEN_ENV)
+    ):
+        # Temporary STS credentials are a three-part contract. The explicit
+        # pair authority deliberately stores only two locators, so leave this
+        # request on botocore's ambient chain where the session token survives.
+        return None, None, None
+    if (
+        environment.get(_AWS_ACCESS_KEY_ID_ENV, "").strip()
+        and environment.get(_AWS_SECRET_ACCESS_KEY_ENV, "").strip()
+    ):
+        return _AWS_SECRET_ACCESS_KEY_ENV, _AWS_ACCESS_KEY_ID_ENV, "access_key_pair"
+    return None, None, None
+
+
+def requires_ambient_bedrock_auth(environment: Mapping[str, str] | None) -> bool:
+    """Return whether temporary credentials require the complete ambient chain."""
+    if environment is None or environment.get(_BEDROCK_BEARER_ENV, "").strip():
+        return False
+    return any(
+        environment.get(name, "").strip()
+        for name in (_AWS_SESSION_TOKEN_ENV, _AWS_SECURITY_TOKEN_ENV)
+    )

--- a/exp/cli/providers/bedrock_credentials_test.py
+++ b/exp/cli/providers/bedrock_credentials_test.py
@@ -1,0 +1,43 @@
+"""Tests for interactive Bedrock credential-mode inference."""
+
+import pytest
+
+from exp.cli.providers.bedrock_credentials import (
+    infer_bedrock_auth,
+    requires_ambient_bedrock_auth,
+)
+
+
+@pytest.mark.parametrize("session_token_env", ("AWS_SESSION_TOKEN", "AWS_SECURITY_TOKEN"))
+def test_temporary_aws_credentials_stay_on_the_ambient_chain(session_token_env: str) -> None:
+    """A three-part STS credential is never truncated into explicit pair mode."""
+    assert infer_bedrock_auth(
+        {
+            "AWS_ACCESS_KEY_ID": "AKIAEXAMPLEKEY0001",
+            "AWS_SECRET_ACCESS_KEY": "temporary-secret",
+            session_token_env: "temporary-session-token",
+        }
+    ) == (None, None, None)
+
+
+def test_long_lived_aws_pair_uses_explicit_locators() -> None:
+    """A two-part access-key pair remains eligible for explicit authority."""
+    assert infer_bedrock_auth(
+        {
+            "AWS_ACCESS_KEY_ID": "AKIAEXAMPLEKEY0001",
+            "AWS_SECRET_ACCESS_KEY": "long-lived-secret",
+        }
+    ) == ("AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "access_key_pair")
+
+
+@pytest.mark.parametrize("session_token_env", ("AWS_SESSION_TOKEN", "AWS_SECURITY_TOKEN"))
+def test_temporary_aws_credentials_explicitly_require_ambient_reuse(
+    session_token_env: str,
+) -> None:
+    """Setup distinguishes STS intent from an entirely unconfigured environment."""
+    environment = {session_token_env: "temporary-session-token"}
+
+    assert requires_ambient_bedrock_auth(environment)
+    assert not requires_ambient_bedrock_auth(
+        {**environment, "AWS_BEARER_TOKEN_BEDROCK": "bearer-value"}
+    )

--- a/exp/cli/providers/connection_reuse.py
+++ b/exp/cli/providers/connection_reuse.py
@@ -2,8 +2,7 @@
 
 from typing import Literal
 
-from exp.common.models import ConnectionConfig
-from exp.common.models import ProviderConnection
+from exp.common.models import ConnectionConfig, ProviderConnection
 
 
 def _effective_bedrock_auth_mode(
@@ -11,8 +10,8 @@ def _effective_bedrock_auth_mode(
     provider: str,
     api_key_env: str | None,
     aws_access_key_id_env: str | None,
-    bedrock_auth_mode: str | None,
-) -> str | None:
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None,
+) -> Literal["access_key_pair", "api_key"] | None:
     """Canonicalize legacy explicit-pair records for semantic comparison."""
     if (
         provider == "bedrock"
@@ -34,7 +33,7 @@ def reused_connection(
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None,
     region: str | None,
     aws_access_key_id_env: str | None = None,
-    bedrock_auth_mode: str | None = None,
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None,
     require_ambient_bedrock_auth: bool = False,
 ) -> ProviderConnection | None:
     """Return the sole configured connection that semantically matches these fields."""

--- a/exp/cli/providers/connection_reuse.py
+++ b/exp/cli/providers/connection_reuse.py
@@ -1,0 +1,65 @@
+"""Configured provider-connection reuse rules for interactive setup."""
+
+from typing import Literal
+
+from exp.common.models import ConnectionConfig
+from exp.common.models import ProviderConnection
+
+
+def reused_connection(
+    existing_connections: tuple[ProviderConnection, ...],
+    *,
+    provider: str,
+    api_key_env: str | None,
+    base_url: str | None,
+    api_version: str | None,
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None,
+    region: str | None,
+    aws_access_key_id_env: str | None = None,
+    bedrock_auth_mode: str | None = None,
+    require_ambient_bedrock_auth: bool = False,
+) -> ProviderConnection | None:
+    """Return the sole configured connection that semantically matches these fields."""
+    matches: list[ProviderConnection] = []
+    unspecified_bedrock_auth = (
+        provider == "bedrock"
+        and api_key_env is None
+        and aws_access_key_id_env is None
+        and bedrock_auth_mode is None
+    )
+    candidate = ConnectionConfig(
+        provider=provider,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_version=api_version,
+        azure_api_surface=azure_api_surface,
+        region=region,
+        aws_access_key_id_env=aws_access_key_id_env,
+        bedrock_auth_mode=bedrock_auth_mode,
+    )
+    for connection in existing_connections:
+        if require_ambient_bedrock_auth and (
+            connection.api_key_env is not None
+            or connection.aws_access_key_id_env is not None
+            or connection.bedrock_auth_mode is not None
+        ):
+            continue
+        configured = connection.catalog_config()
+        if unspecified_bedrock_auth:
+            configured = configured.model_copy(
+                update={
+                    "api_key_env": None,
+                    "aws_access_key_id_env": None,
+                    "bedrock_auth_mode": None,
+                }
+            )
+        if configured.identity_sha256() != candidate.identity_sha256():
+            continue
+        if (
+            not unspecified_bedrock_auth
+            and api_key_env is not None
+            and connection.api_key_env != api_key_env
+        ):
+            continue
+        matches.append(connection)
+    return matches[0] if len(matches) == 1 else None

--- a/exp/cli/providers/connection_reuse.py
+++ b/exp/cli/providers/connection_reuse.py
@@ -6,6 +6,24 @@ from exp.common.models import ConnectionConfig
 from exp.common.models import ProviderConnection
 
 
+def _effective_bedrock_auth_mode(
+    *,
+    provider: str,
+    api_key_env: str | None,
+    aws_access_key_id_env: str | None,
+    bedrock_auth_mode: str | None,
+) -> str | None:
+    """Canonicalize legacy explicit-pair records for semantic comparison."""
+    if (
+        provider == "bedrock"
+        and bedrock_auth_mode is None
+        and api_key_env is not None
+        and aws_access_key_id_env is not None
+    ):
+        return "access_key_pair"
+    return bedrock_auth_mode
+
+
 def reused_connection(
     existing_connections: tuple[ProviderConnection, ...],
     *,
@@ -27,6 +45,12 @@ def reused_connection(
         and aws_access_key_id_env is None
         and bedrock_auth_mode is None
     )
+    requested_bedrock_auth_mode = _effective_bedrock_auth_mode(
+        provider=provider,
+        api_key_env=api_key_env,
+        aws_access_key_id_env=aws_access_key_id_env,
+        bedrock_auth_mode=bedrock_auth_mode,
+    )
     candidate = ConnectionConfig(
         provider=provider,
         base_url=base_url,
@@ -35,7 +59,7 @@ def reused_connection(
         azure_api_surface=azure_api_surface,
         region=region,
         aws_access_key_id_env=aws_access_key_id_env,
-        bedrock_auth_mode=bedrock_auth_mode,
+        bedrock_auth_mode=requested_bedrock_auth_mode,
     )
     for connection in existing_connections:
         if require_ambient_bedrock_auth and (
@@ -51,6 +75,17 @@ def reused_connection(
                     "api_key_env": None,
                     "aws_access_key_id_env": None,
                     "bedrock_auth_mode": None,
+                }
+            )
+        elif provider == "bedrock":
+            configured = configured.model_copy(
+                update={
+                    "bedrock_auth_mode": _effective_bedrock_auth_mode(
+                        provider=connection.provider,
+                        api_key_env=connection.api_key_env,
+                        aws_access_key_id_env=connection.aws_access_key_id_env,
+                        bedrock_auth_mode=connection.bedrock_auth_mode,
+                    )
                 }
             )
         if configured.identity_sha256() != candidate.identity_sha256():

--- a/exp/cli/providers/provider_picker.py
+++ b/exp/cli/providers/provider_picker.py
@@ -21,6 +21,11 @@ from typing import Literal, cast
 from rich.console import Console
 from rich.prompt import Prompt
 
+from exp.cli.providers.bedrock_credentials import (
+    infer_bedrock_auth,
+    requires_ambient_bedrock_auth,
+)
+from exp.cli.providers.connection_reuse import reused_connection
 from exp.cli.providers.experiential_cloud import (
     SETUP_PICKER_LABEL as HOSTED_SETUP_LABEL,
 )
@@ -86,6 +91,8 @@ _CREDENTIAL_KEEP = "keep"
 _CREDENTIAL_REPLACE = "replace"
 _CREDENTIAL_REMOVE = "remove"
 _PROVIDER_VISIBLE_ROWS = 3
+
+_reused_connection = reused_connection
 
 
 class SetupCancelled(Exception):
@@ -354,6 +361,8 @@ def collect_provider_connection(
     api_version = None
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region = None
+    aws_access_key_id_env = None
+    bedrock_auth_mode = None
     if provider in ("openai-compatible", "azure"):
         base_url = ask_text(f"{SETUP_PROVIDER_LABELS[provider]} base URL", console=console)
         if not base_url:
@@ -383,6 +392,8 @@ def collect_provider_connection(
     api_key_env = (
         None if provider == "openai-compatible" else CANONICAL_CREDENTIAL_ENV.get(provider)
     )
+    if provider == "bedrock":
+        api_key_env, aws_access_key_id_env, bedrock_auth_mode = infer_bedrock_auth(environment)
     return ConnectionConfig(
         provider=provider,
         base_url=base_url,
@@ -390,6 +401,8 @@ def collect_provider_connection(
         api_version=api_version,
         azure_api_surface=azure_api_surface,
         region=region,
+        aws_access_key_id_env=aws_access_key_id_env,
+        bedrock_auth_mode=bedrock_auth_mode,
     )
 
 
@@ -516,6 +529,11 @@ def _resolve_endpoint(
         api_version=config.api_version,
         azure_api_surface=config.azure_api_surface,
         region=config.region,
+        aws_access_key_id_env=config.aws_access_key_id_env,
+        bedrock_auth_mode=config.bedrock_auth_mode,
+        require_ambient_bedrock_auth=(
+            provider == "bedrock" and requires_ambient_bedrock_auth(environment)
+        ),
     )
     configured = connection is not None
     if connection is None:
@@ -528,6 +546,8 @@ def _resolve_endpoint(
             api_version=config.api_version,
             azure_api_surface=config.azure_api_surface,
             region=config.region,
+            aws_access_key_id_env=config.aws_access_key_id_env,
+            bedrock_auth_mode=config.bedrock_auth_mode,
         )
     if provider == "bedrock":
         return PreparedEndpoint(connection=connection, api_key="", configured=configured)
@@ -542,51 +562,6 @@ def _resolve_endpoint(
     if api_key is None:
         return None
     return PreparedEndpoint(connection=connection, api_key=api_key, configured=configured)
-
-
-def _reused_connection(
-    existing_connections: tuple[ProviderConnection, ...],
-    *,
-    provider: str,
-    api_key_env: str | None,
-    base_url: str | None,
-    api_version: str | None,
-    azure_api_surface: Literal["openai_deployments", "model_inference"] | None,
-    region: str | None,
-) -> ProviderConnection | None:
-    """Return the configured connection that already describes this exact endpoint.
-
-    Args:
-        existing_connections: Connections already configured in the catalog.
-        provider: Selected provider kind.
-        api_key_env: Canonical or collected environment override name, if any.
-        base_url: Optional collected endpoint.
-        api_version: Optional Azure API version.
-        azure_api_surface: Optional Azure API surface discriminator.
-        region: Optional Bedrock region.
-
-    Returns:
-        The matching configured connection when exactly one exists, otherwise ``None``.
-    """
-    candidate = ConnectionConfig(
-        provider=provider,
-        base_url=base_url,
-        api_key_env=api_key_env,
-        api_version=api_version,
-        azure_api_surface=azure_api_surface,
-        region=region,
-    )
-    matches: list[ProviderConnection] = []
-    for connection in existing_connections:
-        configured = connection.catalog_config()
-        if configured.identity_sha256() != candidate.identity_sha256():
-            continue
-        if api_key_env is not None and connection.api_key_env != api_key_env:
-            continue
-        matches.append(connection)
-    if len(matches) == 1:
-        return matches[0]
-    return None
 
 
 def _stored_credential_action(

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -1176,6 +1176,34 @@ def test_bedrock_reuses_the_sole_explicit_pair_when_auth_is_not_reentered() -> N
     assert endpoints[0].connection == existing[0]
 
 
+def test_bedrock_reuses_a_legacy_explicit_pair_without_a_stored_mode() -> None:
+    """Legacy pair metadata compares as the canonical access-key-pair auth mode."""
+    existing = (
+        ProviderConnection(
+            name="bedrock-production",
+            provider="bedrock",
+            api_key_env="AWS_SECRET_ACCESS_KEY",
+            aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+            region="us-west-2",
+        ),
+    )
+    prepared = _prepare(
+        ScriptedConsole("us-west-2\n"),
+        providers=("bedrock",),
+        lister=_FakeLister({}),
+        environment={
+            "AWS_ACCESS_KEY_ID": "access-id",
+            "AWS_SECRET_ACCESS_KEY": "secret-value",
+        },
+        existing_connections=existing,
+    )
+
+    assert prepared is not None
+    endpoints, _models = prepared
+    assert endpoints[0].configured
+    assert endpoints[0].connection == existing[0]
+
+
 def test_bedrock_sts_intent_never_reuses_an_explicit_pair() -> None:
     """A session token keeps setup on ambient auth instead of truncating STS."""
     existing = (

--- a/exp/cli/providers/provider_picker_test.py
+++ b/exp/cli/providers/provider_picker_test.py
@@ -25,6 +25,7 @@ from exp.cli.shared.picker import PickerKey
 from exp.cli.shared.picker_test import ScriptedConsole
 from exp.common.auth import ProviderAuthStore, StoredCredentialBinding, default_auth_path
 from exp.common.models import (
+    ConnectionConfig,
     DiscoveredModel,
     PricingSource,
     ProviderConnection,
@@ -1147,6 +1148,102 @@ def test_bedrock_prepares_credential_chain_without_listing_or_identity_invention
         region="us-east-1",
     )
     assert "declare deployment model IDs" in console.output
+
+
+def test_bedrock_reuses_the_sole_explicit_pair_when_auth_is_not_reentered() -> None:
+    """Rerunning setup keeps one existing explicit pair instead of adding ambient auth."""
+    existing = (
+        ProviderConnection(
+            name="bedrock-production",
+            provider="bedrock",
+            api_key_env="AWS_SECRET_ACCESS_KEY",
+            aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+            bedrock_auth_mode="access_key_pair",
+            region="us-west-2",
+        ),
+    )
+    prepared = _prepare(
+        ScriptedConsole("us-west-2\n"),
+        providers=("bedrock",),
+        lister=_FakeLister({}),
+        environment={},
+        existing_connections=existing,
+    )
+
+    assert prepared is not None
+    endpoints, _models = prepared
+    assert endpoints[0].configured
+    assert endpoints[0].connection == existing[0]
+
+
+def test_bedrock_sts_intent_never_reuses_an_explicit_pair() -> None:
+    """A session token keeps setup on ambient auth instead of truncating STS."""
+    existing = (
+        ProviderConnection(
+            name="bedrock-production",
+            provider="bedrock",
+            api_key_env="AWS_SECRET_ACCESS_KEY",
+            aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+            bedrock_auth_mode="access_key_pair",
+            region="us-west-2",
+        ),
+    )
+    prepared = _prepare(
+        ScriptedConsole("us-west-2\n"),
+        providers=("bedrock",),
+        lister=_FakeLister({}),
+        environment={
+            "AWS_ACCESS_KEY_ID": "temporary-access-id",
+            "AWS_SECRET_ACCESS_KEY": "temporary-secret",
+            "AWS_SESSION_TOKEN": "temporary-session-token",
+        },
+        existing_connections=existing,
+    )
+
+    assert prepared is not None
+    endpoints, _models = prepared
+    assert not endpoints[0].configured
+    assert endpoints[0].connection == ProviderConnection(
+        name="bedrock",
+        provider="bedrock",
+        region="us-west-2",
+    )
+
+
+def test_bedrock_authors_an_explicit_pair_from_complete_environment_credentials() -> None:
+    """Complete standard AWS environment credentials become a secret-free pair config."""
+    connection = provider_picker.collect_provider_connection(
+        "bedrock",
+        console=ScriptedConsole("us-west-2\n"),
+        environment={
+            "AWS_ACCESS_KEY_ID": "access-id",
+            "AWS_SECRET_ACCESS_KEY": "secret-value",
+        },
+    )
+
+    assert connection == ConnectionConfig(
+        provider="bedrock",
+        api_key_env="AWS_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+        bedrock_auth_mode="access_key_pair",
+        region="us-west-2",
+    )
+
+
+def test_bedrock_authors_bearer_mode_without_persisting_the_token() -> None:
+    """A Bedrock bearer environment value records only its locator and mode."""
+    connection = provider_picker.collect_provider_connection(
+        "bedrock",
+        console=ScriptedConsole("us-west-2\n"),
+        environment={"AWS_BEARER_TOKEN_BEDROCK": "bearer-value"},
+    )
+
+    assert connection == ConnectionConfig(
+        provider="bedrock",
+        api_key_env="AWS_BEARER_TOKEN_BEDROCK",
+        bedrock_auth_mode="api_key",
+        region="us-west-2",
+    )
 
 
 def test_release_tty_walk_selects_azure_then_completes() -> None:

--- a/exp/cli/providers/setup.py
+++ b/exp/cli/providers/setup.py
@@ -635,6 +635,8 @@ def existing_setup_connections(existing: ModelCatalog | None) -> tuple[ProviderC
             api_version=connection.api_version,
             azure_api_surface=connection.azure_api_surface,
             region=connection.region,
+            aws_access_key_id_env=connection.aws_access_key_id_env,
+            bedrock_auth_mode=connection.bedrock_auth_mode,
         )
         for name, connection in sorted(existing.connections.items())
         if connection.provider in SETUP_PROVIDERS

--- a/exp/cli/providers/setup_test.py
+++ b/exp/cli/providers/setup_test.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from exp.cli.app import app
 from exp.cli.providers.setup import (
     ProviderSetupOptions,
+    existing_setup_connections,
     run_provider_setup,
 )
 from exp.cli.shared.picker_test import ScriptedConsole
@@ -30,6 +31,27 @@ from exp.common.models import (
 from exp.runtime.models.providers import ProviderEndpoint
 
 _RUNNER = CliRunner()
+
+
+def test_existing_setup_preserves_bedrock_explicit_auth_metadata() -> None:
+    """Re-running setup never converts an explicit Bedrock connection to ambient auth."""
+    catalog = ModelCatalog(
+        connections={
+            "bedrock": ConnectionConfig(
+                provider="bedrock",
+                region="us-west-2",
+                api_key_env="AWS_SECRET_ACCESS_KEY",
+                aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+                bedrock_auth_mode="access_key_pair",
+            )
+        },
+        models={},
+    )
+
+    connection = existing_setup_connections(catalog)[0]
+
+    assert connection.aws_access_key_id_env == "AWS_ACCESS_KEY_ID"
+    assert connection.bedrock_auth_mode == "access_key_pair"
 
 
 def _connection_json(name: str, provider: str, env: str) -> str:

--- a/exp/common/auth/store.py
+++ b/exp/common/auth/store.py
@@ -1,9 +1,9 @@
 """Atomic, user-only ``auth.json`` store keyed by provider connection ID.
 
 The document follows the OpenCode ``auth.json`` shape: one object whose keys are connection
-IDs and whose values are ``{"type": "api", "key": "..."}`` records. Optional ``provider``
-and ``endpoint_sha256`` fields bind a key to one secret-free endpoint identity. Secret
-values never appear in ``repr``, ``str``, or raised messages.
+IDs and whose values are ``{"type": "api", "key": "..."}`` records. Optional provider,
+endpoint, and credential-locator fields bind a key to one secret-free connection identity.
+Secret values never appear in ``repr``, ``str``, or raised messages.
 """
 
 from __future__ import annotations
@@ -46,6 +46,7 @@ class StoredCredentialBinding(ContractModel):
 
     provider: str
     endpoint_sha256: Sha256
+    credential_locator_sha256: Sha256 | None = None
 
 
 class StoredCredentialEndpointMismatch(ProviderAuthStoreError):
@@ -304,6 +305,8 @@ def _record_payload(record: _StoredApiRecord) -> dict[str, str]:
     if record.binding is not None:
         payload["provider"] = record.binding.provider
         payload["endpoint_sha256"] = record.binding.endpoint_sha256
+        if record.binding.credential_locator_sha256 is not None:
+            payload["credential_locator_sha256"] = record.binding.credential_locator_sha256
     return payload
 
 
@@ -335,7 +338,13 @@ def _parse_document(payload: object, *, path: Path) -> dict[str, _StoredApiRecor
             fields[field] = value
         record_type = fields.get("type")
         key = fields.get("key")
-        extra = set(fields) - {"type", "key", "provider", "endpoint_sha256"}
+        extra = set(fields) - {
+            "type",
+            "key",
+            "provider",
+            "endpoint_sha256",
+            "credential_locator_sha256",
+        }
         if extra or record_type != "api" or not isinstance(key, str) or not key.strip():
             raise ProviderAuthStoreError(_malformed_message(path))
         records[raw_name] = _StoredApiRecord(
@@ -364,14 +373,23 @@ def _parse_binding(
     """
     provider = raw_record.get("provider")
     endpoint_sha256 = raw_record.get("endpoint_sha256")
-    if provider is None and endpoint_sha256 is None:
+    credential_locator_sha256 = raw_record.get("credential_locator_sha256")
+    if provider is None and endpoint_sha256 is None and credential_locator_sha256 is None:
         return None
     if not isinstance(provider, str) or not provider:
         raise ProviderAuthStoreError(_malformed_message(path))
     if not isinstance(endpoint_sha256, str) or not endpoint_sha256:
         raise ProviderAuthStoreError(_malformed_message(path))
+    if credential_locator_sha256 is not None and (
+        not isinstance(credential_locator_sha256, str) or not credential_locator_sha256
+    ):
+        raise ProviderAuthStoreError(_malformed_message(path))
     try:
-        return StoredCredentialBinding(provider=provider, endpoint_sha256=endpoint_sha256)
+        return StoredCredentialBinding(
+            provider=provider,
+            endpoint_sha256=endpoint_sha256,
+            credential_locator_sha256=credential_locator_sha256,
+        )
     except ValueError as exc:
         raise ProviderAuthStoreError(_malformed_message(path)) from exc
 

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -84,12 +84,14 @@ class ConnectionConfig(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
+    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
 
-    @field_validator("api_key_env")
+    @field_validator("api_key_env", "aws_access_key_id_env")
     @classmethod
     def _require_environment_variable_name(cls, value: str | None) -> str | None:
         if value is not None and not _ENVIRONMENT_NAME.fullmatch(value):
-            raise ValueError("api_key_env must name one environment variable")
+            raise ValueError("credential environment fields must name environment variables")
         return value
 
     @field_validator("base_url")
@@ -111,6 +113,13 @@ class ConnectionConfig(ContractModel):
     def _require_secret_free_connection_metadata(self) -> ConnectionConfig:
         if self.provider != "azure" and self.azure_api_surface is not None:
             raise ValueError("azure_api_surface is only accepted for provider='azure'")
+        if self.provider != "bedrock" and (
+            self.aws_access_key_id_env is not None or self.bedrock_auth_mode is not None
+        ):
+            raise ValueError(
+                "aws_access_key_id_env and bedrock_auth_mode are only accepted for "
+                "provider='bedrock'"
+            )
         if self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
             raise ValueError(
                 f"native provider {self.provider!r} uses its built-in official endpoint; "
@@ -139,9 +148,21 @@ class ConnectionConfig(ContractModel):
             if self.region is not None:
                 raise ValueError("region is only accepted for provider='bedrock'")
         elif self.provider == "bedrock":
-            if self.api_key_env is not None:
+            if self.bedrock_auth_mode == "api_key":
+                if self.api_key_env is None or self.aws_access_key_id_env is not None:
+                    raise ValueError(
+                        "bedrock api_key auth requires api_key_env and forbids "
+                        "aws_access_key_id_env"
+                    )
+            elif self.bedrock_auth_mode == "access_key_pair":
+                if self.api_key_env is None or self.aws_access_key_id_env is None:
+                    raise ValueError(
+                        "bedrock access_key_pair auth requires both credential environment names"
+                    )
+            elif (self.api_key_env is None) != (self.aws_access_key_id_env is None):
                 raise ValueError(
-                    "bedrock authenticates through the AWS credential chain and rejects api_key_env"
+                    "bedrock explicit access-key auth requires both api_key_env naming the "
+                    "secret access key and aws_access_key_id_env naming the access key id"
                 )
             if self.base_url is not None:
                 raise ValueError("bedrock does not accept base_url")
@@ -191,6 +212,7 @@ class ConnectionConfig(ContractModel):
                     "api_version": self.api_version,
                     "azure_api_surface": self.azure_api_surface,
                     "region": self.region,
+                    "bedrock_auth_mode": self.bedrock_auth_mode,
                 }
             )
         except SecretBoundaryError as exc:
@@ -217,7 +239,28 @@ class ConnectionConfig(ContractModel):
             identity["azure_api_surface"] = "model_inference"
         if self.region is not None:
             identity["region"] = self.region
+        effective_bedrock_auth_mode = self.bedrock_auth_mode
+        if (
+            self.provider == "bedrock"
+            and effective_bedrock_auth_mode is None
+            and self.api_key_env is not None
+            and self.aws_access_key_id_env is not None
+        ):
+            effective_bedrock_auth_mode = "access_key_pair"
+        if effective_bedrock_auth_mode is not None:
+            identity["bedrock_auth_mode"] = effective_bedrock_auth_mode
         return sha256_json(identity)
+
+    def canonicalized(self) -> ConnectionConfig:
+        """Return the canonical persisted shape for Bedrock access-key pairs."""
+        if (
+            self.provider == "bedrock"
+            and self.bedrock_auth_mode is None
+            and self.api_key_env is not None
+            and self.aws_access_key_id_env is not None
+        ):
+            return self.model_copy(update={"bedrock_auth_mode": "access_key_pair"})
+        return self
 
 
 class SFTModelProvenance(ContractModel):

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -38,6 +38,11 @@ _FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openroute
 _EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
 
 
+def _exclude_absent(value: object) -> bool:
+    """Keep new optional connection metadata out of legacy canonical payloads."""
+    return value is None
+
+
 def _normalize_base_url(value: str) -> str:
     """Return the stable endpoint spelling used for connection identity."""
     parsed = urlsplit(value)
@@ -84,8 +89,15 @@ class ConnectionConfig(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
-    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
-    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    aws_access_key_id_env: str | None = Field(
+        default=None,
+        max_length=256,
+        exclude_if=_exclude_absent,
+    )
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = Field(
+        default=None,
+        exclude_if=_exclude_absent,
+    )
 
     @field_validator("api_key_env", "aws_access_key_id_env")
     @classmethod

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -9,7 +9,14 @@ from typing import Literal, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import tomli_w
-from pydantic import AwareDatetime, Field, field_validator, model_validator
+from pydantic import (
+    AwareDatetime,
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from exp.common.core.artifacts import (
     ArtifactId,
@@ -36,11 +43,6 @@ _AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 _VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
 _FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
 _EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
-
-
-def _exclude_absent(value: object) -> bool:
-    """Keep new optional connection metadata out of legacy canonical payloads."""
-    return value is None
 
 
 def _normalize_base_url(value: str) -> str:
@@ -89,15 +91,8 @@ class ConnectionConfig(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
-    aws_access_key_id_env: str | None = Field(
-        default=None,
-        max_length=256,
-        exclude_if=_exclude_absent,
-    )
-    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = Field(
-        default=None,
-        exclude_if=_exclude_absent,
-    )
+    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
 
     @field_validator("api_key_env", "aws_access_key_id_env")
     @classmethod
@@ -273,6 +268,19 @@ class ConnectionConfig(ContractModel):
         ):
             return self.model_copy(update={"bedrock_auth_mode": "access_key_pair"})
         return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_absent_bedrock_metadata(
+        self,
+        handler: SerializerFunctionWrapHandler,
+    ) -> dict[str, object]:
+        """Preserve pre-Bedrock canonical bytes on every supported Pydantic version."""
+        serialized: dict[str, object] = handler(self)
+        if self.aws_access_key_id_env is None:
+            serialized.pop("aws_access_key_id_env", None)
+        if self.bedrock_auth_mode is None:
+            serialized.pop("bedrock_auth_mode", None)
+        return serialized
 
 
 class SFTModelProvenance(ContractModel):

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -628,6 +628,24 @@ def test_bedrock_connection_accepts_complete_key_pair_without_hashing_secret_poi
         ConnectionConfig(provider="bedrock", base_url="https://bedrock.example.test")
 
 
+def test_absent_bedrock_fields_preserve_legacy_connection_payload_shape() -> None:
+    """Optional Bedrock metadata does not rewrite unrelated canonical payloads."""
+    legacy = ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")
+    payload = legacy.model_dump(mode="json", exclude_none=False)
+
+    assert "aws_access_key_id_env" not in payload
+    assert "bedrock_auth_mode" not in payload
+
+    explicit = ConnectionConfig(
+        provider="bedrock",
+        api_key_env="BEDROCK_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="BEDROCK_ACCESS_KEY_ID",
+        bedrock_auth_mode="access_key_pair",
+    ).model_dump(mode="json", exclude_none=False)
+    assert explicit["aws_access_key_id_env"] == "BEDROCK_ACCESS_KEY_ID"
+    assert explicit["bedrock_auth_mode"] == "access_key_pair"
+
+
 def test_azure_and_bedrock_models_require_explicit_capabilities(tmp_path: Path) -> None:
     """Provider names do not imply Azure or Bedrock protocol support or prices."""
     azure_path = tmp_path / "azure.toml"

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -583,8 +583,8 @@ def test_azure_connection_requires_endpoint_key_and_api_version() -> None:
         )
 
 
-def test_bedrock_connection_rejects_api_keys_and_includes_region_in_identity() -> None:
-    """Bedrock catalog records use the AWS chain and keep region in connection identity."""
+def test_bedrock_connection_accepts_complete_key_pair_without_hashing_secret_pointers() -> None:
+    """Bedrock accepts ambient or paired auth while identity remains endpoint-only."""
     with_region = ConnectionConfig(provider="bedrock", region="us-east-1")
     without_region = ConnectionConfig(provider="bedrock")
 
@@ -598,6 +598,32 @@ def test_bedrock_connection_rejects_api_keys_and_includes_region_in_identity() -
     )
     with pytest.raises(ValueError, match="api_key_env"):
         ConnectionConfig(provider="bedrock", api_key_env="AWS_ACCESS_KEY_ID")
+    explicit = ConnectionConfig(
+        provider="bedrock",
+        api_key_env="AWS_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="BEDROCK_ACCESS_KEY_ID",
+        region="us-east-1",
+    )
+    assert explicit.identity_sha256() != with_region.identity_sha256()
+    assert (
+        explicit.identity_sha256()
+        == ConnectionConfig(
+            provider="bedrock",
+            api_key_env="OTHER_SECRET_ACCESS_KEY",
+            aws_access_key_id_env="OTHER_ACCESS_KEY_ID",
+            bedrock_auth_mode="access_key_pair",
+            region="us-east-1",
+        ).identity_sha256()
+    )
+    api_key = ConnectionConfig(
+        provider="bedrock",
+        api_key_env="BEDROCK_API_KEY",
+        bedrock_auth_mode="api_key",
+        region="us-east-1",
+    )
+    assert api_key.identity_sha256() != explicit.identity_sha256()
+    with pytest.raises(ValueError, match="bedrock_auth_mode"):
+        ConnectionConfig(provider="openai", bedrock_auth_mode="api_key")
     with pytest.raises(ValueError, match="base_url"):
         ConnectionConfig(provider="bedrock", base_url="https://bedrock.example.test")
 

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -6,7 +6,7 @@ import hashlib
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, SerializerFunctionWrapHandler, model_serializer, model_validator
 
 from exp.common.core.artifacts import ContractModel
 from exp.common.core.locks import file_write_lock
@@ -34,11 +34,6 @@ SETUP_PROVIDERS = frozenset(
 )
 
 
-def _exclude_absent(value: object) -> bool:
-    """Keep new optional Bedrock metadata out of legacy setup payloads."""
-    return value is None
-
-
 class ProviderSetupError(ValueError):
     """Provider setup cannot be applied without replacing or losing catalog state."""
 
@@ -53,15 +48,8 @@ class ProviderConnection(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
-    aws_access_key_id_env: str | None = Field(
-        default=None,
-        max_length=256,
-        exclude_if=_exclude_absent,
-    )
-    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = Field(
-        default=None,
-        exclude_if=_exclude_absent,
-    )
+    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
 
     @model_validator(mode="after")
     def _require_supported_connection_shape(self) -> ProviderConnection:
@@ -152,6 +140,19 @@ class ProviderConnection(ContractModel):
             aws_access_key_id_env=self.aws_access_key_id_env,
             bedrock_auth_mode=self.bedrock_auth_mode,
         )
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_absent_bedrock_metadata(
+        self,
+        handler: SerializerFunctionWrapHandler,
+    ) -> dict[str, object]:
+        """Preserve legacy setup payload bytes without requiring Pydantic 2.12."""
+        serialized: dict[str, object] = handler(self)
+        if self.aws_access_key_id_env is None:
+            serialized.pop("aws_access_key_id_env", None)
+        if self.bedrock_auth_mode is None:
+            serialized.pop("bedrock_auth_mode", None)
+        return serialized
 
 
 class ProviderModelSelection(ContractModel):

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -34,6 +34,11 @@ SETUP_PROVIDERS = frozenset(
 )
 
 
+def _exclude_absent(value: object) -> bool:
+    """Keep new optional Bedrock metadata out of legacy setup payloads."""
+    return value is None
+
+
 class ProviderSetupError(ValueError):
     """Provider setup cannot be applied without replacing or losing catalog state."""
 
@@ -48,8 +53,15 @@ class ProviderConnection(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
-    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
-    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    aws_access_key_id_env: str | None = Field(
+        default=None,
+        max_length=256,
+        exclude_if=_exclude_absent,
+    )
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = Field(
+        default=None,
+        exclude_if=_exclude_absent,
+    )
 
     @model_validator(mode="after")
     def _require_supported_connection_shape(self) -> ProviderConnection:

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -48,9 +48,18 @@ class ProviderConnection(ContractModel):
     api_version: str | None = Field(default=None, max_length=64)
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=64)
+    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
 
     @model_validator(mode="after")
     def _require_supported_connection_shape(self) -> ProviderConnection:
+        if self.provider != "bedrock" and (
+            self.aws_access_key_id_env is not None or self.bedrock_auth_mode is not None
+        ):
+            raise ValueError(
+                "aws_access_key_id_env and bedrock_auth_mode are only accepted for "
+                "provider='bedrock'"
+            )
         if self.provider not in SETUP_PROVIDERS:
             choices = ", ".join(sorted(SETUP_PROVIDERS))
             raise ValueError(f"provider must be one of: {choices}")
@@ -64,9 +73,21 @@ class ProviderConnection(ContractModel):
             if self.api_version is None:
                 raise ValueError("azure requires an explicit api_version")
         elif self.provider == "bedrock":
-            if self.api_key_env is not None:
+            if self.bedrock_auth_mode == "api_key":
+                if self.api_key_env is None or self.aws_access_key_id_env is not None:
+                    raise ValueError(
+                        "bedrock api_key auth requires api_key_env and forbids "
+                        "aws_access_key_id_env"
+                    )
+            elif self.bedrock_auth_mode == "access_key_pair":
+                if self.api_key_env is None or self.aws_access_key_id_env is None:
+                    raise ValueError(
+                        "bedrock access_key_pair auth requires both credential environment names"
+                    )
+            elif (self.api_key_env is None) != (self.aws_access_key_id_env is None):
                 raise ValueError(
-                    "bedrock authenticates through the AWS credential chain and rejects api_key_env"
+                    "bedrock explicit access-key auth requires both api_key_env naming the "
+                    "secret access key and aws_access_key_id_env naming the access key id"
                 )
             if self.base_url is not None:
                 raise ValueError("bedrock does not accept base_url")
@@ -102,6 +123,8 @@ class ProviderConnection(ContractModel):
             api_version=self.api_version,
             azure_api_surface=self.azure_api_surface,
             region=self.region,
+            aws_access_key_id_env=self.aws_access_key_id_env,
+            bedrock_auth_mode=self.bedrock_auth_mode,
         )
         return self
 
@@ -114,6 +137,8 @@ class ProviderConnection(ContractModel):
             api_version=self.api_version,
             azure_api_surface=self.azure_api_surface,
             region=self.region,
+            aws_access_key_id_env=self.aws_access_key_id_env,
+            bedrock_auth_mode=self.bedrock_auth_mode,
         )
 
 

--- a/exp/common/models/setup_test.py
+++ b/exp/common/models/setup_test.py
@@ -286,8 +286,8 @@ def test_setup_accepts_each_supported_connection(
     assert connection.region == region
 
 
-def test_setup_rejects_bedrock_api_key_env() -> None:
-    """Bedrock setup cannot invent an API-key abstraction."""
+def test_setup_rejects_an_incomplete_bedrock_access_key_pair() -> None:
+    """Bedrock setup never accepts a secret reference without its access-key identifier."""
     with pytest.raises(ValueError, match="api_key_env"):
         ProviderConnection(
             name="bedrock",
@@ -295,3 +295,32 @@ def test_setup_rejects_bedrock_api_key_env() -> None:
             api_key_env="AWS_ACCESS_KEY_ID",
             region="us-east-1",
         )
+
+
+def test_setup_accepts_an_explicit_bedrock_access_key_pair() -> None:
+    """Stored Bedrock connections may pair a named secret with a non-secret key ID."""
+    connection = ProviderConnection(
+        name="bedrock",
+        provider="bedrock",
+        api_key_env="AWS_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="BEDROCK_ACCESS_KEY_ID",
+        bedrock_auth_mode="access_key_pair",
+        region="us-east-1",
+    )
+
+    assert connection.catalog_config().aws_access_key_id_env == "BEDROCK_ACCESS_KEY_ID"
+    assert connection.catalog_config().bedrock_auth_mode == "access_key_pair"
+
+
+def test_setup_accepts_a_bedrock_api_key_without_an_access_key_id() -> None:
+    """Bedrock bearer setup preserves its explicit authentication mode."""
+    connection = ProviderConnection(
+        name="bedrock",
+        provider="bedrock",
+        api_key_env="BEDROCK_API_KEY",
+        bedrock_auth_mode="api_key",
+        region="us-east-1",
+    )
+
+    assert connection.catalog_config().bedrock_auth_mode == "api_key"
+    assert connection.catalog_config().aws_access_key_id_env is None

--- a/exp/common/models/setup_test.py
+++ b/exp/common/models/setup_test.py
@@ -324,3 +324,17 @@ def test_setup_accepts_a_bedrock_api_key_without_an_access_key_id() -> None:
 
     assert connection.catalog_config().bedrock_auth_mode == "api_key"
     assert connection.catalog_config().aws_access_key_id_env is None
+
+
+def test_absent_bedrock_fields_preserve_legacy_setup_payload_shape() -> None:
+    """New setup metadata remains absent from pre-Bedrock connection shapes."""
+    connection = ProviderConnection(
+        name="openai-main",
+        provider="openai",
+        api_key_env="OPENAI_API_KEY",
+    )
+
+    payload = connection.model_dump(mode="json", exclude_none=False)
+
+    assert "aws_access_key_id_env" not in payload
+    assert "bedrock_auth_mode" not in payload

--- a/exp/common/tests/dependency_surface_test.py
+++ b/exp/common/tests/dependency_surface_test.py
@@ -34,6 +34,12 @@ def test_forbidden_provider_imports_are_absent() -> None:
             ("runtime/models/providers/bedrock.py", "botocore.auth"),
             ("runtime/models/providers/bedrock.py", "botocore.awsrequest"),
             ("runtime/models/providers/bedrock.py", "botocore.config"),
+            ("runtime/models/providers/bedrock.py", "botocore.configprovider"),
+            ("runtime/models/providers/bedrock.py", "botocore"),
+            ("runtime/models/providers/bedrock.py", "botocore.session"),
+            ("runtime/models/providers/bedrock.py", "botocore.tokens"),
+            ("runtime/models/providers/bedrock_endpoints.py", "botocore.loaders"),
+            ("runtime/models/providers/bedrock_endpoints.py", "botocore.regions"),
         },
     )
     assert not violations, f"forbidden provider imports present: {violations}"

--- a/exp/runtime/gateway/catalog_authority.py
+++ b/exp/runtime/gateway/catalog_authority.py
@@ -570,8 +570,12 @@ def _write_catalog_snapshot(
     """
     snapshot = root / "gateway" / "catalog-snapshots" / f"{normalized.identity_sha256()}.json"
     authored = authored_snapshot_path(snapshot)
-    if not authored.exists():
-        write_bytes_atomic(authored, canonical_json_bytes(catalog), follow_symlinks=False)
+    authored_bytes = canonical_json_bytes(catalog)
+    if not authored.exists() or authored.read_bytes() != authored_bytes:
+        # The normalized route identity intentionally excludes credential
+        # locators. Refresh its companion when those secret-free locators rotate
+        # so new alias revisions bind the current provider authority.
+        write_bytes_atomic(authored, authored_bytes, follow_symlinks=False)
         os.chmod(authored, 0o600)
     if not snapshot.exists():
         write_bytes_atomic(snapshot, canonical_json_bytes(normalized), follow_symlinks=False)

--- a/exp/runtime/gateway/catalog_authority_test.py
+++ b/exp/runtime/gateway/catalog_authority_test.py
@@ -23,7 +23,11 @@ from exp.common.models import (
     ModelRoles,
     write_model_catalog,
 )
-from exp.runtime.gateway.catalog_authority import upsert_singleton_deployment
+from exp.runtime.gateway.catalog_authority import (
+    authored_snapshot_path,
+    upsert_singleton_deployment,
+)
+from exp.runtime.gateway.management import GatewayManagement
 
 
 def _pooled_catalog(root: Path) -> Path:
@@ -109,3 +113,57 @@ def test_valid_singleton_deployment_still_persists_after_validation(tmp_path: Pa
     assert snapshot.exists()
     assert "extra" in {pool.pool_id for pool in normalized.pools}
     assert b"extra" in path.read_bytes()
+
+
+def test_same_mode_bedrock_credential_rotation_refreshes_authored_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A locator-only rotation rebinds without changing normalized route identity."""
+    manager = GatewayManagement(tmp_path)
+    manager.initialize()
+
+    def connection(secret_env: str, access_env: str) -> ConnectionConfig:
+        return ConnectionConfig(
+            provider="bedrock",
+            region="us-west-2",
+            api_key_env=secret_env,
+            aws_access_key_id_env=access_env,
+            bedrock_auth_mode="access_key_pair",
+        )
+
+    old = connection("OLD_SECRET", "OLD_ACCESS")
+    manager.upsert_provider_connection(connection_id="bedrock-main", config=old)
+
+    def upsert(config: ConnectionConfig, *, replace: bool) -> Path:
+        _normalized, snapshot, _changed = upsert_singleton_deployment(
+            tmp_path,
+            deployment_alias="bedrock",
+            connection_name="bedrock-main",
+            provider_model="amazon.nova-lite-v1:0",
+            exact_model_id="nova-lite",
+            revision=None,
+            capabilities=ModelCapabilities(supports_completions=True),
+            gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+            prices=GatewayTokenPrices(),
+            pricing_source=None,
+            replace=replace,
+            serving_connections={"bedrock-main": config},
+        )
+        return snapshot
+
+    first_snapshot = upsert(old, replace=False)
+
+    new = connection("NEW_SECRET", "NEW_ACCESS")
+    manager.upsert_provider_connection(
+        connection_id="bedrock-main",
+        config=new,
+        replace=True,
+    )
+    second_snapshot = upsert(new, replace=True)
+
+    assert second_snapshot == first_snapshot
+    authored = ModelCatalog.model_validate_json(
+        authored_snapshot_path(second_snapshot).read_bytes()
+    )
+    assert authored.connections["bedrock-main"] == new
+    assert manager.provider_bindings(authored)

--- a/exp/runtime/gateway/management.py
+++ b/exp/runtime/gateway/management.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from pydantic import Field
 
-from exp.common.core.artifacts import ContractModel, stable_id
+from exp.common.core.artifacts import ContractModel
 from exp.common.models import (
     GATEWAY_EXCLUDED_PROVIDERS,
     ConnectionConfig,
@@ -23,6 +23,7 @@ from exp.runtime.gateway.sqlite.provider_authority import (
     ProviderConnectionAuthority,
     ProviderConnectionBinding,
     ProviderConnectionMutation,
+    provider_connection_revision_id,
 )
 from exp.runtime.gateway.sqlite.store import GatewayStoreError, SQLiteGatewayStore
 from exp.runtime.models import SUPPORTED_PROVIDERS
@@ -185,18 +186,13 @@ class GatewayManagement:
             connection_id=connection_id,
             provider=config.provider,
         )
-        revision_id = stable_id(
-            "provider-connection-revision",
-            {
-                "connection_id": connection_id,
-                "config": config.model_dump(mode="json", exclude_none=False),
-            },
-        )
+        canonical = config.canonicalized()
+        revision_id = provider_connection_revision_id(connection_id, canonical)
         return self.require_initialized().upsert_provider_connection(
             organization_id=self.organization_id,
             connection_id=connection_id,
             revision_id=revision_id,
-            config=config,
+            config=canonical,
             replace=replace,
         )
 
@@ -230,14 +226,8 @@ class GatewayManagement:
         mutations = tuple(
             ProviderConnectionMutation(
                 connection_id=connection_id,
-                revision_id=stable_id(
-                    "provider-connection-revision",
-                    {
-                        "connection_id": connection_id,
-                        "config": config.model_dump(mode="json", exclude_none=False),
-                    },
-                ),
-                config=config,
+                revision_id=provider_connection_revision_id(connection_id, config),
+                config=config.canonicalized(),
             )
             for connection_id, config in sorted(provider_connections.items())
         )
@@ -292,14 +282,8 @@ class GatewayManagement:
         mutations = tuple(
             ProviderConnectionMutation(
                 connection_id=connection_id,
-                revision_id=stable_id(
-                    "provider-connection-revision",
-                    {
-                        "connection_id": connection_id,
-                        "config": config.model_dump(mode="json", exclude_none=False),
-                    },
-                ),
-                config=config,
+                revision_id=provider_connection_revision_id(connection_id, config),
+                config=config.canonicalized(),
             )
             for connection_id, config in sorted(provider_connections.items())
         )
@@ -364,7 +348,7 @@ class GatewayManagement:
         bindings: list[ProviderConnectionBinding] = []
         for connection_id, config in sorted(catalog.connections.items()):
             authority = authorities.get(connection_id)
-            if authority is None or authority.config != config:
+            if authority is None or authority.config != config.canonicalized():
                 raise GatewayStoreError(
                     f"provider connection {connection_id!r} differs from SQLite authority"
                 )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -37,7 +37,7 @@ import logging
 import time
 from collections.abc import Callable
 
-from exp.common.core.artifacts import JsonObject
+from exp.common.core.artifacts import JsonObject, sha256_bytes
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
@@ -65,6 +65,7 @@ from exp.runtime.gateway.native_execution import (
     MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
     MAXIMUM_TOTAL_ATTEMPTS,
     DeadRung,
+    FrozenDispatchBinding,
     InflightRequest,
     NativeDialectUnavailableError,
     deployment_health_key,
@@ -426,6 +427,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                 )
             wire_route: list[JsonObject] = []
             signers: list[GatewayDispatchSigner | None] = []
+            dispatch_bindings: list[FrozenDispatchBinding | None] = []
             for deployment, (profile, client) in zip(
                 route.deployments, resolved_wires, strict=True
             ):
@@ -447,6 +449,14 @@ class NativeControlPlane(NativeObservabilityMixin):
                     )
                 )
                 signers.append(dispatch_signer)
+                dispatch_bindings.append(
+                    None
+                    if dispatch_signer is None or upstream_body is None
+                    else FrozenDispatchBinding(
+                        url=profile.url,
+                        body_sha256=sha256_bytes(upstream_body.encode("utf-8")),
+                    )
+                )
         except (ProviderParameterError, ProviderCapabilityError) as exc:
             # One shared normalizer keeps both pre-dispatch rejections
             # field-specific: the parameter path names the parameter and the
@@ -473,6 +483,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                 continuation=continuation_context,
                 policy=policy,
                 signers=tuple(signers),
+                dispatch_bindings=tuple(dispatch_bindings),
             )
         )
         response: JsonObject = {
@@ -519,15 +530,33 @@ class NativeControlPlane(NativeObservabilityMixin):
         data = json.loads(argument)
         entry = self._accounting.entry(str(data.get("request_id") or ""))
         signer = None
+        binding = None
         if entry is not None and entry.active_attempt_id is not None:
             depth = entry.attempt_depths.get(entry.active_attempt_id)
             if depth is not None and depth < len(entry.signers):
                 signer = entry.signers[depth]
+            if depth is not None and depth < len(entry.dispatch_bindings):
+                binding = entry.dispatch_bindings[depth]
         try:
+            url = str(data["url"])
+            body = str(data["body"])
+            if (
+                binding is None
+                or url != binding.url
+                or sha256_bytes(body.encode("utf-8")) != binding.body_sha256
+            ):
+                raise public_failure_error(
+                    GatewayFailure(
+                        failure_class=GatewayFailureClass.INTERNAL,
+                        safe_message=(
+                            "gateway dispatch differs from the admitted destination or frozen body"
+                        ),
+                    )
+                )
             headers = dispatch_signature_headers(
                 signer,
-                url=str(data["url"]),
-                body=str(data["body"]),
+                url=url,
+                body=body,
             )
         except OpenAIProtocolError as exc:
             raise NativeBridgeError(exc) from exc

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -434,9 +434,14 @@ def test_abandoned_inflight_attempts_are_swept_after_the_deadline(tmp_path: Path
     assert report["totals"]["requests"] == 2
 
 
+@pytest.mark.parametrize(
+    "auth_mode",
+    ("ambient_pair", "ambient_bearer", "explicit_bearer", "explicit_pair"),
+)
 def test_admit_serves_bedrock_natively_with_a_signed_frozen_body(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    auth_mode: str,
 ) -> None:
     """A Bedrock alias admits natively: the wire config carries the exact
     pre-serialized Converse body and SigV4 headers computed over it."""
@@ -451,15 +456,51 @@ def test_admit_serves_bedrock_natively_with_a_signed_frozen_body(
         upsert_singleton_deployment,
     )
 
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "sigv4-secret-canary")
-    monkeypatch.setenv("AWS_SESSION_TOKEN", "session-token-canary")
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
     monkeypatch.delenv("AWS_PROFILE", raising=False)
+    environment = {"TEST_PROVIDER_KEY": "provider-secret-canary"}
+    api_key_env = None
+    aws_access_key_id_env = None
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    if auth_mode == "ambient_pair":
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "sigv4-secret-canary")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "session-token-canary")
+    elif auth_mode == "ambient_bearer":
+        environment["AWS_BEARER_TOKEN_BEDROCK"] = "ambient-bearer-canary"
+    elif auth_mode == "explicit_bearer":
+        environment.update(
+            {
+                "AWS_BEARER_TOKEN_BEDROCK": "ambient-bearer-must-not-win",
+                "BEDROCK_API_KEY": "explicit-bearer-canary",
+            }
+        )
+        api_key_env = "BEDROCK_API_KEY"
+        bedrock_auth_mode = "api_key"
+    else:
+        environment.update(
+            {
+                "AWS_BEARER_TOKEN_BEDROCK": "ambient-bearer-must-not-win",
+                "BEDROCK_ACCESS_KEY_ID": "AKIAEXPLICITKEY001",
+                "BEDROCK_SECRET_ACCESS_KEY": "explicit-secret-canary",
+            }
+        )
+        api_key_env = "BEDROCK_SECRET_ACCESS_KEY"
+        aws_access_key_id_env = "BEDROCK_ACCESS_KEY_ID"
     manager, raw_key = _configured_gateway(tmp_path)
     upsert_connection(
         tmp_path,
         name="bedrock-main",
-        connection=ConnectionConfig(provider="bedrock", region="us-east-1"),
+        connection=ConnectionConfig(
+            provider="bedrock",
+            region="us-east-1",
+            api_key_env=api_key_env,
+            aws_access_key_id_env=aws_access_key_id_env,
+            bedrock_auth_mode=bedrock_auth_mode,
+        ),
         replace=False,
     )
     normalized, snapshot, _changed = upsert_singleton_deployment(
@@ -494,7 +535,7 @@ def test_admit_serves_bedrock_natively_with_a_signed_frozen_body(
     manager.add_grant(identity_id="default", alias_id="bed")
     components = load_gateway_components(
         tmp_path,
-        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+        environment=environment,
     )
     control = NativeControlPlane(components)
     body_schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
@@ -571,13 +612,58 @@ def test_admit_serves_bedrock_natively_with_a_signed_frozen_body(
         )
     )
     headers = signed["headers"]
-    assert headers["X-Amz-Security-Token"] == "session-token-canary"
-    authorization = headers["Authorization"]
+    authorization = headers.get("Authorization") or headers.get("authorization")
     assert isinstance(authorization, str)
-    assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
-    assert "/us-east-1/bedrock/aws4_request" in authorization
-    assert "sigv4-secret-canary" not in json.dumps(admission)
-    assert "sigv4-secret-canary" not in json.dumps(signed)
+    if auth_mode in {"ambient_bearer", "explicit_bearer"}:
+        expected = (
+            "ambient-bearer-canary" if auth_mode == "ambient_bearer" else "explicit-bearer-canary"
+        )
+        assert authorization == f"Bearer {expected}"
+    else:
+        expected_key = "AKIDEXAMPLE" if auth_mode == "ambient_pair" else "AKIAEXPLICITKEY001"
+        assert authorization.startswith(f"AWS4-HMAC-SHA256 Credential={expected_key}/")
+        assert "/us-east-1/bedrock/aws4_request" in authorization
+        if auth_mode == "ambient_pair":
+            assert headers["X-Amz-Security-Token"] == "session-token-canary"
+    for secret in (
+        "sigv4-secret-canary",
+        "ambient-bearer-canary",
+        "ambient-bearer-must-not-win",
+        "explicit-bearer-canary",
+        "explicit-secret-canary",
+    ):
+        assert secret not in json.dumps(admission)
+    signed_json = json.dumps(signed)
+    if auth_mode in {"ambient_bearer", "explicit_bearer"}:
+        assert "ambient-bearer-must-not-win" not in signed_json
+        assert "explicit-secret-canary" not in signed_json
+    else:
+        for secret in (
+            "sigv4-secret-canary",
+            "ambient-bearer-must-not-win",
+            "explicit-secret-canary",
+        ):
+            assert secret not in signed_json
+    with pytest.raises(NativeBridgeError):
+        control.sign_dispatch(
+            json.dumps(
+                {
+                    "request_id": started["request_id"],
+                    "url": "https://untrusted.example/collect",
+                    "body": body,
+                }
+            )
+        )
+    with pytest.raises(NativeBridgeError):
+        control.sign_dispatch(
+            json.dumps(
+                {
+                    "request_id": started["request_id"],
+                    "url": started["url"],
+                    "body": body + " ",
+                }
+            )
+        )
     # Attempts without a retained signer fail closed and sanitized.
     with pytest.raises(NativeBridgeError):
         control.sign_dispatch(

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -52,6 +52,14 @@ class NativeDialectUnavailableError(RuntimeError):
     """The resolved provider has no native dialect, so the route cannot serve."""
 
 
+@dataclass(frozen=True)
+class FrozenDispatchBinding:
+    """Exact admitted destination and body identity for one signed route depth."""
+
+    url: str
+    body_sha256: str
+
+
 @dataclass
 class InflightRequest:
     """One admitted request awaiting its terminal settlement.
@@ -81,6 +89,7 @@ class InflightRequest:
     # One signer per route deployment, for body-signing dialects (Bedrock
     # SigV4); ``None`` at a depth whose dialect serializes its own payload.
     signers: tuple[GatewayDispatchSigner | None, ...] = ()
+    dispatch_bindings: tuple[FrozenDispatchBinding | None, ...] = ()
 
     def __post_init__(self) -> None:
         """Size the per-deployment attempt counters to the frozen route."""

--- a/exp/runtime/gateway/platform.py
+++ b/exp/runtime/gateway/platform.py
@@ -146,6 +146,8 @@ class ProviderConnectionRevision(ContractModel):
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=256)
     secret_reference: OpaqueSecretReference | None = None
+    access_key_id_reference: OpaqueSecretReference | None = None
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
     connection_sha256: Sha256
     active: bool = True
     created_at: AwareDatetime
@@ -562,6 +564,8 @@ class UpsertProviderConnectionCommand(ContractModel):
     azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
     region: str | None = Field(default=None, max_length=256)
     secret_reference: OpaqueSecretReference | None = None
+    access_key_id_reference: OpaqueSecretReference | None = None
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
     replace: bool = False
 
 

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 
 class GatewaySchemaError(RuntimeError):
@@ -592,6 +592,18 @@ _MIGRATION_11 = (
     "('openai_deployments', 'model_inference'))",
 )
 
+_MIGRATION_12 = (
+    "ALTER TABLE provider_connection_revisions ADD COLUMN aws_access_key_id_env TEXT",
+    """
+    ALTER TABLE provider_connection_revisions
+    ADD COLUMN bedrock_auth_mode TEXT
+    CHECK (
+        bedrock_auth_mode IS NULL
+        OR bedrock_auth_mode IN ('access_key_pair', 'api_key')
+    )
+    """,
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -604,6 +616,7 @@ _MIGRATIONS = {
     9: _MIGRATION_9,
     10: _MIGRATION_10,
     11: _MIGRATION_11,
+    12: _MIGRATION_12,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -27,6 +27,7 @@ from exp.runtime.gateway.sqlite.migrations import (
     initialize_database,
     persistent_connection,
 )
+from exp.runtime.gateway.sqlite.provider_authority import active_provider_connections
 
 
 def test_persistent_connection_reuses_one_idle_connection_per_thread(tmp_path: Path) -> None:
@@ -915,5 +916,74 @@ def test_v11_migration_adds_azure_surface_without_rewriting_existing_authority(
                 "UPDATE provider_connection_revisions SET azure_api_surface = 'bogus' "
                 "WHERE revision_id = 'rev'"
             )
+    finally:
+        migrated.close()
+
+
+def test_v12_adds_bedrock_auth_locators_and_preserves_ambient_authority(
+    tmp_path: Path,
+) -> None:
+    """The current schema gains nullable Bedrock metadata without changing ambient identity."""
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    ambient = ConnectionConfig(provider="bedrock", region="us-west-2")
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for version in range(1, 12):
+            for statement in migrations._MIGRATIONS[version]:
+                connection.execute(statement)
+        connection.execute("PRAGMA user_version = 11")
+        connection.execute("INSERT INTO organizations VALUES ('org', 'org', 'Org', 1, 't', 't')")
+        connection.execute(
+            """
+            INSERT INTO provider_connections (
+                connection_id, organization_id, active_revision_id,
+                active, created_at, updated_at
+            ) VALUES ('bedrock', 'org', NULL, 1, 't', 't')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_connection_revisions (
+                revision_id, organization_id, connection_id, revision_number,
+                provider, region, azure_api_surface, connection_sha256, created_at
+            ) VALUES ('bedrock-revision', 'org', 'bedrock', 1,
+                      'bedrock', 'us-west-2', NULL, ?, 't')
+            """,
+            (ambient.identity_sha256(),),
+        )
+        connection.execute(
+            "UPDATE provider_connections SET active_revision_id = 'bedrock-revision' "
+            "WHERE connection_id = 'bedrock'"
+        )
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None and backup.exists()
+    migrated = connect_database(path)
+    try:
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        columns = {
+            str(row[1])
+            for row in migrated.execute(
+                "PRAGMA table_info(provider_connection_revisions)"
+            ).fetchall()
+        }
+        assert {"aws_access_key_id_env", "bedrock_auth_mode"} <= columns
+        row = migrated.execute(
+            "SELECT aws_access_key_id_env, bedrock_auth_mode, connection_sha256 "
+            "FROM provider_connection_revisions WHERE revision_id = 'bedrock-revision'"
+        ).fetchone()
+        assert tuple(row) == (None, None, ambient.identity_sha256())
+        authorities = active_provider_connections(migrated, organization_id="org")
+        assert len(authorities) == 1
+        assert authorities[0].config == ambient
+        assert migrated.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
     finally:
         migrated.close()

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import Literal, cast
 
 from exp.common.core.artifacts import stable_id
-from exp.common.models import ConnectionConfig
 from exp.common.models.gateway_catalog import NormalizedGatewayCatalog
 from exp.runtime.gateway.budgets import (
     BudgetScope,
@@ -85,6 +85,7 @@ from exp.runtime.gateway.sqlite.platform_records import (
 from exp.runtime.gateway.sqlite.platform_records import (
     reservation_record as _reservation_record,
 )
+from exp.runtime.gateway.sqlite.provider_commands import sqlite_connection_config
 from exp.runtime.gateway.sqlite.store import SQLiteGatewayStore
 
 
@@ -190,26 +191,11 @@ class SQLiteGatewayPlatform:
             require_gateway_servable_provider(
                 connection_id=command.connection_id, provider=command.provider
             )
-            secret_reference = command.secret_reference
-            if (
-                secret_reference is not None
-                and secret_reference.scheme is not OpaqueSecretScheme.ENVIRONMENT
-            ):
-                raise ValueError(
-                    "SQLite provider connections currently require an environment secret reference"
-                )
             changed, authority = self.control.upsert_provider_connection(
                 organization_id=command.organization_id,
                 connection_id=command.connection_id,
                 revision_id=command.revision_id,
-                config=ConnectionConfig(
-                    provider=command.provider,
-                    base_url=command.base_url,
-                    api_key_env=(None if secret_reference is None else secret_reference.reference),
-                    api_version=command.api_version,
-                    azure_api_surface=command.azure_api_surface,
-                    region=command.region,
-                ),
+                config=sqlite_connection_config(command),
                 replace=command.replace,
             )
             if not changed and authority.revision_id != command.revision_id:
@@ -433,6 +419,21 @@ class SQLiteGatewayPlatform:
                     else OpaqueSecretReference(
                         scheme=OpaqueSecretScheme.ENVIRONMENT,
                         reference=str(row["api_key_env"]),
+                    )
+                ),
+                access_key_id_reference=(
+                    None
+                    if row["aws_access_key_id_env"] is None
+                    else OpaqueSecretReference(
+                        scheme=OpaqueSecretScheme.ENVIRONMENT,
+                        reference=str(row["aws_access_key_id_env"]),
+                    )
+                ),
+                bedrock_auth_mode=(
+                    None
+                    if row["bedrock_auth_mode"] is None
+                    else cast(
+                        'Literal["access_key_pair", "api_key"]', str(row["bedrock_auth_mode"])
                     )
                 ),
                 connection_sha256=str(row["connection_sha256"]),

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -437,8 +437,7 @@ class SQLiteGatewayPlatform:
                     )
                 ),
                 connection_sha256=str(row["connection_sha256"]),
-                active=bool(row["active"])
-                and str(row["active_revision_id"]) == str(row["revision_id"]),
+                active=bool(row["active"]) and row["active_revision_id"] == row["revision_id"],
                 created_at=_datetime(row["created_at"]),
             )
             for row in rows

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -439,6 +439,97 @@ def test_alias_reactivation_requires_current_provider_bindings(tmp_path: Path) -
         platform.mutate_alias(alias)
 
 
+def test_bedrock_auth_modes_survive_management_restart_and_alias_binding(
+    tmp_path: Path,
+) -> None:
+    """Ambient, explicit-pair, and bearer authorities round-trip without ambiguity."""
+    platform = _platform(tmp_path)
+    secret = OpaqueSecretReference(
+        scheme=OpaqueSecretScheme.ENVIRONMENT,
+        reference="AWS_SECRET_ACCESS_KEY",
+    )
+    access_key_id = OpaqueSecretReference(
+        scheme=OpaqueSecretScheme.ENVIRONMENT,
+        reference="AWS_ACCESS_KEY_ID",
+    )
+    commands = (
+        UpsertProviderConnectionCommand(
+            organization_id="org-one",
+            connection_id="bedrock-ambient",
+            revision_id="bedrock-ambient-revision",
+            provider="bedrock",
+            region="us-west-2",
+        ),
+        UpsertProviderConnectionCommand(
+            organization_id="org-one",
+            connection_id="bedrock-pair",
+            revision_id="bedrock-pair-revision",
+            provider="bedrock",
+            region="us-west-2",
+            secret_reference=secret,
+            access_key_id_reference=access_key_id,
+            bedrock_auth_mode="access_key_pair",
+        ),
+        UpsertProviderConnectionCommand(
+            organization_id="org-one",
+            connection_id="bedrock-bearer",
+            revision_id="bedrock-bearer-revision",
+            provider="bedrock",
+            region="us-west-2",
+            secret_reference=secret.model_copy(update={"reference": "BEDROCK_API_KEY"}),
+            bedrock_auth_mode="api_key",
+        ),
+    )
+    for command in commands:
+        assert platform.mutate_provider_connection(command).changed
+    pair = next(
+        revision
+        for revision in platform.provider_connection_revisions(organization_id="org-one")
+        if revision.connection_id == "bedrock-pair"
+    )
+    platform.control.register_catalog_snapshot(
+        organization_id="org-one",
+        snapshot_ref="catalog-one",
+        catalog_sha256=_DIGEST,
+    )
+    assert platform.mutate_alias(
+        ActivateAliasRevisionCommand(
+            organization_id="org-one",
+            alias_id="coding",
+            alias_name="coding",
+            revision_id="alias-revision-one",
+            target=DirectTarget(pool_id="coding-pool"),
+            snapshot_ref="catalog-one",
+            catalog_sha256=_DIGEST,
+            provider_connections=(
+                ProviderRevisionBinding(
+                    connection_id=pair.connection_id,
+                    connection_revision_id=pair.revision_id,
+                    connection_sha256=pair.connection_sha256,
+                ),
+            ),
+        )
+    ).changed
+
+    restarted = SQLiteGatewayPlatform(
+        platform.database_path,
+        budgets=SQLiteBudgetStore(platform.database_path),
+        attempts=SQLiteAttemptLedger(platform.database_path),
+        pool_revisions=_PoolRevisions(),
+    )
+    revisions = {
+        revision.connection_id: revision
+        for revision in restarted.provider_connection_revisions(organization_id="org-one")
+    }
+
+    assert revisions["bedrock-ambient"].bedrock_auth_mode is None
+    assert revisions["bedrock-pair"].bedrock_auth_mode == "access_key_pair"
+    assert revisions["bedrock-pair"].access_key_id_reference == access_key_id
+    assert revisions["bedrock-bearer"].bedrock_auth_mode == "api_key"
+    assert revisions["bedrock-bearer"].access_key_id_reference is None
+    assert restarted.alias_revisions(organization_id="org-one")[0].active
+
+
 def test_revision_reads_forward_existing_sqlite_authority(tmp_path: Path) -> None:
     """The adapter exposes exact provider, alias, and catalog-owned pool revisions."""
     platform = _platform(tmp_path)

--- a/exp/runtime/gateway/sqlite/provider_authority.py
+++ b/exp/runtime/gateway/sqlite/provider_authority.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Literal, cast
 
-from exp.common.core.artifacts import ContractModel, Sha256
+from exp.common.core.artifacts import ContractModel, Sha256, stable_id
 from exp.common.models import ConnectionConfig
 
 
@@ -40,6 +40,18 @@ class ProviderConnectionAuthority(ContractModel):
     active: bool = True
 
 
+def provider_connection_revision_id(connection_id: str, config: ConnectionConfig) -> str:
+    """Derive one immutable revision from canonical serving authority."""
+    canonical = config.canonicalized()
+    return stable_id(
+        "provider-connection-revision",
+        {
+            "connection_id": connection_id,
+            "config": canonical.model_dump(mode="json", exclude_none=False),
+        },
+    )
+
+
 def upsert_provider_connection(
     connection: sqlite3.Connection,
     *,
@@ -67,6 +79,7 @@ def upsert_provider_connection(
     Raises:
         ProviderAuthorityError: Identity, replacement, or revision invariants conflict.
     """
+    config = config.canonicalized()
     current = _active_row(
         connection,
         organization_id=organization_id,
@@ -115,8 +128,8 @@ def upsert_provider_connection(
         INSERT INTO provider_connection_revisions (
             revision_id, organization_id, connection_id, revision_number,
             provider, base_url, api_key_env, api_version, azure_api_surface, region,
-            connection_sha256, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            aws_access_key_id_env, bedrock_auth_mode, connection_sha256, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             revision_id,
@@ -129,6 +142,8 @@ def upsert_provider_connection(
             config.api_version,
             config.azure_api_surface,
             config.region,
+            config.aws_access_key_id_env,
+            config.bedrock_auth_mode,
             digest,
             now,
         ),
@@ -183,6 +198,7 @@ def bound_provider_connections(
         SELECT c.connection_id, r.revision_id, r.revision_number,
                r.provider, r.base_url, r.api_key_env, r.api_version,
                r.azure_api_surface, r.region,
+               r.aws_access_key_id_env, r.bedrock_auth_mode,
                r.connection_sha256, c.active
         FROM alias_revision_provider_connections AS b
         JOIN provider_connections AS c
@@ -316,6 +332,14 @@ def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
             None if row["azure_api_surface"] is None else str(row["azure_api_surface"]),
         ),
         region=None if row["region"] is None else str(row["region"]),
+        aws_access_key_id_env=(
+            None if row["aws_access_key_id_env"] is None else str(row["aws_access_key_id_env"])
+        ),
+        bedrock_auth_mode=(
+            None
+            if row["bedrock_auth_mode"] is None
+            else cast('Literal["access_key_pair", "api_key"]', str(row["bedrock_auth_mode"]))
+        ),
     )
     digest = str(row["connection_sha256"])
     if config.identity_sha256() != digest:
@@ -334,6 +358,7 @@ _SELECT_AUTHORITY = """
 SELECT c.connection_id, r.revision_id, r.revision_number,
        r.provider, r.base_url, r.api_key_env, r.api_version,
        r.azure_api_surface, r.region,
+       r.aws_access_key_id_env, r.bedrock_auth_mode,
        r.connection_sha256, c.active
 FROM provider_connections AS c
 JOIN provider_connection_revisions AS r

--- a/exp/runtime/gateway/sqlite/provider_commands.py
+++ b/exp/runtime/gateway/sqlite/provider_commands.py
@@ -1,0 +1,37 @@
+"""Translate storage-neutral provider commands into SQLite environment locators."""
+
+from __future__ import annotations
+
+from exp.common.models import ConnectionConfig
+from exp.runtime.gateway.platform import (
+    OpaqueSecretReference,
+    OpaqueSecretScheme,
+    UpsertProviderConnectionCommand,
+)
+
+
+def sqlite_connection_config(command: UpsertProviderConnectionCommand) -> ConnectionConfig:
+    """Return the secret-free connection accepted by the local SQLite authority."""
+    references = (command.secret_reference, command.access_key_id_reference)
+    if any(
+        reference is not None and reference.scheme is not OpaqueSecretScheme.ENVIRONMENT
+        for reference in references
+    ):
+        raise ValueError(
+            "SQLite provider connections currently require an environment secret reference"
+        )
+    return ConnectionConfig(
+        provider=command.provider,
+        base_url=command.base_url,
+        api_key_env=_environment_name(command.secret_reference),
+        api_version=command.api_version,
+        azure_api_surface=command.azure_api_surface,
+        region=command.region,
+        aws_access_key_id_env=_environment_name(command.access_key_id_reference),
+        bedrock_auth_mode=command.bedrock_auth_mode,
+    )
+
+
+def _environment_name(reference: OpaqueSecretReference | None) -> str | None:
+    """Return one already-validated environment locator name."""
+    return None if reference is None else reference.reference

--- a/exp/runtime/models/credentials.py
+++ b/exp/runtime/models/credentials.py
@@ -17,6 +17,7 @@ from exp.common.auth import (
     StoredCredentialEndpointMismatch,
     StoredCredentialStatus,
 )
+from exp.common.core.artifacts import sha256_json
 from exp.common.models import ConnectionConfig
 
 CredentialSource = Literal["environment", "stored", "prompt"]
@@ -66,8 +67,8 @@ def lookup_connection_credential(
 ) -> CredentialResolution | None:
     """Resolve one credential from the environment, then the stored connection record.
 
-    A non-empty environment value wins and does not rewrite the store. Bedrock connections
-    do not participate; they authenticate through the AWS credential chain.
+    A non-empty environment value wins and does not rewrite the store. Ambient Bedrock
+    connections do not participate; explicit Bedrock pairs resolve their secret access key here.
 
     Args:
         connection: Secret-free connection metadata.
@@ -81,7 +82,7 @@ def lookup_connection_credential(
     Raises:
         ProviderAuthStoreError: The local credential file exists but cannot be used.
     """
-    if connection.provider == "bedrock":
+    if connection.provider == "bedrock" and connection.api_key_env is None:
         return None
     values = os.environ if environment is None else environment
     if connection.api_key_env is not None:
@@ -113,7 +114,7 @@ def describe_connection_credential(
     Returns:
         Connection identity, provider, source, and environment-variable name.
     """
-    if connection.provider == "bedrock":
+    if connection.provider == "bedrock" and connection.api_key_env is None:
         return StoredCredentialStatus(
             connection_id=connection_id,
             provider=connection.provider,
@@ -190,10 +191,8 @@ def read_connection_api_key(
             environment variable and stored credential are absent.
         ProviderAuthStoreError: The local credential file exists but cannot be used.
     """
-    if connection.provider == "bedrock":
-        raise ModelCredentialError(
-            "bedrock authenticates through the AWS credential chain and has no stored API key"
-        )
+    if connection.provider == "bedrock" and connection.api_key_env is None:
+        raise ModelCredentialError("bedrock ambient authentication has no stored secret access key")
     try:
         resolved = lookup_connection_credential(
             connection,
@@ -265,15 +264,25 @@ def resolve_or_prompt_connection_api_key(
 
 
 def _credential_binding(connection: ConnectionConfig) -> StoredCredentialBinding:
-    """Return the secret-free endpoint identity stored with one API key.
+    """Return the secret-free endpoint and credential-locator identity for one key.
 
     Args:
         connection: Secret-free connection metadata.
 
     Returns:
-        Provider name plus the catalog endpoint digest.
+        Provider name, catalog endpoint digest, and Bedrock locator digest when needed.
     """
+    credential_locator_sha256 = None
+    if connection.provider == "bedrock" and connection.api_key_env is not None:
+        credential_locator_sha256 = sha256_json(
+            {
+                "api_key_env": connection.api_key_env,
+                "aws_access_key_id_env": connection.aws_access_key_id_env,
+                "bedrock_auth_mode": connection.canonicalized().bedrock_auth_mode,
+            }
+        )
     return StoredCredentialBinding(
         provider=connection.provider,
         endpoint_sha256=connection.identity_sha256(),
+        credential_locator_sha256=credential_locator_sha256,
     )

--- a/exp/runtime/models/credentials_test.py
+++ b/exp/runtime/models/credentials_test.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from exp.common.auth import ProviderAuthStore, StoredCredentialBinding
+from exp.common.auth import (
+    ProviderAuthStore,
+    StoredCredentialBinding,
+    StoredCredentialEndpointMismatch,
+)
 from exp.common.models import ConnectionConfig
 from exp.runtime.models.credentials import (
     CredentialResolution,
@@ -126,6 +130,40 @@ def test_azure_model_inference_root_and_models_path_share_stored_credential(
     )
 
     assert api_key == _SECRET
+
+
+def test_bedrock_pair_secret_is_bound_to_both_credential_locators(tmp_path: Path) -> None:
+    """A stored secret-access key cannot be reused after both locator names change."""
+    store = ProviderAuthStore(tmp_path / "auth.json")
+    original = ConnectionConfig(
+        provider="bedrock",
+        api_key_env="AWS_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+        region="us-west-2",
+        bedrock_auth_mode="access_key_pair",
+    )
+    resolve_or_prompt_connection_api_key(
+        original,
+        connection_id="bedrock",
+        environment={},
+        store=store,
+        prompt=lambda: _SECRET,
+        persist=True,
+    )
+    swapped = original.model_copy(
+        update={
+            "api_key_env": "SECONDARY_AWS_SECRET_ACCESS_KEY",
+            "aws_access_key_id_env": "SECONDARY_AWS_ACCESS_KEY_ID",
+        }
+    )
+
+    with pytest.raises(StoredCredentialEndpointMismatch):
+        lookup_connection_credential(
+            swapped,
+            connection_id="bedrock",
+            environment={},
+            store=store,
+        )
 
 
 def test_store_resolves_when_the_connection_omits_an_env_name(tmp_path: Path) -> None:
@@ -301,6 +339,46 @@ def test_stored_key_is_rejected_when_the_endpoint_identity_changes(tmp_path: Pat
 
     assert _SECRET not in str(captured.value)
     assert store.get("acme") == _SECRET
+
+
+@pytest.mark.parametrize(
+    ("original_mode", "replacement_mode"),
+    (("access_key_pair", "api_key"), ("api_key", "access_key_pair")),
+)
+def test_bedrock_stored_credentials_never_cross_auth_modes(
+    tmp_path: Path,
+    original_mode: str,
+    replacement_mode: str,
+) -> None:
+    """A secret access key can never be replayed as a bearer, or vice versa."""
+    store = ProviderAuthStore(tmp_path / "auth.json")
+
+    def connection(mode: str) -> ConnectionConfig:
+        if mode == "api_key":
+            return ConnectionConfig(
+                provider="bedrock",
+                region="us-west-2",
+                api_key_env="BEDROCK_API_KEY",
+                bedrock_auth_mode="api_key",
+            )
+        return ConnectionConfig(
+            provider="bedrock",
+            region="us-west-2",
+            api_key_env="AWS_SECRET_ACCESS_KEY",
+            aws_access_key_id_env="AWS_ACCESS_KEY_ID",
+            bedrock_auth_mode="access_key_pair",
+        )
+
+    original = connection(original_mode)
+    store.put("bedrock", _SECRET, binding=_binding(original))
+
+    with pytest.raises(ModelCredentialError, match="does not match"):
+        read_connection_api_key(
+            connection(replacement_mode),
+            connection_id="bedrock",
+            environment={},
+            store=store,
+        )
 
 
 def test_resolution_repr_never_includes_the_secret() -> None:

--- a/exp/runtime/models/providers/bedrock.py
+++ b/exp/runtime/models/providers/bedrock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from collections.abc import Callable, Mapping, Sequence
@@ -23,6 +24,11 @@ from exp.common.models import (
     Usage,
 )
 from exp.runtime.models.providers.base import DEFAULT_RETRY_POLICY, GatewayWireProfile
+from exp.runtime.models.providers.bedrock_endpoints import (
+    bedrock_runtime_origin,
+    bedrock_signing_region,
+    built_in_botocore_loader,
+)
 from exp.runtime.models.providers.bedrock_requests import converse_request
 from exp.runtime.models.providers.errors import (
     ProviderRefusalError,
@@ -43,6 +49,7 @@ from exp.runtime.models.providers.transport import (
 
 AWS_REGION_ENV = "AWS_REGION"
 AWS_DEFAULT_REGION_ENV = "AWS_DEFAULT_REGION"
+AWS_BEARER_TOKEN_BEDROCK_ENV = "AWS_BEARER_TOKEN_BEDROCK"
 CONNECT_TIMEOUT_SECONDS = 15.0
 READ_TIMEOUT_SECONDS = 600.0
 _REGION_SOURCES = (
@@ -106,8 +113,47 @@ class _BotoSession(Protocol):
 class _Boto3Module(Protocol):
     """Lazy boto3 module surface used only at request time."""
 
-    def Session(self) -> _BotoSession:
-        """Return a boto session that reads the standard AWS chain."""
+    def Session(self, **credentials: object) -> _BotoSession:
+        """Return a boto session using explicit credentials or the standard AWS chain."""
+
+
+class _BotocoreSession(Protocol):
+    """Botocore session surface used to isolate bearer token providers."""
+
+    def register_component(self, name: str, component: object) -> None:
+        """Replace one lazy session component before client construction."""
+
+    def get_component(self, name: str) -> object:
+        """Return one already-registered botocore session component."""
+
+    def get_credentials(self) -> _ResolvableCredentials | None:
+        """Return credentials bound to this isolated session, when any."""
+
+    def set_config_variable(self, logical_name: str, value: object) -> None:
+        """Override one ambient configuration source for this session only."""
+
+    def set_credentials(
+        self,
+        access_key: str,
+        secret_key: str,
+        token: str | None = None,
+    ) -> None:
+        """Bind an exact credential triple to this isolated session."""
+
+
+class _ConfigValueStore(Protocol):
+    """Botocore configuration store used to replace ambient profile lookup."""
+
+    def set_config_provider(self, logical_name: str, provider: object) -> None:
+        """Replace one variable's entire provider chain."""
+
+
+class _NoAmbientTokenProvider:
+    """Token provider that deliberately ignores every ambient AWS login."""
+
+    def load_token(self, **_: object) -> None:
+        """Return no ambient token; the exact bearer is bound per client later."""
+        return None
 
 
 def resolve_bedrock_region(
@@ -134,7 +180,13 @@ def resolve_bedrock_region(
     return session_region
 
 
-def create_bedrock_runtime_client(*, region_name: str) -> BedrockRuntime:
+def create_bedrock_runtime_client(
+    *,
+    region_name: str,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+    bearer_token: str | None = None,
+) -> BedrockRuntime:
     """Construct one ``bedrock-runtime`` client with bounded timeouts and no hidden retries.
 
     Args:
@@ -148,19 +200,105 @@ def create_bedrock_runtime_client(*, region_name: str) -> BedrockRuntime:
     """
     boto3 = _import_boto3()
     config_cls = _import_botocore_config()
-    session = boto3.Session()
+    if bearer_token is not None and (
+        aws_access_key_id is not None or aws_secret_access_key is not None
+    ):
+        raise ValueError("Bedrock bearer auth cannot be combined with access-key credentials")
+    session_kwargs = _explicit_session_kwargs(aws_access_key_id, aws_secret_access_key)
+    explicit_auth = bearer_token is not None or bool(session_kwargs)
+    if explicit_auth:
+        botocore_session = _import_isolated_botocore_session()
+        if session_kwargs:
+            botocore_session.set_credentials(
+                session_kwargs["aws_access_key_id"],
+                session_kwargs["aws_secret_access_key"],
+            )
+        session = boto3.Session(botocore_session=botocore_session)
+    else:
+        session = boto3.Session()
+    config_kwargs: dict[str, object] = {
+        "connect_timeout": CONNECT_TIMEOUT_SECONDS,
+        "read_timeout": READ_TIMEOUT_SECONDS,
+        "retries": {"max_attempts": 1, "mode": "standard"},
+        "tcp_keepalive": True,
+    }
+    if explicit_auth:
+        # Explicit credentials are pinned to the public regional endpoint and
+        # cannot inherit process-wide endpoint/profile configuration.
+        config_kwargs["ignore_configured_endpoint_urls"] = True
+        config_kwargs["defaults_mode"] = "legacy"
+        config_kwargs["use_dualstack_endpoint"] = False
+        config_kwargs["use_fips_endpoint"] = False
+    if bearer_token is not None:
+        # UNSIGNED prevents client construction from touching the ambient AWS
+        # credential chain. The isolated per-client bearer signer is installed
+        # immediately after construction.
+        config_kwargs["signature_version"] = _import_botocore_unsigned()
     with _CLIENT_CONSTRUCTION_LOCK:
         client = session.client(
             "bedrock-runtime",
             region_name=region_name,
-            config=config_cls(
-                connect_timeout=CONNECT_TIMEOUT_SECONDS,
-                read_timeout=READ_TIMEOUT_SECONDS,
-                retries={"max_attempts": 1, "mode": "standard"},
-                tcp_keepalive=True,
-            ),
+            config=config_cls(**config_kwargs),
         )
+        if bearer_token is not None:
+            _bind_bedrock_bearer(client, bearer_token)
     return cast("BedrockRuntime", client)
+
+
+class _BearerEvents(Protocol):
+    """Per-client botocore event registry used to select bearer signing."""
+
+    def register(self, event_name: str, handler: Callable[..., str]) -> None:
+        """Register one signer-selection callback."""
+
+
+class _BearerClientMeta(Protocol):
+    """Botocore client metadata carrying its isolated event registry."""
+
+    events: _BearerEvents
+
+
+class _BearerRequestSigner(Protocol):
+    """Narrow botocore request-signer token seam."""
+
+    _auth_token: object
+
+
+class _PinnedBearerToken:
+    """Opaque non-refreshing token provider compatible with supported botocore versions."""
+
+    __slots__ = ("_token",)
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def get_frozen_token(self) -> object:
+        """Return botocore's immutable token shape without consulting ambient providers."""
+        from botocore.tokens import FrozenAuthToken
+
+        return FrozenAuthToken(self._token, expiration=None)
+
+    def __repr__(self) -> str:
+        """Keep the raw bearer out of diagnostics."""
+        return "_PinnedBearerToken([REDACTED])"
+
+    __str__ = __repr__
+
+
+class _BearerClient(Protocol):
+    """Dynamic botocore client fields required for bearer injection."""
+
+    meta: _BearerClientMeta
+    _request_signer: _BearerRequestSigner
+
+
+def _bind_bedrock_bearer(client: object, token: str) -> None:
+    """Pin one Bedrock API-key bearer to one botocore client."""
+    scoped = cast("_BearerClient", client)
+    events = scoped.meta.events
+    events.register("choose-signer.bedrock-runtime", lambda **_: "bearer")
+    events.register("choose-signer.bedrock", lambda **_: "bearer")
+    scoped._request_signer._auth_token = _PinnedBearerToken(token)  # noqa: SLF001
 
 
 class _FrozenCredentials(Protocol):
@@ -217,8 +355,24 @@ class _SigV4SignerFactory(Protocol):
         """Return one bound signer."""
 
 
+def _explicit_session_kwargs(
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+) -> dict[str, str]:
+    """Return boto Session kwargs only when an explicit access-key pair is configured."""
+    if (aws_access_key_id is None) != (aws_secret_access_key is None):
+        raise ValueError("explicit Bedrock credentials require both access-key fields")
+    if aws_access_key_id is None:
+        return {}
+    assert aws_secret_access_key is not None
+    return {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+    }
+
+
 class BedrockClient:
-    """Calls one Bedrock model or inference profile without failover or API-key auth."""
+    """Calls one Bedrock model or inference profile without provider failover."""
 
     def __init__(
         self,
@@ -226,6 +380,9 @@ class BedrockClient:
         model: ModelSnapshot,
         region: str | None,
         environment: Mapping[str, str],
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        bearer_token: str | None = None,
         runtime_factory: BedrockRuntimeFactory | None = None,
         retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
         supports_temperature: bool = True,
@@ -239,12 +396,21 @@ class BedrockClient:
             model: Resolved identity whose ``model_id`` is the exact Bedrock model ID.
             region: Optional catalog region. ``AWS_REGION`` and the boto chain follow it.
             environment: Process or injected environment mapping used for region lookup.
+            aws_access_key_id: Optional non-secret access-key identifier.
+            aws_secret_access_key: Optional secret access key resolved from the credential seam.
             runtime_factory: Optional deterministic factory used by tests.
             retry_policy: Bounded same-region retry policy applied outside botocore.
         """
         self._model = model
         self._configured_region = region
         self._environment = environment
+        if (aws_access_key_id is None) != (aws_secret_access_key is None):
+            raise ValueError("explicit Bedrock credentials require both access-key fields")
+        if bearer_token is not None and aws_access_key_id is not None:
+            raise ValueError("Bedrock bearer auth cannot be combined with access-key credentials")
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+        self._bearer_token = bearer_token
         self._runtime_factory = runtime_factory
         self._retry_policy = retry_policy
         self._supports_temperature = supports_temperature
@@ -325,8 +491,20 @@ class BedrockClient:
             return existing
         with self._lock:
             if self._client is None:
-                factory = self._runtime_factory or create_bedrock_runtime_client
-                self._client = factory(region_name=self._region_name())
+                if self._runtime_factory is not None:
+                    self._client = self._runtime_factory(region_name=self._region_name())
+                else:
+                    if self._bearer_token is not None:
+                        self._client = create_bedrock_runtime_client(
+                            region_name=self._region_name(),
+                            bearer_token=self._bearer_token,
+                        )
+                    else:
+                        self._client = create_bedrock_runtime_client(
+                            region_name=self._region_name(),
+                            aws_access_key_id=self._aws_access_key_id,
+                            aws_secret_access_key=self._aws_secret_access_key,
+                        )
             return self._client
 
     def _region_name(self) -> str:
@@ -361,7 +539,18 @@ class BedrockClient:
         """
         with self._lock:
             if self._signing_credentials is None:
-                self._signing_credentials = _import_boto3().Session().get_credentials()
+                session_kwargs = _explicit_session_kwargs(
+                    self._aws_access_key_id, self._aws_secret_access_key
+                )
+                if session_kwargs:
+                    session = _import_isolated_botocore_session()
+                    session.set_credentials(
+                        session_kwargs["aws_access_key_id"],
+                        session_kwargs["aws_secret_access_key"],
+                    )
+                    self._signing_credentials = session.get_credentials()
+                else:
+                    self._signing_credentials = _import_boto3().Session().get_credentials()
             credentials = self._signing_credentials
         if credentials is None:
             raise ProviderTransportError(
@@ -410,9 +599,8 @@ class BedrockClient:
         """
         region = self._region_name()
         encoded_model = quote(self._model.model_id, safe="/~")
-        return (
-            f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded_model}/converse-stream"
-        )
+        origin = bedrock_runtime_origin(region)
+        return f"{origin}/model/{encoded_model}/converse-stream"
 
     def sign_gateway_dispatch(self, *, url: str, body: str) -> Mapping[str, str]:
         """Compute SigV4 headers for one frozen native-dispatch request body.
@@ -438,6 +626,22 @@ class BedrockClient:
             RuntimeError: ``boto3`` or ``botocore`` is not installed.
         """
         region = self._region_name()
+        expected_url = self.converse_stream_url()
+        if url != expected_url:
+            raise ProviderTransportError(
+                "Bedrock dispatch URL differs from the admitted regional model endpoint"
+            )
+        bearer_token = self._bearer_token
+        if bearer_token is None and self._aws_access_key_id is None:
+            bearer_token = (
+                self._environment.get(AWS_BEARER_TOKEN_BEDROCK_ENV) or ""
+            ).strip() or None
+        if bearer_token is not None:
+            return {
+                "authorization": f"Bearer {bearer_token}",
+                "content-type": "application/json",
+                "accept": "application/vnd.amazon.eventstream",
+            }
         auth_factory, request_factory = _import_botocore_signing()
         frozen = self._resolved_signing_credentials().get_frozen_credentials()
         request = request_factory(
@@ -449,7 +653,7 @@ class BedrockClient:
                 "accept": "application/vnd.amazon.eventstream",
             },
         )
-        auth_factory(frozen, "bedrock", region).add_auth(request)
+        auth_factory(frozen, "bedrock", bedrock_signing_region(region)).add_auth(request)
         return {str(name): str(value) for name, value in dict(request.headers).items()}
 
     def _call_with_retry(
@@ -560,6 +764,39 @@ def _import_botocore_config() -> type[object]:
     except ImportError as exc:
         raise RuntimeError("Bedrock requires botocore; install experiential") from exc
     return Config
+
+
+def _import_botocore_unsigned() -> object:
+    """Import botocore's sentinel that disables ambient SigV4 resolution."""
+    try:
+        from botocore import UNSIGNED
+    except ImportError as exc:
+        raise RuntimeError("Bedrock requires botocore; install experiential") from exc
+    return UNSIGNED
+
+
+def _import_isolated_botocore_session() -> _BotocoreSession:
+    """Create a botocore session that cannot consult ambient AWS configuration."""
+    try:
+        from botocore.configprovider import BOTOCORE_DEFAUT_SESSION_VARIABLES, ConstantProvider
+        from botocore.session import get_session
+    except ImportError as exc:
+        raise RuntimeError("Bedrock requires botocore; install experiential") from exc
+    session = cast("_BotocoreSession", get_session())
+    config_store = cast("_ConfigValueStore", session.get_component("config_store"))
+    for logical_name, (
+        _,
+        environment_name,
+        default,
+        _,
+    ) in BOTOCORE_DEFAUT_SESSION_VARIABLES.items():
+        if environment_name is not None:
+            config_store.set_config_provider(logical_name, ConstantProvider(default))
+    config_store.set_config_provider("config_file", ConstantProvider(os.devnull))
+    config_store.set_config_provider("credentials_file", ConstantProvider(os.devnull))
+    session.register_component("data_loader", built_in_botocore_loader())
+    session.register_component("token_provider", _NoAmbientTokenProvider())
+    return session
 
 
 def _import_botocore_signing() -> tuple[_SigV4SignerFactory, _AwsRequestFactory]:

--- a/exp/runtime/models/providers/bedrock.py
+++ b/exp/runtime/models/providers/bedrock.py
@@ -398,6 +398,7 @@ class BedrockClient:
             environment: Process or injected environment mapping used for region lookup.
             aws_access_key_id: Optional non-secret access-key identifier.
             aws_secret_access_key: Optional secret access key resolved from the credential seam.
+            bearer_token: Optional bearer resolved from the credential seam.
             runtime_factory: Optional deterministic factory used by tests.
             retry_policy: Bounded same-region retry policy applied outside botocore.
         """
@@ -410,7 +411,10 @@ class BedrockClient:
             raise ValueError("Bedrock bearer auth cannot be combined with access-key credentials")
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key
-        self._bearer_token = bearer_token
+        effective_bearer = bearer_token
+        if effective_bearer is None and aws_access_key_id is None:
+            effective_bearer = (environment.get(AWS_BEARER_TOKEN_BEDROCK_ENV) or "").strip() or None
+        self._bearer_token = effective_bearer
         self._runtime_factory = runtime_factory
         self._retry_policy = retry_policy
         self._supports_temperature = supports_temperature
@@ -631,14 +635,9 @@ class BedrockClient:
             raise ProviderTransportError(
                 "Bedrock dispatch URL differs from the admitted regional model endpoint"
             )
-        bearer_token = self._bearer_token
-        if bearer_token is None and self._aws_access_key_id is None:
-            bearer_token = (
-                self._environment.get(AWS_BEARER_TOKEN_BEDROCK_ENV) or ""
-            ).strip() or None
-        if bearer_token is not None:
+        if self._bearer_token is not None:
             return {
-                "authorization": f"Bearer {bearer_token}",
+                "authorization": f"Bearer {self._bearer_token}",
                 "content-type": "application/json",
                 "accept": "application/vnd.amazon.eventstream",
             }

--- a/exp/runtime/models/providers/bedrock_endpoints.py
+++ b/exp/runtime/models/providers/bedrock_endpoints.py
@@ -1,0 +1,103 @@
+"""Package-owned Amazon Bedrock endpoint metadata resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from functools import cache
+from typing import NamedTuple, Protocol, cast
+
+from exp.runtime.models.providers.transport import ProviderTransportError
+
+
+class BotocoreLoader(Protocol):
+    """Built-in-only botocore data loader."""
+
+    def load_data(self, name: str) -> Mapping[str, object]:
+        """Load one bundled botocore metadata document."""
+
+
+class _EndpointResolver(Protocol):
+    """Botocore partition resolver used for the native streaming origin."""
+
+    def construct_endpoint(
+        self,
+        service_name: str,
+        region_name: str,
+        *,
+        use_fips_endpoint: bool = False,
+    ) -> Mapping[str, object] | None:
+        """Resolve one service endpoint without constructing a client."""
+
+
+class BedrockRuntimeEndpoint(NamedTuple):
+    """Official runtime origin and canonical SigV4 region."""
+
+    origin: str
+    signing_region: str
+
+
+@cache
+def resolve_bedrock_runtime_endpoint(region_name: str) -> BedrockRuntimeEndpoint:
+    """Resolve the official origin and signing region from bundled metadata."""
+    try:
+        from botocore.regions import EndpointResolver
+    except ImportError as exc:
+        raise RuntimeError("Bedrock requires botocore; install experiential") from exc
+    resolver = cast(
+        "_EndpointResolver",
+        EndpointResolver(built_in_botocore_loader().load_data("endpoints")),
+    )
+    canonical_region, use_fips = _canonical_fips_region(region_name)
+    endpoint = resolver.construct_endpoint(
+        "bedrock-runtime",
+        canonical_region,
+        use_fips_endpoint=use_fips,
+    )
+    hostname = None if endpoint is None else endpoint.get("hostname")
+    protocols = () if endpoint is None else endpoint.get("protocols", ())
+    if (
+        not isinstance(hostname, str)
+        or not isinstance(protocols, Sequence)
+        or "https" not in protocols
+    ):
+        raise ProviderTransportError(
+            f"Bedrock has no HTTPS runtime endpoint for region {region_name!r}"
+        )
+    return BedrockRuntimeEndpoint(
+        origin=f"https://{hostname}",
+        signing_region=canonical_region,
+    )
+
+
+def bedrock_runtime_origin(region_name: str) -> str:
+    """Return the official HTTPS Bedrock Runtime origin."""
+    return resolve_bedrock_runtime_endpoint(region_name).origin
+
+
+def bedrock_signing_region(region_name: str) -> str:
+    """Return the canonical region used in Bedrock SigV4 scope."""
+    return resolve_bedrock_runtime_endpoint(region_name).signing_region
+
+
+def _canonical_fips_region(region_name: str) -> tuple[str, bool]:
+    """Normalize either botocore-supported FIPS pseudo-region spelling."""
+    if region_name.startswith("fips-"):
+        return region_name.removeprefix("fips-"), True
+    if region_name.endswith("-fips"):
+        return region_name.removesuffix("-fips"), True
+    return region_name, False
+
+
+def built_in_botocore_loader() -> BotocoreLoader:
+    """Create a loader restricted to package-owned endpoint metadata."""
+    try:
+        from botocore.loaders import Loader
+    except ImportError as exc:
+        raise RuntimeError("Bedrock requires botocore; install experiential") from exc
+    return cast(
+        "BotocoreLoader",
+        Loader(
+            extra_search_paths=[Loader.BUILTIN_DATA_PATH],
+            include_default_search_paths=False,
+        ),
+    )

--- a/exp/runtime/models/providers/bedrock_test.py
+++ b/exp/runtime/models/providers/bedrock_test.py
@@ -6,9 +6,12 @@ import asyncio
 import json
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
+import exp.runtime.models.providers.bedrock_endpoints as bedrock_endpoints
 from exp.common.models import (
     BillingSource,
     ConnectionConfig,
@@ -23,8 +26,10 @@ from exp.common.models import (
     ModelRoles,
     ModelSnapshot,
 )
+from exp.runtime.models.credentials import MissingModelCredentialError
 from exp.runtime.models.providers.async_transport import RequestDeadline
 from exp.runtime.models.providers.bedrock import (
+    AWS_BEARER_TOKEN_BEDROCK_ENV,
     AWS_DEFAULT_REGION_ENV,
     AWS_REGION_ENV,
     CONNECT_TIMEOUT_SECONDS,
@@ -115,7 +120,7 @@ def test_complete_sends_the_exact_model_id_and_preserves_cache_usage() -> None:
     client = BedrockClient(
         model=_snapshot("us.anthropic.claude-sonnet-4-5"),
         region="us-west-2",
-        environment={},
+        environment={"BEDROCK_ACCESS_KEY_ID": "AKIAEXAMPLEKEY0001"},
         runtime_factory=lambda *, region_name: runtime,
     )
 
@@ -313,8 +318,8 @@ def test_retries_stay_on_the_same_region_and_model() -> None:
     assert runtime.converse_calls[0]["modelId"] == "exact-model"
 
 
-def test_catalog_rejects_bedrock_api_key_env_and_resolves_without_http() -> None:
-    """Bedrock catalog records cannot carry api_key_env and resolve through RuntimeModelCatalog."""
+def test_catalog_requires_a_complete_bedrock_access_key_pair_and_resolves_ambient() -> None:
+    """Bedrock rejects half-configured credentials and preserves ambient-chain resolution."""
     with pytest.raises(ValueError, match="api_key_env"):
         ConnectionConfig(provider="bedrock", api_key_env="AWS_ACCESS_KEY_ID")
     runtime = _FakeBedrockRuntime()
@@ -369,6 +374,179 @@ def test_catalog_rejects_bedrock_api_key_env_and_resolves_without_http() -> None
     assert response.output.content == "ok"
     assert asyncio.run(complete_through_bounded_lane()) == "ok"
     assert vectors[0].values == (0.6, 0.8)
+
+
+def test_catalog_resolves_explicit_bedrock_access_key_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named secret access key and non-secret key ID reach the default boto seam together."""
+    runtime = _FakeBedrockRuntime()
+    seen: dict[str, str | None] = {}
+
+    def create_runtime(
+        *,
+        region_name: str,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+    ) -> BedrockRuntime:
+        """Capture explicit credentials without exposing them in production diagnostics."""
+        seen.update(
+            region=region_name,
+            access_key_id=aws_access_key_id,
+            secret_access_key=aws_secret_access_key,
+        )
+        return runtime
+
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock.create_bedrock_runtime_client", create_runtime
+    )
+    connection = ConnectionConfig(
+        provider="bedrock",
+        region="us-west-2",
+        api_key_env="BEDROCK_SECRET_ACCESS_KEY",
+        aws_access_key_id_env="BEDROCK_ACCESS_KEY_ID",
+    )
+    catalog = RuntimeModelCatalog(
+        ModelCatalog(
+            connections={"bedrock": connection},
+            models={
+                "claude": ModelRecord(
+                    billing_source=BillingSource.HOST_MANAGED,
+                    connection="bedrock",
+                    model="us.anthropic.claude-sonnet-4-5",
+                    capabilities=ModelCapabilities(supports_completions=True),
+                )
+            },
+            roles=ModelRoles(world_model="claude", judge="claude"),
+        ),
+        environment={
+            "BEDROCK_ACCESS_KEY_ID": "AKIAEXAMPLEKEY0001",
+            "BEDROCK_SECRET_ACCESS_KEY": "resolved-secret-access-key",
+        },
+    )
+
+    response = catalog.resolve("claude").client.complete(_request())
+
+    assert response.output.content == "ok"
+    assert seen == {
+        "region": "us-west-2",
+        "access_key_id": "AKIAEXAMPLEKEY0001",
+        "secret_access_key": "resolved-secret-access-key",
+    }
+
+
+def test_catalog_resolves_bedrock_api_key_without_sigv4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bedrock API key stays a per-connection bearer through both runtime paths."""
+    runtime = _FakeBedrockRuntime()
+    seen: dict[str, str | None] = {}
+
+    def create_runtime(
+        *,
+        region_name: str,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        bearer_token: str | None = None,
+    ) -> BedrockRuntime:
+        seen.update(
+            region=region_name,
+            access_key_id=aws_access_key_id,
+            secret_access_key=aws_secret_access_key,
+            bearer_token=bearer_token,
+        )
+        return runtime
+
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock.create_bedrock_runtime_client", create_runtime
+    )
+    connection = ConnectionConfig(
+        provider="bedrock",
+        region="us-west-2",
+        api_key_env="BEDROCK_API_KEY",
+        bedrock_auth_mode="api_key",
+    )
+    catalog = RuntimeModelCatalog(
+        ModelCatalog(
+            connections={"bedrock": connection},
+            models={
+                "claude": ModelRecord(
+                    billing_source=BillingSource.CUSTOMER_MANAGED,
+                    connection="bedrock",
+                    model="us.anthropic.claude-sonnet-4-5",
+                    capabilities=ModelCapabilities(supports_completions=True),
+                )
+            },
+            roles=ModelRoles(world_model="claude", judge="claude"),
+        ),
+        environment={"BEDROCK_API_KEY": "bedrock-bearer-token"},
+    )
+
+    resolved = catalog.resolve("claude")
+    response = resolved.client.complete(_request())
+    assert isinstance(resolved.client, BoundedBedrockClient)
+    runtime_client = resolved.client._client  # noqa: SLF001
+    assert isinstance(runtime_client, BedrockClient)
+    headers = runtime_client.sign_gateway_dispatch(
+        url=(
+            "https://bedrock-runtime.us-west-2.amazonaws.com/model/"
+            "us.anthropic.claude-sonnet-4-5/converse-stream"
+        ),
+        body="{}",
+    )
+
+    assert response.output.content == "ok"
+    assert seen == {
+        "region": "us-west-2",
+        "access_key_id": None,
+        "secret_access_key": None,
+        "bearer_token": "bedrock-bearer-token",
+    }
+    assert headers["authorization"] == "Bearer bedrock-bearer-token"
+    with pytest.raises(ProviderTransportError, match="differs"):
+        runtime_client.sign_gateway_dispatch(
+            url="https://untrusted.example/collect",
+            body="{}",
+        )
+
+
+def test_catalog_fails_closed_when_explicit_bedrock_secret_is_missing() -> None:
+    """An explicit key ID never falls back to the ambient chain when its paired secret is absent."""
+    catalog = RuntimeModelCatalog(
+        ModelCatalog(
+            connections={
+                "bedrock": ConnectionConfig(
+                    provider="bedrock",
+                    region="us-east-1",
+                    api_key_env="BEDROCK_SECRET_ACCESS_KEY",
+                    aws_access_key_id_env="BEDROCK_ACCESS_KEY_ID",
+                )
+            },
+            models={
+                "claude": ModelRecord(
+                    billing_source=BillingSource.HOST_MANAGED,
+                    connection="bedrock",
+                    model="us.anthropic.claude-sonnet-4-5",
+                    capabilities=ModelCapabilities(supports_completions=True),
+                )
+            },
+            roles=ModelRoles(world_model="claude", judge="claude"),
+        ),
+        environment={"BEDROCK_ACCESS_KEY_ID": "AKIAEXAMPLEKEY0001"},
+    )
+
+    with pytest.raises(MissingModelCredentialError, match="BEDROCK_SECRET_ACCESS_KEY"):
+        catalog.resolve("claude")
+
+
+def test_low_level_bedrock_factory_rejects_a_half_explicit_pair() -> None:
+    """The lowest credential helper never falls through to ambient auth on a half pair."""
+    from exp.runtime.models.providers.bedrock import _explicit_session_kwargs
+
+    with pytest.raises(ValueError, match="both access-key fields"):
+        _explicit_session_kwargs("AKIAEXAMPLEKEY0001", None)
+    with pytest.raises(ValueError, match="both access-key fields"):
+        _explicit_session_kwargs(None, "secret-access-key")
 
 
 def test_snapshot_does_not_construct_a_bedrock_runtime() -> None:
@@ -471,6 +649,286 @@ def test_runtime_construction_uses_the_aws_session_chain(
     assert _Recorded.retries == {"max_attempts": 1, "mode": "standard"}
     assert _Recorded.tcp_keepalive is True
     assert runtime is not None
+
+
+def test_bearer_client_construction_never_resolves_ambient_aws_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bearer construction is unsigned until its isolated token signer is bound."""
+
+    class _FakeConfig:
+        """Capture the selected signature version."""
+
+        def __init__(self, **kwargs: object) -> None:
+            self.signature_version = kwargs.get("signature_version")
+
+    class _FakeSession:
+        """Reject any client that was not explicitly made unsigned."""
+
+        def client(self, service_name: str, *, region_name: str, config: object) -> object:
+            assert service_name == "bedrock-runtime"
+            assert region_name == "us-west-2"
+            assert isinstance(config, _FakeConfig)
+            assert config.signature_version is unsigned
+            return object()
+
+    class _FakeBoto3:
+        """Session construction itself carries no ambient credential lookup."""
+
+        def Session(self, **credentials: object) -> _FakeSession:
+            assert credentials == {"botocore_session": isolated_session}
+            return _FakeSession()
+
+    unsigned = object()
+    isolated_session = object()
+    bound: list[tuple[object, str]] = []
+    monkeypatch.setattr("exp.runtime.models.providers.bedrock._import_boto3", _FakeBoto3)
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock._import_botocore_config", lambda: _FakeConfig
+    )
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock._import_botocore_unsigned", lambda: unsigned
+    )
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock._import_isolated_botocore_session",
+        lambda: isolated_session,
+    )
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock._bind_bedrock_bearer",
+        lambda client, token: bound.append((client, token)),
+    )
+
+    runtime = create_bedrock_runtime_client(
+        region_name="us-west-2",
+        bearer_token="bedrock-bearer",
+    )
+
+    assert bound == [(runtime, "bedrock-bearer")]
+
+
+def test_real_bearer_client_ignores_hostile_ambient_token_and_credential_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real botocore constructs a token-only client without loading ambient auth."""
+    import botocore.credentials
+    import botocore.tokens
+
+    def forbidden(*_: object, **__: object) -> object:
+        raise AssertionError("ambient AWS authentication was consulted")
+
+    monkeypatch.setattr(
+        botocore.credentials.CredentialResolver,
+        "load_credentials",
+        forbidden,
+    )
+    monkeypatch.setattr(botocore.tokens.SSOTokenProvider, "load_token", forbidden)
+
+    runtime = create_bedrock_runtime_client(
+        region_name="us-west-2",
+        bearer_token="bedrock-bearer",
+    )
+
+    assert runtime is not None
+
+
+def test_real_bearer_client_ignores_hostile_profile_and_endpoint_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Bearer mode uses the official regional endpoint and no ambient AWS profile."""
+    malformed = tmp_path / "malformed-aws-config"
+    malformed.write_text("[profile broken\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_PROFILE", "profile-that-does-not-exist")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(malformed))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(malformed))
+    monkeypatch.setenv(
+        "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
+        "https://credential-exfiltration.invalid",
+    )
+    monkeypatch.setenv("AWS_DEFAULTS_MODE", "invalid-ambient-mode")
+    monkeypatch.setenv("AWS_USE_DUALSTACK_ENDPOINT", "true")
+    monkeypatch.setenv("AWS_USE_FIPS_ENDPOINT", "true")
+
+    runtime = create_bedrock_runtime_client(
+        region_name="us-west-2",
+        bearer_token="bedrock-bearer",
+    )
+
+    endpoint = cast("Any", runtime)._endpoint
+    assert endpoint.host == "https://bedrock-runtime.us-west-2.amazonaws.com"
+
+
+def test_real_access_key_client_ignores_hostile_ambient_aws_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An explicit pair uses only its pinned keys and the public regional endpoint."""
+    malformed = tmp_path / "malformed-aws-config"
+    malformed.write_text("[profile broken\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_PROFILE", "profile-that-does-not-exist")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(malformed))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(malformed))
+    monkeypatch.setenv(
+        "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
+        "https://credential-exfiltration.invalid",
+    )
+    monkeypatch.setenv("AWS_DEFAULTS_MODE", "invalid-ambient-mode")
+    monkeypatch.setenv("AWS_USE_DUALSTACK_ENDPOINT", "true")
+    monkeypatch.setenv("AWS_USE_FIPS_ENDPOINT", "true")
+
+    runtime = create_bedrock_runtime_client(
+        region_name="us-west-2",
+        aws_access_key_id="AKIAEXPLICITKEY001",
+        aws_secret_access_key="explicit-secret-access-key",
+    )
+
+    scoped = cast("Any", runtime)
+    assert scoped._endpoint.host == "https://bedrock-runtime.us-west-2.amazonaws.com"
+    credentials = scoped._request_signer._credentials.get_frozen_credentials()
+    assert credentials.access_key == "AKIAEXPLICITKEY001"
+    assert credentials.secret_key == "explicit-secret-access-key"
+    assert credentials.token is None
+
+
+@pytest.mark.parametrize("auth_mode", ("pair", "bearer"))
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    (
+        ("AWS_REQUEST_CHECKSUM_CALCULATION", "invalid-mode"),
+        ("AWS_REQUEST_MIN_COMPRESSION_SIZE_BYTES", "not-an-integer"),
+    ),
+)
+def test_real_explicit_clients_ignore_hostile_environment_client_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_mode: str,
+    variable: str,
+    value: str,
+) -> None:
+    """Explicit pair and bearer clients ignore every environment config chain."""
+    monkeypatch.setenv(variable, value)
+    kwargs = (
+        {"bearer_token": "bedrock-bearer"}
+        if auth_mode == "bearer"
+        else {
+            "aws_access_key_id": "AKIAEXPLICITKEY001",
+            "aws_secret_access_key": "explicit-secret-access-key",
+        }
+    )
+
+    runtime = create_bedrock_runtime_client(region_name="us-west-2", **kwargs)
+
+    assert runtime is not None
+
+
+@pytest.mark.parametrize("auth_mode", ("pair", "bearer"))
+def test_explicit_clients_ignore_hostile_customer_endpoint_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    auth_mode: str,
+) -> None:
+    """Customer botocore models cannot redirect explicit credentials or signing."""
+    from botocore.loaders import Loader
+
+    customer_data = tmp_path / "models"
+    customer_data.mkdir()
+    built_in = Loader(
+        extra_search_paths=[Loader.BUILTIN_DATA_PATH],
+        include_default_search_paths=False,
+    ).load_data("endpoints")
+    aws_partition = next(
+        partition
+        for partition in cast("Any", built_in)["partitions"]
+        if partition["partition"] == "aws"
+    )
+    aws_partition["services"]["bedrock-runtime"] = {
+        "endpoints": {
+            "us-west-2": {
+                "hostname": "credential-exfiltration.invalid",
+                "protocols": ["https"],
+                "signatureVersions": ["v4"],
+            }
+        }
+    }
+    (customer_data / "endpoints.json").write_text(
+        json.dumps(built_in),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Loader, "CUSTOMER_DATA_PATH", str(customer_data))
+    bedrock_endpoints.resolve_bedrock_runtime_endpoint.cache_clear()
+    try:
+        if auth_mode == "bearer":
+            runtime = create_bedrock_runtime_client(
+                region_name="us-west-2",
+                bearer_token="bedrock-bearer",
+            )
+            native = BedrockClient(
+                model=_snapshot(),
+                region="us-west-2",
+                environment={},
+                runtime_factory=None,
+                bearer_token="bedrock-bearer",
+            )
+        else:
+            runtime = create_bedrock_runtime_client(
+                region_name="us-west-2",
+                aws_access_key_id="AKIAEXPLICITKEY001",
+                aws_secret_access_key="explicit-secret-access-key",
+            )
+            native = BedrockClient(
+                model=_snapshot(),
+                region="us-west-2",
+                environment={},
+                runtime_factory=None,
+                aws_access_key_id="AKIAEXPLICITKEY001",
+                aws_secret_access_key="explicit-secret-access-key",
+            )
+
+        assert cast("Any", runtime)._endpoint.host == (
+            "https://bedrock-runtime.us-west-2.amazonaws.com"
+        )
+        assert native.converse_stream_url().startswith(
+            "https://bedrock-runtime.us-west-2.amazonaws.com/"
+        )
+    finally:
+        bedrock_endpoints.resolve_bedrock_runtime_endpoint.cache_clear()
+
+
+def test_real_bearer_request_emits_only_the_pinned_authorization_token() -> None:
+    """A serialized Converse request carries the exact bearer before network dispatch."""
+
+    class _StopBeforeNetwork(Exception):
+        """Abort after botocore has serialized and signed the request."""
+
+    captured: dict[str, str] = {}
+    runtime = create_bedrock_runtime_client(
+        region_name="us-west-2",
+        bearer_token="bedrock-bearer",
+    )
+    pinned = cast("Any", runtime)._request_signer._auth_token
+    assert pinned.get_frozen_token().token == "bedrock-bearer"
+    assert "bedrock-bearer" not in repr(pinned)
+    assert "bedrock-bearer" not in str(pinned)
+
+    def capture(request: object, **_: object) -> None:
+        headers = cast("Any", request).headers
+        value = headers.get("Authorization")
+        captured["authorization"] = (
+            value.decode("utf-8") if isinstance(value, bytes) else str(value)
+        )
+        raise _StopBeforeNetwork
+
+    cast("Any", runtime).meta.events.register(
+        "before-send.bedrock-runtime.Converse",
+        capture,
+    )
+
+    with pytest.raises(_StopBeforeNetwork):
+        runtime.converse(
+            modelId="amazon.nova-lite-v1:0",
+            messages=[{"role": "user", "content": [{"text": "ping"}]}],
+        )
+
+    assert captured == {"authorization": "Bearer bedrock-bearer"}
 
 
 def test_converse_response_normalizes_cache_legs_without_double_counting() -> None:
@@ -579,6 +1037,95 @@ def test_converse_stream_url_encodes_the_model_like_botocore() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("region", "suffix"),
+    (
+        ("cn-north-1", "amazonaws.com.cn"),
+        ("us-iso-east-1", "c2s.ic.gov"),
+        ("us-isob-east-1", "sc2s.sgov.gov"),
+    ),
+)
+def test_converse_stream_url_uses_the_region_partition_endpoint(
+    region: str,
+    suffix: str,
+) -> None:
+    """Native streaming derives China and isolated-partition DNS correctly."""
+    client = BedrockClient(
+        model=_snapshot(),
+        region=region,
+        environment={},
+        runtime_factory=None,
+    )
+
+    assert client.converse_stream_url().startswith(
+        f"https://bedrock-runtime.{region}.{suffix}/model/"
+    )
+
+
+@pytest.mark.parametrize("region", ("us-west-2-fips", "fips-us-west-2"))
+@pytest.mark.parametrize("auth_mode", ("pair", "bearer"))
+def test_native_fips_dispatch_uses_official_origin_and_canonical_signing_region(
+    region: str,
+    auth_mode: str,
+) -> None:
+    """Both FIPS spellings match boto endpoint and SigV4 behavior."""
+    if auth_mode == "bearer":
+        client = BedrockClient(
+            model=_snapshot(),
+            region=region,
+            environment={},
+            bearer_token="bedrock-bearer",
+            runtime_factory=None,
+        )
+    else:
+        client = BedrockClient(
+            model=_snapshot(),
+            region=region,
+            environment={},
+            aws_access_key_id="AKIAEXPLICITKEY001",
+            aws_secret_access_key="explicit-secret-access-key",
+            runtime_factory=None,
+        )
+    url = client.converse_stream_url()
+
+    assert url.startswith("https://bedrock-runtime-fips.us-west-2.amazonaws.com/model/")
+    headers = client.sign_gateway_dispatch(url=url, body='{"messages":[]}')
+    if auth_mode == "bearer":
+        assert headers["authorization"] == "Bearer bedrock-bearer"
+    else:
+        assert "/us-west-2/bedrock/aws4_request" in headers["Authorization"]
+
+
+def test_converse_stream_url_caches_bundled_endpoint_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated URL and signing checks do not reparse botocore endpoint data."""
+    real_loader = bedrock_endpoints.built_in_botocore_loader
+    calls = 0
+
+    def counted_loader() -> bedrock_endpoints.BotocoreLoader:
+        nonlocal calls
+        calls += 1
+        return real_loader()
+
+    monkeypatch.setattr(bedrock_endpoints, "built_in_botocore_loader", counted_loader)
+    bedrock_endpoints.resolve_bedrock_runtime_endpoint.cache_clear()
+    client = BedrockClient(
+        model=_snapshot(),
+        region="us-west-2",
+        environment={},
+        runtime_factory=None,
+    )
+    try:
+        first = client.converse_stream_url()
+        second = client.converse_stream_url()
+    finally:
+        bedrock_endpoints.resolve_bedrock_runtime_endpoint.cache_clear()
+
+    assert first == second
+    assert calls == 1
+
+
 def test_sign_gateway_dispatch_matches_an_independent_sigv4_computation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -648,6 +1195,125 @@ def test_sign_gateway_dispatch_forwards_the_session_token_and_binds_the_body(
     second = client.sign_gateway_dispatch(url=url, body='{"messages":[{}]}')
     if first["X-Amz-Date"] == second["X-Amz-Date"]:
         assert first["Authorization"] != second["Authorization"]
+
+
+def test_bedrock_dispatch_signing_rejects_every_non_admitted_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither SigV4 nor bearer credentials can be released to another origin."""
+    client = _signing_client(monkeypatch, token=None)
+
+    with pytest.raises(ProviderTransportError, match="differs"):
+        client.sign_gateway_dispatch(
+            url="https://untrusted.example/collect",
+            body='{"messages":[]}',
+        )
+
+
+def test_sign_gateway_dispatch_uses_the_explicit_access_key_pair(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Native ConverseStream signing resolves the configured pair, not the ambient chain."""
+    malformed = tmp_path / "malformed-aws-config"
+    malformed.write_text("[profile broken\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(malformed))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(malformed))
+    monkeypatch.setenv("AWS_PROFILE", "profile-that-does-not-exist")
+    monkeypatch.setenv("AWS_DEFAULTS_MODE", "invalid-ambient-mode")
+    client = BedrockClient(
+        model=_snapshot(),
+        region="us-west-2",
+        environment={AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bearer-must-not-win"},
+        aws_access_key_id="AKIAEXPLICITKEY001",
+        aws_secret_access_key="explicit-secret-access-key",
+        runtime_factory=None,
+    )
+
+    headers = client.sign_gateway_dispatch(
+        url=client.converse_stream_url(),
+        body='{"messages":[]}',
+    )
+
+    assert "Credential=AKIAEXPLICITKEY001/" in headers["Authorization"]
+
+
+def test_sign_gateway_dispatch_uses_the_ambient_bedrock_bearer() -> None:
+    """Ambient API-key auth reaches native dispatch without requiring access keys."""
+    client = BedrockClient(
+        model=_snapshot(),
+        region="us-west-2",
+        environment={AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer"},
+        runtime_factory=None,
+    )
+
+    headers = client.sign_gateway_dispatch(
+        url=client.converse_stream_url(),
+        body='{"messages":[]}',
+    )
+
+    assert headers["authorization"] == "Bearer ambient-bedrock-bearer"
+    assert headers["content-type"] == "application/json"
+
+
+def test_sign_gateway_dispatch_prefers_the_explicit_bearer() -> None:
+    """A catalog-resolved bearer cannot be shadowed by ambient process state."""
+    client = BedrockClient(
+        model=_snapshot(),
+        region="us-west-2",
+        environment={AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer"},
+        bearer_token="explicit-bedrock-bearer",
+        runtime_factory=None,
+    )
+
+    headers = client.sign_gateway_dispatch(
+        url=client.converse_stream_url(),
+        body='{"messages":[]}',
+    )
+
+    assert headers["authorization"] == "Bearer explicit-bedrock-bearer"
+
+
+def test_ambient_bearer_does_not_isolate_the_sdk_credential_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient API-key dispatch leaves ordinary boto SDK construction ambient."""
+    runtime = _FakeBedrockRuntime()
+    seen: dict[str, object] = {}
+
+    def create_runtime(
+        *,
+        region_name: str,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        bearer_token: str | None = None,
+    ) -> BedrockRuntime:
+        seen.update(
+            region_name=region_name,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            bearer_token=bearer_token,
+        )
+        return runtime
+
+    monkeypatch.setattr(
+        "exp.runtime.models.providers.bedrock.create_bedrock_runtime_client",
+        create_runtime,
+    )
+    client = BedrockClient(
+        model=_snapshot(),
+        region="us-west-2",
+        environment={AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer"},
+        runtime_factory=None,
+    )
+
+    assert client._runtime() is runtime  # noqa: SLF001
+    assert seen == {
+        "region_name": "us-west-2",
+        "aws_access_key_id": None,
+        "aws_secret_access_key": None,
+        "bearer_token": None,
+    }
 
 
 def test_bounded_client_wire_profile_marks_the_body_for_signing() -> None:

--- a/exp/runtime/models/providers/bedrock_test.py
+++ b/exp/runtime/models/providers/bedrock_test.py
@@ -1274,10 +1274,22 @@ def test_sign_gateway_dispatch_prefers_the_explicit_bearer() -> None:
     assert headers["authorization"] == "Bearer explicit-bedrock-bearer"
 
 
-def test_ambient_bearer_does_not_isolate_the_sdk_credential_chain(
+@pytest.mark.parametrize(
+    "environment",
+    (
+        {AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer"},
+        {
+            AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer",
+            "AWS_ACCESS_KEY_ID": "AKIAAMBIENTKEY0001",
+            "AWS_SECRET_ACCESS_KEY": "ambient-secret-access-key",
+        },
+    ),
+)
+def test_ambient_bearer_is_shared_by_buffered_and_native_paths(
     monkeypatch: pytest.MonkeyPatch,
+    environment: Mapping[str, str],
 ) -> None:
-    """Ambient API-key dispatch leaves ordinary boto SDK construction ambient."""
+    """Ambient bearer auth stays authoritative even when ambient access keys also exist."""
     runtime = _FakeBedrockRuntime()
     seen: dict[str, object] = {}
 
@@ -1303,17 +1315,22 @@ def test_ambient_bearer_does_not_isolate_the_sdk_credential_chain(
     client = BedrockClient(
         model=_snapshot(),
         region="us-west-2",
-        environment={AWS_BEARER_TOKEN_BEDROCK_ENV: "ambient-bedrock-bearer"},
+        environment=environment,
         runtime_factory=None,
     )
 
     assert client._runtime() is runtime  # noqa: SLF001
+    headers = client.sign_gateway_dispatch(
+        url=client.converse_stream_url(),
+        body='{"messages":[]}',
+    )
     assert seen == {
         "region_name": "us-west-2",
         "aws_access_key_id": None,
         "aws_secret_access_key": None,
-        "bearer_token": None,
+        "bearer_token": "ambient-bedrock-bearer",
     }
+    assert headers["authorization"] == "Bearer ambient-bedrock-bearer"
 
 
 def test_bounded_client_wire_profile_marks_the_body_for_signing() -> None:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -55,22 +55,14 @@ _NO_PARALLEL_TOOL_CONTROL_DIALECTS = frozenset(
 )
 
 
-def _fireworks_continuation_required(
-    profile: GatewayWireProfile,
-    request: GatewayRequest,
-) -> bool:
+def _fireworks_continuation_required(profile: GatewayWireProfile, request: GatewayRequest) -> bool:
     """Return whether a Fireworks Responses turn can emit an unretained tool call."""
     return (
         request.surface == GatewayApiSurface.RESPONSES
-        and _is_fireworks_profile(profile)
+        and (urlsplit(profile.url).hostname or "").lower() == "api.fireworks.ai"
         and bool(request.tools)
         and request.tool_choice != "none"
     )
-
-
-def _is_fireworks_profile(profile: GatewayWireProfile) -> bool:
-    """Return whether one wire profile targets the public Fireworks API."""
-    return (urlsplit(profile.url).hostname or "").lower() == "api.fireworks.ai"
 
 
 def dialect_stream_payload(

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -218,6 +218,10 @@ class RuntimeModelCatalog:
                 current_connection["azure_api_surface"] = connection.azure_api_surface
             if connection.region is not None:
                 current_connection["region"] = connection.region
+            if connection.aws_access_key_id_env is not None:
+                current_connection["aws_access_key_id_env"] = connection.aws_access_key_id_env
+            if connection.bedrock_auth_mode is not None:
+                current_connection["bedrock_auth_mode"] = connection.bedrock_auth_mode
             current_connection_sha256 = sha256_json(current_connection)
             if provenance.connection_config_sha256 != current_connection_sha256:
                 raise ModelConnectionError(
@@ -226,10 +230,38 @@ class RuntimeModelCatalog:
                 )
         provider = connection.provider
         if provider == "bedrock":
+            bearer_token = None
+            access_key_id = (
+                None
+                if connection.aws_access_key_id_env is None
+                else self._environment.get(connection.aws_access_key_id_env)
+            )
+            if connection.aws_access_key_id_env is not None and not access_key_id:
+                raise ModelConnectionError(
+                    f"bedrock connection {record.connection!r} requires environment variable "
+                    f"{connection.aws_access_key_id_env!r}"
+                )
+            released_credential = (
+                None
+                if connection.api_key_env is None
+                else read_connection_api_key(
+                    connection,
+                    connection_id=record.connection,
+                    environment=self._environment,
+                )
+            )
+            if connection.bedrock_auth_mode == "api_key":
+                bearer_token = released_credential
+                secret_access_key = None
+            else:
+                secret_access_key = released_credential
             bedrock_client = BedrockClient(
                 model=snapshot,
                 region=connection.region,
                 environment=self._environment,
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+                bearer_token=bearer_token,
                 runtime_factory=self._bedrock_runtime_factory,
                 supports_temperature=capabilities.supports_temperature,
                 supports_top_p=_supports_top_p(capabilities),


### PR DESCRIPTION
## Summary

- support explicit Bedrock access-key pairs and bearer credentials with region and endpoint metadata
- preserve credential usability through catalog reload and worker restart without persisting raw secrets
- bind admitted endpoint, request body, and signing inputs exactly, while isolating explicit credentials from ambient AWS state
- add current-schema SQLite replay and CLI setup/reuse support

## Exact regressions

- access-key and bearer modes survive catalog reload and gateway restart
- admitted endpoint and body are the exact values used for Bedrock authentication/signing
- explicit credentials do not fall back to or mix with ambient credentials
- persisted catalog and SQLite rows contain references/metadata, never raw secrets

## Verification

- focused Python: 289 passed
- full non-dirty suite: 2,720 passed, 2 skipped
- botocore 1.35 without CRT: 8 passed
- Ruff, formatting, Ty, wheel, and sdist: passed
- CI and exact-head Greptile review required before this is ready

## Supersedes from #639

Accounts for the Bedrock credential, endpoint, setup, catalog, replay, and restart-safe persistence hunks from #639. It intentionally excludes PR repair migrations, Azure, Fireworks, OpenAI Responses, package/version bumps, and release metadata.

No production verification is claimed. Do not merge or enqueue without explicit approval.
