### PR TITLE
fix: exclude nested agent worktrees from ty/ruff and gitignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ wandb/
 
 # Local agent scratchpads: never tracked, never in PRs (AGENTS.md, Repository layout).
 .agents/
+
+# Agent worktrees nested inside a checkout: independent checkouts, never tracked here.
+# (.claude/ itself stays tracked for committed skills; only its worktrees are local.)
+.codex/
+.claude/worktrees/
+.worktree/
+.worktrees/
+implementation-worktrees/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ testpaths = ["exp"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+# Agent worktrees nested inside a checkout are independent checkouts, not project sources.
+extend-exclude = [
+    ".codex",
+    ".claude",
+    ".worktree",
+    ".worktrees",
+    "implementation-worktrees",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "ANN", "BLE", "T20"]
@@ -94,6 +102,16 @@ convention = "google"
 "**/*_test.py" = ["D"]
 [tool.ty.environment]
 python-version = "3.12"
+
+[tool.ty.src]
+# Agent worktrees nested inside a checkout are independent checkouts, not project sources.
+exclude = [
+    ".codex/",
+    ".claude/",
+    ".worktree/",
+    ".worktrees/",
+    "implementation-worktrees/",
+]
 
 [tool.uv.sources]
 # The one permitted path source (AGENTS.md "One package"): repo checkouts rebuild the


### PR DESCRIPTION
## Problem (measured on the main checkout)

`just gate` was not runnable and not clean on a fresh checkout:

- `uv run ty check` reported 1,149 diagnostics, of which ~1,130 came from stale agent worktrees nested inside the tree (`.codex/worktrees/...`, `.worktree/...`, historical `implementation-worktrees/`). ty and ruff had no excludes for these directories, and they were not gitignored.
- The checkout's venv lacked pytest entirely (stale `uv sync`), so the gate could not run at all.

Result: contributors push without gating, and CI (gate.yml, ~5.5 min) bounces roughly 40% of recent runs.

## What changed

- `pyproject.toml`: added `extend-exclude` under `[tool.ruff]` and `exclude` under a new `[tool.ty.src]` table for `.codex/`, `.claude/`, `.worktree/`, `.worktrees/`, `implementation-worktrees/`.
- `.gitignore`: ignore `.codex/`, `.worktree/`, `.worktrees/`, `implementation-worktrees/`, and `.claude/worktrees/`. The tracked `.claude/` skills stay committed; only its `worktrees/` subdirectory is ignored (the ruff/ty exclusion of `.claude` is safe since it contains no Python).

No source code changes; `exp/runtime/gateway/native/` untouched.

## Proof: full gate on a fresh main-based worktree with this change

```
uv run ruff check .          -> All checks passed!
uv run ruff format --check . -> 724 files already formatted
uv run ty check              -> All checks passed!
uv run pytest -q             -> 2908 passed, 2 skipped in 280.27s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)