### PR TITLE
anthropic: accept eager_input_streaming and classify the full SDK tool surface

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -228,10 +228,16 @@ adaptive default; on the adaptive-only generation, which rejects `enabled`/`disa
 configs outright, an `enabled` config translates to adaptive with the dropped
 `thinking.budget_tokens` disclosed as ignored, and `disabled` is rejected by name
 because those models cannot turn thinking off), requires
-`max_tokens`, validates `cache_control` (dropping it everywhere except on `tool_use` blocks,
-where the hint forwards natively; non-Anthropic routes disclose the omission through
-`ignored_parameters`), and rejects image and document blocks loudly because the surface is
-text-only. Thinking carriers
+`max_tokens`, validates `cache_control` (carrying it where the Anthropic wire caches natively:
+`tool_use` blocks, tool definitions, and the top-level automatic marker forward verbatim, while
+content-block hints drop; non-Anthropic routes disclose each omission through
+`ignored_parameters`), carries the provider-native tool annotations (`strict`,
+`eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
+bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with
+disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded
+decision behind an SDK-surface drift gate in
+`exp/runtime/anthropic_protocol/manifest.py`, and rejects image and document blocks loudly
+because the surface is text-only. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
 `anthropic_messages` dialect; on the Responses surface over Anthropic routes, thinking text is
 projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -60,11 +60,39 @@ MESSAGES_MANIFEST = CompatibilityManifest(
             CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
             "fast_mode",
         ),
+        _field(
+            "cache_control",
+            CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
+            "prompt_caching",
+        ),
+        _field(
+            "inference_geo",
+            CompatibilityDisposition.CONDITIONALLY_SUPPORTED,
+            "inference_geo",
+        ),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
-        # ``thread`` is Anthropic's server-held conversation state (it
-        # replaces ``messages`` upstream); the stateless gateway cannot
-        # proxy it truthfully, so it stays a conscious rejection until a
-        # verified contract exists.
+        # Conscious rejections, each with a recorded reason:
+        # - ``thread`` is Anthropic's server-held conversation state (it
+        #   replaces ``messages`` upstream); the stateless gateway cannot
+        #   proxy it truthfully, so it stays rejected until a verified
+        #   contract exists.
+        # - ``container`` and ``mcp_servers`` bind provider-hosted execution
+        #   state this gateway does not serve (server tools are rejected on
+        #   the same grounds).
+        # - ``service_tier`` selects provider priority capacity priced above
+        #   the gateway's committed billing model.
+        # - ``fallbacks`` and ``fallback_credit_token`` swap the upstream
+        #   model mid-request, which would falsify this gateway's committed
+        #   route identity and billing (the matching ``server-side-fallback-*``
+        #   and ``fallback-credit-*`` beta tokens are dropped for the same
+        #   reason).
+        # - ``betas`` (the body-level form) is redundant with the
+        #   ``anthropic-beta`` header, which is the one allowlisted opt-in
+        #   channel; a second, body-borne channel would bypass it.
+        # - ``user_profile_id`` attributes the request to another party under
+        #   the ``user-profiles`` beta, an org-trust delegation this gateway
+        #   does not make (the provider itself rejects the bare field,
+        #   verified live 2026-08-30).
         *(
             _field(path, CompatibilityDisposition.UNSUPPORTED)
             for path in (
@@ -72,10 +100,49 @@ MESSAGES_MANIFEST = CompatibilityManifest(
                 "mcp_servers",
                 "service_tier",
                 "thread",
+                "fallbacks",
+                "fallback_credit_token",
+                "betas",
+                "user_profile_id",
             )
         ),
     ),
 )
