### PR TITLE
gateway: decode Codex reasoning echoes; only Idempotency-Key keys replay

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -267,7 +267,10 @@ alias-revision-scoped stores. A `store: false` request skips continuation retent
 `include: ["reasoning.encrypted_content"]` forwards the encrypted reasoning request to native
 OpenAI Responses routes, whose opaque payloads replay verbatim from the caller's input; the
 replayed reasoning item's `id` is never forwarded upstream because the provider binds the
-encrypted payload to its original item id and callers echo this gateway's own minted public ids. Replay is opt-in through an idempotency or client request key. Restart
+encrypted payload to its original item id and callers echo this gateway's own minted public ids. Replay is opt-in through the standard `Idempotency-Key` header only;
+`X-Client-Request-Id` is caller correlation identity (Codex sends its session id there on
+every request of a session), echoed on responses and used for route affinity, never as an
+operation key. Restart
 or eviction returns an explicit unavailable error and never reconstructs content from SQLite.
 
 ## Content-free observability and lifecycle

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -215,6 +215,11 @@ class SQLiteAttemptLedger:
                 if str(prior["canonical_request_sha256"]) != (
                     authorization.canonical_request_sha256
                 ):
+                    # Deliberately fail closed even when the prior attempt
+                    # failed: after an ambiguous failure the provider may
+                    # have executed, so different content under one
+                    # operation identity is a client bug the key exists to
+                    # surface. Retrying different content needs a new key.
                     raise IdempotencyConflictError(
                         "caller operation key was reused with different request content"
                     )

--- a/exp/runtime/gateway/ledger_test.py
+++ b/exp/runtime/gateway/ledger_test.py
@@ -96,12 +96,18 @@ def _deployment(
     )
 
 
-def _request(content: str, *, idempotency_key: str | None = None) -> GatewayRequest:
+def _request(
+    content: str,
+    *,
+    idempotency_key: str | None = None,
+    client_request_id: str | None = None,
+) -> GatewayRequest:
     """Create one request whose content must not enter SQLite."""
     return GatewayRequest(
         surface=GatewayApiSurface.CHAT_COMPLETIONS,
         messages=(GatewayMessage(role="user", content=content),),
         idempotency_key=idempotency_key,
+        client_request_id=client_request_id,
     )
 
 
@@ -714,6 +720,58 @@ def test_idempotency_is_opt_in_and_restart_replay_fails_closed(tmp_path: Path) -
     )
     with pytest.raises(IdempotencyConflictError, match="different request"):
         restarted.accept_request(authorization=conflicting)
