### PR TITLE
test: guard Unix-only imports in root conftest for Windows compatibility

### DIFF
--- a/exp/conftest.py
+++ b/exp/conftest.py
@@ -3,19 +3,26 @@
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
-import pty
 import re
 import select
 import struct
 import subprocess
 import sys
-import termios
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+if sys.platform != "win32":
+    import fcntl
+    import pty
+    import termios
+else:
+    fcntl: Any = None
+    pty: Any = None
+    termios: Any = None
 
 import pytest
 
@@ -213,6 +220,8 @@ def _run_terminal_child(
     Returns:
         The transcript, the still-visible screen, and the child exit status.
     """
+    if pty is None or fcntl is None or termios is None:
+        pytest.skip("pseudo-terminal execution requires a POSIX environment")
     master, slave = pty.openpty()
     fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", size[0], size[1], 0, 0))
     child_environment = dict(os.environ if environment is None else environment)


### PR DESCRIPTION
### Summary

Unconditionally importing Unix-specific modules (\cntl\, \pty\, \	ermios\) at module scope in \exp/conftest.py\ breaks test collection and execution on Windows with \ModuleNotFoundError: No module named 'fcntl'\.

### Key Changes
- Platform-guards imports of \cntl\, \pty\, and \	ermios\ in \exp/conftest.py\ when running on non-POSIX platforms (\sys.platform != 'win32'\).
- Gracefully skips pseudo-terminal execution in \_run_terminal_child\ on unsupported platforms instead of crashing during fixture collection.
- Enables the full test suite to be collected and executed cleanly on Windows development environments.

### Verification
- Verified \uv run ruff check exp/conftest.py\
- Verified \uv run ruff format --check exp/conftest.py\
- Verified \uv run pytest exp/tests/repo_layout_test.py exp/tests/repo_import_boundaries_test.py -q\ passes on Windows.