+
+
+MESSAGES_TOOL_FIELDS_ACCEPTED = frozenset(
+    {
+        "name",
+        "description",
+        "input_schema",
+        "type",
+        "cache_control",
+        "strict",
+        "eager_input_streaming",
+        "defer_loading",
+        "allowed_callers",
+        "input_examples",
+    }
+)
+"""Custom tool-definition fields the strict decoder accepts.
+
+This is the tool-level half of the drift gate: every field on the official
+SDK's custom ``ToolParam`` must appear here or in
+:data:`MESSAGES_TOOL_FIELDS_REJECTED`, so an SDK bump turns new tool surface
+into a loud decision instead of a silent customer-facing 400 (the
+``eager_input_streaming`` incident class). ``strict`` maps onto the canonical
+tool contract; ``cache_control`` forwards on Anthropic rungs as a cost-only
+hint; the remaining provider-native annotations forward verbatim on Anthropic
+rungs, which own their validity rules, and drop with disclosure elsewhere.
+"""
+
+MESSAGES_TOOL_FIELDS_REJECTED: frozenset[str] = frozenset()
+"""Custom tool-definition fields consciously rejected, currently none.
+
+Server-defined tools (bash, text editor, web search, code execution, tool
+search) are rejected wholesale through the closed ``type`` literal instead
+of field-by-field: the gateway serves no provider-hosted execution.
+"""
 
 
 MESSAGES_BETA_TOKENS_FORWARDED = frozenset(

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -22,3 +22,77 @@ def test_required_protocol_and_sampling_fields_are_supported() -> None:
     assert decisions["thinking"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert decisions["output_config"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert decisions["top_k"] == CompatibilityDisposition.SUPPORTED
+
+
+def _decided(new_fields: frozenset[str] | set[str], surface: str) -> str:
+    """Render the drift-gate failure text naming exactly what must be decided."""
+    listed = ", ".join(sorted(new_fields))
+    return (
+        f"The installed anthropic SDK carries {surface} fields this gateway has never "
+        f"classified: {listed}. Decide each one now: add it to MESSAGES_MANIFEST or the "
+        "tool-field decision tables in exp/runtime/anthropic_protocol/manifest.py with a "
+        "written rationale. Silent drift here is how paying customers become the first "
+        "detector (a live Claude Code session was the first detector for "
+        "tools.eager_input_streaming)."
+    )
+
+
+def test_every_official_sdk_top_level_field_is_consciously_classified() -> None:
+    """The SDK-surface drift gate: an ``anthropic`` bump may add request fields.
+
+    Every top-level field the official GA and beta Messages request types
+    carry must appear in the manifest, in exactly one disposition bucket, so
+    a dependency bump turns new Anthropic surface into a loud decision
+    instead of a silent customer-facing 400.
+    """
+    from anthropic.types import message_create_params
+    from anthropic.types.beta import message_create_params as beta_message_create_params
+
+    sdk_fields = (
+        set(message_create_params.MessageCreateParamsBase.__annotations__)
+        | set(beta_message_create_params.MessageCreateParamsBase.__annotations__)
+        | {"stream"}
+    )
+    decided = {field.field_path for field in MESSAGES_MANIFEST.fields}
+    undecided = sdk_fields - decided
+    assert not undecided, _decided(undecided, "Messages")
+
+
+def test_every_official_sdk_tool_definition_field_is_consciously_classified() -> None:
+    """Custom tool-definition fields are part of the drift gate.
+
+    Claude Code sends tool annotations conditionally (a production session
+    sent ``eager_input_streaming`` and was answered with a 400), so every
+    field on the official custom tool types must be a conscious decision:
+    accepted or rejected by name, never a silent 400.
+    """
+    from anthropic.types import tool_param
+    from anthropic.types.beta import beta_tool_param
+
+    from exp.runtime.anthropic_protocol.manifest import (
+        MESSAGES_TOOL_FIELDS_ACCEPTED,
+        MESSAGES_TOOL_FIELDS_REJECTED,
+    )
+
+    assert not MESSAGES_TOOL_FIELDS_ACCEPTED & MESSAGES_TOOL_FIELDS_REJECTED
+    sdk_fields = set(tool_param.ToolParam.__annotations__) | set(
+        beta_tool_param.BetaToolParam.__annotations__
+    )
+    undecided = sdk_fields - MESSAGES_TOOL_FIELDS_ACCEPTED - MESSAGES_TOOL_FIELDS_REJECTED
+    assert not undecided, _decided(undecided, "custom tool")
+
+    # The accepted table is executable, not aspirational: the strict wire
+    # model must accept exactly the accepted fields.
+    from exp.runtime.anthropic_protocol import requests as anthropic_requests
+
+    wire_fields = set(anthropic_requests._Tool.model_fields)
+    assert wire_fields == set(MESSAGES_TOOL_FIELDS_ACCEPTED)
+
+
+def test_route_identity_and_delegation_fields_are_recorded_rejections() -> None:
+    """Fallbacks, body-borne betas, and third-party attribution stay rejected."""
+    decisions = {field.field_path: field.disposition for field in MESSAGES_MANIFEST.fields}
+    for path in ("fallbacks", "fallback_credit_token", "betas", "user_profile_id"):
+        assert decisions[path] == CompatibilityDisposition.UNSUPPORTED
+    for path in ("cache_control", "inference_geo"):
+        assert decisions[path] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -3,10 +3,12 @@
 The decoder is strict and lossless for supported content: text, ``tool_use``,
 ``tool_result``, ``thinking``, and ``redacted_thinking`` blocks translate
 faithfully (thinking history rides the opaque provider-reasoning carrier with
-byte-exact signatures); ``cache_control`` annotations are validated and
-dropped because they do not change model semantics; ``image`` and
-``document`` blocks are rejected loudly because the serving surface cannot
-preserve them. Unknown or unsupported fields are rejected with a
+byte-exact signatures); ``cache_control`` annotations are validated
+everywhere and carried on the surfaces the Anthropic wire caches natively
+(tool_use blocks, tool definitions, and the top-level automatic marker),
+while content-block hints are dropped because they do not change model
+semantics; ``image`` and ``document`` blocks are rejected loudly because
+the serving surface cannot preserve them. Unknown or unsupported fields are rejected with a
 field-specific error, never silently dropped. Errors raise
 :class:`OpenAIProtocolError` so the shared boundary stays single-authority;
 the HTTP layer renders them in the Anthropic envelope.
@@ -142,6 +144,13 @@ class _Tool(_WireModel):
     40k-character descriptions live (verified 2026-08-30) and a real Claude
     Code toolset exceeded the earlier 8k bound; the request-body size cap
     remains the effective total limit.
+
+    ``eager_input_streaming``, ``defer_loading``, ``allowed_callers``, and
+    ``input_examples`` are provider-native tool annotations the live API
+    accepts bare (each verified 2026-08-30; Claude Code sends
+    ``eager_input_streaming`` conditionally). They forward verbatim on
+    Anthropic rungs, which own their validity rules, and drop with
+    disclosure elsewhere.
     """
 
     name: str = Field(min_length=1, max_length=256)
@@ -149,6 +158,11 @@ class _Tool(_WireModel):
     input_schema: JsonObject
     cache_control: _CacheControl | None = None
     type: Literal["custom"] | None = None
+    strict: bool = False
+    eager_input_streaming: bool | None = None
+    defer_loading: bool | None = None
+    allowed_callers: tuple[str, ...] | None = None
+    input_examples: tuple[JsonObject, ...] | None = None
 
 
 class _ToolChoice(_WireModel):
@@ -209,6 +223,15 @@ class _MessagesRequest(_WireModel):
     accepted live behind its beta header, 2026-08-30). Bounded but
     deliberately not enumerated: the value set is an evolving provider
     surface."""
+    cache_control: _CacheControl | None = None
+    """Top-level automatic prompt-caching marker (accepted live without a
+    beta, 2026-08-30). Validated closed, forwarded verbatim on Anthropic
+    rungs, and dropped with disclosure elsewhere: a cache hint changes
+    cost, not semantics."""
+    inference_geo: str | None = Field(default=None, min_length=1, max_length=64)
+    """Inference-region selector, forwarded verbatim (accepted live without
+    a beta, 2026-08-30). Bounded but deliberately not enumerated: the
+    region set is an evolving provider surface."""
 
 
 def decode_messages(
@@ -270,6 +293,14 @@ def decode_messages(
             context_management=_context_management(payload),
             diagnostics=_diagnostics(payload),
             speed=request.speed,
+            # Raw payload value, mirroring thinking: the provider receives the
+            # caller's cache marker byte-for-byte on Anthropic rungs.
+            provider_cache_control=(
+                cast(JsonObject, payload["cache_control"])
+                if request.cache_control is not None
+                else None
+            ),
+            inference_geo=request.inference_geo,
             provider_beta_tokens=forwarded_betas,
             ignored_parameters=dropped_beta_disclosures,
             reasoning_effort=_output_config_effort(request.output_config),
@@ -398,7 +429,13 @@ def _validate_wire(payload: JsonObject) -> _MessagesRequest:
 
 
 def _validation_error(first: ErrorDetails) -> OpenAIProtocolError:
-    """Convert one Pydantic error location into a stable dotted field error."""
+    """Convert one Pydantic error location into a stable dotted field error.
+
+    The public message keeps the expected-vs-got shape: it names the field
+    and states what the decoder expected there (Pydantic's own expectation
+    text, which never echoes the caller's value), so a rejected request says
+    what to fix instead of only where it failed.
+    """
     location = first["loc"]
     cleaned: list[str] = []
     for part in location:
@@ -407,7 +444,13 @@ def _validation_error(first: ErrorDetails) -> OpenAIProtocolError:
         if isinstance(part, str) and (part.startswith("_") or "[" in text):
             continue
         cleaned.append(text)
-    return invalid_field(".".join(cleaned) or "body")
+    param = ".".join(cleaned) or "body"
+    if first["type"] == "extra_forbidden":
+        return invalid_field(
+            param,
+            f"Unknown parameter '{param}'. Remove the field and resend the request.",
+        )
+    return invalid_field(param, f"Invalid value for '{param}': {first['msg']}.")
 
 
 def _rejected_block_hint(payload: JsonObject) -> str | None:
@@ -460,6 +503,16 @@ def _gateway_tool(tool: _Tool) -> GatewayToolDefinition:
         name=tool.name,
         description=tool.description,
         parameters=tool.input_schema,
+        strict=tool.strict,
+        cache_control=(
+            tool.cache_control.model_dump(mode="json", exclude_none=True)
+            if tool.cache_control is not None
+            else None
+        ),
+        eager_input_streaming=tool.eager_input_streaming,
+        defer_loading=tool.defer_loading,
+        allowed_callers=tool.allowed_callers,
+        input_examples=tool.input_examples,
     )
 
 

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -593,3 +593,116 @@ def test_a_real_toolset_tool_description_over_8k_decodes() -> None:
     decoded = decode_messages(_body(tools=tools))
     description = decoded.request.tools[1].description
     assert description is not None and len(description) == 40_000
+
+
+def test_decode_accepts_the_live_eager_input_streaming_tool_shape() -> None:
+    """Live-captured 2026-08-30: a production Claude Code session sent a tool
+    carrying ``eager_input_streaming`` and got "Invalid value for
+    'tools.0.eager_input_streaming'" while api.anthropic.com accepts the field
+    bare (no beta header). The exact wire shape stays accepted."""
+    decoded = decode_messages(
+        _body(
+            stream=True,
+            tools=[
+                {
+                    "name": "Bash",
+                    "description": "Executes a bash command and returns its output.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                    "eager_input_streaming": True,
+                }
+            ],
+        )
+    )
+    tool = decoded.request.tools[0]
+    assert tool.eager_input_streaming is True
+    assert decoded.request.ignored_parameters == ()
+
+
+def test_decode_carries_every_provider_native_tool_annotation() -> None:
+    """The provider-native tool annotations land on the canonical tool
+    (each accepted bare by the live API, verified 2026-08-30)."""
+    decoded = decode_messages(
+        _body(
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "Get weather.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                    "eager_input_streaming": False,
+                    "defer_loading": False,
+                    "allowed_callers": ["code_execution_20260120"],
+                    "input_examples": [{"city": "Paris"}],
+                }
+            ]
+        )
+    )
+    tool = decoded.request.tools[0]
+    assert tool.strict is True
+    assert tool.cache_control == {"type": "ephemeral", "ttl": "1h"}
+    assert tool.eager_input_streaming is False
+    assert tool.defer_loading is False
+    assert tool.allowed_callers == ("code_execution_20260120",)
+    assert tool.input_examples == ({"city": "Paris"},)
+
+    bare = decode_messages(
+        _body(tools=[{"name": "get_weather", "input_schema": {"type": "object"}}])
+    ).request.tools[0]
+    assert bare.strict is False
+    assert bare.cache_control is None
+    assert bare.eager_input_streaming is None
+    assert bare.defer_loading is None
+    assert bare.allowed_callers is None
+    assert bare.input_examples is None
+
+
+def test_decode_carries_top_level_cache_control_and_inference_geo() -> None:
+    """Top-level auto-caching and the inference region ride their carriers
+    verbatim (both accepted bare by the live API, verified 2026-08-30)."""
+    decoded = decode_messages(_body(cache_control={"type": "ephemeral"}, inference_geo="us"))
+    assert decoded.request.provider_cache_control == {"type": "ephemeral"}
+    assert decoded.request.inference_geo == "us"
+    absent = decode_messages(_body()).request
+    assert absent.provider_cache_control is None
+    assert absent.inference_geo is None
+
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(_body(cache_control={"type": "persistent"}))
+    assert excinfo.value.detail.param == "cache_control.type"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["user_profile_id", "fallbacks", "fallback_credit_token", "betas"],
+)
+def test_route_identity_and_delegation_fields_stay_consciously_rejected(field: str) -> None:
+    """Fallback model swaps, body-borne beta opt-ins, and third-party
+    attribution are recorded rejections, each answered by its named 400."""
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(_body(**{field: "x"}))
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail.param == field
+
+
+def test_validation_errors_state_the_expectation_not_only_the_field() -> None:
+    """A strict-decode 400 names the field and what was expected there."""
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        decode_messages(_body(tools=[{"name": "t", "input_schema": {}, "eager_streaming": True}]))
+    assert unknown.value.detail.param == "tools.0.eager_streaming"
+    assert "Unknown parameter 'tools.0.eager_streaming'" in unknown.value.detail.message
+
+    with pytest.raises(OpenAIProtocolError) as invalid:
+        decode_messages(_body(tools=[{"name": "t", "input_schema": {}, "strict": "maybe"}]))
+    assert invalid.value.detail.param == "tools.0.strict"
+    assert "Invalid value for 'tools.0.strict'" in invalid.value.detail.message
+    assert "bool" in invalid.value.detail.message

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -66,6 +66,59 @@ class GatewayToolDefinition(ContractModel):
     description: str | None = Field(default=None, max_length=65_536)
     parameters: JsonObject
     strict: bool = False