+
+
+def test_a_session_correlation_id_never_keys_duplicate_detection(tmp_path: Path) -> None:
+    """Sequential distinct requests sharing one X-Client-Request-Id all accept.
+
+    Codex sends its session id in that header on every request of a session
+    (captured live 2026-08-29), so treating it as an operation key would
+    reject the second request of every real session as a conflict.
+    """
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    for content in ("first turn", "second turn", "third turn"):
+        authorization = store.authorize_request(
+            raw_key=raw_key,
+            alias="coding",
+            request=_request(content, client_request_id="codex-session-one"),
+            deadline_monotonic=clock.monotonic() + 30,
+        )
+        assert authorization.caller_operation_sha256 is None
+        ledger.accept_request(authorization=authorization)
+
+
+def test_a_failed_keyed_request_still_conflicts_a_mutated_retry(tmp_path: Path) -> None:
+    """Reusing an Idempotency-Key with a different body fails closed even
+    after the prior attempt failed: after a transport-ambiguous failure the
+    provider may have executed, so silently running different content under
+    the same operation identity is exactly what the key exists to prevent.
+    A stuck client must mint a new key rather than mutate the body."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    failed = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("original", idempotency_key="retry-operation"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=failed)
+    ledger.finish_request(
+        authorization=failed,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.TRANSPORT,
+            safe_message="provider unavailable",
+        ),
+    )
+    mutated = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("mutated", idempotency_key="retry-operation"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    with pytest.raises(IdempotencyConflictError, match="different request"):
+        ledger.accept_request(authorization=mutated)
 
 
 def test_crash_reconciliation_waits_for_deadline_and_cleanup_bound(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.7"
+version = "0.3.8"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -70,10 +70,13 @@ pub(crate) async fn chat(
     // bounded replay store dedupes concurrent duplicates and replays the
     // owner's exact stored response. Headers are decoded latin-1 so any
     // HTTP-legal value matches the python engine's view byte for byte.
+    // Only the standard Idempotency-Key opts into replay: callers reuse
+    // x-client-request-id as a session correlation id across distinct
+    // sequential requests, so it never keys an operation.
     let idempotency_key = latin1_header(&headers, "idempotency-key");
     let client_request_id = latin1_header(&headers, "x-client-request-id");
     let mut lease: Option<OwnerLease> = None;
-    if idempotency_key.is_some() || client_request_id.is_some() {
+    if idempotency_key.is_some() {
         let scope_argument = compact_json(&json!({
             "raw_key": raw_key,
             "body": body_text,

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -71,10 +71,14 @@ pub(crate) async fn responses(
     // protocol natively, sharing the same bounded replay store and
     // tenant-scoped key derivation the chat surface uses (the surface is
     // part of the key, so chat and Responses operations never collide).
+    // Only the standard Idempotency-Key opts into replay: Codex reuses
+    // x-client-request-id (its session id) across distinct sequential
+    // requests, so that header is correlation and affinity identity, never
+    // an operation key.
     let idempotency_key = latin1_header(&headers, "idempotency-key");
     let client_request_id = latin1_header(&headers, "x-client-request-id");
     let mut lease: Option<OwnerLease> = None;
-    if idempotency_key.is_some() || client_request_id.is_some() {
+    if idempotency_key.is_some() {
         let scope_argument = compact_json(&json!({
             "raw_key": raw_key,
             "body": body_text,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -795,7 +795,10 @@ class NativeControlPlane(NativeObservabilityMixin):
             client_request_id=optional_text(data.get("client_request_id")),
         )
         request = decoded.request
-        caller_operation = request.idempotency_key or request.client_request_id
+        # Only the standard Idempotency-Key names a retriable operation;
+        # client_request_id is a session correlation id real callers reuse
+        # across distinct requests, so it never keys replay.
+        caller_operation = request.idempotency_key
         if caller_operation is None:
             raise NativeBridgeError(
                 OpenAIProtocolError(
@@ -954,7 +957,9 @@ class NativeControlPlane(NativeObservabilityMixin):
                     identity_id=authorization.identity_id,
                     alias_revision_id=authorization.alias_revision_id,
                 ),
-                caller_episode_key=request.idempotency_key or request.client_request_id,
+                # The session-scoped correlation id is the stronger affinity
+                # scope; a per-operation idempotency key only pins retries.
+                caller_episode_key=request.client_request_id or request.idempotency_key,
                 request_id=authorization.request_id,
             )
         return self._components.routes.resolve_project_blocking(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1888,16 +1888,18 @@ def test_claim_scope_matches_the_python_replay_key(tmp_path: Path) -> None:
     assert scope["caller_operation_sha256"] == hashlib.sha256(b"operation-one").hexdigest()
     repeat = _claim_scope(control, raw_key, _chat_body(), idempotency_key="operation-one")
     assert repeat == scope
-    # The caller operation hashes identically through either header; the
-    # canonical request digest covers the decoded request, which records
-    # which header carried it, exactly as the shared decoder canonicalizes.
-    via_client_id = _claim_scope(
-        control,
-        raw_key,
-        _chat_body(),
-        client_request_id="operation-one",
-    )
-    assert via_client_id["caller_operation_sha256"] == scope["caller_operation_sha256"]
+    # X-Client-Request-Id is session correlation identity, never an
+    # operation key: a scope claim without an Idempotency-Key fails closed.
+    with pytest.raises(NativeBridgeError) as unkeyed:
+        _claim_scope(
+            control,
+            raw_key,
+            _chat_body(),
+            client_request_id="operation-one",
+        )
+    payload = json.loads(unkeyed.value.public_error_json)
+    assert payload["status_code"] == 400
+    assert payload["param"] == "Idempotency-Key"
     different_body = _claim_scope(
         control,
         raw_key,
@@ -1969,17 +1971,16 @@ def test_claim_scope_validates_headers_with_python_parity(tmp_path: Path) -> Non
             decode_chat(json.loads(_chat_body()), idempotency_key=bad_value)
         assert payload["code"] == expected.value.detail.code
         assert payload["message"] == expected.value.detail.message
-    with pytest.raises(NativeBridgeError) as mismatch:
-        _claim_scope(
-            control,
-            raw_key,
-            _chat_body(),
-            idempotency_key="one",
-            client_request_id="two",
-        )
-    payload = json.loads(mismatch.value.public_error_json)
-    assert payload["status_code"] == 400
-    assert payload["code"] == "idempotency_conflict"
+    # The two headers name independent concepts (operation vs session), so
+    # divergent values are legal and the operation key alone scopes replay.
+    divergent = _claim_scope(
+        control,
+        raw_key,
+        _chat_body(),
+        idempotency_key="one",
+        client_request_id="two",
+    )
+    assert divergent["caller_operation_sha256"] == hashlib.sha256(b"one").hexdigest()
 
 
 def test_keyed_admissions_enforce_the_durable_ledger_idempotency_rows(

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -108,7 +108,9 @@ def continued_request(
     if request.previous_response_id is None:
         episode = episode_namespace(
             namespace=namespace,
-            caller_episode_key=request.idempotency_key or request.client_request_id,
+            # The session-scoped correlation id is the stronger affinity
+            # scope; a per-operation idempotency key only pins retries.
+            caller_episode_key=request.client_request_id or request.idempotency_key,
             request_id=authorization.request_id,
         )
         return (

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -955,22 +955,19 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
 def _caller_operation_sha256(request: GatewayRequest) -> Sha256 | None:
     """Hash an opted-in caller operation without retaining the raw identifier.
 
