### PR TITLE
release: bump version to 0.7.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.8"
+version = "0.7.9"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.8"
+version = "0.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps `experiential` 0.7.8 → 0.7.9 to ship #683 (native Anthropic dialect drops empty assistant text blocks — unblocks Opus 5 tool threads). Follows the standard release-bump pattern (#681, #678, …); once merged I'll cut the `v0.7.9` GitHub Release, which publishes to PyPI via OIDC, then bump the platform pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)