+    cache_control: JsonObject | None = Field(default=None, exclude=True)
+    """Validated caller prompt-caching hint attached to this tool definition.
+
+    Forwarded onto the native Anthropic tool block and dropped with
+    disclosure on other wires. Like ``ToolCall.cache_control``, a cache hint
+    changes cost, not semantics, so it joins neither serialization nor
+    replay identity: two requests differing only here are the same request.
+    """
+    eager_input_streaming: bool | None = Field(default=None, exclude=True)
+    """Verbatim Anthropic fine-grained tool-input streaming selector.
+
+    Accepted bare by the provider (verified live 2026-08-30; no beta
+    header). Claude Code sends it conditionally. It changes how the
+    provider frames tool-input deltas, so like the other Anthropic-native
+    carriers it is excluded from serialization (tool digests predate it)
+    and a present value joins replay identity through
+    :func:`canonical_request_sha256`.
+    """
+    defer_loading: bool | None = Field(default=None, exclude=True)
+    """Verbatim Anthropic tool-search deferred-loading selector.
+
+    Accepted bare by the provider, which owns the cross-tool validity rules
+    (verified live 2026-08-30: ``false`` is a no-op and an all-deferred
+    toolset is the provider's own 400). Excluded from serialization; a
+    present value changes what the model initially sees, so it joins replay
+    identity through :func:`canonical_request_sha256`.
+    """
+    allowed_callers: tuple[str, ...] | None = Field(default=None, exclude=True)
+    """Verbatim Anthropic programmatic-tool-calling caller allowlist.
+
+    Accepted bare by the provider even without a companion server tool
+    (verified live 2026-08-30), so the provider stays the authority on the
+    combination rules. Excluded from serialization; a present value joins
+    replay identity through :func:`canonical_request_sha256`.
+    """
+    input_examples: tuple[JsonObject, ...] | None = Field(default=None, exclude=True)
+    """Verbatim Anthropic example tool inputs.
+
+    Accepted bare by the provider (verified live 2026-08-30). Examples add
+    provider-visible prompt content, so a present value is excluded from
+    serialization and joins replay identity through
+    :func:`canonical_request_sha256`; reservation counts its bytes with the
+    rest of the replay envelope.
+    """
+
+    def has_anthropic_tool_carriers(self) -> bool:
+        """Whether any Anthropic-native tool carrier is present on this tool."""
+        return (
+            self.eager_input_streaming is not None
+            or self.defer_loading is not None
+            or self.allowed_callers is not None
+            or self.input_examples is not None
+        )
 
 
 class StructuredTextFormat(ContractModel):