+    Only the standard ``Idempotency-Key`` names a retriable operation.
+    ``client_request_id`` is a caller correlation identity that real
+    sessions reuse across distinct sequential requests, so it never keys
+    duplicate detection.
+
     Args:
         request: Canonical gateway request.
 
     Returns:
         Namespaced caller-operation digest, or ``None`` for ordinary requests.
-
-    Raises:
-        GatewayStoreError: Both supported headers name different operations.
     """
-    if (
-        request.idempotency_key is not None
-        and request.client_request_id is not None
-        and request.idempotency_key != request.client_request_id
-    ):
-        raise GatewayStoreError("idempotency and client request IDs must match when both are set")
-    value = request.idempotency_key or request.client_request_id
-    if value is None:
+    if request.idempotency_key is None:
         return None
-    return hashlib.sha256(f"gateway-caller-operation-v1\0{value}".encode()).hexdigest()
+    return hashlib.sha256(
+        f"gateway-caller-operation-v1\0{request.idempotency_key}".encode()
+    ).hexdigest()

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -191,7 +191,7 @@ impossible and accepting it would be silent."""
 
 
 RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED: dict[str, frozenset[str]] = {
-    "message": frozenset({"type", "role", "content", "id", "status"}),
+    "message": frozenset({"type", "role", "content", "id", "status", "phase"}),
     "function_call": frozenset({"type", "call_id", "name", "arguments", "id", "status"}),
     "function_call_output": frozenset({"type", "call_id", "output", "id", "status"}),
     "reasoning": frozenset({"type", "id", "encrypted_content", "summary", "content", "status"}),
@@ -200,10 +200,14 @@ RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED: dict[str, frozenset[str]] = {
 
 Stateless continuations resend prior OUTPUT items verbatim as the next
 INPUT, so every field this gateway's own output items carry must decode.
+Codex echoes assistant messages with ``phase`` and reasoning items with an
+explicit ``content: null`` (both captured live 2026-08-29); the message
+``phase`` is retained for replay identity and the null reasoning content
+is validated and dropped like its populated form.
 """
 
 RESPONSES_INPUT_ITEM_FIELDS_REJECTED: dict[str, frozenset[str]] = {
-    "message": frozenset({"phase"}),
+    "message": frozenset(),
     "function_call": frozenset({"caller", "namespace"}),
     "function_call_output": frozenset({"caller", "namespace", "name"}),
     "reasoning": frozenset(),
@@ -211,8 +215,7 @@ RESPONSES_INPUT_ITEM_FIELDS_REJECTED: dict[str, frozenset[str]] = {
 """Echoable input-item fields consciously rejected with a named 400.
 
 ``caller``/``namespace`` attribute server-tool invocations this gateway does
-not serve, ``phase`` is a provider response-phase marker outside the replay
-contract, and a ``name`` on a function output duplicates the call linkage
+not serve, and a ``name`` on a function output duplicates the call linkage
 already carried by ``call_id``.
 """
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -15,6 +15,7 @@ from pydantic import (
     TypeAdapter,
     ValidationError,
 )
+from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import ContractModel, JsonObject
 from exp.common.models.model import ToolCall
@@ -137,7 +138,9 @@ def decode_chat(
         extension_fields={"top_k", "reasoning_effort"},
     )
     request = _validate_wire(_ChatRequest, payload)
-    operation = _caller_operation(idempotency_key, client_request_id)
+    idempotency_key, client_request_id = _validated_operation_headers(
+        idempotency_key, client_request_id
+    )
     maximum = request.max_completion_tokens or request.max_tokens
     stop = (
         ()
@@ -177,8 +180,8 @@ def decode_chat(
             safety_identifier=request.safety_identifier,
             user=request.user,
             prompt_cache_key=request.prompt_cache_key,
-            idempotency_key=operation if idempotency_key is not None else None,
-            client_request_id=operation if client_request_id is not None else None,
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
         )
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
@@ -210,11 +213,13 @@ def decode_responses(
     request = _validate_wire(_ResponsesRequest, payload)
     official_probe = dict(payload)
     if isinstance(raw := payload.get("input"), list):
-        # The installed SDK lags the live surface on echoed message items:
-        # it has no `phase` and requires `status` alongside `id`, while real
-        # Codex echoes carry id+phase and omit status (captured 2026-08-29).
-        # The strict wire model owns that contract, so the official probe
-        # sees a normalized item.
+        # The installed SDK lags the live surface on echoed output items:
+        # it has no message `phase` and requires `status` alongside `id`,
+        # while real Codex echoes carry id+phase and omit status, and it
+        # requires reasoning `content` to be an array while Codex echoes an
+        # explicit null that the provider accepts (both captured
+        # 2026-08-29). The strict wire model owns those contracts, so the
+        # official probe sees a normalized item.
         adapted: list[JsonValue] = []
         for entry in cast("list[JsonValue]", raw):
             if isinstance(entry, dict) and entry.get("type") == "message":
@@ -222,6 +227,13 @@ def decode_responses(
                 if item.get("id") is not None and "status" not in item:
                     item["status"] = "completed"
                 adapted.append(item)
+            elif (
+                isinstance(entry, dict)
+                and entry.get("type") == "reasoning"
+                and "content" in entry
+                and entry.get("content") is None
+            ):
+                adapted.append({key: value for key, value in entry.items() if key != "content"})
             else:
                 adapted.append(entry)
         official_probe["input"] = adapted
@@ -231,7 +243,9 @@ def decode_responses(
         extension_fields={"top_k", "reasoning", "client_metadata"},
     )
     include_encrypted_reasoning = _include_encrypted_reasoning(request.include)
-    operation = _caller_operation(idempotency_key, client_request_id)
+    idempotency_key, client_request_id = _validated_operation_headers(
+        idempotency_key, client_request_id
+    )
     raw_input = payload.get("input")
     messages = list(
         _response_input_messages(
@@ -289,8 +303,8 @@ def decode_responses(
             safety_identifier=request.safety_identifier,
             user=request.user,
             prompt_cache_key=request.prompt_cache_key,
-            idempotency_key=operation if idempotency_key is not None else None,
-            client_request_id=operation if client_request_id is not None else None,
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
         )
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
@@ -378,6 +392,67 @@ def _cleaned_location(location: tuple[str | int, ...]) -> tuple[str, ...]:
     return tuple(cleaned)
 
 
+_WIRE_TYPE_NAMES = {
+    "str": "a string",
+    "int": "an integer",
+    "float": "a number",
+    "bool": "a boolean",
+    "list": "an array",
+    "tuple": "an array",
+    "dict": "an object",
+    "NoneType": "null",
+}
+"""JSON-shape names for python input types, used in expected/got messages."""
+
+_EXPECTED_BY_ERROR_TYPE = {
+    "string_type": "a string",
+    "string_too_short": "a non-empty string",
+    "int_type": "an integer",
+    "int_parsing": "an integer",
+    "float_type": "a number",
+    "float_parsing": "a number",
+    "bool_type": "a boolean",
+    "list_type": "an array",
+    "tuple_type": "an array",
+    "dict_type": "an object",
+    "model_type": "an object",
+    "model_attributes_type": "an object",
+    "missing": "a value",
+    "none_required": "null",
+}
+"""Shape-level expectations for the pydantic error types worth naming."""
+
+
+def _shape_message(param: str, details: list[ErrorDetails]) -> str | None:
+    """Describe what shape a field expected versus what arrived.
+
+    Only structural facts appear: expectations come from this gateway's own
+    wire models and the got side is the JSON type of the caller's value,
+    never the value itself and never provider prose.
+    """
+    expected: list[str] = []
+    got: str | None = None
+    for detail in details:
+        phrase = _EXPECTED_BY_ERROR_TYPE.get(detail["type"])
+        if detail["type"] in {"literal_error", "enum"}:
+            context = detail.get("ctx") or {}
+            allowed = context.get("expected")
+            if isinstance(allowed, str):
+                phrase = f"one of {allowed}"
+        if phrase is not None and phrase not in expected:
+            expected.append(phrase)
+        # A missing-field complaint carries the parent object as its input,
+        # so it contributes no honest "got" type.
+        if detail["type"] != "missing" and "input" in detail:
+            got = _WIRE_TYPE_NAMES.get(type(detail["input"]).__name__, got)
+    if not expected:
+        return None
+    description = " or ".join(expected)
+    if got is not None:
+        return f"Invalid value for '{param}': expected {description}, but got {got} instead."
+    return f"Invalid value for '{param}': expected {description}."
+
+
 def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
     """Convert Pydantic locations into stable dotted OpenAI ``param`` paths.
 
@@ -386,27 +461,43 @@ def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
     most field-specific groups, the branch the caller actually meant is the
     one with the fewest complaints, so its deepest cleaned location names
     the real field (an echoed item's ``input.1.caller``), never a union
-    branch label such as ``input.str``.
+    branch label such as ``input.str``. The chosen field's own complaints
+    then name the expected shape against the arriving JSON type.
     """
-    groups: dict[tuple[str | int, ...], list[tuple[str, ...]]] = {}
+    groups: dict[tuple[str | int, ...], list[tuple[tuple[str, ...], ErrorDetails]]] = {}
     for detail in error.errors(include_url=False):
-        groups.setdefault(tuple(detail["loc"][:-1]), []).append(_cleaned_location(detail["loc"]))
+        groups.setdefault(tuple(detail["loc"][:-1]), []).append(
+            (_cleaned_location(detail["loc"]), detail)
+        )
     if not groups:
         return invalid_field("body")
-    deepest = max(len(location) for locations in groups.values() for location in locations)
+    deepest = max(len(location) for members in groups.values() for location, _ in members)
     candidates = [
-        locations
-        for locations in groups.values()
-        if any(len(location) == deepest for location in locations)
+        members
+        for members in groups.values()
+        if any(len(location) == deepest for location, _ in members)
     ]
     best = min(candidates, key=len)
-    location = max(best, key=len, default=())
+    location = max((cleaned for cleaned, _ in best), key=len, default=())
     param = ".".join(location) or "body"
-    return invalid_field(param)
+    details = [detail for cleaned, detail in best if cleaned == location]
+    return invalid_field(param, _shape_message(param, details))
 
 
-def _caller_operation(idempotency_key: str | None, client_request_id: str | None) -> str | None:
-    """Require two optional caller-operation headers to agree exactly."""
+def _validated_operation_headers(
+    idempotency_key: str | None, client_request_id: str | None
+) -> tuple[str | None, str | None]:
+    """Validate the two caller identity headers as independent concepts.
+
+    ``Idempotency-Key`` names one retriable operation and is the only header
+    that keys replay and duplicate detection. ``X-Client-Request-Id`` is a
+    caller correlation identity: Codex sends its session id there on every
+    request of a session (captured live 2026-08-29), and the provider serves
+    those requests without deduplication, so treating it as an operation key
+    would reject the second request of every real session as a conflict. It
+    is echoed on responses and scopes route affinity only, and the two
+    headers may therefore carry different values.
+    """
     for name, value in (
         ("Idempotency-Key", idempotency_key),
         ("X-Client-Request-Id", client_request_id),
@@ -415,18 +506,7 @@ def _caller_operation(idempotency_key: str | None, client_request_id: str | None
             not value or len(value) > 512 or any(ord(char) < 32 for char in value)
         ):
             raise invalid_field(name, f"{name} must be a non-empty display-safe value.")
-    if (
-        idempotency_key is not None
-        and client_request_id is not None
-        and idempotency_key != client_request_id
-    ):
-        raise OpenAIProtocolError(
-            status_code=400,
-            code="idempotency_conflict",
-            message="Idempotency-Key and X-Client-Request-Id must identify the same operation.",
-            param="Idempotency-Key",
-        )
-    return idempotency_key or client_request_id
+    return idempotency_key, client_request_id
 
 
 def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessage, ...]:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -9,7 +9,11 @@ from typing import cast
 import pytest
 
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayNamedToolChoice
+from exp.runtime.gateway.contracts import (
+    EncryptedReasoningBlock,
+    GatewayApiSurface,
+    GatewayNamedToolChoice,
+)
 from exp.runtime.gateway.reasoning_carrier import FIREWORKS_REASONING_CONTENT_PREFIX
 from exp.runtime.models.providers.streaming_requests import openai_responses_stream_payload
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
@@ -415,8 +419,8 @@ def test_chat_decoder_still_rejects_populated_unsupported_message_fields() -> No
         assert param is not None and param.startswith("messages.0.")
 
 
-def test_invalid_tool_arguments_and_conflicting_operation_headers_are_specific() -> None:
-    """Malformed history and mismatched dedup headers identify the exact public field."""
+def test_invalid_tool_arguments_and_divergent_operation_headers_are_specific() -> None:
+    """Malformed history names its field; independent identity headers both decode."""
     with pytest.raises(OpenAIProtocolError) as arguments:
         decode_chat(
             {
@@ -437,14 +441,16 @@ def test_invalid_tool_arguments_and_conflicting_operation_headers_are_specific()
         )
     assert arguments.value.detail.param == "messages.0.tool_calls.0.function.arguments"
 
-    with pytest.raises(OpenAIProtocolError) as operation:
-        decode_responses(
-            {"model": "coding", "input": "x"},
-            idempotency_key="one",
-            client_request_id="two",
-        )
-    assert operation.value.detail.code == "idempotency_conflict"
-    assert operation.value.detail.param == "Idempotency-Key"
+    # Idempotency-Key names one retriable operation; X-Client-Request-Id is
+    # session correlation identity (Codex sends its session id on every
+    # request of a session), so divergent values decode side by side.
+    decoded = decode_responses(
+        {"model": "coding", "input": "x"},
+        idempotency_key="one",
+        client_request_id="two",
+    )
+    assert decoded.request.idempotency_key == "one"
+    assert decoded.request.client_request_id == "two"
 
 
 def _assert_no_cache_control(decoded: DecodedGatewayRequest) -> None:
@@ -1587,3 +1593,106 @@ def test_the_captured_codex_request_shape_decodes_losslessly() -> None:
     assert echo.provider_item_id == "msg_echo_fixture"
     assert echo.provider_status is None
     assert echo.provider_phase == "commentary"
+
+
+def test_the_captured_codex_reasoning_echo_with_null_content_decodes() -> None:
+    """Regression fixture: the third request of a real Codex (0.151.0)
+    session, trimmed from a live capture (2026-08-29). After a
+    custom_tool_call round Codex echoes the reasoning output item with an
+    explicit ``content: null``; the provider accepts that request, so the
+    gateway must decode it instead of rejecting ``input.N.content``."""
+    reasoning_echo = {
+        "type": "reasoning",
+        "id": "rs_fixture",
+        "summary": [],
+        "content": None,
+        "encrypted_content": "gAAAAABfixture",
+    }
+    decoded = decode_responses(
+        {
+            "model": "gpt-5.6-sol",
+            "store": False,
+            "stream": True,
+            "include": ["reasoning.encrypted_content"],
+            "reasoning": {"effort": "max", "context": "all_turns"},
+            "tool_choice": "auto",
+            "parallel_tool_calls": False,
+            "prompt_cache_key": "session-fixture",
+            "client_metadata": {"thread_id": "thread-fixture"},
+            "input": [
+                {
+                    "type": "message",
+                    "id": "msg_user_fixture",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Read data.txt."}],
+                },
+                reasoning_echo,
+                {
+                    "type": "custom_tool_call",
+                    "id": "ctc_fixture",
+                    "status": "completed",
+                    "call_id": "call_fixture",
+                    "name": "exec",
+                    "input": 'const r = await tools.exec_command({cmd:"cat data.txt"});',
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "id": "ctco_fixture",
+                    "call_id": "call_fixture",
+                    "output": [
+                        {"type": "input_text", "text": "Script completed\n"},
+                        {"type": "input_text", "text": "gateway test file\n"},
+                    ],
+                },
+            ],
+        }
+    )
+    request = decoded.request
+    roles = [message.role for message in request.messages]
+    assert roles == ["user", "assistant", "assistant", "tool"]
+    carrier = request.messages[1].provider_reasoning
+    assert len(carrier) == 1
+    assert isinstance(carrier[0], EncryptedReasoningBlock)
+    assert carrier[0].encrypted_content == "gAAAAABfixture"
+
+
+def test_decode_errors_name_the_expected_shape_against_the_arriving_type() -> None:
+    """Union rejections say what shape the field expected and what arrived,
+    at type level only, matching the provider's own error style."""
+    with pytest.raises(OpenAIProtocolError) as content:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_bad",
+                        "encrypted_content": "gAAAAABfixture",
+                        "content": 7,
+                    }
+                ],
+            }
+        )
+    assert content.value.detail.param == "input.0.content"
+    assert content.value.detail.message == (
+        "Invalid value for 'input.0.content': expected an array, but got an integer instead."
+    )
+
+    with pytest.raises(OpenAIProtocolError) as summary:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_bad",
+                        "encrypted_content": "gAAAAABfixture",
+                        "summary": None,
+                    }
+                ],
+            }
+        )
+    assert summary.value.detail.param == "input.0.summary"
+    assert summary.value.detail.message == (
+        "Invalid value for 'input.0.summary': expected an array, but got null instead."
+    )

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -277,14 +277,17 @@ class _ResponseReasoningItem(_WireModel):
     ``encrypted_content`` is the round-trip payload; the display-only
     ``summary`` and ``content`` parts and the echoed lifecycle ``status``
     are validated and dropped because the provider derives the
