### PR TITLE
gateway: attribute provider-rejected parameters in sanitized client errors

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -140,6 +140,14 @@ result can advance to the next certified deployment, while mixed semantic output
 commits and flushes the original route. Provider-internal retry layers are disabled so every
 possible billable dispatch is visible to the gateway ledger.
 
+Provider client-errors stay sanitized: no provider error prose or body content ever reaches the
+caller. The one provider-derived fact a 4xx rejection may relay is the parameter path the provider
+named, extracted per dialect (OpenAI `error.param`; Anthropic's leading `path:` message token;
+Gemini `google.rpc.BadRequest` field violations; Bedrock never) and only when it validates against
+a strict path grammar. The path surfaces as `param` in OpenAI-shaped envelopes and folds into the
+message as `(param: ...)` on the Anthropic surface; anything unextractable keeps today's
+content-free message.
+
 Before each physical dispatch, the same immediate SQLite transaction reserves the request's
 conservative maximum integer micro-USD cost and inserts its attempt row. Applicable hard limits can
 cover the local team, one identity, one alias pool, and each provider deployment within that pool.

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -642,6 +642,8 @@ class GatewayFailure(ContractModel):
     retryable_same_deployment: bool = False
     failover_eligible: bool = False
     safe_details: JsonObject = Field(default_factory=dict)
+    rejected_parameter: str | None = Field(default=None, min_length=1, max_length=128)
+    """Validated provider-named parameter path; never provider prose."""
 
 
 class ProjectSelection(ContractModel):

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.3"
+version = "0.3.4"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -166,6 +166,10 @@ pub struct Failure {
     pub retryable_same_deployment: bool,
     #[serde(default)]
     pub failover_eligible: bool,
+    /// Validated provider-named parameter path (never provider prose); the
+    /// only provider-derived content a sanitized client-error may relay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejected_parameter: Option<String>,
 }
 
 impl Failure {
@@ -175,7 +179,14 @@ impl Failure {
             safe_message: safe_message.to_string(),
             retryable_same_deployment: false,
             failover_eligible: false,
+            rejected_parameter: None,
         }
+    }
+
+    /// Attach one already-validated provider parameter path.
+    pub fn with_rejected_parameter(mut self, parameter: Option<String>) -> Self {
+        self.rejected_parameter = parameter;
+        self
     }
 
     /// Attach the python taxonomy's retry classification to this failure.
@@ -225,6 +236,9 @@ impl Failure {
             _ => (502, "all_routes_failed", "api_error"),
         };
         let mut error = PublicError::new(status, code, &self.safe_message, error_type);
