### PR TITLE
gateway: serve Anthropic server tools (WebSearch) end to end

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -237,7 +237,17 @@ bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthr
 disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded
 decision behind an SDK-surface drift gate in
 `exp/runtime/anthropic_protocol/manifest.py`, and rejects image and document blocks loudly
-because the surface is text-only. Thinking carriers
+because the surface is text-only. Anthropic server tools are decided per type by the same
+manifest: verified `web_search_*` entries forward verbatim after the converted custom tools,
+their streamed output (`server_tool_use`, `web_search_tool_result`, citation-bearing text
+blocks, and the `pause_turn` stop reason) reaches the caller intact on both response paths, and
+a next-turn echo of those blocks (each carried verbatim as a whole-message block) re-serves
+byte-for-byte; every other Anthropic-defined tool type is rejected by name because the data
+plane does not yet carry its result blocks. Like the thinking carriers, server tools replay
+only on the Anthropic wire, so a route with any other rung rejects them by name instead of
+dropping a requested capability. The terminal `message_delta` usage report supersedes the
+`message_start` input legs when present, because server-tool turns re-read fetched results as
+input and the start-frame count severely undercounts the billed total. Thinking carriers
 replay only on the Anthropic wire, so route admission requires every waterfall rung to speak the
 `anthropic_messages` dialect; on the Responses surface over Anthropic routes, thinking text is
 projected onto the reasoning-summary channel (signatures deliberately dropped) so callers receive

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -201,13 +201,17 @@ MESSAGES_SERVER_TOOL_TYPES_REJECTED = frozenset(
 """Anthropic-defined tool types consciously rejected by name.
 
 Each is rejected because the gateway cannot yet serve it truthfully, not
-because the provider would refuse it: ``web_fetch_*``, ``code_execution_*``,
+because the provider would refuse it (a live probe on a plain key,
+2026-08-31, accepted the current-generation types bare; beta headers only
+matter for the 2024-10-22 family): ``web_fetch_*``, ``code_execution_*``,
 and ``tool_search_*`` stream result blocks the data plane does not carry
 (silently dropping them would falsify the response); ``code_execution_*``,
 ``browser_toolset_*``, ``computer*``, and ``mcp_toolset`` additionally bind
-provider-hosted execution state; ``computer*``, ``bash_*``, ``text_editor_*``,
-``memory_*``, and ``advisor_*`` are client-executed but unverified here and
-several require beta headers this gateway does not forward. Accepting one
+provider-hosted execution state. ``bash_20250124``,
+``text_editor_20250728``, and ``memory_20250818`` are client-executed
+through ordinary ``tool_use`` blocks (no new block vocabulary in that
+probe), making them the nearest accept candidates once verified end to end;
+the remaining client-executed types are unverified here. Accepting one
 means moving it to :data:`MESSAGES_SERVER_TOOL_TYPES_ACCEPTED` with live
 block-vocabulary evidence, exactly as web_search was.
 """

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from exp.runtime.gateway.contracts import (
+from exp.runtime.gateway.compatibility import (
     CompatibilityDisposition,
     CompatibilityField,
     CompatibilityManifest,
-    GatewayApiSurface,
 )
+from exp.runtime.gateway.contracts import GatewayApiSurface
 
 
 def _field(
@@ -77,8 +77,9 @@ MESSAGES_MANIFEST = CompatibilityManifest(
         #   proxy it truthfully, so it stays rejected until a verified
         #   contract exists.
         # - ``container`` and ``mcp_servers`` bind provider-hosted execution
-        #   state this gateway does not serve (server tools are rejected on
-        #   the same grounds).
+        #   state this gateway does not serve (server tools whose result
+        #   blocks the gateway cannot carry are rejected on the same grounds;
+        #   see MESSAGES_SERVER_TOOL_TYPES_ACCEPTED).
         # - ``service_tier`` selects provider priority capacity priced above
         #   the gateway's committed billing model.
         # - ``fallbacks`` and ``fallback_credit_token`` swap the upstream
@@ -139,9 +140,76 @@ rungs, which own their validity rules, and drop with disclosure elsewhere.
 MESSAGES_TOOL_FIELDS_REJECTED: frozenset[str] = frozenset()
 """Custom tool-definition fields consciously rejected, currently none.
 
-Server-defined tools (bash, text editor, web search, code execution, tool
-search) are rejected wholesale through the closed ``type`` literal instead
-of field-by-field: the gateway serves no provider-hosted execution.
+Anthropic-defined tools (bash, text editor, web search, code execution,
+tool search) are decided per type through
+:data:`MESSAGES_SERVER_TOOL_TYPES_ACCEPTED` and
+:data:`MESSAGES_SERVER_TOOL_TYPES_REJECTED` instead of field-by-field: an
+accepted entry forwards verbatim, so its per-type configuration is the
+provider's own validity surface.
+"""
+
+
+MESSAGES_SERVER_TOOL_TYPES_ACCEPTED = frozenset(
+    {
+        "web_search_20250305",
+        "web_search_20260209",
+        "web_search_20260318",
+    }
+)
+"""Anthropic-defined tool types the gateway forwards verbatim.
+
+The bar for acceptance is truthful end-to-end serving, not decode success:
+the data plane must carry every block the tool makes the provider stream.
+All three web_search versions were verified live (2026-08-31) to emit the
+same block vocabulary this gateway carries intact: ``server_tool_use``,
+``web_search_tool_result``, and citation-bearing ``text`` blocks (the newer
+two default to programmatic calling on some models; that 400 is the
+provider's own, named and actionable). Claude Code's WebSearch sends
+``web_search_20250305`` by default.
+"""
+
+MESSAGES_SERVER_TOOL_TYPES_REJECTED = frozenset(
+    {
+        "advisor_20260301",
+        "bash_20241022",
+        "bash_20250124",
+        "browser_toolset_20260801",
+        "code_execution_20250522",
+        "code_execution_20250825",
+        "code_execution_20260120",
+        "code_execution_20260521",
+        "computer_20241022",
+        "computer_20250124",
+        "computer_20251124",
+        "computer_toolset_20260801",
+        "mcp_toolset",
+        "memory_20250818",
+        "text_editor_20241022",
+        "text_editor_20250124",
+        "text_editor_20250429",
+        "text_editor_20250728",
+        "tool_search_tool_bm25",
+        "tool_search_tool_bm25_20251119",
+        "tool_search_tool_regex",
+        "tool_search_tool_regex_20251119",
+        "web_fetch_20250910",
+        "web_fetch_20260209",
+        "web_fetch_20260309",
+        "web_fetch_20260318",
+    }
+)
+"""Anthropic-defined tool types consciously rejected by name.
+
+Each is rejected because the gateway cannot yet serve it truthfully, not
+because the provider would refuse it: ``web_fetch_*``, ``code_execution_*``,
+and ``tool_search_*`` stream result blocks the data plane does not carry
+(silently dropping them would falsify the response); ``code_execution_*``,
+``browser_toolset_*``, ``computer*``, and ``mcp_toolset`` additionally bind
+provider-hosted execution state; ``computer*``, ``bash_*``, ``text_editor_*``,
+``memory_*``, and ``advisor_*`` are client-executed but unverified here and
+several require beta headers this gateway does not forward. Accepting one
+means moving it to :data:`MESSAGES_SERVER_TOOL_TYPES_ACCEPTED` with live
+block-vocabulary evidence, exactly as web_search was.
 """
 
 

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from exp.runtime.anthropic_protocol.manifest import MESSAGES_MANIFEST
-from exp.runtime.gateway.contracts import CompatibilityDisposition, GatewayApiSurface
+from exp.runtime.gateway.compatibility import CompatibilityDisposition
+from exp.runtime.gateway.contracts import GatewayApiSurface
 
 
 def test_manifest_binds_the_messages_surface_with_unique_fields() -> None:
@@ -96,3 +97,48 @@ def test_route_identity_and_delegation_fields_are_recorded_rejections() -> None:
         assert decisions[path] == CompatibilityDisposition.UNSUPPORTED
     for path in ("cache_control", "inference_geo"):
         assert decisions[path] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
+
+
+def _sdk_tool_type_literals() -> set[str]:
+    """Collect every ``type`` literal on the official GA and beta tool unions."""
+    import typing
+
+    from anthropic.types import tool_union_param
+    from anthropic.types.beta import beta_tool_union_param
+
+    literals: set[str] = set()
+    for union in (tool_union_param.ToolUnionParam, beta_tool_union_param.BetaToolUnionParam):
+        for member in typing.get_args(union):
+            if typing.get_origin(member) is not None:
+                member = typing.get_args(member)[0]
+            annotation = typing.get_type_hints(member, include_extras=True)["type"]
+            while typing.get_origin(annotation) is not typing.Literal:
+                arguments = typing.get_args(annotation)
+                assert arguments, f"{member.__name__}.type carries no literal"
+                annotation = arguments[0]
+            literals.update(typing.get_args(annotation))
+    return literals
+
+
+def test_every_official_sdk_tool_type_is_consciously_classified() -> None:
+    """Anthropic-defined tool types are part of the drift gate.
+
+    Claude Code's WebSearch sends ``web_search_20250305`` by default (a
+    production session was answered with a 400 before the accept table
+    existed), so every ``type`` literal on the official tool unions must be
+    a conscious decision: served verbatim, or rejected by name with the
+    reason recorded in the table docstrings.
+    """
+    from exp.runtime.anthropic_protocol.manifest import (
+        MESSAGES_SERVER_TOOL_TYPES_ACCEPTED,
+        MESSAGES_SERVER_TOOL_TYPES_REJECTED,
+    )
+
+    assert not MESSAGES_SERVER_TOOL_TYPES_ACCEPTED & MESSAGES_SERVER_TOOL_TYPES_REJECTED
+    # "custom" is the caller-defined tool discriminator handled by the strict
+    # custom-tool model, never a server tool decision.
+    sdk_types = _sdk_tool_type_literals() - {"custom"}
+    undecided = (
+        sdk_types - MESSAGES_SERVER_TOOL_TYPES_ACCEPTED - MESSAGES_SERVER_TOOL_TYPES_REJECTED
+    )
+    assert not undecided, _decided(undecided, "Anthropic-defined tool")

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -3,7 +3,10 @@
 The decoder is strict and lossless for supported content: text, ``tool_use``,
 ``tool_result``, ``thinking``, and ``redacted_thinking`` blocks translate
 faithfully (thinking history rides the opaque provider-reasoning carrier with
-byte-exact signatures); ``cache_control`` annotations are validated
+byte-exact signatures); echoed server-tool output (``server_tool_use``,
+``web_search_tool_result``, and citation-bearing ``text`` blocks) rides the
+verbatim per-block carrier so it round-trips byte-for-byte to native
+Anthropic rungs; ``cache_control`` annotations are validated
 everywhere and carried on the surfaces the Anthropic wire caches natively
 (tool_use blocks, tool definitions, and the top-level automatic marker),
 while content-block hints are dropped because they do not change model
@@ -27,9 +30,10 @@ from exp.common.models.model import ReasoningEffort, ToolCall
 from exp.runtime.anthropic_protocol.manifest import (
     MESSAGES_BETA_TOKENS_FORWARDED,
     MESSAGES_MANIFEST,
+    MESSAGES_SERVER_TOOL_TYPES_ACCEPTED,
 )
+from exp.runtime.gateway.compatibility import CompatibilityDisposition
 from exp.runtime.gateway.contracts import (
-    CompatibilityDisposition,
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
@@ -51,8 +55,6 @@ from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 _REJECTED_BLOCK_HINTS = {
     "image": "image blocks are not supported: this gateway surface is text-only",
     "document": "document blocks are not supported: this gateway surface is text-only",
-    "server_tool_use": "server tools are not supported by this gateway",
-    "web_search_tool_result": "server tools are not supported by this gateway",
 }
 
 
@@ -70,11 +72,19 @@ class _CacheControl(_WireModel):
 
 
 class _TextBlock(_WireModel):
-    """One plain text content block."""
+    """One plain text content block.
+
+    ``citations`` exists only as server-tool output echoed back in assistant
+    history (Claude Code resends the cited answer verbatim, and the SDK
+    accumulator materializes the key as null for uncited blocks); each
+    citation is an evolving provider shape with a provider-issued encrypted
+    index, so validation is deliberately shallow.
+    """
 
     type: Literal["text"]
     text: str
     cache_control: _CacheControl | None = None
+    citations: tuple[JsonObject, ...] | None = None
 
 
 class _ThinkingBlock(_WireModel):
@@ -119,8 +129,36 @@ class _ToolResultBlock(_WireModel):
     cache_control: _CacheControl | None = None
 
 
+class _ServerToolUseBlock(BaseModel):
+    """One server-tool invocation echoed in history, carried shallowly.
+
+    Server-tool block shapes are an evolving provider surface; a closed
+    model here would recreate the reject-what-real-clients-send incident
+    class, so only the discriminator is validated and the raw block forwards
+    byte-for-byte on native Anthropic rungs.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["server_tool_use"]
+
+
+class _WebSearchToolResultBlock(BaseModel):
+    """One server-tool result echoed in history, carried shallowly."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["web_search_tool_result"]
+
+
 _ContentBlock = (
-    _TextBlock | _ThinkingBlock | _RedactedThinkingBlock | _ToolUseBlock | _ToolResultBlock
+    _TextBlock
+    | _ThinkingBlock
+    | _RedactedThinkingBlock
+    | _ToolUseBlock
+    | _ToolResultBlock
+    | _ServerToolUseBlock
+    | _WebSearchToolResultBlock
 )
 
 
@@ -163,6 +201,28 @@ class _Tool(_WireModel):
     defer_loading: bool | None = None
     allowed_callers: tuple[str, ...] | None = None
     input_examples: tuple[JsonObject, ...] | None = None
+
+
+class _ServerTool(BaseModel):
+    """One Anthropic server tool, validated shallowly and carried verbatim.
+
+    Server tools (``web_search_20250305``-style) execute at the provider and
+    carry no ``input_schema``; their per-type configuration is an evolving
+    provider surface, so only the discriminator pair is validated and the
+    raw entry forwards byte-for-byte on native Anthropic rungs.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9_]*$")
+    name: str = Field(min_length=1, max_length=256)
+
+    @model_validator(mode="after")
+    def _require_server_type(self) -> _ServerTool:
+        """Reject the custom discriminator: custom tools take the strict model."""
+        if self.type == "custom":
+            raise ValueError("custom tools must declare an input_schema")
+        return self
 
 
 class _ToolChoice(_WireModel):
@@ -211,7 +271,7 @@ class _MessagesRequest(_WireModel):
     top_k: int | None = Field(default=None, ge=0)
     stop_sequences: tuple[str, ...] | None = None
     stream: bool = False
-    tools: tuple[_Tool, ...] = ()
+    tools: tuple[_Tool | _ServerTool, ...] = ()
     tool_choice: _ToolChoice | None = None
     metadata: _Metadata | None = None
     thinking: _ThinkingConfig | None = None
@@ -259,6 +319,7 @@ def decode_messages(
     """
     _validate_manifest(payload)
     request = _validate_wire(payload)
+    _require_served_server_tool_types(request.tools)
     forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
     system_text = _system_text(request.system)
@@ -273,7 +334,14 @@ def decode_messages(
         canonical = GatewayRequest(
             surface=GatewayApiSurface.MESSAGES,
             messages=tuple(messages),
-            tools=tuple(_gateway_tool(tool) for tool in request.tools),
+            tools=tuple(_gateway_tool(tool) for tool in request.tools if isinstance(tool, _Tool)),
+            # Raw payload entries, mirroring thinking: the provider receives
+            # each server tool byte-for-byte on Anthropic rungs.
+            provider_server_tools=tuple(
+                cast(JsonObject, cast(list, payload["tools"])[tool_index])
+                for tool_index, tool in enumerate(request.tools)
+                if isinstance(tool, _ServerTool)
+            ),
             tool_choice=_gateway_tool_choice(request.tool_choice),
             parallel_tool_calls=parallel_tool_calls,
             maximum_output_tokens=request.max_tokens,
@@ -313,6 +381,28 @@ def decode_messages(
     except ValidationError as exc:
         raise _validation_error(exc.errors(include_url=False)[0]) from exc
     return DecodedGatewayRequest(alias=request.model, request=canonical)
+
+
+def _require_served_server_tool_types(tools: tuple[_Tool | _ServerTool, ...]) -> None:
+    """Reject any server tool type the gateway cannot serve truthfully.
+
+    Acceptance means the data plane carries every block the tool makes the
+    provider stream (see the decision tables in ``manifest.py``); an
+    unclassified type stays rejected until the SDK drift gate forces its
+    decision, so a new provider tool never half-works silently.
+
+    Raises:
+        OpenAIProtocolError: A tool entry names an unserved server tool type.
+    """
+    for tool_index, tool in enumerate(tools):
+        if isinstance(tool, _ServerTool) and tool.type not in MESSAGES_SERVER_TOOL_TYPES_ACCEPTED:
+            supported = ", ".join(sorted(MESSAGES_SERVER_TOOL_TYPES_ACCEPTED))
+            raise invalid_field(
+                f"tools.{tool_index}.type",
+                f"the server tool type '{tool.type}' is not supported by this gateway. "
+                f"Supported server tool types: {supported}. Remove the tool or use a "
+                "supported type.",
+            )
 
 
 def _output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
@@ -589,6 +679,27 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
 
     for block_index, block in enumerate(message.content):
         if isinstance(block, _TextBlock):
+            if block.citations:
+                if message.role != "assistant":
+                    raise invalid_field(
+                        f"{param}.content.{block_index}",
+                        "citations are only valid in assistant messages.",
+                    )
+                # A cited answer is server-tool output; the block re-emits
+                # verbatim so provider-issued encrypted indexes round-trip.
+                flush()
+                out.append(
+                    GatewayMessage(
+                        role="assistant",
+                        provider_anthropic_block=block.model_dump(
+                            mode="json", exclude_none=True, exclude={"cache_control"}
+                        ),
+                    )
+                )
+                continue
+            # An empty citations array (the SDK accumulator's uncited shape)
+            # is dropped with the other content-block hints: it carries no
+            # information and the bare text round-trips on every wire.
             text_parts.append(block.text)
         elif isinstance(block, (_ThinkingBlock, _RedactedThinkingBlock)):
             if message.role != "assistant":
@@ -620,6 +731,21 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                         if block.cache_control is not None
                         else None
                     ),
+                )
+            )
+        elif isinstance(block, (_ServerToolUseBlock, _WebSearchToolResultBlock)):
+            if message.role != "assistant":
+                raise invalid_field(
+                    f"{param}.content.{block_index}",
+                    "server tool blocks are only valid in assistant messages.",
+                )
+            # The raw echoed block (extras included) carries the whole
+            # message, mirroring provider_native_item on the Responses wire.
+            flush()
+            out.append(
+                GatewayMessage(
+                    role="assistant",
+                    provider_anthropic_block=block.model_dump(mode="json"),
                 )
             )
         else:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -706,3 +706,199 @@ def test_validation_errors_state_the_expectation_not_only_the_field() -> None:
     assert invalid.value.detail.param == "tools.0.strict"
     assert "Invalid value for 'tools.0.strict'" in invalid.value.detail.message
     assert "bool" in invalid.value.detail.message
+
+
+def test_the_prod_failing_web_search_tool_shape_decodes() -> None:
+    """The exact Claude Code WebSearch entry decodes and carries verbatim.
+
+    Production incident (2026-08-31 class): the strict custom-tool model
+    400d every session with WebSearch enabled because the server tool entry
+    carries no input_schema.
+    """
+    server_entry: JsonObject = {
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": 8,
+    }
+    decoded = decode_messages(
+        _body(
+            tools=[
+                {"name": "Bash", "description": "run", "input_schema": {"type": "object"}},
+                server_entry,
+            ],
+            tool_choice={"type": "auto"},
+        )
+    )
+    request = decoded.request
+    assert tuple(tool.name for tool in request.tools) == ("Bash",)
+    # The carried entry equals the raw payload object byte-for-byte.
+    assert request.provider_server_tools == (server_entry,)
+
+
+def test_every_verified_web_search_version_decodes() -> None:
+    """All live-verified web_search versions pass the accept table."""
+    for tool_type in ("web_search_20250305", "web_search_20260209", "web_search_20260318"):
+        decoded = decode_messages(_body(tools=[{"type": tool_type, "name": "web_search"}]))
+        entries = decoded.request.provider_server_tools
+        assert len(entries) == 1 and entries[0]["type"] == tool_type
+
+
+def test_unserved_server_tool_types_are_rejected_by_name() -> None:
+    """A classified-but-unserved or unknown server tool type 400s loudly."""
+    for tool_type in ("web_fetch_20250910", "code_execution_20250522", "someday_20990101"):
+        with pytest.raises(OpenAIProtocolError) as error:
+            decode_messages(_body(tools=[{"type": tool_type, "name": "t"}]))
+        assert error.value.status_code == 400
+        assert tool_type in error.value.detail.message
+        assert "web_search_20250305" in error.value.detail.message
+
+
+def test_malformed_server_tool_entries_are_rejected() -> None:
+    """A non-pattern type or a nameless server entry stays a validation error."""
+    for entry in (
+        {"type": "Web Search!", "name": "web_search"},
+        {"type": "web_search_20250305"},
+    ):
+        with pytest.raises(OpenAIProtocolError) as error:
+            decode_messages(_body(tools=[entry]))
+        assert error.value.status_code == 400
+
+
+def _echoed_web_search_turn() -> list[JsonObject]:
+    """The assistant blocks a served WebSearch turn echoes back (live shape)."""
+    return [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_fixture",
+            "name": "web_search",
+            "input": {"query": "current stable Python"},
+        },
+        {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_fixture",
+            "content": [
+                {
+                    "type": "web_search_result",
+                    "title": "Python versions",
+                    "url": "https://www.python.org/doc/versions/",
+                    "encrypted_content": "Et8QCioIExgC",
+                    "page_age": "March 12, 2026",
+                }
+            ],
+            "caller": {"type": "direct"},
+        },
+        {
+            "citations": [
+                {
+                    "type": "web_search_result_location",
+                    "cited_text": "Python 3.14.7, released on 5 August 2026",
+                    "url": "https://www.python.org/doc/versions/",
+                    "title": "Python versions",
+                    "encrypted_index": "Eo8BCioIExgC",
+                }
+            ],
+            "type": "text",
+            "text": "The current stable Python version is 3.14.7.",
+        },
+    ]
+
+
+def test_echoed_server_tool_turn_rides_the_verbatim_block_carrier() -> None:
+    """A turn-2 echo decodes into ordered verbatim per-block messages.
+
+    The echoed turn (server_tool_use, web_search_tool_result, cited text)
+    must round-trip byte-faithfully: every block, extras and provider-issued
+    encrypted payloads included, becomes one whole-message carrier at its
+    position.
+    """
+    blocks = _echoed_web_search_turn()
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "search please"},
+                {"role": "assistant", "content": blocks},
+                {"role": "user", "content": "thanks, just the version"},
+            ],
+            tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 2}],
+        )
+    )
+    messages = decoded.request.messages
+    assert [message.role for message in messages] == [
+        "user",
+        "assistant",
+        "assistant",
+        "assistant",
+        "user",
+    ]
+    carried = [
+        message.provider_anthropic_block
+        for message in messages
+        if message.provider_anthropic_block is not None
+    ]
+    assert carried == blocks
+    assert messages[-1].content == "thanks, just the version"
+
+
+def test_cited_text_splits_around_plain_assistant_text_in_order() -> None:
+    """Plain text merges as content while cited text carries verbatim."""
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me check."},
+                        {
+                            "type": "text",
+                            "text": "It is 3.14.7.",
+                            "citations": [{"type": "web_search_result_location"}],
+                        },
+                        {"type": "text", "text": "Anything else?"},
+                    ],
+                },
+                {"role": "user", "content": "no"},
+            ]
+        )
+    )
+    assistant = decoded.request.messages[1:4]
+    assert assistant[0].content == "Let me check."
+    assert assistant[1].provider_anthropic_block == {
+        "type": "text",
+        "text": "It is 3.14.7.",
+        "citations": [{"type": "web_search_result_location"}],
+    }
+    assert assistant[2].content == "Anything else?"
+
+
+def test_uncited_citation_shapes_stay_on_the_plain_text_path() -> None:
+    """The SDK accumulator's null and empty citations decode as plain text."""
+    for citations in (None, []):
+        decoded = decode_messages(
+            _body(
+                messages=[
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "ok", "citations": citations}],
+                    },
+                    {"role": "user", "content": "next"},
+                ]
+            )
+        )
+        assistant = decoded.request.messages[1]
+        assert assistant.content == "ok"
+        assert assistant.provider_anthropic_block is None
+
+
+def test_server_tool_blocks_and_citations_are_assistant_only() -> None:
+    """Server-tool output shapes in a user turn are rejected with the field."""
+    for content in (
+        [{"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {}}],
+        [{"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []}],
+        [{"type": "text", "text": "hi", "citations": [{"type": "char_location"}]}],
+    ):
+        with pytest.raises(OpenAIProtocolError) as error:
+            decode_messages(_body(messages=[{"role": "user", "content": content}]))
+        assert error.value.status_code == 400
+        assert "assistant" in error.value.detail.message

--- a/exp/runtime/gateway/__init__.py
+++ b/exp/runtime/gateway/__init__.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from exp.runtime.gateway.contracts import (
-    AuthorizationSnapshot,
+from exp.runtime.gateway.compatibility import (
     CompatibilityDisposition,
     CompatibilityField,
     CompatibilityManifest,
+)
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
     DirectTarget,
     ExecutionSnapshot,
     GatewayApiSurface,

--- a/exp/runtime/gateway/compatibility.py
+++ b/exp/runtime/gateway/compatibility.py
@@ -1,0 +1,61 @@
+"""Versioned public-field compatibility manifests shared by the API surfaces.
+
+Split from :mod:`exp.runtime.gateway.contracts` for the module line
+budget: each public surface declares one closed manifest of explicit
+field decisions here, and its decoder enforces it.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import Field, model_validator
+
+from exp.common.core.artifacts import ContractModel
+from exp.runtime.gateway.contracts import GatewayApiSurface
+
+
+class CompatibilityDisposition(StrEnum):
+    """How one installed public request field is handled by the gateway.
+
+    ``IGNORED`` keeps a compatibility field valid at the public boundary while
+    deliberately omitting it from provider dispatch when the normalized gateway
+    response cannot preserve its result.
+    """
+
+    SUPPORTED = "supported"
+    CONDITIONALLY_SUPPORTED = "conditionally_supported"
+    METADATA_ONLY = "metadata_only"
+    IGNORED = "ignored"
+    UNSUPPORTED = "unsupported"
+
+
+class CompatibilityField(ContractModel):
+    """One explicit public-field decision in a versioned compatibility manifest."""
+
+    field_path: str = Field(min_length=1, max_length=512)
+    disposition: CompatibilityDisposition
+    capability: str | None = Field(default=None, min_length=1, max_length=256)
+
+
+class CompatibilityManifest(ContractModel):
+    """Closed field-classification contract for one public API surface."""
+
+    schema_version: int = Field(ge=1)
+    surface: GatewayApiSurface
+    fields: tuple[CompatibilityField, ...]
+
+    @model_validator(mode="after")
+    def _require_unique_field_paths(self) -> CompatibilityManifest:
+        """Reject duplicate field decisions that could make parsing ambiguous.
+
+        Returns:
+            The validated manifest.
+
+        Raises:
+            ValueError: A field path appears more than once.
+        """
+        paths = tuple(field.field_path for field in self.fields)
+        if len(set(paths)) != len(paths):
+            raise ValueError("compatibility manifest field paths must be unique")
+        return self

--- a/exp/runtime/gateway/compatibility_test.py
+++ b/exp/runtime/gateway/compatibility_test.py
@@ -1,0 +1,4 @@
+"""Compatibility-manifest behavior is covered with the surface manifests in
+:mod:`exp.runtime.openai_protocol.manifest_test`,
+:mod:`exp.runtime.anthropic_protocol.manifest_test`, and
+:mod:`exp.runtime.gateway.contracts_test`."""

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -261,6 +261,20 @@ class GatewayMessage(ContractModel):
     other carriers so item-free digests are unperturbed; a present item
     joins replay identity through :func:`canonical_request_sha256`.
     """
+    provider_anthropic_block: JsonObject | None = Field(default=None, exclude=True)
+    """One verbatim Anthropic content block the gateway carries opaquely.
+
+    Server tools return ``server_tool_use`` and ``web_search_tool_result``
+    blocks, plus citation-bearing ``text`` blocks (citations exist only as
+    server-tool output), whose shapes exist on no other wire; a caller
+    echoing them in history gets each carried shallowly at its position and
+    re-emitted byte-for-byte on native Anthropic rungs only (route admission
+    mirrors ``provider_native_item``). Decode splits the assistant turn at
+    block boundaries so re-emission preserves the exact block order. A
+    message carrying it carries nothing else. Excluded from serialization
+    like the other carriers so block-free digests are unperturbed; a present
+    block joins replay identity through :func:`canonical_request_sha256`.
+    """
 
     @model_validator(mode="after")
     def _require_role_coherence(self) -> GatewayMessage:
@@ -282,6 +296,17 @@ class GatewayMessage(ContractModel):
                 or self.tool_is_error
             ):
                 raise ValueError("a native provider item carries the whole message")
+            return self
+        if self.provider_anthropic_block is not None:
+            if (
+                self.content is not None
+                or self.tool_calls
+                or self.provider_reasoning
+                or self.provider_item_id is not None
+                or self.tool_call_id is not None
+                or self.tool_is_error
+            ):
+                raise ValueError("a native Anthropic block carries the whole message")
             return self
         if (
             self.content is None
@@ -462,6 +487,20 @@ class GatewayRequest(ContractModel):
     other Anthropic-only carriers; a present value joins replay identity
     through :func:`canonical_request_sha256`.
     """
+    provider_server_tools: tuple[JsonObject, ...] = Field(default=(), exclude=True)
+    """Verbatim Anthropic server-tool entries from the Messages ``tools`` array.
+
+    Server tools (``web_search_20250305``-style typed entries with no
+    ``input_schema``) execute at the provider; their per-type configuration
+    is an evolving provider surface, so each entry is validated shallowly at
+    decode and re-emitted byte-for-byte AFTER the converted custom tools on
+    native Anthropic rungs only (an accepted ordering deviation from the
+    caller's interleaving). Other rungs cannot execute them, so route
+    admission rejects by name instead of silently dropping a capability the
+    caller asked for. Excluded from serialization like the other carriers so
+    server-tool-free digests are unperturbed; present entries join replay
+    identity through :func:`canonical_request_sha256`.
+    """
     stream: bool = False
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
@@ -532,12 +571,18 @@ class GatewayRequest(ContractModel):
         names = tuple(tool.name for tool in self.tools)
         if len(set(names)) != len(names):
             raise ValueError("gateway tool names must not repeat")
+        # Server tools are addressable by tool_choice too; the provider owns
+        # cross-set name rules for the verbatim entries.
+        server_names = tuple(
+            str(entry["name"]) for entry in self.provider_server_tools if "name" in entry
+        )
         if (
             isinstance(self.tool_choice, GatewayNamedToolChoice)
             and self.tool_choice.name not in names
+            and self.tool_choice.name not in server_names
         ):
             raise ValueError("named gateway tool choice must name a request tool")
-        if self.tool_choice == "required" and not self.tools:
+        if self.tool_choice == "required" and not self.tools and not self.provider_server_tools:
             raise ValueError("required gateway tool choice needs at least one tool")
         if self.include_usage and not self.stream:
             raise ValueError("include_usage is valid only for streaming requests")
@@ -574,6 +619,8 @@ class GatewayRequest(ContractModel):
             raise ValueError("Anthropic tool carriers are valid only for Messages requests")
         if self.provider_beta_tokens and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("provider_beta_tokens are valid only for Messages requests")
+        if self.provider_server_tools and self.surface != GatewayApiSurface.MESSAGES:
+            raise ValueError("provider_server_tools are valid only for Messages requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
             raise ValueError("maximum output parameter requires a maximum output value")
         if self.reasoning_summary_parameters and self.reasoning_summary is None:
@@ -611,6 +658,8 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
             authority["provider_phase"] = message.provider_phase
         if message.provider_native_item is not None:
             authority["provider_native_item"] = message.provider_native_item
+        if message.provider_anthropic_block is not None:
+            authority["provider_anthropic_block"] = message.provider_anthropic_block
         if message.provider_reasoning:
             blocks: list[JsonObject] = []
             for block in message.provider_reasoning:
@@ -671,6 +720,7 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
         and request.speed is None
         and request.inference_geo is None
         and not request.provider_beta_tokens
+        and not request.provider_server_tools
     ):
         return None
     envelope: JsonObject = {
@@ -692,6 +742,8 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
         envelope["tools"] = retained_tools
     if request.provider_beta_tokens:
         envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
+    if request.provider_server_tools:
+        envelope["provider_server_tools"] = list(request.provider_server_tools)
     return envelope
 
 
@@ -922,49 +974,3 @@ class ExecutionSnapshot(ContractModel):
     exact_model_id: ExactModelId
     pool_id: ExactModelPoolId
     deployment_ids: tuple[DeploymentId, ...] = Field(min_length=1)
-
-
-class CompatibilityDisposition(StrEnum):
-    """How one installed public request field is handled by the gateway.
-
-    ``IGNORED`` keeps a compatibility field valid at the public boundary while
-    deliberately omitting it from provider dispatch when the normalized gateway
-    response cannot preserve its result.
-    """
-
-    SUPPORTED = "supported"
-    CONDITIONALLY_SUPPORTED = "conditionally_supported"
-    METADATA_ONLY = "metadata_only"
-    IGNORED = "ignored"
-    UNSUPPORTED = "unsupported"
-
-
-class CompatibilityField(ContractModel):
-    """One explicit public-field decision in a versioned compatibility manifest."""
-
-    field_path: str = Field(min_length=1, max_length=512)
-    disposition: CompatibilityDisposition
-    capability: str | None = Field(default=None, min_length=1, max_length=256)
-
-
-class CompatibilityManifest(ContractModel):
-    """Closed field-classification contract for one public API surface."""
-
-    schema_version: int = Field(ge=1)
-    surface: GatewayApiSurface
-    fields: tuple[CompatibilityField, ...]
-
-    @model_validator(mode="after")
-    def _require_unique_field_paths(self) -> CompatibilityManifest:
-        """Reject duplicate field decisions that could make parsing ambiguous.
-
-        Returns:
-            The validated manifest.
-
-        Raises:
-            ValueError: A field path appears more than once.
-        """
-        paths = tuple(field.field_path for field in self.fields)
-        if len(set(paths)) != len(paths):
-            raise ValueError("compatibility manifest field paths must be unique")
-        return self

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -7,12 +7,15 @@ from typing import Literal
 import pytest
 from pydantic import ValidationError
 
+from exp.common.core.artifacts import JsonObject
 from exp.common.models.model import ToolCall
-from exp.runtime.gateway.contracts import (
-    AuthorizationSnapshot,
+from exp.runtime.gateway.compatibility import (
     CompatibilityDisposition,
     CompatibilityField,
     CompatibilityManifest,
+)
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
     DirectTarget,
     ExecutionSnapshot,
     GatewayApiSurface,
@@ -600,4 +603,70 @@ def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
                     eager_input_streaming=True,
                 ),
             ),
+        )
+
+
+def test_server_tool_carriers_are_scoped_verbatim_and_join_replay_identity() -> None:
+    """Server tool entries and echoed blocks are Messages-only whole-message carriers."""
+    from exp.runtime.gateway.contracts import canonical_request_sha256
+
+    server_entry: JsonObject = {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+    bare = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="search"),),
+    )
+    carried = bare.model_copy(update={"provider_server_tools": (server_entry,)})
+    # Excluded from serialization, distinct in replay identity.
+    assert carried.model_dump() == bare.model_dump()
+    assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
+
+    echoed = bare.model_copy(
+        update={
+            "messages": bare.messages
+            + (
+                GatewayMessage(
+                    role="assistant",
+                    provider_anthropic_block={
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_1",
+                        "name": "web_search",
+                        "input": {},
+                    },
+                ),
+            )
+        }
+    )
+    assert canonical_request_sha256(echoed) != canonical_request_sha256(bare)
+
+    with pytest.raises(ValidationError, match="valid only for Messages"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_server_tools=(server_entry,),
+        )
+    with pytest.raises(ValidationError, match="carries the whole message"):
+        GatewayMessage(
+            role="assistant",
+            content="also text",
+            provider_anthropic_block={"type": "server_tool_use"},
+        )
+
+
+def test_tool_choice_may_name_a_server_tool() -> None:
+    """Named and required selectors count verbatim server tools as tools."""
+    server_entry: JsonObject = {"type": "web_search_20250305", "name": "web_search"}
+    for tool_choice in (GatewayNamedToolChoice(name="web_search"), "required"):
+        request = GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_server_tools=(server_entry,),
+            tool_choice=tool_choice,
+        )
+        assert request.provider_server_tools == (server_entry,)
+    with pytest.raises(ValidationError, match="must name a request tool"):
+        GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_server_tools=(server_entry,),
+            tool_choice=GatewayNamedToolChoice(name="absent"),
         )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -140,13 +140,24 @@ fn complete_streamed_tool(
     // input is legitimately empty text.
     if tool.raw_arguments.is_empty() && !tool.custom {
         tool.raw_arguments.push_str("{}");
-        events.push(Event::ToolArgumentsDelta {
-            index,
-            delta: "{}".to_string(),
+        events.push(if tool.server {
+            Event::ServerToolArgumentsDelta {
+                index,
+                delta: "{}".to_string(),
+            }
+        } else {
+            Event::ToolArgumentsDelta {
+                index,
+                delta: "{}".to_string(),
+            }
         });
     }
     let call = tool.complete().map_err(|message| malformed(&message))?;
-    events.push(Event::ToolCallCompleted { index, call });
+    events.push(if tool.server {
+        Event::ServerToolUseCompleted { index, call }
+    } else {
+        Event::ToolCallCompleted { index, call }
+    });
     Ok(())
 }
 

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -9,9 +9,11 @@ use super::{
     complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
     provider_stream_failed, refusal_failure, Normalizer,
 };
+use crate::encode::compact_json;
 use crate::errors::Failure;
 use crate::events::{
-    count_or_zero, require_string, require_u64, Event, ToolAccumulator, Usage, MAXIMUM_LEDGER_COUNT,
+    count_if_present, count_or_zero, require_string, require_u64, Event, ToolAccumulator, Usage,
+    MAXIMUM_LEDGER_COUNT,
 };
 
 impl Normalizer {
@@ -81,7 +83,44 @@ impl Normalizer {
                             name,
                         });
                     }
+                    Some("server_tool_use") => {
+                        // Provider-executed server tool (web search): same
+                        // start/argument lifecycle as a client tool, but on
+                        // dedicated events so it never becomes client tool
+                        // history or a tool_use stop reason.
+                        let call_id = require_string(block, "id", "Anthropic server tool ID")
+                            .map_err(|message| malformed(&message))?;
+                        let name = require_string(block, "name", "Anthropic server tool name")
+                            .map_err(|message| malformed(&message))?;
+                        if self.tools.contains_key(&index) {
+                            return Err(malformed("Anthropic stream repeated a tool-call start"));
+                        }
+                        self.reserve_tool_entry(index)?;
+                        let mut tool = ToolAccumulator::new(call_id.clone(), name.clone());
+                        tool.server = true;
+                        self.tools.insert(index, tool);
+                        events.push(Event::ServerToolUseStarted {
+                            index,
+                            call_id,
+                            name,
+                        });
+                    }
+                    Some("web_search_tool_result") => {
+                        // The result arrives whole in the start frame and is
+                        // carried verbatim so the caller (and its next-turn
+                        // echo) sees exactly what the provider produced.
+                        let serialized = compact_json(&Value::Object(block.clone()));
+                        self.reserve_tool_bytes(serialized.len())?;
+                        events.push(Event::ServerToolResult {
+                            index,
+                            block: serialized,
+                        });
+                    }
                     Some("text") => {
+                        // The boundary event lets the Messages encoder mirror
+                        // the provider's text-block structure, which is what
+                        // citations attach to.
+                        events.push(Event::TextBlockStarted { index });
                         let text = optional_text(block, "text", "Anthropic initial text")?;
                         if !text.is_empty() {
                             events.push(Event::TextDelta(text));
@@ -133,9 +172,33 @@ impl Normalizer {
                             malformed("provider emitted arguments before a tool start")
                         })?;
                         tool.raw_arguments.push_str(&fragment);
-                        events.push(Event::ToolArgumentsDelta {
+                        events.push(if tool.server {
+                            Event::ServerToolArgumentsDelta {
+                                index,
+                                delta: fragment,
+                            }
+                        } else {
+                            Event::ToolArgumentsDelta {
+                                index,
+                                delta: fragment,
+                            }
+                        });
+                    }
+                    Some("citations_delta") => {
+                        // One whole citation object attached to the open text
+                        // block, carried verbatim (server-tool answers cite
+                        // their web sources through these).
+                        let citation = delta
+                            .get("citation")
+                            .and_then(Value::as_object)
+                            .ok_or_else(|| {
+                                malformed("Anthropic citations_delta.citation must be an object")
+                            })?;
+                        let serialized = compact_json(&Value::Object(citation.clone()));
+                        self.reserve_tool_bytes(serialized.len())?;
+                        events.push(Event::CitationDelta {
                             index,
-                            delta: fragment,
+                            citation: serialized,
                         });
                     }
                     Some("refusal_delta") => {
@@ -186,6 +249,21 @@ impl Normalizer {
                 self.output_tokens =
                     count_or_zero(usage, "output_tokens", "Anthropic output_tokens")
                         .map_err(|message| malformed(&message))?;
+                // The terminal usage report supersedes message_start when its
+                // input legs are present: server-tool turns re-read fetched
+                // results as input, so the start-frame count undercounts the
+                // billed total severely (verified live 2026-08-31).
+                for (key, slot) in [
+                    ("input_tokens", &mut self.input_tokens),
+                    ("cache_read_input_tokens", &mut self.cache_read),
+                    ("cache_creation_input_tokens", &mut self.cache_write),
+                ] {
+                    if let Some(value) = count_if_present(usage, key, "Anthropic message_delta")
+                        .map_err(|message| malformed(&message))?
+                    {
+                        *slot = value;
+                    }
+                }
                 if self.stop_reason.as_deref() == Some("refusal") && !self.refusal_seen {
                     self.refusal_seen = true;
                     events.push(Event::RefusalDelta(String::new()));
@@ -217,6 +295,11 @@ impl Normalizer {
                     events.push(Event::Failed(refusal_failure()));
                 } else if self.stop_reason.as_deref() == Some("max_tokens") {
                     events.push(Event::Incomplete);
+                } else if self.stop_reason.as_deref() == Some("pause_turn") {
+                    // A paused server-tool turn must keep its stop reason:
+                    // the caller resumes it by resending the conversation,
+                    // and an end_turn rewrite would end the task instead.
+                    events.push(Event::PausedTurn);
                 } else {
                     events.push(Event::Completed);
                 }
@@ -288,5 +371,125 @@ mod tests {
             events.as_slice(),
             [Event::RedactedThinking { index: 1, data }] if data == "opaque=="
         ));
+    }
+
+    /// Frame shapes captured live from one web_search stream (2026-08-31):
+    /// server tool use with a leading empty input fragment, the whole result
+    /// in its start frame, a cited answer, terminal usage that supersedes the
+    /// start-frame input count, and the pause_turn stop reason.
+    #[test]
+    fn server_tool_frames_normalize_to_dedicated_events() {
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let start_message = frame(serde_json::json!({
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 2230, "output_tokens": 25}},
+        }));
+        assert!(normalizer.feed(&start_message).expect("start").is_empty());
+
+        let start = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {},
+            },
+        }));
+        let events = normalizer.feed(&start).expect("server tool start");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ServerToolUseStarted { index: 0, call_id, name }]
+                if call_id == "srvtoolu_1" && name == "web_search"
+        ));
+
+        // The provider legally leads with an empty input fragment.
+        for partial in ["", "{\"query\": \"python\"}"] {
+            let delta = frame(serde_json::json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": partial},
+            }));
+            let events = normalizer.feed(&delta).expect("server input delta");
+            assert!(matches!(
+                events.as_slice(),
+                [Event::ServerToolArgumentsDelta { index: 0, delta }] if delta == partial
+            ));
+        }
+        let stop = frame(serde_json::json!({"type": "content_block_stop", "index": 0}));
+        let events = normalizer.feed(&stop).expect("server tool stop");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::ServerToolUseCompleted { index: 0, call }]
+                if call.raw_arguments == "{\"query\": \"python\"}" && !call.custom
+        ));
+
+        let result = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "content": [{"type": "web_search_result", "url": "https://example.com"}],
+                "caller": {"type": "direct"},
+            },
+        }));
+        let events = normalizer.feed(&result).expect("server tool result");
+        match events.as_slice() {
+            [Event::ServerToolResult { index: 1, block }] => {
+                assert!(block.contains("\"caller\":{\"type\":\"direct\"}"));
+            }
+            other => panic!("unexpected events: {other:?}"),
+        }
+
+        let text_start = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {"citations": [], "type": "text", "text": ""},
+        }));
+        let events = normalizer.feed(&text_start).expect("text start");
+        assert!(matches!(
+            events.as_slice(),
+            [Event::TextBlockStarted { index: 2 }]
+        ));
+        let citation = frame(serde_json::json!({
+            "type": "content_block_delta",
+            "index": 2,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {"type": "web_search_result_location", "cited_text": "3.14.7"},
+            },
+        }));
+        let events = normalizer.feed(&citation).expect("citation delta");
+        match events.as_slice() {
+            [Event::CitationDelta { index: 2, citation }] => {
+                assert!(citation.contains("\"cited_text\":\"3.14.7\""));
+            }
+            other => panic!("unexpected events: {other:?}"),
+        }
+
+        // The terminal usage report supersedes the start-frame input legs.
+        let message_delta = frame(serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "pause_turn", "stop_sequence": null},
+            "usage": {
+                "input_tokens": 12284,
+                "cache_read_input_tokens": 4,
+                "cache_creation_input_tokens": 6,
+                "output_tokens": 103,
+                "server_tool_use": {"web_search_requests": 1},
+            },
+        }));
+        assert!(normalizer.feed(&message_delta).expect("delta").is_empty());
+        let stop_message = frame(serde_json::json!({"type": "message_stop"}));
+        let events = normalizer.feed(&stop_message).expect("message stop");
+        match events.as_slice() {
+            [Event::Usage(usage), Event::PausedTurn] => {
+                assert_eq!(usage.input_tokens, Some(12294));
+                assert_eq!(usage.output_tokens, Some(103));
+                assert_eq!(usage.cached_input_tokens, Some(4));
+            }
+            other => panic!("unexpected events: {other:?}"),
+        }
     }
 }

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -259,6 +259,17 @@ impl ChatSseEncoder {
             | Event::ThinkingSignature { .. }
             | Event::RedactedThinking { .. }
             | Event::EncryptedReasoning { .. } => Ok(Vec::new()),
+            // Anthropic text-block boundaries and citation metadata have no
+            // Chat representation; the text itself streams through TextDelta.
+            Event::TextBlockStarted { .. } | Event::CitationDelta { .. } => Ok(Vec::new()),
+            // Server tools enter only through a Messages request, which
+            // never encodes on the Chat surface.
+            Event::ServerToolUseStarted { .. }
+            | Event::ServerToolArgumentsDelta { .. }
+            | Event::ServerToolUseCompleted { .. }
+            | Event::ServerToolResult { .. } => Err(invalid_provider_stream(
+                "Chat cannot represent a provider server tool.",
+            )),
             Event::ToolCallStarted {
                 index,
                 call_id,
@@ -330,7 +341,7 @@ impl ChatSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete => {
+            Event::Completed | Event::Incomplete | Event::PausedTurn => {
                 self.terminal = true;
                 let finish_reason = if matches!(event, Event::Incomplete) {
                     "length"

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -49,21 +49,22 @@ fn invalid_provider_stream(message: &str) -> PublicError {
     PublicError::new(502, "invalid_provider_stream", message, "api_error")
 }
 
-/// Map the terminal outcome to the Anthropic stop reason.
-fn stop_reason(incomplete: bool, saw_tool_use: bool) -> &'static str {
-    if incomplete {
-        "max_tokens"
-    } else if saw_tool_use {
-        "tool_use"
-    } else {
-        "end_turn"
+/// Map the terminal outcome to the Anthropic stop reason. Server tool use is
+/// provider-executed and deliberately never yields `tool_use`; a paused
+/// server-tool turn must keep `pause_turn` so the caller resumes it.
+pub(super) fn stop_reason(terminal: &Event, saw_tool_use: bool) -> &'static str {
+    match terminal {
+        Event::Incomplete => "max_tokens",
+        Event::PausedTurn => "pause_turn",
+        _ if saw_tool_use => "tool_use",
+        _ => "end_turn",
     }
 }
 
 /// The Anthropic usage shape from `messages_usage`: cached reads come back
 /// out of the normalized input total, and unknown usage reports zero counts
 /// because the Anthropic shape requires both fields.
-fn messages_usage(usage: Option<&Usage>) -> Value {
+pub(super) fn messages_usage(usage: Option<&Usage>) -> Value {
     let usage = match usage {
         Some(usage) if usage.has_token_counts() => usage,
         _ => return json!({"input_tokens": 0, "output_tokens": 0}),
@@ -102,6 +103,11 @@ enum BlockKind {
     Tool(u32),
     Thinking(u32),
     Redacted,
+    /// Provider-executed server tool use, streamed like a tool block but
+    /// re-emitted as `server_tool_use` and excluded from the tool_use stop.
+    ServerTool(u32),
+    /// One whole verbatim server-tool result block (arrives complete).
+    ServerResult,
 }
 
 /// One scheduled content block, buffered until it can stream in order.
@@ -119,6 +125,12 @@ struct PendingBlock {
     pending_signature: String,
     /// Redacted only: the whole opaque payload travels in the start frame.
     redacted_data: Option<String>,
+    /// Server result only: the whole verbatim block (validated compact JSON
+    /// text) travels in the start frame.
+    server_result_block: Option<String>,
+    /// Text only: verbatim citation objects (validated compact JSON text),
+    /// each flushed as one `citations_delta` while the block is open.
+    pending_citations: Vec<String>,
     anthropic_index: Option<u32>,
 }
 
@@ -129,6 +141,8 @@ impl PendingBlock {
             pending: String::new(),
             pending_signature: String::new(),
             redacted_data: None,
+            server_result_block: None,
+            pending_citations: Vec::new(),
             anthropic_index: None,
         }
     }
@@ -157,6 +171,9 @@ pub struct MessagesSseEncoder {
     tool_identities: HashMap<u32, (String, String)>,
     tool_arguments: HashMap<u32, String>,
     tool_completed: HashSet<u32>,
+    server_identities: HashMap<u32, (String, String)>,
+    server_arguments: HashMap<u32, String>,
+    server_completed: HashSet<u32>,
     saw_tool_use: bool,
     refusal_seen: bool,
     usage: Option<Usage>,
@@ -178,6 +195,9 @@ impl MessagesSseEncoder {
             tool_identities: HashMap::new(),
             tool_arguments: HashMap::new(),
             tool_completed: HashSet::new(),
+            server_identities: HashMap::new(),
+            server_arguments: HashMap::new(),
+            server_completed: HashSet::new(),
             saw_tool_use: false,
             refusal_seen: false,
             usage: None,
@@ -287,13 +307,51 @@ impl MessagesSseEncoder {
                 self.tool_completed.insert(*index);
                 Ok(self.advance())
             }
+            Event::TextBlockStarted { .. } => {
+                // A provider text-block boundary starts a fresh caller block
+                // so citations attach to the block they belong to.
+                self.blocks.push(PendingBlock::new(BlockKind::Text));
+                Ok(self.advance())
+            }
+            Event::CitationDelta { citation, .. } => self.citation_delta(citation),
+            Event::ServerToolUseStarted {
+                index,
+                call_id,
+                name,
+            } => self.server_tool_started(*index, call_id, name),
+            Event::ServerToolArgumentsDelta { index, delta } => {
+                self.server_tool_arguments_delta(*index, delta)
+            }
+            Event::ServerToolUseCompleted { index, call } => {
+                let identity = self.server_identities.get(index);
+                if identity.is_none() || self.server_completed.contains(index) {
+                    return Err(invalid_provider_stream(
+                        "Messages server tool completion omitted its started tool use.",
+                    ));
+                }
+                let streamed = self
+                    .server_arguments
+                    .get(index)
+                    .cloned()
+                    .unwrap_or_default();
+                if identity != Some(&(call.call_id.clone(), call.name.clone()))
+                    || streamed != call.raw_arguments
+                {
+                    return Err(invalid_provider_stream(
+                        "Messages server tool completion changed streamed identity or bytes.",
+                    ));
+                }
+                self.server_completed.insert(*index);
+                Ok(self.advance())
+            }
+            Event::ServerToolResult { block, .. } => self.server_tool_result(block),
             Event::Usage(usage) => {
                 if usage.has_token_counts() {
                     self.usage = Some(usage.clone());
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete => {
+            Event::Completed | Event::Incomplete | Event::PausedTurn => {
                 self.terminal = true;
                 if self.refusal_seen {
                     return Ok(vec![error_frame(&refusal_failure())]);
@@ -305,10 +363,7 @@ impl MessagesSseEncoder {
                     &json!({
                         "type": "message_delta",
                         "delta": {
-                            "stop_reason": stop_reason(
-                                matches!(event, Event::Incomplete),
-                                self.saw_tool_use,
-                            ),
+                            "stop_reason": stop_reason(event, self.saw_tool_use),
                             "stop_sequence": Value::Null,
                         },
                         "usage": messages_usage(self.usage.as_ref()),
@@ -397,6 +452,109 @@ impl MessagesSseEncoder {
         self.blocks.len() - 1
     }
 
+    /// Attach one verbatim citation to the newest text block, creating one
+    /// when the citation leads its block's content.
+    fn citation_delta(&mut self, citation: &str) -> Result<Vec<String>, PublicError> {
+        self.buffered_bytes = self.buffered_bytes.saturating_add(citation.len());
+        if self.buffered_bytes > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(invalid_provider_stream(
+                "Messages stream buffered blocks exceeded the gateway response limit.",
+            ));
+        }
+        if serde_json::from_str::<Value>(citation).is_err() {
+            return Err(invalid_provider_stream(
+                "Messages citation was not valid JSON.",
+            ));
+        }
+        let position = match self
+            .blocks
+            .iter()
+            .rposition(|block| block.kind == BlockKind::Text)
+        {
+            Some(position) => position,
+            None => {
+                self.blocks.push(PendingBlock::new(BlockKind::Text));
+                self.blocks.len() - 1
+            }
+        };
+        self.blocks[position]
+            .pending_citations
+            .push(citation.to_string());
+        let mut frames = self.advance();
+        self.flush_open(&mut frames);
+        Ok(frames)
+    }
+
+    /// Schedule one server_tool_use block at its start position.
+    fn server_tool_started(
+        &mut self,
+        tool_index: u32,
+        call_id: &str,
+        name: &str,
+    ) -> Result<Vec<String>, PublicError> {
+        if self.server_identities.contains_key(&tool_index) {
+            return Err(invalid_provider_stream(
+                "A Messages server tool index was started twice.",
+            ));
+        }
+        self.server_identities
+            .insert(tool_index, (call_id.to_string(), name.to_string()));
+        self.server_arguments.insert(tool_index, String::new());
+        self.blocks
+            .push(PendingBlock::new(BlockKind::ServerTool(tool_index)));
+        Ok(self.advance())
+    }
+
+    /// Schedule one raw server-tool input fragment behind earlier blocks.
+    fn server_tool_arguments_delta(
+        &mut self,
+        tool_index: u32,
+        delta: &str,
+    ) -> Result<Vec<String>, PublicError> {
+        if !self.server_identities.contains_key(&tool_index) {
+            return Err(invalid_provider_stream(
+                "Messages server tool arguments arrived before its start.",
+            ));
+        }
+        if self.server_completed.contains(&tool_index) {
+            return Err(invalid_provider_stream(
+                "Messages server tool arguments arrived after completion.",
+            ));
+        }
+        self.server_arguments
+            .get_mut(&tool_index)
+            .expect("started server tool has accumulated arguments")
+            .push_str(delta);
+        let position = self
+            .blocks
+            .iter()
+            .position(|block| block.kind == BlockKind::ServerTool(tool_index))
+            .expect("started server tool has a scheduled block");
+        self.buffer(position, delta)?;
+        let mut frames = self.advance();
+        self.flush_open(&mut frames);
+        Ok(frames)
+    }
+
+    /// Schedule one whole verbatim server-tool result block at its position.
+    fn server_tool_result(&mut self, block: &str) -> Result<Vec<String>, PublicError> {
+        self.buffered_bytes = self.buffered_bytes.saturating_add(block.len());
+        if self.buffered_bytes > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(invalid_provider_stream(
+                "Messages stream buffered blocks exceeded the gateway response limit.",
+            ));
+        }
+        if serde_json::from_str::<Value>(block).is_err() {
+            return Err(invalid_provider_stream(
+                "Messages server tool result was not valid JSON.",
+            ));
+        }
+        let mut pending = PendingBlock::new(BlockKind::ServerResult);
+        pending.server_result_block = Some(block.to_string());
+        self.blocks.push(pending);
+        Ok(self.advance())
+    }
+
     /// Schedule one tool_use block at its start position.
     fn tool_started(
         &mut self,
@@ -475,12 +633,19 @@ impl MessagesSseEncoder {
                 let last = position == self.blocks.len() - 1;
                 let closable = self.draining
                     || match block.kind {
-                        BlockKind::Text | BlockKind::Thinking(_) | BlockKind::Redacted => !last,
+                        BlockKind::Text
+                        | BlockKind::Thinking(_)
+                        | BlockKind::Redacted
+                        | BlockKind::ServerResult => !last,
                         BlockKind::Tool(tool_index) => self.tool_completed.contains(&tool_index),
+                        BlockKind::ServerTool(tool_index) => {
+                            self.server_completed.contains(&tool_index)
+                        }
                     };
                 if !closable {
                     return frames;
                 }
+                self.flush_citations(position, &mut frames);
                 self.flush_signature(position, &mut frames);
                 let block = &self.blocks[position];
                 frames.push(event_frame(
@@ -524,6 +689,24 @@ impl MessagesSseEncoder {
                         "input": {},
                     })
                 }
+                BlockKind::ServerTool(tool_index) => {
+                    let identity = self
+                        .server_identities
+                        .get(&tool_index)
+                        .expect("scheduled server tool has an identity");
+                    json!({
+                        "type": "server_tool_use",
+                        "id": identity.0,
+                        "name": identity.1,
+                        "input": {},
+                    })
+                }
+                BlockKind::ServerResult => {
+                    let raw = block.server_result_block.take().unwrap_or_default();
+                    self.buffered_bytes = self.buffered_bytes.saturating_sub(raw.len());
+                    serde_json::from_str(&raw)
+                        .expect("scheduled server result was validated as JSON")
+                }
             };
             frames.push(event_frame(
                 "content_block_start",
@@ -534,6 +717,28 @@ impl MessagesSseEncoder {
                 }),
             ));
             self.flush_open(&mut frames);
+        }
+    }
+
+    /// Emit each retained verbatim citation as one `citations_delta` frame.
+    fn flush_citations(&mut self, position: usize, frames: &mut Vec<String>) {
+        let block = &mut self.blocks[position];
+        if block.kind != BlockKind::Text || block.pending_citations.is_empty() {
+            return;
+        }
+        let anthropic_index = block.anthropic_index;
+        for citation in block.pending_citations.drain(..) {
+            self.buffered_bytes = self.buffered_bytes.saturating_sub(citation.len());
+            let parsed: Value =
+                serde_json::from_str(&citation).expect("retained citation was validated as JSON");
+            frames.push(event_frame(
+                "content_block_delta",
+                &json!({
+                    "type": "content_block_delta",
+                    "index": anthropic_index,
+                    "delta": {"type": "citations_delta", "citation": parsed},
+                }),
+            ));
         }
     }
 
@@ -558,10 +763,14 @@ impl MessagesSseEncoder {
     }
 
     /// Emit the open block's buffered content as one delta, if any.
+    /// Citations flush first: on the provider wire a block's citations can
+    /// precede the text they cover, and the accumulated block is identical
+    /// either way.
     fn flush_open(&mut self, frames: &mut Vec<String>) {
         let Some(position) = self.open_position else {
             return;
         };
+        self.flush_citations(position, frames);
         let block = &mut self.blocks[position];
         if block.pending.is_empty() {
             return;
@@ -569,10 +778,10 @@ impl MessagesSseEncoder {
         let delta = match block.kind {
             BlockKind::Text => json!({"type": "text_delta", "text": block.pending}),
             BlockKind::Thinking(_) => json!({"type": "thinking_delta", "thinking": block.pending}),
-            // Redacted blocks carry their payload in the start frame and
-            // never buffer deltas.
-            BlockKind::Redacted => return,
-            BlockKind::Tool(_) => {
+            // Redacted and server-result blocks carry their whole payload in
+            // the start frame and never buffer deltas.
+            BlockKind::Redacted | BlockKind::ServerResult => return,
+            BlockKind::Tool(_) | BlockKind::ServerTool(_) => {
                 json!({"type": "input_json_delta", "partial_json": block.pending})
             }
         };
@@ -589,178 +798,9 @@ impl MessagesSseEncoder {
     }
 }
 
-/// The terminal outcome aggregated from one Messages event stream.
-pub struct AggregatedMessage {
-    pub body: Value,
-    pub failure: Option<Failure>,
-    pub usage: Option<Usage>,
-    pub incomplete: bool,
-    pub tool_names: Vec<String>,
-}
+mod aggregate;
 
-/// Build one non-streaming Anthropic message from ordered events, mirroring
-/// the python `completed_messages_body`. Provider refusal content has no
-/// Anthropic message shape, so it aggregates as a sanitized failure.
-pub fn completed_messages_body(
-    request_id: &str,
-    model: &str,
-    events: &[Event],
-) -> Result<AggregatedMessage, PublicError> {
-    let terminal = events.iter().rev().find(|event| event.is_terminal());
-    let terminal = match terminal {
-        Some(event) => event,
-        None => {
-            return Err(PublicError::new(
-                502,
-                "all_routes_failed",
-                "Provider stream ended without a terminal result.",
-                "api_error",
-            ))
-        }
-    };
-    let mut usage: Option<Usage> = None;
-    for event in events.iter().rev() {
-        if let Event::Usage(candidate) = event {
-            if candidate.has_token_counts() {
-                usage = Some(candidate.clone());
-                break;
-            }
-        }
-    }
-    let mut tool_names: Vec<String> = Vec::new();
-    for event in events {
-        if let Event::ToolCallCompleted { call, .. } = event {
-            if !tool_names.contains(&call.name) {
-                tool_names.push(call.name.clone());
-            }
-        }
-    }
-    if let Event::Failed(failure) = terminal {
-        return Ok(AggregatedMessage {
-            body: Value::Null,
-            failure: Some(failure.clone()),
-            usage,
-            incomplete: false,
-            tool_names,
-        });
-    }
-    let incomplete = matches!(terminal, Event::Incomplete);
-    if events.iter().any(|event| {
-        matches!(
-            event,
-            Event::RefusalDelta(_) | Event::ProviderRefusalDelta { .. }
-        )
-    }) {
-        return Ok(AggregatedMessage {
-            body: Value::Null,
-            failure: Some(refusal_failure()),
-            usage,
-            incomplete,
-            tool_names,
-        });
-    }
-    // Blocks preserve provider order, merging adjacent text deltas, so the
-    // non-streaming content sequence equals the streaming block sequence.
-    // Tool blocks anchor at their start position: some dialects (OpenAI-
-    // compatible streams) emit every tool completion only at their terminal
-    // sentinel, after later text.
-    let mut slots: Vec<Option<Value>> = Vec::new();
-    let mut tool_positions: HashMap<u32, usize> = HashMap::new();
-    let mut thinking_positions: HashMap<u32, usize> = HashMap::new();
-    let mut saw_tool_use = false;
-    // Resolve one thinking slot per provider index, creating the block with
-    // the SDK-required empty fields on first use.
-    fn thinking_slot<'a>(
-        slots: &'a mut Vec<Option<Value>>,
-        positions: &mut HashMap<u32, usize>,
-        index: u32,
-    ) -> &'a mut Value {
-        let position = *positions.entry(index).or_insert_with(|| {
-            slots.push(Some(
-                json!({"type": "thinking", "thinking": "", "signature": ""}),
-            ));
-            slots.len() - 1
-        });
-        slots[position].as_mut().expect("thinking slot is filled")
-    }
-    for event in events {
-        match event {
-            Event::TextDelta(delta) | Event::ProviderTextDelta { delta, .. }
-                if !delta.is_empty() =>
-            {
-                let appended = match slots.last_mut() {
-                    Some(Some(block)) if block["type"] == json!("text") => {
-                        if let Some(Value::String(text)) = block.get_mut("text") {
-                            text.push_str(delta);
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                    _ => false,
-                };
-                if !appended {
-                    slots.push(Some(json!({"type": "text", "text": delta})));
-                }
-            }
-            Event::ThinkingDelta { index, delta } if !delta.is_empty() => {
-                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
-                if let Some(Value::String(text)) = block.get_mut("thinking") {
-                    text.push_str(delta);
-                }
-            }
-            Event::ThinkingSignature { index, signature } => {
-                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
-                if let Some(Value::String(text)) = block.get_mut("signature") {
-                    text.push_str(signature);
-                }
-            }
-            Event::RedactedThinking { data, .. } => {
-                slots.push(Some(json!({"type": "redacted_thinking", "data": data})));
-            }
-            Event::ToolCallStarted { index, .. } => {
-                tool_positions.insert(*index, slots.len());
-                slots.push(None);
-            }
-            Event::ToolCallCompleted { index, call } => {
-                if let Some(position) = tool_positions.get(index) {
-                    saw_tool_use = true;
-                    // The raw argument text was validated as one JSON object
-                    // by the normalizer; preserve_order keeps its key order,
-                    // matching the python engine's parsed-object
-                    // serialization.
-                    let input: Value = serde_json::from_str(&call.raw_arguments)
-                        .map_err(|_| PublicError::internal())?;
-                    slots[*position] = Some(json!({
-                        "type": "tool_use",
-                        "id": call.call_id,
-                        "name": call.name,
-                        "input": input,
-                    }));
-                }
-            }
-            _ => {}
-        }
-    }
-    let content: Vec<Value> = slots.into_iter().flatten().collect();
-    let body = json!({
-        "id": stable_public_id("msg", request_id),
-        "type": "message",
-        "role": "assistant",
-        "model": model,
-        "content": content,
-        "stop_reason": stop_reason(incomplete, saw_tool_use),
-        "stop_sequence": Value::Null,
-        "usage": messages_usage(usage.as_ref()),
-    });
-    Ok(AggregatedMessage {
-        body,
-        failure: None,
-        usage,
-        incomplete,
-        tool_names,
-    })
-}
+pub use aggregate::completed_messages_body;
 
 #[cfg(test)]
 mod tests;

--- a/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
@@ -1,0 +1,239 @@
+//! Non-streaming aggregation for the public Anthropic Messages surface,
+//! split from `encode_messages` so the implementation stays within the
+//! repository line budget.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+use crate::encode::stable_public_id;
+use crate::errors::{Failure, PublicError};
+use crate::events::{Event, Usage};
+
+use super::{messages_usage, refusal_failure, stop_reason};
+
+/// The terminal outcome aggregated from one Messages event stream.
+pub struct AggregatedMessage {
+    pub body: Value,
+    pub failure: Option<Failure>,
+    pub usage: Option<Usage>,
+    pub incomplete: bool,
+    pub tool_names: Vec<String>,
+}
+
+/// Build one non-streaming Anthropic message from ordered events, mirroring
+/// the python `completed_messages_body`. Provider refusal content has no
+/// Anthropic message shape, so it aggregates as a sanitized failure.
+pub fn completed_messages_body(
+    request_id: &str,
+    model: &str,
+    events: &[Event],
+) -> Result<AggregatedMessage, PublicError> {
+    let terminal = events.iter().rev().find(|event| event.is_terminal());
+    let terminal = match terminal {
+        Some(event) => event,
+        None => {
+            return Err(PublicError::new(
+                502,
+                "all_routes_failed",
+                "Provider stream ended without a terminal result.",
+                "api_error",
+            ))
+        }
+    };
+    let mut usage: Option<Usage> = None;
+    for event in events.iter().rev() {
+        if let Event::Usage(candidate) = event {
+            if candidate.has_token_counts() {
+                usage = Some(candidate.clone());
+                break;
+            }
+        }
+    }
+    let mut tool_names: Vec<String> = Vec::new();
+    for event in events {
+        if let Event::ToolCallCompleted { call, .. } | Event::ServerToolUseCompleted { call, .. } =
+            event
+        {
+            if !tool_names.contains(&call.name) {
+                tool_names.push(call.name.clone());
+            }
+        }
+    }
+    if let Event::Failed(failure) = terminal {
+        return Ok(AggregatedMessage {
+            body: Value::Null,
+            failure: Some(failure.clone()),
+            usage,
+            incomplete: false,
+            tool_names,
+        });
+    }
+    let incomplete = matches!(terminal, Event::Incomplete);
+    if events.iter().any(|event| {
+        matches!(
+            event,
+            Event::RefusalDelta(_) | Event::ProviderRefusalDelta { .. }
+        )
+    }) {
+        return Ok(AggregatedMessage {
+            body: Value::Null,
+            failure: Some(refusal_failure()),
+            usage,
+            incomplete,
+            tool_names,
+        });
+    }
+    // Blocks preserve provider order, merging adjacent text deltas, so the
+    // non-streaming content sequence equals the streaming block sequence.
+    // Tool blocks anchor at their start position: some dialects (OpenAI-
+    // compatible streams) emit every tool completion only at their terminal
+    // sentinel, after later text.
+    let mut slots: Vec<Option<Value>> = Vec::new();
+    let mut tool_positions: HashMap<u32, usize> = HashMap::new();
+    let mut server_positions: HashMap<u32, usize> = HashMap::new();
+    let mut thinking_positions: HashMap<u32, usize> = HashMap::new();
+    let mut saw_tool_use = false;
+    // Resolve one thinking slot per provider index, creating the block with
+    // the SDK-required empty fields on first use.
+    fn thinking_slot<'a>(
+        slots: &'a mut Vec<Option<Value>>,
+        positions: &mut HashMap<u32, usize>,
+        index: u32,
+    ) -> &'a mut Value {
+        let position = *positions.entry(index).or_insert_with(|| {
+            slots.push(Some(
+                json!({"type": "thinking", "thinking": "", "signature": ""}),
+            ));
+            slots.len() - 1
+        });
+        slots[position].as_mut().expect("thinking slot is filled")
+    }
+    for event in events {
+        match event {
+            Event::TextBlockStarted { .. } => {
+                // A provider block boundary starts a fresh text slot so
+                // adjacent provider text blocks (and their citations) never
+                // merge.
+                slots.push(Some(json!({"type": "text", "text": ""})));
+            }
+            Event::CitationDelta { citation, .. } => {
+                let position = slots.iter().rposition(
+                    |slot| matches!(slot, Some(block) if block["type"] == json!("text")),
+                );
+                let position = match position {
+                    Some(position) => position,
+                    None => {
+                        slots.push(Some(json!({"type": "text", "text": ""})));
+                        slots.len() - 1
+                    }
+                };
+                let parsed: Value =
+                    serde_json::from_str(citation).map_err(|_| PublicError::internal())?;
+                let block = slots[position].as_mut().expect("text slot is filled");
+                match block.get_mut("citations") {
+                    Some(Value::Array(citations)) => citations.push(parsed),
+                    _ => {
+                        block["citations"] = Value::Array(vec![parsed]);
+                    }
+                }
+            }
+            Event::TextDelta(delta) | Event::ProviderTextDelta { delta, .. }
+                if !delta.is_empty() =>
+            {
+                let appended = match slots.last_mut() {
+                    Some(Some(block)) if block["type"] == json!("text") => {
+                        if let Some(Value::String(text)) = block.get_mut("text") {
+                            text.push_str(delta);
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                };
+                if !appended {
+                    slots.push(Some(json!({"type": "text", "text": delta})));
+                }
+            }
+            Event::ThinkingDelta { index, delta } if !delta.is_empty() => {
+                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
+                if let Some(Value::String(text)) = block.get_mut("thinking") {
+                    text.push_str(delta);
+                }
+            }
+            Event::ThinkingSignature { index, signature } => {
+                let block = thinking_slot(&mut slots, &mut thinking_positions, *index);
+                if let Some(Value::String(text)) = block.get_mut("signature") {
+                    text.push_str(signature);
+                }
+            }
+            Event::RedactedThinking { data, .. } => {
+                slots.push(Some(json!({"type": "redacted_thinking", "data": data})));
+            }
+            Event::ToolCallStarted { index, .. } => {
+                tool_positions.insert(*index, slots.len());
+                slots.push(None);
+            }
+            Event::ToolCallCompleted { index, call } => {
+                if let Some(position) = tool_positions.get(index) {
+                    saw_tool_use = true;
+                    // The raw argument text was validated as one JSON object
+                    // by the normalizer; preserve_order keeps its key order,
+                    // matching the python engine's parsed-object
+                    // serialization.
+                    let input: Value = serde_json::from_str(&call.raw_arguments)
+                        .map_err(|_| PublicError::internal())?;
+                    slots[*position] = Some(json!({
+                        "type": "tool_use",
+                        "id": call.call_id,
+                        "name": call.name,
+                        "input": input,
+                    }));
+                }
+            }
+            Event::ServerToolUseStarted { index, .. } => {
+                server_positions.insert(*index, slots.len());
+                slots.push(None);
+            }
+            Event::ServerToolUseCompleted { index, call } => {
+                // Provider-executed tool use anchors at its start position
+                // and never contributes to the tool_use stop reason.
+                if let Some(position) = server_positions.get(index) {
+                    let input: Value = serde_json::from_str(&call.raw_arguments)
+                        .map_err(|_| PublicError::internal())?;
+                    slots[*position] = Some(json!({
+                        "type": "server_tool_use",
+                        "id": call.call_id,
+                        "name": call.name,
+                        "input": input,
+                    }));
+                }
+            }
+            Event::ServerToolResult { block, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(block).map_err(|_| PublicError::internal())?;
+                slots.push(Some(parsed));
+            }
+            _ => {}
+        }
+    }
+    let content: Vec<Value> = slots.into_iter().flatten().collect();
+    let body = json!({
+        "id": stable_public_id("msg", request_id),
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content,
+        "stop_reason": stop_reason(terminal, saw_tool_use),
+        "stop_sequence": Value::Null,
+        "usage": messages_usage(usage.as_ref()),
+    });
+    Ok(AggregatedMessage {
+        body,
+        failure: None,
+        usage,
+        incomplete,
+        tool_names,
+    })
+}

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -404,3 +404,188 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
     assert_eq!(aggregated.body["content"][1]["type"], json!("tool_use"));
     assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
 }
+
+/// The captured live WebSearch lifecycle (2026-08-31): server tool use with
+/// streamed input, one whole verbatim result block, then a cited answer.
+fn web_search_events() -> Vec<Event> {
+    let result_block = json!({
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "content": [{
+            "type": "web_search_result",
+            "title": "Python versions",
+            "url": "https://www.python.org/doc/versions/",
+            "encrypted_content": "EtGzBA==",
+            "page_age": "March 12, 2026",
+        }],
+        "caller": {"type": "direct"},
+    });
+    let citation = json!({
+        "type": "web_search_result_location",
+        "cited_text": "Python 3.14.7, released on 5 August 2026",
+        "url": "https://www.python.org/doc/versions/",
+        "title": "Python versions",
+        "encrypted_index": "Eo8BCg==",
+    });
+    vec![
+        Event::ServerToolUseStarted {
+            index: 0,
+            call_id: "srvtoolu_1".to_string(),
+            name: "web_search".to_string(),
+        },
+        Event::ServerToolArgumentsDelta {
+            index: 0,
+            delta: "{\"query\": \"current stable Python\"}".to_string(),
+        },
+        Event::ServerToolUseCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "srvtoolu_1".to_string(),
+                name: "web_search".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{\"query\": \"current stable Python\"}".to_string(),
+                custom: false,
+            },
+        },
+        Event::ServerToolResult {
+            index: 1,
+            block: compact_json(&result_block),
+        },
+        Event::TextBlockStarted { index: 2 },
+        Event::CitationDelta {
+            index: 2,
+            citation: compact_json(&citation),
+        },
+        Event::TextDelta("The current stable Python version is 3.14.7.".to_string()),
+        Event::Completed,
+    ]
+}
+
+#[test]
+fn server_tool_blocks_stream_in_valid_anthropic_order() {
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &web_search_events() {
+        frames.extend(encoder.feed(event).expect("streams server tools"));
+    }
+    let names: Vec<&str> = frames
+        .iter()
+        .map(|frame| {
+            frame
+                .lines()
+                .next()
+                .and_then(|line| line.strip_prefix("event: "))
+                .expect("named frame")
+        })
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+    );
+    assert!(
+        frames[2].contains(
+            "{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_1\",\"name\":\"web_search\",\"input\":{}}"
+        ),
+        "server tool start frame: {}",
+        frames[2]
+    );
+    assert!(frames[3]
+        .contains("{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\": \\\"current stable Python\\\"}\"}"));
+    // The whole verbatim result block rides its start frame, caller field
+    // included.
+    assert!(frames[5].contains("\"type\":\"web_search_tool_result\""));
+    assert!(frames[5].contains("\"caller\":{\"type\":\"direct\"}"));
+    // Citations flush on the text block before its text, mirroring the
+    // provider's own delta order.
+    assert!(frames[8].contains("\"type\":\"citations_delta\""));
+    assert!(frames[8].contains("\"cited_text\":\"Python 3.14.7, released on 5 August 2026\""));
+    assert!(frames[9].contains("\"type\":\"text_delta\""));
+    // Server tool use is provider-executed: the turn still ends end_turn.
+    assert!(frames[11].contains("\"stop_reason\":\"end_turn\""));
+}
+
+#[test]
+fn completed_body_carries_server_tool_blocks_and_citations() {
+    let aggregated =
+        completed_messages_body("request-abc", "coding", &web_search_events()).expect("aggregates");
+    assert!(aggregated.failure.is_none());
+    assert_eq!(aggregated.body["stop_reason"], json!("end_turn"));
+    assert_eq!(aggregated.tool_names, vec!["web_search".to_string()]);
+    let content = aggregated.body["content"].as_array().expect("content");
+    assert_eq!(content.len(), 3);
+    assert_eq!(
+        content[0],
+        json!({
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "current stable Python"},
+        })
+    );
+    assert_eq!(content[1]["type"], json!("web_search_tool_result"));
+    assert_eq!(content[1]["caller"], json!({"type": "direct"}));
+    assert_eq!(
+        content[2]["text"],
+        json!("The current stable Python version is 3.14.7.")
+    );
+    assert_eq!(
+        content[2]["citations"][0]["cited_text"],
+        json!("Python 3.14.7, released on 5 August 2026")
+    );
+}
+
+#[test]
+fn paused_turn_keeps_its_stop_reason_on_both_paths() {
+    let events = vec![
+        Event::ServerToolUseStarted {
+            index: 0,
+            call_id: "srvtoolu_1".to_string(),
+            name: "web_search".to_string(),
+        },
+        Event::ServerToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ServerToolUseCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                call_id: "srvtoolu_1".to_string(),
+                name: "web_search".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{}".to_string(),
+                custom: false,
+            },
+        },
+        Event::PausedTurn,
+    ];
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams pause"));
+    }
+    assert!(encoder.saw_terminal());
+    let message_delta = frames
+        .iter()
+        .find(|frame| frame.starts_with("event: message_delta"))
+        .expect("message_delta frame");
+    assert!(message_delta.contains("\"stop_reason\":\"pause_turn\""));
+    let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert_eq!(aggregated.body["stop_reason"], json!("pause_turn"));
+    assert!(!aggregated.incomplete);
+}

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -299,13 +299,24 @@ impl ResponsesSseEncoder {
             } => self.tool_started(*index, call_id, name),
             Event::ToolArgumentsDelta { index, delta } => self.tool_arguments(*index, delta),
             Event::ToolCallCompleted { index, call } => self.tool_completed(*index, call),
+            // Anthropic text-block boundaries and citation metadata have no
+            // Responses representation; the text itself streams as deltas.
+            Event::TextBlockStarted { .. } | Event::CitationDelta { .. } => Ok(Vec::new()),
+            // Server tools enter only through a Messages request, which
+            // never encodes on the Responses surface.
+            Event::ServerToolUseStarted { .. }
+            | Event::ServerToolArgumentsDelta { .. }
+            | Event::ServerToolUseCompleted { .. }
+            | Event::ServerToolResult { .. } => Err(invalid_provider_stream(
+                "Responses cannot represent a provider server tool.",
+            )),
             Event::Usage(usage) => {
                 if usage.has_token_counts() {
                     self.usage = Some(usage.clone());
                 }
                 Ok(Vec::new())
             }
-            Event::Completed => self.finish("completed", None),
+            Event::Completed | Event::PausedTurn => self.finish("completed", None),
             Event::Incomplete => self.finish("incomplete", None),
             Event::Failed(failure) => self.finish("failed", Some(failure)),
         }

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -174,9 +174,52 @@ pub enum Event {
         index: u32,
         call: CompletedToolCall,
     },
+    /// One provider-executed Anthropic server tool invocation opening
+    /// (`server_tool_use`); the provider runs the tool itself, so these
+    /// never become client tool calls or affect the tool-use stop reason.
+    ServerToolUseStarted {
+        index: u32,
+        call_id: String,
+        name: String,
+    },
+    /// Raw provider-order input fragment for one open server tool use.
+    ServerToolArgumentsDelta {
+        index: u32,
+        delta: String,
+    },
+    /// One completed server tool invocation with its validated input text.
+    ServerToolUseCompleted {
+        index: u32,
+        call: CompletedToolCall,
+    },
+    /// One whole verbatim Anthropic server-tool result content block
+    /// (`web_search_tool_result`), carried as compact JSON text: the result
+    /// arrives complete in its start frame and must reach the caller intact.
+    ServerToolResult {
+        index: u32,
+        block: String,
+    },
+    /// Provider text content-block boundary on the Anthropic wire. Emitted
+    /// before that block's first text delta so the Messages encoder can
+    /// mirror the provider's block structure (citations attach per block);
+    /// encoders without a block concept ignore it.
+    TextBlockStarted {
+        index: u32,
+    },
+    /// One whole verbatim citation object attached to the open Anthropic
+    /// text block (`citations_delta`), carried as compact JSON text.
+    CitationDelta {
+        index: u32,
+        citation: String,
+    },
     Usage(Usage),
     Completed,
     Incomplete,
+    /// Anthropic `pause_turn` terminal: the provider paused a long-running
+    /// server-tool turn and expects the caller to resend the conversation to
+    /// continue it. Settlement treats it like a completed turn; the Messages
+    /// encoder must preserve the stop reason or the caller never resumes.
+    PausedTurn,
     Failed(Failure),
 }
 
@@ -184,7 +227,7 @@ impl Event {
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            Event::Completed | Event::Incomplete | Event::Failed(_)
+            Event::Completed | Event::Incomplete | Event::PausedTurn | Event::Failed(_)
         )
     }
 
@@ -208,8 +251,9 @@ impl Event {
             | Event::ReasoningSummaryDelta { delta, .. }
             | Event::ThinkingDelta { delta, .. }
             | Event::ReasoningContentDelta { delta, .. }
-            | Event::ToolArgumentsDelta { delta, .. } => !delta.is_empty(),
-            Event::ToolCallStarted { .. } => true,
+            | Event::ToolArgumentsDelta { delta, .. }
+            | Event::ServerToolArgumentsDelta { delta, .. } => !delta.is_empty(),
+            Event::ToolCallStarted { .. } | Event::ServerToolUseStarted { .. } => true,
             _ => false,
         }
     }
@@ -358,6 +402,42 @@ pub fn simplified_event(event: &Event) -> Value {
             }
             payload
         }
+        Event::ServerToolUseStarted {
+            index,
+            call_id,
+            name,
+        } => serde_json::json!({
+            "kind": "server_tool_use_started",
+            "index": index,
+            "call_id": call_id,
+            "name": name,
+        }),
+        Event::ServerToolArgumentsDelta { index, delta } => serde_json::json!({
+            "kind": "server_tool_arguments_delta",
+            "index": index,
+            "text": delta,
+        }),
+        Event::ServerToolUseCompleted { index, call } => serde_json::json!({
+            "kind": "server_tool_use_completed",
+            "index": index,
+            "call_id": call.call_id,
+            "name": call.name,
+            "raw_arguments": call.raw_arguments,
+        }),
+        Event::ServerToolResult { index, block } => serde_json::json!({
+            "kind": "server_tool_result",
+            "index": index,
+            "block": block,
+        }),
+        Event::TextBlockStarted { index } => serde_json::json!({
+            "kind": "text_block_started",
+            "index": index,
+        }),
+        Event::CitationDelta { index, citation } => serde_json::json!({
+            "kind": "citation_delta",
+            "index": index,
+            "citation": citation,
+        }),
         Event::Usage(usage) => serde_json::json!({
             "kind": "usage",
             "input_tokens": usage.input_tokens,
@@ -367,6 +447,7 @@ pub fn simplified_event(event: &Event) -> Value {
         }),
         Event::Completed => serde_json::json!({"kind": "completed"}),
         Event::Incomplete => serde_json::json!({"kind": "incomplete"}),
+        Event::PausedTurn => serde_json::json!({"kind": "paused_turn"}),
         Event::Failed(failure) => serde_json::json!({
             "kind": "failed",
             "failure_class": failure.failure_class.as_str(),
@@ -411,6 +492,10 @@ pub struct ToolAccumulator {
     pub raw_arguments: String,
     pub completed: bool,
     pub custom: bool,
+    /// Whether this is a provider-executed Anthropic server tool
+    /// (`server_tool_use`), whose lifecycle events stay on the dedicated
+    /// server-tool variants and never count toward the tool-use stop reason.
+    pub server: bool,
 }
 
 impl ToolAccumulator {
@@ -423,6 +508,7 @@ impl ToolAccumulator {
             raw_arguments: String::new(),
             completed: false,
             custom: false,
+            server: false,
         }
     }
 
@@ -470,6 +556,24 @@ pub fn count_or_zero(object: &Map<String, Value>, key: &str, label: &str) -> Res
             .as_u64()
             .filter(|count| *count <= MAXIMUM_LEDGER_COUNT)
             .ok_or_else(|| format!("{label} must be a non-negative integer")),
+    }
+}
+
+/// Read one count only when its key is present and non-null: an absent key
+/// yields `None` so a partial usage report never overwrites an earlier leg
+/// with an invented zero.
+pub fn count_if_present(
+    object: &Map<String, Value>,
+    key: &str,
+    label: &str,
+) -> Result<Option<u64>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_u64()
+            .filter(|count| *count <= MAXIMUM_LEDGER_COUNT)
+            .map(Some)
+            .ok_or_else(|| format!("{label}.{key} must be a non-negative integer")),
     }
 }
 

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -86,6 +86,15 @@ pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event>
             | Event::ThinkingSignature { .. }
             | Event::RedactedThinking { .. }
             | Event::EncryptedReasoning { .. } => {}
+            // Server-tool activity and citations carry the fetched content
+            // (queries, result payloads, cited text) that a rewrite must not
+            // leak, so they drop with the reasoning channel.
+            Event::TextBlockStarted { .. }
+            | Event::CitationDelta { .. }
+            | Event::ServerToolUseStarted { .. }
+            | Event::ServerToolArgumentsDelta { .. }
+            | Event::ServerToolUseCompleted { .. }
+            | Event::ServerToolResult { .. } => {}
             Event::TextDelta(_) | Event::ProviderTextDelta { .. } => {
                 if inserted {
                     continue;
@@ -93,7 +102,9 @@ pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event>
                 rewritten.push(Event::TextDelta(replacement.to_string()));
                 inserted = true;
             }
-            Event::Completed | Event::Incomplete | Event::Failed(_) if !inserted => {
+            Event::Completed | Event::Incomplete | Event::PausedTurn | Event::Failed(_)
+                if !inserted =>
+            {
                 rewritten.push(Event::TextDelta(replacement.to_string()));
                 inserted = true;
                 rewritten.push(event.clone());

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -486,8 +486,65 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                     .get("reasoning_tokens")
                     .and_then(serde_json::Value::as_u64),
             }),
+            "server_tool_use_started" => events::Event::ServerToolUseStarted {
+                index,
+                call_id: object
+                    .get("call_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                name: object
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "server_tool_arguments_delta" => {
+                events::Event::ServerToolArgumentsDelta { index, delta: text }
+            }
+            "server_tool_use_completed" => events::Event::ServerToolUseCompleted {
+                index,
+                call: events::CompletedToolCall {
+                    call_id: object
+                        .get("call_id")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    name: object
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                    raw_arguments: object
+                        .get("raw_arguments")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    custom: false,
+                },
+            },
+            "server_tool_result" => events::Event::ServerToolResult {
+                index,
+                block: object
+                    .get("block")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
+            "text_block_started" => events::Event::TextBlockStarted { index },
+            "citation_delta" => events::Event::CitationDelta {
+                index,
+                citation: object
+                    .get("citation")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+            },
             "completed" => events::Event::Completed,
             "incomplete" => events::Event::Incomplete,
+            "paused_turn" => events::Event::PausedTurn,
             "failed" => events::Event::Failed(errors::Failure::new(
                 errors::FailureClass::ProviderInternal,
                 if text.is_empty() {

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -45,8 +45,14 @@ pub fn event_retained_bytes(event: &Event) -> usize {
             encrypted_content, ..
         } => encrypted_content.len(),
         Event::ReasoningContentDelta { delta, .. } => delta.len(),
-        Event::ToolArgumentsDelta { delta, .. } => delta.len(),
-        Event::ToolCallCompleted { call, .. } => call.raw_arguments.len().max(64),
+        Event::ToolArgumentsDelta { delta, .. } | Event::ServerToolArgumentsDelta { delta, .. } => {
+            delta.len()
+        }
+        Event::ToolCallCompleted { call, .. } | Event::ServerToolUseCompleted { call, .. } => {
+            call.raw_arguments.len().max(64)
+        }
+        Event::ServerToolResult { block, .. } => block.len(),
+        Event::CitationDelta { citation, .. } => citation.len(),
         _ => 64,
     }
 }
@@ -104,7 +110,12 @@ pub fn track_event(event: &Event, usage: &mut Option<Usage>, tool_names: &mut Ve
         Event::Usage(candidate) if candidate.has_token_counts() => {
             *usage = Some(candidate.clone());
         }
-        Event::ToolCallCompleted { call, .. } if !tool_names.contains(&call.name) => {
+        Event::ToolCallCompleted { call, .. } | Event::ServerToolUseCompleted { call, .. }
+            if !tool_names.contains(&call.name) =>
+        {
+            // Server tool invocations are provider-executed but still
+            // invoked tools: their names join usage so operators can see
+            // (and price) per-invocation server tool activity.
             tool_names.push(call.name.clone());
         }
         _ => {}

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -183,6 +183,12 @@ fn is_semantic(event: &Event) -> bool {
             | Event::ToolCallStarted { .. }
             | Event::ToolArgumentsDelta { .. }
             | Event::ToolCallCompleted { .. }
+            | Event::TextBlockStarted { .. }
+            | Event::CitationDelta { .. }
+            | Event::ServerToolUseStarted { .. }
+            | Event::ServerToolArgumentsDelta { .. }
+            | Event::ServerToolUseCompleted { .. }
+            | Event::ServerToolResult { .. }
     )
 }
 

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4314,3 +4314,84 @@ def test_effort_none_drops_with_disclosure_on_a_reasoning_less_route(
     assert payload["status_code"] == 400
     assert payload["param"] == "reasoning_effort"
     assert payload["code"] == "unsupported_parameter"
+
+
+def _web_search_fixture_json() -> str:
+    """One WebSearch event stream in the fixture-event vocabulary."""
+    result_block = (
+        '{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1",'
+        '"content":[{"type":"web_search_result","encrypted_content":"Et8Q"}],'
+        '"caller":{"type":"direct"}}'
+    )
+    citation = '{"type":"web_search_result_location","cited_text":"3.14.7"}'
+    return json.dumps(
+        [
+            {
+                "kind": "server_tool_use_started",
+                "index": 0,
+                "call_id": "srvtoolu_1",
+                "name": "web_search",
+            },
+            {"kind": "server_tool_arguments_delta", "index": 0, "text": '{"query": "python"}'},
+            {
+                "kind": "server_tool_use_completed",
+                "index": 0,
+                "call_id": "srvtoolu_1",
+                "name": "web_search",
+                "raw_arguments": '{"query": "python"}',
+            },
+            {"kind": "server_tool_result", "index": 1, "block": result_block},
+            {"kind": "text_block_started", "index": 2},
+            {"kind": "citation_delta", "index": 2, "citation": citation},
+            {"kind": "text_delta", "text": "It is 3.14.7."},
+            {"kind": "usage", "input_tokens": 12284, "output_tokens": 103},
+            {"kind": "completed"},
+        ]
+    )
+
+
+def test_rust_messages_streams_server_tool_blocks_intact() -> None:
+    """Server tool events stream back as their native Anthropic blocks."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    frames = list(
+        native.encode_messages_fixture("request-abc", "coding", _web_search_fixture_json())
+    )
+    joined = "".join(frames)
+    assert '"type":"server_tool_use","id":"srvtoolu_1","name":"web_search"' in joined
+    assert '"type":"web_search_tool_result"' in joined
+    assert '"caller":{"type":"direct"}' in joined
+    assert '"type":"citations_delta"' in joined
+    # Provider-executed tool use never becomes the tool_use stop reason.
+    assert '"stop_reason":"end_turn"' in joined
+
+
+def test_rust_messages_completed_body_carries_server_tool_blocks() -> None:
+    """The non-streaming aggregation keeps every server-tool block in order."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    body = json.loads(
+        native.completed_messages_fixture("request-abc", "coding", _web_search_fixture_json())
+    )
+    kinds = [block["type"] for block in body["content"]]
+    assert kinds == ["server_tool_use", "web_search_tool_result", "text"]
+    assert body["content"][2]["citations"] == [
+        {"type": "web_search_result_location", "cited_text": "3.14.7"}
+    ]
+    assert body["stop_reason"] == "end_turn"
+
+
+def test_rust_messages_paused_turn_keeps_its_stop_reason() -> None:
+    """A pause_turn terminal survives to the caller instead of end_turn."""
+    native = pytest.importorskip("exp_gateway_native")
+
+    fixture = json.dumps(
+        [
+            {"kind": "text_delta", "text": "searching"},
+            {"kind": "paused_turn"},
+        ]
+    )
+    frames = "".join(native.encode_messages_fixture("request-abc", "coding", fixture))
+    assert '"stop_reason":"pause_turn"' in frames
+    body = json.loads(native.completed_messages_fixture("request-abc", "coding", fixture))
+    assert body["stop_reason"] == "pause_turn"

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -443,6 +443,10 @@ ANTHROPIC_THINKING_EVENTS: tuple[JsonObject, ...] = (
     {"kind": "thinking_delta", "index": 0, "text": "step one"},
     {"kind": "thinking_signature", "index": 0, "signature": "c2ln"},
     {"kind": "redacted_thinking", "index": 1, "data": "b3BhcXVl"},
+    # Every Anthropic text block opens with its boundary event so the
+    # Messages encoder mirrors the provider's block structure (citations
+    # attach per block); block-less encoders ignore it.
+    {"kind": "text_block_started", "index": 2},
     {"kind": "text_delta", "text": "Hi"},
     {
         "kind": "usage",
@@ -577,6 +581,123 @@ def test_native_anthropic_normalizer_completes_a_zero_argument_tool_call() -> No
         },
         {"kind": "completed"},
     ]
+
+
+# Captured from a live api.anthropic.com web_search stream (2026-08-31,
+# claude-haiku-4-5, ids neutralized, results trimmed to one and encrypted
+# payloads shortened; structure and frame order are the real wire): the
+# server_tool_use block streams input like a client tool but with an
+# srvtoolu_ id, the whole web_search_tool_result block (caller field
+# included) rides its start frame, the answer text block opens with an empty
+# citations array and its citations_delta arrives BEFORE the first
+# text_delta, and the terminal usage reports the true post-search input
+# total (12284) that the message_start count (2230) severely undercounts.
+ANTHROPIC_LIVE_WEB_SEARCH_FRAMES: tuple[bytes, ...] = (
+    b'event: message_start\ndata: {"type":"message_start","message":{"model":"claude-haiku-4-5",'
+    b'"id":"msg_fixture","type":"message","role":"assistant","content":[],"stop_reason":null,'
+    b'"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2230,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":'
+    b'{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":25,'
+    b'"service_tier":"standard","inference_geo":"not_available"}}         }\n\n',
+    b'event: content_block_start\ndata: {"type":"content_block_start","index":0,'
+    b'"content_block":{"type":"server_tool_use","id":"srvtoolu_fixture","name":"web_search",'
+    b'"input":{}}            }\n\n',
+    b'event: ping\ndata: {"type": "ping"}\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":""}             }\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":"{\\"query\\": \\"c"}}\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+    b'"delta":{"type":"input_json_delta","partial_json":"urrent stable Python\\"}"}  }\n\n',
+    b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0 }\n\n',
+    b'event: content_block_start\ndata: {"type":"content_block_start","index":1,'
+    b'"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_fixture",'
+    b'"content":[{"type":"web_search_result","title":"Python versions",'
+    b'"url":"https://www.python.org/doc/versions/","encrypted_content":"Et8QCioIExgC",'
+    b'"page_age":"March 12, 2026"}],"caller":{"type":"direct"}}        }\n\n',
+    b'event: content_block_stop\ndata: {"type":"content_block_stop","index":1    }\n\n',
+    b'event: content_block_start\ndata: {"type":"content_block_start","index":2,'
+    b'"content_block":{"citations":[],"type":"text","text":""}}\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,'
+    b'"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location",'
+    b'"cited_text":"Python 3.14.7, released on 5 August 2026",'
+    b'"url":"https://www.python.org/doc/versions/","title":"Python versions",'
+    b'"encrypted_index":"Eo8BCioIExgC"}}  }\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,'
+    b'"delta":{"type":"text_delta","text":"The"}       }\n\n',
+    b'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,'
+    b'"delta":{"type":"text_delta","text":" current stable Python version is 3.14.7."} }\n\n',
+    b'event: content_block_stop\ndata: {"type":"content_block_stop","index":2 }\n\n',
+    b'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn",'
+    b'"stop_sequence":null,"stop_details":null},"usage":{"input_tokens":12284,'
+    b'"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":103,'
+    b'"server_tool_use":{"web_search_requests":1,"web_fetch_requests":0}}     }\n\n',
+    b'event: message_stop\ndata: {"type":"message_stop"  }\n\n',
+)
+
+ANTHROPIC_LIVE_WEB_SEARCH_EVENTS: tuple[JsonObject, ...] = (
+    {
+        "kind": "server_tool_use_started",
+        "index": 0,
+        "call_id": "srvtoolu_fixture",
+        "name": "web_search",
+    },
+    {"kind": "server_tool_arguments_delta", "index": 0, "text": ""},
+    {"kind": "server_tool_arguments_delta", "index": 0, "text": '{"query": "c'},
+    {"kind": "server_tool_arguments_delta", "index": 0, "text": 'urrent stable Python"}'},
+    {
+        "kind": "server_tool_use_completed",
+        "index": 0,
+        "call_id": "srvtoolu_fixture",
+        "name": "web_search",
+        "raw_arguments": '{"query": "current stable Python"}',
+    },
+    {
+        "kind": "server_tool_result",
+        "index": 1,
+        "block": (
+            '{"type":"web_search_tool_result","tool_use_id":"srvtoolu_fixture",'
+            '"content":[{"type":"web_search_result","title":"Python versions",'
+            '"url":"https://www.python.org/doc/versions/","encrypted_content":"Et8QCioIExgC",'
+            '"page_age":"March 12, 2026"}],"caller":{"type":"direct"}}'
+        ),
+    },
+    {"kind": "text_block_started", "index": 2},
+    {
+        "kind": "citation_delta",
+        "index": 2,
+        "citation": (
+            '{"type":"web_search_result_location",'
+            '"cited_text":"Python 3.14.7, released on 5 August 2026",'
+            '"url":"https://www.python.org/doc/versions/","title":"Python versions",'
+            '"encrypted_index":"Eo8BCioIExgC"}'
+        ),
+    },
+    {"kind": "text_delta", "text": "The"},
+    {"kind": "text_delta", "text": " current stable Python version is 3.14.7."},
+    {
+        "kind": "usage",
+        # The terminal usage report supersedes the start-frame input legs:
+        # the model re-reads fetched results as input.
+        "input_tokens": 12284,
+        "output_tokens": 103,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": None,
+    },
+    {"kind": "completed"},
+)
+
+
+def test_native_anthropic_normalizer_decodes_the_live_web_search_wire() -> None:
+    """The captured WebSearch wire decodes to dedicated server-tool events.
+
+    Production incident (2026-08-31 class): server_tool_use blocks were
+    skipped as unknown, so their input_json_delta frames failed the whole
+    stream as malformed, and the request itself 400d at decode.
+    """
+    result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_WEB_SEARCH_FRAMES)
+    assert result["failure"] is None
+    assert result["events"] == list(ANTHROPIC_LIVE_WEB_SEARCH_EVENTS)
 
 
 def test_native_responses_preserves_multi_message_status_phase_and_idless_call() -> None:

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -111,6 +111,16 @@ def anthropic_messages_stream_payload(
                 translated["input_examples"] = list(tool.input_examples)
             tools.append(translated)
         payload["tools"] = tools
+    if request.provider_server_tools:
+        # Server tools re-emit verbatim after the converted custom tools (an
+        # accepted ordering deviation); route admission guarantees this
+        # dispatch is an Anthropic rung, which owns their validity rules.
+        server_entries = [dict(entry) for entry in request.provider_server_tools]
+        existing_tools = payload.get("tools")
+        if isinstance(existing_tools, list):
+            existing_tools.extend(server_entries)
+        else:
+            payload["tools"] = server_entries
     tool_choice: JsonObject | None = None
     if request.tool_choice is not None:
         if isinstance(request.tool_choice, GatewayNamedToolChoice):

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -546,6 +546,25 @@ def route_generation_parameter_requests(
                 param="thinking.type",
                 code="unsupported_parameter",
             )
+    server_tools_present = bool(request.provider_server_tools) or any(
+        message.provider_anthropic_block is not None for message in request.messages
+    )
+    if server_tools_present and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        # Server tools execute at the provider; silently dropping a search
+        # capability the caller asked for would be a behavior lie, so a
+        # route that cannot serve them rejects by name instead.
+        raise ProviderParameterError(
+            message=(
+                "The request carries Anthropic server tools (web_search-style "
+                "entries or their echoed result blocks) that only a native "
+                "Anthropic route can serve. Remove the server tools or choose "
+                "a different model alias."
+            ),
+            param="tools",
+            code="unsupported_parameter",
+        )
     if any(message.provider_native_item is not None for message in request.messages) and not all(
         profile.dialect == "openai_responses" for profile in profiles
     ):
@@ -608,7 +627,12 @@ def route_generation_parameter_requests(
 
     # Tool-selection controls have no semantics without tool definitions and
     # several provider APIs reject the otherwise harmless combination.
-    if not request.tools:
+    # Verbatim server tools are tool definitions too: a request carrying only
+    # web_search keeps its tool_choice on the wire.
+    server_tool_names = tuple(
+        str(entry["name"]) for entry in request.provider_server_tools if "name" in entry
+    )
+    if not request.tools and not request.provider_server_tools:
         if request.tool_choice == "required" or isinstance(
             request.tool_choice, GatewayNamedToolChoice
         ):
@@ -624,8 +648,10 @@ def route_generation_parameter_requests(
             ignore("tool_choice")
         if request.parallel_tool_calls is not None:
             ignore("parallel_tool_calls")
-    elif isinstance(request.tool_choice, GatewayNamedToolChoice) and not any(
-        tool.name == request.tool_choice.name for tool in request.tools
+    elif (
+        isinstance(request.tool_choice, GatewayNamedToolChoice)
+        and not any(tool.name == request.tool_choice.name for tool in request.tools)
+        and request.tool_choice.name not in server_tool_names
     ):
         raise ProviderParameterError(
             message=(

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2176,3 +2176,148 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     }
     assert mixed_provider.provider_cache_control is None
     assert mixed_provider.inference_geo is None
+
+
+def _web_search_messages_request(
+    *,
+    tool_choice: Literal["auto", "none", "required"] | GatewayNamedToolChoice | None = None,
+    echoed_block: bool = False,
+) -> GatewayRequest:
+    """Build one Messages request carrying a verbatim web_search server tool."""
+    messages: tuple[GatewayMessage, ...] = (GatewayMessage(role="user", content="search"),)
+    if echoed_block:
+        messages += (
+            GatewayMessage(
+                role="assistant",
+                provider_anthropic_block={
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_1",
+                    "name": "web_search",
+                    "input": {"query": "python"},
+                },
+            ),
+            GatewayMessage(role="user", content="and now?"),
+        )
+    return GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=messages,
+        provider_server_tools=(
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+        ),
+        tool_choice=tool_choice,
+        maximum_output_tokens=256,
+        maximum_output_tokens_parameter="max_tokens",
+        stream=True,
+        include_usage=True,
+    )
+
+
+def _anthropic_web_search_profile(url: str = "https://anthropic.test") -> GatewayWireProfile:
+    """Return one native Anthropic Messages wire profile."""
+    return GatewayWireProfile(
+        dialect="anthropic_messages",
+        url=url,
+        model_id="claude-haiku-4-5",
+        reasoning_wire_format="anthropic_adaptive",
+    )
+
+
+def test_server_tools_reject_mixed_routes_by_name() -> None:
+    """A route with any non-Anthropic rung cannot serve server tools.
+
+    Rejection, not disclosure-drop: silently removing a search capability
+    the caller asked for would falsify every answer that needed it.
+    """
+    profiles = (
+        _anthropic_web_search_profile(),
+        GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test"),
+    )
+    for request in (
+        _web_search_messages_request(),
+        _web_search_messages_request(echoed_block=True).model_copy(
+            update={"provider_server_tools": ()}
+        ),
+    ):
+        with pytest.raises(ProviderParameterError) as raised:
+            route_generation_parameter_requests(profiles, request)
+        assert raised.value.code == "unsupported_parameter"
+        assert raised.value.param == "tools"
+        assert "Anthropic" in str(raised.value)
+
+
+def test_server_tools_keep_tool_choice_on_an_anthropic_route() -> None:
+    """Server tools count as tool definitions for the no-op selector rule."""
+    profiles = (
+        _anthropic_web_search_profile(),
+        _anthropic_web_search_profile("https://anthropic-b.test"),
+    )
+    for tool_choice in ("auto", "required", GatewayNamedToolChoice(name="web_search")):
+        request = _web_search_messages_request(tool_choice=tool_choice)
+        public_request, provider_request = route_generation_parameter_requests(profiles, request)
+        assert "tool_choice" not in public_request.ignored_parameters
+        assert provider_request.tool_choice == tool_choice
+        assert provider_request.provider_server_tools == request.provider_server_tools
+
+
+def test_anthropic_payload_appends_server_tools_verbatim_after_custom_tools() -> None:
+    """Server tool entries re-emit byte-for-byte after the converted tools."""
+    request = _web_search_messages_request(tool_choice="auto").model_copy(
+        update={
+            "tools": (GatewayToolDefinition(name="Bash", parameters={"type": "object"}),),
+        }
+    )
+    payload = anthropic_messages_stream_payload("claude-haiku-4-5", request)
+    assert payload["tools"] == [
+        {"name": "Bash", "input_schema": {"type": "object"}},
+        {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+    ]
+    assert payload["tool_choice"] == {"type": "auto"}
+
+
+def test_anthropic_payload_serves_a_server_tool_only_toolset() -> None:
+    """A request whose only tools are server tools still sends a tools array."""
+    payload = anthropic_messages_stream_payload("claude-haiku-4-5", _web_search_messages_request())
+    assert payload["tools"] == [
+        {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
+    ]
+
+
+def test_anthropic_payload_reemits_echoed_server_blocks_in_order() -> None:
+    """Echoed server-tool blocks re-emit verbatim at their positions."""
+    cited_text: JsonObject = {
+        "citations": [{"type": "web_search_result_location", "encrypted_index": "Eo8B"}],
+        "type": "text",
+        "text": "It is 3.14.7.",
+    }
+    result_block: JsonObject = {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "content": [{"type": "web_search_result", "encrypted_content": "Et8Q"}],
+        "caller": {"type": "direct"},
+    }
+    request = _web_search_messages_request(echoed_block=True)
+    messages = (
+        request.messages[:2]
+        + (
+            GatewayMessage(role="assistant", provider_anthropic_block=result_block),
+            GatewayMessage(role="assistant", provider_anthropic_block=cited_text),
+        )
+        + request.messages[2:]
+    )
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5", request.model_copy(update={"messages": messages})
+    )
+    wire_messages = cast(list[JsonObject], payload["messages"])
+    assert [message["role"] for message in wire_messages] == ["user", "assistant", "user"]
+    # Consecutive assistant carrier messages merge back into one turn with
+    # the exact echoed block order.
+    assert wire_messages[1]["content"] == [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "python"},
+        },
+        result_block,
+        cited_text,
+    ]

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -124,6 +124,10 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         return "user", [{"type": "text", "text": message.content or ""}]
     if message.role != "assistant":
         raise ProviderResponseError("unsupported Anthropic message role")
+    if message.provider_anthropic_block is not None:
+        # An echoed server-tool block re-emits byte-for-byte at its position;
+        # route admission guarantees this dispatch is an Anthropic rung.
+        return "assistant", [message.provider_anthropic_block]
     blocks: list[JsonObject] = []
     for reasoning in message.provider_reasoning:
         # Thinking blocks lead the assistant turn (the Anthropic contract)

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from exp.runtime.gateway.contracts import (
+from exp.runtime.gateway.compatibility import (
     CompatibilityDisposition,
     CompatibilityField,
     CompatibilityManifest,
-    GatewayApiSurface,
 )
+from exp.runtime.gateway.contracts import GatewayApiSurface
 
 
 def _field(

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -7,7 +7,10 @@ import typing
 import pytest
 
 from exp.common.models.model import ReasoningEffort
-from exp.runtime.gateway.contracts import CompatibilityDisposition, CompatibilityManifest
+from exp.runtime.gateway.compatibility import (
+    CompatibilityDisposition,
+    CompatibilityManifest,
+)
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     RESPONSES_INCLUDE_PATHS_ACCEPTED,

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -19,9 +19,11 @@ from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import ContractModel, JsonObject
 from exp.common.models.model import ToolCall
-from exp.runtime.gateway.contracts import (
+from exp.runtime.gateway.compatibility import (
     CompatibilityDisposition,
     CompatibilityManifest,
+)
+from exp.runtime.gateway.contracts import (
     EncryptedReasoningBlock,
     GatewayApiSurface,
     GatewayMessage,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.11,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.12,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.11"
+version = "0.3.12"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
Serve Anthropic server tools (WebSearch) end to end through the gateway.

## Problem

Claude Code's WebSearch sends a tools entry the strict Messages decoder cannot
represent (`{"type":"web_search_20250305","name":"web_search",...}`, no
`input_schema`), so every session with WebSearch enabled got a 400. Three more
layers sat behind that 400, each verified against the live API with the house
key (2026-08-31):

1. **Stream failure.** The native normalizer skipped `server_tool_use` start
   blocks as unknown, then failed the whole stream at the block's first
   `input_json_delta` ("provider emitted arguments before a tool start").
2. **Turn-2 echo failure.** Multi-turn sessions echo the served blocks back;
   `_REJECTED_BLOCK_HINTS` consciously 400d `server_tool_use` and
   `web_search_tool_result` history blocks, and the strict `_TextBlock`
   rejected the `citations` array every cited answer carries.
3. **Fidelity lies.** `citations_delta` frames were silently dropped, a
   `pause_turn` stop reason would have been rewritten to `end_turn` (the caller
   would never resume the paused turn), and the terminal `message_delta` usage
   (the TRUE post-search input count: 12284 vs 2230 at `message_start` on the
   captured stream, a 5.5x billing undercount) was never read.

## Change

**Request (python decode → canonical contract):**
- `tools` decodes as `_Tool | _ServerTool`; server entries are shallow-validated
  (evolving provider surface) and carried raw on a new Messages-only
  `GatewayRequest.provider_server_tools` carrier that joins replay identity,
  mirroring `provider_thinking_config`.
- Accept/reject decision tables in `manifest.py`
  (`MESSAGES_SERVER_TOOL_TYPES_ACCEPTED/REJECTED`) with a new SDK drift gate
  over `ToolUnionParam`/`BetaToolUnionParam`: all three `web_search_*` versions
  accepted (each verified live to emit the block vocabulary this gateway now
  carries); every other Anthropic-defined type rejected BY NAME because the
  data plane does not carry its result blocks (never a silent half-serve).
- Echoed history blocks (`server_tool_use`, `web_search_tool_result`,
  citation-bearing `text`) ride a new whole-message verbatim carrier
  (`GatewayMessage.provider_anthropic_block`, mirroring `provider_native_item`);
  decode splits the assistant turn at block boundaries and the anthropic
  payload builder merges consecutive assistant messages back, so re-emission
  preserves exact block order. Server tools re-emit after converted custom
  tools (documented ordering deviation).
- Route narrowing rejects server tools on any non-Anthropic rung by name
  (reject-not-drop: silently removing a requested search capability would
  falsify answers). `tool_choice` may name a server tool; a server-tool-only
  toolset no longer no-op-drops `tool_choice`.

**Response (Rust data plane, crate 0.3.11 → 0.3.12):**
- New events: `ServerToolUseStarted/ArgumentsDelta/UseCompleted`,
  `ServerToolResult` (whole verbatim block), `TextBlockStarted` (provider
  text-block boundary so citations attach per block), `CitationDelta`
  (verbatim citation object), and the `PausedTurn` terminal.
- The anthropic normalizer parses all of them, keeps `pause_turn`, and now
  folds the terminal `message_delta` input/cache legs when present (billing
  fix; live plain turns carry the same legs, verified).
- The Messages encoder streams the blocks back in valid Anthropic lifecycle
  order and aggregates them identically for non-streaming callers; server tool
  use never yields the `tool_use` stop reason. Chat/Responses encoders reject
  server-tool events (unreachable by construction) and ignore
  boundary/citation metadata like the thinking family. Guardrail text
  replacement drops server-tool content with the reasoning channel (fetched
  content must not leak through a rewrite). Server tool names join usage
  `tool_names` for per-invocation observability (searches are provider-priced
  at $10/1k; platform-side pricing of search units is a named follow-up).

## Evidence

- Live capture pinned as a parity golden
  (`test_native_anthropic_normalizer_decodes_the_live_web_search_wire`):
  ids neutralized, results trimmed, frame order and shapes are the real wire.
- Live acceptance through a locally served native gateway with the house key:
  turn 1 streamed a real WebSearch 200 end to end
  (`server_tool_use` → `web_search_tool_result` → cited text, stop `end_turn`,
  usage 12282/103), turn 2 echoed the returned blocks and re-served ("3.14.7").
- Turn-2 echo also verified directly against api.anthropic.com with the exact
  captured blocks (200), including the `caller: {"type":"direct"}` extras.
- `web_search_20260209`/`20260318` probed live: identical block vocabulary
  (they 400 on haiku unless `allowed_callers: ["direct"]`; the provider's own
  named, actionable error).

## Gates

- `uv run ruff format` / `ruff check` / `ty check`: clean.
- `uv run pytest -q`: full suite green.
- `cargo test --no-default-features` (118), `cargo clippy -D warnings`,
  `cargo fmt`: clean.

## Known follow-ups (out of scope, named)

- `web_fetch_*` is the obvious next accept: live probes (2026-08-31) show
  `web_fetch_20250910` accepted bare with the same
  `server_tool_use`/`web_fetch_tool_result` lifecycle, so it needs only that
  result-block carriage plus a pinned fixture (bare-accept probes show every
  current-generation type is accepted without beta headers; only the legacy
  2024-10-22 family is beta-gated).
- `bash_20250124`, `text_editor_20250728`, and `memory_20250818` are
  client-executed and emit only ordinary `tool_use` blocks (verified live in
  the #689 probe session), so they are cheap fast-follow accepts once decided
  consciously; they stay rejected by name here.
- On `max_uses` exhaustion the provider replaces the result block's `content`
  list with a single error object. The verbatim carriage handles that shape
  structurally, but no fixture pins it yet; noted as an unpinned case.
- Per-search provider fees are NOT yet customer-billed: Anthropic charges
  $10 per 1,000 searches on the house key, and the gateway's usage contract
  meters tokens only. The `web_search` entry now present in usage
  `tool_names` gives the platform the per-invocation signal to price against;
  the pricing model itself is a platform follow-up for the owner to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
