### PR TITLE
release: bump version to 0.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.2"
+version = "0.7.3"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.3 release. Ships #658 (P0 wire fixes, all live-verified): zero-argument tool calls decode on all four dialect lanes (empty input_json_delta accumulation seeded to {}), null tool descriptions never reach the Anthropic wire, enabled-thinking translates to explicit adaptive on the adaptive-only Claude generation with the dropped budget disclosed, echoed Responses output items (id/status) accepted-and-dropped with drift-gate coverage, and the gpt-5.6 effort table corrected to provider truth (max admits, ultra fails loud with the provider's own list — reverses the 0.7.2 ultra addition). Ships experiential 0.7.3 + exp-gateway-native 0.3.1 (crate bump in #658).

🤖 Generated with [Claude Code](https://claude.com/claude-code)