### PR TITLE
anthropic: serve server tools end to end (web_search) with verbatim block carry

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -237,7 +237,20 @@ bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthr
 disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded
 decision behind an SDK-surface drift gate in
 `exp/runtime/anthropic_protocol/manifest.py`, and rejects image and document blocks loudly
-because the surface is text-only. Thinking carriers
+because the surface is text-only. Typed Anthropic tool entries (web search, web fetch, code
+execution, tool search, bash, text editor, memory; every accepted type bare-accepted live,
+verified 2026-08-31) decode onto a verbatim server-tool carrier that re-enters the tools array
+at its exact caller position on Anthropic rungs, and the echoed `server_tool_use` and
+`*_tool_result` assistant history blocks ride an opaque per-block carrier the same way; any
+non-Anthropic rung is a named rejection for both, never a disclosure-drop, because silently
+removing a declared search or execution capability would change what the model can do. On the
+response side the native normalizer folds `server_tool_use` input fragments into one verbatim
+block, delivers result blocks whole, honors the provider's `pause_turn` stop reason, and reads
+the cumulative `message_delta` usage so search-inflated input tokens bill correctly; the
+per-search provider fee itself is deliberately not modeled yet (searched content is billed
+through the grown input-token total). Text citations from search results are not carried yet:
+the answer text streams uncited, and `search_result` input blocks stay rejected for the same
+reason. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
 `anthropic_messages` dialect; on the Responses surface over Anthropic routes, thinking text is
 projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -137,12 +137,100 @@ rungs, which own their validity rules, and drop with disclosure elsewhere.
 """
 
 MESSAGES_TOOL_FIELDS_REJECTED: frozenset[str] = frozenset()
-"""Custom tool-definition fields consciously rejected, currently none.
+"""Custom tool-definition fields consciously rejected, currently none."""
 
-Server-defined tools (bash, text editor, web search, code execution, tool
-search) are rejected wholesale through the closed ``type`` literal instead
-of field-by-field: the gateway serves no provider-hosted execution.
+
+MESSAGES_SERVER_TOOL_TYPES_ACCEPTED = frozenset(
+    {
+        "bash_20250124",
+        "text_editor_20250124",
+        "text_editor_20250429",
+        "text_editor_20250728",
+        "memory_20250818",
+        "web_search_20250305",
+        "web_search_20260209",
+        "web_search_20260318",
+        "web_fetch_20250910",
+        "web_fetch_20260209",
+        "web_fetch_20260309",
+        "web_fetch_20260318",
+        "code_execution_20250522",
+        "code_execution_20250825",
+        "code_execution_20260120",
+        "code_execution_20260521",
+        "tool_search_tool_bm25_20251119",
+        "tool_search_tool_bm25",
+        "tool_search_tool_regex_20251119",
+        "tool_search_tool_regex",
+        "browser_toolset_20260801",
+        "computer_toolset_20260801",
+    }
+)
+"""Typed Anthropic tool entries carried verbatim on Anthropic rungs.
+
+Every type here is accepted bare by the live API on a plain key (verified
+2026-08-31; the only 400s are the provider's own per-model support errors),
+so the gateway forwards the entry byte-for-byte and the provider stays the
+authority on per-model and cross-tool validity. A route with any
+non-Anthropic rung rejects by name: silently dropping a search or execution
+capability the caller declared would change what the model can do.
 """
