### PR TITLE
gateway: serve conditional Claude Code fields (diagnostics, speed, tool-description caps, caller-beta allowlist)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -145,7 +145,12 @@ default are accepted and preserved. On the Messages surface, `output_config` for
 Anthropic rungs (a canonical `effort` also rides `reasoning_effort`, caller keys always win over
 engine-derived ones), mid-conversation `system` turns keep their position on wires that express
 them (instruction-hoisting rungs narrow out), and `thinking.display` rides the verbatim thinking
-config. On the Responses surface, `client_metadata` and `text.verbosity` forward on native rungs
+config. The conditional Claude Code fields `diagnostics` and `speed` forward verbatim on
+Anthropic rungs with their required `anthropic-beta` tokens and drop with disclosure elsewhere.
+A caller `anthropic-beta` header forwards through an exact token allowlist (notably
+`context-1m-2025-08-07`, which activates the provider's 1M context window; without it the
+provider serves 200K); non-allowlisted tokens drop with a per-token
+`anthropic-beta.<token>` disclosure, never a rejection and never a blind forward. On the Responses surface, `client_metadata` and `text.verbosity` forward on native rungs
 and drop with disclosure elsewhere; Codex-native input items (`additional_tools` tool namespaces,
 `custom_tool_call`/`custom_tool_call_output` freeform history) carry byte-for-byte and require a
 homogeneous native Responses route; echoed message items accept `id`/`phase` with `status`

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -50,14 +50,58 @@ MESSAGES_MANIFEST = CompatibilityManifest(
             CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
             "output_config",
         ),
+        _field(
+            "diagnostics",
+            CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
+            "diagnostics",
+        ),
+        _field(
+            "speed",
+            CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
+            "fast_mode",
+        ),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
+        # ``thread`` is Anthropic's server-held conversation state (it
+        # replaces ``messages`` upstream); the stateless gateway cannot
+        # proxy it truthfully, so it stays a conscious rejection until a
+        # verified contract exists.
         *(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
             for path in (
                 "container",
                 "mcp_servers",
                 "service_tier",
+                "thread",
             )
         ),
     ),
 )
+
+
+MESSAGES_BETA_TOKENS_FORWARDED = frozenset(
+    {
+        "context-1m-2025-08-07",
+        "interleaved-thinking-2025-05-14",
+        "context-management-2025-06-27",
+        "cache-diagnosis-2026-04-07",
+        "fast-mode-2026-02-01",
+    }
+)
+"""Caller ``anthropic-beta`` tokens forwarded verbatim on Anthropic rungs.
+
+A caller beta header is operator-trust surface, so forwarding is an exact
+allowlist, never a pattern: each listed token's behavior is understood and
+safe to relay. ``context-1m-2025-08-07`` activates the 1M context window
+(Claude Code sends it with 1M-suffixed models; without forwarding, the
+provider serves 200K and long sessions fail). ``interleaved-thinking``
+gates thinking between tool calls, whose blocks this gateway already
+carries opaquely. The remaining three are the same tokens the gateway
+injects itself when the bound field (``context_management``,
+``diagnostics``, ``speed``) is present. Every other caller token is
+validated and dropped with an ``anthropic-beta.<token>`` disclosure, never
+rejected and never blind-forwarded; notable deliberate drops are
+``server-side-fallback-*`` and ``fallback-credit-*`` (an upstream model
+swap would falsify this gateway's committed route identity and billing)
+and ``claude-code-20250219`` (an umbrella product token with an
+unenumerated behavior surface).
+"""

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -22,7 +22,10 @@ from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.model import ReasoningEffort, ToolCall
-from exp.runtime.anthropic_protocol.manifest import MESSAGES_MANIFEST
+from exp.runtime.anthropic_protocol.manifest import (
+    MESSAGES_BETA_TOKENS_FORWARDED,
+    MESSAGES_MANIFEST,
+)
 from exp.runtime.gateway.contracts import (
     CompatibilityDisposition,
     GatewayApiSurface,
@@ -133,10 +136,16 @@ class _Message(_WireModel):
 
 
 class _Tool(_WireModel):
-    """One caller-defined custom tool with its JSON Schema declaration."""
+    """One caller-defined custom tool with its JSON Schema declaration.
+
+    The description bound is generous on purpose: the provider accepts
+    40k-character descriptions live (verified 2026-08-30) and a real Claude
+    Code toolset exceeded the earlier 8k bound; the request-body size cap
+    remains the effective total limit.
+    """
 
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=65_536)
     input_schema: JsonObject
     cache_control: _CacheControl | None = None
     type: Literal["custom"] | None = None
