### PR TITLE
gateway: honor tool-call cache_control, decode empty tool-argument echoes

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -189,8 +189,10 @@ adaptive default; on the adaptive-only generation, which rejects `enabled`/`disa
 configs outright, an `enabled` config translates to adaptive with the dropped
 `thinking.budget_tokens` disclosed as ignored, and `disabled` is rejected by name
 because those models cannot turn thinking off), requires
-`max_tokens`, validates and drops `cache_control` (the gateway has no prompt-caching channel),
-and rejects image and document blocks loudly because the surface is text-only. Thinking carriers
+`max_tokens`, validates `cache_control` (dropping it everywhere except on `tool_use` blocks,
+where the hint forwards natively; non-Anthropic routes disclose the omission through
+`ignored_parameters`), and rejects image and document blocks loudly because the surface is
+text-only. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
 `anthropic_messages` dialect; on the Responses surface over Anthropic routes, thinking text is
 projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -195,6 +195,16 @@ class ToolCall(ContractModel):
         max_length=4_000_000,
         exclude=True,
     )
+    cache_control: JsonObject | None = Field(default=None, exclude=True)
+    """Validated caller prompt-caching hint attached to this tool call.
+
+    OpenAI-compatible callers (the @ai-sdk stack) attach an Anthropic-style
+    ephemeral ``cache_control`` to a message's last content part, which lands
+    inside the ``tool_calls`` entry when that part is a tool call. The hint
+    forwards onto the native Anthropic ``tool_use`` block and is a no-op on
+    other wires. Like ``raw_arguments``, it is excluded from serialization so
+    a cache hint can never affect immutable artifacts or request digests.
+    """
 
     @model_validator(mode="after")
     def _require_matching_raw_arguments(self) -> ToolCall:

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -424,6 +424,11 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                     raw_arguments=json.dumps(
                         block.input, separators=(",", ":"), ensure_ascii=False
                     ),
+                    cache_control=(
+                        block.cache_control.model_dump(mode="json", exclude_none=True)
+                        if block.cache_control is not None
+                        else None
+                    ),
                 )
             )
         else:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -359,6 +359,17 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
 
+    # A tool-call cache hint is honored only on the Anthropic wire; any other
+    # rung silently cannot cache, so the omission is disclosed, never a
+    # rejection (a cache hint changes cost, not semantics).
+    if any(
+        call.cache_control is not None
+        for message in request.messages
+        for call in message.tool_calls
+    ) and not all(profile.dialect == "anthropic_messages" for profile in profiles):
+        if "messages.tool_calls.cache_control" not in ignored:
+            ignored.append("messages.tool_calls.cache_control")
+
     # Opaque provider-reasoning carriers replay only on the one wire that
     # issued them, so a mixed waterfall is rejected instead of dropping them.
     anthropic_reasoning_present = request.provider_thinking_config is not None or any(

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -5,7 +5,7 @@ from typing import cast
 import pytest
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models.model import ReasoningEffort
+from exp.common.models.model import ReasoningEffort, ToolCall
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
@@ -1577,3 +1577,58 @@ def test_disabled_thinking_rejects_by_name_on_adaptive_only_models() -> None:
         (_anthropic_profile("claude-opus-4-6"),), _thinking_config_request({"type": "disabled"})
     )
     assert provider.provider_thinking_config == {"type": "disabled"}
+
+
+def test_tool_call_cache_hint_forwards_to_anthropic_and_discloses_elsewhere() -> None:
+    """The validated cache hint reaches only the tool_use block that can honor it."""
+    from exp.common.core.artifacts import sha256_json
+
+    hinted = ToolCall(
+        call_id="call-2",
+        name="read_file",
+        arguments={"path": "b.txt"},
+        cache_control={"type": "ephemeral"},
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="read"),
+            GatewayMessage(
+                role="assistant",
+                tool_calls=(
+                    ToolCall(call_id="call-1", name="read_file", arguments={"path": "a.txt"}),
+                    hinted,
+                ),
+            ),
+            GatewayMessage(role="tool", content="a", tool_call_id="call-1"),
+            GatewayMessage(role="tool", content="b", tool_call_id="call-2"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+
+    anthropic_payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    messages = cast(list[JsonObject], anthropic_payload["messages"])
+    blocks = cast(list[JsonObject], messages[1]["content"])
+    assert "cache_control" not in blocks[0]
+    assert blocks[1]["cache_control"] == {"type": "ephemeral"}
+
+    # OpenAI-family wires never see the hint; the route discloses the no-op.
+    chat_payload = openai_compatible_stream_payload("gpt-5.5", request)
+    import json
+
+    assert "cache_control" not in json.dumps(chat_payload)
+    public, _provider = route_generation_parameter_requests(
+        (GatewayWireProfile(dialect="openai_compatible", url="https://openai.test"),),
+        request,
+    )
+    assert "messages.tool_calls.cache_control" in public.ignored_parameters
+    anthropic_public, _provider = route_generation_parameter_requests(
+        (GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test"),),
+        request,
+    )
+    assert "messages.tool_calls.cache_control" not in anthropic_public.ignored_parameters
+
+    # The hint never perturbs digests, artifacts, or replay identity.
+    bare = hinted.model_copy(update={"cache_control": None})
+    assert sha256_json(hinted) == sha256_json(bare)

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -96,15 +96,18 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             raise ProviderResponseError("encrypted reasoning cannot replay on the Anthropic wire")
     if message.content is not None:
         blocks.append({"type": "text", "text": message.content})
-    blocks.extend(
-        {
+    for call in message.tool_calls:
+        tool_use: JsonObject = {
             "type": "tool_use",
             "id": call.call_id,
             "name": call.name,
             "input": call.arguments,
         }
-        for call in message.tool_calls
-    )
+        # A validated caller cache hint forwards only on this wire, which
+        # defines tool_use-block prompt caching natively.
+        if call.cache_control is not None:
+            tool_use["cache_control"] = call.cache_control
+        blocks.append(tool_use)
     return "assistant", blocks
 
 

--- a/exp/runtime/openai_protocol/cache_control.py
+++ b/exp/runtime/openai_protocol/cache_control.py
@@ -1,0 +1,160 @@
+"""OpenCode-style ``cache_control`` normalization for the Chat surface.
+
+The @ai-sdk stack attaches Anthropic-style ephemeral cache hints to recent
+messages for Claude-family model ids. Placements are classified in
+``CHAT_CACHE_CONTROL_PLACEMENTS``: message-level and text-part hints are
+validated and dropped here before official validation, while a hint inside a
+``tool_calls`` entry is carried by the request decoder onto the canonical
+tool call for the one wire that honors it.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, JsonValue, ValidationError, field_validator
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.openai_protocol.errors import invalid_field
+
+_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
+
+
+class _HintWireModel(BaseModel):
+    """Strict private wire model rejecting unknown nested fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EphemeralCacheControl(_HintWireModel):
+    """OpenCode/Anthropic cache breakpoint accepted only so it can be dropped.
+
+    The object form is ``{"type": "ephemeral"}`` with an optional ``ttl`` of
+    ``5m`` or ``1h``. An explicit ``ttl: null`` is not in that allowlist.
+    """
+
+    type: Literal["ephemeral"]
+    ttl: Literal["5m", "1h"] | None = None
+
+    @field_validator("ttl", mode="before")
+    @classmethod
+    def _reject_null_ttl(cls, value: object) -> object:
+        """Reject an explicit null TTL while still allowing the key to be omitted."""
+        if value is None:
+            raise ValueError("ttl must be 5m or 1h when present")
+        return value
+
+
+def drop_opencode_cache_control(payload: JsonObject) -> JsonObject:
+    """Remove supported OpenCode ``cache_control`` annotations from Chat messages.
+
+    Args:
+        payload: Parsed Chat Completions body.
+
+    Returns:
+        The original payload, or a shallow copy whose messages no longer carry
+        a supported ``cache_control`` annotation.
+
+    Raises:
+        OpenAIProtocolError: A ``cache_control`` value is malformed or unsupported.
+    """
+    raw_messages = payload.get("messages")
+    if not isinstance(raw_messages, list):
+        return payload
+    cleaned_messages: list[JsonValue] = []
+    changed = False
+    for index, raw_message in enumerate(raw_messages):
+        message, message_changed = _without_message_hint(raw_message, index)
+        cleaned_messages.append(message)
+        changed = changed or message_changed
+    if not changed:
+        return payload
+    cleaned_payload = dict(payload)
+    cleaned_payload["messages"] = cleaned_messages
+    return cleaned_payload
+
+
+def _without_message_hint(raw_message: JsonValue, index: int) -> tuple[JsonValue, bool]:
+    """Drop a supported ``cache_control`` annotation from one Chat message.
+
+    Args:
+        raw_message: One ``messages`` entry.
+        index: Zero-based message index used in public error paths.
+
+    Returns:
+        The message (copied when an annotation is removed) and whether it changed.
+
+    Raises:
+        OpenAIProtocolError: The annotation is present but not a supported form.
+    """
+    if not isinstance(raw_message, dict):
+        return raw_message, False
+    message = cast(JsonObject, raw_message)
+    changed = False
+    if "cache_control" in message:
+        require_supported_cache_control(message["cache_control"], f"messages.{index}.cache_control")
+        message = {key: value for key, value in message.items() if key != "cache_control"}
+        changed = True
+    content = message.get("content")
+    if isinstance(content, list):
+        cleaned_content, content_changed = _without_text_part_hint(
+            cast(list[JsonValue], content), index
+        )
+        if content_changed:
+            if not changed:
+                message = dict(message)
+            message["content"] = cleaned_content
+            changed = True
+    return message, changed
+
+
+def _without_text_part_hint(
+    parts: list[JsonValue], message_index: int
+) -> tuple[list[JsonValue], bool]:
+    """Drop supported ``cache_control`` from OpenCode text content parts.
+
+    Args:
+        parts: Message ``content`` array.
+        message_index: Zero-based parent message index used in public error paths.
+
+    Returns:
+        The content array (copied when an annotation is removed) and whether it changed.
+
+    Raises:
+        OpenAIProtocolError: A text-part annotation is present but not a supported form.
+    """
+    cleaned: list[JsonValue] = []
+    changed = False
+    for part_index, raw_part in enumerate(parts):
+        if not isinstance(raw_part, dict) or "cache_control" not in raw_part:
+            cleaned.append(raw_part)
+            continue
+        part = cast(JsonObject, raw_part)
+        if part.get("type") not in _TEXT_PART_TYPES:
+            cleaned.append(raw_part)
+            continue
+        require_supported_cache_control(
+            part["cache_control"],
+            f"messages.{message_index}.content.{part_index}.cache_control",
+        )
+        cleaned.append({key: value for key, value in part.items() if key != "cache_control"})
+        changed = True
+    return (cleaned, True) if changed else (parts, False)
+
+
+def require_supported_cache_control(value: JsonValue, param: str) -> None:
+    """Accept null or a supported ephemeral ``cache_control`` object.
+
+    Args:
+        value: Raw ``cache_control`` annotation.
+        param: Public dotted field path used in the error.
+
+    Raises:
+        OpenAIProtocolError: The annotation is malformed or unsupported.
+    """
+    if value is None:
+        return
+    try:
+        EphemeralCacheControl.model_validate(value)
+    except ValidationError as exc:
+        raise invalid_field(param) from exc

--- a/exp/runtime/openai_protocol/cache_control_test.py
+++ b/exp/runtime/openai_protocol/cache_control_test.py
@@ -1,0 +1,2 @@
+"""Covered through the Chat decoder in
+:mod:`exp.runtime.openai_protocol.requests_test`."""

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -212,6 +212,24 @@ already carried by ``call_id``.
 """
 
 
+CHAT_CACHE_CONTROL_PLACEMENTS: dict[str, str] = {
+    "messages": "validated_and_dropped",
+    "messages.content": "validated_and_dropped",
+    "messages.tool_calls": "validated_and_forwarded_to_anthropic_tool_use",
+}
+"""Every Chat-surface ``cache_control`` placement and its conscious decision.
+
+The @ai-sdk stack attaches an Anthropic-style ephemeral cache hint to the
+last content part of recent messages for Claude-family model ids; depending
+on that part's shape the hint lands on the message, a text part, or inside a
+``tool_calls`` entry. Placements are classified here so a new placement is a
+recorded decision (this table plus its behavior test), never a silent 400.
+Only the tool-call placement forwards: Anthropic defines tool_use-block
+caching natively, and non-Anthropic routes disclose the omission through
+``ignored_parameters``.
+"""
+
+
 def disposition_map(manifest: CompatibilityManifest) -> dict[str, CompatibilityDisposition]:
     """Index one manifest by exact top-level request field.
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -15,7 +15,6 @@ from pydantic import (
     JsonValue,
     TypeAdapter,
     ValidationError,
-    field_validator,
     model_validator,
 )
 
@@ -31,6 +30,10 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayToolDefinition,
     StructuredTextFormat,
+)
+from exp.runtime.openai_protocol.cache_control import (
+    EphemeralCacheControl,
+    drop_opencode_cache_control,
 )
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import (
@@ -55,25 +58,6 @@ class _WireModel(BaseModel):
     """Strict private OpenAI wire model used only after official shape validation."""
 
     model_config = ConfigDict(extra="forbid")
-
-
-class _EphemeralCacheControl(_WireModel):
-    """OpenCode/Anthropic cache breakpoint accepted only so it can be dropped.
-
-    The object form is ``{"type": "ephemeral"}`` with an optional ``ttl`` of
-    ``5m`` or ``1h``. An explicit ``ttl: null`` is not in that allowlist.
-    """
-
-    type: Literal["ephemeral"]
-    ttl: Literal["5m", "1h"] | None = None
-
-    @field_validator("ttl", mode="before")
-    @classmethod
-    def _reject_null_ttl(cls, value: object) -> object:
-        """Reject an explicit null TTL while still allowing the key to be omitted."""
-        if value is None:
-            raise ValueError("ttl must be 5m or 1h when present")
-        return value
 
 
 _EchoedItemStatus = Literal["in_progress", "completed", "incomplete"]
@@ -113,7 +97,7 @@ class _AssistantToolCall(_WireModel):
     id: str = Field(min_length=1, max_length=256)
     type: Literal["function"] = "function"
     function: _FunctionCall
-    cache_control: _EphemeralCacheControl | None = None
+    cache_control: EphemeralCacheControl | None = None
 
 
 class _Message(_WireModel):
@@ -422,7 +406,7 @@ def decode_chat(
     Raises:
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
     """
-    payload = _drop_opencode_cache_control(payload)
+    payload = drop_opencode_cache_control(payload)
     _validate_manifest(payload, CHAT_MANIFEST)
     # The installed SDK's effort literal lags the newest provider tier
     # ("ultra"), so the strict wire model owns reasoning validation.
@@ -557,123 +541,6 @@ def decode_responses(
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
     return DecodedGatewayRequest(alias=request.model, request=canonical)
-
-
-def _drop_opencode_cache_control(payload: JsonObject) -> JsonObject:
-    """Remove supported OpenCode ``cache_control`` annotations from Chat messages.
-
-    Args:
-        payload: Parsed Chat Completions body.
-
-    Returns:
-        The original payload, or a shallow copy whose messages no longer carry
-        a supported ``cache_control`` annotation.
-
-    Raises:
-        OpenAIProtocolError: A ``cache_control`` value is malformed or unsupported.
-    """
-    raw_messages = payload.get("messages")
-    if not isinstance(raw_messages, list):
-        return payload
-    cleaned_messages: list[JsonValue] = []
-    changed = False
-    for index, raw_message in enumerate(raw_messages):
-        message, message_changed = _without_message_cache_control(raw_message, index)
-        cleaned_messages.append(message)
-        changed = changed or message_changed
-    if not changed:
-        return payload
-    cleaned_payload = dict(payload)
-    cleaned_payload["messages"] = cleaned_messages
-    return cleaned_payload
-
-
-def _without_message_cache_control(raw_message: JsonValue, index: int) -> tuple[JsonValue, bool]:
-    """Drop a supported ``cache_control`` annotation from one Chat message.
-
-    Args:
-        raw_message: One ``messages`` entry.
-        index: Zero-based message index used in public error paths.
-
-    Returns:
-        The message (copied when an annotation is removed) and whether it changed.
-
-    Raises:
-        OpenAIProtocolError: The annotation is present but not a supported form.
-    """
-    if not isinstance(raw_message, dict):
-        return raw_message, False
-    message = cast(JsonObject, raw_message)
-    changed = False
-    if "cache_control" in message:
-        _require_supported_cache_control(
-            message["cache_control"], f"messages.{index}.cache_control"
-        )
-        message = {key: value for key, value in message.items() if key != "cache_control"}
-        changed = True
-    content = message.get("content")
-    if isinstance(content, list):
-        cleaned_content, content_changed = _without_text_part_cache_control(
-            cast(list[JsonValue], content), index
-        )
-        if content_changed:
-            if not changed:
-                message = dict(message)
-            message["content"] = cleaned_content
-            changed = True
-    return message, changed
-
-
-def _without_text_part_cache_control(
-    parts: list[JsonValue], message_index: int
-) -> tuple[list[JsonValue], bool]:
-    """Drop supported ``cache_control`` from OpenCode text content parts.
-
-    Args:
-        parts: Message ``content`` array.
-        message_index: Zero-based parent message index used in public error paths.
-
-    Returns:
-        The content array (copied when an annotation is removed) and whether it changed.
-
-    Raises:
-        OpenAIProtocolError: A text-part annotation is present but not a supported form.
-    """
-    cleaned: list[JsonValue] = []
-    changed = False
-    for part_index, raw_part in enumerate(parts):
-        if not isinstance(raw_part, dict) or "cache_control" not in raw_part:
-            cleaned.append(raw_part)
-            continue
-        part = cast(JsonObject, raw_part)
-        if part.get("type") not in _TEXT_PART_TYPES:
-            cleaned.append(raw_part)
-            continue
-        _require_supported_cache_control(
-            part["cache_control"],
-            f"messages.{message_index}.content.{part_index}.cache_control",
-        )
-        cleaned.append({key: value for key, value in part.items() if key != "cache_control"})
-        changed = True
-    return (cleaned, True) if changed else (parts, False)
-
-
-def _require_supported_cache_control(value: JsonValue, param: str) -> None:
-    """Accept null or a supported ephemeral ``cache_control`` object.
-
-    Args:
-        value: Raw ``cache_control`` annotation.
-        param: Public dotted field path used in the error.
-
-    Raises:
-        OpenAIProtocolError: The annotation is malformed or unsupported.
-    """
-    if value is None:
-        return
-    try:
-        _EphemeralCacheControl.model_validate(value)
-    except ValidationError as exc:
-        raise invalid_field(param) from exc
 
 
 def _validate_manifest(payload: JsonObject, manifest: CompatibilityManifest) -> None:

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -102,11 +102,18 @@ class _FunctionCall(_WireModel):
 
 
 class _AssistantToolCall(_WireModel):
-    """One assistant function call retained in request history."""
+    """One assistant function call retained in request history.
+
+    OpenCode-style callers attach an Anthropic ``cache_control`` to the last
+    content part of recent messages; when that part is a tool call the hint
+    lands inside this entry, so the supported ephemeral form is accepted and
+    carried for the one wire that can honor it.
+    """
 
     id: str = Field(min_length=1, max_length=256)
     type: Literal["function"] = "function"
     function: _FunctionCall
+    cache_control: _EphemeralCacheControl | None = None
 
 
 class _Message(_WireModel):
@@ -800,8 +807,12 @@ def _content(content: str | tuple[_TextPart, ...] | None) -> str | None:
 
 def _tool_call(call: _AssistantToolCall, param: str) -> ToolCall:
     """Parse one complete tool call while retaining its exact raw argument string."""
+    # Some SDK stacks echo a zero-argument call as an empty string; the
+    # canonical empty object mirrors the streaming completion seed, since no
+    # provider wire accepts empty argument bytes.
+    raw_arguments = call.function.arguments or "{}"
     try:
-        parsed = json.loads(call.function.arguments)
+        parsed = json.loads(raw_arguments)
     except json.JSONDecodeError as exc:
         raise invalid_field(param, f"'{param}' must encode one JSON object.") from exc
     if not isinstance(parsed, dict):
@@ -810,7 +821,12 @@ def _tool_call(call: _AssistantToolCall, param: str) -> ToolCall:
         call_id=call.id,
         name=call.function.name,
         arguments=cast(JsonObject, parsed),
-        raw_arguments=call.function.arguments,
+        raw_arguments=raw_arguments,
+        cache_control=(
+            call.cache_control.model_dump(mode="json", exclude_none=True)
+            if call.cache_control is not None
+            else None
+        ),
     )
 
 

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -889,3 +889,124 @@ def test_responses_union_errors_name_the_item_field_not_the_branch() -> None:
             }
         )
     assert raised.value.detail.param == "input.1.caller"
+
+
+def test_every_chat_cache_control_placement_follows_its_classified_decision() -> None:
+    """Each classified cache_control placement decodes per the manifest table.
+
+    Customer repro (opencode, 2026-08-28): the @ai-sdk stack lands the hint
+    inside a ``tool_calls`` entry when the message's last content part is a
+    tool call, and the closed wire model 400ed every Claude-family multi-turn
+    tool session with no client-side workaround.
+    """
+    from exp.runtime.openai_protocol.manifest import CHAT_CACHE_CONTROL_PLACEMENTS
+
+    assert CHAT_CACHE_CONTROL_PLACEMENTS == {
+        "messages": "validated_and_dropped",
+        "messages.content": "validated_and_dropped",
+        "messages.tool_calls": "validated_and_forwarded_to_anthropic_tool_use",
+    }
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "read both files",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                    "cache_control": {"type": "ephemeral", "ttl": "5m"},
+                },
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": '{"path":"a.txt"}'},
+                        },
+                        {
+                            "id": "call-2",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": '{"path":"b.txt"}'},
+                            "cache_control": {"type": "ephemeral"},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "a"},
+                {"role": "tool", "tool_call_id": "call-2", "content": "b"},
+            ],
+        }
+    )
+    calls = decoded.request.messages[1].tool_calls
+    assert calls[0].cache_control is None
+    assert calls[1].cache_control == {"type": "ephemeral"}
+    # Message- and part-level hints stay validated-and-dropped.
+    assert "cache_control" not in decoded.request.messages[0].model_dump(mode="json")
+
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "read_file", "arguments": "{}"},
+                                "cache_control": {"type": "persistent"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    assert "cache_control" in str(raised.value.detail.param)
+
+
+def test_empty_tool_call_arguments_decode_as_the_canonical_empty_object() -> None:
+    """A zero-argument echo with arguments '' decodes as {} on both surfaces.
+
+    Mirrors the streaming completion seed: no provider wire accepts empty
+    argument bytes, and the @ai-sdk stack normally sends "{}", so the empty
+    string is normalized instead of 400ing the continuation.
+    """
+    chat = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "get_time", "arguments": ""},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "noon"},
+            ],
+        }
+    )
+    call = chat.request.messages[0].tool_calls[0]
+    assert call.arguments == {}
+    assert call.raw_arguments == "{}"
+
+    responses = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": "call-1", "name": "get_time", "arguments": ""},
+                {"type": "function_call_output", "call_id": "call-1", "output": "noon"},
+            ],
+        }
+    )
+    assert responses.request.messages[0].tool_calls[0].raw_arguments == "{}"


### PR DESCRIPTION
## What (customer-blocking, 0.7.4)

`POST /v1/chat/completions` 400ed (`Invalid value for 'messages.N.tool_calls.i.cache_control'`) whenever an assistant message's `tool_calls[i]` carried `"cache_control": {"type": "ephemeral"}`. OpenCode (and the @ai-sdk/openai-compatible stack generally) attaches an Anthropic-style cache hint to the last content part of recent messages for any Claude-family model id; when that part is a tool call, the hint lands inside the `tool_calls` entry, so every Claude-family multi-turn tool session died on the continuation with no client-side workaround. The gateway already accepted the identical hint on message content parts, so the placement gap was pure inconsistency.

## How

- The supported ephemeral form is accepted on Chat `tool_calls` entries and on native Messages `tool_use` blocks (which previously validated-and-dropped it), carried on `ToolCall.cache_control` as a digest-excluded hint (mirroring `raw_arguments`: a cache hint can never perturb immutable artifacts or replay identity — sha256 equality pinned).
- On Anthropic rungs, the hint forwards onto the native `tool_use`-block `cache_control` — a real prompt-caching win Anthropic defines natively. Live-verified: the customer's exact failing body decodes and the hinted payload streams clean through api.anthropic.com (`cache_control` present on the emitted `tool_use` block, HTTP 200).
- On routes with any non-Anthropic rung, the hint is a disclosed no-op: `messages.tool_calls.cache_control` joins `ignored_parameters`; it never narrows or rejects a route (a cache hint changes cost, not semantics). Non-Anthropic wires never see the field.
- `CHAT_CACHE_CONTROL_PLACEMENTS` in `manifest.py` classifies every placement (message-level: validated-and-dropped; content-part: validated-and-dropped; tool_calls entry: forwarded-on-Anthropic), with a behavior test exercising each, so a new placement is a recorded decision, never a silent 400.
- Related probe decided: a zero-argument echo sent as `arguments: ""` now decodes as the canonical empty object on both OpenAI surfaces instead of 400ing, mirroring the streaming completion seed shipped in 0.7.3 (no provider wire accepts empty argument bytes; the parsed/raw contract stays coherent as `{}`/`"{}"`).
- Structural: the change pushed `requests.py` over the 999-line budget; the cohesive OpenCode cache-hint validation/stripping seam moved verbatim to `exp/runtime/openai_protocol/cache_control.py`.

## Tests

Placement-table behavior test (all three placements, plus a named 400 for an unsupported cache_control form), empty-arguments echo decode on both surfaces, Anthropic wire emission + non-Anthropic disclosure + digest invariance, and the customer's exact repro shape. Python-only; the crate is untouched.

## Gates

`uv run pytest -q`: 2688 passed, 2 skipped, 0 failed. `ruff check .`, `ruff format --check .`, `ty check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
