### PR TITLE
gateway: fix live Anthropic and OpenAI wire failures for tools, thinking, and echoes (P0)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -184,7 +184,11 @@ the same virtual key, and every failure on this surface is rendered in the Anthr
 envelope `{"type": "error", "error": {...}}`. The decoder translates text, `tool_use`,
 `tool_result`, `thinking`, and `redacted_thinking` blocks faithfully (thinking history rides an
 opaque provider-reasoning carrier with byte-exact signatures, and a caller `thinking`
-configuration is forwarded verbatim, overriding the catalog's adaptive default), requires
+configuration is forwarded verbatim on models that honor it, overriding the catalog's
+adaptive default; on the adaptive-only generation, which rejects `enabled`/`disabled`
+configs outright, an `enabled` config translates to adaptive with the dropped
+`thinking.budget_tokens` disclosed as ignored, and `disabled` is rejected by name
+because those models cannot turn thinking off), requires
 `max_tokens`, validates and drops `cache_control` (the gateway has no prompt-caching channel),
 and rejects image and document blocks loudly because the surface is text-only. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -124,16 +124,35 @@ fn optional_text(object: &Map<String, Value>, key: &str, label: &str) -> Result<
     }
 }
 
+/// Complete one streamed tool call, defaulting a zero-argument call to `{}`.
+///
+/// Providers legally stream no argument fragments (or a single empty one)
+/// for a call whose input is empty, so completion seeds the canonical empty
+/// object and emits the seeding fragment first, keeping every downstream
+/// byte verification consistent with what was streamed.
+fn complete_streamed_tool(
+    index: u32,
+    tool: &mut ToolAccumulator,
+    events: &mut Vec<Event>,
+) -> Result<(), Failure> {
+    tool.completed = true;
+    if tool.raw_arguments.is_empty() {
+        tool.raw_arguments.push_str("{}");
+        events.push(Event::ToolArgumentsDelta {
+            index,
+            delta: "{}".to_string(),
+        });
+    }
+    let call = tool.complete().map_err(|message| malformed(&message))?;
+    events.push(Event::ToolCallCompleted { index, call });
+    Ok(())
+}
+
 fn finish_open_tools(tools: &mut BTreeMap<u32, ToolAccumulator>) -> Result<Vec<Event>, Failure> {
     let mut events = Vec::new();
     for (index, tool) in tools.iter_mut() {
         if !tool.completed {
-            tool.completed = true;
-            let call = tool.complete().map_err(|message| malformed(&message))?;
-            events.push(Event::ToolCallCompleted {
-                index: *index,
-                call,
-            });
+            complete_streamed_tool(*index, tool, &mut events)?;
         }
     }
     Ok(events)

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -6,8 +6,8 @@
 use serde_json::Value;
 
 use super::{
-    finish_open_tools, malformed, optional_text, parse_object, provider_stream_failed,
-    refusal_failure, Normalizer,
+    complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
+    provider_stream_failed, refusal_failure, Normalizer,
 };
 use crate::errors::Failure;
 use crate::events::{
@@ -167,9 +167,7 @@ impl Normalizer {
                     .map_err(|message| malformed(&message))? as u32;
                 if let Some(tool) = self.tools.get_mut(&index) {
                     if !tool.completed {
-                        tool.completed = true;
-                        let call = tool.complete().map_err(|message| malformed(&message))?;
-                        events.push(Event::ToolCallCompleted { index, call });
+                        complete_streamed_tool(index, tool, &mut events)?;
                     }
                 }
             }

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -3,7 +3,7 @@
 
 use serde_json::{Map, Value};
 
-use super::{malformed, parse_object, refusal_failure, Normalizer};
+use super::{complete_streamed_tool, malformed, parse_object, refusal_failure, Normalizer};
 use crate::errors::{Failure, FailureClass};
 use crate::events::{bedrock_usage, require_string, require_u64, Event, ToolAccumulator};
 
@@ -154,11 +154,12 @@ impl Normalizer {
         let payload = parse_object(&frame.data)?;
         let index = require_u64(&payload, "contentBlockIndex", "Bedrock contentBlockIndex")
             .map_err(|message| malformed(&message))? as u32;
-        let Some(tool) = self.tools.remove(&index) else {
+        let Some(mut tool) = self.tools.remove(&index) else {
             return Ok(Vec::new());
         };
-        let call = tool.complete().map_err(|message| malformed(&message))?;
-        Ok(vec![Event::ToolCallCompleted { index, call }])
+        let mut events = Vec::new();
+        complete_streamed_tool(index, &mut tool, &mut events)?;
+        Ok(events)
     }
 
     /// Flush Bedrock usage and, once the stop reason is retained, terminate.

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -4,8 +4,8 @@
 use serde_json::Value;
 
 use super::{
-    finish_open_tools, malformed, optional_text, parse_object, provider_stream_failed,
-    refusal_failure, Normalizer,
+    complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
+    provider_stream_failed, refusal_failure, Normalizer,
 };
 use crate::errors::{Failure, FailureClass};
 use crate::events::{
@@ -206,9 +206,7 @@ impl Normalizer {
                         }
                     }
                     let tool = self.tools.get_mut(&index).expect("tool just checked");
-                    tool.completed = true;
-                    let call = tool.complete().map_err(|message| malformed(&message))?;
-                    events.push(Event::ToolCallCompleted { index, call });
+                    complete_streamed_tool(index, tool, &mut events)?;
                 }
             }
             "response.completed" | "response.incomplete" => {

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -520,3 +520,59 @@ def test_native_anthropic_normalizer_decodes_the_live_tool_use_wire() -> None:
     result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_TOOL_FRAMES)
     assert result["failure"] is None
     assert result["events"] == list(ANTHROPIC_LIVE_TOOL_EVENTS)
+
+
+# Captured live (2026-08-28, claude-haiku-4-5, ids neutralized): a
+# zero-argument tool call streams exactly one EMPTY input_json_delta and no
+# other fragments, so completion must default the accumulated arguments to
+# the canonical empty object instead of failing the stream as malformed.
+ANTHROPIC_LIVE_ZERO_ARG_FRAMES: tuple[bytes, ...] = (
+    b'event: message_start\ndata: {"type":"message_start","message":{"model":"claude-haiku-4-5",'
+    b'"id":"msg_fixture","type":"message","role":"assistant","content":[],"stop_reason":null,'
+    b'"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":550,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":21}}      }\n\n',
+    b'event: content_block_start\ndata: {"type":"content_block_start","index":0,'
+    b'"content_block":{"type":"tool_use","id":"toolu_fixture","name":"get_time",'
+    b'"input":{},"caller":{"type":"direct"}}      }\n\n',
+    b'event: ping\ndata: {"type": "ping"}\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":""}            }\n\n',
+    b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0     }\n\n',
+    b'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use",'
+    b'"stop_sequence":null,"stop_details":null},"usage":{"input_tokens":550,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":37}}\n\n',
+    b'event: message_stop\ndata: {"type":"message_stop"               }\n\n',
+)
+
+
+def test_native_anthropic_normalizer_completes_a_zero_argument_tool_call() -> None:
+    """The live zero-argument wire completes with {} instead of malforming.
+
+    Production incident (2026-08-28): every zero-argument tool (the shape
+    most coding agents ship) failed with malformed_response because the
+    accumulated raw arguments stayed empty.
+    """
+    result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_ZERO_ARG_FRAMES)
+    assert result["failure"] is None
+    assert result["events"] == [
+        {"kind": "tool_call_started", "index": 0, "call_id": "toolu_fixture", "name": "get_time"},
+        {"kind": "tool_arguments_delta", "index": 0, "text": ""},
+        # The completion-time seed streams before the completed call so every
+        # downstream byte verification matches the accumulated fragments.
+        {"kind": "tool_arguments_delta", "index": 0, "text": "{}"},
+        {
+            "kind": "tool_call_completed",
+            "index": 0,
+            "call_id": "toolu_fixture",
+            "name": "get_time",
+            "raw_arguments": "{}",
+        },
+        {
+            "kind": "usage",
+            "input_tokens": 550,
+            "output_tokens": 37,
+            "cached_input_tokens": 0,
+            "reasoning_tokens": None,
+        },
+        {"kind": "completed"},
+    ]

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -461,3 +461,62 @@ def test_native_anthropic_normalizer_emits_thinking_events() -> None:
     result = _native_normalized("anthropic_messages", ANTHROPIC_THINKING_CHUNKS)
     assert result["failure"] is None
     assert result["events"] == list(ANTHROPIC_THINKING_EVENTS)