@@ -194,9 +203,19 @@ class _MessagesRequest(_WireModel):
     thinking: _ThinkingConfig | None = None
     context_management: JsonObject | None = None
     output_config: JsonObject | None = None
+    diagnostics: JsonObject | None = None
+    speed: str | None = Field(default=None, min_length=1, max_length=64)
+    """Fast-mode selector, forwarded verbatim (Claude Code sends "fast";
+    accepted live behind its beta header, 2026-08-30). Bounded but
+    deliberately not enumerated: the value set is an evolving provider
+    surface."""
 
 
-def decode_messages(payload: JsonObject) -> DecodedGatewayRequest:
+def decode_messages(
+    payload: JsonObject,
+    *,
+    anthropic_beta: str | None = None,
+) -> DecodedGatewayRequest:
     """Decode one Anthropic Messages body without silently dropping fields.
 
     The Anthropic protocol defines no idempotency header, so this surface
@@ -204,6 +223,9 @@ def decode_messages(payload: JsonObject) -> DecodedGatewayRequest:
 
     Args:
         payload: Parsed JSON request body.
+        anthropic_beta: Optional raw caller ``anthropic-beta`` header value.
+            Allowlisted tokens are retained for Anthropic dispatch; the rest
+            are dropped with a per-token disclosure.
 
     Returns:
         Public alias and lossless canonical gateway request.
@@ -214,6 +236,7 @@ def decode_messages(payload: JsonObject) -> DecodedGatewayRequest:
     """
     _validate_manifest(payload)
     request = _validate_wire(payload)
+    forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
     system_text = _system_text(request.system)
     if system_text:
@@ -245,6 +268,10 @@ def decode_messages(payload: JsonObject) -> DecodedGatewayRequest:
                 cast(JsonObject, payload["thinking"]) if request.thinking is not None else None
             ),
             context_management=_context_management(payload),
