### PR TITLE
gateway: emit first_token_at from the native data plane (restore TTFT capture)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.10"
+version = "0.3.11"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -187,6 +187,32 @@ impl Event {
             Event::Completed | Event::Incomplete | Event::Failed(_)
         )
     }
+
+    /// Whether this event carries the first visible model output, used to
+    /// stamp time-to-first-token. A content, refusal, reasoning, or tool-argument
+    /// delta counts only when it carries at least one character: an empty delta
+    /// (a role-establishing or empty refusal frame) is not a visible token and
+    /// must not stamp TTFT early. A tool-call start is itself the first token of
+    /// a tool-only turn, so it counts even before any arguments stream. Purely
+    /// structural frames are excluded so TTFT is not stamped early: the Responses
+    /// `ProviderOutputItemStarted` reserves a slot at the item-start boundary
+    /// *before* the first delta arrives, and the opaque reasoning-carrier frames
+    /// (`ThinkingSignature`, `RedactedThinking`, `EncryptedReasoning`) never lead
+    /// a turn on their own. Usage, item-close, and lifecycle/terminal frames are
+    /// not output tokens either.
+    pub fn is_output_token(&self) -> bool {
+        match self {
+            Event::TextDelta(text) | Event::RefusalDelta(text) => !text.is_empty(),
+            Event::ProviderTextDelta { delta, .. }
+            | Event::ProviderRefusalDelta { delta, .. }
+            | Event::ReasoningSummaryDelta { delta, .. }
+            | Event::ThinkingDelta { delta, .. }
+            | Event::ReasoningContentDelta { delta, .. }
+            | Event::ToolArgumentsDelta { delta, .. } => !delta.is_empty(),
+            Event::ToolCallStarted { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 /// Render one event as the content-bearing JSON object used by dialect parity
@@ -655,6 +681,60 @@ pub fn require_u64(object: &Map<String, Value>, key: &str, label: &str) -> Resul
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn output_tokens_lead_a_turn_but_control_frames_do_not() {
+        // Content, reasoning, and tool-call deltas are the first visible output.
+        assert!(Event::TextDelta("hi".to_string()).is_output_token());
+        assert!(Event::RefusalDelta("no".to_string()).is_output_token());
+        assert!(Event::ProviderTextDelta {
+            output_index: 0,
+            item_id: "msg_1".to_string(),
+            delta: "hi".to_string(),
+        }
+        .is_output_token());
+        assert!(Event::ThinkingDelta {
+            index: 0,
+            delta: "hmm".to_string(),
+        }
+        .is_output_token());
+        // A tool-only turn's first token is the tool call itself.
+        assert!(Event::ToolCallStarted {
+            index: 0,
+            call_id: "call_1".to_string(),
+            name: "get".to_string(),
+        }
+        .is_output_token());
+        // Usage, terminals, and opaque reasoning-carrier frames never lead.
+        assert!(!Event::Usage(Usage::default()).is_output_token());
+        assert!(!Event::Completed.is_output_token());
+        assert!(!Event::Incomplete.is_output_token());
+        assert!(!Event::ThinkingSignature {
+            index: 0,
+            signature: "sig".to_string(),
+        }
+        .is_output_token());
+        // A Responses item-start reserves a slot before the first delta; it
+        // must not stamp TTFT early -- the following delta is the real token.
+        assert!(!Event::ProviderOutputItemStarted {
+            output_index: 0,
+            item_id: Some("msg_1".to_string()),
+            kind: ProviderOutputItemKind::Message,
+            status: None,
+            phase: None,
+        }
+        .is_output_token());
+        // An empty delta (role-establishing or empty refusal frame) carries no
+        // visible token, so it must not stamp TTFT.
+        assert!(!Event::TextDelta(String::new()).is_output_token());
+        assert!(!Event::RefusalDelta(String::new()).is_output_token());
+        assert!(!Event::ProviderTextDelta {
+            output_index: 0,
+            item_id: "msg_1".to_string(),
+            delta: String::new(),
+        }
+        .is_output_token());
+    }
 
     #[test]
     fn openai_compatible_usage_counts_absent_fields_as_zero() {

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -4,7 +4,7 @@
 //! deployment; the HTTP surfaces then drain it live or to completion.
 
 use std::collections::VecDeque;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use bytes::Bytes;
 use futures_util::stream::BoxStream;
@@ -126,6 +126,12 @@ pub struct UpstreamRelay {
     /// per-chunk timeout instead, so a slow reasoning model can stream for a
     /// long time after it has started answering.
     first_byte_deadline: Instant,
+    /// Wall-clock time this relay yielded its first output token (a content,
+    /// reasoning, or tool-call delta), or `None` before any token arrives.
+    /// Distinct from `first_byte_recorded`: the first byte can be an SSE frame
+    /// carrying only role/lifecycle scaffolding, so time-to-first-token is
+    /// stamped on the first event that carries visible model output.
+    first_token_at: Option<SystemTime>,
 }
 
 impl UpstreamRelay {
@@ -177,7 +183,15 @@ impl UpstreamRelay {
             eof: false,
             first_byte_recorded: false,
             first_byte_deadline,
+            first_token_at: None,
         }
+    }
+
+    /// The wall-clock time this relay yielded its first output token, or
+    /// `None` if it has not produced one yet. Read at settlement to report
+    /// the winning attempt's time-to-first-token.
+    pub fn first_token_at(&self) -> Option<SystemTime> {
+        self.first_token_at
     }
 
     /// Yield the next normalized event. `Ok(None)` means the upstream closed
@@ -192,6 +206,14 @@ impl UpstreamRelay {
     ) -> Result<Option<Event>, Failure> {
         loop {
             if let Some(event) = self.pending.pop_front() {
+                // Every yielded event exits here, so this is the one place that
+                // stamps time-to-first-token: the first event carrying visible
+                // model output. Prefix events peeked during commit also passed
+                // through here, so the winning attempt's first token is stamped
+                // whether it is later replayed from a prefix or drained live.
+                if self.first_token_at.is_none() && event.is_output_token() {
+                    self.first_token_at = Some(SystemTime::now());
+                }
                 return Ok(Some(event));
             }
             if self.eof {
@@ -308,7 +330,44 @@ pub async fn collect_committed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dialects::Dialect;
+    use crate::events::Event;
     use futures_util::stream;
+
+    #[tokio::test]
+    async fn first_token_at_is_stamped_on_the_first_output_delta() {
+        // A content delta then the OpenAI terminal sentinel.
+        let frames = vec![
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let mut relay = UpstreamRelay::from_stream(
+            stream::iter(frames).boxed(),
+            Dialect::OpenAiCompatible,
+            Instant::now() + Duration::from_secs(5),
+        );
+        assert!(
+            relay.first_token_at().is_none(),
+            "no first-token time before any event is yielded"
+        );
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let per_chunk = Duration::from_secs(5);
+        let first = relay
+            .next_event(deadline, per_chunk, Instant::now())
+            .await
+            .expect("the stream yields")
+            .expect("an event is produced");
+        assert!(
+            matches!(&first, Event::TextDelta(text) if text == "hi"),
+            "the first output event is the content delta"
+        );
+        assert!(
+            relay.first_token_at().is_some(),
+            "the first content delta stamps time-to-first-token"
+        );
+    }
 
     #[test]
     fn a_first_byte_stall_fails_over_without_redialing_the_dead_lane() {

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -632,27 +632,30 @@ async fn completed_response(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let events =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                if let Some(mut owner) = lease.take() {
-                    owner.abandon().await;
-                }
-                return error_response(&error);
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let events = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            if let Some(mut owner) = lease.take() {
+                owner.abandon().await;
             }
-        };
+            return error_response(&error);
+        }
+    };
     respond_from_chat_events(
         admission,
         guard,
@@ -681,27 +684,30 @@ async fn guarded_chat_response(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let collected =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                if let Some(mut owner) = lease.take() {
-                    owner.abandon().await;
-                }
-                return error_response(&error);
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let collected = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            if let Some(mut owner) = lease.take() {
+                owner.abandon().await;
             }
-        };
+            return error_response(&error);
+        }
+    };
     let events = match apply_output_guardrail(&admission, &guard.bridge, collected).await {
         Ok(events) => events,
         Err(failure) => {
@@ -804,6 +810,8 @@ async fn stream_response(
             }};
         }
 
+        // Mirror any prefix-peeked first token before a start-frame send can cancel and drop it.
+        guard.record_first_token(committed.relay.first_token_at());
         let start_frames = match encoder.start() {
             Ok(frames) => frames,
             Err(_) => {
@@ -845,6 +853,8 @@ async fn stream_response(
                 }
             };
             track_event(&event, &mut usage, &mut tool_names);
+            // Mirror the relay's first-token time onto the guard as tokens stream.
+            guard.record_first_token(committed.relay.first_token_at());
             if matches!(
                 event,
                 Event::RefusalDelta(_) | Event::ProviderRefusalDelta { .. }

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -374,24 +374,27 @@ async fn completed_messages(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let events =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                return messages_error_response(&error);
-            }
-        };
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let events = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            return messages_error_response(&error);
+        }
+    };
     respond_from_messages_events(
         admission,
         guard,
@@ -413,24 +416,27 @@ async fn guarded_messages(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let collected =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                return messages_error_response(&error);
-            }
-        };
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let collected = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            return messages_error_response(&error);
+        }
+    };
     let events = match apply_output_guardrail(&admission, &guard.bridge, collected).await {
         Ok(events) => events,
         Err(failure) => {
@@ -498,6 +504,8 @@ async fn stream_messages(
             }};
         }
 
+        // Mirror any prefix-peeked first token before a start-frame send can cancel and drop it.
+        guard.record_first_token(committed.relay.first_token_at());
         let start_frames = match encoder.start() {
             Ok(frames) => frames,
             Err(_) => {
@@ -535,6 +543,8 @@ async fn stream_messages(
                 }
             };
             track_event(&event, &mut usage, &mut tool_names);
+            // Mirror the relay's first-token time onto the guard as tokens stream.
+            guard.record_first_token(committed.relay.first_token_at());
             if matches!(
                 event,
                 Event::RefusalDelta(_) | Event::ProviderRefusalDelta { .. }

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -575,27 +575,30 @@ async fn completed_responses(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let events =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                if let Some(mut owner) = lease.take() {
-                    owner.abandon().await;
-                }
-                return error_response(&error);
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let events = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            if let Some(mut owner) = lease.take() {
+                owner.abandon().await;
             }
-        };
+            return error_response(&error);
+        }
+    };
     respond_from_responses_events(
         state,
         admission,
@@ -654,27 +657,30 @@ async fn guarded_responses(
 ) -> Response {
     let _permit = permit;
     let phase_timeout = admission.phase_timeout(committed.depth);
-    let collected =
-        match collect_committed(&mut committed, deadline, phase_timeout, guard.started).await {
-            Ok(events) => events,
-            Err(failure) => {
-                let failure = failure.boundary();
-                let error = collection_public_error(&failure);
-                guard
-                    .settle(
-                        "failed",
-                        committed.usage.as_ref(),
-                        &committed.tool_names,
-                        Some(&failure),
-                        true,
-                    )
-                    .await;
-                if let Some(mut owner) = lease.take() {
-                    owner.abandon().await;
-                }
-                return error_response(&error);
+    let collection =
+        collect_committed(&mut committed, deadline, phase_timeout, guard.started).await;
+    // Record TTFT before any settle so a mid-collection failure still keeps an observed first token.
+    guard.record_first_token(committed.relay.first_token_at());
+    let collected = match collection {
+        Ok(events) => events,
+        Err(failure) => {
+            let failure = failure.boundary();
+            let error = collection_public_error(&failure);
+            guard
+                .settle(
+                    "failed",
+                    committed.usage.as_ref(),
+                    &committed.tool_names,
+                    Some(&failure),
+                    true,
+                )
+                .await;
+            if let Some(mut owner) = lease.take() {
+                owner.abandon().await;
             }
-        };
+            return error_response(&error);
+        }
+    };
     let events = match apply_output_guardrail(&admission, &guard.bridge, collected).await {
         Ok(events) => events,
         Err(failure) => {
@@ -768,6 +774,8 @@ async fn stream_responses(
             }};
         }
 
+        // Mirror any prefix-peeked first token before a start-frame send can cancel and drop it.
+        guard.record_first_token(committed.relay.first_token_at());
         let start_frames = match encoder.start() {
             Ok(frames) => frames,
             Err(_) => {
@@ -810,6 +818,8 @@ async fn stream_responses(
             };
             track_event(&event, &mut usage, &mut tool_names);
             retention.track(&event);
+            // Mirror the relay's first-token time onto the guard as tokens stream.
+            guard.record_first_token(committed.relay.first_token_at());
             if matches!(
                 event,
                 Event::RefusalDelta(_) | Event::ProviderRefusalDelta { .. }

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -8,7 +8,7 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
@@ -17,6 +17,41 @@ use crate::encode::compact_json;
 use crate::errors::{Failure, FailureClass};
 use crate::events::Usage;
 use crate::metrics::METRICS;
+
+/// Format one wall-clock instant as an RFC 3339 / ISO 8601 UTC string with
+/// millisecond precision, e.g. `2026-08-30T12:34:56.789+00:00`.
+///
+/// The control plane parses this with `datetime.fromisoformat`, so the output
+/// stays inside that grammar (explicit `+00:00` offset, millisecond fraction).
+/// The crate carries no datetime dependency, so the civil date is derived from
+/// the Unix epoch with Howard Hinnant's `civil_from_days` algorithm; a time
+/// before the epoch (never expected for a served token) clamps to the epoch.
+fn system_time_to_rfc3339(at: SystemTime) -> String {
+    let since_epoch = at.duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = since_epoch.as_secs() as i64;
+    let millis = since_epoch.subsec_millis();
+    let days = secs.div_euclid(86_400);
+    let seconds_of_day = secs.rem_euclid(86_400);
+    let (hour, minute, second) = (
+        seconds_of_day / 3_600,
+        (seconds_of_day % 3_600) / 60,
+        seconds_of_day % 60,
+    );
+    // civil_from_days: shift the epoch to a 0000-03-01 era so leap handling is
+    // branch-free, then recover the Gregorian year/month/day.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097; // [0, 146_096]
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let mp = (5 * day_of_year + 2) / 153; // [0, 11], months shifted so March = 0
+    let day = day_of_year - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = if month <= 2 { year + 1 } else { year };
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}+00:00")
+}
 
 /// Build the settle callback argument shared by explicit settlement and the
 /// drop backstop.
@@ -30,6 +65,7 @@ fn settle_argument(
     failure: Option<&Failure>,
     finalize: bool,
     opened: bool,
+    first_token_at: Option<SystemTime>,
 ) -> String {
     compact_json(&json!({
         "request_id": request_id,
@@ -48,6 +84,7 @@ fn settle_argument(
         })),
         "finalize": finalize,
         "opened": opened,
+        "first_token_at": first_token_at.map(system_time_to_rfc3339),
     }))
 }
 
@@ -109,6 +146,10 @@ pub struct AttemptGuard {
     /// diverge from the recorded metric.
     decided_settlement: Option<String>,
     pub started: Instant,
+    /// Wall-clock time the winning attempt streamed its first output token,
+    /// reported in the finalizing settlement so the control plane can derive
+    /// time-to-first-token. `None` until an attempt observes a first token.
+    first_token_at: Option<SystemTime>,
 }
 
 /// Holds one unit of the shutdown drain counter for a detached stream task,
@@ -153,6 +194,7 @@ impl AttemptGuard {
             opened: false,
             decided_settlement: None,
             started,
+            first_token_at: None,
         }
     }
 
@@ -161,6 +203,18 @@ impl AttemptGuard {
         self.attempt_id = Some(attempt_id);
         self.opened = false;
         self.decided_settlement = None;
+        // Each physical attempt observes its own first token; a prior failed
+        // attempt's timing never carries into its successor.
+        self.first_token_at = None;
+    }
+
+    /// Record the wall-clock time the active attempt streamed its first output
+    /// token, read from its relay just before settlement. Only the first
+    /// observation for the attempt is kept.
+    pub fn record_first_token(&mut self, at: Option<SystemTime>) {
+        if self.first_token_at.is_none() {
+            self.first_token_at = at;
+        }
     }
 
     /// Record that the active attempt's provider dispatch opened.
@@ -208,6 +262,7 @@ impl AttemptGuard {
             failure,
             finalize,
             self.opened,
+            self.first_token_at,
         );
         if finalize {
             let cancelled = failure.map(|failure| failure.failure_class == FailureClass::Cancelled)
@@ -314,6 +369,7 @@ impl Drop for AttemptGuard {
                             )),
                             true,
                             self.opened,
+                            self.first_token_at,
                         ),
                     )
                 }
@@ -343,5 +399,53 @@ impl Drop for AttemptGuard {
             deliver(&bridge, method, argument).await;
             pending.fetch_sub(1, Ordering::SeqCst);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_formats_epoch_seconds_and_millis_in_utc() {
+        assert_eq!(
+            system_time_to_rfc3339(UNIX_EPOCH),
+            "1970-01-01T00:00:00.000+00:00"
+        );
+        // A fixed instant with sub-second precision (1_700_000_000.500s).
+        let at = UNIX_EPOCH + Duration::from_millis(1_700_000_000_500);
+        assert_eq!(system_time_to_rfc3339(at), "2023-11-14T22:13:20.500+00:00");
+        // A leap day exercises the civil-from-days month/day recovery.
+        let leap = UNIX_EPOCH + Duration::from_secs(1_582_934_400);
+        assert_eq!(
+            system_time_to_rfc3339(leap),
+            "2020-02-29T00:00:00.000+00:00"
+        );
+    }
+
+    #[test]
+    fn settle_argument_carries_first_token_at_only_when_observed() {
+        let observed = UNIX_EPOCH + Duration::from_millis(1_700_000_000_500);
+        let with_token = settle_argument(
+            "req",
+            "att",
+            "completed",
+            None,
+            &[],
+            None,
+            true,
+            true,
+            Some(observed),
+        );
+        let parsed: Value = serde_json::from_str(&with_token).expect("valid json");
+        assert_eq!(
+            parsed["first_token_at"],
+            Value::String("2023-11-14T22:13:20.500+00:00".to_string())
+        );
+        // A non-streaming attempt observes no first token: the field is null,
+        // matching the control plane's backward-compatible parse.
+        let without = settle_argument("req", "att", "completed", None, &[], None, true, true, None);
+        let parsed: Value = serde_json::from_str(&without).expect("valid json");
+        assert_eq!(parsed["first_token_at"], Value::Null);
     }
 }

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from exp.runtime.gateway.contracts import GatewayEventKind, GatewayFailureClass
 from exp.runtime.gateway.native_settlement import (
     _usage_from_payload,  # noqa: PLC2701 - direct unit coverage for normalization.
+    first_token_at_from_settlement,
     terminal_from_settlement,
 )
+
+
+def test_first_token_at_parses_the_native_plane_rfc3339_wire_format() -> None:
+    # The exact string the Rust data plane emits (settlement.rs
+    # `system_time_to_rfc3339`): explicit +00:00 offset, millisecond fraction.
+    # This pins the producer/consumer contract so a format drift on either side
+    # fails loudly instead of silently dropping time-to-first-token.
+    parsed = first_token_at_from_settlement({"first_token_at": "2023-11-14T22:13:20.500+00:00"})
+    assert parsed == datetime(2023, 11, 14, 22, 13, 20, 500_000, tzinfo=UTC)
+
+
+def test_first_token_at_is_none_when_absent_or_malformed() -> None:
+    # A non-streaming attempt observes no first token, so the field is absent;
+    # a malformed value never crashes accounting.
+    assert first_token_at_from_settlement({}) is None
+    assert first_token_at_from_settlement({"first_token_at": None}) is None
+    assert first_token_at_from_settlement({"first_token_at": 1_700_000_000}) is None
+    assert first_token_at_from_settlement({"first_token_at": "not-a-timestamp"}) is None
 
 
 def test_usage_from_payload_handles_tokens_and_tool_names() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.10"
+version = "0.7.11"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.10,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.11,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.10"
+version = "0.3.11"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.10"
+version = "0.7.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

`gateway_attempts.first_token_at` — and the `gateway_usage_events.ttft_ms` derived from it — **dropped to 0% the day serving cut over from the retired Python data plane to the native (Rust) one.** In production, `first_token_at` was ~69% populated on 08-26 (206/298 attempts) and **exactly zero from 08-27 onward** (thousands of attempts/day, none with a first-token time).

Root cause: the Rust data plane never emitted `first_token_at` in its settle payload. The control plane has carried the whole downstream the entire time — the parser (`first_token_at_from_settlement`), the settle argument (`gateway_settle_attempt.p_first_token_at`), and the derivation (`gateway_finalize_usage`) — so **only the producer was missing.**

This is the keystone that blocks the model-catalog moving to true time-to-first-token latency and decode-rate throughput (currently it shows end-to-end totals, which read as "slow" for tool-calling / long-output traffic).

## What

- Capture the first output token's wall-clock time at the single relay choke point, `UpstreamRelay::next_event` (sibling to `first_byte_recorded`). The first event carrying visible model output — content, refusal, reasoning, or a tool call — stamps `first_token_at`. `is_output_token()` excludes usage, lifecycle, terminals, and opaque reasoning-carrier frames.
- Because prefix events peeked during commit also flow through `next_event`, the winning attempt's first token is stamped whether it is later replayed from the prefix or drained live — across all three protocol lanes (chat / responses / messages) and both the buffered and streaming paths.
- Thread it onto the settlement (`AttemptGuard.record_first_token` → `settle_argument`), serialized as an RFC 3339 UTC string the control plane already parses. The hot-path crate stays dependency-free via a small civil-from-days formatter.

`first_token_at` is inherently streaming-only (a non-streaming upstream call has no observable first token), matching the field's original ~70% coverage. No control-plane, schema, or migration change is needed — the platform side already consumes it.

## Tests
- `events`: `is_output_token` classifies content/reasoning/tool deltas as first output, control/terminal frames as not.
- `relay`: the first content delta stamps `first_token_at`; it is `None` before any event.
- `settlement`: the RFC 3339 formatter (epoch, sub-second, leap day) and that the settle argument carries the field only when observed.
- `native_settlement_test.py`: the Python parser round-trips the **exact** wire string the Rust formatter emits (pins the producer/consumer contract so a format drift on either side fails loudly).

Green locally: `cargo test --no-default-features` (114), `cargo clippy -D warnings`, `pytest exp/runtime/gateway` (603), rust bridge parity (`-k rust`, 18), ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)