+
+
+# Captured from a live api.anthropic.com tool_use stream (2026-08-28,
+# claude-haiku-4-5, ids neutralized): the real wire pads data lines with
+# trailing whitespace inside the JSON, opens tool_use blocks with a `caller`
+# object, nests a `cache_creation` breakdown in usage, carries
+# `stop_details`, and emits one empty leading `input_json_delta`.
+ANTHROPIC_LIVE_TOOL_FRAMES: tuple[bytes, ...] = (
+    b'event: message_start\ndata: {"type":"message_start","message":{"model":"claude-haiku-4-5",'
+    b'"id":"msg_fixture","type":"message","role":"assistant","content":[],"stop_reason":null,'
+    b'"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":663,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":'
+    b'{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,'
+    b'"service_tier":"standard","inference_geo":"not_available"}}       }\n\n',
+    b'event: content_block_start\ndata: {"type":"content_block_start","index":0,'
+    b'"content_block":{"type":"tool_use","id":"toolu_fixture","name":"get_weather",'
+    b'"input":{},"caller":{"type":"direct"}}     }\n\n',
+    b'event: ping\ndata: {"type": "ping"}\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":""}     }\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":"{\\"city\\""}   }\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":": \\"Paris\\"}"}           }\n\n',
+    b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0          }\n\n',
+    b'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use",'
+    b'"stop_sequence":null,"stop_details":null},"usage":{"input_tokens":663,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":33}  }\n\n',
+    b'event: message_stop\ndata: {"type":"message_stop"           }\n\n',
+)
+
+ANTHROPIC_LIVE_TOOL_EVENTS: tuple[JsonObject, ...] = (
+    {"kind": "tool_call_started", "index": 0, "call_id": "toolu_fixture", "name": "get_weather"},
+    {"kind": "tool_arguments_delta", "index": 0, "text": ""},
+    {"kind": "tool_arguments_delta", "index": 0, "text": '{"city"'},
+    {"kind": "tool_arguments_delta", "index": 0, "text": ': "Paris"}'},
+    {
+        "kind": "tool_call_completed",
+        "index": 0,
+        "call_id": "toolu_fixture",
+        "name": "get_weather",
+        "raw_arguments": '{"city": "Paris"}',
+    },
+    {
+        "kind": "usage",
+        "input_tokens": 663,
+        "output_tokens": 33,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": None,
+    },
+    {"kind": "completed"},
+)
+
+
+def test_native_anthropic_normalizer_decodes_the_live_tool_use_wire() -> None:
+    """The real captured tool_use wire decodes to the canonical event stream."""
+    result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_TOOL_FRAMES)
+    assert result["failure"] is None
+    assert result["events"] == list(ANTHROPIC_LIVE_TOOL_EVENTS)