-    model-visible reasoning from the encrypted payload alone.
+    model-visible reasoning from the encrypted payload alone. Codex echoes
+    reasoning output items with an explicit ``content: null`` (captured
+    live 2026-08-29); the provider accepts that null while rejecting a
+    null ``summary``, so exactly ``content`` is nullable here.
     """
 
     type: Literal["reasoning"]
     id: str = Field(min_length=1, max_length=256)
     encrypted_content: str = Field(min_length=1)
     summary: tuple[_ReasoningSummaryPart, ...] = ()
-    content: tuple[_ReasoningTextPart, ...] = ()
+    content: tuple[_ReasoningTextPart, ...] | None = None
     status: _EchoedItemStatus | None = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.7,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.8,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.7"
+version = "0.3.8"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What broke

A real multi-turn Codex 0.151.0 session against the hosted gateway (engine 0.7.6 + native 0.3.5) exposed two serving failures. Both were captured live on 2026-08-29 with a logging proxy in front of the production gateway, and both reproduce deterministically with `codex exec` reading a file through a `custom_tool_call` round.

**1. Echoed reasoning items with `content: null` were rejected (the input.7.content 400).**
After the tool round, Codex resends the prior reasoning output item verbatim as input:

```json
{"type": "reasoning", "id": "rs_…", "summary": [], "content": null, "encrypted_content": "gAAAA…"}
```

`_ResponseReasoningItem.content` was `tuple[...] = ()` (no null), and the official SDK probe also requires an array, so the request 400d with `Invalid value for 'input.7.content'` and the session died. The exact captured body was replayed against `api.openai.com` with a plain API key: **200 completed**. A probe with `summary: null` is rejected there (`Invalid type for 'input[7].summary'`), so exactly `content` becomes nullable, in the wire model plus an official-probe normalization branch (the same pattern as the phase/status adaptation from #672). The captured shape is pinned as a trimmed committed fixture.

**2. `x-client-request-id` acted as an idempotency key and 409-looped real sessions.**
Codex sends `x-client-request-id` = its **session id** on every request of a session. The gateway derived the caller operation from `Idempotency-Key` OR `x-client-request-id`, so the second request of a session (same header, different body) hit a deterministic `409 idempotency_conflict` against the first request's published replay entry. Captured live: a six-attempt reconnect loop, every attempt 409 "The caller operation was reused with a different request body", with the prior attempt a plain 200 (so the earlier "fail-open after a failed prior" framing would not have fixed it).

Decision, applied across the Rust routes, bridge claim scope, store digest, and durable ledger: **the standard `Idempotency-Key` is the only operation key**, which is also the documented contract ("Chat retries use the standard Idempotency-Key"). `X-Client-Request-Id` remains correlation identity: validated, echoed on responses, and now preferred over the idempotency key for route affinity (a session id is the stronger affinity scope; a per-operation key only pins retries). The two headers no longer need to agree, since they name independent concepts. Canonical request digests are unchanged for every previously legal input.

Kept deliberately fail-closed and now documented at the ledger seam + pinned by tests: reusing a real `Idempotency-Key` with a **different body** still conflicts even when the prior attempt failed, because after an ambiguous failure the provider may have executed; different content needs a new key.

**3. (Ride-along) Descriptive decode errors.** Union rejections now name the expected shape against the arriving JSON type, e.g. `Invalid value for 'input.7.content': expected an array, but got null instead.` Type level only, never caller content or provider prose, mirroring OpenAI's own error style.

Also: the stale manifest classification for echoed message `phase` (still listed "rejected", but accepted and retained for replay since #672) moves to the accepted table.

## Proof

- In-process: the exact captured failing body decodes; the fixture and error-shape tests pin it.
- Live OpenAI: exact body → 200 at api.openai.com; `summary: null` probe → 400 there (why only `content` widened).
- End to end: a native gateway served locally **from this revision** with a real OpenAI route completed the full real-CLI `codex exec` session with all Codex headers intact (2/2 Responses requests `completed` in the ledger, zero caller-operation rows), and returned 200 for the exact captured prod-failing body.
- Suites: full `uv run pytest -q` 2929 passed / 2 skipped (the two W16 release-evidence tests only fail on a dirty tree and pass post-commit), cargo test 106 passed, cargo fmt/clippy clean, ruff format/check clean, ty clean.

`exp-gateway-native` 0.3.7 → 0.3.8 (crate changed; gate requires the bump).

Platform note for the release pin: after this ships, the hosted worker stops deduping on `x-client-request-id`; any platform test that relied on that keying needs `Idempotency-Key` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)