@@ -336,6 +389,26 @@ class GatewayRequest(ContractModel):
     so a present value joins replay identity through
     :func:`canonical_request_sha256`.
     """
+    provider_cache_control: JsonObject | None = Field(default=None, exclude=True)
+    """Verbatim caller top-level ``cache_control`` from the Messages surface.
+
+    Anthropic's automatic prompt-caching marker for the last cacheable
+    block (accepted bare, verified live 2026-08-30). Forwarded byte-for-byte
+    on Anthropic rungs and dropped with disclosure elsewhere. Like the
+    tool-call cache hint, it changes cost, not semantics, so it deliberately
+    joins NEITHER serialization NOR replay identity: two requests differing
+    only here are the same request.
+    """
+    inference_geo: str | None = Field(default=None, max_length=64, exclude=True)
+    """Verbatim caller ``inference_geo`` selector from the Messages surface.
+
+    Anthropic's inference-region selector (accepted bare, verified live
+    2026-08-30). Bounded but deliberately not enumerated: the region set is
+    an evolving provider surface. Forwarded verbatim on Anthropic rungs and
+    dropped with disclosure elsewhere. Where inference runs is a
+    caller-visible processing commitment, so a present value joins replay
+    identity through :func:`canonical_request_sha256`.
+    """
     provider_beta_tokens: tuple[str, ...] = Field(default=(), exclude=True)
     """Allowlisted caller ``anthropic-beta`` tokens from the Messages surface.
 