--- a/exp/runtime/models/providers/anthropic.py
+++ b/exp/runtime/models/providers/anthropic.py
@@ -79,14 +79,15 @@ def anthropic_messages_request(
     if system_parts:
         payload["system"] = "\n\n".join(system_parts)
     if request.tools:
-        payload["tools"] = [
-            {
-                "name": tool.name,
-                "description": tool.description,
-                "input_schema": tool.input_schema,
-            }
-            for tool in request.tools
-        ]
+        tools: list[JsonObject] = []
+        for tool in request.tools:
+            translated: JsonObject = {"name": tool.name, "input_schema": tool.input_schema}
+            # Anthropic rejects an explicit null description ("Input should
+            # be a valid string"), so an absent description stays absent.
+            if tool.description is not None:
+                translated["description"] = tool.description
+            tools.append(translated)
+        payload["tools"] = tools
     if request.tool_choice is not None:
         payload["tool_choice"] = _anthropic_tool_choice(request.tool_choice)
     if request.temperature is not None and supports_temperature:

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -117,6 +117,37 @@ def supported_reasoning_efforts(
     return tuple(effort for effort in _EFFORT_ORDER if effort in supported)
 
 
+_ANTHROPIC_ADAPTIVE_ONLY_FAMILIES = (
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+)
+
+
+def anthropic_adaptive_only_thinking(model_id: str) -> bool:
+    """Return whether one Anthropic model accepts only adaptive thinking.
+
+    The adaptive-thinking generation (verified against the live API on
+    2026-08-28) rejects ``thinking.type.enabled`` and
+    ``thinking.type.disabled`` outright; earlier families (sonnet-4-6,
+    opus-4-6, haiku-4-5, and older) still honor the budgeted ``enabled``
+    form verbatim. The family list matches the xhigh effort generation.
+
+    Args:
+        model_id: Exact Anthropic model identifier.
+
+    Returns:
+        ``True`` when the model rejects caller thinking configs other than
+        adaptive.
+    """
+    normalized = _normalized_model(model_id)
+    return any(family in normalized for family in _ANTHROPIC_ADAPTIVE_ONLY_FAMILIES)
+
+
 def anthropic_reasoning_effort(model_id: str, effort: str) -> str:
     """Return one exact Anthropic effort or reject it before provider dispatch."""
     return _require_exact_effort(

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -213,9 +213,9 @@ def _openai_supported_efforts(model_id: str) -> Collection[str] | None:
     elif identity in {"gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro"}:
         supported = ("medium", "high", "xhigh")
     elif identity.startswith("gpt-5.6-"):
-        # The gpt-5.6 family is the first to document the "ultra" tier
-        # (Codex sends it by default at its highest setting).
-        supported = ("low", "medium", "high", "xhigh", "ultra")
+        # Provider-verified 2026-08-28: gpt-5.6-sol and gpt-5.6-codex accept
+        # exactly these seven and reject "ultra" by name.
+        supported = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
     elif identity in {
         "gpt-5.2",
         "gpt-5.4",

--- a/exp/runtime/models/providers/reasoning_compat_test.py
+++ b/exp/runtime/models/providers/reasoning_compat_test.py
@@ -53,8 +53,12 @@ def test_openai_reasoning_efforts_follow_exact_model_tables() -> None:
     with pytest.raises(UnsupportedReasoningEffortError):
         openai_reasoning_effort("gpt-5.2-pro", "low")
     assert openai_reasoning_effort("gpt-5.4-pro-2026-03-05", "xhigh") == "xhigh"
+    # Provider-verified 2026-08-28: the gpt-5.6 family accepts the full
+    # seven-effort ladder (and rejects "ultra" by name).
+    assert openai_reasoning_effort("gpt-5.6-sol", "minimal") == "minimal"
+    assert openai_reasoning_effort("gpt-5.6-sol", "max") == "max"
     with pytest.raises(UnsupportedReasoningEffortError):
-        openai_reasoning_effort("gpt-5.6-sol", "minimal")
+        openai_reasoning_effort("gpt-5.6-sol", "ultra")
     with pytest.raises(UnsupportedReasoningEffortError):
         openai_reasoning_effort("gpt-5.5", "minimal")
     with pytest.raises(UnsupportedReasoningEffortError):

--- a/exp/runtime/models/providers/reasoning_compat_test.py
+++ b/exp/runtime/models/providers/reasoning_compat_test.py
@@ -123,3 +123,22 @@ def test_default_effort_is_always_valid_for_the_exact_model() -> None:
     assert default_reasoning_effort("gpt-5-pro", "openai_responses") == "high"
     assert default_reasoning_effort("gemini-3-pro-preview", "gemini_thinking") == "high"
     assert default_reasoning_effort("vendor/reasoner", "reasoning") == "medium"
+
+
+def test_adaptive_only_thinking_families_match_the_live_api_boundary() -> None:
+    """The adaptive-only set was verified against the live API on 2026-08-28:
+    the xhigh generation rejects thinking.type.enabled while the 4.6/4.5 line
+    still honors budgeted thinking verbatim."""
+    from exp.runtime.models.providers.reasoning_compat import anthropic_adaptive_only_thinking
+
+    for model in (
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4.7",
+        "claude-sonnet-5",
+    ):
+        assert anthropic_adaptive_only_thinking(model), model
+    for model in ("claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5", "claude-haiku-4.5"):
+        assert not anthropic_adaptive_only_thinking(model), model

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -386,10 +386,13 @@ def route_generation_parameter_requests(
             anthropic_adaptive_only_thinking(profile.model_id) for profile in profiles
         )
         if adaptive_only and config_type == "enabled":
-            # Translate to the model's one supported mode. The token budget
-            # has no adaptive equivalent, so it is disclosed as ignored
-            # rather than silently mapped onto an effort level.
-            ignore("provider_thinking_config", "thinking.budget_tokens")
+            # Translate to the model's one supported mode, emitted explicitly
+            # so the promise holds even on routes with no pinned effort. The
+            # token budget has no adaptive equivalent, so it is disclosed as
+            # ignored rather than silently mapped onto an effort level.
+            provider_updates["provider_thinking_config"] = {"type": "adaptive"}
+            if "thinking.budget_tokens" not in ignored:
+                ignored.append("thinking.budget_tokens")
             _logger.warning(
                 "translated a caller 'enabled' thinking config to adaptive for an "
                 "adaptive-only Anthropic route; thinking.budget_tokens was disclosed "
@@ -751,8 +754,18 @@ def anthropic_messages_stream_payload(
     if request.provider_thinking_config is not None:
         # The caller's exact thinking configuration wins over the catalog's
         # adaptive default and travels verbatim, so budget semantics are
-        # never reinterpreted by the gateway.
+        # never reinterpreted by the gateway. An adaptive config (caller-sent
+        # or route-translated) still composes with the route's pinned effort,
+        # exactly like a request that carried no thinking config.
         payload["thinking"] = request.provider_thinking_config
+        if (
+            request.provider_thinking_config.get("type") == "adaptive"
+            and supports_reasoning
+            and effective_reasoning_effort is not None
+        ):
+            output_config["effort"] = anthropic_reasoning_effort(
+                model_id, effective_reasoning_effort
+            )
     elif supports_reasoning and effective_reasoning_effort is not None:
         payload["thinking"] = {"type": "adaptive"}
         output_config["effort"] = anthropic_reasoning_effort(model_id, effective_reasoning_effort)

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,7 @@ from exp.runtime.models.providers.errors import (
 from exp.runtime.models.providers.gemini_requests import gemini_generate_request
 from exp.runtime.models.providers.reasoning_compat import (
     REASONING_EFFORTS,
+    anthropic_adaptive_only_thinking,
     anthropic_reasoning_effort,
     openai_reasoning_effort,
     require_sampling_reasoning_compatibility,
@@ -36,6 +38,8 @@ from exp.runtime.openai_protocol.model_adapter import model_request as gateway_m
 
 if TYPE_CHECKING:
     from exp.runtime.models.providers.base import GatewayWireProfile
+
+_logger = logging.getLogger(__name__)
 
 _ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT = 4096
 GATEWAY_GENERATION_PARAMETER_CONTRACT_VERSION = 2
@@ -373,6 +377,34 @@ def route_generation_parameter_requests(
             param="thinking",
             code="unsupported_parameter",
         )
+    if request.provider_thinking_config is not None:
+        # The adaptive-thinking generation rejects caller enabled/disabled
+        # configs outright, so verbatim forwarding is family-gated (a route
+        # is one exact-model pool, so the answer is uniform across rungs).
+        config_type = str(request.provider_thinking_config.get("type"))
+        adaptive_only = all(
+            anthropic_adaptive_only_thinking(profile.model_id) for profile in profiles
+        )
+        if adaptive_only and config_type == "enabled":
+            # Translate to the model's one supported mode. The token budget
+            # has no adaptive equivalent, so it is disclosed as ignored
+            # rather than silently mapped onto an effort level.
+            ignore("provider_thinking_config", "thinking.budget_tokens")
+            _logger.warning(
+                "translated a caller 'enabled' thinking config to adaptive for an "
+                "adaptive-only Anthropic route; thinking.budget_tokens was disclosed "
+                "as ignored"
+            )
+        elif adaptive_only and config_type == "disabled":
+            raise ProviderParameterError(
+                message=(
+                    "The parameter 'thinking.type' cannot be 'disabled' on this model: "
+                    "it always reasons adaptively. Remove the thinking field or choose "
+                    "a model that supports disabling thinking."
+                ),
+                param="thinking.type",
+                code="unsupported_parameter",
+            )
     encrypted_reasoning_present = request.include_encrypted_reasoning or any(
         block.kind == "encrypted_reasoning"
         for message in request.messages
@@ -686,9 +718,12 @@ def anthropic_messages_stream_payload(
         for tool in request.tools:
             translated: JsonObject = {
                 "name": tool.name,
-                "description": tool.description,
                 "input_schema": tool.parameters,
             }
+            # Anthropic rejects an explicit null description ("Input should
+            # be a valid string"), so an absent description stays absent.
+            if tool.description is not None:
+                translated["description"] = tool.description
             if tool.strict:
                 translated["strict"] = True
             tools.append(translated)

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1519,7 +1519,7 @@ def test_enabled_thinking_translates_to_adaptive_on_adaptive_only_models() -> No
         (_anthropic_profile("claude-fable-5"),), request
     )
     assert "thinking.budget_tokens" in public.ignored_parameters
-    assert provider.provider_thinking_config is None
+    assert provider.provider_thinking_config == {"type": "adaptive"}
     payload = anthropic_messages_stream_payload(
         "claude-fable-5",
         provider,
@@ -1528,6 +1528,11 @@ def test_enabled_thinking_translates_to_adaptive_on_adaptive_only_models() -> No
     )
     assert payload["thinking"] == {"type": "adaptive"}
     assert payload["output_config"] == {"effort": "medium"}
+    # The translation stays explicit on routes that pin no effort, so the
+    # caller's request to think never degrades to an implicit provider default.
+    bare = anthropic_messages_stream_payload("claude-fable-5", provider)
+    assert bare["thinking"] == {"type": "adaptive"}
+    assert "output_config" not in bare
 
 
 def test_enabled_thinking_stays_verbatim_on_budget_capable_models() -> None:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -5,6 +5,7 @@ from typing import cast
 import pytest
 
 from exp.common.core.artifacts import JsonObject
+from exp.common.models.model import ReasoningEffort
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
@@ -380,7 +381,7 @@ def test_route_rejects_an_unsupported_configured_effort_without_clamping() -> No
                     model_id="gpt-5.6-sol",
                     supports_reasoning=True,
                     reasoning_wire_format="openai_responses",
-                    reasoning_effort="minimal",
+                    reasoning_effort="ultra",
                     reasoning_effort_required=True,
                 ),
             ),
@@ -388,7 +389,9 @@ def test_route_rejects_an_unsupported_configured_effort_without_clamping() -> No
         )
 
     assert raised.value.param == "reasoning_effort"
-    assert "Supported values: 'low', 'medium', 'high', 'xhigh'" in str(raised.value)
+    assert "Supported values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'" in str(
+        raised.value
+    )
 
 
 def test_route_preserves_each_required_reasoning_default_across_fallbacks() -> None:
@@ -1387,13 +1390,14 @@ def test_route_rejects_encrypted_reasoning_outside_native_responses() -> None:
     assert raised.value.code == "unsupported_parameter"
 
 
-def test_ultra_effort_is_admitted_only_where_the_family_documents_it() -> None:
-    """The gpt-5.6 family accepts ultra; other routes reject it before dispatch."""
-    request = GatewayRequest(
-        surface=GatewayApiSurface.RESPONSES,
-        messages=(GatewayMessage(role="user", content="go"),),
-        reasoning_effort="ultra",
-    )
+def test_gpt_56_efforts_match_the_provider_and_ultra_rejects_loud() -> None:
+    """The gpt-5.6 family accepts the provider-verified seven efforts.
+
+    Live check 2026-08-28: gpt-5.6-sol and gpt-5.6-codex reject "ultra" by
+    name and accept none through xhigh plus max, so admission mirrors the
+    provider exactly: decode still accepts the token, and the route rejects
+    it with the supported list before any dispatch.
+    """
     codex = GatewayWireProfile(
         dialect="openai_responses",
         url="https://openai.test",
@@ -1401,24 +1405,29 @@ def test_ultra_effort_is_admitted_only_where_the_family_documents_it() -> None:
         supports_reasoning=True,
         reasoning_wire_format="openai_responses",
     )
-    route_generation_parameter_requests((codex,), request)
+
+    def request_with(effort: str) -> GatewayRequest:
+        """Build one Responses request carrying the given effort."""
+        return GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(GatewayMessage(role="user", content="go"),),
+            reasoning_effort=cast("ReasoningEffort", effort),
+        )
+
+    max_request = request_with("max")
+    route_generation_parameter_requests((codex,), max_request)
     payload = openai_responses_stream_payload(
         "gpt-5.6-sol",
-        request,
+        max_request,
         supports_temperature=True,
         supports_reasoning=True,
     )
-    assert payload["reasoning"] == {"effort": "ultra"}
+    assert payload["reasoning"] == {"effort": "max"}
 
-    older = GatewayWireProfile(
-        dialect="openai_responses",
-        url="https://openai.test",
-        model_id="gpt-5.2",
-        supports_reasoning=True,
-        reasoning_wire_format="openai_responses",
-    )
-    with pytest.raises(UnsupportedReasoningEffortError):
-        route_generation_parameter_requests((older,), request)
+    with pytest.raises(UnsupportedReasoningEffortError) as raised:
+        route_generation_parameter_requests((codex,), request_with("ultra"))
+    assert "'ultra'" in str(raised.value)
+    assert "'max'" in str(raised.value)
 
 
 def test_reasoning_context_passes_through_verbatim_and_narrows_per_rung() -> None:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1460,3 +1460,106 @@ def test_reasoning_context_passes_through_verbatim_and_narrows_per_rung() -> Non
         route_generation_parameter_requests((fallback,), request)
     assert raised.value.param == "reasoning.context"
     assert raised.value.code == "unsupported_parameter"
+
+
+def test_anthropic_tools_omit_an_absent_description() -> None:
+    """Anthropic 400s an explicit null description, so the key stays absent.
+
+    Live repro (2026-08-28): a tool without a description produced
+    "tools.0.custom.description: Input should be a valid string" and every
+    tools request on the route failed before streaming.
+    """
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        tools=(
+            GatewayToolDefinition(name="bare", parameters={"type": "object"}),
+            GatewayToolDefinition(
+                name="described", description="Look up.", parameters={"type": "object"}
+            ),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    tools = cast(list[JsonObject], payload["tools"])
+    assert "description" not in tools[0]
+    assert tools[1]["description"] == "Look up."
+
+
+def _thinking_config_request(config: JsonObject) -> GatewayRequest:
+    """Build one Messages request carrying a verbatim thinking config."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        provider_thinking_config=config,
+        stream=True,
+        include_usage=True,
+    )
+
+
+def _anthropic_profile(model_id: str) -> GatewayWireProfile:
+    """Build one reasoning-capable Anthropic wire profile."""
+    return GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        model_id=model_id,
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+        reasoning_effort="medium",
+    )
+
+
+def test_enabled_thinking_translates_to_adaptive_on_adaptive_only_models() -> None:
+    """The adaptive-only generation rejects caller enabled configs, so the
+    route translates to adaptive and DISCLOSES the dropped token budget
+    instead of silently mapping or silently failing."""
+    request = _thinking_config_request({"type": "enabled", "budget_tokens": 2048})
+    public, provider = route_generation_parameter_requests(
+        (_anthropic_profile("claude-fable-5"),), request
+    )
+    assert "thinking.budget_tokens" in public.ignored_parameters
+    assert provider.provider_thinking_config is None
+    payload = anthropic_messages_stream_payload(
+        "claude-fable-5",
+        provider,
+        supports_reasoning=True,
+        reasoning_effort="medium",
+    )
+    assert payload["thinking"] == {"type": "adaptive"}
+    assert payload["output_config"] == {"effort": "medium"}
+
+
+def test_enabled_thinking_stays_verbatim_on_budget_capable_models() -> None:
+    """The pre-adaptive generation still honors the caller's exact config."""
+    config: JsonObject = {"type": "enabled", "budget_tokens": 2048}
+    request = _thinking_config_request(config)
+    public, provider = route_generation_parameter_requests(
+        (_anthropic_profile("claude-haiku-4-5"),), request
+    )
+    assert "thinking.budget_tokens" not in public.ignored_parameters
+    assert provider.provider_thinking_config == config
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        provider,
+        supports_reasoning=True,
+        reasoning_effort="medium",
+    )
+    assert payload["thinking"] == config
+
+
+def test_disabled_thinking_rejects_by_name_on_adaptive_only_models() -> None:
+    """Thinking cannot be turned off on the adaptive generation; silently
+    letting the model think anyway would bill the caller for reasoning they
+    explicitly disabled."""
+    request = _thinking_config_request({"type": "disabled"})
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((_anthropic_profile("claude-sonnet-5"),), request)
+    assert raised.value.param == "thinking.type"
+    assert raised.value.code == "unsupported_parameter"
+
+    # The pre-adaptive generation still accepts an explicit disabled config.
+    _public, provider = route_generation_parameter_requests(
+        (_anthropic_profile("claude-opus-4-6"),), _thinking_config_request({"type": "disabled"})
+    )
+    assert provider.provider_thinking_config == {"type": "disabled"}

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -185,6 +185,33 @@ multimodal surface this gateway does not serve, so honoring the selector is
 impossible and accepting it would be silent."""
 
 
+RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED: dict[str, frozenset[str]] = {
+    "message": frozenset({"type", "role", "content", "id", "status"}),
+    "function_call": frozenset({"type", "call_id", "name", "arguments", "id", "status"}),
+    "function_call_output": frozenset({"type", "call_id", "output", "id", "status"}),
+    "reasoning": frozenset({"type", "id", "encrypted_content", "summary", "content", "status"}),
+}
+"""Echoable input-item fields the Responses decoder models per item type.
+
+Stateless continuations resend prior OUTPUT items verbatim as the next
+INPUT, so every field this gateway's own output items carry must decode.
+"""
+
+RESPONSES_INPUT_ITEM_FIELDS_REJECTED: dict[str, frozenset[str]] = {
+    "message": frozenset({"phase"}),
+    "function_call": frozenset({"caller", "namespace"}),
+    "function_call_output": frozenset({"caller", "namespace", "name"}),
+    "reasoning": frozenset(),
+}
+"""Echoable input-item fields consciously rejected with a named 400.
+
+``caller``/``namespace`` attribute server-tool invocations this gateway does
+not serve, ``phase`` is a provider response-phase marker outside the replay
+contract, and a ``name`` on a function output duplicates the call linkage
+already carried by ``call_id``.
+"""
+
+
 def disposition_map(manifest: CompatibilityManifest) -> dict[str, CompatibilityDisposition]:
     """Index one manifest by exact top-level request field.
 

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -12,6 +12,8 @@ from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     RESPONSES_INCLUDE_PATHS_ACCEPTED,
     RESPONSES_INCLUDE_PATHS_REJECTED,
+    RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED,
+    RESPONSES_INPUT_ITEM_FIELDS_REJECTED,
     RESPONSES_MANIFEST,
     RESPONSES_REASONING_CONTEXTS_ACCEPTED,
     RESPONSES_REASONING_EFFORTS_ACCEPTED,
@@ -141,3 +143,31 @@ def test_every_official_sdk_include_selector_is_decided() -> None:
     undecided = sdk_selectors - RESPONSES_INCLUDE_PATHS_ACCEPTED - RESPONSES_INCLUDE_PATHS_REJECTED
     assert not undecided, _decided(undecided, "include selector")
     assert not RESPONSES_INCLUDE_PATHS_ACCEPTED & RESPONSES_INCLUDE_PATHS_REJECTED
+
+
+def test_every_official_sdk_echoable_input_item_field_is_decided() -> None:
+    """Echoed output items are part of the drift gate.
+
+    A stateless caller resends prior output items verbatim as input, so a
+    new SDK field on any echoable item type must be a conscious decision:
+    accepted-and-dropped or rejected by name, never a silent 400.
+    """
+    from openai.types.responses.response_function_tool_call_param import (
+        ResponseFunctionToolCallParam,
+    )
+    from openai.types.responses.response_input_param import FunctionCallOutput
+    from openai.types.responses.response_output_message_param import ResponseOutputMessageParam
+    from openai.types.responses.response_reasoning_item_param import ResponseReasoningItemParam
+
+    sdk_items = {
+        "message": ResponseOutputMessageParam,
+        "function_call": ResponseFunctionToolCallParam,
+        "function_call_output": FunctionCallOutput,
+        "reasoning": ResponseReasoningItemParam,
+    }
+    for item_type, sdk_type in sdk_items.items():
+        accepted = RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED[item_type]
+        rejected = RESPONSES_INPUT_ITEM_FIELDS_REJECTED[item_type]
+        assert not accepted & rejected, item_type
+        undecided = set(sdk_type.__annotations__) - accepted - rejected
+        assert not undecided, _decided(undecided, f"echoed {item_type} input item")

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -76,11 +76,22 @@ class _EphemeralCacheControl(_WireModel):
         return value
 
 
+_EchoedItemStatus = Literal["in_progress", "completed", "incomplete"]
+"""Lifecycle marker carried by echoed output items; validated and dropped."""
+
+
 class _TextPart(_WireModel):
-    """One supported text-only content part."""
+    """One supported text-only content part.
+
+    Echoed ``output_text`` parts carry empty ``annotations`` and ``logprobs``
+    arrays (this gateway emits them and callers resend prior output verbatim
+    on continuations); only a populated value is rejected as unsupported.
+    """
 
     type: Literal["text", "input_text", "output_text"]
     text: str
+    annotations: tuple[()] | None = None
+    logprobs: tuple[()] | None = None
 
 
 class _FunctionCall(_WireModel):
@@ -137,9 +148,16 @@ class _Message(_WireModel):
 
 
 class _ResponseMessage(_Message):
-    """Responses message item with its optional official discriminator."""
+    """Responses message item with its optional official discriminator.
+
+    Stateless continuations echo prior OUTPUT items verbatim into the next
+    input, so the provider-issued ``id`` and lifecycle ``status`` are
+    accepted and dropped; the gateway mints its own public identities.
+    """
 
     type: Literal["message"] = "message"
+    id: str | None = Field(default=None, min_length=1, max_length=256)
+    status: _EchoedItemStatus | None = None
 
 
 class _FunctionDefinition(_WireModel):
@@ -234,20 +252,32 @@ class _ResponseTool(_WireModel):
 
 
 class _ResponseFunctionCall(_WireModel):
-    """Completed Responses function call included as assistant history."""
+    """Completed Responses function call included as assistant history.
+
+    ``id`` and ``status`` arrive on verbatim echoes of prior output items
+    and are accepted and dropped; ``call_id`` is the linkage that matters.
+    """
 
     type: Literal["function_call"]
     call_id: str = Field(min_length=1, max_length=256)
     name: str = Field(min_length=1, max_length=256)
     arguments: str = Field(max_length=4_000_000)
+    id: str | None = Field(default=None, min_length=1, max_length=256)
+    status: _EchoedItemStatus | None = None
 
 
 class _ResponseFunctionOutput(_WireModel):
-    """Text function result included as Responses tool history."""
+    """Text function result included as Responses tool history.
+
+    ``id`` and ``status`` arrive when a stored turn's input items are
+    re-listed and echoed; accepted and dropped like the other echo markers.
+    """
 
     type: Literal["function_call_output"]
     call_id: str = Field(min_length=1, max_length=256)
     output: str
+    id: str | None = Field(default=None, min_length=1, max_length=256)
+    status: _EchoedItemStatus | None = None
 
 
 class _ReasoningSummaryPart(_WireModel):
@@ -257,18 +287,28 @@ class _ReasoningSummaryPart(_WireModel):
     text: str
 
 
+class _ReasoningTextPart(_WireModel):
+    """One display-only reasoning text part replayed inside a reasoning item."""
+
+    type: Literal["reasoning_text"]
+    text: str
+
+
 class _ResponseReasoningItem(_WireModel):
     """One opaque reasoning item a stateless caller replays with its input.
 
     ``encrypted_content`` is the round-trip payload; the display-only
-    ``summary`` parts are validated and dropped because the provider derives
-    the model-visible reasoning from the encrypted payload alone.
+    ``summary`` and ``content`` parts and the echoed lifecycle ``status``
+    are validated and dropped because the provider derives the
+    model-visible reasoning from the encrypted payload alone.
     """
 
     type: Literal["reasoning"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     encrypted_content: str = Field(min_length=1)
     summary: tuple[_ReasoningSummaryPart, ...] = ()
+    content: tuple[_ReasoningTextPart, ...] = ()
+    status: _EchoedItemStatus | None = None
 
 
 class _ResponseFormat(_WireModel):
@@ -662,13 +702,49 @@ def _validate_wire[ModelT: BaseModel](model: type[ModelT], payload: JsonObject) 
         raise _validation_protocol_error(exc) from exc
 
 
+_LOCATION_NOISE = {"body", "non-streaming", "streaming"}
+_UNION_BRANCH_TYPES = {"str", "int", "float", "bool", "list", "tuple", "dict", "NoneType"}
+
+
+def _cleaned_location(location: tuple[str | int, ...]) -> tuple[str, ...]:
+    """Drop pydantic union-branch labels so the path names request fields."""
+    cleaned: list[str] = []
+    for part in location:
+        text = str(part)
+        if text in _LOCATION_NOISE:
+            continue
+        if isinstance(part, str) and (
+            part.startswith("_") or "[" in text or text in _UNION_BRANCH_TYPES
+        ):
+            continue
+        cleaned.append(text)
+    return tuple(cleaned)
+
+
 def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
-    """Convert Pydantic locations into stable dotted OpenAI ``param`` paths."""
-    first = error.errors(include_url=False)[0]
-    location = tuple(
-        part for part in first["loc"] if part not in {"body", "non-streaming", "streaming"}
-    )
-    param = ".".join(str(part) for part in location) or "body"
+    """Convert Pydantic locations into stable dotted OpenAI ``param`` paths.
+
+    Union validation reports every branch's complaints. Errors group by
+    their branch (the location minus its final field segment); among the
+    most field-specific groups, the branch the caller actually meant is the
+    one with the fewest complaints, so its deepest cleaned location names
+    the real field (an echoed item's ``input.1.caller``), never a union
+    branch label such as ``input.str``.
+    """
+    groups: dict[tuple[str | int, ...], list[tuple[str, ...]]] = {}
+    for detail in error.errors(include_url=False):
+        groups.setdefault(tuple(detail["loc"][:-1]), []).append(_cleaned_location(detail["loc"]))
+    if not groups:
+        return invalid_field("body")
+    deepest = max(len(location) for locations in groups.values() for location in locations)
+    candidates = [
+        locations
+        for locations in groups.values()
+        if any(len(location) == deepest for location in locations)
+    ]
+    best = min(candidates, key=len)
+    location = max(best, key=len, default=())
+    param = ".".join(location) or "body"
     return invalid_field(param)
 
 

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -805,3 +805,87 @@ def test_responses_decoder_accepts_reasoning_context_and_names_rejections() -> N
             }
         )
     assert rejected_field.value.detail.param == "reasoning.mode"
+
+
+def test_responses_decoder_accepts_verbatim_echoes_of_prior_output_items() -> None:
+    """Turn-2 input echoing turn-1 output items verbatim must decode.
+
+    Customer repro (Codex continuation model, 2026-08-28): a function_call
+    output item carries {arguments, call_id, id, name, status, type}; echoing
+    it with its function_call_output failed 400 on the echo-only ``id`` and
+    ``status`` markers. Every item shape below mirrors what this gateway (and
+    OpenAI-direct) actually emit.
+    """
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "message", "role": "user", "content": "Weather in Paris?"},
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "plan"}],
+                    "content": [{"type": "reasoning_text", "text": "thinking"}],
+                    "encrypted_content": "blob==",
+                    "status": "completed",
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call-1",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                    "status": "completed",
+                },
+                {
+                    "type": "function_call_output",
+                    "id": "fco_1",
+                    "call_id": "call-1",
+                    "output": "sunny",
+                    "status": "completed",
+                },
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "It is sunny.",
+                            "annotations": [],
+                            "logprobs": [],
+                        }
+                    ],
+                },
+                {"type": "message", "role": "user", "content": "And tomorrow?"},
+            ],
+        }
+    )
+    roles = [message.role for message in decoded.request.messages]
+    assert roles == ["user", "assistant", "tool", "assistant", "user"]
+    assistant_call = decoded.request.messages[1]
+    assert assistant_call.tool_calls[0].call_id == "call-1"
+    assert assistant_call.provider_reasoning[0].kind == "encrypted_reasoning"
+    assert decoded.request.messages[3].content == "It is sunny."
+
+
+def test_responses_union_errors_name_the_item_field_not_the_branch() -> None:
+    """A bad echoed item names its field, never a union branch like input.str."""
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {"type": "message", "role": "user", "content": "hi"},
+                    {
+                        "type": "function_call",
+                        "call_id": "call-1",
+                        "name": "get_weather",
+                        "arguments": "{}",
+                        "caller": {"type": "direct"},
+                    },
+                ],
+            }
+        )
+    assert raised.value.detail.param == "input.1.caller"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.0,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.1,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.0"
+version = "0.3.1"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What (P0: production Anthropic tools + thinking configs)