+            diagnostics=_diagnostics(payload),
+            speed=request.speed,
+            provider_beta_tokens=forwarded_betas,
+            ignored_parameters=dropped_beta_disclosures,
             reasoning_effort=_output_config_effort(request.output_config),
             provider_output_config=(
                 cast(JsonObject, payload["output_config"])
@@ -292,6 +319,61 @@ def _context_management(payload: JsonObject) -> JsonObject | None:
     if not isinstance(value, dict):
         raise invalid_field("context_management", "context_management must be a JSON object.")
     return cast(JsonObject, value)
+
+
+def _diagnostics(payload: JsonObject) -> JsonObject | None:
+    """Validate the caller's diagnostics correlation as an object, verbatim.
+
+    Like ``context_management``, the nested shape is an evolving Anthropic
+    beta the gateway forwards byte-for-byte (with the required beta
+    header), so validation is deliberately shallow.
+
+    Raises:
+        OpenAIProtocolError: The field is present but not a JSON object.
+    """
+    value = payload.get("diagnostics")
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise invalid_field("diagnostics", "diagnostics must be a JSON object.")
+    return cast(JsonObject, value)
+
+
+def _beta_tokens(header: str | None) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Partition a caller ``anthropic-beta`` header into forward and drop sets.
+
+    Forwarding is an exact allowlist (:data:`MESSAGES_BETA_TOKENS_FORWARDED`):
+    a caller header is operator-trust surface and is never blind-forwarded.
+    Dropped tokens are disclosed per token, never rejected, because the
+    provider itself tolerates unknown beta tokens.
+
+    Args:
+        header: Raw comma-separated header value, or ``None``.
+
+    Returns:
+        ``(forwarded_tokens, dropped_disclosures)`` in caller order, deduped.
+
+    Raises:
+        OpenAIProtocolError: The header carries a non-display-safe value.
+    """
+    if header is None:
+        return (), ()
+    if len(header) > 4_096 or any(ord(char) < 32 for char in header):
+        raise invalid_field("anthropic-beta", "anthropic-beta must be a display-safe header value.")
+    forwarded: list[str] = []
+    dropped: list[str] = []
+    for raw_token in header.split(","):
+        token = raw_token.strip()
+        if not token:
+            continue
+        if token in MESSAGES_BETA_TOKENS_FORWARDED:
+            if token not in forwarded:
+                forwarded.append(token)
+        else:
+            disclosure = f"anthropic-beta.{token}"
+            if disclosure not in dropped:
+                dropped.append(disclosure)
+    return tuple(forwarded), tuple(dropped)
 
 
 def _validate_manifest(payload: JsonObject) -> None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -528,3 +528,68 @@ def test_the_captured_claude_code_request_shape_decodes_losslessly() -> None:
     assert request.context_management is not None
     assert request.metadata == {"user_id": "device-hash-redacted"}
     assert request.ignored_parameters == ()
+
+
+def test_diagnostics_and_speed_are_carried_verbatim_and_shallow_validated() -> None:
+    """Claude Code's conditional diagnostics and fast-mode fields decode.
+
+    Production incident (real Claude Code CLI, 2026-08-29): ``diagnostics``
+    was undecided and every diagnostics-carrying session 400ed with "The
+    parameter 'diagnostics' is not supported". Both fields are accepted by
+    the provider behind their beta headers (verified live 2026-08-30), so
+    the gateway carries them verbatim; validation stays shallow because the
+    shapes are evolving provider betas.
+    """
+    decoded = decode_messages(_body(diagnostics={"previous_message_id": None}, speed="fast"))
+    assert decoded.request.diagnostics == {"previous_message_id": None}
+    assert decoded.request.speed == "fast"
+    assert decode_messages(_body()).request.diagnostics is None
+    assert decode_messages(_body()).request.speed is None
+
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_messages(_body(diagnostics="on"))
+    assert raised.value.detail.param == "diagnostics"
+
+
+def test_caller_beta_tokens_partition_into_allowlist_and_disclosures() -> None:
+    """The caller anthropic-beta header forwards only allowlisted tokens.
+
+    Claude Code activates the 1M context window with a caller-sent
+    ``context-1m-2025-08-07`` token (captured live 2026-08-30); without
+    forwarding it the provider serves 200K and long sessions fail. Every
+    non-allowlisted token drops with a per-token disclosure, never a
+    rejection and never a blind forward.
+    """
+    header = (
+        "claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,"
+        "thinking-token-count-2026-05-13,fallback-credit-2026-06-01"
+    )
+    decoded = decode_messages(_body(), anthropic_beta=header)
+    assert decoded.request.provider_beta_tokens == (
+        "context-1m-2025-08-07",
+        "interleaved-thinking-2025-05-14",
+    )
+    assert decoded.request.ignored_parameters == (
+        "anthropic-beta.claude-code-20250219",
+        "anthropic-beta.thinking-token-count-2026-05-13",
+        "anthropic-beta.fallback-credit-2026-06-01",
+    )
+    assert decode_messages(_body()).request.provider_beta_tokens == ()
+
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_messages(_body(), anthropic_beta="bad\nvalue")
+    assert raised.value.detail.param == "anthropic-beta"
+
+
+def test_a_real_toolset_tool_description_over_8k_decodes() -> None:
+    """Tool descriptions bound generously: a real Claude Code toolset
+    carried a description past the earlier 8k cap and 400ed with
+    "Invalid value for 'tools.1.description'" while the provider accepts
+    40k-character descriptions live (verified 2026-08-30)."""
+    tools = [
+        {"name": "small", "description": "x", "input_schema": {"type": "object"}},
+        {"name": "large", "description": "y" * 40_000, "input_schema": {"type": "object"}},
+    ]
+    decoded = decode_messages(_body(tools=tools))
+    description = decoded.request.tools[1].description
+    assert description is not None and len(description) == 40_000

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -54,10 +54,16 @@ class GatewayApiSurface(StrEnum):
 
 
 class GatewayToolDefinition(ContractModel):
-    """One caller-defined function tool with its exact JSON Schema declaration."""
+    """One caller-defined function tool with its exact JSON Schema declaration.
+
+    The description bound is deliberately generous: both providers accept
+    40k-character tool descriptions live (verified 2026-08-30), and real
+    Claude Code toolsets exceeded the earlier 8k bound. The request-body
+    size cap remains the effective total limit.
+    """
 
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=65_536)
     parameters: JsonObject
     strict: bool = False
 
@@ -308,6 +314,40 @@ class GatewayRequest(ContractModel):
     config-free digests are unperturbed; a present value joins replay
     identity through :func:`canonical_request_sha256`.
     """
+    diagnostics: JsonObject | None = Field(default=None, exclude=True)
+    """Verbatim caller ``diagnostics`` from the Messages surface.
+
+    Anthropic's diagnostics-correlation object (Claude Code sends
+    ``{"previous_message_id": ...}`` conditionally). Validated only as an
+    object and forwarded byte-for-byte with the required beta header on
+    Anthropic rungs, dropped with disclosure elsewhere; the shape is an
+    evolving provider beta, so validation stays shallow. Excluded from
+    serialization; a present value joins replay identity through
+    :func:`canonical_request_sha256`.
+    """
+    speed: str | None = Field(default=None, max_length=64, exclude=True)
+    """Verbatim caller ``speed`` selector from the Messages surface.
+
+    Anthropic's fast-mode selector (Claude Code sends ``"fast"``; accepted
+    live behind its beta header, 2026-08-30). Bounded but deliberately not
+    enumerated: the value set is an evolving provider surface. Forwarded
+    with the required beta header on Anthropic rungs and dropped with
+    disclosure elsewhere. Fast-mode output is provider-priced at a premium,
+    so a present value joins replay identity through
+    :func:`canonical_request_sha256`.
+    """
+    provider_beta_tokens: tuple[str, ...] = Field(default=(), exclude=True)
+    """Allowlisted caller ``anthropic-beta`` tokens from the Messages surface.
+
+    Only tokens on the decoder's explicit forward allowlist appear here (a
+    caller header is operator-trust surface and is never blind-forwarded);
+    the rest are dropped at decode with an ``anthropic-beta.<token>``
+    disclosure. Forwarded tokens merge with the gateway's own per-field
+    injections on Anthropic rungs and are dropped with disclosure
+    elsewhere. Tokens change provider behavior and pricing (the 1M context
+    window rides one), so present tokens join replay identity through
+    :func:`canonical_request_sha256`.
+    """
     response_store: bool | None = None
     """Caller ``store`` selector from the Responses surface.
 
@@ -446,6 +486,12 @@ class GatewayRequest(ContractModel):
             raise ValueError("client_metadata is valid only for Responses requests")
         if self.context_management is not None and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("context_management is valid only for Messages requests")
+        if self.diagnostics is not None and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("diagnostics is valid only for Messages requests")
+        if self.speed is not None and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("speed is valid only for Messages requests")
+        if self.provider_beta_tokens and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("provider_beta_tokens are valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
             raise ValueError("maximum output parameter requires a maximum output value")
         if self.reasoning_summary_parameters and self.reasoning_summary is None:
@@ -523,18 +569,28 @@ def canonical_request_sha256(request: GatewayRequest) -> Sha256:
         and request.reasoning_context is None
         and request.context_management is None
         and request.provider_output_config is None
+        and request.diagnostics is None
+        and request.speed is None
+        and not request.provider_beta_tokens
     ):
         return sha256_json(request)
-    return sha256_json(
-        {
-            "request_sha256": sha256_json(request),
-            "provider_replay": replay,
-            "provider_thinking_config": request.provider_thinking_config,
-            "reasoning_context": request.reasoning_context,
-            "context_management": request.context_management,
-            "provider_output_config": request.provider_output_config,
-        }
-    )
+    envelope: JsonObject = {
+        "request_sha256": sha256_json(request),
+        "provider_replay": replay,
+        "provider_thinking_config": request.provider_thinking_config,
+        "reasoning_context": request.reasoning_context,
+        "context_management": request.context_management,
+        "provider_output_config": request.provider_output_config,
+    }
+    # The newer Messages carriers join the envelope only when present, so
+    # every request decoded before they existed keeps its exact digest.
+    if request.diagnostics is not None:
+        envelope["diagnostics"] = request.diagnostics
+    if request.speed is not None:
+        envelope["speed"] = request.speed
+    if request.provider_beta_tokens:
+        envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
+    return sha256_json(envelope)
 
 
 class GatewayUsage(ContractModel):

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.8"
+version = "0.3.9"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/respond.rs
+++ b/exp/runtime/gateway/native/src/respond.rs
@@ -114,6 +114,24 @@ pub(crate) fn latin1_header(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(|value| value.as_bytes().iter().map(|&byte| byte as char).collect())
 }
 
+/// Read every value of a repeated list-typed header as latin-1 text, joined
+/// with commas in arrival order, the combining HTTP itself defines for
+/// list-typed fields. A caller or intermediary may split a comma list such as
+/// `anthropic-beta` across header lines; reading only the first line would
+/// silently drop the later tokens.
+pub(crate) fn latin1_header_list(headers: &HeaderMap, name: &str) -> Option<String> {
+    let values: Vec<String> = headers
+        .get_all(name)
+        .iter()
+        .map(|value| value.as_bytes().iter().map(|&byte| byte as char).collect())
+        .collect();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
+}
+
 /// Re-encode one latin-1 decoded header value to its original bytes.
 pub(crate) fn latin1_bytes(value: &str) -> Vec<u8> {
     value
@@ -299,5 +317,44 @@ pub(crate) async fn finish_stream_terminal(
         if !send_bounded(sender, deadline, data).await {
             return;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_list_header_lines_join_in_arrival_order() {
+        let mut headers = HeaderMap::new();
+        headers.append("anthropic-beta", "context-1m-2025-08-07".parse().unwrap());
+        headers.append(
+            "anthropic-beta",
+            "interleaved-thinking-2025-05-14,fast-mode-2026-02-01"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            latin1_header_list(&headers, "anthropic-beta").as_deref(),
+            Some("context-1m-2025-08-07,interleaved-thinking-2025-05-14,fast-mode-2026-02-01")
+        );
+    }
+
+    #[test]
+    fn an_absent_list_header_reads_as_none() {
+        assert_eq!(
+            latin1_header_list(&HeaderMap::new(), "anthropic-beta"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_single_list_header_line_reads_verbatim() {
+        let mut headers = HeaderMap::new();
+        headers.append("anthropic-beta", "context-1m-2025-08-07".parse().unwrap());
+        assert_eq!(
+            latin1_header_list(&headers, "anthropic-beta").as_deref(),
+            Some("context-1m-2025-08-07")
+        );
     }
 }

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -27,8 +27,8 @@ use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
 use crate::relay::{collect_committed, collection_public_error, track_event};
 use crate::respond::{
-    bearer_key, complete_visible_refusal, escalation_error, json_response, read_body, send_bounded,
-    settle_stream_end, sse_body_response,
+    bearer_key, complete_visible_refusal, escalation_error, json_response, latin1_header,
+    read_body, send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
@@ -117,10 +117,15 @@ pub(crate) async fn messages(
         Err(_) => return messages_error_response(&PublicError::invalid_json()),
     };
 
+    // The caller's anthropic-beta header joins admission so the shared
+    // decoder can retain allowlisted tokens (e.g. the 1M context window)
+    // for Anthropic dispatch and disclose the rest.
+    let anthropic_beta = latin1_header(&headers, "anthropic-beta");
     let admit_argument = compact_json(&json!({
         "raw_key": raw_key,
         "body": body_text,
         "surface": "messages",
+        "anthropic_beta": anthropic_beta,
     }));
     let admission_text = match state.bridge.call("admit", admit_argument).await {
         Ok(text) => text,

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -27,7 +27,7 @@ use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
 use crate::relay::{collect_committed, collection_public_error, track_event};
 use crate::respond::{
-    bearer_key, complete_visible_refusal, escalation_error, json_response, latin1_header,
+    bearer_key, complete_visible_refusal, escalation_error, json_response, latin1_header_list,
     read_body, send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::server::AppState;
@@ -120,7 +120,7 @@ pub(crate) async fn messages(
     // The caller's anthropic-beta header joins admission so the shared
     // decoder can retain allowlisted tokens (e.g. the 1M context window)
     // for Anthropic dispatch and disclose the rest.
-    let anthropic_beta = latin1_header(&headers, "anthropic-beta");
+    let anthropic_beta = latin1_header_list(&headers, "anthropic-beta");
     let admit_argument = compact_json(&json!({
         "raw_key": raw_key,
         "body": body_text,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -272,6 +272,7 @@ class NativeControlPlane(NativeObservabilityMixin):
             surface=surface,
             idempotency_key=optional_text(data.get("idempotency_key")),
             client_request_id=optional_text(data.get("client_request_id")),
+            anthropic_beta=optional_text(data.get("anthropic_beta")),
         )
         request = decoded.request
         deadline = time.monotonic() + self._request_timeout_seconds
@@ -885,6 +886,7 @@ class NativeControlPlane(NativeObservabilityMixin):
         surface: str = "chat",
         idempotency_key: str | None = None,
         client_request_id: str | None = None,
+        anthropic_beta: str | None = None,
     ) -> DecodedGatewayRequest:
         """Decode one raw request body with the shared surface decoder."""
         try:
@@ -893,6 +895,7 @@ class NativeControlPlane(NativeObservabilityMixin):
                 surface=surface,
                 idempotency_key=idempotency_key,
                 client_request_id=client_request_id,
+                anthropic_beta=anthropic_beta,
             )
         except NativeDecodeError as exc:
             raise NativeBridgeError(exc.error) from exc

--- a/exp/runtime/gateway/native_decode.py
+++ b/exp/runtime/gateway/native_decode.py
@@ -32,6 +32,7 @@ def decode_native_body(
     surface: str = "chat",
     idempotency_key: str | None = None,
     client_request_id: str | None = None,
+    anthropic_beta: str | None = None,
 ) -> DecodedGatewayRequest:
     """Decode one raw request body with the shared surface decoder.
 
@@ -43,6 +44,9 @@ def decode_native_body(
             idempotency header.
         client_request_id: Optional raw ``X-Client-Request-Id`` header value.
             Ignored on the Anthropic Messages surface.
+        anthropic_beta: Optional raw caller ``anthropic-beta`` header value.
+            Meaningful only on the Messages surface, where allowlisted
+            tokens are retained for Anthropic dispatch.
 
     Returns:
         The public alias and canonical request.
@@ -71,7 +75,7 @@ def decode_native_body(
         )
     try:
         if surface == "messages":
-            return decode_messages(payload)
+            return decode_messages(payload, anthropic_beta=anthropic_beta)
         decoder = decode_responses if surface == "responses" else decode_chat
         return decoder(
             payload,

--- a/exp/runtime/gateway/native_decode_test.py
+++ b/exp/runtime/gateway/native_decode_test.py
@@ -28,3 +28,15 @@ def test_invalid_json_is_a_native_decode_error() -> None:
 
     assert raised.value.error.status_code == 400
     assert raised.value.error.detail.code == "invalid_json"
+
+
+def test_messages_surface_threads_the_caller_beta_header() -> None:
+    """The Messages decode receives the caller anthropic-beta header so
+    allowlisted tokens (the 1M context window) survive to dispatch."""
+    decoded = decode_native_body(
+        '{"model":"public-model","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}',
+        surface="messages",
+        anthropic_beta="claude-code-20250219,context-1m-2025-08-07",
+    )
+    assert decoded.request.provider_beta_tokens == ("context-1m-2025-08-07",)
+    assert decoded.request.ignored_parameters == ("anthropic-beta.claude-code-20250219",)

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -130,6 +130,12 @@ def anthropic_messages_stream_payload(
         # required beta header joins the dispatch via
         # anthropic_request_headers.
         payload["context_management"] = request.context_management
+    if request.diagnostics is not None:
+        # Same treatment: verbatim object, beta header via
+        # anthropic_request_headers.
+        payload["diagnostics"] = request.diagnostics
+    if request.speed is not None:
+        payload["speed"] = request.speed
     if request.provider_thinking_config is not None:
         # The caller's exact thinking configuration wins over the catalog's
         # adaptive default and travels verbatim, so budget semantics are

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -411,6 +411,26 @@ def route_generation_parameter_requests(
     ):
         ignore("context_management")
 
+    # Diagnostics correlation, fast mode, and forwarded beta tokens are
+    # equally Anthropic-native; a mixed route drops them with disclosure
+    # (Claude Code sends them conditionally), never a rejection.
+    if request.diagnostics is not None and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        ignore("diagnostics")
+    if request.speed is not None and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        ignore("speed")
+    if request.provider_beta_tokens and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        for token in request.provider_beta_tokens:
+            path = f"anthropic-beta.{token}"
+            if path not in ignored:
+                ignored.append(path)
+        provider_updates["provider_beta_tokens"] = ()
+
     # A caller output_config whose only content is a canonical effort rides
     # reasoning_effort everywhere; anything more is Anthropic-native and is
     # disclosed-dropped when any rung cannot honor it (Claude Code sends

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2043,3 +2043,53 @@ def test_client_metadata_and_verbosity_forward_native_and_disclose_elsewhere() -
     assert set(public.ignored_parameters) == {"client_metadata", "text.verbosity"}
     assert provider.client_metadata is None
     assert provider.text_verbosity is None
+
+
+def test_diagnostics_speed_and_betas_forward_on_anthropic_and_disclose_elsewhere() -> None:
+    """The conditional Claude Code carriers ride Anthropic rungs verbatim
+    with their required beta tokens merged into one header; a route with
+    any other rung drops each with disclosure, never a rejection."""
+    from exp.runtime.models.providers.wire_messages import (
+        ANTHROPIC_DIAGNOSTICS_BETA,
+        ANTHROPIC_FAST_MODE_BETA,
+        anthropic_request_headers,
+    )
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        diagnostics={"previous_message_id": "msg_prior"},
+        speed="fast",
+        provider_beta_tokens=("context-1m-2025-08-07",),
+        stream=True,
+        include_usage=True,
+    )
+    payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    assert payload["diagnostics"] == {"previous_message_id": "msg_prior"}
+    assert payload["speed"] == "fast"
+
+    headers = anthropic_request_headers({"anthropic-beta": "operator-token"}, request)
+    assert headers["anthropic-beta"] == (
+        "operator-token,context-1m-2025-08-07,"
+        f"{ANTHROPIC_DIAGNOSTICS_BETA},{ANTHROPIC_FAST_MODE_BETA}"
+    )
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+    public, provider = route_generation_parameter_requests((anthropic,), request)
+    assert public.ignored_parameters == ()
+    assert provider.diagnostics == {"previous_message_id": "msg_prior"}
+    assert provider.speed == "fast"
+    assert provider.provider_beta_tokens == ("context-1m-2025-08-07",)
+
+    mixed_public, mixed_provider = route_generation_parameter_requests(
+        (anthropic, fallback), request
+    )
+    assert set(mixed_public.ignored_parameters) == {
+        "diagnostics",
+        "speed",
+        "anthropic-beta.context-1m-2025-08-07",
+    }
+    assert mixed_provider.diagnostics is None
+    assert mixed_provider.speed is None
+    assert mixed_provider.provider_beta_tokens == ()

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -159,6 +159,15 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
 ANTHROPIC_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
 """Beta token Anthropic requires before it accepts ``context_management``."""
 
+ANTHROPIC_DIAGNOSTICS_BETA = "cache-diagnosis-2026-04-07"
+"""Beta token Anthropic requires before it accepts ``diagnostics``
+(verified live 2026-08-30: the field alone is "Extra inputs are not
+permitted"; with this token it is accepted)."""
+
+ANTHROPIC_FAST_MODE_BETA = "fast-mode-2026-02-01"
+"""Beta token Anthropic requires before it accepts ``speed``
+(verified live 2026-08-30)."""
+
 
 def anthropic_request_headers(
     profile_headers: dict[str, str],
@@ -166,11 +175,14 @@ def anthropic_request_headers(
 ) -> dict[str, str]:
     """Return the per-request Anthropic headers for one dispatch.
 
-    ``context_management`` is served behind an ``anthropic-beta`` token
-    (verified live 2026-08-29: the field alone is "Extra inputs are not
-    permitted"), so the token joins the connection's static headers exactly
-    when the request carries the field, merging with any operator-declared
-    beta list.
+    ``context_management``, ``diagnostics``, and ``speed`` are each served
+    behind an ``anthropic-beta`` token (each verified live: the bare field
+    is "Extra inputs are not permitted"), so their tokens join the
+    connection's static headers exactly when the request carries the field.
+    Allowlisted caller-forwarded tokens (``request.provider_beta_tokens``,
+    e.g. the 1M context window) merge the same way. The merged list keeps
+    operator tokens first, then caller tokens, then field-required tokens,
+    deduped in that order.
 
     Args:
         profile_headers: The connection's static wire headers.
@@ -180,13 +192,21 @@ def anthropic_request_headers(
         Headers to send verbatim for this request.
     """
     headers = dict(profile_headers)
-    if request.context_management is None:
+    required: list[str] = list(request.provider_beta_tokens)
+    if request.context_management is not None:
+        required.append(ANTHROPIC_CONTEXT_MANAGEMENT_BETA)
+    if request.diagnostics is not None:
+        required.append(ANTHROPIC_DIAGNOSTICS_BETA)
+    if request.speed is not None:
+        required.append(ANTHROPIC_FAST_MODE_BETA)
+    if not required:
         return headers
     existing = headers.get("anthropic-beta")
-    if existing is None:
-        headers["anthropic-beta"] = ANTHROPIC_CONTEXT_MANAGEMENT_BETA
-    elif ANTHROPIC_CONTEXT_MANAGEMENT_BETA not in existing.split(","):
-        headers["anthropic-beta"] = f"{existing},{ANTHROPIC_CONTEXT_MANAGEMENT_BETA}"
+    tokens = [token for token in (existing.split(",") if existing else []) if token]
+    for token in required:
+        if token not in tokens:
+            tokens.append(token)
+    headers["anthropic-beta"] = ",".join(tokens)
     return headers
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.8,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.9,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.8"
+version = "0.3.9"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
Real Claude Code sessions against the hosted gateway exposed the next compatibility class: fields the CLI sends conditionally, which the capture-driven fixture set never saw. Every field below was verified live (2026-08-30) against api.anthropic.com with a plain API key before the gateway behavior was written.

## What changes

- **`diagnostics`** (`{"previous_message_id": ...}`): accepted by Anthropic only behind the `cache-diagnosis-2026-04-07` beta; bare it is rejected with "Extra inputs are not permitted". The gateway now decodes it shallowly (like `context_management`), forwards it verbatim on Anthropic rungs with the beta injected, and drops it with disclosure elsewhere.
- **`speed: "fast"`**: accepted behind `fast-mode-2026-02-01`; same inject-on-Anthropic / disclose-and-drop-elsewhere treatment. Fast-mode output is provider-priced at a premium, so the value joins replay identity.
- **Tool description caps widen 8k to 64k**: a real Claude Code toolset 400d on our 8k caps while the provider accepts 40k-character descriptions (verified live on both the Anthropic and OpenAI surfaces). The Messages wire model and the canonical tool contract widen to 64k; the body-size cap remains the effective bound.
- **Caller `anthropic-beta` forwarding**: an exact token allowlist (`context-1m-2025-08-07`, `interleaved-thinking-2025-05-14`, plus the gateway's own per-field injections) merges with injected tokens and forwards; every other token drops with a per-token disclosure, never a rejection and never a blind forward. `context-1m-2025-08-07` is the allowlist's reason to exist: Claude Code strips a `[1m]` model-name suffix into exactly this caller token (captured live). The deliberate drops (`server-side-fallback`, `fallback-credit`) would falsify committed route identity and billing if relayed.
- **`thread`** (server-held conversation state that replaces `messages`) becomes a conscious manifest rejection rather than an unknown.

## Live verification (original evidence, re-validated post-rebase)

Proven through a locally served gateway on this revision:

- The previously 400ing `diagnostics` and `speed` bodies stream 200 end to end; bare against api.anthropic.com they are rejected, with the beta token they are 200 (both directions probed, so the injection is load-bearing).
- A real `claude -p` session completes through the served gateway.
- A real `claude -p --model "claude-opus-5[1m]"` session completes with the caller 1M token forwarded.
- A 221K-token and a 621K-token request cross the lane and are served.

## Long-context finding for the platform (report, not code)

Current 5-era models serve >200K input even without the beta on plain API keys, so the premium long-context billing exposure already exists today, and `GatewayTokenPrices` has no input-tier field to price it. The ~200K "Context limit reached" wall is Claude Code's client-side window for unsuffixed custom models; `[1m]` or `CLAUDE_CODE_MAX_CONTEXT_TOKENS` unlocks the client.

## Release

exp-gateway-native 0.3.9 (route_messages.rs forwards the merged beta header set).

## Gates

- `cargo test --no-default-features`: 106 passed
- `cargo fmt --check`, `cargo clippy -D warnings`: clean
- `uv run pytest -q`: full suite green
- `ruff format --check`, `ruff check`, `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
