### PR TITLE
release: bump version to 0.7.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.7"
+version = "0.7.8"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.8 release — the Claude Code-activation train:
- #679: conditional Claude Code fields served — diagnostics + speed behind their live-verified betas, 64k tool-description caps (our 8k cap was the tools.1.description bug), allowlisted caller anthropic-beta forwarding incl. context-1m (with repeated-header join — a dropped duplicate line could silently lose the 1M token), thread stays consciously rejected.
- #680: GatewayTokenPrices.long_context whole-request input tiers (threshold-boundary pinned; live consumer: Gemini Pro's published 200K tiers — Anthropic 4.6+ is flat at 1M per its published schedule) + input-scaled TTFB allowance (15s + 240s/1M tokens, per-deployment overridable; 942,875-token fable-5 acceptance call completed in 13.3s and settled to the micro-dollar).

Ships experiential 0.7.8 + exp-gateway-native 0.3.10 (SQLite schema v13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)