Two live wire rejections, both root-caused against api.anthropic.com today with the house key and reproduced through production:

**1. Tools with no description fail every Anthropic request.** The Messages builders serialized an absent tool description as `"description": null`, which Anthropic rejects: `tools.0.custom.description: Input should be a valid string`. Any OpenAI-style or Messages request whose tool omits a description (Claude Code and most agent harnesses routinely do) failed on every Anthropic route, both surfaces. Tools WITH descriptions passed, which is why the plain repro matrix looked model-wide rather than payload-shaped. Fix: both the streaming payload builder and the non-streaming client omit the key when the description is absent.

**2. Caller thinking configs 400 on the adaptive generation.** The 0.7.x product decision forwarded `thinking` verbatim. The live API now rejects `thinking.type.enabled` AND `thinking.type.disabled` on the adaptive-only generation, verified model by model: claude-fable-5, claude-mythos-5, claude-opus-5, claude-sonnet-5, claude-opus-4-8, and claude-opus-4-7 reject both, while claude-sonnet-4-6, claude-opus-4-6, and claude-haiku-4-5 still honor budgeted `enabled` (thinking blocks stream back). Claude Code always sends `enabled` + `budget_tokens`, so this blocked wiring it to the gateway. Fix, honoring the no-silent-snap rule:

- On adaptive-only routes (a route is one exact-model pool, so the family answer is uniform), `enabled` translates to `{"type": "adaptive"}` + the route's pinned effort, the dropped `thinking.budget_tokens` is DISCLOSED through `ignored_parameters`, and a warning is logged. The budget is deliberately not mapped onto an effort level: that would be an undisclosed semantic snap.
- `disabled` on adaptive-only routes rejects by name (`thinking.type`, `unsupported_parameter`): those models cannot turn thinking off, and silently letting them think would bill the caller for reasoning they explicitly disabled.
- The 4.6/4.5 line keeps exact verbatim forwarding.
- The family table (`anthropic_adaptive_only_thinking`) matches the xhigh effort generation and records the verification date.

## Tests

- Decode regression from the real captured tool_use wire (the live stream carries a `caller` object on tool_use blocks, a nested `cache_creation` usage breakdown, `stop_details`, whitespace-padded data frames, and an empty leading `input_json_delta`) — pinned as an exact-events fixture so wire drift in the normalizer is caught by CI, not customers.
- Builder tests: description omission (both builders), enabled-to-adaptive translation with disclosure, verbatim retention on haiku-4-5, named `disabled` rejection on sonnet-5 with verbatim retention on opus-4-6, family-boundary test for the new predicate.
- End-to-end proof: the previously failing combination (description-less tool + `enabled` thinking on claude-fable-5) was re-driven against the live API through the fixed builders: HTTP 200, clean tool_use stream.