+        if self.failure_class == FailureClass::InvalidRequest {
+            error.param = self.rejected_parameter.clone();
+        }
         error.retry_after_seconds = match self.failure_class {
             FailureClass::Throttled => Some(5),
             FailureClass::QuotaExceeded => Some(3600),
@@ -237,6 +251,29 @@ impl Failure {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejected_parameter_reaches_the_public_error_only_for_invalid_requests() {
+        let attributed = Failure::new(FailureClass::InvalidRequest, "provider rejected")
+            .with_rejected_parameter(Some("input[1].status".to_string()));
+        assert_eq!(
+            attributed.public_error().param.as_deref(),
+            Some("input[1].status")
+        );
+        // Any other class stays param-free even if a parameter leaked in.
+        let internal = Failure::new(FailureClass::ProviderInternal, "provider failed")
+            .with_rejected_parameter(Some("input[1].status".to_string()));
+        assert_eq!(internal.public_error().param, None);
+        // Serde omits the field when absent, so boundary payloads are unchanged.
+        let bare = serde_json::to_value(Failure::new(FailureClass::InvalidRequest, "x"))
+            .expect("serializable");
+        assert!(bare.get("rejected_parameter").is_none());
+        let carried = serde_json::to_value(attributed).expect("serializable");
+        assert_eq!(
+            carried["rejected_parameter"].as_str(),
+            Some("input[1].status")
+        );
+    }
 
     #[test]
     fn boundary_replaces_malformed_detail_with_the_generic_message() {

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -17,6 +17,7 @@ mod eventstream;
 mod guardrails;
 mod memory;
 mod metrics;
+mod param_attribution;
 mod relay;
 mod replay;
 mod respond;

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -1,0 +1,288 @@
+//! Provider-rejected parameter attribution for sanitized 400s.
+//!
+//! When a provider rejects a dispatched request with a client-error status,
+//! the public failure stays sanitized: no provider prose or body content ever
+//! crosses the boundary. The ONE fact this module may relay is the parameter
+//! path the provider named, and only when it validates against the strict
+//! path grammar below — anything else keeps today's content-free message.
+//!
+//! Extraction classification per dialect (a new [`Dialect`] variant fails to
+//! compile until it is classified here, and the exhaustiveness test pins the
+//! documented source):
+//!
+//! | dialect                 | source                                        |
+//! |-------------------------|-----------------------------------------------|
+//! | `OpenAiResponses`       | `error.param` field, verbatim JSON string      |
+//! | `OpenAiCompatible`      | `error.param` field, verbatim JSON string      |
+//! | `AnthropicMessages`     | leading `path: ` token of `error.message`      |
+//! | `GeminiGenerateContent` | `fieldViolations[].field`, else `* path: ` msg |
+//! | `BedrockConverseStream` | none — no machine-readable parameter contract  |
+
+use serde_json::Value;
+
+use crate::dialects::Dialect;
+
+/// Longest parameter path relayed; anything longer is treated as prose.
+const MAXIMUM_PATH_LENGTH: usize = 128;
+
+/// Extract the provider-named parameter path from one client-error body.
+///
+/// Returns `Some(path)` only when the dialect's documented source yields a
+/// string that passes [`valid_parameter_path`]; every other body — missing
+/// fields, prose, oversized or non-path content, non-JSON — yields `None`
+/// and the caller keeps the content-free sanitized message.
+pub fn rejected_parameter(dialect: Dialect, body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    let candidate = match dialect {
+        Dialect::OpenAiResponses | Dialect::OpenAiCompatible => value
+            .get("error")?
+            .get("param")?
+            .as_str()
+            .map(str::to_string),
+        Dialect::AnthropicMessages => {
+            let message = value.get("error")?.get("message")?.as_str()?;
+            let (head, _rest) = message.split_once(": ")?;
+            Some(head.to_string())
+        }
+        Dialect::GeminiGenerateContent => gemini_field_violation(&value),
+        Dialect::BedrockConverseStream => None,
+    }?;
+    valid_parameter_path(&candidate).then_some(candidate)
+}
+
+/// `fieldViolations[].field` when a `google.rpc.BadRequest` detail exists,
+/// else the leading `* <path>: ` token of the message (the shape the live
+/// API returned for a generation-config violation, 2026-08-29).
+fn gemini_field_violation(value: &Value) -> Option<String> {
+    let error = value.get("error")?;
+    if let Some(details) = error.get("details").and_then(Value::as_array) {
+        for detail in details {
+            let type_url = detail.get("@type").and_then(Value::as_str).unwrap_or("");
+            if !type_url.ends_with("google.rpc.BadRequest") {
+                continue;
+            }
+            if let Some(field) = detail
+                .get("fieldViolations")
+                .and_then(Value::as_array)
+                .and_then(|violations| {
+                    violations
+                        .iter()
+                        .find_map(|violation| violation.get("field").and_then(Value::as_str))
+                })
+            {
+                return Some(field.to_string());
+            }
+        }
+    }
+    let message = error.get("message")?.as_str()?;
+    let head = message.strip_prefix("* ")?;
+    let (path, _rest) = head.split_once(": ")?;
+    Some(path.to_string())
+}
+
+/// Whether one candidate is a parameter path and cannot be prose.
+///
+/// Grammar: ASCII segments of `[A-Za-z0-9_-]` joined by `.`, with optional
+/// numeric `[N]` indexes; no whitespace, no empty segments, bounded length.
+/// This is deliberately narrower than what providers could emit: a rejected
+/// candidate costs only attribution, while an accepted one crosses the
+/// sanitization boundary.
+pub fn valid_parameter_path(candidate: &str) -> bool {
+    if candidate.is_empty() || candidate.len() > MAXIMUM_PATH_LENGTH {
+        return false;
+    }
+    if !candidate.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+        return false;
+    }
+    let mut chars = candidate.chars().peekable();
+    let mut segment_open = false;
+    while let Some(c) = chars.next() {
+        match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' => segment_open = true,
+            '.' => {
+                if !segment_open || chars.peek().is_none() {
+                    return false;
+                }
+                segment_open = false;
+            }
+            '[' => {
+                if !segment_open {
+                    return false;
+                }
+                let mut digits = 0usize;
+                loop {
+                    match chars.next() {
+                        Some(d) if d.is_ascii_digit() => digits += 1,
+                        Some(']') if digits > 0 => break,
+                        _ => return false,
+                    }
+                }
+            }
+            _ => return false,
+        }
+    }
+    segment_open
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_param_field_is_relayed_when_it_is_a_path() {
+        // Exact body captured live from api.openai.com (2026-08-29).
+        let body = r#"{"error": {"message": "Unknown parameter: 'input[1].status'.",
+            "type": "invalid_request_error", "param": "input[1].status",
+            "code": "unknown_parameter"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::OpenAiResponses, body).as_deref(),
+            Some("input[1].status")
+        );
+        assert_eq!(
+            rejected_parameter(Dialect::OpenAiCompatible, body).as_deref(),
+            Some("input[1].status")
+        );
+    }
+
+    #[test]
+    fn anthropic_leading_message_token_is_relayed_when_it_is_a_path() {
+        // Anthropic names the field as a leading `path: ` message token.
+        let body = r#"{"type": "error", "error": {"type": "invalid_request_error",
+            "message": "context_management: Extra inputs are not permitted"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::AnthropicMessages, body).as_deref(),
+            Some("context_management")
+        );
+        let nested = r#"{"type": "error", "error": {"type": "invalid_request_error",
+            "message": "messages.1.content.0.text: Field required"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::AnthropicMessages, nested).as_deref(),
+            Some("messages.1.content.0.text")
+        );
+    }
+
+    #[test]
+    fn gemini_message_path_token_is_relayed_without_violation_details() {
+        // Exact live shape from generativelanguage.googleapis.com (2026-08-29).
+        let body = r#"{"error": {"code": 400, "status": "INVALID_ARGUMENT",
+            "message": "* GenerateContentRequest.generation_config.temperature: temperature must be in the range [0.0, 2.0].\n"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::GeminiGenerateContent, body).as_deref(),
+            Some("GenerateContentRequest.generation_config.temperature")
+        );
+        // Prose-leading messages stay content-free.
+        let prose = r#"{"error": {"code": 400, "message": "API key not valid: renew it"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::GeminiGenerateContent, prose),
+            None
+        );
+    }
+
+    #[test]
+    fn gemini_bad_request_field_violation_is_relayed() {
+        let body = r#"{"error": {"code": 400, "status": "INVALID_ARGUMENT",
+            "message": "Invalid JSON payload received.",
+            "details": [{"@type": "type.googleapis.com/google.rpc.BadRequest",
+                "fieldViolations": [{"field": "generation_config.temperature",
+                    "description": "out of range"}]}]}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::GeminiGenerateContent, body).as_deref(),
+            Some("generation_config.temperature")
+        );
+    }
+
+    #[test]
+    fn bedrock_never_attributes() {
+        let body = r#"{"message": "Malformed input request: extraneous key [topK]"}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::BedrockConverseStream, body),
+            None
+        );
+    }
+
+    #[test]
+    fn provider_prose_never_crosses_the_boundary() {
+        // A prose-bearing param field, prose-only Anthropic messages, and
+        // adversarial path-shaped content all stay content-free.
+        let prose_param = r#"{"error": {"param": "please contact support at example.com"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::OpenAiResponses, prose_param),
+            None
+        );
+        let no_path_message =
+            r#"{"type": "error", "error": {"message": "Extra inputs are not permitted"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::AnthropicMessages, no_path_message),
+            None
+        );
+        let prose_head = r#"{"error": {"message": "Your credit balance is too low: top up"}}"#;
+        assert_eq!(
+            rejected_parameter(Dialect::AnthropicMessages, prose_head),
+            None
+        );
+        let not_json = "upstream said no";
+        assert_eq!(rejected_parameter(Dialect::OpenAiResponses, not_json), None);
+    }
+
+    #[test]
+    fn the_path_grammar_is_strict() {
+        for accepted in [
+            "temperature",
+            "input[1].status",
+            "messages.1.content.0.text",
+            "tools[0].function.name",
+            "generation_config.top_k",
+            "anthropic-beta",
+        ] {
+            assert!(valid_parameter_path(accepted), "{accepted}");
+        }
+        for rejected in [
+            "",
+            "has space",
+            "trailing.",
+            ".leading",
+            "double..dot",
+            "input[].status",
+            "input[1.status",
+            "input[a]",
+            "9starts_with_digit",
+            "unicode_ĸey",
+            "a]b",
+            "semi;colon",
+            "path\nnewline",
+        ] {
+            assert!(!valid_parameter_path(rejected), "{rejected}");
+        }
+        assert!(!valid_parameter_path(&"x".repeat(129)));
+    }
+
+    /// The documented extraction source for one dialect.
+    ///
+    /// The match is exhaustive on purpose: adding a dialect without deciding
+    /// its attribution contract fails this drift gate at compile time, and
+    /// `rejected_parameter`'s own exhaustive match enforces the same in the
+    /// production path.
+    fn extraction_classification(dialect: Dialect) -> &'static str {
+        match dialect {
+            Dialect::OpenAiResponses | Dialect::OpenAiCompatible => "error.param field",
+            Dialect::AnthropicMessages => "leading path token of error.message",
+            Dialect::GeminiGenerateContent => {
+                "google.rpc.BadRequest fieldViolations, else leading message path token"
+            }
+            Dialect::BedrockConverseStream => "none: no machine-readable parameter contract",
+        }
+    }
+
+    #[test]
+    fn every_dialect_carries_an_explicit_extraction_classification() {
+        for dialect in [
+            Dialect::OpenAiResponses,
+            Dialect::AnthropicMessages,
+            Dialect::OpenAiCompatible,
+            Dialect::GeminiGenerateContent,
+            Dialect::BedrockConverseStream,
+        ] {
+            assert!(!extraction_classification(dialect).is_empty());
+        }
+    }
+}

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 
 use serde_json::Value;
 