@@ -490,6 +563,15 @@ class GatewayRequest(ContractModel):
             raise ValueError("diagnostics is valid only for Messages requests")
         if self.speed is not None and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("speed is valid only for Messages requests")
+        if self.provider_cache_control is not None and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("provider_cache_control is valid only for Messages requests")
+        if self.inference_geo is not None and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("inference_geo is valid only for Messages requests")
+        if (
+            any(tool.has_anthropic_tool_carriers() for tool in self.tools)
+            and self.surface != GatewayApiSurface.MESSAGES
+        ):
+            raise ValueError("Anthropic tool carriers are valid only for Messages requests")
         if self.provider_beta_tokens and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("provider_beta_tokens are valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
@@ -564,14 +646,30 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
             authority["tool_is_error"] = True
         if len(authority) > 1:
             replay.append(authority)
+    retained_tools: list[JsonObject] = []
+    for tool_index, tool in enumerate(request.tools):
+        if not tool.has_anthropic_tool_carriers():
+            continue
+        retained_tool: JsonObject = {"tool_index": tool_index, "name": tool.name}
+        if tool.eager_input_streaming is not None:
+            retained_tool["eager_input_streaming"] = tool.eager_input_streaming
+        if tool.defer_loading is not None:
+            retained_tool["defer_loading"] = tool.defer_loading
+        if tool.allowed_callers is not None:
+            retained_tool["allowed_callers"] = list(tool.allowed_callers)
+        if tool.input_examples is not None:
+            retained_tool["input_examples"] = list(tool.input_examples)
+        retained_tools.append(retained_tool)
     if (
         not replay
+        and not retained_tools
         and request.provider_thinking_config is None
         and request.reasoning_context is None
         and request.context_management is None
         and request.provider_output_config is None
         and request.diagnostics is None
         and request.speed is None
+        and request.inference_geo is None
         and not request.provider_beta_tokens
     ):
         return None
@@ -588,6 +686,10 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
         envelope["diagnostics"] = request.diagnostics
     if request.speed is not None:
         envelope["speed"] = request.speed
+    if request.inference_geo is not None:
+        envelope["inference_geo"] = request.inference_geo
+    if retained_tools:
+        envelope["tools"] = retained_tools
     if request.provider_beta_tokens:
         envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
     return envelope

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -511,3 +511,93 @@ def test_context_management_is_digest_excluded_but_joins_replay_identity() -> No
             messages=messages,
             context_management={"edits": []},
         )