## Known gap (flagged, not silent)

`ignored_parameters` disclosure reaches Chat/Responses callers via the existing `x-experiential-ignored-parameters` extension; the Anthropic Messages envelope has no such channel today, so a Messages caller sees the translation only via behavior and gateway logs. Adding an Anthropic-envelope disclosure field is a public-surface decision left to the owner.

## Gates

`uv run pytest -q`: 2680 passed, 2 skipped, 0 failed. `ruff check .`, `ruff format --check .`, `ty check`: clean. Python-only (normalizer needed no change: the real wire decodes clean, proven by the new fixture); no crate bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum (same 0.7.3 train, all live-verified)

**3. Zero-argument tool calls (the actual production tools outage).** The lead's corrected repro isolated the discriminator: an empty-properties schema. Root cause found on the wire: a call whose input is empty streams exactly one EMPTY `input_json_delta` and nothing else, so completion rejected the empty accumulation as invalid JSON and every zero-argument tool failed as `malformed_response` — matching the alert-window failures precisely. The empty-properties schema itself passes through untouched (hypothesis 1 disproven live: Anthropic 200s our exact payload). Fix: a shared completion helper across all four dialect normalizers seeds the canonical `{}` and emits the seeding fragment first, so downstream byte verification stays consistent; the same hazard existed on the OpenAI-compatible and Bedrock lanes. The captured zero-argument wire is pinned as a regression fixture; the acceptance case (described zero-argument tool on claude-fable-5) was re-driven live through the fixed stack: 200, `raw_arguments: "{}"`. Crate moves to 0.3.1.

