### PR TITLE
fix(gateway): secure Fireworks reasoning continuations

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -115,8 +115,35 @@ class EncryptedReasoningBlock(ContractModel):
     )
 
 
+class OpaqueReasoningContentBlock(ContractModel):
+    """Authenticated Fireworks reasoning retained only inside the gateway.
+
+    The provider-issued text is never accepted directly from a caller. Public
+    decoding creates a sealed block, and admission replaces it with this
+    plaintext form only after authenticating the carrier against the exact
+    current deployment and credential authority.
+    """
+
+    kind: Literal["reasoning_content"] = "reasoning_content"
+    route_sha256: Sha256
+    content: str = Field(min_length=1, max_length=8 * 1024 * 1024)
+    carrier_size_bytes: int = Field(default=0, ge=0, exclude=True)
+
+
+class SealedReasoningContentBlock(ContractModel):
+    """One bounded, still-encrypted Fireworks continuation carrier."""
+
+    kind: Literal["sealed_reasoning_content"] = "sealed_reasoning_content"
+    carrier: str = Field(min_length=1)
+    deployment_hint: str = Field(min_length=1, max_length=256)
+
+
 ProviderReasoningBlock = Annotated[
-    ThinkingBlock | RedactedThinkingBlock | EncryptedReasoningBlock,
+    ThinkingBlock
+    | RedactedThinkingBlock
+    | EncryptedReasoningBlock
+    | OpaqueReasoningContentBlock
+    | SealedReasoningContentBlock,
     Field(discriminator="kind"),
 ]
 

--- a/exp/runtime/gateway/guardrails/enforcement.py
+++ b/exp/runtime/gateway/guardrails/enforcement.py
@@ -62,6 +62,34 @@ def _restored_provider_authority(
         return (
             None if any(has_authority(message) for message in replacement) else tuple(replacement)
         )
+    original_fireworks_carriers = tuple(
+        index
+        for index, message in enumerate(original)
+        if any(
+            block.kind in {"reasoning_content", "sealed_reasoning_content"}
+            for block in message.provider_reasoning
+        )
+    )
+    replacement_fireworks_carriers = tuple(
+        index
+        for index, message in enumerate(replacement)
+        if any(
+            block.kind in {"reasoning_content", "sealed_reasoning_content"}
+            for block in message.provider_reasoning
+        )
+    )
+    if original_fireworks_carriers:
+        if not replacement_fireworks_carriers:
+            return (
+                tuple(replacement)
+                if all(message.role in {"system", "developer", "user"} for message in replacement)
+                else None
+            )
+        if replacement_fireworks_carriers != original_fireworks_carriers:
+            return None
+        for index in original_fireworks_carriers:
+            if original[index] != replacement[index]:
+                return None
     bound = original_carrier_indexes[-1]
     if len(replacement) <= bound:
         return None

--- a/exp/runtime/gateway/guardrails/enforcement_test.py
+++ b/exp/runtime/gateway/guardrails/enforcement_test.py
@@ -19,6 +19,8 @@ from exp.runtime.gateway.contracts import (
     GatewayMessage,
     GatewayRequest,
     GatewayToolDefinition,
+    OpaqueReasoningContentBlock,
+    SealedReasoningContentBlock,
 )
 from exp.runtime.gateway.guardrails.bounded import BoundedInspect
 from exp.runtime.gateway.guardrails.classifiers import (
@@ -278,6 +280,141 @@ def test_input_chain_runs_once_and_can_transform_the_request() -> None:
 
     assert result.messages == replacement
     assert classifier.input_calls == 1
+
+
+def test_input_modifier_rejects_carrier_removal_with_bound_tool_history() -> None:
+    """A guardrail cannot keep a Fireworks tool turn after removing its carrier."""
+    call = ToolCall(
+        call_id="call-one",
+        name="lookup",
+        arguments={},
+        raw_arguments="{}",
+    )
+    original_messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        GatewayMessage(
+            role="assistant",
+            tool_calls=(call,),
+            provider_reasoning=(
+                OpaqueReasoningContentBlock(
+                    route_sha256="a" * 64,
+                    content="private reasoning",
+                ),
+            ),
+        ),
+        GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+    )
+    replacement = (
+        original_messages[0],
+        original_messages[1].model_copy(update={"provider_reasoning": ()}),
+        original_messages[2],
+    )
+    engine, _classifier = _engine(
+        classifier=ScriptedClassifier(
+            input_verdict=ClassifierVerdict(
+                flagged=True,
+                replacement_messages=replacement,
+            )
+        ),
+        checks=(_check("input-modify", action=GuardrailAction.MODIFY),),
+    )
+    policy = engine.policy_for("organization-one", "identity-one")
+    assert policy is not None
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=original_messages,
+    )
+
+    with pytest.raises(GuardrailRejected):
+        _awaited(
+            engine.enforce_input(
+                policy=policy,
+                request=request,
+                deadline_monotonic=200.0,
+            )
+        )
+
+
+def test_input_modifier_may_redact_after_an_exact_sealed_turn() -> None:
+    """A modifier may redact a tool result after preserving the sealed turn exactly."""
+    call = ToolCall(call_id="call-one", name="lookup", arguments={}, raw_arguments="{}")
+    assistant = GatewayMessage(
+        role="assistant",
+        tool_calls=(call,),
+        provider_reasoning=(
+            SealedReasoningContentBlock(carrier="opaque-carrier", deployment_hint="rung-one"),
+        ),
+    )
+    tool = GatewayMessage(role="tool", content="done", tool_call_id="call-one")
+    original = (GatewayMessage(role="user", content="secret"), assistant, tool)
+    replacement = (
+        original[0],
+        assistant,
+        tool.model_copy(update={"content": "redacted"}),
+    )
+    engine, _classifier = _engine(
+        classifier=ScriptedClassifier(
+            input_verdict=ClassifierVerdict(
+                flagged=True,
+                replacement_messages=replacement,
+            )
+        ),
+        checks=(_check("input-modify", action=GuardrailAction.MODIFY),),
+    )
+    policy = engine.policy_for("organization-one", "identity-one")
+    assert policy is not None
+
+    result = _awaited(
+        engine.enforce_input(
+            policy=policy,
+            request=GatewayRequest(surface=GatewayApiSurface.CHAT_COMPLETIONS, messages=original),
+            deadline_monotonic=200.0,
+        )
+    )
+
+    assert result.messages == replacement
+
+
+def test_input_modifier_may_fully_redact_carrier_bound_history() -> None:
+    """A user-only replacement safely clears the entire carrier-bound tool turn."""
+    original_messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        GatewayMessage(
+            role="assistant",
+            content="working",
+            provider_reasoning=(
+                OpaqueReasoningContentBlock(
+                    route_sha256="a" * 64,
+                    content="private reasoning",
+                ),
+            ),
+        ),
+    )
+    replacement = (GatewayMessage(role="user", content="redacted"),)
+    engine, _classifier = _engine(
+        classifier=ScriptedClassifier(
+            input_verdict=ClassifierVerdict(
+                flagged=True,
+                replacement_messages=replacement,
+            )
+        ),
+        checks=(_check("input-modify", action=GuardrailAction.MODIFY),),
+    )
+    policy = engine.policy_for("organization-one", "identity-one")
+    assert policy is not None
+
+    result = _awaited(
+        engine.enforce_input(
+            policy=policy,
+            request=GatewayRequest(
+                surface=GatewayApiSurface.CHAT_COMPLETIONS,
+                messages=original_messages,
+            ),
+            deadline_monotonic=200.0,
+        )
+    )
+
+    assert result.messages == replacement
     assert engine.input_invocations == 1
 
 

--- a/exp/runtime/gateway/guardrails/http_json.py
+++ b/exp/runtime/gateway/guardrails/http_json.py
@@ -17,7 +17,7 @@ import httpx
 from pydantic import ValidationError
 
 from exp.common.core.artifacts import JsonObject, canonical_json_bytes
-from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.contracts import GatewayMessage, GatewayRequest
 from exp.runtime.gateway.guardrails.contracts import (
     ClassifierVerdict,
     GuardrailAction,
@@ -224,10 +224,17 @@ class HttpJsonClassifier:
         check: GuardrailCheck,
     ) -> ClassifierVerdict:
         """Inspect one canonical request and return a validated verdict."""
-        return await self._inspect(
+        verdict = await self._inspect(
             check=check,
             payload=_inspect_payload(check=check, request=request, completion=None),
         )
+        if verdict.replacement_messages is None:
+            return verdict
+        replacement = _reattach_hidden_request_authority(
+            request.messages,
+            verdict.replacement_messages,
+        )
+        return verdict.model_copy(update={"replacement_messages": replacement})
 
     async def inspect_output(
         self,
@@ -278,6 +285,70 @@ class HttpJsonClassifier:
         except httpx.HTTPError as exc:
             raise ClassifierProtocolError("classifier transport failed") from exc
         return _verdict_from_body(body, check=check)
+
+
+def _reattach_hidden_request_authority(
+    original: tuple[GatewayMessage, ...],
+    replacement: tuple[GatewayMessage, ...],
+) -> tuple[GatewayMessage, ...]:
+    """Restore authority omitted from the hosted classifier wire contract.
+
+    Provider reasoning, raw tool arguments, and tool-error state never leave the
+    gateway. A hosted modifier may return the same visible assistant/tool history
+    with user text redacted, so compare the classifier-visible representation and
+    then restore the exact hidden gateway-owned messages. A user-only full
+    redaction remains valid and deliberately discards the prior tool history.
+
+    Args:
+        original: Canonical request supplied to the hosted classifier.
+        replacement: Classifier-returned visible replacement messages.
+
+    Returns:
+        Replacement messages with exact hidden authority reattached.
+
+    Raises:
+        ClassifierProtocolError: The replacement retained carrier-bound history
+            while changing its visible assistant/tool authority.
+    """
+    carrier_indexes = tuple(
+        index
+        for index, message in enumerate(original)
+        if any(
+            block.kind in {"reasoning_content", "sealed_reasoning_content"}
+            for block in message.provider_reasoning
+        )
+    )
+    if not carrier_indexes:
+        return replacement
+    if all(message.role in {"system", "developer", "user"} for message in replacement):
+        return replacement
+    bound = carrier_indexes[-1]
+    if len(replacement) <= bound:
+        raise ClassifierProtocolError(
+            "classifier replacement truncated provider-reasoning authority"
+        )
+    restored = list(replacement)
+    for index, original_message in enumerate(original[: bound + 1]):
+        replacement_message = replacement[index]
+        if original_message.role != replacement_message.role:
+            raise ClassifierProtocolError(
+                "classifier replacement changed provider-reasoning message roles"
+            )
+        if original_message.role not in {"assistant", "tool"}:
+            continue
+        if _classifier_visible_message(original_message) != _classifier_visible_message(
+            replacement_message
+        ):
+            raise ClassifierProtocolError(
+                "classifier replacement changed provider-reasoning assistant/tool history"
+            )
+        restored[index] = original_message
+    return tuple(restored)
+
+
+def _classifier_visible_message(message: GatewayMessage) -> JsonObject:
+    """Return the exact message representation exposed to hosted classifiers."""
+    return message.model_dump(mode="json", by_alias=True, exclude_none=False)
 
 
 def _authorization_header(bearer_env: str | None) -> str | None:

--- a/exp/runtime/gateway/guardrails/http_json_test.py
+++ b/exp/runtime/gateway/guardrails/http_json_test.py
@@ -10,7 +10,13 @@ import httpx
 import pytest
 
 from exp.common.core.artifacts import JsonObject, canonical_json_bytes
-from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.common.models import ToolCall
+from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    SealedReasoningContentBlock,
+)
 from exp.runtime.gateway.guardrails.contracts import (
     GuardrailAction,
     GuardrailCapabilityKind,
@@ -180,6 +186,45 @@ def test_outbound_request_subject_matches_request_content_bytes() -> None:
 
     assert canonical_json_bytes(captured["request"]) == canonical_json_bytes(request)
     assert request_content_bytes(request) == len(canonical_json_bytes(request))
+
+
+def test_hosted_modifier_reattaches_hidden_reasoning_authority() -> None:
+    """A hosted user rewrite cannot strip unchanged gateway-owned tool authority."""
+    call = ToolCall(call_id="call-one", name="lookup", arguments={}, raw_arguments="{}")
+    assistant = GatewayMessage(
+        role="assistant",
+        tool_calls=(call,),
+        provider_reasoning=(
+            SealedReasoningContentBlock(carrier="opaque-carrier", deployment_hint="rung-one"),
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="Use the tool"),
+            assistant,
+            GatewayMessage(role="tool", tool_call_id="call-one", content="done"),
+            GatewayMessage(role="user", content="secret follow-up"),
+        ),
+    )
+
+    def handler(http_request: httpx.Request) -> httpx.Response:
+        """Return the wire-visible history with only the latest user redacted."""
+        messages = json.loads(http_request.content)["request"]["messages"]
+        assert "provider_reasoning" not in messages[1]
+        messages[-1]["content"] = "redacted follow-up"
+        return httpx.Response(
+            200,
+            json={"flagged": True, "replacement_messages": messages},
+        )
+
+    adapter, _client = _classifier(httpx.MockTransport(handler))
+    verdict = asyncio.run(adapter.inspect_input(request=request, check=_input_check()))
+
+    replacement = verdict.replacement_messages
+    assert replacement is not None
+    assert replacement[1] == assistant
+    assert replacement[-1].content == "redacted follow-up"
 
 
 def test_bearer_env_sends_authorization_without_embedding_the_value() -> None:

--- a/exp/runtime/gateway/interfaces.py
+++ b/exp/runtime/gateway/interfaces.py
@@ -14,8 +14,8 @@ from exp.runtime.gateway.contracts import (
     GatewayEvent,
     GatewayFailure,
     GatewayRequest,
-    GatewayTarget,
     ProjectSelection,
+    ProjectTarget,
 )
 
 
@@ -123,7 +123,7 @@ class ProjectTargetResolver(Protocol):
     async def select(
         self,
         *,
-        target: GatewayTarget,
+        target: ProjectTarget,
         request: GatewayRequest,
         episode_namespace: tuple[ArtifactId, ArtifactId, ArtifactId, str],
         deadline_monotonic: float,
@@ -134,12 +134,21 @@ class ProjectTargetResolver(Protocol):
     def select_blocking(
         self,
         *,
-        target: GatewayTarget,
+        target: ProjectTarget,
         request: GatewayRequest,
         episode_namespace: tuple[ArtifactId, ArtifactId, ArtifactId, str],
         deadline_monotonic: float,
     ) -> ProjectSelection:
         """Resolve one project target synchronously for callers without an event loop."""
+        ...
+
+    def authorize_deployment_hint(
+        self,
+        *,
+        target: ProjectTarget,
+        deployment: ExactModelDeployment,
+    ) -> None:
+        """Require one carrier deployment to belong to the frozen activation."""
         ...
 
 

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.2"
+version = "0.3.3"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -182,10 +182,19 @@ pub struct Normalizer {
     // provider supplies no tool index; assignment order mirrors the python
     // mapper's local counter.
     gemini_tool_index: u32,
+    // Fireworks-only route identity authorizing reasoning_content capture.
+    reasoning_content_route_sha256: Option<String>,
 }
 
 impl Normalizer {
     pub fn new(dialect: Dialect) -> Self {
+        Self::new_with_reasoning_content_route(dialect, None)
+    }
+
+    pub fn new_with_reasoning_content_route(
+        dialect: Dialect,
+        reasoning_content_route_sha256: Option<String>,
+    ) -> Self {
         Self {
             dialect,
             tools: BTreeMap::new(),
@@ -204,6 +213,7 @@ impl Normalizer {
             usage: None,
             finish_reason: None,
             gemini_tool_index: 0,
+            reasoning_content_route_sha256,
         }
     }
 

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -649,6 +649,22 @@ impl Normalizer {
             self.refusal_seen = true;
             events.push(Event::RefusalDelta(refusal.clone()));
         }
+        if let Some(route_sha256) = self.reasoning_content_route_sha256.clone() {
+            if let Some(value) = delta.get("reasoning_content") {
+                let reasoning = match value {
+                    Value::Null => None,
+                    Value::String(text) => Some(text),
+                    _ => return Err(malformed("Fireworks reasoning_content delta must be text")),
+                };
+                if let Some(reasoning) = reasoning.filter(|text| !text.is_empty()) {
+                    self.reserve_summary_bytes(reasoning.len())?;
+                    events.push(Event::ReasoningContentDelta {
+                        route_sha256,
+                        delta: reasoning.clone(),
+                    });
+                }
+            }
+        }
         if let Some(raw_tools) = delta.get("tool_calls") {
             if !raw_tools.is_null() {
                 let items = raw_tools
@@ -747,6 +763,63 @@ mod tests {
             })
             .to_string(),
         }
+    }
+
+    #[test]
+    fn compatible_reasoning_content_requires_fireworks_route_authority() {
+        let frame = SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "delta": {"reasoning_content": "provider private"},
+                    "finish_reason": null,
+                }]
+            })
+            .to_string(),
+        };
+        let route_sha256 = "a".repeat(64);
+        let mut authorized = Normalizer::new_with_reasoning_content_route(
+            Dialect::OpenAiCompatible,
+            Some(route_sha256.clone()),
+        );
+        let events = authorized
+            .feed(&frame)
+            .expect("authorized Fireworks reasoning must normalize");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ReasoningContentDelta {
+                route_sha256: route,
+                delta,
+            }] if route == &route_sha256 && delta == "provider private"
+        ));
+
+        let mut generic = Normalizer::new(Dialect::OpenAiCompatible);
+        assert!(generic
+            .feed(&frame)
+            .expect("generic compatible extension is ignored")
+            .is_empty());
+    }
+
+    #[test]
+    fn fireworks_reasoning_content_rejects_non_text_values() {
+        let frame = SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "delta": {"reasoning_content": {"private": true}},
+                    "finish_reason": null,
+                }]
+            })
+            .to_string(),
+        };
+        let mut normalizer = Normalizer::new_with_reasoning_content_route(
+            Dialect::OpenAiCompatible,
+            Some("a".repeat(64)),
+        );
+
+        assert!(normalizer.feed(&frame).is_err());
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -1,7 +1,7 @@
 //! Public Chat Completions encoding, the Rust mirror of `ChatSseEncoder` and
 //! the chat branch of `completed_body`.
 
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -20,6 +20,148 @@ fn invalid_provider_stream(message: &str) -> PublicError {
     PublicError::new(502, "invalid_provider_stream", message, "api_error")
 }
 
+const MAXIMUM_REASONING_CONTENT_BYTES: usize = 8 * 1024 * 1024;
+
+/// Hidden reasoning plus exact completed tool identities awaiting AEAD sealing.
+pub struct ReasoningCarrierCandidate {
+    pub route_sha256: String,
+    pub content: String,
+    pub assistant_content: Option<String>,
+    pub tool_calls: Vec<ReasoningCarrierToolCall>,
+}
+
+/// One exact provider-issued tool call bound into the issuing-turn digest.
+pub struct ReasoningCarrierToolCall {
+    pub call_id: String,
+    pub name: String,
+    pub raw_arguments: String,
+}
+
+#[derive(Default)]
+struct ReasoningCarrierState {
+    route_sha256: Option<String>,
+    content: String,
+    assistant_content: String,
+    tool_order: Vec<u32>,
+    tool_ids: HashMap<u32, (String, String)>,
+    completed: HashMap<u32, crate::events::CompletedToolCall>,
+}
+
+impl ReasoningCarrierState {
+    fn observe(&mut self, event: &Event) -> Result<(), PublicError> {
+        match event {
+            Event::TextDelta(delta) => self.assistant_content.push_str(delta),
+            Event::ReasoningContentDelta {
+                route_sha256,
+                delta,
+            } => {
+                if self
+                    .route_sha256
+                    .as_ref()
+                    .is_some_and(|current| current != route_sha256)
+                {
+                    return Err(invalid_provider_stream(
+                        "Chat reasoning content changed provider route.",
+                    ));
+                }
+                if self.content.len().saturating_add(delta.len()) > MAXIMUM_REASONING_CONTENT_BYTES
+                {
+                    return Err(invalid_provider_stream(
+                        "Chat reasoning content exceeded the gateway carrier bound.",
+                    ));
+                }
+                self.route_sha256 = Some(route_sha256.clone());
+                self.content.push_str(delta);
+            }
+            Event::ToolCallStarted {
+                index,
+                call_id,
+                name,
+            } => {
+                if self.tool_ids.contains_key(index)
+                    || self
+                        .tool_ids
+                        .values()
+                        .any(|(existing, _name)| existing == call_id)
+                {
+                    return Err(invalid_provider_stream(
+                        "A Chat tool-call ID was started twice.",
+                    ));
+                }
+                self.tool_ids
+                    .insert(*index, (call_id.clone(), name.clone()));
+                self.tool_order.push(*index);
+            }
+            Event::ToolCallCompleted { index, call } => {
+                match self.tool_ids.get(index) {
+                    Some((call_id, name)) if call_id == &call.call_id && name == &call.name => {}
+                    _ => {
+                        return Err(invalid_provider_stream(
+                            "Chat tool completion changed or duplicated its identity.",
+                        ))
+                    }
+                }
+                match self.completed.entry(*index) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(call.clone());
+                    }
+                    Entry::Occupied(_) => {
+                        return Err(invalid_provider_stream(
+                            "Chat tool completion changed or duplicated its identity.",
+                        ))
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn candidate(&self) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
+        if self.content.is_empty() || self.tool_ids.is_empty() {
+            return Ok(None);
+        }
+        if self.completed.len() != self.tool_ids.len() {
+            return Err(invalid_provider_stream(
+                "Chat reasoning content requires complete unique tool calls.",
+            ));
+        }
+        let route_sha256 = self.route_sha256.clone().ok_or_else(|| {
+            invalid_provider_stream("Chat reasoning content omitted provider route identity.")
+        })?;
+        Ok(Some(ReasoningCarrierCandidate {
+            route_sha256,
+            content: self.content.clone(),
+            assistant_content: (!self.assistant_content.is_empty())
+                .then(|| self.assistant_content.clone()),
+            tool_calls: self
+                .tool_order
+                .iter()
+                .copied()
+                .map(|index| {
+                    let call = &self.completed[&index];
+                    ReasoningCarrierToolCall {
+                        call_id: call.call_id.clone(),
+                        name: call.name.clone(),
+                        raw_arguments: call.raw_arguments.clone(),
+                    }
+                })
+                .collect(),
+        }))
+    }
+}
+
+/// Validate retained events and build a carrier candidate when needed.
+pub fn reasoning_carrier_candidate(
+    events: &[Event],
+) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
+    let mut state = ReasoningCarrierState::default();
+    for event in events {
+        state.observe(event)?;
+    }
+    state.candidate()
+}
+
 /// Stateful Chat Completions SSE encoder with stable tool indices and one
 /// terminal, emitting byte-identical frames to the Python encoder.
 pub struct ChatSseEncoder {
@@ -33,6 +175,8 @@ pub struct ChatSseEncoder {
     tool_indices: HashMap<u32, (String, String)>,
     tool_arguments: HashMap<u32, String>,
     usage: Option<Usage>,
+    reasoning: ReasoningCarrierState,
+    reasoning_content_carrier: Option<String>,
 }
 
 impl ChatSseEncoder {
@@ -55,7 +199,21 @@ impl ChatSseEncoder {
             tool_indices: HashMap::new(),
             tool_arguments: HashMap::new(),
             usage: None,
+            reasoning: ReasoningCarrierState::default(),
+            reasoning_content_carrier: None,
         }
+    }
+
+    /// Attach an authenticated carrier before the terminal is encoded.
+    pub fn set_reasoning_content_carrier(&mut self, carrier: String) {
+        self.reasoning_content_carrier = Some(carrier);
+    }
+
+    /// Return the validated candidate accumulated by a live stream.
+    pub fn reasoning_carrier_candidate(
+        &self,
+    ) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
+        self.reasoning.candidate()
     }
 
     /// Emit the single initial assistant-role chunk.
@@ -81,6 +239,7 @@ impl ChatSseEncoder {
                 "Chat stream received an event after its terminal.",
             ));
         }
