### PR TITLE
gateway: pin the zero-argument tool sequence on every public lane

### DIFF
--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3258,6 +3258,15 @@ def test_zero_argument_tool_calls_encode_on_every_public_lane() -> None:
     frames = native.encode_messages_fixture("request-abc", "coding", fixture)
     assert any('"type":"tool_use"' in frame for frame in frames)
     assert frames[-1].startswith("event: message_stop")
+    streamed_input = "".join(
+        payload["delta"]["partial_json"]
+        for payload in (
+            json.loads(frame.split("data: ", 1)[1].strip()) for frame in frames if frame
+        )
+        if payload["type"] == "content_block_delta"
+        and payload["delta"]["type"] == "input_json_delta"
+    )
+    assert streamed_input == "{}"
     messages_body = json.loads(native.completed_messages_fixture("request-abc", "coding", fixture))
     assert messages_body["content"][0] == {
         "type": "tool_use",
@@ -3270,6 +3279,17 @@ def test_zero_argument_tool_calls_encode_on_every_public_lane() -> None:
     chat_frames = native.encode_chat_fixture("request-abc", "coding", 1_700_000_000, True, fixture)
     assert chat_frames[-1] == "data: [DONE]\n\n"
     assert any('"finish_reason":"tool_calls"' in frame for frame in chat_frames)
+    streamed_arguments = "".join(
+        call["function"]["arguments"]
+        for payload in (
+            json.loads(frame.split("data: ", 1)[1].strip())
+            for frame in chat_frames
+            if frame.startswith("data: {")
+        )
+        for choice in payload.get("choices", ())
+        for call in choice.get("delta", {}).get("tool_calls", ())
+    )
+    assert streamed_arguments == "{}"
     responses_body = json.loads(
         native.completed_responses_fixture("request-abc", "coding", 1_700_000_000.0, "{}", fixture)
     )

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3218,3 +3218,61 @@ def test_reasoning_context_reflects_in_the_envelope_only_when_sent() -> None:
     }
     without = decode_responses({"model": "coding", "input": "hi"}).request
     assert responses_envelope(without)["reasoning"] == {"effort": None, "summary": None}
+
+
+def _zero_argument_tool_fixture_json() -> str:
+    """Return the normalized event sequence a zero-argument tool call produces.
+
+    Mirrors the live captured wire (2026-08-28): one empty streamed fragment,
+    then the completion-time `{}` seed, then the verified completed call.
+    """
+    return json.dumps(
+        [
+            {"kind": "tool_call_started", "index": 0, "call_id": "call-1", "name": "get_time"},
+            {"kind": "tool_arguments_delta", "index": 0, "text": ""},
+            {"kind": "tool_arguments_delta", "index": 0, "text": "{}"},
+            {
+                "kind": "tool_call_completed",
+                "index": 0,
+                "call_id": "call-1",
+                "name": "get_time",
+                "raw_arguments": "{}",
+            },
+            {"kind": "usage", "input_tokens": 5, "output_tokens": 3},
+            {"kind": "completed"},
+        ]
+    )
+
+
+def test_zero_argument_tool_calls_encode_on_every_public_lane() -> None:
+    """The zero-argument completion sequence serves both lanes, both modes.
+
+    Production incident (2026-08-28): every zero-argument tool failed as
+    malformed_response. The normalizer fix seeds `{}` at completion; these
+    assertions pin that the seeded sequence encodes as a valid Anthropic
+    tool_use block and a valid Chat tool call, streaming and non-streaming.
+    """
+    native = pytest.importorskip("exp_gateway_native")
+    fixture = _zero_argument_tool_fixture_json()
+
+    frames = native.encode_messages_fixture("request-abc", "coding", fixture)
+    assert any('"type":"tool_use"' in frame for frame in frames)
+    assert frames[-1].startswith("event: message_stop")
+    messages_body = json.loads(native.completed_messages_fixture("request-abc", "coding", fixture))
+    assert messages_body["content"][0] == {
+        "type": "tool_use",
+        "id": "call-1",
+        "name": "get_time",
+        "input": {},
+    }
+    assert messages_body["stop_reason"] == "tool_use"
+
+    chat_frames = native.encode_chat_fixture("request-abc", "coding", 1_700_000_000, True, fixture)
+    assert chat_frames[-1] == "data: [DONE]\n\n"
+    assert any('"finish_reason":"tool_calls"' in frame for frame in chat_frames)
+    responses_body = json.loads(
+        native.completed_responses_fixture("request-abc", "coding", 1_700_000_000.0, "{}", fixture)
+    )
+    call_items = [item for item in responses_body["output"] if item["type"] == "function_call"]
+    assert call_items[0]["arguments"] == "{}"
+    assert call_items[0]["status"] == "completed"


### PR DESCRIPTION
## What

Test-only follow-up to #658: it merged moments before this commit was pushed, stranding the last correction ask. The zero-argument completion sequence (empty streamed fragment, completion-time `{}` seed, verified completed call) is now pinned at the PUBLIC encoder level on both lanes and both modes: the Anthropic Messages SSE stream and non-streaming body carry a valid `tool_use` block with `input: {}` and `stop_reason: tool_use`, and the Chat/Responses lanes finish with `tool_calls` and `arguments: "{}"`. A lane regression can no longer reintroduce the zero-argument outage silently even if the normalizer fixture stays green.

## Gates

Targeted suite 70 passed; ruff, format, ty clean; no production code change.

Rides the 0.7.3 train (no version implications: test-only on top of #658's 0.3.1 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)