**4. Responses input echo (Codex continuation blocker).** The input wire models now accept-and-drop the echo-only markers on every echoable item type: item `id` and lifecycle `status` on `function_call`, `message`, `function_call_output`, and `reasoning`; empty `annotations`/`logprobs` arrays on echoed `output_text` parts; display-only reasoning `content` parts. `caller`, `namespace`, and `phase` stay consciously rejected (server-tool attribution and phase markers this gateway does not serve), and the drift gate now walks all four echoable SDK item types so a new echo field fails CI by name. The union error text fix rode along: errors group per union branch and the most field-specific branch with the fewest complaints wins, so a bad echo now yields `input.1.caller` instead of `input.str`.

**5. Missing reasoning item: NOT a gateway bug — plus the effort table that hid it.** Provider-isolated: OpenAI-direct at `high` effort returns `[function_call]` with `reasoning_tokens: 0` and NO reasoning item for the same request that the gateway serves — identical outputs, gateway matches OpenAI-direct exactly. At `max` effort the provider emits the reasoning item with `encrypted_content`, and the real captured stream replayed through our normalizer and encoder delivers it verbatim on the public item (encrypted_content also proved to GROW between `output_item.added` and `.done`, so reading only `.done` is correct). What WAS wrong: the gpt-5.6 effort table. Live check: gpt-5.6-sol and gpt-5.6-codex accept exactly `none minimal low medium high xhigh max` and reject `ultra` by name — our table had `ultra` (now provider-rejected) and lacked `max` (the very tier where reasoning items appear). Table corrected to provider truth; `ultra` now fails loud at admission with the provider's own supported list, `max` admits. Note for the release notes: the 0.7.2 `ultra` addition is reversed by provider reality; decode still accepts the token (grammar), admission rejects it per family exactly as OpenAI does.
