### PR TITLE
release: bump version to 0.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.3"
+version = "0.7.4"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.4 release. Ships #662: cache_control accepted on Chat tool_calls entries and native Messages tool_use blocks, forwarded to Anthropic's native tool_use-block cache_control on anthropic rungs (live-verified; real prompt-caching win) and disclosed as ignored on other rungs; digest-excluded so cache hints never perturb replay identity; CHAT_CACHE_CONTROL_PLACEMENTS classification table; empty-string tool arguments normalize to the canonical empty object on both OpenAI surfaces. Unblocks opencode (and any @ai-sdk/openai-compatible client) running Claude-family multi-turn tool sessions. Python-only; exp-gateway-native stays 0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)