+
+MESSAGES_SERVER_TOOL_TYPES_REJECTED = frozenset(
+    {
+        # Legacy Claude 3.5 tool versions served only behind the
+        # computer-use-2024-10-22 beta; no current client sends them.
+        "bash_20241022",
+        "text_editor_20241022",
+        # Computer use is beta-gated (computer-use-*) and unverified here.
+        "computer_20241022",
+        "computer_20250124",
+        "computer_20251124",
+        # The advisor tool runs a second, differently priced model inside
+        # the same request, which would falsify this gateway's committed
+        # route identity and billing (the fallbacks rationale).
+        "advisor_20260301",
+        # MCP toolsets bind the rejected mcp_servers field.
+        "mcp_toolset",
+    }
+)
+"""Typed Anthropic tool entries consciously rejected, each with a reason."""
+
+
+MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED = frozenset(
+    {
+        "server_tool_use",
+        "web_search_tool_result",
+        "web_fetch_tool_result",
+        "code_execution_tool_result",
+        "bash_code_execution_tool_result",
+        "text_editor_code_execution_tool_result",
+        "tool_search_tool_result",
+    }
+)
+"""Assistant history blocks carried verbatim for server-tool replay.
+
+Callers echo these blocks back on the turn after a server tool ran; their
+shapes evolve per family, so decode validates them shallowly and Anthropic
+rungs replay them byte-for-byte. This set must stay equal to the native
+normalizer's ``ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`` so every block the
+gateway can emit is a block it accepts back.
+"""
+
+MESSAGES_CONTENT_BLOCKS_REJECTED = frozenset(
+    {
+        # This gateway surface is text-only.
+        "image",
+        "document",
+        # Requires the rejected container field.
+        "container_upload",
+        # Citation source blocks: the gateway does not serve citations yet,
+        # so accepting search-result inputs would promise grounding it
+        # cannot return.
+        "search_result",
+    }
+)
+"""Caller content blocks consciously rejected, each with a reason."""
 
 
 MESSAGES_BETA_TOKENS_FORWARDED = frozenset(

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -96,3 +96,116 @@ def test_route_identity_and_delegation_fields_are_recorded_rejections() -> None:
         assert decisions[path] == CompatibilityDisposition.UNSUPPORTED
     for path in ("cache_control", "inference_geo"):
         assert decisions[path] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
+
+
+def test_every_official_sdk_tool_union_type_is_consciously_classified() -> None:
+    """The tool-type union is part of the drift gate.
+
+    A production Claude Code WebSearch request 400ed (engine 0.7.10) because
+    the tool decode classified custom-tool fields but not the typed
+    server-tool union members, so every ``type`` literal on the official GA
+    and beta tool unions must be a recorded decision.
+    """
+    import typing
+
+    from anthropic.types.beta.beta_tool_union_param import BetaToolUnionParam
+    from anthropic.types.tool_union_param import ToolUnionParam
+
+    from exp.runtime.anthropic_protocol.manifest import (
+        MESSAGES_SERVER_TOOL_TYPES_ACCEPTED,
+        MESSAGES_SERVER_TOOL_TYPES_REJECTED,
+    )
+
+    def type_literals(union: object) -> set[str]:
+        """Collect every ``type`` literal across one tool union."""
+        values: set[str] = set()
+
+        def walk(node: object) -> None:
+            """Accumulate string literals depth-first across wrappers."""
+            if typing.get_origin(node) is typing.Literal:
+                values.update(arg for arg in typing.get_args(node) if isinstance(arg, str))
+                return
+            for argument in typing.get_args(node):
+                walk(argument)
+
+        for member in typing.get_args(union):
+            walk(typing.get_type_hints(member).get("type"))
+        return values
+
+    assert not MESSAGES_SERVER_TOOL_TYPES_ACCEPTED & MESSAGES_SERVER_TOOL_TYPES_REJECTED
+    sdk_types = type_literals(ToolUnionParam) | type_literals(BetaToolUnionParam)
+    undecided = (
+        sdk_types
+        - {"custom"}
+        - MESSAGES_SERVER_TOOL_TYPES_ACCEPTED
+        - MESSAGES_SERVER_TOOL_TYPES_REJECTED
+    )
+    assert not undecided, _decided(undecided, "tool-union type")
+
+
+def test_every_official_sdk_content_block_type_is_consciously_classified() -> None:
+    """Caller content-block types are part of the drift gate."""
+    import typing
+
+    from anthropic.types.content_block_param import ContentBlockParam
+
+    from exp.runtime.anthropic_protocol.manifest import (
+        MESSAGES_CONTENT_BLOCKS_REJECTED,
+        MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED,
+    )
+
+    values: set[str] = set()
+
+    def walk(node: object) -> None:
+        """Accumulate string literals depth-first across wrappers."""
+        if typing.get_origin(node) is typing.Literal:
+            values.update(arg for arg in typing.get_args(node) if isinstance(arg, str))
+            return
+        for argument in typing.get_args(node):
+            walk(argument)
+
+    for member in typing.get_args(ContentBlockParam):
+        walk(typing.get_type_hints(member).get("type"))
+    translated = {"text", "tool_use", "tool_result", "thinking", "redacted_thinking"}
+    undecided = (
+        values
+        - translated
+        - MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED
+        - MESSAGES_CONTENT_BLOCKS_REJECTED
+    )
+    assert not undecided, _decided(undecided, "content-block type")
+    assert not MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED & MESSAGES_CONTENT_BLOCKS_REJECTED
+
+
+def test_server_tool_block_tables_match_the_wire_and_native_sets() -> None:
+    """The accepted history-block set is executable in both engines.
+
+    The strict wire literal and the native normalizer's opaque-carry set
+    must both equal the manifest table, so every block the gateway can emit
+    is a block it accepts back and vice versa.
+    """
+    import re
+    import typing
+    from pathlib import Path
+
+    from exp.runtime.anthropic_protocol import requests as anthropic_requests
+    from exp.runtime.anthropic_protocol.manifest import (
+        MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED,
+    )
+
+    wire_literal = set(
+        typing.get_args(typing.get_type_hints(anthropic_requests._ServerToolHistoryBlock)["type"])
+    )
+    assert wire_literal == set(MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED)
+
+    dialects_source = (
+        Path(__file__).resolve().parents[1] / "gateway" / "native" / "src" / "dialects.rs"
+    ).read_text(encoding="utf-8")
+    constant = re.search(
+        r"ANTHROPIC_SERVER_TOOL_BLOCK_TYPES: &\[&str\] = &\[(.*?)\];",
+        dialects_source,
+        re.DOTALL,
+    )
+    assert constant is not None
+    native_set = set(re.findall(r'"([a-z_]+)"', constant.group(1)))
+    assert native_set == set(MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED)

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -17,9 +17,18 @@ the HTTP layer renders them in the Anthropic envelope.
 from __future__ import annotations
 
 import json
-from typing import Literal, cast
+from typing import Annotated, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import JsonObject
@@ -27,6 +36,8 @@ from exp.common.models.model import ReasoningEffort, ToolCall
 from exp.runtime.anthropic_protocol.manifest import (
     MESSAGES_BETA_TOKENS_FORWARDED,
     MESSAGES_MANIFEST,
+    MESSAGES_SERVER_TOOL_TYPES_ACCEPTED,
+    MESSAGES_SERVER_TOOL_TYPES_REJECTED,
 )
 from exp.runtime.gateway.contracts import (
     CompatibilityDisposition,
@@ -34,6 +45,7 @@ from exp.runtime.gateway.contracts import (
     GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
+    GatewayServerTool,
     GatewayToolDefinition,
     ProviderReasoningBlock,
     RedactedThinkingBlock,
@@ -51,8 +63,8 @@ from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 _REJECTED_BLOCK_HINTS = {
     "image": "image blocks are not supported: this gateway surface is text-only",
     "document": "document blocks are not supported: this gateway surface is text-only",
-    "server_tool_use": "server tools are not supported by this gateway",
-    "web_search_tool_result": "server tools are not supported by this gateway",
+    "container_upload": "container_upload blocks require the unsupported container field",
+    "search_result": "search_result blocks are not supported: this gateway serves no citations",
 }
 
 
@@ -119,8 +131,41 @@ class _ToolResultBlock(_WireModel):
     cache_control: _CacheControl | None = None
 
 
+class _ServerToolHistoryBlock(BaseModel):
+    """One echoed assistant server-tool block, validated shallowly.
+
+    Callers resend prior-turn ``server_tool_use`` and result blocks
+    verbatim; their shapes evolve per tool family, so only the closed type
+    set is enforced here and the whole block is carried byte-for-byte for
+    Anthropic replay. The literal list must stay equal to
+    ``MESSAGES_SERVER_TOOL_RESULT_BLOCKS_ACCEPTED`` (pinned by the manifest
+    tests).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal[
+        "server_tool_use",
+        "web_search_tool_result",
+        "web_fetch_tool_result",
+        "code_execution_tool_result",
+        "bash_code_execution_tool_result",
+        "text_editor_code_execution_tool_result",
+        "tool_search_tool_result",
+    ]
+
+    def verbatim(self) -> JsonObject:
+        """The whole block, declared field plus every extra, for replay."""
+        return cast(JsonObject, self.model_dump(mode="json"))
+
+
 _ContentBlock = (
-    _TextBlock | _ThinkingBlock | _RedactedThinkingBlock | _ToolUseBlock | _ToolResultBlock
+    _TextBlock
+    | _ThinkingBlock
+    | _RedactedThinkingBlock
+    | _ToolUseBlock
+    | _ToolResultBlock
+    | _ServerToolHistoryBlock
 )
 
 
@@ -163,6 +208,59 @@ class _Tool(_WireModel):
     defer_loading: bool | None = None
     allowed_callers: tuple[str, ...] | None = None
     input_examples: tuple[JsonObject, ...] | None = None
+
+
+class _ServerToolEntry(BaseModel):
+    """One typed Anthropic tool entry (server or Anthropic-defined), shallow.
+
+    These entries carry no ``input_schema`` and their per-family config
+    evolves with the provider (``max_uses``, domain filters, citations,
+    ``max_characters``, ...), so validation is deliberately shallow: a
+    closed, recorded type set plus a bounded name, with the raw entry
+    forwarded byte-for-byte on Anthropic rungs, which own per-model and
+    cross-tool validity (every accepted type is bare-accepted live,
+    verified 2026-08-31).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(min_length=1, max_length=256)
+    name: str | None = Field(default=None, min_length=1, max_length=256)
+    cache_control: _CacheControl | None = None
+
+    @field_validator("type")
+    @classmethod
+    def _require_recorded_type(cls, value: str) -> str:
+        """Accept only the recorded tool types, naming the decision."""
+        if value in MESSAGES_SERVER_TOOL_TYPES_ACCEPTED:
+            return value
+        if value in MESSAGES_SERVER_TOOL_TYPES_REJECTED:
+            raise ValueError(f"tool type '{value}' is consciously not served by this gateway")
+        raise ValueError(
+            f"unknown tool type '{value}'; expected 'custom' or one of the supported "
+            "Anthropic tool types"
+        )
+
+
+def _tool_entry_kind(value: object) -> str:
+    """Route one tools[] entry to the custom or typed wire branch.
+
+    The tag labels are underscore-prefixed so the shared error renderer
+    strips them from public field paths like union member class names.
+    """
+    if isinstance(value, _ServerToolEntry):
+        return "_server"
+    if isinstance(value, dict):
+        entry_type = cast(JsonObject, value).get("type")
+        if isinstance(entry_type, str) and entry_type != "custom":
+            return "_server"
+    return "_custom"
+
+
+_ToolEntry = Annotated[
+    Annotated[_Tool, Tag("_custom")] | Annotated[_ServerToolEntry, Tag("_server")],
+    Discriminator(_tool_entry_kind),
+]
 
 
 class _ToolChoice(_WireModel):
@@ -211,7 +309,7 @@ class _MessagesRequest(_WireModel):
     top_k: int | None = Field(default=None, ge=0)
     stop_sequences: tuple[str, ...] | None = None
     stream: bool = False
-    tools: tuple[_Tool, ...] = ()
+    tools: tuple[_ToolEntry, ...] = ()
     tool_choice: _ToolChoice | None = None
     metadata: _Metadata | None = None
     thinking: _ThinkingConfig | None = None
@@ -269,11 +367,24 @@ def decode_messages(
     parallel_tool_calls: bool | None = None
     if request.tool_choice is not None and request.tool_choice.disable_parallel_tool_use:
         parallel_tool_calls = False
+    client_tools: list[GatewayToolDefinition] = []
+    server_tools: list[GatewayServerTool] = []
+    raw_tools = cast(list[JsonObject], payload.get("tools", []))
+    for position, entry in enumerate(request.tools):
+        if isinstance(entry, _ServerToolEntry):
+            # The raw payload entry, not the re-serialized wire model, so the
+            # provider receives the caller's typed tool byte-for-byte.
+            server_tools.append(
+                GatewayServerTool(position=position, definition=raw_tools[position])
+            )
+        else:
+            client_tools.append(_gateway_tool(entry))
     try:
         canonical = GatewayRequest(
             surface=GatewayApiSurface.MESSAGES,
             messages=tuple(messages),
-            tools=tuple(_gateway_tool(tool) for tool in request.tools),
+            tools=tuple(client_tools),
+            provider_server_tools=tuple(server_tools),
             tool_choice=_gateway_tool_choice(request.tool_choice),
             parallel_tool_calls=parallel_tool_calls,
             maximum_output_tokens=request.max_tokens,
@@ -620,6 +731,23 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                         if block.cache_control is not None
                         else None
                     ),
+                )
+            )
+        elif isinstance(block, _ServerToolHistoryBlock):
+            if message.role != "assistant":
+                raise invalid_field(
+                    f"{param}.content.{block_index}",
+                    "server-tool blocks are only valid in assistant messages.",
+                )
+            # An opaque server-tool block carries its own canonical message
+            # at its exact position, mirroring the tool_result split; the
+            # Anthropic emitter merges consecutive assistant messages back
+            # into one content list.
+            flush()
+            out.append(
+                GatewayMessage(
+                    role="assistant",
+                    provider_server_tool_block=block.verbatim(),
                 )
             )
         else:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -706,3 +706,86 @@ def test_validation_errors_state_the_expectation_not_only_the_field() -> None:
     assert invalid.value.detail.param == "tools.0.strict"
     assert "Invalid value for 'tools.0.strict'" in invalid.value.detail.message
     assert "bool" in invalid.value.detail.message
+
+
+def test_decode_accepts_the_live_web_search_server_tool_shape() -> None:
+    """Live repro (engine 0.7.10, 2026-08-31): a Claude Code WebSearch tool
+    definition 400ed with "Invalid value for 'tools.0.input_schema'" because
+    server-tool entries carry no input_schema. The typed entry decodes onto
+    the verbatim server-tool carrier at its caller position."""
+    decoded = decode_messages(
+        _body(
+            stream=True,
+            tools=[
+                {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+                {
+                    "name": "Bash",
+                    "description": "Executes a bash command.",
+                    "input_schema": {"type": "object"},
+                },
+            ],
+        )
+    )
+    request = decoded.request
+    assert [tool.name for tool in request.tools] == ["Bash"]
+    assert len(request.provider_server_tools) == 1
+    server = request.provider_server_tools[0]
+    assert server.position == 0
+    assert server.definition == {
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": 8,
+    }
+    assert request.ignored_parameters == ()
+
+
+def test_decode_names_rejected_and_unknown_tool_types() -> None:
+    """Typed tool entries answer recorded, named 400s."""
+    with pytest.raises(OpenAIProtocolError) as rejected:
+        decode_messages(_body(tools=[{"type": "mcp_toolset", "name": "srv"}]))
+    assert rejected.value.detail.param == "tools.0.type"
+    assert "consciously not served" in rejected.value.detail.message
+
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        decode_messages(_body(tools=[{"type": "web_search_20990101", "name": "web_search"}]))
+    assert unknown.value.detail.param == "tools.0.type"
+    assert "unknown tool type" in unknown.value.detail.message
+
+
+def test_decode_carries_echoed_server_tool_history_blocks_verbatim() -> None:
+    """The turn-2 echo of a web_search turn splits into ordered verbatim
+    carrier messages so Anthropic rungs replay the exact assistant content."""
+    search_block: JsonObject = {
+        "type": "server_tool_use",
+        "id": "srvtoolu_1",
+        "name": "web_search",
+        "input": {"query": "utc"},
+    }
+    result_block: JsonObject = {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "caller": {"type": "direct"},
+        "content": [{"type": "web_search_result", "url": "https://utc.test"}],
+    }
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "what is the date"},
+                {
+                    "role": "assistant",
+                    "content": [search_block, result_block, {"type": "text", "text": "Monday."}],
+                },
+                {"role": "user", "content": "thanks, and tomorrow?"},
+            ],
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
+        )
+    )
+    roles = [message.role for message in decoded.request.messages]
+    assert roles == ["user", "assistant", "assistant", "assistant", "user"]
+    assert decoded.request.messages[1].provider_server_tool_block == search_block
+    assert decoded.request.messages[2].provider_server_tool_block == result_block
+    assert decoded.request.messages[3].content == "Monday."
+
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(_body(messages=[{"role": "user", "content": [search_block]}]))
+    assert "only valid in assistant messages" in excinfo.value.detail.message

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -18,8 +18,9 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
 )
 from exp.runtime.gateway.auth import utc_text
-from exp.runtime.gateway.contracts import GatewayRequest, provider_replay_authority
+from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.gateway.interfaces import GatewayClock
+from exp.runtime.gateway.replay_identity import provider_replay_authority
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.store import SystemGatewayClock
 

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -1046,7 +1046,7 @@ def test_reservation_counts_excluded_provider_carriers_toward_the_tier_bound() -
         ),
         maximum_output_tokens=16,
     )
-    from exp.runtime.gateway.contracts import provider_replay_authority
+    from exp.runtime.gateway.replay_identity import provider_replay_authority
 
     visible_bytes = len(canonical_json_bytes(carried))
     assert visible_bytes < 2_048

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256, sha256_json
+from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256
 from exp.common.models.gateway_catalog import (
     DeploymentId,
     ExactModelId,
@@ -119,6 +119,36 @@ class GatewayToolDefinition(ContractModel):
             or self.allowed_callers is not None
             or self.input_examples is not None
         )
+
+
+class GatewayServerTool(ContractModel):
+    """One verbatim Anthropic server or Anthropic-defined tool entry.
+
+    Typed tool-union entries (``web_search_*``, ``web_fetch_*``,
+    ``code_execution_*``, ``tool_search_*``, ``bash``, ``text_editor``,
+    ``memory``) carry no ``input_schema`` and evolve per family, so the
+    gateway validates them shallowly against the manifest's accepted type
+    set and forwards the entry byte-for-byte on Anthropic rungs, which own
+    the per-model validity rules (every current type is accepted bare on
+    the live API, verified 2026-08-31). ``position`` is the entry's index
+    in the caller's ``tools`` array so the provider sees the exact caller
+    ordering. Server tools change what the provider executes, so a present
+    entry joins replay identity through :func:`canonical_request_sha256`.
+    """
+
+    position: int = Field(ge=0)
+    definition: JsonObject
+
+    @property
+    def tool_type(self) -> str:
+        """The entry's provider tool type."""
+        return str(self.definition.get("type", ""))
+
+    @property
+    def name(self) -> str | None:
+        """The entry's fixed provider tool name, when it declares one."""
+        name = self.definition.get("name")
+        return name if isinstance(name, str) else None
 
 
 class StructuredTextFormat(ContractModel):
