### PR TITLE
gateway: class an unavailable Responses continuation as a client failure, not internal

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -427,11 +427,21 @@ class NativeControlPlane(NativeObservabilityMixin):
         except NativeDialectUnavailableError as exc:
             return self._escalate_accepted(authorization, str(exc))
         except OpenAIProtocolError as exc:
+            # A continuation whose bound provider authority is no longer
+            # available is a CLIENT error (400 continuation_unavailable: resend
+            # the full conversation), not a gateway-internal fault. Class the
+            # durable failure by the public status so usage and health read it
+            # as a client failure and it never pages as internal; the caller
+            # still receives the exact public error unchanged.
             self._accounting.finish_request_quietly(
                 authorization,
                 GatewayFailure(
-                    failure_class=GatewayFailureClass.INTERNAL,
-                    safe_message="retained provider continuation authority was unavailable",
+                    failure_class=(
+                        GatewayFailureClass.INTERNAL
+                        if exc.status_code >= 500
+                        else GatewayFailureClass.INVALID_REQUEST
+                    ),
+                    safe_message=exc.detail.message,
                 ),
             )
             raise NativeBridgeError(exc) from exc

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1607,6 +1607,7 @@ def _openai_responses_pool_control_plane(
 def test_encrypted_reasoning_pins_winning_fallback_and_rejects_credential_drift(
     tmp_path: Path,
     rotated_beta: str | None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Retained ciphertext can replay only on its exact winning authenticated wire."""
     environment = {"TEST_ALPHA_KEY": "alpha-secret", "TEST_BETA_KEY": "beta-secret"}
@@ -1709,6 +1710,18 @@ def test_encrypted_reasoning_pins_winning_fallback_and_rejects_credential_drift(
     else:
         environment["TEST_BETA_KEY"] = rotated_beta
     assert environment["TEST_ALPHA_KEY"] == "alpha-secret"
+    # Capture the durable failure the accepted request records: a continuation
+    # that cannot bind is a client 400, so it must NOT be stamped internal (a
+    # 5xx-class ledger row would page the internal-error alert for a caller
+    # mistake).
+    recorded: list[GatewayFailure] = []
+    original_finish = control._accounting.finish_request_quietly  # noqa: SLF001
+
+    def _capture_finish(authorization: AuthorizationSnapshot, failure: GatewayFailure) -> None:
+        recorded.append(failure)
+        return original_finish(authorization, failure)
+
+    monkeypatch.setattr(control._accounting, "finish_request_quietly", _capture_finish)  # noqa: SLF001
     with pytest.raises(NativeBridgeError) as rejected:
         _admit_responses(
             control,
@@ -1719,6 +1732,8 @@ def test_encrypted_reasoning_pins_winning_fallback_and_rejects_credential_drift(
     assert error["status_code"] == 400
     assert error["code"] == "continuation_unavailable"
     assert error["param"] == "previous_response_id"
+    assert recorded, "the unavailable continuation must record a durable failure"
+    assert recorded[-1].failure_class == GatewayFailureClass.INVALID_REQUEST
 
 
 def test_admit_skips_a_dead_lead_rung_and_serves_the_fallback(tmp_path: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.11"
+version = "0.7.12"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.11"
+version = "0.7.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

Prod paged repeatedly on `internal` failures reading **"retained provider continuation authority was unavailable"** — across chat, embeddings, TTS, and image models. Root cause: a Responses request with a `previous_response_id` **continuation** whose bound provider authority is no longer available (rotated credential, evicted binding) is a **client 400** (`continuation_unavailable`: "resend the full conversation history"). The caller already receives that correct 400 — but the admit path recorded the durable request failure as `GatewayFailureClass.INTERNAL`, so a **caller mistake was stamped as a 5xx-class ledger row**, tripping the internal-error alert and reading as a gateway fault in usage/health.

## What

`native_bridge.py` now classes the durable failure by the public error's status: a 4xx `OpenAIProtocolError` records as `INVALID_REQUEST` with its actual message; only a genuine 5xx stays `INTERNAL`. The caller's response is unchanged (still the exact public error).

## Reproduced + locked

The existing `test_encrypted_reasoning_pins_winning_fallback_and_rejects_credential_drift` already drives the exact path (rotate the bound key → re-admit the continuation → 400). It now also captures the durable failure and asserts its class is `INVALID_REQUEST`, not `INTERNAL` (the assertion fails on the old code).

Green locally: `pytest exp/runtime/gateway/native_bridge_test.py` (107), ruff + ty.

Python-only change → bumps `experiential` to 0.7.12 (`exp-gateway-native` unchanged).

## Not included (separate)
- The `azure_openai-*` `internal` admission failures are a **catalog-data** problem, not an engine bug: 699 deployments are labeled with a provider (`azure_openai`) the engine has never supported (`SUPPORTED_PROVIDERS` has `azure`), and all 699 are `status='disabled'` with no endpoint/credential/connection. They're listed-but-unservable stubs. Resolution (unlist vs provision a real Azure connection) is an owner decision, tracked separately.
- The `provider_not_found` / `provider_authentication` **attempts**-stream alert is post-dispatch provider replies, under separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)