### PR TITLE
release: bump version to 0.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.6"
+version = "0.7.7"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.6"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.7 release — the Codex-activation train (#677):
- Echoed reasoning items with `content: null` (Codex 0.151.0's echo shape) decode; OpenAI-verified (accepts null content, rejects null summary — exactly content widened).
- **Idempotency-Key is the only replay/dedupe operation key.** `x-client-request-id` (a per-SESSION id in Codex) no longer keys idempotency — previously any client reusing it deterministically 409'd on its second same-worker request. It remains correlation + route affinity. Explicit different-body Idempotency-Key reuse stays fail-closed.
- Decode errors state expected-vs-got at shape level.

Live acceptance: real 3-turn Codex CLI session completes through a served gateway; the exact captured prod-failing body replays 200.

Ships experiential 0.7.7 + exp-gateway-native 0.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)