@@ -261,6 +291,18 @@ class GatewayMessage(ContractModel):
     other carriers so item-free digests are unperturbed; a present item
     joins replay identity through :func:`canonical_request_sha256`.
     """
+    provider_server_tool_block: JsonObject | None = Field(default=None, exclude=True)
+    """One verbatim Anthropic server-tool history block carried opaquely.
+
+    Callers echo prior-turn ``server_tool_use`` and ``*_tool_result``
+    assistant blocks back on the next turn; their shapes evolve per tool
+    family, so decode validates them shallowly and Anthropic rungs receive
+    them byte-for-byte at their positions (route admission rejects every
+    other rung: no other wire can replay them). A message carrying one
+    carries nothing else, mirroring ``provider_native_item``. Excluded from
+    serialization so block-free digests are unperturbed; a present block
+    joins replay identity through :func:`canonical_request_sha256`.
+    """
 
     @model_validator(mode="after")
     def _require_role_coherence(self) -> GatewayMessage:
@@ -280,8 +322,22 @@ class GatewayMessage(ContractModel):
                 or self.provider_item_id is not None
                 or self.tool_call_id is not None
                 or self.tool_is_error
+                or self.provider_server_tool_block is not None
             ):
                 raise ValueError("a native provider item carries the whole message")
+            return self
+        if self.provider_server_tool_block is not None:
+            if self.role != "assistant":
+                raise ValueError("server-tool blocks are valid only for assistant messages")
+            if (
+                self.content is not None
+                or self.tool_calls
+                or self.provider_reasoning
+                or self.provider_item_id is not None
+                or self.tool_call_id is not None
+                or self.tool_is_error
+            ):
+                raise ValueError("a server-tool block carries the whole message")
             return self
         if (
             self.content is None
@@ -409,6 +465,17 @@ class GatewayRequest(ContractModel):
     caller-visible processing commitment, so a present value joins replay
     identity through :func:`canonical_request_sha256`.
     """
+    provider_server_tools: tuple[GatewayServerTool, ...] = Field(default=(), exclude=True)
+    """Verbatim Anthropic server and Anthropic-defined tool entries.
+
+    Each entry keeps its exact caller position among ``tools`` and forwards
+    byte-for-byte on Anthropic rungs only; route admission rejects any
+    other rung by name because dropping a search or execution capability
+    the caller asked for would silently change what the model can do.
+    Excluded from serialization so entry-free digests are unperturbed;
+    present entries join replay identity through
+    :func:`canonical_request_sha256`.
+    """
     provider_beta_tokens: tuple[str, ...] = Field(default=(), exclude=True)
     """Allowlisted caller ``anthropic-beta`` tokens from the Messages surface.
 
@@ -529,7 +596,10 @@ class GatewayRequest(ContractModel):
         Raises:
             ValueError: Tool definitions or tool choice are incoherent.
         """
-        names = tuple(tool.name for tool in self.tools)
+        server_names = tuple(
+            tool.name for tool in self.provider_server_tools if tool.name is not None
+        )
+        names = tuple(tool.name for tool in self.tools) + server_names
         if len(set(names)) != len(names):
             raise ValueError("gateway tool names must not repeat")
         if (
@@ -537,8 +607,14 @@ class GatewayRequest(ContractModel):
             and self.tool_choice.name not in names
         ):
             raise ValueError("named gateway tool choice must name a request tool")
-        if self.tool_choice == "required" and not self.tools:
+        if self.tool_choice == "required" and not self.tools and not self.provider_server_tools:
             raise ValueError("required gateway tool choice needs at least one tool")
+        server_positions = tuple(tool.position for tool in self.provider_server_tools)
+        total_entries = len(self.tools) + len(self.provider_server_tools)
+        if len(set(server_positions)) != len(server_positions) or any(
+            position >= total_entries for position in server_positions
+        ):
+            raise ValueError("server tool positions must be unique caller tools indexes")
         if self.include_usage and not self.stream:
             raise ValueError("include_usage is valid only for streaming requests")
         if self.reasoning_summary is not None and self.surface != GatewayApiSurface.RESPONSES:
@@ -572,6 +648,13 @@ class GatewayRequest(ContractModel):
             and self.surface != GatewayApiSurface.MESSAGES
         ):
             raise ValueError("Anthropic tool carriers are valid only for Messages requests")
