### PR TITLE
release: bump version to 0.7.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.9"
+version = "0.7.10"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.10 release. Ships #685: Anthropic tool-definition annotations accepted and forwarded (eager_input_streaming — the field a real Claude Code session hit in production — plus strict, defer_loading, input_examples, allowed_callers; top-level inference_geo and cache_control), all live-verified as bare-accepted at api.anthropic.com; user_profile_id and fallback tokens stay conscious rejections with rationale. Adds the Anthropic-SDK drift gate so any future unclassified tool/top-level field fails CI by name. Python-only; native stays 0.3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)