### PR TITLE
gateway: class an unavailable Responses continuation as a client failure, not internal

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -430,8 +430,8 @@ class NativeControlPlane(NativeObservabilityMixin):
             self._accounting.finish_request_quietly(
                 authorization,
                 GatewayFailure(
-                    failure_class=GatewayFailureClass.INTERNAL,
-                    safe_message="retained provider continuation authority was unavailable",
+                    failure_class=GatewayFailureClass.INVALID_REQUEST,
+                    safe_message=exc.message,
                 ),
             )
             raise NativeBridgeError(exc) from exc


### PR DESCRIPTION
### Summary

When a Responses continuation request (previous_response_id) references an unavailable or expired route binding, _require_bound_wire_authority raises OpenAIProtocolError with status code 400 (continuation_unavailable).

However, NativeControlPlane.serve_request was catching this error and recording it as GatewayFailureClass.INTERNAL in durable request accounting instead of GatewayFailureClass.INVALID_REQUEST.

### Key Changes
- Maps the reachable continuation_unavailable protocol error to GatewayFailureClass.INVALID_REQUEST in exp/runtime/gateway/native_bridge.py.
- Persists the protocol-safe continuation error message (exc.message) in the terminal request record.
- Prevents routine client 400 bad requests from polluting internal gateway crash metrics and error alarms.

### Verification
- Verified: uv run ruff check exp/runtime/gateway/native_bridge.py
- Verified: uv run ruff format --check exp/runtime/gateway/native_bridge.py