+use crate::dialects::Dialect;
 use crate::errors::{Failure, FailureClass};
+use crate::param_attribution::rejected_parameter;
 
 /// Build the shared pooled upstream client, mirroring the pooling constants in
 /// `providers.async_transport` (64 keep-alive) and its no-redirect policy so a
@@ -117,6 +119,7 @@ fn open_timeout_failure() -> Failure {
 /// `raw_body` carries the exact pre-serialized body for body-signing dialects
 /// (Bedrock SigV4): its signature covers those exact bytes, so it is sent
 /// verbatim with the signed headers instead of re-serializing `payload`.
+#[allow(clippy::too_many_arguments)]
 pub async fn open_stream(
     client: &reqwest::Client,
     url: &str,
@@ -125,6 +128,7 @@ pub async fn open_stream(
     payload: &Value,
     raw_body: Option<&str>,
     phase_timeout: Duration,
+    dialect: Dialect,
 ) -> Result<reqwest::Response, Failure> {
     let mut request = client.post(url);
     for (name, value) in headers {
@@ -150,9 +154,41 @@ pub async fn open_stream(
     };
     let status = response.status().as_u16();
     if !(200..300).contains(&status) {
-        return Err(transport_failure(Some(status)));
+        let failure = transport_failure(Some(status));
+        // Only the generic client-error class may carry attribution: the
+        // body is read bounded and the sole relayable fact is a validated
+        // parameter path; everything else stays content-free.
+        if failure.failure_class != FailureClass::InvalidRequest {
+            return Err(failure);
+        }
+        let parameter =
+            match tokio::time::timeout(ERROR_BODY_READ_TIMEOUT, bounded_error_body(response)).await
+            {
+                Ok(Some(body)) => rejected_parameter(dialect, &body),
+                _ => None,
+            };
+        return Err(failure.with_rejected_parameter(parameter));
     }
     Ok(response)
+}
+
+/// Longest provider error body read for parameter attribution.
+const ERROR_BODY_READ_LIMIT: usize = 16 * 1024;
+
+/// Bound on the whole attribution body read; a stalling error stream is
+/// abandoned and the failure stays content-free.
+const ERROR_BODY_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Read at most `ERROR_BODY_READ_LIMIT` bytes of one error response body.
+async fn bounded_error_body(mut response: reqwest::Response) -> Option<String> {
+    let mut collected: Vec<u8> = Vec::new();
+    while let Ok(Some(chunk)) = response.chunk().await {
+        if collected.len() + chunk.len() > ERROR_BODY_READ_LIMIT {
+            return None;
+        }
+        collected.extend_from_slice(&chunk);
+    }
+    String::from_utf8(collected).ok()
 }
 
 #[cfg(test)]

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -439,6 +439,7 @@ async fn run_attempt(
         &wire.upstream_payload,
         wire.upstream_body.as_deref(),
         open_bound,
+        dialect,
     )
     .await
     {

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -121,11 +121,17 @@ def _failure_from_payload(payload: object) -> GatewayFailure | None:
     if not isinstance(payload, dict):
         return None
     data = cast("JsonObject", payload)
+    rejected_parameter = data.get("rejected_parameter")
     return GatewayFailure(
         failure_class=GatewayFailureClass(str(data["failure_class"])),
         safe_message=str(data["safe_message"]),
         retryable_same_deployment=bool(data.get("retryable_same_deployment", False)),
         failover_eligible=bool(data.get("failover_eligible", False)),
+        rejected_parameter=(
+            rejected_parameter
+            if isinstance(rejected_parameter, str) and rejected_parameter
+            else None
+        ),
     )
 
 
@@ -373,14 +379,14 @@ class NativeAttemptAccounting:
         self.finish_request_quietly(entry.authorization, exhaustion)
         with self._lock:
             self._inflight.pop(request_id, None)
+        failure_payload: JsonObject = {
+            "failure_class": exhaustion.failure_class.value,
+            "safe_message": exhaustion.safe_message,
+        }
+        if exhaustion.rejected_parameter is not None:
+            failure_payload["rejected_parameter"] = exhaustion.rejected_parameter
         return json.dumps(
-            {
-                "exhausted": True,
-                "failure": {
-                    "failure_class": exhaustion.failure_class.value,
-                    "safe_message": exhaustion.safe_message,
-                },
-            },
+            {"exhausted": True, "failure": failure_payload},
             separators=(",", ":"),
         )
 

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -380,3 +380,48 @@ def test_sweep_cancels_the_active_attempt_after_the_deadline() -> None:
     ]
     assert registry.entry("request-one") is None
     assert registry.counters()[1] == 1
+
+
+def test_rejected_parameter_crosses_the_boundary_only_as_a_string() -> None:
+    """The provider-named parameter path survives the failure payload decode."""
+    registry, _ledger, _entry = _registry()
+    started = _start(registry, ordinal=0)
+    assert (
+        _settle(
+            registry,
+            attempt_id=str(started["attempt_id"]),
+            outcome="failed",
+            finalize=False,
+            failure={
+                "failure_class": "invalid_request",
+                "safe_message": "provider rejected the request",
+                "rejected_parameter": "input[1].status",
+            },
+        )
+        == "{}"
+    )
+    exhausted = _start(
+        registry,
+        ordinal=1,
+        current_depth=0,
+        failure={
+            "failure_class": "invalid_request",
+            "safe_message": "provider rejected the request",
+            "rejected_parameter": "input[1].status",
+        },
+    )
+    assert exhausted["exhausted"] is True
+    failure_payload = exhausted["failure"]
+    assert isinstance(failure_payload, dict)
+    assert failure_payload["rejected_parameter"] == "input[1].status"
+    # Non-string or empty payload values decode to None, never a coerced str.
+    from exp.runtime.gateway.native_accounting import _failure_from_payload
+
+    numeric = _failure_from_payload(
+        {"failure_class": "invalid_request", "safe_message": "x", "rejected_parameter": 7}
+    )
+    assert numeric is not None and numeric.rejected_parameter is None
+    empty = _failure_from_payload(
+        {"failure_class": "invalid_request", "safe_message": "x", "rejected_parameter": ""}
+    )
+    assert empty is not None and empty.rejected_parameter is None

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -173,6 +173,25 @@ class _SseUpstream(BaseHTTPRequestHandler):
         with self.payloads_lock:
             self.payloads.append(payload)
         prompt = payload["messages"][-1]["content"]
+        if prompt == "reject-param-token":
+            # Provider 400 naming the rejected parameter, with deliberate
+            # prose markers that must never reach the public error.
+            body = json.dumps(
+                {
+                    "error": {
+                        "message": "PROVIDER-PROSE-MARKER: 'input[1].status' is unknown.",
+                        "type": "invalid_request_error",
+                        "param": "input[1].status",
+                        "code": "unknown_parameter",
+                    }
+                }
+            ).encode()
+            self.send_response(400)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         self.send_response(200)
         self.send_header("content-type", "text/event-stream")
         self.end_headers()
@@ -1302,3 +1321,44 @@ def test_store_false_responses_cannot_be_continued(engine: _ServingEngine) -> No
     )
     assert continued.status_code == 400
     assert continued.json()["error"]["code"] == "continuation_unavailable"
+
+
+def test_provider_400_attributes_the_rejected_parameter_without_provider_prose(
+    engine: _ServingEngine,
+) -> None:
+    """A provider client-error relays ONLY the validated parameter path.
+
+    The mock provider's 400 body names ``input[1].status`` in its ``param``
+    field and carries a prose marker in its message; the public error must
+    surface the path and keep the sanitized message, never the marker.
+    """
+    native = httpx.post(
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json=_messages_body("reject-param-token"),
+        timeout=30.0,
+    )
+    assert native.status_code == 400
+    error = native.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert "PROVIDER-PROSE-MARKER" not in json.dumps(native.json())
+    # The Anthropic envelope folds a present param pointer into the message.
+    assert error["message"] == (
+        "provider rejected the request; verify the request fields against "
+        "the model alias capabilities (param: input[1].status)"
+    )
+
+    # The OpenAI envelope carries the same attribution as the param field.
+    chat = httpx.post(
+        f"{engine.base}/v1/chat/completions",
+        headers={"authorization": f"Bearer {engine.raw_key}"},
+        json={
+            "model": "coding",
+            "messages": [{"role": "user", "content": "reject-param-token"}],
+        },
+        timeout=30.0,
+    )
+    assert chat.status_code == 400
+    chat_error = chat.json()["error"]
+    assert chat_error["param"] == "input[1].status"
+    assert "PROVIDER-PROSE-MARKER" not in json.dumps(chat.json())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.3,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.4,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.3"
+version = "0.3.4"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What

Owner-approved 0.7.6 item: provider-param attribution in sanitized transport errors. A provider client-error stays exactly as sanitized as today — no provider prose or body content ever crosses — except for ONE validated fact: the parameter path the provider named.

- **Per-dialect extraction** (`param_attribution.rs`, exhaustive over `Dialect` so a new dialect fails to compile until classified): OpenAI Responses/compatible read `error.param`; Anthropic reads the leading `path: ` token of `error.message`; Gemini reads `google.rpc.BadRequest fieldViolations[].field` with a fallback to the leading `* path: ` message token; Bedrock never attributes (no machine-readable parameter contract).
- **Strict path grammar** gate: ASCII identifier segments joined by dots with numeric `[N]` indexes, bounded at 128 chars, must start alphabetic — a candidate that could be prose is dropped and the failure stays content-free (owner's rule: no extractable param → today's message).
- **Bounded read**: the error body is read only for the generic client-error class (400/422-style; 401/403/404/408/429 stay body-free), capped at 16KB under a 2s timeout; a stalling or oversized error stream keeps the content-free message.
- **Surfacing**: `Failure.rejected_parameter` (serde-optional, omitted when absent so boundary payloads are unchanged) folds into the public error only for `InvalidRequest`: as the `param` field in OpenAI-shaped envelopes, and as the existing `(param: ...)` message fold on the Anthropic surface. Python `GatewayFailure` mirrors the optional field and the exhaustion payload carries it.

## Evidence

- Every extractor is pinned on a live-captured provider body (all 2026-08-29): OpenAI `"param": "input[1].status"` (from the reasoning-status probe), Anthropic `"bogus_field: Extra inputs are not permitted"` / `"messages.0.content.0.text.text: Field required"`, Gemini `"* GenerateContentRequest.generation_config.temperature: ..."` (the live API returned NO fieldViolations detail, which is why the message fallback exists).
- No-prose guarantee tests: prose in the `param` field, prose-leading messages, adversarial path-shaped injections, oversize, non-ASCII — all stay content-free.
- E2E (`native_messages_test`): a mock provider 400 carrying a `PROVIDER-PROSE-MARKER` in its message yields the public sanitized message + `param` on the chat surface and the `(param: ...)` fold on the Messages surface, with the marker asserted absent from the full response body on both.

## Gates

Full suite 2909 passed / 0 failed (the two release-evidence tests require the committed tree and pass post-commit). `cargo test` 97 passed, `cargo fmt`, `clippy` clean, `ruff`/`ty` clean. exp-gateway-native 0.3.4 (Cargo.toml, Cargo.lock, pyproject, root pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