+
+
+def test_anthropic_tool_annotations_are_digest_free_but_bind_replay_identity() -> None:
+    """Tool carriers never perturb plain digests; present ones bind replay."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.contracts import GatewayToolDefinition, canonical_request_sha256
+
+    def request(tool: GatewayToolDefinition) -> GatewayRequest:
+        return GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            tools=(tool,),
+        )
+
+    plain_tool = GatewayToolDefinition(name="bash", parameters={"type": "object"})
+    bare = request(plain_tool)
+    eager = request(plain_tool.model_copy(update={"eager_input_streaming": True}))
+    assert eager.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(eager) == sha256_json(bare)
+    assert canonical_request_sha256(bare) == sha256_json(bare)
+    assert canonical_request_sha256(eager) != canonical_request_sha256(bare)
+    assert canonical_request_sha256(eager) == canonical_request_sha256(
+        request(plain_tool.model_copy(update={"eager_input_streaming": True}))
+    )
+    assert canonical_request_sha256(eager) != canonical_request_sha256(
+        request(plain_tool.model_copy(update={"eager_input_streaming": False}))
+    )
+    for annotated in (
+        plain_tool.model_copy(update={"defer_loading": False}),
+        plain_tool.model_copy(update={"allowed_callers": ("code_execution_20260120",)}),
+        plain_tool.model_copy(update={"input_examples": ({"city": "Paris"},)}),
+    ):
+        assert canonical_request_sha256(request(annotated)) != canonical_request_sha256(bare)
+
+    # A cache hint changes cost, not semantics: neither digest nor replay moves.
+    hinted = request(plain_tool.model_copy(update={"cache_control": {"type": "ephemeral"}}))
+    assert sha256_json(hinted) == sha256_json(bare)
+    assert canonical_request_sha256(hinted) == canonical_request_sha256(bare)
+
+
+def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
+    """The top-level cache marker stays identity-inert; the region binds replay."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.contracts import canonical_request_sha256
+
+    messages = (GatewayMessage(role="user", content="hi"),)
+    bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
+    cached = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        provider_cache_control={"type": "ephemeral"},
+    )
+    assert cached.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(cached) == sha256_json(bare)
+    assert canonical_request_sha256(cached) == canonical_request_sha256(bare)
+
+    regional = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        inference_geo="us",
+    )
+    assert sha256_json(regional) == sha256_json(bare)
+    assert canonical_request_sha256(regional) != canonical_request_sha256(bare)
+
+    with pytest.raises(ValidationError, match="provider_cache_control is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=messages,
+            provider_cache_control={"type": "ephemeral"},
+        )
+    with pytest.raises(ValidationError, match="inference_geo is valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=messages,
+            inference_geo="us",
+        )
+    from exp.runtime.gateway.contracts import GatewayToolDefinition
+
+    with pytest.raises(ValidationError, match="Anthropic tool carriers are valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=messages,
+            tools=(
+                GatewayToolDefinition(
+                    name="bash",
+                    parameters={"type": "object"},
+                    eager_input_streaming=True,
+                ),
+            ),
+        )

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -96,6 +96,19 @@ def anthropic_messages_stream_payload(
                 translated["description"] = tool.description
             if tool.strict:
                 translated["strict"] = True
+            # Anthropic-native tool annotations forward verbatim on this
+            # wire only; the provider owns their validity rules. An absent
+            # value stays absent so provider defaults keep applying.
+            if tool.cache_control is not None:
+                translated["cache_control"] = tool.cache_control
+            if tool.eager_input_streaming is not None:
+                translated["eager_input_streaming"] = tool.eager_input_streaming
+            if tool.defer_loading is not None:
+                translated["defer_loading"] = tool.defer_loading
+            if tool.allowed_callers is not None:
+                translated["allowed_callers"] = list(tool.allowed_callers)
+            if tool.input_examples is not None:
+                translated["input_examples"] = list(tool.input_examples)
             tools.append(translated)
         payload["tools"] = tools
     tool_choice: JsonObject | None = None
@@ -136,6 +149,12 @@ def anthropic_messages_stream_payload(
         payload["diagnostics"] = request.diagnostics
     if request.speed is not None:
         payload["speed"] = request.speed
+    if request.provider_cache_control is not None:
+        # The top-level automatic caching marker forwards byte-for-byte; the
+        # provider accepts it bare (verified live 2026-08-30).
+        payload["cache_control"] = request.provider_cache_control
+    if request.inference_geo is not None:
+        payload["inference_geo"] = request.inference_geo
     if request.provider_thinking_config is not None:
         # The caller's exact thinking configuration wins over the catalog's
         # adaptive default and travels verbatim, so budget semantics are

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -422,6 +422,14 @@ def route_generation_parameter_requests(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
         ignore("speed")
+    if request.provider_cache_control is not None and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        ignore("provider_cache_control", "cache_control")
+    if request.inference_geo is not None and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        ignore("inference_geo")
     if request.provider_beta_tokens and not all(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
@@ -464,6 +472,30 @@ def route_generation_parameter_requests(
     ) and not all(profile.dialect == "anthropic_messages" for profile in profiles):
         if "messages.tool_calls.cache_control" not in ignored:
             ignored.append("messages.tool_calls.cache_control")
+
+    # Anthropic-native tool-definition annotations exist only on that wire;
+    # every other rung drops each one with a per-field disclosure, never a
+    # rejection (Claude Code sends eager_input_streaming conditionally).
+    if not all(profile.dialect == "anthropic_messages" for profile in profiles):
+        tool_annotation_paths = (
+            ("tools.cache_control", any(tool.cache_control is not None for tool in request.tools)),
+            (
+                "tools.eager_input_streaming",
+                any(tool.eager_input_streaming is not None for tool in request.tools),
+            ),
+            ("tools.defer_loading", any(tool.defer_loading is not None for tool in request.tools)),
+            (
+                "tools.allowed_callers",
+                any(tool.allowed_callers is not None for tool in request.tools),
+            ),
+            (
+                "tools.input_examples",
+                any(tool.input_examples is not None for tool in request.tools),
+            ),
+        )
+        for path, present in tool_annotation_paths:
+            if present and path not in ignored:
+                ignored.append(path)
 
     # Opaque provider-reasoning carriers replay only on the one wire that
     # issued them, so a mixed waterfall is rejected instead of dropping them.

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2093,3 +2093,86 @@ def test_diagnostics_speed_and_betas_forward_on_anthropic_and_disclose_elsewhere
     assert mixed_provider.diagnostics is None
     assert mixed_provider.speed is None
     assert mixed_provider.provider_beta_tokens == ()
+
+
+def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_elsewhere() -> None:
+    """Provider-native tool annotations plus the top-level cache marker and
+    inference region reach only the Anthropic wire; any other rung drops
+    each with a per-field disclosure, never a rejection (a production
+    Claude Code session sent ``eager_input_streaming`` and was 400ed)."""
+    from exp.runtime.gateway.contracts import GatewayToolDefinition
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="run"),),
+        tools=(
+            GatewayToolDefinition(
+                name="Bash",
+                description="Executes a bash command.",
+                parameters={"type": "object"},
+                cache_control={"type": "ephemeral"},
+                eager_input_streaming=True,
+                defer_loading=False,
+                allowed_callers=("code_execution_20260120",),
+                input_examples=({"command": "ls"},),
+            ),
+        ),
+        provider_cache_control={"type": "ephemeral"},
+        inference_geo="us",
+        stream=True,
+        include_usage=True,
+    )
+
+    payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    tool = cast(list[JsonObject], payload["tools"])[0]
+    assert tool["cache_control"] == {"type": "ephemeral"}
+    assert tool["eager_input_streaming"] is True
+    assert tool["defer_loading"] is False
+    assert tool["allowed_callers"] == ["code_execution_20260120"]
+    assert tool["input_examples"] == [{"command": "ls"}]
+    assert payload["cache_control"] == {"type": "ephemeral"}
+    assert payload["inference_geo"] == "us"
+
+    # None of these accepted fields require a beta token (verified live
+    # 2026-08-30), so the dispatch headers stay untouched.
+    from exp.runtime.models.providers.wire_messages import anthropic_request_headers
+
+    assert anthropic_request_headers({}, request) == {}
+
+    # OpenAI-family wires never see the annotations; the route discloses
+    # each dropped field by name.
+    import json
+
+    chat_payload = openai_compatible_stream_payload("gpt-5.5", request)
+    serialized = json.dumps(chat_payload)
+    for marker in (
+        "cache_control",
+        "eager_input_streaming",
+        "defer_loading",
+        "allowed_callers",
+        "input_examples",
+        "inference_geo",
+    ):
+        assert marker not in serialized
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+    public, provider = route_generation_parameter_requests((anthropic,), request)
+    assert public.ignored_parameters == ()
+    assert provider.provider_cache_control == {"type": "ephemeral"}
+    assert provider.inference_geo == "us"
+
+    mixed_public, mixed_provider = route_generation_parameter_requests(
+        (anthropic, fallback), request
+    )
+    assert set(mixed_public.ignored_parameters) == {
+        "cache_control",
+        "inference_geo",
+        "tools.cache_control",
+        "tools.eager_input_streaming",
+        "tools.defer_loading",
+        "tools.allowed_callers",
+        "tools.input_examples",
+    }
+    assert mixed_provider.provider_cache_control is None
+    assert mixed_provider.inference_geo is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ sft = ["tinker>=0.23,<0.24", "tinker-cookbook>=0.4.3,<0.5"]
 dev = [
     "pytest>=8.0",
     "pytest-xdist>=3.8",
+    # Powers the Anthropic SDK-surface drift gate in the Messages manifest tests,
+    # mirroring the runtime `openai` dependency's drift gate: an SDK bump turns new
+    # request surface into a loud classification decision instead of a silent 400.
+    "anthropic>=1.2,<2",
     "ruff>=0.5",
     "ty>=0.0.1a1",
     "experiential[sft]",

--- a/uv.lock
+++ b/uv.lock
@@ -149,6 +149,24 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/1a/b5af41cc1fa14da277ec20ca5554dd2fcbc09b8523ac59b7a97fbb88e452/anthropic-1.2.0.tar.gz", hash = "sha256:12f8eedee7b7fb5685837b1371b7bfae1b281703f62355f4632598ec2fc53b34", size = 1137443, upload-time = "2026-08-27T20:29:12.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/78/3f8b52708b03309e511990700bb8d0ec7a0c9db3d2a1e0d1c3ca417a4604/anthropic-1.2.0-py3-none-any.whl", hash = "sha256:b60642b3e3cd6b8e3e328a2d3f2863ad2b6e743f1037e42cc0143f7df99f63c6", size = 1289535, upload-time = "2026-08-27T20:29:11.01Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -600,6 +618,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +663,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "anthropic" },
     { name = "maturin" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -651,6 +679,7 @@ sft = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "boto3", specifier = ">=1.35,<2" },
     { name = "botocore", specifier = ">=1.35,<2" },
     { name = "click", specifier = ">=8.2" },


### PR DESCRIPTION
## Problem

A real Claude Code session in production sent a tool definition carrying `eager_input_streaming` and the gateway answered:

```
400 "Invalid value for 'tools.0.eager_input_streaming'. (param: tools.0.eager_input_streaming)"
```

Same conditional-field class as `cache_control` (#662) and `context_management`/`diagnostics`/`speed` (#665, #679): fields real first-party clients send conditionally that the strict decode rejects. This PR fixes the named field, sweeps every sibling on the current official SDK, and installs a drift gate so the next SDK field is a loud classification decision instead of a customer-facing 400.

## Live verification (api.anthropic.com, house key, 2026-08-30)

Bare acceptance probes, no beta header:

| Field | Bare result |
|---|---|
| `tools[].eager_input_streaming` (true/false, stream and non-stream) | 200 |
| `tools[].strict` | 200 |
| `tools[].defer_loading: false` | 200 (`true` for every tool is the provider's own 400: "At least one tool must have defer_loading=false") |
| `tools[].input_examples` | 200 |
| `tools[].allowed_callers` | 200 (even without a companion server tool) |
| top-level `cache_control` | 200 |
| top-level `inference_geo` | 200 |
| top-level `service_tier: standard_only` | 200 |
| top-level `user_profile_id` | 400 "Extra inputs are not permitted" (needs the `user-profiles` beta) |

End-to-end: the exact production repro body now decodes, and the gateway-built payload (carrying `eager_input_streaming`, top-level `cache_control`, `inference_geo`) streams 200 from api.anthropic.com.

## Decisions (each a table entry with a test)

**Accept and forward verbatim on Anthropic rungs, drop with per-field disclosure elsewhere:**
- `tools[].eager_input_streaming`, `tools[].defer_loading`, `tools[].allowed_callers`, `tools[].input_examples`: excluded from serialization (pre-existing digests hold byte-identical) and folded into `canonical_request_sha256` replay identity when present, following the newer Messages carriers exactly. No beta token is required for any of them (verified live), so `anthropic_request_headers` is untouched.
- top-level `inference_geo`: Messages-only carrier, joins replay identity when present (where inference runs is a caller-visible processing commitment).
- top-level `cache_control` and `tools[].cache_control`: forwarded like the existing `tool_use` cache hint; a cache hint changes cost, not semantics, so they join neither serialization nor replay identity. Tool-definition `cache_control` was previously validated and silently dropped on every wire, losing native tool-block caching; it now forwards on Anthropic rungs.
- `tools[].strict`: maps onto the existing canonical `GatewayToolDefinition.strict` (already plumbed through every wire and the strict-tools coercion policy).

**Conscious rejections, recorded in the manifest with rationale:**
- `fallbacks`, `fallback_credit_token`: an upstream model swap falsifies the gateway's committed route identity and billing (consistent with the deliberately dropped `server-side-fallback-*`/`fallback-credit-*` beta tokens).
- `betas` (body form): the `anthropic-beta` header allowlist is the one beta opt-in channel; a body-borne channel would bypass it.
- `user_profile_id`: third-party attribution under the `user-profiles` beta is an org-trust delegation the gateway does not make; the provider rejects the bare field anyway.
- `service_tier`, `container`, `mcp_servers`, `thread`: unchanged existing rejections, rationales now written down.

## Drift gate (#649 pattern)

`anthropic>=1.2,<2` joins the dev extra (mirroring the runtime `openai` dependency's drift gate). New tests walk the GA and beta `MessageCreateParams` plus `ToolParam`/`BetaToolParam` annotations and fail with a decide-this-now message if any field is unclassified. The accepted tool table is executable: the strict wire model must accept exactly the accepted set.

## Error path (#671 standard)

Strict-decode 400s now state the expectation, not only the field: unknown fields answer "Unknown parameter 'tools.0.x'. Remove the field and resend the request." and invalid values carry pydantic's expectation text (which never echoes the caller's value), e.g. "Invalid value for 'tools.0.strict': Input should be a valid boolean...".

## Regression fixtures

The live-captured production tool shape (`eager_input_streaming: true` on a Bash tool, stream mode) is pinned in `requests_test.py`. Digest tests prove carrier-free requests keep their exact pre-change digests and replay identity.

## Gates

- `uv run ruff format` / `uv run ruff check .`: clean
- `uv run ty check`: clean
- `uv run pytest -q`: 2966 passed, 2 skipped (the two release-evidence tests fail only on a dirty tree and pass after commit)
- No Rust changes: the native engine takes its payloads from the shared Python builders, so no crate version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
