### PR TITLE
test: fix sandbox wall-timer flake in silent-agent cleanup test

### DIFF
--- a/exp/simulation/engines/sandbox_test.py
+++ b/exp/simulation/engines/sandbox_test.py
@@ -228,12 +228,16 @@ def test_maximum_time_interrupts_a_silent_agent_and_still_cleans_up(tmp_path: Pa
     )
     started = time.monotonic()
 
+    # The wall bound must outlast pre-episode setup on a loaded runner: _Deadline starts
+    # at construction, and an expired deadline raises before the environment ever opens,
+    # which would make close_calls 0 without any cleanup having been skipped. Interrupting
+    # the 2.0s sleep is proven by finishing well under 2.0s, not by a tiny bound.
     artifact_set = simulator.run(
-        _spec(plan_input, task_input, ("cell-a",), maximum_time_seconds=0.02)
+        _spec(plan_input, task_input, ("cell-a",), maximum_time_seconds=0.5)
     )
     rollout = _load_rollout(store, artifact_set.artifact_ids[0])
 
-    assert time.monotonic() - started < 1.0
+    assert time.monotonic() - started < 1.5
     assert rollout.stop_reason == StopReason.MAXIMUM_TIME
     assert rollout.failure is not None
     assert rollout.failure.exception_type == "SandboxTimeLimitError"


### PR DESCRIPTION
## What

`test_maximum_time_interrupts_a_silent_agent_and_still_cleans_up` failed on an unrelated PR's gate (run 33228765574) with `close_calls == 0`. Root cause: the 20ms wall bound starts at `_Deadline` construction, and on a loaded runner the pre-episode setup between construction and `signal.setitimer(deadline.remaining())` can exceed 20ms — `remaining()` then raises `SandboxTimeLimitError` before the environment ever opens, so the stop reason and failure type still match while cleanup was never owed. The test's intent (a silent agent cannot evade the bound, and cleanup runs once) only needs the run to finish well under the agent's 2.0s sleep, not a tiny bound, so the bound widens to 0.5s and the elapsed assertion to 1.5s, with a comment pinning the constraint.

Same flake family as the two prior timing-tolerance fixes; test-only change.

## Gates

`pytest exp/simulation/engines/sandbox_test.py`: 13 passed. ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)