+        self.reasoning.observe(event)?;
         match event {
             Event::TextDelta(text) => Ok(vec![self.chunk(json!({"content": text}), None)]),
             Event::RefusalDelta(text) => Ok(vec![self.chunk(json!({"refusal": text}), None)]),
@@ -90,6 +249,7 @@ impl ChatSseEncoder {
             Event::ProviderRefusalDelta { delta, .. } => {
                 Ok(vec![self.chunk(json!({"refusal": delta}), None)])
             }
+            Event::ReasoningContentDelta { .. } => Ok(Vec::new()),
             // The Chat wire has no reasoning representation, so provider
             // reasoning follows the summary path and is deliberately dropped.
             Event::ProviderOutputItemStarted { .. }
@@ -172,7 +332,16 @@ impl ChatSseEncoder {
                 } else {
                     "stop"
                 };
-                let mut frames = vec![self.chunk(json!({}), Some(finish_reason))];
+                let mut frames = Vec::new();
+                if matches!(event, Event::Completed) && self.reasoning.candidate()?.is_some() {
+                    let carrier = self.reasoning_content_carrier.as_ref().ok_or_else(|| {
+                        invalid_provider_stream(
+                            "Chat reasoning content was not sealed by the gateway authority.",
+                        )
+                    })?;
+                    frames.push(self.chunk(json!({"reasoning_content": carrier}), None));
+                }
+                frames.push(self.chunk(json!({}), Some(finish_reason)));
                 if self.include_usage {
                     if let Some(usage) = &self.usage {
                         frames.push(self.usage_chunk(usage));
@@ -301,6 +470,25 @@ pub fn completed_chat_body_with_ignored(
     events: &[Event],
     ignored_parameters: &[String],
 ) -> Result<AggregatedCompletion, PublicError> {
+    completed_chat_body_with_carrier(
+        request_id,
+        model,
+        created_at,
+        events,
+        ignored_parameters,
+        None,
+    )
+}
+
+/// Build one non-streaming Chat result with an authenticated reasoning carrier.
+pub fn completed_chat_body_with_carrier(
+    request_id: &str,
+    model: &str,
+    created_at: i64,
+    events: &[Event],
+    ignored_parameters: &[String],
+    reasoning_content_carrier: Option<&str>,
+) -> Result<AggregatedCompletion, PublicError> {
     let terminal = events.iter().rev().find(|event| event.is_terminal());
     let terminal = match terminal {
         Some(event) => event,
@@ -368,6 +556,7 @@ pub fn completed_chat_body_with_ignored(
             _ => None,
         })
         .collect();
+    let reasoning = reasoning_carrier_candidate(events)?;
     let incomplete = matches!(terminal, Event::Incomplete);
     let finish_reason = if incomplete {
         "length"
@@ -376,12 +565,27 @@ pub fn completed_chat_body_with_ignored(
     } else {
         "stop"
     };
-    let message = json!({
+    let has_tool_calls = !tool_calls.is_empty();
+    let mut message = json!({
         "role": "assistant",
         "content": if text.is_empty() { Value::Null } else { Value::String(text) },
         "refusal": if refusal.is_empty() { Value::Null } else { Value::String(refusal) },
         "tool_calls": if tool_calls.is_empty() { Value::Null } else { Value::Array(tool_calls) },
     });
+    if matches!(terminal, Event::Completed) && has_tool_calls && reasoning.is_some() {
+        let carrier = reasoning_content_carrier.ok_or_else(|| {
+            invalid_provider_stream(
+                "Chat reasoning content was not sealed by the gateway authority.",
+            )
+        })?;
+        message
+            .as_object_mut()
+            .expect("chat message is an object")
+            .insert(
+                "reasoning_content".to_string(),
+                Value::String(carrier.to_string()),
+            );
+    }
     let mut body = json!({
         "id": stable_public_id("chatcmpl", request_id),
         "object": "chat.completion",
@@ -417,6 +621,144 @@ pub fn completed_chat_body_with_ignored(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fireworks_tool_events() -> Vec<Event> {
+        vec![
+            Event::ReasoningContentDelta {
+                route_sha256: "a".repeat(64),
+                delta: "hidden provider reasoning".to_string(),
+            },
+            Event::ToolCallStarted {
+                index: 0,
+                call_id: "call-one".to_string(),
+                name: "lookup".to_string(),
+            },
+            Event::ToolArgumentsDelta {
+                index: 0,
+                delta: "{}".to_string(),
+            },
+            Event::ToolCallCompleted {
+                index: 0,
+                call: crate::events::CompletedToolCall {
+                    call_id: "call-one".to_string(),
+                    name: "lookup".to_string(),
+                    raw_arguments: "{}".to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                },
+            },
+            Event::Completed,
+        ]
+    }
+
+    #[test]
+    fn fireworks_chat_reasoning_round_trips_only_as_sealed_carrier() {
+        let events = fireworks_tool_events();
+        let mut stream = ChatSseEncoder::new_with_ignored(
+            "request-1",
+            "coding",
+            1_700_000_000,
+            false,
+            Vec::new(),
+        );
+        stream.set_reasoning_content_carrier("authenticated-carrier-v2".to_string());
+        let mut frames = stream.start().expect("stream start must encode");
+        for event in &events {
+            frames.extend(stream.feed(event).expect("event must encode"));
+        }
+        let public = frames.join("");
+        assert!(!public.contains("hidden provider reasoning"));
+        assert!(public.contains("authenticated-carrier-v2"));
+
+        let completed = completed_chat_body_with_carrier(
+            "request-1",
+            "coding",
+            1_700_000_000,
+            &events,
+            &[],
+            Some("authenticated-carrier-v2"),
+        )
+        .expect("completed body must preserve the carrier");
+        assert_eq!(
+            completed.body["choices"][0]["message"]["reasoning_content"],
+            json!("authenticated-carrier-v2")
+        );
+        assert!(!completed
+            .body
+            .to_string()
+            .contains("hidden provider reasoning"));
+    }
+
+    #[test]
+    fn fireworks_chat_reasoning_fails_closed_without_carrier_or_unique_completion() {
+        let events = fireworks_tool_events();
+        assert!(completed_chat_body_with_ignored(
+            "request-1",
+            "coding",
+            1_700_000_000,
+            &events,
+            &[],
+        )
+        .is_err());
+
+        let mut duplicate = events[..events.len() - 1].to_vec();
+        duplicate.push(events[3].clone());
+        duplicate.push(Event::Completed);
+        assert!(reasoning_carrier_candidate(&duplicate).is_err());
+    }
+
+    #[test]
+    fn reasoning_carrier_preserves_provider_tool_start_order() {
+        let events = vec![
+            Event::ReasoningContentDelta {
+                route_sha256: "a".repeat(64),
+                delta: "hidden".to_string(),
+            },
+            Event::ToolCallStarted {
+                index: 1,
+                call_id: "call-one".to_string(),
+                name: "first".to_string(),
+            },
+            Event::ToolCallStarted {
+                index: 0,
+                call_id: "call-zero".to_string(),
+                name: "second".to_string(),
+            },
+            Event::ToolCallCompleted {
+                index: 0,
+                call: crate::events::CompletedToolCall {
+                    call_id: "call-zero".to_string(),
+                    name: "second".to_string(),
+                    raw_arguments: "{\"order\":0}".to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                },
+            },
+            Event::ToolCallCompleted {
+                index: 1,
+                call: crate::events::CompletedToolCall {
+                    call_id: "call-one".to_string(),
+                    name: "first".to_string(),
+                    raw_arguments: "{\"order\":1}".to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                },
+            },
+        ];
+
+        let candidate = reasoning_carrier_candidate(&events)
+            .expect("provider events must validate")
+            .expect("reasoning plus tools must produce a carrier");
+
+        assert_eq!(
+            candidate
+                .tool_calls
+                .iter()
+                .map(|call| call.call_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["call-one", "call-zero"]
+        );
+    }
 
     #[test]
     fn ignored_generation_controls_are_disclosed_by_both_chat_encoders() {

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -244,7 +244,8 @@ impl MessagesSseEncoder {
             Event::ProviderOutputItemStarted { .. }
             | Event::ProviderOutputItemCompleted { .. }
             | Event::ReasoningSummaryDelta { .. }
-            | Event::EncryptedReasoning { .. } => Ok(Vec::new()),
+            | Event::EncryptedReasoning { .. }
+            | Event::ReasoningContentDelta { .. } => Ok(Vec::new()),
             Event::ThinkingDelta { index, delta } => self.thinking_delta(*index, delta),
             Event::ThinkingSignature { index, signature } => {
                 self.thinking_signature(*index, signature)

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde_json::{json, Value};
 
-use crate::encode::{compact_json, stable_public_id};
+use crate::encode::stable_public_id;
 use crate::errors::{Failure, PublicError};
 use crate::events::{
     CompletedToolCall, Event, ProviderAssistantMessagePhase, ProviderOutputItemKind,
@@ -14,9 +14,10 @@ use crate::events::{
 
 mod aggregate;
 mod envelope;
+mod output;
 mod provider;
 
-pub use aggregate::completed_responses_body;
+pub use aggregate::{completed_responses_body, completed_responses_body_with_carrier};
 pub use envelope::ResponsesEnvelope;
 
 fn invalid_provider_stream(message: &str) -> PublicError {
@@ -161,6 +162,7 @@ enum OutputSlot {
     Message(MessageKey),
     Tool(u32),
     Reasoning(u32),
+    FireworksReasoning,
 }
 
 /// Incremental Responses lifecycle encoder with one monotonic terminal event,
@@ -177,6 +179,9 @@ pub struct ResponsesSseEncoder {
     output_order: Vec<OutputSlot>,
     tools: HashMap<u32, ToolState>,
     reasoning: HashMap<u32, ReasoningState>,
+    fireworks_reasoning: Option<ReasoningState>,
+    fireworks_reasoning_route_sha256: Option<String>,
+    reasoning_content_carrier: Option<String>,
     messages: HashMap<MessageKey, MessageState>,
     provider_output_starts: HashMap<u32, ProviderOutputStart>,
     usage: Option<Usage>,
@@ -201,6 +206,9 @@ impl ResponsesSseEncoder {
             output_order: Vec::new(),
             tools: HashMap::new(),
             reasoning: HashMap::new(),
+            fireworks_reasoning: None,
+            fireworks_reasoning_route_sha256: None,
+            reasoning_content_carrier: None,
             messages: HashMap::new(),
             provider_output_starts: HashMap::new(),
             usage: None,
@@ -305,6 +313,10 @@ impl ResponsesSseEncoder {
                 self.reasoning_summary_delta(*index, 0, &item_id, delta)
             }
             Event::ThinkingSignature { .. } | Event::RedactedThinking { .. } => Ok(Vec::new()),
+            Event::ReasoningContentDelta {
+                route_sha256,
+                delta,
+            } => self.fireworks_reasoning(route_sha256, delta),
             Event::EncryptedReasoning {
                 output_index,
                 item_id,
@@ -323,14 +335,25 @@ impl ResponsesSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed => Ok(self.finish("completed", None)),
-            Event::Incomplete => Ok(self.finish("incomplete", None)),
-            Event::Failed(failure) => Ok(self.finish("failed", Some(failure))),
+            Event::Completed => self.finish("completed", None),
+            Event::Incomplete => self.finish("incomplete", None),
+            Event::Failed(failure) => self.finish("failed", Some(failure)),
         }
     }
 
     pub fn saw_terminal(&self) -> bool {
         self.terminal
+    }
+
+    /// Attach the authenticated carrier before a Fireworks terminal is encoded.
+    pub fn set_reasoning_content_carrier(&mut self, carrier: String) -> Result<(), PublicError> {
+        if self.terminal || self.reasoning_content_carrier.is_some() {
+            return Err(invalid_provider_stream(
+                "Responses reasoning carrier was assigned outside its open stream.",
+            ));
+        }
+        self.reasoning_content_carrier = Some(carrier);
+        Ok(())
     }
 
     /// Start one output message/content part as needed and emit its delta.
@@ -467,6 +490,48 @@ impl ResponsesSseEncoder {
             }),
         ));
         Ok(())
+    }
+
+    /// Open one opaque Fireworks reasoning item without exposing plaintext.
+    fn fireworks_reasoning(
+        &mut self,
+        route_sha256: &str,
+        _delta: &str,
+    ) -> Result<Vec<String>, PublicError> {
+        if let Some(existing) = &self.fireworks_reasoning_route_sha256 {
+            if existing != route_sha256 {
+                return Err(invalid_provider_stream(
+                    "Responses Fireworks reasoning changed provider route.",
+                ));
+            }
+        } else {
+            self.fireworks_reasoning_route_sha256 = Some(route_sha256.to_string());
+        }
+        if self.fireworks_reasoning.is_some() {
+            return Ok(Vec::new());
+        }
+        let state = ReasoningState {
+            item_id: stable_public_id("rs", &format!("{}:fireworks", self.response_id)),
+            output_index: self.output_order.len(),
+            parts: BTreeMap::new(),
+            encrypted_content: None,
+            status: Some(ProviderOutputItemStatus::InProgress),
+            done: false,
+        };
+        let frame = self.event(
+            "response.output_item.added",
+            json!({
+                "output_index": state.output_index,
+                "item": state.item(
+                    false,
+                    ProviderOutputItemStatus::InProgress,
+                    false,
+                ),
+            }),
+        );
+        self.fireworks_reasoning = Some(state);
+        self.output_order.push(OutputSlot::FireworksReasoning);
+        Ok(vec![frame])
     }
 
     /// Start one reasoning item/summary part as needed and emit its text delta.
@@ -679,7 +744,23 @@ impl ResponsesSseEncoder {
     }
 
     /// Close open items and emit exactly one Responses terminal lifecycle event.
-    fn finish(&mut self, status: &str, failure: Option<&Failure>) -> Vec<String> {
+    fn finish(
+        &mut self,
+        status: &str,
+        failure: Option<&Failure>,
+    ) -> Result<Vec<String>, PublicError> {
+        if status == "completed" && !self.tools.is_empty() {
+            if let Some(reasoning) = self.fireworks_reasoning.as_mut() {
+                let carrier = self.reasoning_content_carrier.clone().ok_or_else(|| {
+                    invalid_provider_stream(
+                        "Responses Fireworks reasoning was not sealed by gateway authority.",
+                    )
+                })?;
+                if self.envelope.include_encrypted_reasoning {
+                    reasoning.encrypted_content = Some(carrier);
+                }
+            }
+        }
         let mut frames = Vec::new();
         let fallback_status = if status == "completed" {
             ProviderOutputItemStatus::Completed
@@ -712,6 +793,9 @@ impl ResponsesSseEncoder {
                     };
                     frames.extend(self.close_reasoning(index, item_status));
                 }
+                OutputSlot::FireworksReasoning => {
+                    frames.extend(self.close_fireworks_reasoning(fallback_status));
+                }
                 OutputSlot::Message(_) | OutputSlot::Tool(_) | OutputSlot::Reasoning(_) => {}
             }
         }
@@ -722,7 +806,32 @@ impl ResponsesSseEncoder {
             json!({"response": self.response(status, failure)}),
         );
         frames.push(frame);
-        frames
+        Ok(frames)
+    }
+
+    /// Complete the gateway-issued Fireworks reasoning item.
+    fn close_fireworks_reasoning(
+        &mut self,
+        fallback_status: ProviderOutputItemStatus,
+    ) -> Vec<String> {
+        let Some(state) = self.fireworks_reasoning.as_mut() else {
+            return Vec::new();
+        };
+        if state.done {
+            return Vec::new();
+        }
+        state.done = true;
+        state.status = Some(fallback_status);
+        let output_index = state.output_index;
+        let item = state.item(
+            true,
+            fallback_status,
+            self.envelope.include_encrypted_reasoning,
+        );
+        vec![self.event(
+            "response.output_item.done",
+            json!({"output_index": output_index, "item": item}),
+        )]
     }
 
     /// Complete every summary part and its containing reasoning item.
@@ -870,96 +979,6 @@ impl ResponsesSseEncoder {
             }),
         ));
         frames
-    }
-
-    /// Build one SDK-readable Responses envelope for the current lifecycle state.
-    fn response(&self, status: &str, failure: Option<&Failure>) -> Value {
-        let include_content = status != "in_progress";
-        let fallback_status = match status {
-            "in_progress" => ProviderOutputItemStatus::InProgress,
-            "completed" => ProviderOutputItemStatus::Completed,
-            _ => ProviderOutputItemStatus::Incomplete,
-        };
-        let output: Vec<Value> = self
-            .output_order
-            .iter()
-            .map(|slot| match slot {
-                OutputSlot::Message(key) => {
-                    self.messages[key].item(include_content, fallback_status)
-                }
-                OutputSlot::Tool(index) => self.tools[index].item(fallback_status),
-                OutputSlot::Reasoning(index) => self.reasoning[index].item(
-                    include_content,
-                    fallback_status,
-                    self.envelope.include_encrypted_reasoning,
-                ),
-            })
-            .collect();
-        let error = if status == "failed" {
-            json!({
-                "code": "server_error",
-                "message": failure
-                    .map(|failure| failure.safe_message.clone())
-                    .unwrap_or_else(|| "Gateway stream failed.".to_string()),
-            })
-        } else {
-            Value::Null
-        };
-        let mut response = json!({
-            "id": self.response_id,
-            "object": "response",
-            "created_at": self.created_at,
-            "completed_at": if status == "completed" { json!(self.created_at) } else { Value::Null },
-            "status": status,
-            "error": error,
-            "incomplete_details": if status == "incomplete" {
-                json!({"reason": "max_output_tokens"})
-            } else {
-                Value::Null
-            },
-            "instructions": Value::Null,
-            "metadata": self.envelope.metadata,
-            "model": self.model,
-            "output": output,
-            "parallel_tool_calls": self.envelope.parallel_tool_calls,
-            "temperature": self.envelope.temperature,
-            "top_p": self.envelope.top_p,
-            "reasoning": self.envelope.reasoning,
-            "tool_choice": self.envelope.tool_choice,
-            "tools": self.envelope.tools,
-            "max_output_tokens": self.envelope.max_output_tokens,
-            "previous_response_id": self.envelope.previous_response_id,
-            "usage": if include_content {
-                aggregate::responses_usage(self.usage.as_ref())
-            } else {
-                Value::Null
-            },
-        });
-        if !self.envelope.ignored_parameters.is_empty() {
-            response
-                .as_object_mut()
-                .expect("response envelope is an object")
-                .insert(
-                    "x-experiential-ignored-parameters".to_string(),
-                    json!(self.envelope.ignored_parameters),
-                );
-        }
-        response
-    }
-
-    /// Assign one monotonic sequence number and frame a named SSE event.
-    fn event(&mut self, event_type: &str, fields: Value) -> String {
-        let mut payload = serde_json::Map::new();
-        payload.insert("type".to_string(), Value::String(event_type.to_string()));
-        payload.insert("sequence_number".to_string(), json!(self.sequence));
-        if let Value::Object(entries) = fields {
-            for (key, value) in entries {
-                payload.insert(key, value);
-            }
-        }
-        self.sequence += 1;
-        let encoded = compact_json(&Value::Object(payload));
-        format!("event: {event_type}\ndata: {encoded}\n\n")
     }
 }
 

--- a/exp/runtime/gateway/native/src/encode_responses/aggregate.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/aggregate.rs
@@ -36,6 +36,18 @@ pub fn completed_responses_body(
     envelope: ResponsesEnvelope,
     events: &[Event],
 ) -> Result<AggregatedResponses, PublicError> {
+    completed_responses_body_with_carrier(request_id, model, created_at, envelope, events, None)
+}
+
+/// Build one non-streaming result with an authenticated Fireworks carrier.
+pub fn completed_responses_body_with_carrier(
+    request_id: &str,
+    model: &str,
+    created_at: f64,
+    envelope: ResponsesEnvelope,
+    events: &[Event],
+    reasoning_content_carrier: Option<&str>,
+) -> Result<AggregatedResponses, PublicError> {
     let terminal = events.iter().rev().find(|event| event.is_terminal());
     let terminal = match terminal {
         Some(event) => event,
@@ -75,6 +87,9 @@ pub fn completed_responses_body(
         });
     }
     let mut encoder = ResponsesSseEncoder::new(request_id, model, created_at, envelope);
+    if let Some(carrier) = reasoning_content_carrier {
+        encoder.set_reasoning_content_carrier(carrier.to_string())?;
+    }
     encoder.start()?;
     let mut terminal_frames = Vec::new();
     for event in events {

--- a/exp/runtime/gateway/native/src/encode_responses/output.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/output.rs
@@ -1,0 +1,109 @@
+//! Final public envelope and SSE framing for the Responses encoder.
+
+use serde_json::{json, Value};
+
+use super::{aggregate, OutputSlot, ResponsesSseEncoder};
+use crate::encode::compact_json;
+use crate::errors::Failure;
+use crate::events::ProviderOutputItemStatus;
+
+impl ResponsesSseEncoder {
+    /// Build one SDK-readable Responses envelope for the current lifecycle state.
+    pub(super) fn response(&self, status: &str, failure: Option<&Failure>) -> Value {
+        let include_content = status != "in_progress";
+        let fallback_status = match status {
+            "in_progress" => ProviderOutputItemStatus::InProgress,
+            "completed" => ProviderOutputItemStatus::Completed,
+            _ => ProviderOutputItemStatus::Incomplete,
+        };
+        let output: Vec<Value> = self
+            .output_order
+            .iter()
+            .map(|slot| match slot {
+                OutputSlot::Message(key) => {
+                    self.messages[key].item(include_content, fallback_status)
+                }
+                OutputSlot::Tool(index) => self.tools[index].item(fallback_status),
+                OutputSlot::Reasoning(index) => self.reasoning[index].item(
+                    include_content,
+                    fallback_status,
+                    self.envelope.include_encrypted_reasoning,
+                ),
+                OutputSlot::FireworksReasoning => self
+                    .fireworks_reasoning
+                    .as_ref()
+                    .expect("Fireworks output slot has state")
+                    .item(
+                        include_content,
+                        fallback_status,
+                        self.envelope.include_encrypted_reasoning,
+                    ),
+            })
+            .collect();
+        let error = if status == "failed" {
+            json!({
+                "code": "server_error",
+                "message": failure
+                    .map(|failure| failure.safe_message.clone())
+                    .unwrap_or_else(|| "Gateway stream failed.".to_string()),
+            })
+        } else {
+            Value::Null
+        };
+        let mut response = json!({
+            "id": self.response_id,
+            "object": "response",
+            "created_at": self.created_at,
+            "completed_at": if status == "completed" { json!(self.created_at) } else { Value::Null },
+            "status": status,
+            "error": error,
+            "incomplete_details": if status == "incomplete" {
+                json!({"reason": "max_output_tokens"})
+            } else {
+                Value::Null
+            },
+            "instructions": Value::Null,
+            "metadata": self.envelope.metadata,
+            "model": self.model,
+            "output": output,
+            "parallel_tool_calls": self.envelope.parallel_tool_calls,
+            "temperature": self.envelope.temperature,
+            "top_p": self.envelope.top_p,
+            "reasoning": self.envelope.reasoning,
+            "tool_choice": self.envelope.tool_choice,
+            "tools": self.envelope.tools,
+            "max_output_tokens": self.envelope.max_output_tokens,
+            "previous_response_id": self.envelope.previous_response_id,
+            "usage": if include_content {
+                aggregate::responses_usage(self.usage.as_ref())
+            } else {
+                Value::Null
+            },
+        });
+        if !self.envelope.ignored_parameters.is_empty() {
+            response
+                .as_object_mut()
+                .expect("response envelope is an object")
+                .insert(
+                    "x-experiential-ignored-parameters".to_string(),
+                    json!(self.envelope.ignored_parameters),
+                );
+        }
+        response
+    }
+
+    /// Assign one monotonic sequence number and frame a named SSE event.
+    pub(super) fn event(&mut self, event_type: &str, fields: Value) -> String {
+        let mut payload = serde_json::Map::new();
+        payload.insert("type".to_string(), Value::String(event_type.to_string()));
+        payload.insert("sequence_number".to_string(), json!(self.sequence));
+        if let Value::Object(entries) = fields {
+            for (key, value) in entries {
+                payload.insert(key, value);
+            }
+        }
+        self.sequence += 1;
+        let encoded = compact_json(&Value::Object(payload));
+        format!("event: {event_type}\ndata: {encoded}\n\n")
+    }
+}

--- a/exp/runtime/gateway/native/src/encode_responses/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tests.rs
@@ -2,6 +2,7 @@
 //! implementation stays within the repository line budget.
 
 use super::*;
+use crate::encode::reasoning_carrier_candidate;
 #[test]
 fn ignored_generation_controls_are_disclosed_by_responses_encoder() {
     let envelope = ResponsesEnvelope {
@@ -55,6 +56,164 @@ fn thinking_deltas_project_onto_reasoning_summary_parts() {
         })
         .expect("signature is dropped")
         .is_empty());
+}
+
+fn fireworks_tool_events() -> Vec<Event> {
+    vec![
+        Event::ReasoningContentDelta {
+            route_sha256: "a".repeat(64),
+            delta: "hidden provider reasoning".to_string(),
+        },
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-one".to_string(),
+            name: "lookup".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-one".to_string(),
+                name: "lookup".to_string(),
+                raw_arguments: "{}".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+            },
+        },
+        Event::Completed,
+    ]
+}
+
+#[test]
+fn fireworks_responses_reasoning_round_trips_as_encrypted_content() {
+    let events = fireworks_tool_events();
+    let envelope = ResponsesEnvelope {
+        include_encrypted_reasoning: true,
+        ..ResponsesEnvelope::default()
+    };
+    let mut encoder =
+        ResponsesSseEncoder::new("request-1", "coding", 1_700_000_000.0, envelope.clone());
+    encoder.start().expect("stream start must encode");
+    encoder
+        .set_reasoning_content_carrier("authenticated-carrier-v2".to_string())
+        .expect("carrier must attach");
+    let mut frames = Vec::new();
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("Responses event must encode"));
+    }
+    let public = frames.join("");
+    assert!(!public.contains("hidden provider reasoning"));
+    assert!(public.contains("\"encrypted_content\":\"authenticated-carrier-v2\""));
+
+    let completed = completed_responses_body_with_carrier(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        envelope,
+        &events,
+        Some("authenticated-carrier-v2"),
+    )
+    .expect("completed body must preserve carrier");
+    assert_eq!(
+        completed.body["output"][0]["encrypted_content"],
+        json!("authenticated-carrier-v2")
+    );
+    assert!(!completed
+        .body
+        .to_string()
+        .contains("hidden provider reasoning"));
+}
+
+#[test]
+fn fireworks_responses_reasoning_fails_closed_without_a_sealed_carrier() {
+    assert!(completed_responses_body(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &fireworks_tool_events(),
+    )
+    .is_err());
+}
+
+#[test]
+fn fireworks_parallel_tools_share_public_and_carrier_order() {
+    let events = vec![
+        Event::ReasoningContentDelta {
+            route_sha256: "a".repeat(64),
+            delta: "hidden".to_string(),
+        },
+        Event::ToolCallStarted {
+            index: 1,
+            call_id: "call-one".to_string(),
+            name: "first".to_string(),
+        },
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-zero".to_string(),
+            name: "second".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{\"order\":0}".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 1,
+            delta: "{\"order\":1}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "call-zero".to_string(),
+                name: "second".to_string(),
+                raw_arguments: "{\"order\":0}".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+            },
+        },
+        Event::ToolCallCompleted {
+            index: 1,
+            call: CompletedToolCall {
+                call_id: "call-one".to_string(),
+                name: "first".to_string(),
+                raw_arguments: "{\"order\":1}".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+            },
+        },
+        Event::Completed,
+    ];
+    let candidate = reasoning_carrier_candidate(&events)
+        .expect("provider events must validate")
+        .expect("reasoning plus tools must produce a carrier");
+    let completed = completed_responses_body_with_carrier(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &events,
+        Some("authenticated-carrier-v2"),
+    )
+    .expect("Responses output must encode");
+    let output = completed.body["output"]
+        .as_array()
+        .expect("Responses output must be an array");
+    let public_calls = output
+        .iter()
+        .filter(|item| item["type"] == "function_call")
+        .map(|item| item["call_id"].as_str().expect("call ID must be text"))
+        .collect::<Vec<_>>();
+    let carrier_calls = candidate
+        .tool_calls
+        .iter()
+        .map(|call| call.call_id.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(public_calls, vec!["call-one", "call-zero"]);
+    assert_eq!(carrier_calls, public_calls);
 }
 
 #[test]

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -152,6 +152,11 @@ pub enum Event {
         item_id: String,
         encrypted_content: String,
     },
+    /// Opaque Fireworks Chat reasoning, bound to the exact issuing route.
+    ReasoningContentDelta {
+        route_sha256: String,
+        delta: String,
+    },
     ToolCallStarted {
         index: u32,
         call_id: String,
@@ -281,6 +286,14 @@ pub fn simplified_event(event: &Event) -> Value {
             "output_index": output_index,
             "item_id": item_id,
             "encrypted_content": encrypted_content,
+        }),
+        Event::ReasoningContentDelta {
+            route_sha256,
+            delta,
+        } => serde_json::json!({
+            "kind": "reasoning_content_delta",
+            "route_sha256": route_sha256,
+            "text": delta,
         }),
         Event::ToolCallStarted {
             index,

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -44,6 +44,7 @@ pub fn event_retained_bytes(event: &Event) -> usize {
         Event::EncryptedReasoning {
             encrypted_content, ..
         } => encrypted_content.len(),
+        Event::ReasoningContentDelta { delta, .. } => delta.len(),
         Event::ToolArgumentsDelta { delta, .. } => delta.len(),
         Event::ToolCallCompleted { call, .. } => call.raw_arguments.len().max(64),
         _ => 64,
@@ -133,22 +134,45 @@ impl UpstreamRelay {
         dialect: Dialect,
         first_byte_deadline: Instant,
     ) -> Self {
-        Self::from_stream(
+        Self::new_with_reasoning_content_route(response, dialect, first_byte_deadline, None)
+    }
+
+    pub fn new_with_reasoning_content_route(
+        response: reqwest::Response,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+        reasoning_content_route_sha256: Option<String>,
+    ) -> Self {
+        Self::from_stream_with_reasoning_content_route(
             response.bytes_stream().boxed(),
             dialect,
             first_byte_deadline,
+            reasoning_content_route_sha256,
         )
     }
 
+    #[cfg(test)]
     fn from_stream(
         stream: BoxStream<'static, reqwest::Result<Bytes>>,
         dialect: Dialect,
         first_byte_deadline: Instant,
     ) -> Self {
+        Self::from_stream_with_reasoning_content_route(stream, dialect, first_byte_deadline, None)
+    }
+
+    fn from_stream_with_reasoning_content_route(
+        stream: BoxStream<'static, reqwest::Result<Bytes>>,
+        dialect: Dialect,
+        first_byte_deadline: Instant,
+        reasoning_content_route_sha256: Option<String>,
+    ) -> Self {
         Self {
             stream,
             decoder: FrameDecoder::new(dialect),
-            normalizer: Normalizer::new(dialect),
+            normalizer: Normalizer::new_with_reasoning_content_route(
+                dialect,
+                reasoning_content_route_sha256,
+            ),
             pending: VecDeque::new(),
             eof: false,
             first_byte_recorded: false,

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -40,6 +40,7 @@ pub(crate) struct ResponsesRetention {
     completed_tools: BTreeSet<u32>,
     tool_statuses: BTreeMap<u32, ProviderOutputItemStatus>,
     reasoning: BTreeMap<u32, RetainedReasoning>,
+    pub(crate) carrier_events: Vec<Event>,
     retained_bytes: usize,
     pub(crate) overflowed: bool,
 }
@@ -58,7 +59,18 @@ impl ResponsesRetention {
             self.messages.clear();
             self.tool_calls.clear();
             self.reasoning.clear();
+            self.carrier_events.clear();
             return;
+        }
+        if matches!(
+            event,
+            Event::TextDelta(_)
+                | Event::ReasoningContentDelta { .. }
+                | Event::ToolCallStarted { .. }
+                | Event::ToolArgumentsDelta { .. }
+                | Event::ToolCallCompleted { .. }
+        ) {
+            self.carrier_events.push(event.clone());
         }
         match event {
             Event::ProviderOutputItemStarted {
@@ -220,7 +232,11 @@ impl ResponsesRetention {
 }
 
 /// Build the retention payload consumed by the control plane's `remember`.
-pub(crate) fn remember_argument(request_id: &str, retention: &ResponsesRetention) -> String {
+pub(crate) fn remember_argument(
+    request_id: &str,
+    retention: &ResponsesRetention,
+    reasoning_content_carrier: Option<&str>,
+) -> String {
     compact_json(&json!({
         "request_id": request_id,
         "text": retention.text,
@@ -232,6 +248,7 @@ pub(crate) fn remember_argument(request_id: &str, retention: &ResponsesRetention
             "phase": message.phase.map(ProviderAssistantMessagePhase::as_str),
         })).collect::<Vec<Value>>(),
         "refusal": retention.refusal,
+        "reasoning_content_carrier": reasoning_content_carrier,
         "encrypted_reasoning": retention.reasoning.iter()
             .filter(|(_, reasoning)| !reasoning.encrypted_content.is_empty())
             .map(|(output_index, reasoning)| json!({
@@ -350,8 +367,9 @@ mod tests {
         for event in &events {
             retention.track(event);
         }
-        let payload: Value = serde_json::from_str(&remember_argument("request-1", &retention))
-            .expect("retention payload is JSON");
+        let payload: Value =
+            serde_json::from_str(&remember_argument("request-1", &retention, None))
+                .expect("retention payload is JSON");
         assert_eq!(payload["encrypted_reasoning"][0]["status"], "incomplete");
         assert_eq!(payload["message_outputs"][0]["status"], "incomplete");
         assert_eq!(payload["message_outputs"][0]["phase"], "commentary");
@@ -386,8 +404,9 @@ mod tests {
         }
 
         assert!(!retention.is_empty());
-        let payload: Value = serde_json::from_str(&remember_argument("request-1", &retention))
-            .expect("retention payload is JSON");
+        let payload: Value =
+            serde_json::from_str(&remember_argument("request-1", &retention, None))
+                .expect("retention payload is JSON");
         assert_eq!(payload["message_outputs"][0]["item_id"], "msg-empty");
         assert_eq!(payload["message_outputs"][0]["text"], "");
         assert_eq!(payload["message_outputs"][0]["status"], "incomplete");

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -18,7 +18,10 @@ use crate::admission::{
     acquire_permit, apply_output_guardrail, commit_dependent, commit_independent, new_guard,
     wire_drift_response, Admission,
 };
-use crate::encode::{chat_data, compact_json, completed_chat_body_with_ignored, ChatSseEncoder};
+use crate::encode::{
+    chat_data, compact_json, completed_chat_body_with_carrier, completed_chat_body_with_ignored,
+    reasoning_carrier_candidate, ChatSseEncoder, ReasoningCarrierCandidate,
+};
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
@@ -279,7 +282,7 @@ async fn settled_chat_response(
             if admission.stream {
                 // The withheld refusal output and its failing terminal flush
                 // outward as the stream's only frames.
-                let body = match encode_chat_sse(admission, created_at, &events) {
+                let body = match encode_chat_sse(admission, created_at, &events, None) {
                     Ok(body) => body,
                     Err(error) => return error_response(&error),
                 };
@@ -299,7 +302,7 @@ async fn settled_chat_response(
     let mut headers = commit_independent(admission, client_request_id.as_deref());
     headers.extend(commit_dependent(admission, settled.depth));
     if admission.stream {
-        let body = match encode_chat_sse(admission, created_at, &events) {
+        let body = match encode_chat_sse(admission, created_at, &events, None) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -356,6 +359,7 @@ fn encode_chat_sse(
     admission: &Admission,
     created_at: i64,
     events: &[Event],
+    reasoning_content_carrier: Option<&str>,
 ) -> Result<Vec<u8>, PublicError> {
     let mut encoder = ChatSseEncoder::new_with_ignored(
         &admission.request_id,
@@ -364,6 +368,9 @@ fn encode_chat_sse(
         admission.include_usage,
         admission.ignored_parameters.clone(),
     );
+    if let Some(carrier) = reasoning_content_carrier {
+        encoder.set_reasoning_content_carrier(carrier.to_string());
+    }
     let mut body = Vec::new();
     for frame in encoder.start().map_err(|_| PublicError::internal())? {
         body.extend_from_slice(frame.as_bytes());
@@ -374,6 +381,77 @@ fn encode_chat_sse(
         }
     }
     Ok(body)
+}
+
+/// Seal one completed provider turn when it contains Fireworks reasoning.
+pub(crate) async fn seal_reasoning_events(
+    bridge: &crate::bridge::Bridge,
+    request_id: &str,
+    route_depth: usize,
+    events: &[Event],
+) -> Result<Option<String>, Failure> {
+    if !matches!(
+        events.iter().rev().find(|event| event.is_terminal()),
+        Some(Event::Completed)
+    ) {
+        return Ok(None);
+    }
+    let candidate = reasoning_carrier_candidate(events).map_err(|_| {
+        Failure::new(
+            FailureClass::MalformedResponse,
+            "provider returned malformed reasoning continuation data",
+        )
+    })?;
+    seal_reasoning_candidate(bridge, request_id, route_depth, candidate).await
+}
+
+/// Ask the Python authority to bind and encrypt one validated native turn.
+pub(crate) async fn seal_reasoning_candidate(
+    bridge: &crate::bridge::Bridge,
+    request_id: &str,
+    route_depth: usize,
+    candidate: Option<ReasoningCarrierCandidate>,
+) -> Result<Option<String>, Failure> {
+    let Some(candidate) = candidate else {
+        return Ok(None);
+    };
+    let argument = compact_json(&json!({
+        "request_id": request_id,
+        "route_depth": route_depth,
+        "route_sha256": candidate.route_sha256,
+        "content": candidate.content,
+        "assistant_content": candidate.assistant_content,
+        "tool_calls": candidate.tool_calls.into_iter().map(|call| json!({
+            "call_id": call.call_id,
+            "name": call.name,
+            "raw_arguments": call.raw_arguments,
+        })).collect::<Vec<_>>(),
+    }));
+    let response = bridge
+        .call("seal_reasoning_content", argument)
+        .await
+        .map_err(|_| {
+            Failure::new(
+                FailureClass::MalformedResponse,
+                "provider reasoning continuation could not be authenticated",
+            )
+        })?;
+    let payload: Value = serde_json::from_str(&response).map_err(|_| {
+        Failure::new(
+            FailureClass::Internal,
+            "gateway returned an invalid reasoning carrier response",
+        )
+    })?;
+    let carrier = payload
+        .get("carrier")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Failure::new(
+                FailureClass::Internal,
+                "gateway omitted the authenticated reasoning carrier",
+            )
+        })?;
+    Ok(Some(carrier.to_string()))
 }
 
 /// Aggregate one committed non-streaming or guarded chat attempt and answer
@@ -392,12 +470,29 @@ async fn respond_from_chat_events(
     stream_body: bool,
 ) -> Response {
     let refusal_completed = complete_visible_refusal(&mut events);
-    let aggregated = match completed_chat_body_with_ignored(
+    let carrier = if refusal_completed.is_some() {
+        None
+    } else {
+        match seal_reasoning_events(&guard.bridge, &admission.request_id, depth, &events).await {
+            Ok(carrier) => carrier,
+            Err(failure) => {
+                guard
+                    .settle("failed", usage.as_ref(), &tool_names, Some(&failure), true)
+                    .await;
+                if let Some(mut owner) = lease.take() {
+                    owner.abandon().await;
+                }
+                return error_response(&failure.public_error());
+            }
+        }
+    };
+    let aggregated = match completed_chat_body_with_carrier(
         &admission.request_id,
         &admission.alias,
         created_at,
         &events,
         &admission.ignored_parameters,
+        carrier.as_deref(),
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => {
@@ -477,7 +572,7 @@ async fn respond_from_chat_events(
     let mut headers = commit_independent(&admission, client_request_id.as_deref());
     headers.extend(commit_dependent(&admission, depth));
     if stream_body {
-        let body = match encode_chat_sse(&admission, created_at, &events) {
+        let body = match encode_chat_sse(&admission, created_at, &events, carrier.as_deref()) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -759,6 +854,29 @@ async fn stream_response(
                 other => other.clone(),
             };
             if event.is_terminal() {
+                if matches!(event, Event::Completed) {
+                    let candidate = match encoder.reasoning_carrier_candidate() {
+                        Ok(candidate) => candidate,
+                        Err(_) => {
+                            fail_stream!(Failure::new(
+                                FailureClass::MalformedResponse,
+                                "provider returned malformed reasoning continuation data",
+                            ))
+                        }
+                    };
+                    match seal_reasoning_candidate(
+                        &guard.bridge,
+                        &request_id,
+                        committed.depth,
+                        candidate,
+                    )
+                    .await
+                    {
+                        Ok(Some(carrier)) => encoder.set_reasoning_content_carrier(carrier),
+                        Ok(None) => {}
+                        Err(failure) => fail_stream!(failure),
+                    }
+                }
                 terminal = Some(event.clone());
                 if !settle_stream_end(&mut guard, Some(&event), usage.as_ref(), &tool_names, false)
                     .await

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -19,8 +19,10 @@ use crate::admission::{
     acquire_permit, apply_output_guardrail, commit_dependent, commit_independent, new_guard,
     wire_drift_response, Admission,
 };
-use crate::encode::compact_json;
-use crate::encode_responses::{completed_responses_body, ResponsesSseEncoder};
+use crate::encode::{compact_json, reasoning_carrier_candidate};
+use crate::encode_responses::{
+    completed_responses_body, completed_responses_body_with_carrier, ResponsesSseEncoder,
+};
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
@@ -32,6 +34,7 @@ use crate::respond::{
     send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::responses_retention::{remember_argument, ResponsesRetention};
+use crate::route_chat::{seal_reasoning_candidate, seal_reasoning_events};
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
 use crate::waterfall::{acquire_attempt, CommittedAttempt, SettledAttempt, WaterfallContext, Won};
@@ -270,17 +273,20 @@ async fn remember_continuation(
     state: &AppState,
     request_id: &str,
     retention: &ResponsesRetention,
+    reasoning_content_carrier: Option<&str>,
 ) -> Result<(), PublicError> {
     if retention.overflowed || retention.refusal() || retention.is_empty() {
         return Ok(());
     }
     state
         .bridge
-        .call("remember", remember_argument(request_id, retention))
+        .call(
+            "remember",
+            remember_argument(request_id, retention, reasoning_content_carrier),
+        )
         .await
         .map(|_| ())
 }
-
 /// Answer one Responses attempt that the waterfall already settled: a
 /// successful terminal with no semantic output, or an exhausted ladder
 /// flushing withheld refusal output ahead of the failing terminal.
@@ -305,7 +311,7 @@ async fn settled_responses_response(
     let mut headers = commit_independent(admission, client_request_id.as_deref());
     headers.extend(commit_dependent(admission, settled.depth));
     if admission.stream {
-        let body = match encode_responses_sse(admission, created_at, &events) {
+        let body = match encode_responses_sse(admission, created_at, &events, None) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -383,13 +389,28 @@ async fn respond_from_responses_events(
     stream_body: bool,
 ) -> Response {
     let refusal_completed = complete_visible_refusal(&mut events);
+    let reasoning_content_carrier =
+        match seal_reasoning_events(&guard.bridge, &admission.request_id, depth, &events).await {
+            Ok(carrier) => carrier,
+            Err(failure) => {
+                let failure = failure.boundary();
+                guard
+                    .settle("failed", usage.as_ref(), &tool_names, Some(&failure), true)
+                    .await;
+                if let Some(mut owner) = lease.take() {
+                    owner.abandon().await;
+                }
+                return error_response(&failure.public_error());
+            }
+        };
     let envelope = admission.envelope.clone().unwrap_or_default();
-    let aggregated = match completed_responses_body(
+    let aggregated = match completed_responses_body_with_carrier(
         &admission.request_id,
         &admission.alias,
         created_at,
         envelope,
         &events,
+        reasoning_content_carrier.as_deref(),
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => {
@@ -438,7 +459,13 @@ async fn respond_from_responses_events(
     for event in &events {
         retention.track(event);
     }
-    let remembered = remember_continuation(state, &admission.request_id, &retention).await;
+    let remembered = remember_continuation(
+        state,
+        &admission.request_id,
+        &retention,
+        reasoning_content_carrier.as_deref(),
+    )
+    .await;
     let settled = if let Some(refusal) = &refusal_completed {
         guard
             .settle(
@@ -483,7 +510,12 @@ async fn respond_from_responses_events(
     let mut headers = commit_independent(&admission, client_request_id.as_deref());
     headers.extend(commit_dependent(&admission, depth));
     if stream_body {
-        let body = match encode_responses_sse(&admission, created_at, &events) {
+        let body = match encode_responses_sse(
+            &admission,
+            created_at,
+            &events,
+            reasoning_content_carrier.as_deref(),
+        ) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -575,6 +607,7 @@ fn encode_responses_sse(
     admission: &Admission,
     created_at: f64,
     events: &[Event],
+    reasoning_content_carrier: Option<&str>,
 ) -> Result<Vec<u8>, PublicError> {
     let envelope = admission.envelope.clone().unwrap_or_default();
     let mut encoder = ResponsesSseEncoder::new(
@@ -583,6 +616,9 @@ fn encode_responses_sse(
         created_at,
         envelope,
     );
+    if let Some(carrier) = reasoning_content_carrier {
+        encoder.set_reasoning_content_carrier(carrier.to_string())?;
+    }
     let mut body = Vec::new();
     for frame in encoder.start()? {
         body.extend_from_slice(frame.as_bytes());
@@ -707,6 +743,7 @@ async fn stream_responses(
         let mut visible_refusal = committed.visible_refusal;
         let mut terminal: Option<Event> = None;
         let mut retention = ResponsesRetention::default();
+        let mut reasoning_content_carrier: Option<String> = None;
         // Terminal frames are withheld until continuation retention lands,
         // mirroring the python stream body's ordering.
         let terminal_frames: Vec<String>;
@@ -783,6 +820,40 @@ async fn stream_responses(
             // provider's outcome instead of as a cancellation.
             if event.is_terminal() {
                 terminal = Some(event.clone());
+                if matches!(event, Event::Completed) {
+                    let candidate = match reasoning_carrier_candidate(&retention.carrier_events) {
+                        Ok(candidate) => candidate,
+                        Err(_) => {
+                            fail_stream!(Failure::new(
+                                FailureClass::MalformedResponse,
+                                "provider returned malformed reasoning continuation data",
+                            ))
+                        }
+                    };
+                    match seal_reasoning_candidate(
+                        &guard.bridge,
+                        &request_id,
+                        committed.depth,
+                        candidate,
+                    )
+                    .await
+                    {
+                        Ok(Some(carrier)) => {
+                            if encoder
+                                .set_reasoning_content_carrier(carrier.clone())
+                                .is_err()
+                            {
+                                fail_stream!(Failure::new(
+                                    FailureClass::MalformedResponse,
+                                    "provider reasoning continuation could not be authenticated",
+                                ))
+                            }
+                            reasoning_content_carrier = Some(carrier);
+                        }
+                        Ok(None) => {}
+                        Err(failure) => fail_stream!(failure),
+                    }
+                }
             }
             let encoded = match encoder.feed(&outward) {
                 Ok(encoded) => encoded,
@@ -821,8 +892,13 @@ async fn stream_responses(
         // same observable behavior as the python service.
         let retainable = !matches!(terminal, Some(Event::Failed(_)));
         if retainable {
-            if let Err(_error) =
-                remember_continuation(&state, &admission.request_id, &retention).await
+            if let Err(_error) = remember_continuation(
+                &state,
+                &admission.request_id,
+                &retention,
+                reasoning_content_carrier.as_deref(),
+            )
+            .await
             {
                 settle_stream_end(
                     &mut guard,

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -66,6 +66,8 @@ pub struct DeploymentWire {
     /// it.
     #[serde(default)]
     pub upstream_body: Option<String>,
+    #[serde(default)]
+    pub fireworks_reasoning_route_sha256: Option<String>,
     pub idempotency_key: String,
 }
 
@@ -140,6 +142,7 @@ fn is_semantic(event: &Event) -> bool {
             | Event::ThinkingSignature { .. }
             | Event::RedactedThinking { .. }
             | Event::EncryptedReasoning { .. }
+            | Event::ReasoningContentDelta { .. }
             | Event::ToolCallStarted { .. }
             | Event::ToolArgumentsDelta { .. }
             | Event::ToolCallCompleted { .. }
@@ -452,7 +455,15 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
-    let mut relay = UpstreamRelay::new(response, dialect, first_byte_deadline);
+    let mut relay = match wire.fireworks_reasoning_route_sha256.clone() {
+        Some(route_sha256) => UpstreamRelay::new_with_reasoning_content_route(
+            response,
+            dialect,
+            first_byte_deadline,
+            Some(route_sha256),
+        ),
+        None => UpstreamRelay::new(response, dialect, first_byte_deadline),
+    };
     let mut usage: Option<Usage> = None;
     let mut tool_names: Vec<String> = Vec::new();
     let mut withheld: Vec<Event> = Vec::new();

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -1,17 +1,9 @@
 """Python control plane for the native (Rust) gateway data plane.
 
-The native engine (`exp_gateway_native`) owns the HTTP socket, upstream
-streaming, provider-event normalization, and public SSE encoding. Everything
-protocol- and authority-shaped happens here, in the same code the python
-engine runs: request decoding through ``decode_chat`` and
-``decode_responses``, authorization through the shared control store,
-upstream payload construction through the shared ``streaming_requests``
-builders, Responses continuation state through the shared bounded store, and
-the same durable SQLite ledger transactions. Ledger writes go through the
-blocking facade over the shared group-commit writer, so both engines' writes
-interleave in the same batched fsyncs while every caller still blocks until
-its own write is durable. Every boundary call takes and returns one JSON
-string so the boundary stays narrow and typed on both sides.
+The native engine (`exp_gateway_native`) owns sockets, upstream streaming,
+normalization, and SSE encoding. Shared Python contracts own decoding,
+authorization, payload construction, continuation state, and durable ledger
+transactions. Every boundary call takes and returns one JSON string.
 
 Admission returns the full ordered certified route (one wire configuration
 per deployment) plus the frozen retry-policy facts, accepting the request
@@ -58,6 +50,12 @@ from exp.runtime.gateway.native_accounting import (
 from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
+from exp.runtime.gateway.native_bridge_errors import (
+    escalation as _escalation,
+)
+from exp.runtime.gateway.native_bridge_errors import (
+    public_capability_error as _public_capability_error,
+)
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
 from exp.runtime.gateway.native_continuation import (
     continuation_binding_error as _continuation_binding_error,
@@ -85,6 +83,12 @@ from exp.runtime.gateway.native_execution import (
     select_route_deployments,
 )
 from exp.runtime.gateway.native_observability import NativeObservabilityMixin
+from exp.runtime.gateway.native_reasoning import (
+    authenticate_reasoning_history,
+    has_active_reasoning_content,
+    strip_stale_reasoning_history,
+    unseal_reasoning_history,
+)
 from exp.runtime.gateway.native_responses import (
     ContinuationContext,
     continuation_route_binding,
@@ -93,6 +97,13 @@ from exp.runtime.gateway.native_responses import (
 )
 from exp.runtime.gateway.native_settlement import (
     optional_text,
+)
+from exp.runtime.gateway.reasoning_carrier import (
+    ReasoningCarrierAuthority,
+    parse_reasoning_carrier_tool_calls,
+    reasoning_carrier_authority,
+    reasoning_history_sha256,
+    seal_reasoning_content,
 )
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.models.providers import (
@@ -115,8 +126,8 @@ from exp.runtime.models.providers.streaming_requests import (
 )
 from exp.runtime.openai_protocol.errors import (
     OpenAIProtocolError,
+    invalid_field,
     public_failure_error,
-    unsupported_field,
 )
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 from exp.runtime.openai_protocol.state import (
@@ -127,119 +138,14 @@ from exp.runtime.openai_protocol.state import (
 )
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
-_PUBLIC_REQUEST_CAPABILITY_PARAMS = {
-    GatewayApiSurface.CHAT_COMPLETIONS: {
-        "developer_messages": "messages",
-        "function_tools": "tools",
-        "parallel_tool_calls": "parallel_tool_calls",
-        "stop_sequences": "stop",
-        "streaming": "stream",
-        "streaming_tool_arguments": "stream",
-        "strict_tools": "tools",
-        "structured_output": "response_format",
-        "structured_text": "response_format",
-    },
-    GatewayApiSurface.RESPONSES: {
-        "developer_messages": "instructions",
-        "function_tools": "tools",
-        "parallel_tool_calls": "parallel_tool_calls",
-        "streaming": "stream",
-        "streaming_tool_arguments": "stream",
-        "strict_tools": "tools",
-        "structured_output": "text.format",
-        "structured_text": "text.format",
-    },
-    GatewayApiSurface.MESSAGES: {
-        "developer_messages": "system",
-        "function_tools": "tools",
-        "parallel_tool_calls": "tool_choice.disable_parallel_tool_use",
-        "stop_sequences": "stop_sequences",
-        "streaming": "stream",
-        "streaming_tool_arguments": "stream",
-        "strict_tools": "tools",
-    },
-}
-
-
-def _public_capability_param(
-    capability: str,
-    surface: GatewayApiSurface,
-    *,
-    public_stream: bool = True,
-    public_tools: bool = False,
-) -> str | None:
-    """Translate an internal capability label to the caller's request field."""
-    if capability == "streaming_tool_arguments":
-        return "tools"
-    if capability == "streaming" and not public_stream:
-        return None
-    return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
-
-
-def _public_capability_error(
-    error: ProviderCapabilityError,
-    surface: GatewayApiSurface,
-    *,
-    public_stream: bool,
-    public_tools: bool,
-    developer_messages_param: str | None = None,
-) -> OpenAIProtocolError:
-    """Translate one internal admission label into a stable public 400.
-
-    Provider capability literals are useful for internal accounting but are
-    not part of the public request contract. Known request requirements name
-    the field that activated them. Internal route requirements fail against
-    ``model`` without exposing implementation details.
-    """
-    param = (
-        developer_messages_param
-        if error.capability == "developer_messages" and developer_messages_param is not None
-        else _public_capability_param(
-            error.capability,
-            surface,
-            public_stream=public_stream,
-            public_tools=public_tools,
-        )
-    )
-    if param is not None:
-        return unsupported_field(param, capability=True)
-    return OpenAIProtocolError(
-        status_code=400,
-        code="unsupported_capability",
-        message=(
-            "The selected model route cannot serve this request. "
-            "Choose a different model alias and resend the request."
-        ),
-        param="model",
-    )
-
-
-def _escalation(reason: str) -> str:
-    """Return the admission disposition for a request the plane cannot serve.
-
-    The data plane classifies the reason for content-free metrics and fails
-    the request closed.
-
-    Args:
-        reason: Display-safe reason the native path cannot serve the request.
-
-    Returns:
-        The JSON admission body carrying the escalation disposition.
-    """
-    return json.dumps({"escalate": reason}, separators=(",", ":"))
 
 
 class NativeControlPlane(NativeObservabilityMixin):
     """Authority and accounting callbacks for the native data plane.
 
-    Methods are called from multiple Rust worker threads. Ledger writes block
-    on the shared group-commit writer's blocking facade, so concurrent
-    settlements from both engines amortize one fsync per batch while each
-    caller still observes only its own durable commit; reads use the raw
-    ledger's per-thread connection cache. The in-flight request registry is
-    guarded by one lock and swept opportunistically so an abandoned
-    reservation cannot outlive its request deadline by more than the sweep
-    grace.
+    Rust worker threads share the group-commit writer and the locked in-flight
+    registry. Opportunistic sweeps bound abandoned reservations to the request
+    deadline plus the sweep grace.
     """
 
     def __init__(
@@ -402,6 +308,20 @@ class NativeControlPlane(NativeObservabilityMixin):
             except OpenAIProtocolError as exc:
                 raise NativeBridgeError(exc) from exc
 
+        pinned_reasoning_route: GatewayRoute | None = None
+        try:
+            request, pinned_reasoning_route = authenticate_reasoning_history(
+                self._components,
+                authorization,
+                request,
+            )
+        except Exception as exc:  # noqa: BLE001 - one public shape prevents an oracle.
+            error = invalid_field(
+                "messages.reasoning_content",
+                "'messages.reasoning_content' must be an authentic continuation for this route.",
+            )
+            raise NativeBridgeError(error) from exc
+
         policy = None
         try:
             request, policy = enforce_native_input(
@@ -412,10 +332,39 @@ class NativeControlPlane(NativeObservabilityMixin):
             )
         except GuardrailRejected as exc:
             raise NativeBridgeError(public_failure_error(exc.failure)) from exc
+        retention_request = strip_stale_reasoning_history(request)
+        try:
+            request, verified_reasoning_route = unseal_reasoning_history(
+                self._components,
+                authorization,
+                request,
+            )
+        except Exception as exc:  # noqa: BLE001 - one public shape prevents an oracle.
+            error = invalid_field(
+                "messages.reasoning_content",
+                "'messages.reasoning_content' must be an authentic continuation for this route.",
+            )
+            raise NativeBridgeError(error) from exc
+        if (
+            pinned_reasoning_route is not None
+            and verified_reasoning_route is not None
+            and pinned_reasoning_route.deployment != verified_reasoning_route.deployment
+        ):
+            raise NativeBridgeError(
+                invalid_field(
+                    "messages.reasoning_content",
+                    "'messages.reasoning_content' must be an authentic continuation "
+                    "for this route.",
+                )
+            )
+        pinned_reasoning_route = verified_reasoning_route
+        request = strip_stale_reasoning_history(request)
+        if pinned_reasoning_route is not None and not has_active_reasoning_content(request):
+            pinned_reasoning_route = None
         if continuation_context is not None:
-            # Retain exactly the post-guardrail history dispatched upstream;
-            # otherwise a later continuation could resurrect removed input.
-            continuation_context.messages = request.messages
+            # Execution receives authenticated plaintext, but the bounded
+            # continuation store keeps the post-guardrail history sealed.
+            continuation_context.messages = retention_request.messages
 
         # The ledger accepts the logical request before route selection, so a
         # keyed operation whose durable terminal already exists (or whose key
@@ -435,7 +384,7 @@ class NativeControlPlane(NativeObservabilityMixin):
         route: GatewayRoute | None = None
         resolved_wires: tuple[tuple[GatewayWireProfile, NativeWireClient], ...] | None = None
         try:
-            route = self._resolve_route(
+            route = pinned_reasoning_route or self._resolve_route(
                 authorization,
                 request,
                 continuation=continuation_context,
@@ -558,6 +507,7 @@ class NativeControlPlane(NativeObservabilityMixin):
             wire_route: list[JsonObject] = []
             signers: list[GatewayDispatchSigner | None] = []
             dispatch_bindings: list[FrozenDispatchBinding | None] = []
+            carrier_authorities: list[ReasoningCarrierAuthority | None] = []
             for deployment, (profile, client) in zip(
                 route.deployments, resolved_wires, strict=True
             ):
@@ -586,6 +536,15 @@ class NativeControlPlane(NativeObservabilityMixin):
                     else FrozenDispatchBinding(
                         url=profile.url,
                         body_sha256=sha256_bytes(upstream_body.encode("utf-8")),
+                    )
+                )
+                carrier_authorities.append(
+                    reasoning_carrier_authority(
+                        authorization=authorization,
+                        exact_model_id=route.snapshot.exact_model_id,
+                        pool_id=route.snapshot.pool_id,
+                        deployment=deployment,
+                        profile=profile,
                     )
                 )
             if continuation_context is not None:
@@ -635,6 +594,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                 policy=policy,
                 signers=tuple(signers),
                 dispatch_bindings=tuple(dispatch_bindings),
+                reasoning_carrier_authorities=tuple(carrier_authorities),
             )
         )
         response: JsonObject = {
@@ -776,6 +736,60 @@ class NativeControlPlane(NativeObservabilityMixin):
             argument,
             deadline_monotonic=deadline,
         )
+
+    def seal_reasoning_content(self, argument: str) -> str:
+        """Seal one winning Fireworks turn before terminal settlement."""
+        try:
+            data = json.loads(argument)
+            if not isinstance(data, dict):
+                raise ValueError("reasoning carrier argument must be an object")
+            request_id = data.get("request_id")
+            route_depth = data.get("route_depth")
+            assistant_content = data.get("assistant_content")
+            route_sha256 = data.get("route_sha256")
+            content = data.get("content")
+            if (
+                not isinstance(request_id, str)
+                or not request_id
+                or isinstance(route_depth, bool)
+                or not isinstance(route_depth, int)
+                or (assistant_content is not None and not isinstance(assistant_content, str))
+                or not isinstance(route_sha256, str)
+                or not isinstance(content, str)
+            ):
+                raise ValueError("reasoning carrier argument has invalid field types")
+            tool_calls = parse_reasoning_carrier_tool_calls(data.get("tool_calls"))
+            entry = self._accounting.entry(request_id)
+            if (
+                entry is None
+                or entry.active_attempt_id is None
+                or entry.attempt_depths.get(entry.active_attempt_id) != route_depth
+                or route_depth < 0
+                or route_depth >= len(entry.reasoning_carrier_authorities)
+            ):
+                raise ValueError("reasoning carrier attempt is not active")
+            authority = entry.reasoning_carrier_authorities[route_depth]
+            if authority is None or authority.reasoning_route_sha256 != route_sha256:
+                raise ValueError("reasoning carrier route differs from the active attempt")
+            carrier = seal_reasoning_content(
+                authority,
+                issuing_request_id=request_id,
+                issuing_route_depth=route_depth,
+                issuing_history_sha256=reasoning_history_sha256(entry.request.messages),
+                assistant_content=assistant_content,
+                tool_calls=tool_calls,
+                content=content,
+            )
+        except Exception as exc:  # noqa: BLE001 - never disclose authority or content.
+            raise NativeBridgeError(
+                public_failure_error(
+                    GatewayFailure(
+                        failure_class=GatewayFailureClass.MALFORMED_RESPONSE,
+                        safe_message="the provider returned malformed reasoning continuation data",
+                    )
+                )
+            ) from exc
+        return json.dumps({"carrier": carrier}, separators=(",", ":"))
 
     def claim_scope(self, argument: str) -> str:
         """Resolve the replay-store scope for one keyed request.

--- a/exp/runtime/gateway/native_bridge_errors.py
+++ b/exp/runtime/gateway/native_bridge_errors.py
@@ -1,0 +1,95 @@
+"""Public error translation helpers for the native gateway bridge."""
+
+from __future__ import annotations
+
+import json
+
+from exp.runtime.gateway.contracts import GatewayApiSurface
+from exp.runtime.models.providers.errors import ProviderCapabilityError
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError, unsupported_field
+
+_PUBLIC_REQUEST_CAPABILITY_PARAMS = {
+    GatewayApiSurface.CHAT_COMPLETIONS: {
+        "developer_messages": "messages",
+        "function_tools": "tools",
+        "parallel_tool_calls": "parallel_tool_calls",
+        "stop_sequences": "stop",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+        "structured_output": "response_format",
+        "structured_text": "response_format",
+    },
+    GatewayApiSurface.RESPONSES: {
+        "developer_messages": "instructions",
+        "function_tools": "tools",
+        "parallel_tool_calls": "parallel_tool_calls",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+        "structured_output": "text.format",
+        "structured_text": "text.format",
+    },
+    GatewayApiSurface.MESSAGES: {
+        "developer_messages": "system",
+        "function_tools": "tools",
+        "parallel_tool_calls": "tool_choice.disable_parallel_tool_use",
+        "stop_sequences": "stop_sequences",
+        "streaming": "stream",
+        "streaming_tool_arguments": "stream",
+        "strict_tools": "tools",
+    },
+}
+
+
+def capability_param(
+    capability: str,
+    surface: GatewayApiSurface,
+    *,
+    public_stream: bool = True,
+    public_tools: bool = False,
+) -> str | None:
+    """Translate an internal capability label to the caller's request field."""
+    del public_tools
+    if capability == "streaming_tool_arguments":
+        return "tools"
+    if capability == "streaming" and not public_stream:
+        return None
+    return _PUBLIC_REQUEST_CAPABILITY_PARAMS[surface].get(capability)
+
+
+def public_capability_error(
+    error: ProviderCapabilityError,
+    surface: GatewayApiSurface,
+    *,
+    public_stream: bool,
+    public_tools: bool,
+    developer_messages_param: str | None = None,
+) -> OpenAIProtocolError:
+    """Translate one internal admission label into a stable public 400."""
+    param = (
+        developer_messages_param
+        if error.capability == "developer_messages" and developer_messages_param is not None
+        else capability_param(
+            error.capability,
+            surface,
+            public_stream=public_stream,
+            public_tools=public_tools,
+        )
+    )
+    if param is not None:
+        return unsupported_field(param, capability=True)
+    return OpenAIProtocolError(
+        status_code=400,
+        code="unsupported_capability",
+        message=(
+            "The selected model route cannot serve this request. "
+            "Choose a different model alias and resend the request."
+        ),
+        param="model",
+    )
+
+
+def escalation(reason: str) -> str:
+    """Return a content-free native admission escalation disposition."""
+    return json.dumps({"escalate": reason}, separators=(",", ":"))

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -43,8 +43,8 @@ from exp.runtime.gateway.native_bridge import (
     NativeBridgeError,
     NativeControlPlane,
     _public_capability_error,
-    _public_capability_param,
 )
+from exp.runtime.gateway.native_bridge_errors import capability_param as _public_capability_param
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.models.providers.errors import ProviderCapabilityError
 from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
@@ -277,6 +277,225 @@ def _admit_started(
         client_request_id=client_request_id,
     )
     return _flatten_started(control, admission)
+
+
+def test_fireworks_carrier_round_trip_rejects_tamper_and_credential_rotation(
+    tmp_path: Path,
+) -> None:
+    """A second replica decrypts the exact turn while tamper and rotation fail closed."""
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://api.fireworks.ai/inference/v1",
+        capabilities=ModelCapabilities(supports_tools=True),
+    )
+    first_control = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-fireworks-secret"},
+        )
+    )
+    initial = _admit_started(first_control, raw_key, _chat_body())
+    hidden = "private provider reasoning that must stay opaque"
+    seal_argument = json.dumps(
+        {
+            "request_id": initial["request_id"],
+            "route_depth": initial["route_depth"],
+            "route_sha256": initial["fireworks_reasoning_route_sha256"],
+            "content": hidden,
+            "assistant_content": None,
+            "tool_calls": [{"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}],
+        }
+    )
+    sealed = json.loads(first_control.seal_reasoning_content(seal_argument))["carrier"]
+    assert hidden not in sealed
+    assert "shared-fireworks-secret" not in sealed
+    assert (
+        first_control.settle(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "attempt_id": initial["attempt_id"],
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                    "tool_names": ["lookup"],
+                    "failure": None,
+                }
+            )
+        )
+        == "{}"
+    )
+    with pytest.raises(NativeBridgeError):
+        first_control.seal_reasoning_content(seal_argument)
+    continuation_body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": sealed,
+                    "tool_calls": [
+                        {
+                            "id": "call-one",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+            ],
+        }
+    )
+
+    replica = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-fireworks-secret"},
+        )
+    )
+    continued = _admit(replica, raw_key, continuation_body)
+    route = cast("list[JsonObject]", continued["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    messages = cast("list[JsonObject]", payload["messages"])
+    assert continued["route_reason"] == "reasoning_continuation"
+    assert messages[1]["reasoning_content"] == hidden
+
+    transplanted = json.loads(continuation_body)
+    transplanted["messages"][0]["content"] = "Use this carrier under a different prompt"
+    with pytest.raises(NativeBridgeError) as transplanted_error:
+        _admit(replica, raw_key, json.dumps(transplanted))
+    assert (
+        json.loads(transplanted_error.value.public_error_json)["param"]
+        == "messages.reasoning_content"
+    )
+
+    modified_turn = json.loads(continuation_body)
+    modified_turn["messages"][1]["tool_calls"][0]["function"]["arguments"] = '{"tampered":true}'
+    with pytest.raises(NativeBridgeError) as modified:
+        _admit(replica, raw_key, json.dumps(modified_turn))
+    assert json.loads(modified.value.public_error_json)["param"] == "messages.reasoning_content"
+
+    rotated = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "rotated-fireworks-secret"},
+        )
+    )
+    with pytest.raises(NativeBridgeError) as rejected:
+        _admit(rotated, raw_key, continuation_body)
+    public_error = json.loads(rejected.value.public_error_json)
+    assert public_error["status_code"] == 400
+    assert public_error["param"] == "messages.reasoning_content"
+
+    stale_turn = json.loads(continuation_body)
+    stale_turn["messages"].append({"role": "user", "content": "Start a new turn"})
+    after_rotation = _admit(rotated, raw_key, json.dumps(stale_turn))
+    rotated_route = cast("list[JsonObject]", after_rotation["route"])
+    rotated_payload = cast("JsonObject", rotated_route[0]["upstream_payload"])
+    rotated_messages = cast("list[JsonObject]", rotated_payload["messages"])
+    assert after_rotation["route_reason"] == "direct"
+    assert "reasoning_content" not in rotated_messages[1]
+
+
+def test_fireworks_continuation_pins_the_exact_issuing_fallback_rung(tmp_path: Path) -> None:
+    """A fallback-issued carrier replays only to its exact deployment and credential."""
+    _manager, raw_key = _configured_pool_gateway(
+        tmp_path,
+        base_urls=(
+            "https://api.fireworks.ai/inference/v1",
+            "https://api.fireworks.ai/inference/v1",
+        ),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-fireworks-secret"},
+        )
+    )
+    admission = _admit(control, raw_key, _chat_body())
+    first = _start_first(control, admission)
+    failure = {
+        "failure_class": "provider_internal",
+        "safe_message": "provider service failed",
+        "retryable_same_deployment": False,
+        "failover_eligible": True,
+    }
+    assert (
+        control.settle(
+            json.dumps(
+                {
+                    "request_id": admission["request_id"],
+                    "attempt_id": first["attempt_id"],
+                    "outcome": "failed",
+                    "usage": None,
+                    "tool_names": [],
+                    "failure": failure,
+                    "finalize": False,
+                }
+            )
+        )
+        == "{}"
+    )
+    second = json.loads(
+        control.start_attempt(
+            json.dumps(
+                {
+                    "request_id": admission["request_id"],
+                    "attempt_ordinal": 1,
+                    "current_depth": 0,
+                    "failure": failure,
+                }
+            )
+        )
+    )
+    assert second["route_depth"] == 1
+    route = cast("list[JsonObject]", admission["route"])
+    carrier = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": admission["request_id"],
+                    "route_depth": 1,
+                    "route_sha256": route[1]["fireworks_reasoning_route_sha256"],
+                    "content": "fallback-private-reasoning",
+                    "assistant_content": None,
+                    "tool_calls": [
+                        {"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}
+                    ],
+                }
+            )
+        )
+    )["carrier"]
+    continuation = _admit(
+        control,
+        raw_key,
+        json.dumps(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "reasoning_content": carrier,
+                        "tool_calls": [
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+                ],
+            }
+        ),
+    )
+
+    continued_route = cast("list[JsonObject]", continuation["route"])
+    assert [item["deployment_id"] for item in continued_route] == [route[1]["deployment_id"]]
+    assert continued_route[0]["model_id"] == "beta-model-exact"
 
 
 def test_bridge_error_payload_is_openai_shaped() -> None:
@@ -2782,6 +3001,97 @@ def test_responses_tool_call_retention_survives_continuation(tmp_path: Path) -> 
     first_call = tool_calls[0]
     assert isinstance(first_call, dict)
     assert first_call["function"] == {"name": "search", "arguments": '{"q":"x"}'}
+
+
+def test_fireworks_multihop_responses_retention_stays_sealed(tmp_path: Path) -> None:
+    """Executing a retained carrier never stores its decrypted plaintext copy."""
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://api.fireworks.ai/inference/v1",
+        capabilities=ModelCapabilities(supports_tools=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-fireworks-secret"},
+        )
+    )
+    first = _admit_responses(control, raw_key, _responses_body(with_tools=True))
+    started = _start_first(control, first)
+    route = first["route"]
+    assert isinstance(route, list)
+    depth = started["route_depth"]
+    assert isinstance(depth, int)
+    wire = route[depth]
+    assert isinstance(wire, dict)
+    carrier = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": first["request_id"],
+                    "route_depth": depth,
+                    "route_sha256": wire["fireworks_reasoning_route_sha256"],
+                    "content": "PLAINTEXT-HIDDEN",
+                    "assistant_content": None,
+                    "tool_calls": [
+                        {"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}
+                    ],
+                }
+            )
+        )
+    )["carrier"]
+    assert (
+        control.remember(
+            json.dumps(
+                {
+                    "request_id": first["request_id"],
+                    "text": "",
+                    "refusal": False,
+                    "reasoning_content_carrier": carrier,
+                    "tool_calls": [{"call_id": "call-one", "name": "lookup", "arguments": "{}"}],
+                }
+            )
+        )
+        == "{}"
+    )
+    first_response_id = stable_public_id("resp", _admitted_request_id(first))
+    second_body = json.dumps(
+        {
+            "model": "coding",
+            "previous_response_id": first_response_id,
+            "input": [{"type": "function_call_output", "call_id": "call-one", "output": "done"}],
+        }
+    )
+    second = _admit_responses(control, raw_key, second_body)
+    upstream = _payload_messages(second)
+    assert upstream[1]["reasoning_content"] == "PLAINTEXT-HIDDEN"
+    assert (
+        control.remember(
+            json.dumps(
+                {
+                    "request_id": second["request_id"],
+                    "text": "finished",
+                    "refusal": False,
+                    "tool_calls": [],
+                }
+            )
+        )
+        == "{}"
+    )
+    accounting = control._accounting.entry(_admitted_request_id(second))  # noqa: SLF001
+    assert accounting is not None and accounting.continuation is not None
+    retained = control._continuations.resolve_now(  # noqa: SLF001
+        namespace=accounting.continuation.namespace,
+        previous_response_id=stable_public_id("resp", _admitted_request_id(second)),
+    )
+    kinds = [block.kind for message in retained.messages for block in message.provider_reasoning]
+    assert kinds == ["sealed_reasoning_content"]
+    retained_reasoning = [
+        block.model_dump(mode="json")
+        for message in retained.messages
+        for block in message.provider_reasoning
+    ]
+    assert "PLAINTEXT-HIDDEN" not in json.dumps(retained_reasoning)
 
 
 def test_responses_admission_rejects_invalid_bodies_and_bad_keys(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -33,6 +33,7 @@ from exp.runtime.gateway.guardrails.contracts import GuardrailPolicy
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.native_settlement import deployment_operation_key
+from exp.runtime.gateway.reasoning_carrier import ReasoningCarrierAuthority
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from exp.runtime.models.credentials import ModelCredentialError
@@ -90,6 +91,7 @@ class InflightRequest:
     # SigV4); ``None`` at a depth whose dialect serializes its own payload.
     signers: tuple[GatewayDispatchSigner | None, ...] = ()
     dispatch_bindings: tuple[FrozenDispatchBinding | None, ...] = ()
+    reasoning_carrier_authorities: tuple[ReasoningCarrierAuthority | None, ...] = ()
 
     def __post_init__(self) -> None:
         """Size the per-deployment attempt counters to the frozen route."""
@@ -460,6 +462,7 @@ def deployment_wire_entry(
         "timeout_seconds": profile.timeout_seconds,
         "upstream_payload": None if upstream_body is not None else upstream_payload,
         "upstream_body": upstream_body,
+        "fireworks_reasoning_route_sha256": profile.fireworks_reasoning_route_sha256,
         "idempotency_key": deployment_operation_key(route, deployment),
     }
 

--- a/exp/runtime/gateway/native_reasoning.py
+++ b/exp/runtime/gateway/native_reasoning.py
@@ -1,0 +1,160 @@
+"""Authenticated Fireworks continuation recovery for native admission."""
+
+from __future__ import annotations
+
+from exp.runtime.gateway.contracts import AuthorizationSnapshot, GatewayRequest
+from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.gateway.native_execution import resolve_route_profiles
+from exp.runtime.gateway.reasoning_carrier import (
+    ReasoningCarrierAuthority,
+    reasoning_carrier_authority,
+    unseal_reasoning_content,
+)
+from exp.runtime.gateway.routing import GatewayRoute
+
+
+def has_active_reasoning_content(request: GatewayRequest) -> bool:
+    """Return whether post-user history still carries decrypted Fireworks state."""
+    last_user = max(
+        (index for index, message in enumerate(request.messages) if message.role == "user"),
+        default=-1,
+    )
+    return any(
+        index > last_user
+        and any(block.kind == "reasoning_content" for block in message.provider_reasoning)
+        for index, message in enumerate(request.messages)
+    )
+
+
+def strip_stale_reasoning_history(request: GatewayRequest) -> GatewayRequest:
+    """Remove Fireworks state that precedes the latest user boundary."""
+    last_user = max(
+        (index for index, message in enumerate(request.messages) if message.role == "user"),
+        default=-1,
+    )
+    messages = list(request.messages)
+    for index, message in enumerate(messages):
+        if index > last_user:
+            continue
+        retained = tuple(
+            block
+            for block in message.provider_reasoning
+            if block.kind not in {"sealed_reasoning_content", "reasoning_content"}
+        )
+        if retained != message.provider_reasoning:
+            messages[index] = message.model_copy(update={"provider_reasoning": retained})
+    return request.model_copy(update={"messages": tuple(messages)})
+
+
+def unseal_reasoning_history(
+    components: NativeGatewayComponents,
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+) -> tuple[GatewayRequest, GatewayRoute | None]:
+    """Authenticate hidden Fireworks history and recover its exact issuing rung."""
+    return _process_reasoning_history(
+        components,
+        authorization,
+        request,
+        reveal=True,
+        verify_history=True,
+    )
+
+
+def authenticate_reasoning_history(
+    components: NativeGatewayComponents,
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+) -> tuple[GatewayRequest, GatewayRoute | None]:
+    """Authenticate carrier authority and its assistant turn without revealing plaintext.
+
+    Input guardrails may deterministically rewrite user-visible history. This first phase
+    proves that every carrier was issued by the selected route and belongs to its exact
+    assistant tool turn, while the second phase in :func:`unseal_reasoning_history` binds
+    the post-guardrail canonical conversation prefix before exposing provider reasoning.
+    """
+    return _process_reasoning_history(
+        components,
+        authorization,
+        request,
+        reveal=False,
+        verify_history=False,
+    )
+
+
+def _process_reasoning_history(
+    components: NativeGatewayComponents,
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+    *,
+    reveal: bool,
+    verify_history: bool,
+) -> tuple[GatewayRequest, GatewayRoute | None]:
+    """Validate active Fireworks carriers and optionally recover their plaintext."""
+    request = strip_stale_reasoning_history(request)
+    last_user = max(
+        (index for index, message in enumerate(request.messages) if message.role == "user"),
+        default=-1,
+    )
+    routes: dict[str, tuple[GatewayRoute, ReasoningCarrierAuthority]] = {}
+    messages = list(request.messages)
+    pinned: GatewayRoute | None = None
+    for index, message in enumerate(messages):
+        if index <= last_user:
+            continue
+        sealed = tuple(
+            block
+            for block in message.provider_reasoning
+            if block.kind == "sealed_reasoning_content"
+        )
+        if not sealed:
+            continue
+        if (
+            len(sealed) != 1
+            or len(message.provider_reasoning) != 1
+            or message.role != "assistant"
+            or not message.tool_calls
+        ):
+            raise ValueError("reasoning carrier must accompany one assistant tool turn")
+        carrier = sealed[0]
+        cached = routes.get(carrier.deployment_hint)
+        if cached is None:
+            route = components.routes.resolve_deployment_hint(
+                authorization,
+                carrier.deployment_hint,
+            )
+            resolved = resolve_route_profiles(components.runtime_catalogs, route)
+            if len(resolved) != 1:
+                raise ValueError("reasoning carrier route must resolve one exact deployment")
+            profile, _client = resolved[0]
+            authority = reasoning_carrier_authority(
+                authorization=authorization,
+                exact_model_id=route.snapshot.exact_model_id,
+                pool_id=route.snapshot.pool_id,
+                deployment=route.deployment,
+                profile=profile,
+            )
+            if authority is None:
+                raise ValueError("reasoning carrier route is not Fireworks")
+            cached = (route, authority)
+            routes[carrier.deployment_hint] = cached
+        route, authority = cached
+        block, _claims = unseal_reasoning_content(
+            carrier,
+            authority,
+            assistant_content=message.content,
+            tool_calls=message.tool_calls,
+            history_prefix=tuple(messages[:index]) if verify_history else (),
+        )
+        if reveal:
+            messages[index] = message.model_copy(update={"provider_reasoning": (block,)})
+        if pinned is not None and pinned.deployment != route.deployment:
+            raise ValueError("active reasoning carriers name different issuing rungs")
+        pinned = route
+    if pinned is None and any(
+        index > last_user
+        and any(block.kind == "reasoning_content" for block in message.provider_reasoning)
+        for index, message in enumerate(messages)
+    ):
+        raise ValueError("decrypted reasoning history requires a sealed active carrier")
+    return request.model_copy(update={"messages": tuple(messages)}), pinned

--- a/exp/runtime/gateway/native_reasoning_test.py
+++ b/exp/runtime/gateway/native_reasoning_test.py
@@ -1,0 +1,97 @@
+"""Tests for native Fireworks continuation recovery and cleanup."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import ToolCall
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    OpaqueReasoningContentBlock,
+)
+from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.gateway.native_reasoning import (
+    strip_stale_reasoning_history,
+    unseal_reasoning_history,
+)
+from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
+
+
+def test_new_user_strips_stale_decrypted_fireworks_reasoning_before_mixed_routing() -> None:
+    """Stored plaintext never leaks into a later native Responses provider payload."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="first"),
+            GatewayMessage(
+                role="assistant",
+                content="calling",
+                provider_reasoning=(
+                    OpaqueReasoningContentBlock(
+                        route_sha256="f" * 64,
+                        content="private Fireworks state",
+                    ),
+                ),
+            ),
+            GatewayMessage(role="user", content="second"),
+        ),
+    )
+
+    prepared, pinned = unseal_reasoning_history(
+        cast("NativeGatewayComponents", object()),
+        cast("AuthorizationSnapshot", object()),
+        request,
+    )
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-sol",
+        prepared,
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+
+    assert pinned is None
+    assert prepared.messages[1].provider_reasoning == ()
+    items = cast("list[JsonObject]", payload["input"])
+    assert all("reasoning_content" not in str(item) for item in items)
+
+
+def test_guardrail_appended_user_recloses_decrypted_reasoning_path() -> None:
+    """A post-unseal user boundary strips plaintext before route pinning is reconsidered."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="first"),
+            GatewayMessage(
+                role="assistant",
+                tool_calls=(
+                    ToolCall(
+                        call_id="call-one",
+                        name="lookup",
+                        arguments={},
+                        raw_arguments="{}",
+                    ),
+                ),
+                provider_reasoning=(
+                    OpaqueReasoningContentBlock(
+                        route_sha256="f" * 64,
+                        content="private Fireworks state",
+                    ),
+                ),
+            ),
+            GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+            GatewayMessage(role="user", content="guardrail replacement appended this"),
+        ),
+    )
+
+    prepared = strip_stale_reasoning_history(request)
+
+    assert prepared.messages[1].provider_reasoning == ()
+    assert not any(
+        block.kind == "reasoning_content"
+        for message in prepared.messages
+        for block in message.provider_reasoning
+    )

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -25,6 +25,7 @@ from exp.runtime.gateway.contracts import (
     GatewayMessage,
     GatewayRequest,
 )
+from exp.runtime.gateway.reasoning_carrier import parse_reasoning_content_carrier
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.openai_protocol.state import (
     BoundedContinuationStore,
@@ -343,12 +344,20 @@ def remember_turn(
                 ),
             )
         )
+    raw_carrier = data.get("reasoning_content_carrier")
+    sealed_carrier = None
+    if raw_carrier is not None:
+        if not isinstance(raw_carrier, str):
+            raise ValueError("Responses reasoning carrier must be text")
+        sealed_carrier = parse_reasoning_content_carrier(raw_carrier)
     indexed_output = bool(encrypted or indexed_calls or message_outputs)
+    if sealed_carrier is not None and indexed_output:
+        raise ValueError("Responses reasoning carrier cannot mix with provider-indexed output")
     if text and indexed_output:
         raise ValueError(
             "Responses retained assistant text requires provider item identity and order"
         )
-    if not text and not unindexed_calls and not indexed_output:
+    if not text and not unindexed_calls and not indexed_output and sealed_carrier is None:
         return
 
     output_items: list[tuple[int, str, object]] = [
@@ -400,12 +409,13 @@ def remember_turn(
         else:
             segment_calls.append(cast(ToolCall, item))
     flush_segment()
-    if text or unindexed_calls:
+    if text or unindexed_calls or sealed_carrier is not None:
         retained_messages.append(
             GatewayMessage(
                 role="assistant",
                 content=text or None,
                 tool_calls=tuple(unindexed_calls),
+                provider_reasoning=(sealed_carrier,) if sealed_carrier is not None else (),
             )
         )
 

--- a/exp/runtime/gateway/native_responses_test.py
+++ b/exp/runtime/gateway/native_responses_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from typing import cast
 
 import pytest
@@ -15,6 +16,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
 )
 from exp.runtime.gateway.native_responses import ContinuationContext, remember_turn
+from exp.runtime.gateway.reasoning_carrier import FIREWORKS_REASONING_CONTENT_PREFIX
 from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
 from exp.runtime.openai_protocol.state import (
     BoundedContinuationStore,
@@ -44,6 +46,56 @@ def _context() -> ContinuationContext:
         response_id="response-one",
         messages=(),
     )
+
+
+def _carrier() -> str:
+    """Build one structurally valid sealed Fireworks carrier."""
+    deployment = base64.urlsafe_b64encode(b"fireworks-rung").rstrip(b"=").decode()
+    envelope = base64.urlsafe_b64encode(b"opaque-envelope").rstrip(b"=").decode()
+    return f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment}:{envelope}"
+
+
+def test_remember_turn_retains_the_sealed_responses_carrier() -> None:
+    """Server-side continuation storage never replaces the carrier with plaintext."""
+    store = BoundedContinuationStore()
+    context = _context()
+
+    remember_turn(
+        store,
+        context=context,
+        data={
+            "text": "",
+            "refusal": False,
+            "reasoning_content_carrier": _carrier(),
+            "tool_calls": [{"call_id": "call-one", "name": "lookup", "arguments": "{}"}],
+        },
+    )
+
+    state = store.resolve_now(
+        namespace=context.namespace,
+        previous_response_id=context.response_id,
+    )
+    message = state.messages[-1]
+    assert message.provider_reasoning[0].kind == "sealed_reasoning_content"
+    assert message.provider_reasoning[0].carrier == _carrier()
+
+
+def test_remember_turn_rejects_a_malformed_responses_carrier() -> None:
+    """Continuation storage rejects an unauthenticatable envelope."""
+    store = BoundedContinuationStore()
+    context = _context()
+
+    with pytest.raises(ValueError, match="carrier"):
+        remember_turn(
+            store,
+            context=context,
+            data={
+                "text": "",
+                "refusal": False,
+                "reasoning_content_carrier": "not-a-carrier",
+                "tool_calls": [{"call_id": "call-one", "name": "lookup", "arguments": "{}"}],
+            },
+        )
 
 
 def test_remember_turn_retains_openai_encrypted_reasoning_for_tool_continuation() -> None:

--- a/exp/runtime/gateway/reasoning_carrier.py
+++ b/exp/runtime/gateway/reasoning_carrier.py
@@ -1,0 +1,443 @@
+"""Authenticated Fireworks reasoning carriers bound to exact gateway authority."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pydantic import Field, ValidationError
+
+from exp.common.core.artifacts import (
+    ContractModel,
+    Sha256,
+    canonical_json_bytes,
+    sha256_bytes,
+    sha256_json,
+)
+from exp.common.models import ToolCall
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    GatewayMessage,
+    OpaqueReasoningContentBlock,
+    SealedReasoningContentBlock,
+)
+from exp.runtime.models.providers.base import GatewayWireProfile
+
+FIREWORKS_REASONING_CONTENT_PREFIX = "x-experiential-fireworks-reasoning-v2:"
+"""Public marker for a gateway-authenticated, caller-opaque Fireworks carrier."""
+
+MAXIMUM_REASONING_CONTENT_BYTES = 8 * 1024 * 1024
+"""Maximum decrypted provider reasoning retained for one tool continuation."""
+
+_MAXIMUM_CLAIMS_BYTES = MAXIMUM_REASONING_CONTENT_BYTES + 32 * 1024
+_MAXIMUM_ENVELOPE_BYTES = 12 + _MAXIMUM_CLAIMS_BYTES + 16
+MAXIMUM_REASONING_CARRIER_BYTES = 4 * ((_MAXIMUM_ENVELOPE_BYTES + 2) // 3) + 512
+"""Maximum caller-supplied carrier size before any base64 or AEAD work."""
+
+_NONCE_BYTES = 12
+_KEY_DERIVATION_DOMAIN = b"experiential/fireworks-reasoning-carrier/aes256gcm/v2\0"
+_CREDENTIAL_IDENTITY_DOMAIN = b"experiential/fireworks-reasoning-credential/v2\0"
+
+
+class ReasoningCarrierClaims(ContractModel):
+    """Authenticated plaintext held only while issuing or validating a carrier."""
+
+    schema_version: Literal[2] = 2
+    organization_id: str = Field(min_length=1, max_length=256)
+    identity_id: str = Field(min_length=1, max_length=256)
+    virtual_key_id: str = Field(min_length=1, max_length=256)
+    alias: str = Field(min_length=1, max_length=256)
+    alias_revision_id: str = Field(min_length=1, max_length=256)
+    catalog_sha256: Sha256
+    exact_model_id: str = Field(min_length=1, max_length=256)
+    pool_id: str = Field(min_length=1, max_length=256)
+    deployment_id: str = Field(min_length=1, max_length=256)
+    source_alias: str = Field(min_length=1, max_length=256)
+    provider: str = Field(min_length=1, max_length=128)
+    provider_model: str = Field(min_length=1, max_length=2_048)
+    model_revision: str | None = Field(default=None, max_length=256)
+    connection_id: str = Field(min_length=1, max_length=256)
+    connection_authority_sha256: Sha256
+    credential_identity_sha256: Sha256
+    reasoning_route_sha256: Sha256
+    issuing_request_id: str = Field(min_length=1, max_length=256)
+    issuing_route_depth: int = Field(ge=0)
+    issuing_history_sha256: Sha256
+    issuing_turn_sha256: Sha256
+    tool_call_ids: tuple[str, ...] = Field(min_length=1)
+    content: str = Field(min_length=1, max_length=MAXIMUM_REASONING_CONTENT_BYTES)
+
+
+@dataclass(frozen=True)
+class ReasoningCarrierAuthority:
+    """Exact route authority and ephemeral AEAD key for one Fireworks rung."""
+
+    organization_id: str
+    identity_id: str
+    virtual_key_id: str
+    alias: str
+    alias_revision_id: str
+    catalog_sha256: str
+    exact_model_id: str
+    pool_id: str
+    deployment_id: str
+    source_alias: str
+    provider: str
+    provider_model: str
+    model_revision: str | None
+    connection_id: str
+    connection_authority_sha256: str
+    credential_identity_sha256: str
+    reasoning_route_sha256: str
+    aead_key: bytes = field(repr=False)
+
+
+def parse_reasoning_content_carrier(value: str) -> SealedReasoningContentBlock:
+    """Validate one carrier's bounded public envelope without decrypting it."""
+    raw = _ascii_bytes(value)
+    if len(raw) > MAXIMUM_REASONING_CARRIER_BYTES or not value.startswith(
+        FIREWORKS_REASONING_CONTENT_PREFIX
+    ):
+        raise ValueError("reasoning_content is not a bounded gateway carrier")
+    encoded = value.removeprefix(FIREWORKS_REASONING_CONTENT_PREFIX)
+    deployment_text, separator, envelope_text = encoded.partition(":")
+    if not separator or not deployment_text or not envelope_text or ":" in envelope_text:
+        raise ValueError("reasoning_content is not a complete gateway carrier")
+    deployment_bytes = _decode_urlsafe(deployment_text, maximum_bytes=256)
+    try:
+        deployment_hint = deployment_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("reasoning_content has an invalid deployment hint") from exc
+    if not deployment_hint or len(deployment_hint) > 256:
+        raise ValueError("reasoning_content has an invalid deployment hint")
+    _decode_urlsafe(envelope_text, maximum_bytes=_MAXIMUM_ENVELOPE_BYTES)
+    return SealedReasoningContentBlock(carrier=value, deployment_hint=deployment_hint)
+
+
+def reasoning_carrier_authority(
+    *,
+    authorization: AuthorizationSnapshot,
+    exact_model_id: str,
+    pool_id: str,
+    deployment: ExactModelDeployment,
+    profile: GatewayWireProfile,
+) -> ReasoningCarrierAuthority | None:
+    """Derive one replica-stable Fireworks authority from resolved credential material."""
+    route_sha256 = profile.fireworks_reasoning_route_sha256
+    if route_sha256 is None:
+        return None
+    credential = _bearer_credential(profile.headers)
+    key_context = {
+        "schema_version": 2,
+        "organization_id": authorization.organization_id,
+        "identity_id": authorization.identity_id,
+        "virtual_key_id": authorization.virtual_key_id,
+        "alias": authorization.alias,
+        "alias_revision_id": authorization.alias_revision_id,
+        "catalog_sha256": authorization.catalog_sha256,
+        "exact_model_id": exact_model_id,
+        "pool_id": pool_id,
+        "deployment_id": deployment.deployment_id,
+        "source_alias": deployment.source_alias,
+        "provider": deployment.provider,
+        "provider_model": deployment.provider_model,
+        "model_revision": deployment.revision,
+        "connection_id": deployment.connection,
+        "connection_authority_sha256": deployment.connection_sha256,
+        "reasoning_route_sha256": route_sha256,
+    }
+    aead_key = hmac.new(
+        credential,
+        _KEY_DERIVATION_DOMAIN + canonical_json_bytes(key_context),
+        hashlib.sha256,
+    ).digest()
+    credential_identity = hmac.new(
+        aead_key,
+        _CREDENTIAL_IDENTITY_DOMAIN,
+        hashlib.sha256,
+    ).hexdigest()
+    return ReasoningCarrierAuthority(
+        organization_id=authorization.organization_id,
+        identity_id=authorization.identity_id,
+        virtual_key_id=authorization.virtual_key_id,
+        alias=authorization.alias,
+        alias_revision_id=authorization.alias_revision_id,
+        catalog_sha256=authorization.catalog_sha256,
+        exact_model_id=exact_model_id,
+        pool_id=pool_id,
+        deployment_id=deployment.deployment_id,
+        source_alias=deployment.source_alias,
+        provider=deployment.provider,
+        provider_model=deployment.provider_model,
+        model_revision=deployment.revision,
+        connection_id=deployment.connection,
+        connection_authority_sha256=deployment.connection_sha256,
+        credential_identity_sha256=credential_identity,
+        reasoning_route_sha256=route_sha256,
+        aead_key=aead_key,
+    )
+
+
+def seal_reasoning_content(
+    authority: ReasoningCarrierAuthority,
+    *,
+    issuing_request_id: str,
+    issuing_route_depth: int,
+    issuing_history_sha256: Sha256,
+    assistant_content: str | None,
+    tool_calls: tuple[ToolCall, ...],
+    content: str,
+) -> str:
+    """Seal provider reasoning for one exact issuing turn and waterfall rung."""
+    tool_call_ids = _require_tool_calls(tool_calls)
+    if issuing_route_depth < 0 or not issuing_request_id:
+        raise ValueError("reasoning carrier issuing identity is invalid")
+    if not content or len(content.encode("utf-8")) > MAXIMUM_REASONING_CONTENT_BYTES:
+        raise ValueError("reasoning content exceeds the authenticated carrier bound")
+    claims = ReasoningCarrierClaims.model_validate(
+        {
+            **_authority_claims(authority),
+            "issuing_request_id": issuing_request_id,
+            "issuing_route_depth": issuing_route_depth,
+            "issuing_history_sha256": issuing_history_sha256,
+            "issuing_turn_sha256": _issuing_turn_sha256(assistant_content, tool_calls),
+            "tool_call_ids": tool_call_ids,
+            "content": content,
+        }
+    )
+    plaintext = canonical_json_bytes(claims)
+    if len(plaintext) > _MAXIMUM_CLAIMS_BYTES:
+        raise ValueError("reasoning carrier claims exceed the authenticated bound")
+    deployment_text = _encode_urlsafe(authority.deployment_id.encode("utf-8"))
+    associated_data = _associated_data(deployment_text)
+    nonce = secrets.token_bytes(_NONCE_BYTES)
+    envelope = nonce + AESGCM(authority.aead_key).encrypt(nonce, plaintext, associated_data)
+    carrier = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment_text}:{_encode_urlsafe(envelope)}"
+    if len(carrier.encode("ascii")) > MAXIMUM_REASONING_CARRIER_BYTES:
+        raise ValueError("reasoning carrier exceeds the public envelope bound")
+    return carrier
+
+
+def unseal_reasoning_content(
+    block: SealedReasoningContentBlock,
+    authority: ReasoningCarrierAuthority,
+    *,
+    assistant_content: str | None,
+    tool_calls: tuple[ToolCall, ...],
+    history_prefix: tuple[GatewayMessage, ...] = (),
+) -> tuple[OpaqueReasoningContentBlock, ReasoningCarrierClaims]:
+    """Authenticate and decrypt one carrier against current exact authority."""
+    tool_call_ids = _require_tool_calls(tool_calls)
+    parsed = parse_reasoning_content_carrier(block.carrier)
+    if (
+        parsed.deployment_hint != block.deployment_hint
+        or block.deployment_hint != authority.deployment_id
+    ):
+        raise ValueError("reasoning carrier deployment differs from current authority")
+    encoded = block.carrier.removeprefix(FIREWORKS_REASONING_CONTENT_PREFIX)
+    deployment_text, _separator, envelope_text = encoded.partition(":")
+    envelope = _decode_urlsafe(envelope_text, maximum_bytes=_MAXIMUM_ENVELOPE_BYTES)
+    if len(envelope) <= _NONCE_BYTES + 16:
+        raise ValueError("reasoning carrier envelope is incomplete")
+    nonce = envelope[:_NONCE_BYTES]
+    ciphertext = envelope[_NONCE_BYTES:]
+    try:
+        plaintext = AESGCM(authority.aead_key).decrypt(
+            nonce,
+            ciphertext,
+            _associated_data(deployment_text),
+        )
+    except InvalidTag as exc:
+        raise ValueError("reasoning carrier authentication failed") from exc
+    if len(plaintext) > _MAXIMUM_CLAIMS_BYTES:
+        raise ValueError("reasoning carrier claims exceed the authenticated bound")
+    try:
+        claims = ReasoningCarrierClaims.model_validate(json.loads(plaintext))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValidationError) as exc:
+        raise ValueError("reasoning carrier claims are invalid") from exc
+    expected = _authority_claims(authority)
+    actual = claims.model_dump(
+        mode="json",
+        exclude={
+            "issuing_request_id",
+            "issuing_route_depth",
+            "issuing_history_sha256",
+            "issuing_turn_sha256",
+            "tool_call_ids",
+            "content",
+        },
+    )
+    if (
+        actual != expected
+        or claims.tool_call_ids != tool_call_ids
+        or claims.issuing_turn_sha256 != _issuing_turn_sha256(assistant_content, tool_calls)
+        or (
+            history_prefix
+            and claims.issuing_history_sha256 != reasoning_history_sha256(history_prefix)
+        )
+    ):
+        raise ValueError("reasoning carrier authority or tool-call identity changed")
+    if len(claims.content.encode("utf-8")) > MAXIMUM_REASONING_CONTENT_BYTES:
+        raise ValueError("reasoning content exceeds the authenticated carrier bound")
+    return (
+        OpaqueReasoningContentBlock(
+            route_sha256=claims.reasoning_route_sha256,
+            content=claims.content,
+            carrier_size_bytes=len(block.carrier.encode("ascii")),
+        ),
+        claims,
+    )
+
+
+def reasoning_history_sha256(messages: tuple[GatewayMessage, ...]) -> Sha256:
+    """Digest visible history plus authenticated provider reasoning state.
+
+    ``GatewayMessage`` excludes provider reasoning from ordinary public request and
+    artifact serialization. Carrier chaining is an internal authority boundary, so it
+    deliberately adds the normalized blocks back before hashing. A later carrier then
+    cannot be transplanted across two visually identical turns with different hidden state.
+    """
+    payload: list[dict[str, object]] = []
+    for message in messages:
+        item = message.model_dump(mode="json")
+        item["provider_reasoning"] = [
+            block.model_dump(mode="json") for block in message.provider_reasoning
+        ]
+        payload.append(item)
+    return sha256_json(payload)
+
+
+def parse_reasoning_carrier_tool_calls(value: object) -> tuple[ToolCall, ...]:
+    """Parse the native sealer's exact completed tool-call identities."""
+    if not isinstance(value, list):
+        raise ValueError("reasoning carrier tool calls must be an array")
+    tool_calls: list[ToolCall] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("reasoning carrier tool call must be an object")
+        call_id = item.get("call_id")
+        name = item.get("name")
+        raw_arguments = item.get("raw_arguments")
+        if (
+            not isinstance(call_id, str)
+            or not isinstance(name, str)
+            or not isinstance(raw_arguments, str)
+        ):
+            raise ValueError("reasoning carrier tool call has invalid field types")
+        arguments = json.loads(raw_arguments)
+        if not isinstance(arguments, dict):
+            raise ValueError("reasoning carrier tool arguments must be an object")
+        tool_calls.append(
+            ToolCall(
+                call_id=call_id,
+                name=name,
+                arguments=arguments,
+                raw_arguments=raw_arguments,
+            )
+        )
+    return tuple(tool_calls)
+
+
+def _authority_claims(authority: ReasoningCarrierAuthority) -> dict[str, object]:
+    """Return the canonical claim fields shared by issuance and verification."""
+    return {
+        "schema_version": 2,
+        "organization_id": authority.organization_id,
+        "identity_id": authority.identity_id,
+        "virtual_key_id": authority.virtual_key_id,
+        "alias": authority.alias,
+        "alias_revision_id": authority.alias_revision_id,
+        "catalog_sha256": authority.catalog_sha256,
+        "exact_model_id": authority.exact_model_id,
+        "pool_id": authority.pool_id,
+        "deployment_id": authority.deployment_id,
+        "source_alias": authority.source_alias,
+        "provider": authority.provider,
+        "provider_model": authority.provider_model,
+        "model_revision": authority.model_revision,
+        "connection_id": authority.connection_id,
+        "connection_authority_sha256": authority.connection_authority_sha256,
+        "credential_identity_sha256": authority.credential_identity_sha256,
+        "reasoning_route_sha256": authority.reasoning_route_sha256,
+    }
+
+
+def _bearer_credential(headers: Mapping[str, str]) -> bytes:
+    """Return one Fireworks bearer value without retaining its public prefix."""
+    values = [value for name, value in headers.items() if name.lower() == "authorization"]
+    if len(values) != 1 or not isinstance(values[0], str) or not values[0].startswith("Bearer "):
+        raise ValueError("Fireworks reasoning authority requires one bearer credential")
+    value = values[0].removeprefix("Bearer ").encode("utf-8")
+    if not value:
+        raise ValueError("Fireworks reasoning authority requires one bearer credential")
+    return value
+
+
+def _require_tool_calls(tool_calls: tuple[ToolCall, ...]) -> tuple[str, ...]:
+    """Require one ordered, unique tool-call set and return its IDs."""
+    tool_call_ids = tuple(call.call_id for call in tool_calls)
+    if not tool_call_ids or len(set(tool_call_ids)) != len(tool_call_ids):
+        raise ValueError("reasoning carrier tool-call IDs must be non-empty and unique")
+    return tool_call_ids
+
+
+def _issuing_turn_sha256(
+    assistant_content: str | None,
+    tool_calls: tuple[ToolCall, ...],
+) -> Sha256:
+    """Bind visible assistant text and every exact tool-call field."""
+    return sha256_json(
+        {
+            "assistant_content": assistant_content,
+            "tool_calls": [
+                {
+                    "call_id": call.call_id,
+                    "name": call.name,
+                    "arguments_sha256": sha256_bytes(call.arguments_json().encode("utf-8")),
+                }
+                for call in tool_calls
+            ],
+        }
+    )
+
+
+def _associated_data(deployment_text: str) -> bytes:
+    """Bind the public routing hint and carrier version against retagging."""
+    return f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment_text}".encode("ascii")
+
+
+def _ascii_bytes(value: str) -> bytes:
+    """Encode one public envelope without accepting Unicode lookalikes."""
+    try:
+        return value.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError("reasoning_content carrier must be ASCII") from exc
+
+
+def _encode_urlsafe(value: bytes) -> str:
+    """Return unpadded URL-safe base64."""
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _decode_urlsafe(value: str, *, maximum_bytes: int) -> bytes:
+    """Decode URL-safe base64 only after bounding its maximum output size."""
+    if not value or len(value) > 4 * ((maximum_bytes + 2) // 3):
+        raise ValueError("reasoning carrier component exceeds its decode bound")
+    padding = "=" * (-len(value) % 4)
+    try:
+        decoded = base64.b64decode(value + padding, altchars=b"-_", validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("reasoning carrier component is not valid base64") from exc
+    if len(decoded) > maximum_bytes or _encode_urlsafe(decoded) != value:
+        raise ValueError("reasoning carrier component is non-canonical or exceeds its bound")
+    return decoded

--- a/exp/runtime/gateway/reasoning_carrier_test.py
+++ b/exp/runtime/gateway/reasoning_carrier_test.py
@@ -1,0 +1,320 @@
+"""Authenticated Fireworks reasoning carrier security regressions."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import replace
+
+import pytest
+
+from exp.common.models import ToolCall
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    GatewayApiSurface,
+    GatewayMessage,
+    OpaqueReasoningContentBlock,
+)
+from exp.runtime.gateway.reasoning_carrier import (
+    FIREWORKS_REASONING_CONTENT_PREFIX,
+    MAXIMUM_REASONING_CARRIER_BYTES,
+    ReasoningCarrierAuthority,
+    parse_reasoning_content_carrier,
+    reasoning_carrier_authority,
+    reasoning_history_sha256,
+    seal_reasoning_content,
+    unseal_reasoning_content,
+)
+from exp.runtime.models.providers.base import GatewayWireProfile
+
+_ROUTE_SHA256 = "a" * 64
+_HISTORY_SHA256 = "e" * 64
+
+
+def _tool_calls(
+    *call_ids: str,
+    name: str = "lookup",
+    raw_arguments: str = '{"q":"x"}',
+) -> tuple[ToolCall, ...]:
+    """Build byte-exact tool identities echoed by one assistant turn."""
+    arguments = json.loads(raw_arguments)
+    assert isinstance(arguments, dict)
+    return tuple(
+        ToolCall(
+            call_id=call_id,
+            name=name,
+            arguments=arguments,
+            raw_arguments=raw_arguments,
+        )
+        for call_id in call_ids
+    )
+
+
+def _authorization(**updates: object) -> AuthorizationSnapshot:
+    """Build one exact tenant and alias authority."""
+    values: dict[str, object] = {
+        "request_id": "request-current",
+        "organization_id": "organization-one",
+        "identity_id": "identity-one",
+        "virtual_key_id": "key-one",
+        "alias": "deepseek-v4-flash",
+        "alias_revision_id": "alias-revision-one",
+        "target": DirectTarget(pool_id="pool-one"),
+        "surface": GatewayApiSurface.CHAT_COMPLETIONS,
+        "catalog_sha256": "b" * 64,
+        "canonical_request_sha256": "c" * 64,
+        "deadline_monotonic": 1.0,
+    }
+    values.update(updates)
+    return AuthorizationSnapshot.model_validate(values)
+
+
+def _deployment(**updates: object) -> ExactModelDeployment:
+    """Build one exact Fireworks deployment identity."""
+    values: dict[str, object] = {
+        "deployment_id": "fireworks-rung-one",
+        "source_alias": "fireworks-source",
+        "exact_model_id": "deepseek-exact",
+        "connection": "fireworks-connection",
+        "provider": "fireworks",
+        "provider_model": "accounts/fireworks/models/deepseek-v4-flash-0731",
+        "revision": "provider-revision-one",
+        "connection_sha256": "d" * 64,
+        "capabilities_sha256": "e" * 64,
+    }
+    values.update(updates)
+    return ExactModelDeployment.model_validate(values)
+
+
+def _authority(
+    *,
+    credential: str = "replica-shared-provider-secret",
+    authorization: AuthorizationSnapshot | None = None,
+    deployment: ExactModelDeployment | None = None,
+    route_sha256: str = _ROUTE_SHA256,
+) -> ReasoningCarrierAuthority:
+    """Derive one carrier authority from route and credential material."""
+    authority = reasoning_carrier_authority(
+        authorization=authorization or _authorization(),
+        exact_model_id="deepseek-exact",
+        pool_id="pool-one",
+        deployment=deployment or _deployment(),
+        profile=GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://api.fireworks.ai/inference/v1/chat/completions",
+            headers={"Authorization": f"Bearer {credential}"},
+            model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
+            fireworks_reasoning_route_sha256=route_sha256,
+        ),
+    )
+    assert authority is not None
+    return authority
+
+
+def test_carrier_round_trip_is_opaque_and_cross_replica_stable() -> None:
+    """Replicas sharing exact authority decrypt one byte-exact tool turn."""
+    issuer = _authority()
+    verifier = _authority()
+    content = "private provider reasoning with tenant data"
+    raw_arguments = '{ "q" : "x" }'
+    carrier = seal_reasoning_content(
+        issuer,
+        issuing_request_id="issuing-request",
+        issuing_route_depth=2,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="visible assistant text",
+        tool_calls=_tool_calls("call-one", raw_arguments=raw_arguments),
+        content=content,
+    )
+
+    assert content not in carrier
+    assert issuer.reasoning_route_sha256 not in carrier
+    assert "replica-shared-provider-secret" not in carrier
+    assert issuer.aead_key.hex() not in repr(issuer)
+    block, claims = unseal_reasoning_content(
+        parse_reasoning_content_carrier(carrier),
+        verifier,
+        assistant_content="visible assistant text",
+        tool_calls=_tool_calls("call-one", raw_arguments=raw_arguments),
+    )
+
+    assert block.content == content
+    assert block.carrier_size_bytes == len(carrier)
+    assert claims.issuing_request_id == "issuing-request"
+    assert claims.issuing_route_depth == 2
+    assert claims.issuing_history_sha256 == _HISTORY_SHA256
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        replace(_authority(), organization_id="organization-two"),
+        replace(_authority(), identity_id="identity-two"),
+        replace(_authority(), virtual_key_id="key-two"),
+        replace(_authority(), alias="other-alias"),
+        replace(_authority(), alias_revision_id="alias-revision-two"),
+        replace(_authority(), deployment_id="fireworks-rung-two"),
+        replace(_authority(), connection_authority_sha256="f" * 64),
+        _authority(credential="rotated-provider-secret"),
+        _authority(route_sha256="f" * 64),
+    ),
+)
+def test_carrier_rejects_cross_route_or_credential_authority(
+    changed: ReasoningCarrierAuthority,
+) -> None:
+    """Tenant, deployment, route, connection, and credential changes fail closed."""
+    carrier = seal_reasoning_content(
+        _authority(),
+        issuing_request_id="issuing-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content=None,
+        tool_calls=_tool_calls("call-one"),
+        content="hidden",
+    )
+    with pytest.raises(ValueError):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(carrier),
+            changed,
+            assistant_content=None,
+            tool_calls=_tool_calls("call-one"),
+        )
+
+
+def test_carrier_rejects_tampering_retagging_and_turn_changes() -> None:
+    """Envelope edits, public retagging, and turn changes cannot authenticate."""
+    authority = _authority()
+    carrier = seal_reasoning_content(
+        authority,
+        issuing_request_id="issuing-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="visible assistant text",
+        tool_calls=_tool_calls("call-one", raw_arguments='{ "q" : "x" }'),
+        content="hidden",
+    )
+    parsed = parse_reasoning_content_carrier(carrier)
+    deployment, envelope = carrier.removeprefix(FIREWORKS_REASONING_CONTENT_PREFIX).split(":", 1)
+    tampered_envelope = ("A" if envelope[0] != "A" else "B") + envelope[1:]
+    tampered = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment}:{tampered_envelope}"
+    retagged_deployment = base64.urlsafe_b64encode(b"fireworks-rung-two").rstrip(b"=").decode()
+    retagged = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{retagged_deployment}:{envelope}"
+
+    for candidate in (tampered, retagged):
+        with pytest.raises(ValueError):
+            unseal_reasoning_content(
+                parse_reasoning_content_carrier(candidate),
+                authority,
+                assistant_content="visible assistant text",
+                tool_calls=_tool_calls("call-one", raw_arguments='{ "q" : "x" }'),
+            )
+    with pytest.raises(ValueError):
+        unseal_reasoning_content(
+            parsed,
+            authority,
+            assistant_content="changed assistant text",
+            tool_calls=_tool_calls("call-one", raw_arguments='{ "q" : "x" }'),
+        )
+    with pytest.raises(ValueError):
+        unseal_reasoning_content(
+            parsed,
+            authority,
+            assistant_content="visible assistant text",
+            tool_calls=_tool_calls("call-one", raw_arguments='{"q":"x"}'),
+        )
+
+
+def test_carrier_decode_is_bounded_before_base64_or_aead_work() -> None:
+    """Malformed and oversized public envelopes fail at the bounded parser."""
+    with pytest.raises(ValueError):
+        parse_reasoning_content_carrier("raw provider reasoning")
+    with pytest.raises(ValueError):
+        parse_reasoning_content_carrier("x" * (MAXIMUM_REASONING_CARRIER_BYTES + 1))
+    carrier = seal_reasoning_content(
+        _authority(),
+        issuing_request_id="issuing-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content=None,
+        tool_calls=_tool_calls("call-one"),
+        content="hidden",
+    )
+    with pytest.raises(ValueError):
+        parse_reasoning_content_carrier(f"{carrier}=")
+
+
+def test_carrier_rejects_a_different_nonempty_conversation_prefix() -> None:
+    """A valid turn carrier cannot be transplanted beneath another user prompt."""
+    authority = _authority()
+    issuing_history = (GatewayMessage(role="user", content="original prompt"),)
+    carrier = seal_reasoning_content(
+        authority,
+        issuing_request_id="issuing-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=reasoning_history_sha256(issuing_history),
+        assistant_content=None,
+        tool_calls=_tool_calls("call-one"),
+        content="hidden",
+    )
+
+    with pytest.raises(ValueError, match="authority or tool-call identity changed"):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(carrier),
+            authority,
+            assistant_content=None,
+            tool_calls=_tool_calls("call-one"),
+            history_prefix=(GatewayMessage(role="user", content="different prompt"),),
+        )
+
+
+def test_later_carrier_binds_earlier_authenticated_reasoning() -> None:
+    """Visually identical prefixes with different hidden reasoning cannot be interchanged."""
+    authority = _authority()
+    visible = GatewayMessage(role="user", content="same prompt")
+    first_prefix = (
+        visible,
+        GatewayMessage(
+            role="assistant",
+            content="same answer",
+            provider_reasoning=(
+                OpaqueReasoningContentBlock(
+                    route_sha256=_ROUTE_SHA256,
+                    content="first hidden state",
+                ),
+            ),
+        ),
+    )
+    second_prefix = (
+        visible,
+        first_prefix[1].model_copy(
+            update={
+                "provider_reasoning": (
+                    OpaqueReasoningContentBlock(
+                        route_sha256=_ROUTE_SHA256,
+                        content="second hidden state",
+                    ),
+                )
+            }
+        ),
+    )
+    assert reasoning_history_sha256(first_prefix) != reasoning_history_sha256(second_prefix)
+    carrier = seal_reasoning_content(
+        authority,
+        issuing_request_id="later-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=reasoning_history_sha256(first_prefix),
+        assistant_content=None,
+        tool_calls=_tool_calls("call-later"),
+        content="later hidden state",
+    )
+
+    with pytest.raises(ValueError, match="authority or tool-call identity changed"):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(carrier),
+            authority,
+            assistant_content=None,
+            tool_calls=_tool_calls("call-later"),
+            history_prefix=second_prefix,
+        )

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -303,6 +303,72 @@ class CatalogRouteResolver:
             fallback_reason=None,
         )
 
+    def resolve_deployment_hint(
+        self,
+        authorization: AuthorizationSnapshot,
+        deployment_id: str,
+    ) -> GatewayRoute:
+        """Resolve one untrusted carrier hint only inside current alias authority."""
+        view = self._catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
+        if view is None:
+            raise GatewayRoutingError("authorized catalog snapshot is not active for this revision")
+        target = authorization.target
+        if isinstance(target, DirectTarget):
+            pools = (self._pool(view, target.pool_id),)
+        else:
+            if target.catalog_sha256 != authorization.catalog_sha256:
+                raise GatewayRoutingError(
+                    "project target catalog differs from authorized authority"
+                )
+            deployment = view.deployments.get(deployment_id)
+            if deployment is None:
+                raise GatewayRoutingError("reasoning carrier deployment identity is invalid")
+            self._authorize_project_deployment_hint(target, deployment)
+            pools = tuple(
+                pool for pool in view.catalog.pools if deployment_id in pool.deployment_ids
+            )
+        matching = tuple(pool for pool in pools if deployment_id in pool.deployment_ids)
+        if len(matching) != 1:
+            raise GatewayRoutingError("reasoning carrier deployment is not unambiguous")
+        pool = matching[0]
+        deployment = view.deployments.get(deployment_id)
+        if deployment is None or deployment.exact_model_id != pool.exact_model_id:
+            raise GatewayRoutingError("reasoning carrier deployment identity is invalid")
+        return GatewayRoute(
+            snapshot=ExecutionSnapshot(
+                authorization=authorization,
+                exact_model_id=pool.exact_model_id,
+                pool_id=pool.pool_id,
+                deployment_ids=(deployment_id,),
+            ),
+            deployment=deployment,
+            route_reason="reasoning_continuation",
+            fallback_reason=None,
+        )
+
+    def _authorize_project_deployment_hint(
+        self,
+        target: ProjectTarget,
+        deployment: ExactModelDeployment,
+    ) -> None:
+        """Require the loaded project resolver to authenticate candidate membership."""
+        resolver = self._project_resolver
+        authorize = (
+            None if resolver is None else getattr(resolver, "authorize_deployment_hint", None)
+        )
+        if not callable(authorize):
+            raise GatewayRoutingError(
+                "project resolver cannot authenticate reasoning continuation deployments"
+            )
+        try:
+            authorize(target=target, deployment=deployment)
+        except GatewayRoutingError:
+            raise
+        except Exception as exc:
+            raise GatewayRoutingError(
+                "project resolver rejected reasoning continuation deployment"
+            ) from exc
+
     async def _select_project(
         self,
         *,
@@ -665,6 +731,27 @@ class RouterProjectTargetResolver:
                 prepared=prepared,
             )
         return self._selection(target, decision)
+
+    def authorize_deployment_hint(
+        self,
+        *,
+        target: ProjectTarget,
+        deployment: ExactModelDeployment,
+    ) -> None:
+        """Require one hinted deployment to be a candidate of this activation."""
+        self._runtime(target)
+        exact_model_id = self._exact_models_by_alias.get(
+            (
+                target.project_ref,
+                target.activation_ref,
+                target.catalog_sha256,
+                deployment.source_alias,
+            )
+        )
+        if exact_model_id != deployment.exact_model_id:
+            raise GatewayRoutingError(
+                "reasoning continuation deployment is not a project activation candidate"
+            )
 
     def _runtime(self, target: ProjectTarget) -> RouterRuntime:
         """Return the loaded frozen runtime for one activation or fail closed."""

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -155,6 +155,9 @@ class GatewayWireProfile:
     sampling_requires_reasoning_none: bool = False
     """Whether sampling controls require an exact ``none`` reasoning effort."""
 
+    fireworks_reasoning_route_sha256: str | None = None
+    """Exact Fireworks route identity that authorizes opaque reasoning replay."""
+
     token_limit_key: ChatMaxTokensField = "max_tokens"
     """Wire field carrying the output-token ceiling on Chat Completions."""
 

--- a/exp/runtime/models/providers/fireworks.py
+++ b/exp/runtime/models/providers/fireworks.py
@@ -1,0 +1,152 @@
+"""Fireworks-specific opaque tool-continuation contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from urllib.parse import urlsplit
+
+from exp.common.core.artifacts import Sha256, sha256_json
+from exp.common.models import ModelSnapshot
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.models.providers.errors import ProviderParameterError
+
+
+def is_fireworks_base_url(base_url: str) -> bool:
+    """Return whether one endpoint is the exact public Fireworks inference root."""
+    parsed = urlsplit(base_url)
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname == "api.fireworks.ai"
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.port in {None, 443}
+        and parsed.path.rstrip("/") == "/inference/v1"
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def reasoning_content_route_sha256(model: ModelSnapshot) -> Sha256:
+    """Bind opaque reasoning to one exact provider model revision and connection."""
+    return sha256_json(
+        {
+            "schema_version": 1,
+            "provider": model.provider,
+            "model_id": model.model_id,
+            "revision": model.revision,
+            "connection_sha256": model.connection_sha256,
+        }
+    )
+
+
+def require_responses_continuation_channel(request: GatewayRequest) -> None:
+    """Reject tool-capable Fireworks Responses turns with no replay channel."""
+    if (
+        request.surface == GatewayApiSurface.RESPONSES
+        and request.tools
+        and request.tool_choice != "none"
+        and request.response_store is False
+        and not request.include_encrypted_reasoning
+    ):
+        raise ProviderParameterError(
+            message=(
+                "Fireworks tool continuations require either 'store: true' or "
+                "'include: [\"reasoning.encrypted_content\"]'."
+            ),
+            param="store",
+            code="unsupported_parameter",
+        )
+
+
+def prepare_gateway_reasoning_history(
+    messages: Sequence[GatewayMessage],
+    *,
+    route_sha256: Sha256 | None,
+) -> tuple[tuple[GatewayMessage, ...], bool]:
+    """Strip stale Fireworks reasoning and validate active tool history."""
+    last_user = max(
+        (index for index, message in enumerate(messages) if message.role == "user"),
+        default=-1,
+    )
+    active = False
+    prepared: list[GatewayMessage] = []
+    for index, message in enumerate(messages):
+        blocks = tuple(
+            block for block in message.provider_reasoning if block.kind == "reasoning_content"
+        )
+        keep = index > last_user
+        retained = tuple(
+            block
+            for block in message.provider_reasoning
+            if block.kind != "reasoning_content" or keep
+        )
+        if keep and blocks:
+            active = True
+            _require_active_carrier(message, blocks, route_sha256)
+        prepared.append(
+            message
+            if retained == message.provider_reasoning
+            else message.model_copy(update={"provider_reasoning": retained})
+        )
+    if active:
+        _require_complete_tool_results(prepared[last_user + 1 :])
+    return tuple(prepared), active
+
+
+def _reasoning_parameter_error(message: str) -> ProviderParameterError:
+    """Build one stable field-specific error for an unsafe replay."""
+    return ProviderParameterError(
+        message=message,
+        param="messages.reasoning_content",
+        code="invalid_parameter",
+    )
+
+
+def _require_active_carrier(
+    message: GatewayMessage,
+    blocks: tuple[object, ...],
+    route_sha256: Sha256 | None,
+) -> None:
+    """Require one route-matched carrier on an assistant tool-call message."""
+    if message.role != "assistant" or not message.tool_calls or len(blocks) != 1:
+        raise _reasoning_parameter_error(
+            "Active Fireworks reasoning_content requires one assistant tool-call carrier."
+        )
+    block = blocks[0]
+    if route_sha256 is None or getattr(block, "route_sha256", None) != route_sha256:
+        raise _reasoning_parameter_error(
+            "Fireworks reasoning_content belongs to a different provider route."
+        )
+
+
+def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
+    """Require exactly one result for every active assistant tool call."""
+    pending: set[str] = set()
+    active_call_ids: set[str] = set()
+    completed_call_ids: set[str] = set()
+    for message in messages:
+        if message.role == "assistant":
+            if pending:
+                raise _reasoning_parameter_error(
+                    "Fireworks reasoning_content tool calls need complete tool results."
+                )
+            if any(block.kind == "reasoning_content" for block in message.provider_reasoning):
+                call_ids = tuple(call.call_id for call in message.tool_calls)
+                if len(call_ids) != len(set(call_ids)) or active_call_ids.intersection(call_ids):
+                    raise _reasoning_parameter_error(
+                        "Fireworks reasoning_content tool-call IDs must be unique."
+                    )
+                pending = set(call_ids)
+                active_call_ids.update(call_ids)
+        elif message.role == "tool" and active_call_ids:
+            call_id = message.tool_call_id
+            if call_id not in active_call_ids or call_id in completed_call_ids:
+                raise _reasoning_parameter_error(
+                    "Fireworks reasoning_content requires exactly one result per tool call."
+                )
+            pending.remove(call_id)
+            completed_call_ids.add(call_id)
+    if pending or not messages or messages[-1].role != "tool":
+        raise _reasoning_parameter_error(
+            "Fireworks reasoning_content can replay only in a completed tool continuation."
+        )

--- a/exp/runtime/models/providers/fireworks_test.py
+++ b/exp/runtime/models/providers/fireworks_test.py
@@ -1,0 +1,199 @@
+"""Fireworks opaque tool-continuation contract regressions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from exp.common.models import ToolCall
+from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayToolDefinition,
+    OpaqueReasoningContentBlock,
+)
+from exp.runtime.models.providers.base import GatewayWireProfile
+from exp.runtime.models.providers.errors import ProviderParameterError
+from exp.runtime.models.providers.fireworks import (
+    prepare_gateway_reasoning_history,
+    require_responses_continuation_channel,
+)
+from exp.runtime.models.providers.streaming_requests import dialect_stream_payload
+
+_ROUTE_SHA256 = "a" * 64
+_OTHER_ROUTE_SHA256 = "b" * 64
+
+
+def _call(call_id: str = "call-one") -> ToolCall:
+    """Build one exact provider tool call."""
+    return ToolCall(
+        call_id=call_id,
+        name="lookup",
+        arguments={"q": "x"},
+        raw_arguments='{ "q" : "x" }',
+    )
+
+
+def _assistant(
+    *,
+    call_id: str = "call-one",
+    route_sha256: str = _ROUTE_SHA256,
+    content: str = "private Fireworks reasoning",
+) -> GatewayMessage:
+    """Build one carrier-bound assistant tool turn."""
+    return GatewayMessage(
+        role="assistant",
+        tool_calls=(_call(call_id),),
+        provider_reasoning=(
+            OpaqueReasoningContentBlock(
+                route_sha256=route_sha256,
+                content=content,
+            ),
+        ),
+    )
+
+
+def _profile(route_sha256: str | None = _ROUTE_SHA256) -> GatewayWireProfile:
+    """Build one Fireworks Chat wire profile."""
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://api.fireworks.ai/inference/v1/chat/completions",
+        headers={"Authorization": "Bearer test-secret"},
+        model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
+        fireworks_reasoning_route_sha256=route_sha256,
+    )
+
+
+@pytest.mark.parametrize(
+    ("store", "include_encrypted", "tool_choice"),
+    (
+        (True, False, "auto"),
+        (None, False, "required"),
+        (False, True, "auto"),
+        (False, False, "none"),
+    ),
+)
+def test_fireworks_responses_accepts_each_safe_continuation_shape(
+    store: bool | None,
+    include_encrypted: bool,
+    tool_choice: Literal["auto", "none", "required"],
+) -> None:
+    """Storage, an encrypted carrier, or disabled tools each make replay safe."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="Use a tool"),),
+        tools=(
+            GatewayToolDefinition(
+                name="lookup",
+                parameters={"type": "object"},
+            ),
+        ),
+        tool_choice=tool_choice,
+        response_store=store,
+        include_encrypted_reasoning=include_encrypted,
+    )
+
+    require_responses_continuation_channel(request)
+
+
+def test_fireworks_responses_rejects_tool_capable_turn_without_replay_channel() -> None:
+    """A stateless tool turn cannot expose a call without its authenticated carrier."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="Use a tool"),),
+        tools=(
+            GatewayToolDefinition(
+                name="lookup",
+                parameters={"type": "object"},
+            ),
+        ),
+        tool_choice="auto",
+        response_store=False,
+    )
+
+    with pytest.raises(ProviderParameterError) as raised:
+        require_responses_continuation_channel(request)
+    assert raised.value.param == "store"
+
+
+@pytest.mark.parametrize(
+    "surface",
+    (GatewayApiSurface.CHAT_COMPLETIONS, GatewayApiSurface.RESPONSES),
+)
+def test_chat_and_responses_continuations_replay_exact_reasoning_on_issuing_route(
+    surface: GatewayApiSurface,
+) -> None:
+    """Both public surfaces replay plaintext only on the authenticated Fireworks wire."""
+    request = GatewayRequest(
+        surface=surface,
+        messages=(
+            GatewayMessage(role="user", content="Use a tool"),
+            _assistant(),
+            GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+        ),
+    )
+
+    payload = dialect_stream_payload(_profile(), request)
+
+    assert payload["reasoning_history"] == "interleaved"
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assistant = messages[1]
+    assert isinstance(assistant, dict)
+    assert assistant["reasoning_content"] == "private Fireworks reasoning"
+    tool_calls = assistant["tool_calls"]
+    assert isinstance(tool_calls, list)
+    tool_call = tool_calls[0]
+    assert isinstance(tool_call, dict)
+    function = tool_call["function"]
+    assert isinstance(function, dict)
+    assert function["arguments"] == '{ "q" : "x" }'
+
+
+def test_active_continuation_rejects_cross_route_replay() -> None:
+    """An authenticated carrier cannot replay on a different Fireworks route."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="Use a tool"),
+            _assistant(route_sha256=_OTHER_ROUTE_SHA256),
+            GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+        ),
+    )
+
+    with pytest.raises(ProviderParameterError) as raised:
+        dialect_stream_payload(_profile(), request)
+    assert raised.value.param == "messages.reasoning_content"
+
+
+def test_stale_reasoning_is_stripped_at_the_next_user_boundary() -> None:
+    """A prior turn's carrier is stripped before a new user request."""
+    messages = (
+        GatewayMessage(role="user", content="First turn"),
+        _assistant(content="stale private reasoning"),
+        GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+        GatewayMessage(role="user", content="Second turn"),
+    )
+
+    prepared, active = prepare_gateway_reasoning_history(
+        messages,
+        route_sha256=_OTHER_ROUTE_SHA256,
+    )
+
+    assert not active
+    assert prepared[1].provider_reasoning == ()
+
+
+def test_active_reasoning_rejects_duplicate_tool_results() -> None:
+    """Every carrier-bound call must receive exactly one linked result."""
+    messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        _assistant(),
+        GatewayMessage(role="tool", content="first", tool_call_id="call-one"),
+        GatewayMessage(role="tool", content="duplicate", tool_call_id="call-one"),
+    )
+
+    with pytest.raises(ProviderParameterError, match="exactly one result"):
+        prepare_gateway_reasoning_history(messages, route_sha256=_ROUTE_SHA256)

--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -1,0 +1,70 @@
+"""Shared generation-parameter validation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from exp.runtime.models.providers.base import GatewayWireProfile
+from exp.runtime.models.providers.errors import ProviderParameterError
+from exp.runtime.models.providers.reasoning_compat import supported_reasoning_efforts
+
+
+def effective_profile_reasoning_effort(
+    profile: GatewayWireProfile,
+    requested_effort: str | None,
+) -> str | None:
+    """Return an explicit caller effort or one wire's required default."""
+    if requested_effort is not None:
+        return requested_effort
+    return profile.reasoning_effort if profile.reasoning_effort_required else None
+
+
+def profile_reasoning_efforts(profile: GatewayWireProfile) -> tuple[str, ...]:
+    """Return exact accepted efforts for one deployment wire profile."""
+    if not profile.supports_reasoning or profile.reasoning_wire_format == "none":
+        return ()
+    return supported_reasoning_efforts(
+        profile.model_id,
+        profile.reasoning_wire_format,
+        configured_effort=profile.reasoning_effort,
+        explicit_efforts=profile.supported_reasoning_efforts or None,
+    )
+
+
+def require_route_numeric_parameter(
+    profiles: Sequence[GatewayWireProfile],
+    *,
+    param: str,
+    value: float | int,
+    supported: Callable[[GatewayWireProfile], bool],
+    minimum: Callable[[GatewayWireProfile], float | int],
+    maximum: Callable[[GatewayWireProfile], float | int | None],
+) -> None:
+    """Require every waterfall rung to accept one exact numeric control."""
+    if not all(supported(profile) for profile in profiles):
+        raise ProviderParameterError(
+            message=(
+                f"The parameter {param!r} is not supported by this model route. "
+                "Remove the field or choose a different model."
+            ),
+            param=param,
+            code="unsupported_parameter",
+        )
+    route_minimum = max(minimum(profile) for profile in profiles)
+    maxima = tuple(bound for profile in profiles if (bound := maximum(profile)) is not None)
+    route_maximum = min(maxima) if maxima else None
+    if value >= route_minimum and (route_maximum is None or value <= route_maximum):
+        return
+    range_text = (
+        f"{route_minimum} or greater"
+        if route_maximum is None
+        else f"between {route_minimum} and {route_maximum}"
+    )
+    raise ProviderParameterError(
+        message=(
+            f"The value {value!r} for {param!r} is not supported by this model route. "
+            f"Supported values are {range_text}."
+        ),
+        param=param,
+        code="invalid_parameter",
+    )

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -40,6 +40,10 @@ from exp.runtime.models.providers.errors import (
     require_object,
     require_string,
 )
+from exp.runtime.models.providers.fireworks import (
+    is_fireworks_base_url,
+    reasoning_content_route_sha256,
+)
 from exp.runtime.models.providers.reasoning_compat import (
     openai_reasoning_effort,
     require_sampling_reasoning_compatibility,
@@ -302,6 +306,9 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         self._reasoning_effort = reasoning_effort
         self._token_limit_key: ChatMaxTokensField = chat_max_tokens_field or self.token_limit_key
         self._sampling_requires_reasoning_none = sampling_requires_reasoning_none
+        self._fireworks_reasoning_route_sha256 = (
+            reasoning_content_route_sha256(model) if is_fireworks_base_url(self._base_url) else None
+        )
 
     def gateway_wire_profile(self) -> GatewayWireProfile:
         """Return the Chat Completions wire profile for this connection."""
@@ -320,6 +327,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             reasoning_effort=self._reasoning_effort,
             token_limit_key=self._token_limit_key,
             sampling_requires_reasoning_none=self._sampling_requires_reasoning_none,
+            fireworks_reasoning_route_sha256=self._fireworks_reasoning_route_sha256,
         )
 
     def _completion_path(self) -> str:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -21,14 +21,26 @@ from exp.runtime.models.providers.errors import (
     ProviderResponseError,
     UnsupportedReasoningEffortError,
 )
+from exp.runtime.models.providers.fireworks import (
+    prepare_gateway_reasoning_history,
+    require_responses_continuation_channel,
+)
 from exp.runtime.models.providers.gemini_requests import gemini_generate_request
+from exp.runtime.models.providers.generation_parameter_validation import (
+    effective_profile_reasoning_effort as _effective_profile_reasoning_effort,
+)
+from exp.runtime.models.providers.generation_parameter_validation import (
+    profile_reasoning_efforts as _profile_reasoning_efforts,
+)
+from exp.runtime.models.providers.generation_parameter_validation import (
+    require_route_numeric_parameter as _require_route_numeric_parameter,
+)
 from exp.runtime.models.providers.reasoning_compat import (
     REASONING_EFFORTS,
     anthropic_adaptive_only_thinking,
     anthropic_reasoning_effort,
     openai_reasoning_effort,
     require_sampling_reasoning_compatibility,
-    supported_reasoning_efforts,
 )
 from exp.runtime.models.providers.wire_messages import (
     add_openai_tools,
@@ -83,7 +95,7 @@ def dialect_stream_payload(
             cannot preserve.
     """
     if _fireworks_continuation_required(profile, provider_request):
-        raise ProviderCapabilityError(capability="responses_fireworks_reasoning_continuation")
+        require_responses_continuation_channel(provider_request)
     required_reasoning_effort = (
         profile.reasoning_effort if profile.reasoning_effort_required else None
     )
@@ -147,6 +159,8 @@ def dialect_stream_payload(
             supports_logprobs=profile.supports_logprobs,
         )
     if profile.dialect == "openai_compatible":
+        if profile.fireworks_reasoning_route_sha256 is not None:
+            require_responses_continuation_channel(provider_request)
         return openai_compatible_stream_payload(
             profile.model_id,
             provider_request,
@@ -163,6 +177,7 @@ def dialect_stream_payload(
             reasoning_wire_format=profile.reasoning_wire_format,
             reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
+            fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")
 
@@ -195,15 +210,9 @@ def route_generation_parameter_requests(
     """
     if not profiles:
         raise ValueError("generation parameter shaping requires at least one wire profile")
-    if any(_fireworks_continuation_required(profile, request) for profile in profiles):
-        raise ProviderParameterError(
-            message=(
-                "Fireworks Responses tool continuations are unavailable on this route. Set "
-                "tool_choice to 'none' or choose another provider route."
-            ),
-            param="tool_choice",
-            code="unsupported_parameter",
-        )
+    for profile in profiles:
+        if _fireworks_continuation_required(profile, request):
+            require_responses_continuation_channel(request)
 
     ignored = list(request.ignored_parameters)
     provider_updates: dict[str, object] = {}
@@ -442,7 +451,7 @@ def route_generation_parameter_requests(
                 param="thinking.type",
                 code="unsupported_parameter",
             )
-    encrypted_reasoning_present = request.include_encrypted_reasoning or any(
+    encrypted_reasoning_present = any(
         block.kind == "encrypted_reasoning"
         for message in request.messages
         for block in message.provider_reasoning
@@ -455,6 +464,19 @@ def route_generation_parameter_requests(
                 "The parameter 'reasoning.encrypted_content' is not supported by this "
                 "model route. Remove encrypted reasoning or choose a native OpenAI "
                 "Responses-only route."
+            ),
+            param="include",
+            code="unsupported_parameter",
+        )
+    encrypted_reasoning_channel = request.include_encrypted_reasoning and (
+        all(profile.dialect == "openai_responses" for profile in profiles)
+        or all(profile.fireworks_reasoning_route_sha256 is not None for profile in profiles)
+    )
+    if request.include_encrypted_reasoning and not encrypted_reasoning_channel:
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'reasoning.encrypted_content' requires one homogeneous "
+                "native Responses or Fireworks reasoning-carrier route."
             ),
             param="include",
             code="unsupported_parameter",
@@ -536,67 +558,6 @@ def route_generation_parameter_requests(
     public_request = request.model_copy(update={"ignored_parameters": ignored_parameters})
     provider_request = public_request.model_copy(update=provider_updates)
     return public_request, provider_request
-
-
-def _effective_profile_reasoning_effort(
-    profile: GatewayWireProfile,
-    requested_effort: str | None,
-) -> str | None:
-    """Return an explicit caller effort or one wire's required default."""
-    if requested_effort is not None:
-        return requested_effort
-    return profile.reasoning_effort if profile.reasoning_effort_required else None
-
-
-def _profile_reasoning_efforts(profile: GatewayWireProfile) -> tuple[str, ...]:
-    """Return exact accepted efforts for one deployment wire profile."""
-    if not profile.supports_reasoning or profile.reasoning_wire_format == "none":
-        return ()
-    return supported_reasoning_efforts(
-        profile.model_id,
-        profile.reasoning_wire_format,
-        configured_effort=profile.reasoning_effort,
-        explicit_efforts=profile.supported_reasoning_efforts or None,
-    )
-
-
-def _require_route_numeric_parameter(
-    profiles: Sequence[GatewayWireProfile],
-    *,
-    param: str,
-    value: float | int,
-    supported: Callable[[GatewayWireProfile], bool],
-    minimum: Callable[[GatewayWireProfile], float | int],
-    maximum: Callable[[GatewayWireProfile], float | int | None],
-) -> None:
-    """Require every waterfall rung to accept one exact numeric control."""
-    if not all(supported(profile) for profile in profiles):
-        raise ProviderParameterError(
-            message=(
-                f"The parameter {param!r} is not supported by this model route. "
-                "Remove the field or choose a different model."
-            ),
-            param=param,
-            code="unsupported_parameter",
-        )
-    route_minimum = max(minimum(profile) for profile in profiles)
-    maxima = tuple(bound for profile in profiles if (bound := maximum(profile)) is not None)
-    route_maximum = min(maxima) if maxima else None
-    if value >= route_minimum and (route_maximum is None or value <= route_maximum):
-        return
-    range_text = (
-        f"{route_minimum} or greater"
-        if route_maximum is None
-        else f"between {route_minimum} and {route_maximum}"
-    )
-    raise ProviderParameterError(
-        message=(
-            f"The value {value!r} for {param!r} is not supported by this model route. "
-            f"Supported values are {range_text}."
-        ),
-        param=param,
-        code="invalid_parameter",
-    )
 
 
 def openai_responses_stream_payload(
@@ -933,6 +894,7 @@ def openai_compatible_stream_payload(
     reasoning_wire_format: str = "reasoning_effort",
     reasoning_effort: str | None = None,
     sampling_requires_reasoning_none: bool = False,
+    fireworks_reasoning_route_sha256: str | None = None,
 ) -> JsonObject:
     """Translate one canonical request to streaming Chat Completions JSON.
 
@@ -950,12 +912,24 @@ def openai_compatible_stream_payload(
     Returns:
         Chat Completions request that always asks the provider for terminal usage.
     """
+    messages, active_fireworks_reasoning = prepare_gateway_reasoning_history(
+        request.messages,
+        route_sha256=fireworks_reasoning_route_sha256,
+    )
     payload: JsonObject = {
         "model": model_id,
-        "messages": [openai_chat_message(message) for message in request.messages],
+        "messages": [
+            openai_chat_message(
+                message,
+                fireworks_reasoning_route_sha256=fireworks_reasoning_route_sha256,
+            )
+            for message in messages
+        ],
         "stream": True,
         "stream_options": {"include_usage": True},
     }
+    if active_fireworks_reasoning:
+        payload["reasoning_history"] = "interleaved"
     add_openai_tools(payload, request, responses=False)
     if request.parallel_tool_calls is not None:
         payload["parallel_tool_calls"] = request.parallel_tool_calls

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -17,7 +17,6 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
 from exp.runtime.models.providers.errors import (
-    ProviderCapabilityError,
     ProviderParameterError,
     UnsupportedReasoningEffortError,
 )
@@ -83,6 +82,7 @@ def _fireworks_profile() -> GatewayWireProfile:
         dialect="openai_compatible",
         url="https://api.fireworks.ai/inference/v1/chat/completions",
         model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
+        fireworks_reasoning_route_sha256="f" * 64,
     )
 
 
@@ -110,7 +110,7 @@ def test_fireworks_tools_that_can_run_require_continuation(
 
     with pytest.raises(ProviderParameterError, match="continuation"):
         route_generation_parameter_requests((profile,), request)
-    with pytest.raises(ProviderCapabilityError, match="reasoning_continuation"):
+    with pytest.raises(ProviderParameterError, match="continuation"):
         dialect_stream_payload(profile, request)
 
 
@@ -128,27 +128,26 @@ def test_fireworks_continuation_gate_accepts_no_tools() -> None:
     "update",
     ({"response_store": True}, {"include_encrypted_reasoning": True}),
 )
-def test_fireworks_unimplemented_continuation_channels_still_fail_closed(
+def test_fireworks_continuation_channels_are_accepted(
     update: dict[str, bool],
 ) -> None:
-    """Storage flags cannot claim retention before the carrier PR lands."""
+    """Server retention and encrypted carriers each provide a safe continuation channel."""
     profile = _fireworks_profile()
     request = _fireworks_responses_request().model_copy(update=update)
 
-    with pytest.raises(ProviderParameterError, match="unavailable"):
-        route_generation_parameter_requests((profile,), request)
+    route_generation_parameter_requests((profile,), request)
+    assert dialect_stream_payload(profile, request)["stream"] is True
 
 
-def test_fireworks_encrypted_reasoning_waits_for_the_authenticated_carrier() -> None:
-    """This small gate never claims the incompatible Chat wire preserves encrypted state."""
+def test_fireworks_encrypted_reasoning_uses_the_authenticated_carrier() -> None:
+    """Encrypted reasoning selects the authenticated gateway carrier channel."""
     profile = _fireworks_profile()
     request = _fireworks_responses_request().model_copy(
         update={"include_encrypted_reasoning": True}
     )
 
-    with pytest.raises(ProviderParameterError, match="unavailable") as raised:
-        route_generation_parameter_requests((profile,), request)
-    assert raised.value.param == "tool_choice"
+    route_generation_parameter_requests((profile,), request)
+    assert dialect_stream_payload(profile, request)["stream"] is True
 
 
 def test_openai_compatible_stream_payload_forwards_top_p_and_usage() -> None:
@@ -1529,6 +1528,55 @@ def test_route_rejects_encrypted_reasoning_outside_native_responses() -> None:
         route_generation_parameter_requests((responses, fallback), request)
     assert raised.value.param == "include"
     assert raised.value.code == "unsupported_parameter"
+
+
+def test_fireworks_stateless_carrier_include_survives_route_shaping() -> None:
+    """The gateway-issued Fireworks carrier is distinct from native OpenAI reasoning."""
+    fireworks = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://api.fireworks.ai/inference/v1/chat/completions",
+        model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
+        fireworks_reasoning_route_sha256="f" * 64,
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="use a tool"),),
+        tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
+        response_store=False,
+        include_encrypted_reasoning=True,
+        stream=True,
+        include_usage=True,
+    )
+
+    route_generation_parameter_requests((fireworks,), request)
+    payload = dialect_stream_payload(fireworks, request)
+
+    assert payload["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
+
+
+def test_mixed_native_and_fireworks_reasoning_channels_fail_closed() -> None:
+    """One include selector cannot promise two incompatible carrier authorities."""
+    responses = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://openai.test",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+    )
+    fireworks = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://api.fireworks.ai/inference/v1/chat/completions",
+        fireworks_reasoning_route_sha256="f" * 64,
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        response_store=False,
+        include_encrypted_reasoning=True,
+    )
+
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((responses, fireworks), request)
+    assert raised.value.param == "include"
 
 
 def test_gpt_56_efforts_match_the_provider_and_ultra_rejects_loud() -> None:

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -152,12 +152,12 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
     return "assistant", blocks
 
 
-def openai_chat_message(message: GatewayMessage) -> JsonObject:
+def openai_chat_message(
+    message: GatewayMessage,
+    *,
+    fireworks_reasoning_route_sha256: str | None = None,
+) -> JsonObject:
     """Translate one gateway message to OpenAI Chat wire JSON."""
-    if message.provider_reasoning:
-        # No Chat wire field can replay any reasoning carrier; route
-        # admission rejects the combination before dispatch.
-        raise ProviderResponseError("reasoning carriers cannot replay on the Chat wire")
     if message.role == "tool":
         return {
             "role": "tool",
@@ -174,6 +174,17 @@ def openai_chat_message(message: GatewayMessage) -> JsonObject:
             }
             for call in message.tool_calls
         ]
+    if message.provider_reasoning:
+        if len(message.provider_reasoning) != 1:
+            raise ProviderResponseError("Chat reasoning history requires exactly one carrier")
+        block = message.provider_reasoning[0]
+        if (
+            block.kind != "reasoning_content"
+            or fireworks_reasoning_route_sha256 is None
+            or block.route_sha256 != fireworks_reasoning_route_sha256
+        ):
+            raise ProviderResponseError("reasoning carrier belongs to a different Chat route")
+        payload["reasoning_content"] = block.content
     return payload
 
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -29,7 +29,13 @@ from exp.runtime.gateway.contracts import (
     GatewayNamedToolChoice,
     GatewayRequest,
     GatewayToolDefinition,
+    SealedReasoningContentBlock,
     StructuredTextFormat,
+)
+from exp.runtime.gateway.reasoning_carrier import (
+    FIREWORKS_REASONING_CONTENT_PREFIX,
+    MAXIMUM_REASONING_CARRIER_BYTES,
+    parse_reasoning_content_carrier,
 )
 from exp.runtime.openai_protocol.cache_control import (
     EphemeralCacheControl,
@@ -40,6 +46,13 @@ from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     RESPONSES_MANIFEST,
     disposition_map,
+)
+from exp.runtime.openai_protocol.responses_input import (
+    ReplayedFunctionCall,
+    ReplayedFunctionOutput,
+    ReplayedMessage,
+    ReplayedReasoning,
+    responses_input_messages,
 )
 
 _CHAT_OFFICIAL = TypeAdapter(CompletionCreateParams)
@@ -119,6 +132,10 @@ class _Message(_WireModel):
     annotations: tuple[()] | None = None
     audio: None = None
     function_call: None = None
+    reasoning_content: str | None = Field(
+        default=None,
+        max_length=MAXIMUM_REASONING_CARRIER_BYTES,
+    )
 
     @property
     def history_tool_calls(self) -> tuple[_AssistantToolCall, ...]:
@@ -136,6 +153,8 @@ class _Message(_WireModel):
             raise ValueError("tool_call_id is valid only for tool messages")
         if self.role != "assistant" and self.history_tool_calls:
             raise ValueError("tool_calls are valid only for assistant messages")
+        if self.role != "assistant" and self.reasoning_content is not None:
+            raise ValueError("reasoning_content is valid only for assistant messages")
         call_ids = tuple(call.id for call in self.history_tool_calls)
         if len(call_ids) != len(set(call_ids)):
             raise ValueError("assistant tool call IDs must be unique")
@@ -401,6 +420,24 @@ class _ResponsesRequest(_WireModel):
     prompt_cache_key: str | None = Field(default=None, max_length=1024)
 
 
+def _without_chat_reasoning_content(payload: JsonObject) -> JsonObject:
+    """Hide the authenticated Chat extension from official OpenAI validation."""
+    raw_messages = payload.get("messages")
+    if not isinstance(raw_messages, list):
+        return payload
+    changed = False
+    messages: list[JsonValue] = []
+    for raw_message in raw_messages:
+        if isinstance(raw_message, dict) and "reasoning_content" in raw_message:
+            messages.append(
+                {key: value for key, value in raw_message.items() if key != "reasoning_content"}
+            )
+            changed = True
+        else:
+            messages.append(raw_message)
+    return {**payload, "messages": messages} if changed else payload
+
+
 def decode_chat(
     payload: JsonObject,
     *,
@@ -429,7 +466,11 @@ def decode_chat(
     _validate_manifest(payload, CHAT_MANIFEST)
     # The installed SDK's effort literal lags the newest provider tier
     # ("ultra"), so the strict wire model owns reasoning validation.
-    _validate_official(_CHAT_OFFICIAL, payload, extension_fields={"top_k", "reasoning_effort"})
+    _validate_official(
+        _CHAT_OFFICIAL,
+        _without_chat_reasoning_content(payload),
+        extension_fields={"top_k", "reasoning_effort"},
+    )
     request = _validate_wire(_ChatRequest, payload)
     operation = _caller_operation(idempotency_key, client_request_id)
     maximum = request.max_completion_tokens or request.max_tokens
@@ -694,12 +735,20 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
             _tool_call(call, f"{prefix}.{message_index}.tool_calls.{call_index}.function.arguments")
             for call_index, call in enumerate(message.history_tool_calls)
         )
+        provider_reasoning: tuple[SealedReasoningContentBlock, ...] = ()
+        if message.reasoning_content is not None:
+            try:
+                provider_reasoning = (parse_reasoning_content_carrier(message.reasoning_content),)
+            except ValueError as exc:
+                param = f"{prefix}.{message_index}.reasoning_content"
+                raise invalid_field(param, f"'{param}' must be a gateway-issued carrier.") from exc
         converted.append(
             GatewayMessage(
                 role=message.role,
                 content=_content(message.content),
                 tool_call_id=message.tool_call_id,
                 tool_calls=calls,
+                provider_reasoning=provider_reasoning,
             )
         )
     return tuple(converted)
@@ -847,66 +896,38 @@ def _include_encrypted_reasoning(include: tuple[str, ...] | None) -> bool:
 def _response_input_messages(
     value: str | tuple[_ResponsesInputItem, ...],
 ) -> tuple[GatewayMessage, ...]:
-    """Convert Responses input items into ordered canonical history.
-
-    Provider output items retain their exact identities and indexes. Contiguous
-    function calls form one assistant turn so parallel calls and their leading
-    reasoning replay in the provider's original order.
-    """
+    """Validate replay details and reconstruct OpenAI or Fireworks history."""
     if isinstance(value, str):
-        return (GatewayMessage(role="user", content=value),)
-    messages: list[GatewayMessage] = []
-    pending_reasoning: list[EncryptedReasoningBlock] = []
-    pending_calls: list[ToolCall] = []
-
-    def take_reasoning(role: str) -> tuple[EncryptedReasoningBlock, ...]:
-        """Hand pending reasoning blocks to one assistant successor."""
-        if role != "assistant" or not pending_reasoning:
-            return ()
-        taken = tuple(pending_reasoning)
-        pending_reasoning.clear()
-        return taken
-
-    def flush_orphaned_reasoning() -> None:
-        """Emit reasoning that has no assistant successor as its own turn."""
-        if pending_reasoning:
-            messages.append(
-                GatewayMessage(role="assistant", provider_reasoning=take_reasoning("assistant"))
-            )
-
-    def flush_calls() -> None:
-        """Group contiguous function-call items into their one assistant turn."""
-        if pending_calls:
-            messages.append(
-                GatewayMessage(
-                    role="assistant",
-                    tool_calls=tuple(pending_calls),
-                    provider_reasoning=take_reasoning("assistant"),
-                )
-            )
-            pending_calls.clear()
-
+        return responses_input_messages(value)
+    replayed: list[
+        ReplayedReasoning | ReplayedMessage | ReplayedFunctionCall | ReplayedFunctionOutput
+    ] = []
     for index, item in enumerate(value):
         if isinstance(item, _ResponseReasoningItem):
-            flush_calls()
-            pending_reasoning.append(
-                EncryptedReasoningBlock(
+            if item.encrypted_content.startswith(FIREWORKS_REASONING_CONTENT_PREFIX):
+                try:
+                    block: EncryptedReasoningBlock | SealedReasoningContentBlock = (
+                        parse_reasoning_content_carrier(item.encrypted_content)
+                    )
+                except ValueError as exc:
+                    raise invalid_field(
+                        f"input.{index}.encrypted_content",
+                        "Responses encrypted_content must be a gateway-issued carrier.",
+                    ) from exc
+            else:
+                block = EncryptedReasoningBlock(
                     id=item.id,
                     encrypted_content=item.encrypted_content,
                     output_index=index,
                     status=item.status,
                 )
-            )
+            replayed.append(ReplayedReasoning(index=index, block=block))
         elif isinstance(item, _ResponseMessage):
-            flush_calls()
-            if item.role != "assistant":
-                flush_orphaned_reasoning()
             converted = _messages((item,), f"input.{index}")
             if converted and item.role == "assistant":
                 converted = (
                     converted[0].model_copy(
                         update={
-                            "provider_reasoning": take_reasoning("assistant"),
                             "provider_item_id": item.id,
                             "provider_output_index": index if item.id is not None else None,
                             "provider_status": item.status,
@@ -915,27 +936,26 @@ def _response_input_messages(
                     ),
                     *converted[1:],
                 )
-            messages.extend(converted)
+            replayed.append(ReplayedMessage(index=index, message=converted[0]))
         elif isinstance(item, _ResponseFunctionCall):
             wire_call = _AssistantToolCall(
                 id=item.call_id,
                 function=_FunctionCall(name=item.name, arguments=item.arguments),
             )
-            pending_calls.append(
-                _tool_call(wire_call, f"input.{index}.arguments").model_copy(
-                    update={
-                        "provider_item_id": item.id,
-                        "provider_output_index": index,
-                        "provider_status": item.status,
-                    }
+            replayed.append(
+                ReplayedFunctionCall(
+                    index=index,
+                    call=_tool_call(wire_call, f"input.{index}.arguments").model_copy(
+                        update={
+                            "provider_item_id": item.id,
+                            "provider_output_index": index,
+                            "provider_status": item.status,
+                        }
+                    ),
                 )
             )
         else:
-            flush_calls()
-            flush_orphaned_reasoning()
-            messages.append(
-                GatewayMessage(role="tool", content=item.output, tool_call_id=item.call_id)
+            replayed.append(
+                ReplayedFunctionOutput(index=index, call_id=item.call_id, output=item.output)
             )
-    flush_calls()
-    flush_orphaned_reasoning()
-    return tuple(messages)
+    return responses_input_messages(tuple(replayed))

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from collections.abc import Callable
 from typing import cast
 
@@ -9,6 +10,7 @@ import pytest
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayNamedToolChoice
+from exp.runtime.gateway.reasoning_carrier import FIREWORKS_REASONING_CONTENT_PREFIX
 from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.model_adapter import model_request
@@ -303,6 +305,100 @@ def test_chat_decoder_accepts_echoed_assistant_message_with_empty_sdk_fields() -
     assert decoded.request.messages[1].tool_calls[0].name == "weather"
     assert decoded.request.messages[3].content == "It is sunny."
     assert decoded.request.messages[3].tool_calls == ()
+
+
+def test_chat_decoder_preserves_only_a_gateway_issued_reasoning_carrier() -> None:
+    """A Fireworks continuation stays encrypted until authorized admission."""
+    deployment = base64.urlsafe_b64encode(b"fireworks-rung").rstrip(b"=").decode()
+    envelope = base64.urlsafe_b64encode(b"x" * 32).rstrip(b"=").decode()
+    carrier = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment}:{envelope}"
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "Use a tool"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": carrier,
+                    "tool_calls": [
+                        {
+                            "id": "call-one",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+            ],
+        }
+    )
+
+    block = decoded.request.messages[1].provider_reasoning[0]
+    assert block.kind == "sealed_reasoning_content"
+    assert block.carrier == carrier
+    assert block.deployment_hint == "fireworks-rung"
+    adapted = model_request(decoded.request)
+    assert adapted.messages[1].assistant_action is not None
+    assert "provider_reasoning" not in adapted.messages[1].assistant_action.model_dump()
+
+
+def test_chat_decoder_rejects_duplicate_assistant_tool_call_ids() -> None:
+    """Two active calls cannot share the result-linkage identity."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "first", "arguments": "{}"},
+                            },
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "second", "arguments": "{}"},
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+
+    assert captured.value.detail.param == "messages.0"
+
+
+@pytest.mark.parametrize(
+    "reasoning_content",
+    (
+        "raw provider reasoning",
+        FIREWORKS_REASONING_CONTENT_PREFIX,
+        f"{FIREWORKS_REASONING_CONTENT_PREFIX}not-base64:payload",
+    ),
+)
+def test_chat_decoder_rejects_unbound_or_malformed_reasoning_content(
+    reasoning_content: str,
+) -> None:
+    """Public Chat input accepts only a bounded gateway-issued carrier."""
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "x",
+                        "reasoning_content": reasoning_content,
+                    }
+                ],
+            }
+        )
+    assert raised.value.detail.param == "messages.0.reasoning_content"
 
 
 def test_chat_decoder_still_rejects_populated_unsupported_message_fields() -> None:
@@ -1001,6 +1097,79 @@ def test_responses_decoder_orders_function_calls_without_optional_item_ids() -> 
         '{ "position" : 1 }',
         '{"position":2}',
     ]
+
+
+@pytest.mark.parametrize("reasoning_first", [True, False])
+def test_responses_decoder_groups_fireworks_carrier_with_all_tool_calls(
+    reasoning_first: bool,
+) -> None:
+    """One carrier and contiguous calls reconstruct their exact assistant turn in any order."""
+    deployment = base64.urlsafe_b64encode(b"fireworks-rung").rstrip(b"=").decode()
+    envelope = base64.urlsafe_b64encode(b"x" * 32).rstrip(b"=").decode()
+    carrier = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment}:{envelope}"
+
+    reasoning = {
+        "type": "reasoning",
+        "id": "rs_fireworks",
+        "summary": [],
+        "encrypted_content": carrier,
+    }
+    message = {
+        "type": "message",
+        "role": "assistant",
+        "content": "I will check.",
+    }
+    assistant_items = [reasoning, message] if reasoning_first else [message, reasoning]
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "store": False,
+            "include": ["reasoning.encrypted_content"],
+            "input": [
+                *assistant_items,
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "first",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-2",
+                    "name": "second",
+                    "arguments": '{"value":2}',
+                },
+                {"type": "function_call_output", "call_id": "call-1", "output": "one"},
+                {"type": "function_call_output", "call_id": "call-2", "output": "two"},
+            ],
+        }
+    )
+
+    assistant = decoded.request.messages[0]
+    assert assistant.content == "I will check."
+    assert tuple(call.call_id for call in assistant.tool_calls) == ("call-1", "call-2")
+    assert assistant.provider_reasoning[0].kind == "sealed_reasoning_content"
+    assert assistant.provider_reasoning[0].carrier == carrier
+
+
+def test_responses_decoder_rejects_malformed_gateway_carrier() -> None:
+    """A carrier-prefixed item cannot fall back to native opaque replay."""
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_malformed",
+                        "summary": [],
+                        "encrypted_content": f"{FIREWORKS_REASONING_CONTENT_PREFIX}broken",
+                    }
+                ],
+            }
+        )
+
+    assert raised.value.detail.param == "input.0.encrypted_content"
 
 
 def test_responses_decoder_keeps_orphaned_reasoning_as_its_own_turn() -> None:

--- a/exp/runtime/openai_protocol/responses_input.py
+++ b/exp/runtime/openai_protocol/responses_input.py
@@ -1,0 +1,136 @@
+"""Reconstruct ordered canonical history from replayed Responses output items."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from exp.common.models import ToolCall
+from exp.runtime.gateway.contracts import (
+    EncryptedReasoningBlock,
+    GatewayMessage,
+    SealedReasoningContentBlock,
+)
+from exp.runtime.openai_protocol.errors import invalid_field
+
+
+@dataclass(frozen=True)
+class ReplayedReasoning:
+    """One validated provider reasoning item and its public input index."""
+
+    index: int
+    block: EncryptedReasoningBlock | SealedReasoningContentBlock
+
+
+@dataclass(frozen=True)
+class ReplayedMessage:
+    """One validated canonical Responses message item."""
+
+    index: int
+    message: GatewayMessage
+
+
+@dataclass(frozen=True)
+class ReplayedFunctionCall:
+    """One validated assistant function call."""
+
+    index: int
+    call: ToolCall
+
+
+@dataclass(frozen=True)
+class ReplayedFunctionOutput:
+    """One validated function result."""
+
+    index: int
+    call_id: str
+    output: str
+
+
+ReplayedInput = ReplayedReasoning | ReplayedMessage | ReplayedFunctionCall | ReplayedFunctionOutput
+
+
+def responses_input_messages(value: str | tuple[ReplayedInput, ...]) -> tuple[GatewayMessage, ...]:
+    """Convert replay items while keeping one Fireworks assistant segment indivisible.
+
+    Native Responses output indexes reflect the first observed provider delta, so a
+    Fireworks text item may appear before its reasoning carrier. The carrier authenticates
+    the complete assistant text and calls, therefore all contiguous assistant output items
+    are collected before reconstructing that turn instead of assuming reasoning is first.
+    """
+    if isinstance(value, str):
+        return (GatewayMessage(role="user", content=value),)
+    messages: list[GatewayMessage] = []
+    segment: list[ReplayedReasoning | ReplayedMessage | ReplayedFunctionCall] = []
+
+    def flush_segment() -> None:
+        """Emit one contiguous assistant segment without regrouping ordinary OpenAI items."""
+        if not segment:
+            return
+        reasoning = [item.block for item in segment if isinstance(item, ReplayedReasoning)]
+        if any(block.kind == "sealed_reasoning_content" for block in reasoning):
+            assistant_items = [item for item in segment if isinstance(item, ReplayedMessage)]
+            if len(assistant_items) > 1:
+                raise invalid_field(
+                    f"input.{assistant_items[1].index}",
+                    "A Fireworks continuation may contain only one assistant message item.",
+                )
+            content = assistant_items[0].message.content if assistant_items else None
+            calls = tuple(item.call for item in segment if isinstance(item, ReplayedFunctionCall))
+            messages.append(
+                GatewayMessage(
+                    role="assistant",
+                    content=content,
+                    tool_calls=calls,
+                    provider_reasoning=tuple(reasoning),
+                )
+            )
+            segment.clear()
+            return
+
+        pending: list[EncryptedReasoningBlock | SealedReasoningContentBlock] = []
+        pending_calls: list[ToolCall] = []
+
+        def flush_calls() -> None:
+            """Emit contiguous provider calls as one assistant turn."""
+            if not pending_calls:
+                return
+            messages.append(
+                GatewayMessage(
+                    role="assistant",
+                    tool_calls=tuple(pending_calls),
+                    provider_reasoning=tuple(pending),
+                )
+            )
+            pending.clear()
+            pending_calls.clear()
+
+        for item in segment:
+            if isinstance(item, ReplayedReasoning):
+                flush_calls()
+                pending.append(item.block)
+            elif isinstance(item, ReplayedMessage):
+                flush_calls()
+                messages.append(
+                    item.message.model_copy(update={"provider_reasoning": tuple(pending)})
+                )
+                pending.clear()
+            else:
+                pending_calls.append(item.call)
+        flush_calls()
+        if pending:
+            messages.append(GatewayMessage(role="assistant", provider_reasoning=tuple(pending)))
+        segment.clear()
+
+    for item in value:
+        if isinstance(item, ReplayedMessage) and item.message.role != "assistant":
+            flush_segment()
+            messages.append(item.message)
+        elif isinstance(item, ReplayedFunctionOutput):
+            flush_segment()
+            messages.append(
+                GatewayMessage(role="tool", content=item.output, tool_call_id=item.call_id)
+            )
+        else:
+            segment.append(item)
+    flush_segment()
+    return tuple(messages)

--- a/exp/runtime/openai_protocol/state_test.py
+++ b/exp/runtime/openai_protocol/state_test.py
@@ -11,6 +11,7 @@ from exp.runtime.gateway.contracts import (
     EncryptedReasoningBlock,
     GatewayApiSurface,
     GatewayMessage,
+    SealedReasoningContentBlock,
 )
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.state import (
@@ -309,3 +310,39 @@ def test_continuation_byte_cap_counts_excluded_provider_replay_authority() -> No
 
     with pytest.raises(OpenAIProtocolError, match="too large"):
         store.remember_now(namespace=_namespace(), response_id="resp_large", state=state)
+
+
+def test_continuation_size_counts_excluded_provider_carriers() -> None:
+    """Opaque carrier bytes cannot bypass the continuation store byte ceiling."""
+    small = ContinuationState(
+        episode_key="c" * 64,
+        messages=(
+            GatewayMessage(
+                role="assistant",
+                provider_reasoning=(
+                    SealedReasoningContentBlock(carrier="x", deployment_hint="rung"),
+                ),
+            ),
+        ),
+    )
+    large = small.model_copy(
+        update={
+            "messages": (
+                GatewayMessage(
+                    role="assistant",
+                    provider_reasoning=(
+                        SealedReasoningContentBlock(
+                            carrier="x" * 1_048_576,
+                            deployment_hint="rung",
+                        ),
+                    ),
+                ),
+            )
+        }
+    )
+
+    assert large.size_bytes - small.size_bytes >= 1_048_575
+    store = BoundedContinuationStore(byte_cap=small.size_bytes + 1_024)
+    store.remember_now(namespace=_namespace(), response_id="small", state=small)
+    with pytest.raises(OpenAIProtocolError, match="too large"):
+        store.remember_now(namespace=_namespace(), response_id="large", state=large)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.2,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.3,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -517,43 +517,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.2"
+version = "0.3.3"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
@@ -1447,7 +1447,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1486,7 +1486,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1498,7 +1498,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1528,9 +1528,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1542,7 +1542,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## Summary

- preserve opaque Fireworks `reasoning_content` across complete Chat and Responses tool-call continuations
- seal the carrier with authenticated encryption derived from the exact originating deployment and credential authority
- pin continuation to the authenticated route and reject tampered, stale, duplicate, cross-route, or cross-credential carriers
- fail closed when guardrails strip a carrier but retain its bound assistant/tool history

## Exact regressions

- complete Chat and Responses Fireworks tool-call round trips
- tampered and cross-route carrier rejection
- stale pre-latest-user carrier stripping before route/key resolution
- duplicate tool-result rejection
- guardrail carrier removal with surviving assistant/tool history rejection
- plaintext reasoning never persists in public continuation state

## Verification

- focused Python: 156 passed
- native Rust: 81 passed with no default features
- Ruff, rustfmt, lockfile, and diff checks: passed
- CI and exact-head Greptile review required before this is ready

## Supersedes from #639

Accounts for the Fireworks continuation carrier and follow-up hardening represented by `d3fcdeb6` and `fc64989b`, limited to authenticated reasoning continuation, route binding, native replay, and guardrail enforcement. It intentionally excludes Fireworks reasoning-effort catalog advertising, `tool_choice:none`, OpenAI Responses identity/order, Azure, Bedrock, and release/version changes.

No live Fireworks or production verification is claimed. Do not merge or enqueue without explicit approval.