+        if self.provider_server_tools and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("server tools are valid only for Messages requests")
+        if (
+            any(message.provider_server_tool_block is not None for message in self.messages)
+            and self.surface != GatewayApiSurface.MESSAGES
+        ):
+            raise ValueError("server-tool blocks are valid only for Messages requests")
         if self.provider_beta_tokens and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("provider_beta_tokens are valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
@@ -581,138 +664,6 @@ class GatewayRequest(ContractModel):
         if len(set(self.reasoning_summary_parameters)) != len(self.reasoning_summary_parameters):
             raise ValueError("reasoning summary parameter paths must not repeat")
         return self
-
-
-def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
-    """Collect the provider-significant input excluded from serialization.
-
-    The carriers (replayed reasoning, native items, verbatim provider
-    configurations) are excluded from model serialization so immutable
-    artifacts and pre-existing request digests stay byte-identical, but the
-    provider still reads them as input. Replay identity folds this envelope
-    into :func:`canonical_request_sha256`, and reservation adds its bytes to
-    the conservative input bound so an excluded carrier can never push a
-    request across a pricing threshold unreserved.
-
-    Args:
-        request: Canonical gateway request as decoded from the public wire.
-
-    Returns:
-        The envelope of excluded provider input, or ``None`` when the plain
-        serialization already covers everything.
-    """
-    replay: list[JsonObject] = []
-    for message_index, message in enumerate(request.messages):
-        authority: JsonObject = {"message_index": message_index}
-        if message.provider_item_id is not None:
-            authority["provider_item_id"] = message.provider_item_id
-            authority["provider_output_index"] = message.provider_output_index
-            authority["provider_status"] = message.provider_status
-            authority["provider_phase"] = message.provider_phase
-        if message.provider_native_item is not None:
-            authority["provider_native_item"] = message.provider_native_item
-        if message.provider_reasoning:
-            blocks: list[JsonObject] = []
-            for block in message.provider_reasoning:
-                serialized = block.model_dump(mode="json")
-                if isinstance(block, EncryptedReasoningBlock):
-                    serialized["output_index"] = block.output_index
-                    serialized["status"] = block.status
-                blocks.append(serialized)
-            authority["provider_reasoning"] = blocks
-        retained_calls: list[JsonObject] = []
-        for tool_call_index, call in enumerate(message.tool_calls):
-            if (
-                call.raw_arguments is None
-                and call.provider_item_id is None
-                and call.provider_output_index is None
-                and call.provider_status is None
-            ):
-                continue
-            retained_calls.append(
-                {
-                    "tool_call_index": tool_call_index,
-                    "call_id": call.call_id,
-                    "name": call.name,
-                    "raw_arguments": call.raw_arguments,
-                    "provider_item_id": call.provider_item_id,
-                    "provider_output_index": call.provider_output_index,
-                    "provider_status": call.provider_status,
-                }
-            )
-        if retained_calls:
-            authority["tool_calls"] = retained_calls
-        if message.tool_is_error:
-            authority["tool_is_error"] = True
-        if len(authority) > 1:
-            replay.append(authority)
-    retained_tools: list[JsonObject] = []
-    for tool_index, tool in enumerate(request.tools):
-        if not tool.has_anthropic_tool_carriers():
-            continue
-        retained_tool: JsonObject = {"tool_index": tool_index, "name": tool.name}
-        if tool.eager_input_streaming is not None:
-            retained_tool["eager_input_streaming"] = tool.eager_input_streaming
-        if tool.defer_loading is not None:
-            retained_tool["defer_loading"] = tool.defer_loading
-        if tool.allowed_callers is not None:
-            retained_tool["allowed_callers"] = list(tool.allowed_callers)
-        if tool.input_examples is not None:
-            retained_tool["input_examples"] = list(tool.input_examples)
-        retained_tools.append(retained_tool)
-    if (
-        not replay
-        and not retained_tools
-        and request.provider_thinking_config is None
-        and request.reasoning_context is None
-        and request.context_management is None
-        and request.provider_output_config is None
-        and request.diagnostics is None
-        and request.speed is None
-        and request.inference_geo is None
-        and not request.provider_beta_tokens
-    ):
-        return None
-    envelope: JsonObject = {
-        "provider_replay": replay,
-        "provider_thinking_config": request.provider_thinking_config,
-        "reasoning_context": request.reasoning_context,
-        "context_management": request.context_management,
-        "provider_output_config": request.provider_output_config,
-    }
-    # The newer Messages carriers join the envelope only when present, so
-    # every request decoded before they existed keeps its exact digest.
-    if request.diagnostics is not None:
-        envelope["diagnostics"] = request.diagnostics
-    if request.speed is not None:
-        envelope["speed"] = request.speed
-    if request.inference_geo is not None:
-        envelope["inference_geo"] = request.inference_geo
-    if retained_tools:
-        envelope["tools"] = retained_tools
-    if request.provider_beta_tokens:
-        envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
-    return envelope
-
-
-def canonical_request_sha256(request: GatewayRequest) -> Sha256:
-    """Digest one canonical request including excluded provider replay authority.
-
-    A caller operation key reused with different replayed reasoning must be
-    a rejected conflict, never a silent replay of the earlier response. A
-    request with no carrier digests exactly as its plain serialization, so
-    every request decoded before the carriers existed keeps its identity.
-
-    Args:
-        request: Canonical gateway request as decoded from the public wire.
-
-    Returns:
-        The stable canonical request digest.
-    """
-    envelope = provider_replay_authority(request)
-    if envelope is None:
-        return sha256_json(request)
-    return sha256_json({"request_sha256": sha256_json(request), **envelope})
 
 
 class GatewayUsage(ContractModel):

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -233,7 +233,7 @@ def test_provider_reasoning_carrier_is_ordered_assistant_only_and_digest_free() 
     # Plain digests stay byte-identical (immutable artifacts, pre-carrier
     # requests), but replay identity distinguishes reasoning content so a
     # reused caller operation key with different reasoning conflicts.
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     assert canonical_request_sha256(bare) == sha256_json(bare)
     assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
@@ -313,7 +313,7 @@ def test_reasoning_carrier_request_fields_are_surface_scoped() -> None:
 
 def test_provider_replay_identity_hashes_exact_tool_and_message_state() -> None:
     """Excluded wire identity and raw argument bytes still bind idempotent replay."""
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(*, item_id: str, raw_arguments: str, output_index: int = 2) -> GatewayRequest:
         return GatewayRequest(
@@ -355,7 +355,7 @@ def test_provider_replay_identity_hashes_exact_tool_and_message_state() -> None:
 
 def test_provider_replay_identity_hashes_status_phase_and_idless_call_order() -> None:
     """Excluded OpenAI item fields remain authenticated canonical authority."""
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(
         *,
@@ -460,7 +460,7 @@ def test_reasoning_context_is_digest_excluded_but_joins_replay_identity() -> Non
     context is a conflict, never a silent replay.
     """
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.RESPONSES, messages=messages)
@@ -491,7 +491,7 @@ def test_reasoning_context_is_digest_excluded_but_joins_replay_identity() -> Non
 def test_context_management_is_digest_excluded_but_joins_replay_identity() -> None:
     """Config-free requests digest byte-identically to pre-field traffic."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
@@ -516,7 +516,8 @@ def test_context_management_is_digest_excluded_but_joins_replay_identity() -> No
 def test_anthropic_tool_annotations_are_digest_free_but_bind_replay_identity() -> None:
     """Tool carriers never perturb plain digests; present ones bind replay."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import GatewayToolDefinition, canonical_request_sha256
+    from exp.runtime.gateway.contracts import GatewayToolDefinition
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(tool: GatewayToolDefinition) -> GatewayRequest:
         return GatewayRequest(
@@ -554,7 +555,7 @@ def test_anthropic_tool_annotations_are_digest_free_but_bind_replay_identity() -
 def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
     """The top-level cache marker stays identity-inert; the region binds replay."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
@@ -599,5 +600,94 @@ def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
                     parameters={"type": "object"},
                     eager_input_streaming=True,
                 ),
+            ),
+        )
+
+
+def test_server_tools_and_history_blocks_are_digest_free_but_bind_replay() -> None:
+    """Server-tool carriers never perturb plain digests; present ones bind replay."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.contracts import GatewayServerTool
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    messages = (GatewayMessage(role="user", content="hi"),)
+    bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
+    search_tool = GatewayServerTool(
+        position=0, definition={"type": "web_search_20250305", "name": "web_search"}
+    )
+    with_tool = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        provider_server_tools=(search_tool,),
+    )
+    assert with_tool.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(with_tool) == sha256_json(bare)
+    assert canonical_request_sha256(bare) == sha256_json(bare)
+    assert canonical_request_sha256(with_tool) != canonical_request_sha256(bare)
+
+    echoed = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            GatewayMessage(
+                role="assistant",
+                provider_server_tool_block={
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_1",
+                    "name": "web_search",
+                    "input": {"query": "utc"},
+                },
+            ),
+        ),
+    )
+    assert canonical_request_sha256(echoed) != sha256_json(echoed)
+
+    # Surface scoping and coherence.
+    with pytest.raises(ValidationError, match="server tools are valid only"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=messages,
+            provider_server_tools=(search_tool,),
+        )
+    with pytest.raises(ValidationError, match="valid only for assistant messages"):
+        GatewayMessage(
+            role="user",
+            provider_server_tool_block={"type": "server_tool_use"},
+        )
+    with pytest.raises(ValidationError, match="carries the whole message"):
+        GatewayMessage(
+            role="assistant",
+            content="and text",
+            provider_server_tool_block={"type": "server_tool_use"},
+        )
+    # A server tool name joins the shared name space: collisions reject and
+    # a named tool_choice may select it.
+    from exp.runtime.gateway.contracts import GatewayToolDefinition
+
+    with pytest.raises(ValidationError, match="tool names must not repeat"):
+        GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=messages,
+            tools=(GatewayToolDefinition(name="web_search", parameters={"type": "object"}),),
+            provider_server_tools=(
+                GatewayServerTool(
+                    position=0,
+                    definition={"type": "web_search_20250305", "name": "web_search"},
+                ),
+            ),
+        )
+    chosen = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        provider_server_tools=(search_tool,),
+        tool_choice=GatewayNamedToolChoice(name="web_search"),
+    )
+    assert chosen.provider_server_tools[0].name == "web_search"
+    with pytest.raises(ValidationError, match="unique caller tools indexes"):
+        GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=messages,
+            provider_server_tools=(
+                GatewayServerTool(position=3, definition={"type": "web_search_20250305"}),
             ),
         )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -160,10 +160,37 @@ fn finish_open_tools(tools: &mut BTreeMap<u32, ToolAccumulator>) -> Result<Vec<E
     Ok(events)
 }
 
+/// Anthropic server-tool content-block types carried verbatim through the
+/// gateway. A closed set on purpose: a genuinely unknown block kind keeps
+/// today's skip behavior instead of silently widening the pass-through
+/// contract. `server_tool_use` folds streamed `input_json_delta` fragments
+/// into its final `input`; the result kinds arrive whole in their start
+/// frame (verified on a live web_search capture, 2026-08-31).
+pub const ANTHROPIC_SERVER_TOOL_BLOCK_TYPES: &[&str] = &[
+    "server_tool_use",
+    "web_search_tool_result",
+    "web_fetch_tool_result",
+    "code_execution_tool_result",
+    "bash_code_execution_tool_result",
+    "text_editor_code_execution_tool_result",
+    "tool_search_tool_result",
+];
+
+/// One in-flight opaque Anthropic server-tool block.
+pub(crate) struct OpaqueBlockAccumulator {
+    /// The verbatim `content_block` object from the start frame.
+    pub(crate) start_block: Value,
+    /// Concatenated `input_json_delta` fragments, empty for result blocks.
+    pub(crate) raw_input: String,
+}
+
 /// Incremental normalizer of one upstream SSE stream into gateway events.
 pub struct Normalizer {
     dialect: Dialect,
     tools: BTreeMap<u32, ToolAccumulator>,
+    /// Anthropic-only: opaque server-tool blocks accumulating until their
+    /// `content_block_stop`.
+    opaque_blocks: BTreeMap<u32, OpaqueBlockAccumulator>,
     refusal_seen: bool,
     terminal: bool,
     accumulated_tool_bytes: usize,
@@ -200,6 +227,7 @@ impl Normalizer {
         Self {
             dialect,
             tools: BTreeMap::new(),
+            opaque_blocks: BTreeMap::new(),
             refusal_seen: false,
             terminal: false,
             accumulated_tool_bytes: 0,
@@ -257,6 +285,7 @@ impl Normalizer {
             && self
                 .tools
                 .len()
+                .saturating_add(self.opaque_blocks.len())
                 .saturating_add(self.reasoning_summaries.len())
                 .saturating_add(self.openai_output_items.len())
                 >= MAXIMUM_RETAINED_PROVIDER_ENTRIES
@@ -271,7 +300,9 @@ impl Normalizer {
 
     /// Reserve a new tool-call accumulator when this index is not retained.
     fn reserve_tool_entry(&self, index: u32) -> Result<(), Failure> {
-        self.reserve_provider_entry(self.tools.contains_key(&index))
+        self.reserve_provider_entry(
+            self.tools.contains_key(&index) || self.opaque_blocks.contains_key(&index),
+        )
     }
 
     /// Reserve a new reasoning-summary accumulator when this key is not retained.

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -7,7 +7,8 @@ use serde_json::Value;
 
 use super::{
     complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
-    provider_stream_failed, refusal_failure, Normalizer,
+    provider_stream_failed, refusal_failure, Normalizer, OpaqueBlockAccumulator,
+    ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
 };
 use crate::errors::Failure;
 use crate::events::{
@@ -106,6 +107,25 @@ impl Normalizer {
                         let data = optional_text(block, "data", "Anthropic redacted thinking")?;
                         events.push(Event::RedactedThinking { index, data });
                     }
+                    Some(kind) if ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.contains(&kind) => {
+                        if self.tools.contains_key(&index)
+                            || self.opaque_blocks.contains_key(&index)
+                        {
+                            return Err(malformed("Anthropic stream repeated a block start"));
+                        }
+                        self.reserve_tool_entry(index)?;
+                        let start_block = Value::Object(block.clone());
+                        // The whole block is retained until its stop frame,
+                        // so its bytes join the retained-output budget.
+                        self.reserve_tool_bytes(start_block.to_string().len())?;
+                        self.opaque_blocks.insert(
+                            index,
+                            OpaqueBlockAccumulator {
+                                start_block,
+                                raw_input: String::new(),
+                            },
+                        );
+                    }
                     // Unknown block kinds with no gateway-visible output are
                     // skipped rather than rejected.
                     _ => {}
@@ -129,14 +149,20 @@ impl Normalizer {
                         let fragment =
                             optional_text(delta, "partial_json", "Anthropic argument delta")?;
                         self.reserve_tool_bytes(fragment.len())?;
-                        let tool = self.tools.get_mut(&index).ok_or_else(|| {
-                            malformed("provider emitted arguments before a tool start")
-                        })?;
-                        tool.raw_arguments.push_str(&fragment);
-                        events.push(Event::ToolArgumentsDelta {
-                            index,
-                            delta: fragment,
-                        });
+                        if let Some(opaque) = self.opaque_blocks.get_mut(&index) {
+                            // Server-tool input folds into the verbatim
+                            // block at its stop frame; no event yet.
+                            opaque.raw_input.push_str(&fragment);
+                        } else {
+                            let tool = self.tools.get_mut(&index).ok_or_else(|| {
+                                malformed("provider emitted arguments before a tool start")
+                            })?;
+                            tool.raw_arguments.push_str(&fragment);
+                            events.push(Event::ToolArgumentsDelta {
+                                index,
+                                delta: fragment,
+                            });
+                        }
                     }
                     Some("refusal_delta") => {
                         self.refusal_seen = true;
@@ -169,6 +195,18 @@ impl Normalizer {
                     if !tool.completed {
                         complete_streamed_tool(index, tool, &mut events)?;
                     }
+                } else if let Some(opaque) = self.opaque_blocks.remove(&index) {
+                    let mut block = opaque.start_block;
+                    if !opaque.raw_input.is_empty() {
+                        // The streamed fragments are the block's final
+                        // input; the start frame carried an empty seed.
+                        let input: Value =
+                            serde_json::from_str(&opaque.raw_input).map_err(|_| {
+                                malformed("Anthropic server-tool input is not valid JSON")
+                            })?;
+                        block["input"] = input;
+                    }
+                    events.push(Event::ServerToolBlock { index, block });
                 }
             }
             "message_delta" => {
@@ -186,6 +224,32 @@ impl Normalizer {
                 self.output_tokens =
                     count_or_zero(usage, "output_tokens", "Anthropic output_tokens")
                         .map_err(|message| malformed(&message))?;
+                // The delta usage is cumulative and can exceed message_start:
+                // server tools inject searched or fetched content into the
+                // billed input mid-turn (a live web_search turn grew from
+                // 2230 to 10538 input tokens), so present counts here
+                // supersede the start frame; absent counts keep it.
+                if usage.contains_key("input_tokens") {
+                    self.input_tokens =
+                        count_or_zero(usage, "input_tokens", "Anthropic input_tokens")
+                            .map_err(|message| malformed(&message))?;
+                }
+                if usage.contains_key("cache_read_input_tokens") {
+                    self.cache_read = count_or_zero(
+                        usage,
+                        "cache_read_input_tokens",
+                        "Anthropic cache_read_input_tokens",
+                    )
+                    .map_err(|message| malformed(&message))?;
+                }
+                if usage.contains_key("cache_creation_input_tokens") {
+                    self.cache_write = count_or_zero(
+                        usage,
+                        "cache_creation_input_tokens",
+                        "Anthropic cache_creation_input_tokens",
+                    )
+                    .map_err(|message| malformed(&message))?;
+                }
                 if self.stop_reason.as_deref() == Some("refusal") && !self.refusal_seen {
                     self.refusal_seen = true;
                     events.push(Event::RefusalDelta(String::new()));
@@ -193,6 +257,25 @@ impl Normalizer {
             }
             "message_stop" => {
                 events.extend(finish_open_tools(&mut self.tools)?);
+                // A provider that ends the message without closing a server-
+                // tool block still delivers it whole, mirroring the lenient
+                // open-tool finish above.
+                let open_blocks: Vec<u32> = self.opaque_blocks.keys().copied().collect();
+                for index in open_blocks {
+                    let opaque = self
+                        .opaque_blocks
+                        .remove(&index)
+                        .expect("collected key is present");
+                    let mut block = opaque.start_block;
+                    if !opaque.raw_input.is_empty() {
+                        let input: Value =
+                            serde_json::from_str(&opaque.raw_input).map_err(|_| {
+                                malformed("Anthropic server-tool input is not valid JSON")
+                            })?;
+                        block["input"] = input;
+                    }
+                    events.push(Event::ServerToolBlock { index, block });
+                }
                 // Individually persistable legs whose folded total is not
                 // are a provider contract violation, exactly like the
                 // Bedrock cache-leg fold.
@@ -217,6 +300,10 @@ impl Normalizer {
                     events.push(Event::Failed(refusal_failure()));
                 } else if self.stop_reason.as_deref() == Some("max_tokens") {
                     events.push(Event::Incomplete);
+                } else if self.stop_reason.as_deref() == Some("pause_turn") {
+                    // A paused server-tool turn: the caller resends the
+                    // conversation as-is to continue; billed like completion.
+                    events.push(Event::Paused);
                 } else {
                     events.push(Event::Completed);
                 }
@@ -288,5 +375,74 @@ mod tests {
             events.as_slice(),
             [Event::RedactedThinking { index: 1, data }] if data == "opaque=="
         ));
+    }
+
+    #[test]
+    fn server_tool_blocks_carry_verbatim_and_pause_turn_is_terminal() {
+        // Mirrors the live web_search capture (2026-08-31): server_tool_use
+        // streams its input via input_json_delta, the result block arrives
+        // whole in its start frame, and pause_turn ends the attempt as a
+        // paused terminal instead of a fake end_turn.
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let start = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {},
+            },
+        }));
+        assert!(normalizer.feed(&start).expect("start").is_empty());
+        let delta = frame(serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": "{\"query\": \"utc\"}"},
+        }));
+        assert!(normalizer.feed(&delta).expect("delta").is_empty());
+        let stop = frame(serde_json::json!({"type": "content_block_stop", "index": 0}));
+        let events = normalizer.feed(&stop).expect("stop");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ServerToolBlock { index: 0, block }]
+                if block["input"]["query"] == serde_json::json!("utc")
+                    && block["id"] == serde_json::json!("srvtoolu_1")
+        ));
+
+        let result_start = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "caller": {"type": "direct"},
+                "content": [{"type": "web_search_result", "url": "https://utc.test"}],
+            },
+        }));
+        assert!(normalizer
+            .feed(&result_start)
+            .expect("result start")
+            .is_empty());
+        let result_stop = frame(serde_json::json!({"type": "content_block_stop", "index": 1}));
+        let events = normalizer.feed(&result_stop).expect("result stop");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ServerToolBlock { index: 1, block }]
+                if block["caller"]["type"] == serde_json::json!("direct")
+        ));
+
+        let message_delta = frame(serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "pause_turn", "stop_sequence": null},
+            "usage": {"output_tokens": 9},
+        }));
+        assert!(normalizer
+            .feed(&message_delta)
+            .expect("message delta")
+            .is_empty());
+        let message_stop = frame(serde_json::json!({"type": "message_stop"}));
+        let events = normalizer.feed(&message_stop).expect("message stop");
+        assert!(matches!(events.last(), Some(Event::Paused)));
     }
 }

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -259,6 +259,10 @@ impl ChatSseEncoder {
             | Event::ThinkingSignature { .. }
             | Event::RedactedThinking { .. }
             | Event::EncryptedReasoning { .. } => Ok(Vec::new()),
+            // Server tools enter only through a Messages request onto an
+            // Anthropic-only route, so a Chat stream can never legally carry
+            // one; an arriving block is dropped like the reasoning carriers.
+            Event::ServerToolBlock { .. } => Ok(Vec::new()),
             Event::ToolCallStarted {
                 index,
                 call_id,
@@ -330,7 +334,10 @@ impl ChatSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete => {
+            // A paused server-tool turn cannot legally reach the Chat
+            // surface (server tools enter only through Messages); the
+            // defensive mapping is ordinary completion.
+            Event::Completed | Event::Incomplete | Event::Paused => {
                 self.terminal = true;
                 let finish_reason = if matches!(event, Event::Incomplete) {
                     "length"

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -50,9 +50,13 @@ fn invalid_provider_stream(message: &str) -> PublicError {
 }
 
 /// Map the terminal outcome to the Anthropic stop reason.
-fn stop_reason(incomplete: bool, saw_tool_use: bool) -> &'static str {
+fn stop_reason(incomplete: bool, paused: bool, saw_tool_use: bool) -> &'static str {
     if incomplete {
         "max_tokens"
+    } else if paused {
+        // The provider paused a long-running server-tool turn; the caller
+        // resends the conversation as-is to continue.
+        "pause_turn"
     } else if saw_tool_use {
         "tool_use"
     } else {
@@ -102,6 +106,9 @@ enum BlockKind {
     Tool(u32),
     Thinking(u32),
     Redacted,
+    /// One complete opaque Anthropic server-tool block (server_tool_use or
+    /// a *_tool_result), re-emitted verbatim in its start frame.
+    Server,
 }
 
 /// One scheduled content block, buffered until it can stream in order.
@@ -119,6 +126,8 @@ struct PendingBlock {
     pending_signature: String,
     /// Redacted only: the whole opaque payload travels in the start frame.
     redacted_data: Option<String>,
+    /// Server only: the whole verbatim block travels in the start frame.
+    server_block: Option<Value>,
     anthropic_index: Option<u32>,
 }
 
@@ -129,6 +138,7 @@ impl PendingBlock {
             pending: String::new(),
             pending_signature: String::new(),
             redacted_data: None,
+            server_block: None,
             anthropic_index: None,
         }
     }
@@ -251,6 +261,7 @@ impl MessagesSseEncoder {
                 self.thinking_signature(*index, signature)
             }
             Event::RedactedThinking { data, .. } => self.redacted_thinking(data),
+            Event::ServerToolBlock { block, .. } => self.server_tool_block(block),
             Event::ToolCallStarted {
                 index,
                 call_id,
@@ -293,7 +304,7 @@ impl MessagesSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete => {
+            Event::Completed | Event::Incomplete | Event::Paused => {
                 self.terminal = true;
                 if self.refusal_seen {
                     return Ok(vec![error_frame(&refusal_failure())]);
@@ -307,6 +318,7 @@ impl MessagesSseEncoder {
                         "delta": {
                             "stop_reason": stop_reason(
                                 matches!(event, Event::Incomplete),
+                                matches!(event, Event::Paused),
                                 self.saw_tool_use,
                             ),
                             "stop_sequence": Value::Null,
@@ -366,6 +378,20 @@ impl MessagesSseEncoder {
             ));
         }
         self.blocks[position].pending_signature.push_str(signature);
+        Ok(self.advance())
+    }
+
+    /// Schedule one complete verbatim server-tool block at its arrival position.
+    fn server_tool_block(&mut self, block: &Value) -> Result<Vec<String>, PublicError> {
+        self.buffered_bytes = self.buffered_bytes.saturating_add(block.to_string().len());
+        if self.buffered_bytes > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(invalid_provider_stream(
+                "Messages stream buffered blocks exceeded the gateway response limit.",
+            ));
+        }
+        let mut pending = PendingBlock::new(BlockKind::Server);
+        pending.server_block = Some(block.clone());
+        self.blocks.push(pending);
         Ok(self.advance())
     }
 
@@ -475,7 +501,10 @@ impl MessagesSseEncoder {
                 let last = position == self.blocks.len() - 1;
                 let closable = self.draining
                     || match block.kind {
-                        BlockKind::Text | BlockKind::Thinking(_) | BlockKind::Redacted => !last,
+                        BlockKind::Text
+                        | BlockKind::Thinking(_)
+                        | BlockKind::Redacted
+                        | BlockKind::Server => !last,
                         BlockKind::Tool(tool_index) => self.tool_completed.contains(&tool_index),
                     };
                 if !closable {
@@ -511,6 +540,13 @@ impl MessagesSseEncoder {
                     let data = block.redacted_data.take().unwrap_or_default();
                     self.buffered_bytes = self.buffered_bytes.saturating_sub(data.len());
                     json!({"type": "redacted_thinking", "data": data})
+                }
+                BlockKind::Server => {
+                    let verbatim = block.server_block.take().unwrap_or(Value::Null);
+                    self.buffered_bytes = self
+                        .buffered_bytes
+                        .saturating_sub(verbatim.to_string().len());
+                    verbatim
                 }
                 BlockKind::Tool(tool_index) => {
                     let identity = self
@@ -569,9 +605,9 @@ impl MessagesSseEncoder {
         let delta = match block.kind {
             BlockKind::Text => json!({"type": "text_delta", "text": block.pending}),
             BlockKind::Thinking(_) => json!({"type": "thinking_delta", "thinking": block.pending}),
-            // Redacted blocks carry their payload in the start frame and
-            // never buffer deltas.
-            BlockKind::Redacted => return,
+            // Redacted and server blocks carry their whole payload in the
+            // start frame and never buffer deltas.
+            BlockKind::Redacted | BlockKind::Server => return,
             BlockKind::Tool(_) => {
                 json!({"type": "input_json_delta", "partial_json": block.pending})
             }
@@ -645,6 +681,7 @@ pub fn completed_messages_body(
         });
     }
     let incomplete = matches!(terminal, Event::Incomplete);
+    let paused = matches!(terminal, Event::Paused);
     if events.iter().any(|event| {
         matches!(
             event,
@@ -718,6 +755,9 @@ pub fn completed_messages_body(
             Event::RedactedThinking { data, .. } => {
                 slots.push(Some(json!({"type": "redacted_thinking", "data": data})));
             }
+            Event::ServerToolBlock { block, .. } => {
+                slots.push(Some(block.clone()));
+            }
             Event::ToolCallStarted { index, .. } => {
                 tool_positions.insert(*index, slots.len());
                 slots.push(None);
@@ -749,7 +789,7 @@ pub fn completed_messages_body(
         "role": "assistant",
         "model": model,
         "content": content,
-        "stop_reason": stop_reason(incomplete, saw_tool_use),
+        "stop_reason": stop_reason(incomplete, paused, saw_tool_use),
         "stop_sequence": Value::Null,
         "usage": messages_usage(usage.as_ref()),
     });

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -404,3 +404,92 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
     assert_eq!(aggregated.body["content"][1]["type"], json!("tool_use"));
     assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
 }
+
+#[test]
+fn server_tool_blocks_stream_whole_and_paused_turns_keep_pause_turn() {
+    // The live web_search shape (captured 2026-08-31): a server_tool_use
+    // block, its whole result block, then cited answer text; a paused turn
+    // must reach the caller as the provider's own pause_turn stop reason.
+    let search = json!({
+        "type": "server_tool_use",
+        "id": "srvtoolu_1",
+        "name": "web_search",
+        "input": {"query": "current UTC date"},
+    });
+    let result = json!({
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "caller": {"type": "direct"},
+        "content": [{"type": "web_search_result", "title": "UTC", "url": "https://utc.test"}],
+    });
+    let mut encoder = MessagesSseEncoder::new("req-1", "sonnet");
+    let mut frames = encoder.start().expect("start");
+    frames.extend(
+        encoder
+            .feed(&Event::ServerToolBlock {
+                index: 0,
+                block: search.clone(),
+            })
+            .expect("search block"),
+    );
+    frames.extend(
+        encoder
+            .feed(&Event::ServerToolBlock {
+                index: 1,
+                block: result.clone(),
+            })
+            .expect("result block"),
+    );
+    frames.extend(
+        encoder
+            .feed(&Event::TextDelta("Today is ...".to_string()))
+            .expect("text"),
+    );
+    frames.extend(encoder.feed(&Event::Paused).expect("paused terminal"));
+    let joined = frames.join("");
+    let search_start = format!(
+        "event: content_block_start\ndata: {}\n\n",
+        compact_json(&json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": search,
+        }))
+    );
+    let result_start = format!(
+        "event: content_block_start\ndata: {}\n\n",
+        compact_json(&json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": result,
+        }))
+    );
+    assert!(joined.contains(&search_start));
+    assert!(joined.contains(&result_start));
+    assert!(joined.contains("\"stop_reason\":\"pause_turn\""));
+    // A pure server-tool turn is not a client tool_use stop.
+    assert!(!joined.contains("\"stop_reason\":\"tool_use\""));
+
+    let aggregated = completed_messages_body(
+        "req-1",
+        "sonnet",
+        &[
+            Event::ServerToolBlock {
+                index: 0,
+                block: search.clone(),
+            },
+            Event::ServerToolBlock {
+                index: 1,
+                block: result.clone(),
+            },
+            Event::TextDelta("Today is ...".to_string()),
+            Event::Paused,
+        ],
+    )
+    .expect("aggregate");
+    assert!(aggregated.failure.is_none());
+    assert_eq!(aggregated.body["stop_reason"], json!("pause_turn"));
+    assert_eq!(
+        aggregated.body["content"],
+        json!([search, result, {"type": "text", "text": "Today is ..."}])
+    );
+}

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -283,6 +283,10 @@ impl ResponsesSseEncoder {
                 self.reasoning_summary_delta(*index, 0, &item_id, delta)
             }
             Event::ThinkingSignature { .. } | Event::RedactedThinking { .. } => Ok(Vec::new()),
+            // Server tools enter only through a Messages request onto an
+            // Anthropic-only route, so a Responses stream can never legally
+            // carry one; an arriving block is dropped like the signatures.
+            Event::ServerToolBlock { .. } => Ok(Vec::new()),
             Event::ReasoningContentDelta {
                 route_sha256,
                 delta,
@@ -306,6 +310,9 @@ impl ResponsesSseEncoder {
                 Ok(Vec::new())
             }
             Event::Completed => self.finish("completed", None),
+            // A paused server-tool turn cannot legally reach the Responses
+            // surface; the defensive mapping is ordinary completion.
+            Event::Paused => self.finish("completed", None),
             Event::Incomplete => self.finish("incomplete", None),
             Event::Failed(failure) => self.finish("failed", Some(failure)),
         }

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -174,9 +174,24 @@ pub enum Event {
         index: u32,
         call: CompletedToolCall,
     },
+    /// One complete Anthropic server-tool content block carried verbatim.
+    ///
+    /// `server_tool_use` blocks fold their streamed `input_json_delta`
+    /// fragments into the final `input`; result blocks arrive whole in their
+    /// start frame. Server tools are admitted only onto Anthropic-only
+    /// Messages routes, so exactly the Messages encoder re-emits the block;
+    /// other surfaces can never legally receive it.
+    ServerToolBlock {
+        index: u32,
+        block: Value,
+    },
     Usage(Usage),
     Completed,
     Incomplete,
+    /// The provider paused a long-running server-tool turn (`pause_turn`):
+    /// the caller resends the conversation as-is to continue. Terminal for
+    /// this attempt and billed like a completed turn.
+    Paused,
     Failed(Failure),
 }
 
@@ -184,7 +199,7 @@ impl Event {
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            Event::Completed | Event::Incomplete | Event::Failed(_)
+            Event::Completed | Event::Incomplete | Event::Paused | Event::Failed(_)
         )
     }
 
@@ -210,6 +225,9 @@ impl Event {
             | Event::ReasoningContentDelta { delta, .. }
             | Event::ToolArgumentsDelta { delta, .. } => !delta.is_empty(),
             Event::ToolCallStarted { .. } => true,
+            // A server-tool block is visible model output and may lead a
+            // search-only turn, so it stamps TTFT like a tool-call start.
+            Event::ServerToolBlock { .. } => true,
             _ => false,
         }
     }
@@ -365,8 +383,14 @@ pub fn simplified_event(event: &Event) -> Value {
             "cached_input_tokens": usage.cached_input_tokens,
             "reasoning_tokens": usage.reasoning_tokens,
         }),
+        Event::ServerToolBlock { index, block } => serde_json::json!({
+            "kind": "server_tool_block",
+            "index": index,
+            "block": block,
+        }),
         Event::Completed => serde_json::json!({"kind": "completed"}),
         Event::Incomplete => serde_json::json!({"kind": "incomplete"}),
+        Event::Paused => serde_json::json!({"kind": "paused"}),
         Event::Failed(failure) => serde_json::json!({
             "kind": "failed",
             "failure_class": failure.failure_class.as_str(),

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -86,6 +86,9 @@ pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event>
             | Event::ThinkingSignature { .. }
             | Event::RedactedThinking { .. }
             | Event::EncryptedReasoning { .. } => {}
+            // Server-tool blocks carry searched or fetched content; rewritten
+            // output must not leak the redacted material through them.
+            Event::ServerToolBlock { .. } => {}
             Event::TextDelta(_) | Event::ProviderTextDelta { .. } => {
                 if inserted {
                     continue;
@@ -93,7 +96,9 @@ pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event>
                 rewritten.push(Event::TextDelta(replacement.to_string()));
                 inserted = true;
             }
-            Event::Completed | Event::Incomplete | Event::Failed(_) if !inserted => {
+            Event::Completed | Event::Incomplete | Event::Paused | Event::Failed(_)
+                if !inserted =>
+            {
                 rewritten.push(Event::TextDelta(replacement.to_string()));
                 inserted = true;
                 rewritten.push(event.clone());

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -486,8 +486,16 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                     .get("reasoning_tokens")
                     .and_then(serde_json::Value::as_u64),
             }),
+            "server_tool_block" => events::Event::ServerToolBlock {
+                index,
+                block: object
+                    .get("block")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+            },
             "completed" => events::Event::Completed,
             "incomplete" => events::Event::Incomplete,
+            "paused" => events::Event::Paused,
             "failed" => events::Event::Failed(errors::Failure::new(
                 errors::FailureClass::ProviderInternal,
                 if text.is_empty() {

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4314,3 +4314,51 @@ def test_effort_none_drops_with_disclosure_on_a_reasoning_less_route(
     assert payload["status_code"] == 400
     assert payload["param"] == "reasoning_effort"
     assert payload["code"] == "unsupported_parameter"
+
+
+def test_rust_messages_encoder_streams_server_tool_blocks_and_pause_turn() -> None:
+    """Server-tool blocks re-emit whole in their start frames, in order, and a
+    paused turn reaches the caller as the provider's own pause_turn stop."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    search = {
+        "type": "server_tool_use",
+        "id": "srvtoolu_1",
+        "name": "web_search",
+        "input": {"query": "utc"},
+    }
+    result = {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "caller": {"type": "direct"},
+        "content": [{"type": "web_search_result", "url": "https://utc.test"}],
+    }
+    events = json.dumps(
+        [
+            {"kind": "server_tool_block", "index": 0, "block": search},
+            {"kind": "server_tool_block", "index": 1, "block": result},
+            {"kind": "text_delta", "text": "Monday."},
+            {"kind": "usage", "input_tokens": 10538, "output_tokens": 93, "cached_input_tokens": 0},
+            {"kind": "paused"},
+        ]
+    )
+    frames = list(native.encode_messages_fixture("request-abc", "coding", events))
+    joined = "".join(frames)
+    starts = [
+        json.loads(frame.split("data: ", 1)[1])
+        for frame in frames
+        if frame.startswith("event: content_block_start")
+    ]
+    assert [start["content_block"].get("type") for start in starts] == [
+        "server_tool_use",
+        "web_search_tool_result",
+        "text",
+    ]
+    assert starts[0]["content_block"] == search
+    assert starts[1]["content_block"] == result
+    assert '"stop_reason":"pause_turn"' in joined
+    assert '"input_tokens":10538' in joined
+
+    body = json.loads(native.completed_messages_fixture("request-abc", "coding", events))
+    assert body["stop_reason"] == "pause_turn"
+    assert body["content"] == [search, result, {"type": "text", "text": "Monday."}]

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -1,0 +1,146 @@
+"""Replay identity over canonical gateway requests and their excluded carriers."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject, Sha256, sha256_json
+from exp.runtime.gateway.contracts import EncryptedReasoningBlock, GatewayRequest
+
+
+def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
+    """Collect the provider-significant input excluded from serialization.
+
+    The carriers (replayed reasoning, native items, verbatim provider
+    configurations) are excluded from model serialization so immutable
+    artifacts and pre-existing request digests stay byte-identical, but the
+    provider still reads them as input. Replay identity folds this envelope
+    into :func:`canonical_request_sha256`, and reservation adds its bytes to
+    the conservative input bound so an excluded carrier can never push a
+    request across a pricing threshold unreserved.
+
+    Args:
+        request: Canonical gateway request as decoded from the public wire.
+
+    Returns:
+        The envelope of excluded provider input, or ``None`` when the plain
+        serialization already covers everything.
+    """
+    replay: list[JsonObject] = []
+    for message_index, message in enumerate(request.messages):
+        authority: JsonObject = {"message_index": message_index}
+        if message.provider_item_id is not None:
+            authority["provider_item_id"] = message.provider_item_id
+            authority["provider_output_index"] = message.provider_output_index
+            authority["provider_status"] = message.provider_status
+            authority["provider_phase"] = message.provider_phase
+        if message.provider_native_item is not None:
+            authority["provider_native_item"] = message.provider_native_item
+        if message.provider_server_tool_block is not None:
+            authority["provider_server_tool_block"] = message.provider_server_tool_block
+        if message.provider_reasoning:
+            blocks: list[JsonObject] = []
+            for block in message.provider_reasoning:
+                serialized = block.model_dump(mode="json")
+                if isinstance(block, EncryptedReasoningBlock):
+                    serialized["output_index"] = block.output_index
+                    serialized["status"] = block.status
+                blocks.append(serialized)
+            authority["provider_reasoning"] = blocks
+        retained_calls: list[JsonObject] = []
+        for tool_call_index, call in enumerate(message.tool_calls):
+            if (
+                call.raw_arguments is None
+                and call.provider_item_id is None
+                and call.provider_output_index is None
+                and call.provider_status is None
+            ):
+                continue
+            retained_calls.append(
+                {
+                    "tool_call_index": tool_call_index,
+                    "call_id": call.call_id,
+                    "name": call.name,
+                    "raw_arguments": call.raw_arguments,
+                    "provider_item_id": call.provider_item_id,
+                    "provider_output_index": call.provider_output_index,
+                    "provider_status": call.provider_status,
+                }
+            )
+        if retained_calls:
+            authority["tool_calls"] = retained_calls
+        if message.tool_is_error:
+            authority["tool_is_error"] = True
+        if len(authority) > 1:
+            replay.append(authority)
+    retained_tools: list[JsonObject] = []
+    for tool_index, tool in enumerate(request.tools):
+        if not tool.has_anthropic_tool_carriers():
+            continue
+        retained_tool: JsonObject = {"tool_index": tool_index, "name": tool.name}
+        if tool.eager_input_streaming is not None:
+            retained_tool["eager_input_streaming"] = tool.eager_input_streaming
+        if tool.defer_loading is not None:
+            retained_tool["defer_loading"] = tool.defer_loading
+        if tool.allowed_callers is not None:
+            retained_tool["allowed_callers"] = list(tool.allowed_callers)
+        if tool.input_examples is not None:
+            retained_tool["input_examples"] = list(tool.input_examples)
+        retained_tools.append(retained_tool)
+    if (
+        not replay
+        and not retained_tools
+        and not request.provider_server_tools
+        and request.provider_thinking_config is None
+        and request.reasoning_context is None
+        and request.context_management is None
+        and request.provider_output_config is None
+        and request.diagnostics is None
+        and request.speed is None
+        and request.inference_geo is None
+        and not request.provider_beta_tokens
+    ):
+        return None
+    envelope: JsonObject = {
+        "provider_replay": replay,
+        "provider_thinking_config": request.provider_thinking_config,
+        "reasoning_context": request.reasoning_context,
+        "context_management": request.context_management,
+        "provider_output_config": request.provider_output_config,
+    }
+    # The newer Messages carriers join the envelope only when present, so
+    # every request decoded before they existed keeps its exact digest.
+    if request.diagnostics is not None:
+        envelope["diagnostics"] = request.diagnostics
+    if request.speed is not None:
+        envelope["speed"] = request.speed
+    if request.inference_geo is not None:
+        envelope["inference_geo"] = request.inference_geo
+    if retained_tools:
+        envelope["tools"] = retained_tools
+    if request.provider_server_tools:
+        envelope["server_tools"] = [
+            {"position": tool.position, "definition": tool.definition}
+            for tool in request.provider_server_tools
+        ]
+    if request.provider_beta_tokens:
+        envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
+    return envelope
+
+
+def canonical_request_sha256(request: GatewayRequest) -> Sha256:
+    """Digest one canonical request including excluded provider replay authority.
+
+    A caller operation key reused with different replayed reasoning must be
+    a rejected conflict, never a silent replay of the earlier response. A
+    request with no carrier digests exactly as its plain serialization, so
+    every request decoded before the carriers existed keeps its identity.
+
+    Args:
+        request: Canonical gateway request as decoded from the public wire.
+
+    Returns:
+        The stable canonical request digest.
+    """
+    envelope = provider_replay_authority(request)
+    if envelope is None:
+        return sha256_json(request)
+    return sha256_json({"request_sha256": sha256_json(request), **envelope})

--- a/exp/runtime/gateway/replay_identity_test.py
+++ b/exp/runtime/gateway/replay_identity_test.py
@@ -1,0 +1,1 @@
+"""Replay-identity behavior is covered in contracts_test.py beside the models it digests."""

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -28,9 +28,9 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayTarget,
     ProjectTarget,
-    canonical_request_sha256,
 )
 from exp.runtime.gateway.interfaces import GatewayClock
+from exp.runtime.gateway.replay_identity import canonical_request_sha256
 from exp.runtime.gateway.sqlite import key_delivery
 from exp.runtime.gateway.sqlite.alias_activation import (
     activate_alias_revision_in_transaction,

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -788,3 +788,153 @@ def test_native_responses_preserves_multi_message_status_phase_and_idless_call()
     assert not any(
         payload["type"].startswith("response.function_call_arguments") for payload in payloads
     )
+
+
+# Captured from a live api.anthropic.com web_search stream (2026-08-31,
+# claude-sonnet-4-6, ids and encrypted payloads neutralized, result list
+# truncated to two entries): the real wire opens server_tool_use with an
+# empty input then streams input_json_delta fragments (the first one empty),
+# delivers the whole web_search_tool_result in its start frame (with a
+# `caller` object), opens the answer text block with a `citations` key and a
+# leading citations_delta, and reports the search-inflated cumulative input
+# total (2230 -> 10538) only in message_delta.usage.
+ANTHROPIC_LIVE_WEB_SEARCH_FRAMES: tuple[bytes, ...] = (
+    b'event: message_start\ndata: {"type": "message_start", "message": {"model": "claude-s'
+    b'onnet-4-6", "id": "msg_fixture", "type": "message", "role": "assistant", "content": '
+    b'[], "stop_reason": null, "stop_sequence": null, "stop_details": null, "usage": {"inp'
+    b'ut_tokens": 2230, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "c'
+    b'ache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0}, "o'
+    b'utput_tokens": 22, "service_tier": "standard", "inference_geo": "global"}}}\n\n',
+    b'event: content_block_start\ndata: {"type": "content_block_start", "index": 0, "conte'
+    b'nt_block": {"type": "server_tool_use", "id": "srvtoolu_fixture", "name": "web_search'
+    b'", "input": {}}}\n\n',
+    b'event: ping\ndata: {"type": "ping"}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": ""}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": "{\\"query\\": "}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": "\\"current"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": " UTC"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": " da"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0, "delta'
+    b'": {"type": "input_json_delta", "partial_json": "te today\\"}"}}\n\n',
+    b'event: content_block_stop\ndata: {"type": "content_block_stop", "index": 0}\n\n',
+    b'event: content_block_start\ndata: {"type": "content_block_start", "index": 1, "conte'
+    b'nt_block": {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_fixture", "co'
+    b'ntent": [{"type": "web_search_result", "title": "UTC Time Now", "url": "https://www.'
+    b'utctime.net/", "encrypted_content": "ENCRYPTED_0==", "page_age": null}, {"type": "we'
+    b'b_search_result", "title": "UTC%2B14:00", "url": "https://en.wikipedia.org/wiki/UTC%'
+    b'2B14:00", "encrypted_content": "ENCRYPTED_1==", "page_age": null}], "caller": {"type'
+    b'": "direct"}}}\n\n',
+    b'event: content_block_stop\ndata: {"type": "content_block_stop", "index": 1}\n\n',
+    b'event: content_block_start\ndata: {"type": "content_block_start", "index": 2, "conte'
+    b'nt_block": {"citations": [], "type": "text", "text": ""}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "citations_delta", "citation": {"type": "web_search_result_location", "c'
+    b'ited_text": "UTC current date is 31st Monday August 2026. ", "url": "https://www.utc'
+    b'time.net/", "title": "UTC Time Now", "encrypted_index": "ENCIDX=="}}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": "The current"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": " UTC date"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": " is"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": " **"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": "Monday"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": ", August 31"}}\n\n',
+    b'event: content_block_delta\ndata: {"type": "content_block_delta", "index": 2, "delta'
+    b'": {"type": "text_delta", "text": ", 2026**."}}\n\n',
+    b'event: content_block_stop\ndata: {"type": "content_block_stop", "index": 2}\n\n',
+    b'event: message_delta\ndata: {"type": "message_delta", "delta": {"stop_reason": "end_'
+    b'turn", "stop_sequence": null, "stop_details": null}, "usage": {"input_tokens": 10538'
+    b', "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "output_tokens": 9'
+    b'3, "server_tool_use": {"web_search_requests": 1, "web_fetch_requests": 0}}}\n\n',
+    b'event: message_stop\ndata: {"type": "message_stop"}\n\n',
+)
+
+ANTHROPIC_LIVE_WEB_SEARCH_EVENTS: tuple[JsonObject, ...] = (
+    {
+        "kind": "server_tool_block",
+        "index": 0,
+        "block": {
+            "type": "server_tool_use",
+            "id": "srvtoolu_fixture",
+            "name": "web_search",
+            "input": {"query": "current UTC date today"},
+        },
+    },
+    {
+        "kind": "server_tool_block",
+        "index": 1,
+        "block": {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_fixture",
+            "content": [
+                {
+                    "type": "web_search_result",
+                    "title": "UTC Time Now",
+                    "url": "https://www.utctime.net/",
+                    "encrypted_content": "ENCRYPTED_0==",
+                    "page_age": None,
+                },
+                {
+                    "type": "web_search_result",
+                    "title": "UTC%2B14:00",
+                    "url": "https://en.wikipedia.org/wiki/UTC%2B14:00",
+                    "encrypted_content": "ENCRYPTED_1==",
+                    "page_age": None,
+                },
+            ],
+            "caller": {"type": "direct"},
+        },
+    },
+    {"kind": "text_delta", "text": "The current"},
+    {"kind": "text_delta", "text": " UTC date"},
+    {"kind": "text_delta", "text": " is"},
+    {"kind": "text_delta", "text": " **"},
+    {"kind": "text_delta", "text": "Monday"},
+    {"kind": "text_delta", "text": ", August 31"},
+    {"kind": "text_delta", "text": ", 2026**."},
+    {
+        "kind": "usage",
+        "input_tokens": 10538,
+        "output_tokens": 93,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": None,
+    },
+    {"kind": "completed"},
+)
+
+
+def test_native_anthropic_normalizer_decodes_the_live_web_search_wire() -> None:
+    """The captured web_search wire decodes to verbatim server-tool blocks.
+
+    Production incident (2026-08-31, engine 0.7.10): a Claude Code WebSearch
+    request 400ed at decode, and even past decode the normalizer would have
+    failed the stream at the first server_tool_use input fragment. The
+    pinned wire also proves the billing total: the search-inflated input
+    count from message_delta (10538) supersedes message_start's 2230.
+    """
+    result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_WEB_SEARCH_FRAMES)
+    assert result["failure"] is None
+    assert result["events"] == list(ANTHROPIC_LIVE_WEB_SEARCH_EVENTS)
+
+
+def test_native_anthropic_normalizer_marks_paused_turns_terminal() -> None:
+    """A pause_turn stop reason ends the attempt as a paused terminal."""
+    chunks = list(ANTHROPIC_LIVE_WEB_SEARCH_FRAMES)
+    delta = json.loads(chunks[-2].decode().split("data: ", 1)[1])
+    delta["delta"]["stop_reason"] = "pause_turn"
+    payload = json.dumps(delta, ensure_ascii=False)
+    chunks[-2] = f"event: message_delta\ndata: {payload}\n\n".encode()
+    result = _native_normalized("anthropic_messages", tuple(chunks))
+    assert result["failure"] is None
+    expected = list(ANTHROPIC_LIVE_WEB_SEARCH_EVENTS)
+    expected[-1] = {"kind": "paused"}
+    assert result["events"] == expected

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -83,9 +83,21 @@ def anthropic_messages_stream_payload(
     }
     if system_parts:
         payload["system"] = "\n\n".join(system_parts)
-    if request.tools:
+    if request.tools or request.provider_server_tools:
+        # Typed server and Anthropic-defined entries re-enter the tools array
+        # at their exact caller positions, byte-for-byte; only this wire can
+        # serve them (route admission already rejected every other rung).
+        server_by_position = {
+            server.position: server.definition for server in request.provider_server_tools
+        }
+        client_tools = iter(request.tools)
         tools: list[JsonObject] = []
-        for tool in request.tools:
+        for position in range(len(request.tools) + len(request.provider_server_tools)):
+            server_definition = server_by_position.get(position)
+            if server_definition is not None:
+                tools.append(dict(server_definition))
+                continue
+            tool = next(client_tools)
             translated: JsonObject = {
                 "name": tool.name,
                 "input_schema": tool.parameters,

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -403,6 +403,35 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
 
+    # Server and Anthropic-defined tools execute on the provider, so only a
+    # native Anthropic-only route can serve them; dropping a declared search
+    # or execution capability would silently change what the model can do,
+    # so any other rung is a named rejection, never a disclosure-drop. The
+    # echoed server-tool history blocks replay on the same wire only.
+    if request.provider_server_tools and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        named = ", ".join(sorted({server.tool_type for server in request.provider_server_tools}))
+        raise ProviderParameterError(
+            message=(
+                f"The Anthropic tool types [{named}] are not supported by this model "
+                "route. Remove them or choose a native Anthropic-only route."
+            ),
+            param="tools",
+            code="unsupported_parameter",
+        )
+    if any(
+        message.provider_server_tool_block is not None for message in request.messages
+    ) and not all(profile.dialect == "anthropic_messages" for profile in profiles):
+        raise ProviderParameterError(
+            message=(
+                "Server-tool history blocks are not supported by this model route. "
+                "Remove them or choose a native Anthropic-only route."
+            ),
+            param="messages",
+            code="unsupported_parameter",
+        )
+
     # Context editing is Anthropic-native; any other rung cannot honor it,
     # so the omission is disclosed and the field dropped from dispatch,
     # never a rejection (Claude Code sends it by default).

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2176,3 +2176,77 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     }
     assert mixed_provider.provider_cache_control is None
     assert mixed_provider.inference_geo is None
+
+
+def test_server_tools_interleave_verbatim_on_anthropic_and_reject_elsewhere() -> None:
+    """Typed tool entries re-enter the wire at their caller positions and any
+    non-Anthropic rung is a named rejection, never a silent capability drop
+    (a production Claude Code WebSearch request 400ed on engine 0.7.10)."""
+    from exp.runtime.gateway.contracts import GatewayServerTool, GatewayToolDefinition
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="search"),
+            GatewayMessage(
+                role="assistant",
+                provider_server_tool_block={
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_1",
+                    "name": "web_search",
+                    "input": {"query": "utc"},
+                },
+            ),
+            GatewayMessage(
+                role="assistant",
+                provider_server_tool_block={
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_1",
+                    "caller": {"type": "direct"},
+                    "content": [{"type": "web_search_result", "url": "https://utc.test"}],
+                },
+            ),
+            GatewayMessage(role="assistant", content="Monday."),
+            GatewayMessage(role="user", content="and tomorrow?"),
+        ),
+        tools=(GatewayToolDefinition(name="Bash", parameters={"type": "object"}),),
+        provider_server_tools=(
+            GatewayServerTool(
+                position=0,
+                definition={"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+            ),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+
+    payload = anthropic_messages_stream_payload("claude-sonnet-4-6", request)
+    tools = cast(list[JsonObject], payload["tools"])
+    assert tools[0] == {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+    assert tools[1]["name"] == "Bash"
+    messages = cast(list[JsonObject], payload["messages"])
+    assert [message["role"] for message in messages] == ["user", "assistant", "user"]
+    blocks = cast(list[JsonObject], messages[1]["content"])
+    assert [block["type"] for block in blocks] == [
+        "server_tool_use",
+        "web_search_tool_result",
+        "text",
+    ]
+    assert blocks[0]["input"] == {"query": "utc"}
+    assert blocks[1]["caller"] == {"type": "direct"}
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+    public, provider = route_generation_parameter_requests((anthropic,), request)
+    assert public.ignored_parameters == ()
+    assert provider.provider_server_tools == request.provider_server_tools
+
+    with pytest.raises(ProviderParameterError) as tools_rejected:
+        route_generation_parameter_requests((anthropic, fallback), request)
+    assert tools_rejected.value.param == "tools"
+    assert "web_search_20250305" in str(tools_rejected.value)
+
+    history_only = request.model_copy(update={"provider_server_tools": ()})
+    with pytest.raises(ProviderParameterError) as history_rejected:
+        route_generation_parameter_requests((fallback,), history_only)
+    assert history_rejected.value.param == "messages"

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -109,6 +109,11 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
 
 def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
     """Translate one non-instruction gateway message to Anthropic content blocks."""
+    if message.provider_server_tool_block is not None:
+        # One echoed server-tool block carries the whole message and re-emits
+        # byte-for-byte at its position; the caller's message loop merges
+        # consecutive assistant messages back into one content list.
+        return "assistant", [dict(message.provider_server_tool_block)]
     if message.role == "tool":
         result: JsonObject = {
             "type": "tool_result",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.11,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.12,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Problem

Live repro on production 0.7.10 (2026-08-31): a real Claude Code session invoking WebSearch got

```
400 "Invalid value for 'tools.0.input_schema': Field required"
```

Server-tool definitions (`web_search_20250305`-style typed entries) carry no `input_schema`, and the strict tool wire model required one. The #685 drift gate classified custom-tool fields but not the tool-type union. Worse, acceptance alone would not have fixed the feature: the native normalizer skipped unknown `server_tool_use` block starts and then failed the stream at their first `input_json_delta` ("provider emitted arguments before a tool start"), result blocks would have been silently lost, echoed history blocks were hard-rejected on turn 2, `pause_turn` was rewritten to a fake `end_turn`, and search-inflated input tokens were under-billed. This PR lands the lane end to end.

## Live verification (api.anthropic.com, house key, 2026-08-31)

- Every GA `ToolUnionParam` type probed bare on a plain key: **all accepted with no beta header**; the only 400s are the provider's own per-model support errors ("'claude-sonnet-4-6' does not support tool types: ..."), so the provider stays the authority per model and no beta injection is needed anywhere.
- A full live `web_search` stream was captured and is pinned (neutralized) as a golden normalizer fixture. Real-wire facts it encodes: `server_tool_use` opens with empty input then streams `input_json_delta` fragments (the first one empty); `web_search_tool_result` arrives whole in its start frame with a `caller` object; the answer text block opens with a `citations` key and a leading `citations_delta`; and `message_delta.usage` carries the search-inflated cumulative input total (2230 -> 10538) that `message_start` does not.
- End-to-end proof: the exact production repro body decoded through the new path, the gateway-built payload streamed a real search live (200), the native normalizer produced two verbatim `server_tool_block` events + text + correct usage, the aggregated assistant content was echoed back through decode as turn 2, and the provider accepted the replay and answered from the prior search result.

## Decisions

**Accepted (forward verbatim on Anthropic rungs, at exact caller positions):** all 22 GA union types (web_search/web_fetch/code_execution/tool_search families, bash, text_editor, memory, browser/computer toolsets). Decode validates shallowly against the recorded type table (`MESSAGES_SERVER_TOOL_TYPES_ACCEPTED`); the raw entry rides a new serialization-excluded `GatewayRequest.provider_server_tools` carrier that joins replay identity when present. Server tool names join the shared tool-name space (collisions reject; a named `tool_choice` may select one).

**Echoed history:** `server_tool_use` + the six `*_tool_result` block types decode onto a per-block opaque carrier (`GatewayMessage.provider_server_tool_block`, assistant-only, sole content, mirroring `provider_native_item`) and re-emit byte-for-byte in order; the emitter merges consecutive assistant messages back into one content list.

**Non-Anthropic rungs: NAMED REJECT, not disclosure-drop** — for both definitions and history blocks. Rationale (recorded in code): a server tool changes what the model can do; silently dropping a search capability the caller declared is a behavior lie. This matches the `thinking`/`tool_is_error` precedent for Anthropic-only semantics.

**Recorded rejections with rationales:** `mcp_toolset` (binds the rejected `mcp_servers` field), `advisor_20260301` (a second, differently priced model inside one request falsifies committed route identity/billing — the fallbacks rationale), legacy `bash_20241022`/`text_editor_20241022` and `computer_2024*/2025*` (beta-gated, unverified). Content blocks `search_result` (gateway serves no citations) and `container_upload` (rejected `container` field) get named hints.

## Response side (Rust, crate 0.3.11 -> 0.3.12)

- Normalizer: a closed `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` set accumulates opaque blocks (verbatim start frame + folded `input_json_delta` fragments, byte/entry budgets enforced) and emits one `ServerToolBlock` event per block at its stop frame; genuinely unknown block kinds keep today's skip.
- Messages encoder: server blocks re-emit whole in their `content_block_start` (the `redacted_thinking` precedent), never flip the `tool_use` stop reason, and aggregate verbatim into the non-streaming body.
- `pause_turn` is now a first-class `Paused` terminal: the Messages surface reports the provider's own `pause_turn` stop reason (streaming and aggregated), settlement bills it like completion, and the Chat/Responses surfaces (which can never legally see it) map it defensively to completion.
- Guardrail redaction drops server-tool blocks so rewritten output cannot leak searched/fetched content; a `Paused` terminal still receives the replacement text.
- **Billing fix:** `message_delta` usage counts now supersede `message_start` when present, so searched content injected mid-turn bills at the provider's cumulative total instead of the pre-search count (live turn: 2230 -> 10538 input tokens).

## Deliberate gaps (documented in the architecture doc, flagged for owners)

- **Per-search provider fee is not modeled.** Web search costs the provider account $10/1k searches; the gateway bills the grown input-token total but not the per-use fee, and `usage.server_tool_use.web_search_requests` is not yet surfaced. Follow-up needs a pricing-schema decision (the #680 class).
- **Citations are not carried.** `citations_delta` on text blocks is dropped (answer text streams uncited; the result block with URLs IS delivered), and `search_result` input blocks stay rejected. Carrying citations restructures text-block handling end to end and is its own slice.

## Drift gates

Every GA and beta `ToolUnionParam` type literal and every `ContentBlockParam` type must now be a recorded decision; the accepted history-block set is pinned equal to both the wire literal and the native normalizer's Rust constant, so the two engines cannot drift apart.

## Structure

`contracts.py` crossed the 1000-line budget, so replay identity (`provider_replay_authority`, `canonical_request_sha256`) moved to `exp/runtime/gateway/replay_identity.py` (four importers updated, no aliases left behind).

## Gates

- `uv run ruff format` / `ruff check` / `ty check`: clean
- Full `uv run pytest -q` on the committed tree: 2979 passed, 2 skipped
- `cargo test --no-default-features`: 118 passed; `cargo clippy --all-targets`: clean; `cargo fmt --check`: clean
- Crate version bump chores: crate `Cargo.toml`/`pyproject.toml` 0.3.12, `Cargo.lock`, parent pin floor `>=0.3.12,<0.4`, `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
