### PR TITLE
anthropic: drop empty assistant text blocks instead of emitting them

### DIFF
--- a/exp/runtime/models/providers/anthropic.py
+++ b/exp/runtime/models/providers/anthropic.py
@@ -317,7 +317,11 @@ def _anthropic_blocks(message: ModelMessage) -> tuple[str, list[JsonObject]]:
     action = message.assistant_action
     text = message.content if message.content is not None else action.content if action else None
     blocks: list[JsonObject] = []
-    if text is not None:
+    # Anthropic rejects an empty text content block ("text content blocks must be
+    # non-empty"), so an empty assistant string is dropped, not emitted. Clients
+    # (e.g. OpenCode) routinely send content:"" on an assistant turn that carries
+    # tool calls; the tool_use blocks below still stand on their own.
+    if text:
         blocks.append({"type": "text", "text": text})
     if action is not None:
         blocks.extend(

--- a/exp/runtime/models/providers/tests/native_test.py
+++ b/exp/runtime/models/providers/tests/native_test.py
@@ -8,6 +8,7 @@ from exp.common.models import (
     AssistantAction,
     EmbeddingClient,
     ModelClient,
+    ModelMessage,
     ModelRequest,
     ToolCall,
     ToolChoice,
@@ -368,6 +369,40 @@ def test_anthropic_uses_native_tool_blocks_and_normalizes_cache_usage() -> None:
         "name": "create_ticket",
         "input": {"priority": "normal"},
     }
+
+
+def test_anthropic_drops_empty_assistant_text_block_on_a_tool_turn() -> None:
+    """An empty assistant string never becomes an empty Anthropic text block.
+
+    Clients such as OpenCode send content:"" on an assistant turn that carries
+    tool calls. Anthropic rejects an empty text content block ("text content
+    blocks must be non-empty"), so the dialect must drop it and emit only the
+    tool_use block — otherwise Opus 5 tool threads 400 on the native route.
+    """
+    request = ModelRequest(
+        messages=(
+            ModelMessage(role="user", content="call the tool"),
+            ModelMessage(
+                role="assistant",
+                content="",
+                assistant_action=AssistantAction(
+                    content="",
+                    tool_calls=(ToolCall(call_id="toolu_1", name="get", arguments={}),),
+                ),
+            ),
+            ModelMessage(role="tool", tool_call_id="toolu_1", content="ok"),
+        )
+    )
+
+    payload = anthropic_messages_request("claude-fixture", request)
+
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assert messages[1]["role"] == "assistant"
+    # Only the tool_use block survives — no empty text block leaks onto the wire.
+    assert messages[1]["content"] == [
+        {"type": "tool_use", "id": "toolu_1", "name": "get", "input": {}}
+    ]
 
 
 def test_anthropic_tool_none_keeps_history_schemas_and_uses_native_none() -> None:


### PR DESCRIPTION
## Bug
An assistant turn that carries tool calls but `content:""` (OpenCode's shape) built an **empty** Anthropic text content block, and Anthropic rejects it: `400 "messages: text content blocks must be non-empty"`. This killed **Opus 5 tool threads** on the native Anthropic route (and the hosted-Cloud route that shares the dialect). OpenRouter Opus 5 was fine — different, OpenAI-shaped dialect.

`_anthropic_blocks` gated the text block on `text is not None`, so an empty string still emitted a block. Gate on truthiness (`if text:`) so an empty/None assistant string is dropped; the `tool_use` blocks stand on their own, and an assistant turn with neither text nor tools still raises as before.

## Verification (evidence-backed, real model)
Reproduced directly against Anthropic first (empty text block → the 400), then confirmed the fix end to end: `anthropic_messages_request` on the OpenCode-shaped request now emits only the `tool_use` block, and POSTing that to **live `claude-opus-5` returns 200** where it previously 400'd.

- `uv run ruff check .` / `ruff format --check` / `ty check` — clean (full repo).
- `uv run pytest exp/runtime/models/providers/` — 269 passed, incl. a new regression test (`test_anthropic_drops_empty_assistant_text_block_on_a_tool_turn`).

## Context
This is the real cause of the prod Opus 5 alert — not sampling (a platform-side sampling change, #1013, was a wrong diagnosis and has been reverted). Once this releases, the platform bumps its `experiential` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)