### PR TITLE
release: bump version to 0.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.5"
+version = "0.7.6"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.6 release — the CLI-compat train:
- #672: every field the CURRENT first-party CLIs send by default now decodes, routes, and round-trips — Claude Code (output_config folded into the canonical effort so the sources cannot fight, mid-conversation system forwarded positionally, thinking.display, all pinned on captured bodies) and Codex (additional_tools namespace trees + freeform custom_tool_call carried byte-identical on provider_native_item with full Rust normalizer/replay/accounting support, message ids/optional status echoes, text.verbosity, client_metadata). Both captured turn-2 bodies 200 against the real providers.
- #671: sanitized client errors attribute the provider-rejected parameter path (never provider prose).
- #669, #670 from the parallel lane.

Ships experiential 0.7.6 + exp-gateway-native 0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)