### PR TITLE
Demo: Cache-write fields underbilled

### DIFF
--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -826,19 +826,15 @@ def _unknown_token_volume(
 ) -> tuple[int, int]:
     """Sum observed token volume across one limit's unresolved unknown-cost attempts.
 
-    Input volume includes cached input tokens and output volume includes reasoning
-    tokens, so operators can gauge the real traffic behind attempts whose price is
-    still unknown.
+    Cached-input and reasoning counts are subsets of the total input and output counts,
+    which therefore already include them and must not add them a second time. The result
+    is the real traffic behind attempts whose price is still unknown.
     """
     row = connection.execute(
         """
         SELECT
-            COALESCE(SUM(
-                COALESCE(a.input_tokens, 0) + COALESCE(a.cached_input_tokens, 0)
-            ), 0) AS input_volume,
-            COALESCE(SUM(
-                COALESCE(a.output_tokens, 0) + COALESCE(a.reasoning_tokens, 0)
-            ), 0) AS output_volume
+            COALESCE(SUM(COALESCE(a.input_tokens, 0)), 0) AS input_volume,
+            COALESCE(SUM(COALESCE(a.output_tokens, 0)), 0) AS output_volume
         FROM gateway_attempt_budget_charges AS c
         JOIN gateway_attempts AS a ON a.attempt_id = c.attempt_id
         WHERE c.budget_id = ?

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -528,7 +528,7 @@ def test_default_limit_admits_unpriced_attempts_and_tracks_token_volume(
     remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
     assert remaining.unknown_cost_attempts == 1
     assert remaining.unknown_cost_input_tokens == 120
-    assert remaining.unknown_cost_output_tokens == 20
+    assert remaining.unknown_cost_output_tokens == 16
     assert remaining.remaining_micro_usd == 1_000
     assert not remaining.exhausted
 

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -533,6 +533,84 @@ def test_default_limit_admits_unpriced_attempts_and_tracks_token_volume(
     assert not remaining.exhausted
 
 
+def _reported_volume(root: Path, usage: GatewayUsage) -> tuple[int, int]:
+    """Report one unpriced attempt's observed token volume under a default limit.
+
+    Args:
+        root: Directory holding this attempt's isolated gateway database.
+        usage: Provider-reported token counts for the single unpriced attempt.
+
+    Returns:
+        The limit's reported unknown-cost input and output token volume.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    clock = _Clock()
+    store, ledger, budgets, key = _authority(root, clock)
+    budgets.set_limit(
+        organization_id="org",
+        period="2026-08",
+        scope=BudgetScope(kind=BudgetScopeKind.TEAM),
+        limit_micro_usd=1_000,
+    )
+    _request_value, snapshot = _accepted(store, ledger, clock, key, "volume")
+    attempt = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=_deployment(priced=False),
+        attempt_ordinal=0,
+        route_depth=0,
+        maximum_cost_micro_usd=None,
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=0,
+            usage=usage,
+        ),
+        failure=None,
+    )
+    remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
+    return remaining.unknown_cost_input_tokens, remaining.unknown_cost_output_tokens
+
+
+def test_reported_input_volume_counts_a_cache_hit_once(tmp_path: Path) -> None:
+    """One prompt is the same traffic whether the provider served it fresh or cached.
+
+    ``cached_input_tokens`` is a subset of ``input_tokens``, so a 10,000-token prompt
+    answered entirely from the provider's cache is still 10,000 tokens of traffic.
+    """
+    fresh, _ = _reported_volume(
+        tmp_path / "fresh",
+        GatewayUsage(input_tokens=10_000, output_tokens=50),
+    )
+    cached, _ = _reported_volume(
+        tmp_path / "cached",
+        GatewayUsage(input_tokens=10_000, cached_input_tokens=10_000, output_tokens=50),
+    )
+
+    assert fresh == 10_000
+    assert cached == fresh
+
+
+def test_reported_output_volume_counts_reasoning_once(tmp_path: Path) -> None:
+    """One response is the same traffic whether or not the model reasoned first.
+
+    ``reasoning_tokens`` is a subset of ``output_tokens``, so a 500-token response
+    is 500 tokens of traffic even when every one of them was a reasoning token.
+    """
+    _, plain = _reported_volume(
+        tmp_path / "plain",
+        GatewayUsage(input_tokens=100, output_tokens=500),
+    )
+    _, reasoned = _reported_volume(
+        tmp_path / "reasoned",
+        GatewayUsage(input_tokens=100, output_tokens=500, reasoning_tokens=500),
+    )
+
+    assert plain == 500
+    assert reasoned == plain
+
+
 def test_strict_limit_fails_closed_on_unknown_cost(tmp_path: Path) -> None:
     """A strict limit rejects unpriced attempts and blocks while unknown cost remains."""
     clock = _Clock()

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -788,3 +788,75 @@ def test_native_responses_preserves_multi_message_status_phase_and_idless_call()
     assert not any(
         payload["type"].startswith("response.function_call_arguments") for payload in payloads
     )
+
+
+def _anthropic_prompt_stream(*, fresh: int, cache_write: int) -> tuple[bytes, ...]:
+    """Build one Anthropic stream splitting the prompt between fresh and cache-write tokens.
+
+    Args:
+        fresh: Tokens the provider processed at the ordinary input rate.
+        cache_write: Tokens the provider wrote into its prompt cache.
+
+    Returns:
+        Raw ``message_start`` through ``message_stop`` frames in arrival order.
+    """
+    start = {
+        "type": "message_start",
+        "message": {
+            "model": "claude-haiku-4-5",
+            "id": "msg_fixture",
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "stop_reason": None,
+            "usage": {
+                "input_tokens": fresh,
+                "cache_creation_input_tokens": cache_write,
+                "cache_read_input_tokens": 0,
+                "output_tokens": 0,
+            },
+        },
+    }
+    delta = {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+        "usage": {"output_tokens": 20},
+    }
+    return (
+        b"event: message_start\ndata: " + json.dumps(start).encode() + b"\n\n",
+        b"event: message_delta\ndata: " + json.dumps(delta).encode() + b"\n\n",
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    )
+
+
+def _usage_event(result: JsonObject) -> JsonObject:
+    """Return the single usage event from one normalized stream result.
+
+    Args:
+        result: Decoded ``{"events": [...], "failure": ...}`` fixture result.
+
+    Returns:
+        The usage event in the golden fixture vocabulary.
+    """
+    events = cast(Sequence[JsonObject], result["events"])
+    return next(event for event in events if event["kind"] == "usage")
+
+
+def test_native_anthropic_normalizer_keeps_cache_writes_distinguishable() -> None:
+    """Writing a prompt to the provider cache is not the same billable event as sending it fresh.
+
+    Anthropic bills ``cache_creation_input_tokens`` at 1.25x the ordinary input rate for a
+    five-minute entry and 2x for a one-hour entry, so normalized usage has to keep the write
+    leg separable for the ledger to price either stream correctly.
+    """
+    fresh = _native_normalized(
+        "anthropic_messages",
+        _anthropic_prompt_stream(fresh=1_000, cache_write=0),
+    )
+    written = _native_normalized(
+        "anthropic_messages",
+        _anthropic_prompt_stream(fresh=0, cache_write=1_000),
+    )
+
+    assert _usage_event(fresh)["input_tokens"] == 1_000
+    assert _usage_event(written) != _usage_event(fresh)


### PR DESCRIPTION
Hi Experiential team, thank you for the repo/project.  In reading it to learn more about caching, I think I found a gap.  Claude seems to agree.

Anthropic and OpenAI both report a prompt as a total plus a breakdown:
1. Fresh (normal price)
2. Cache-read (discounted)
3. Cache-write (surcharge)

Arithmetic in `budgets.py` inflated totals by summing input + cached_input.  Output + reasoning.
1. 10,000 token prompt served entirely from cache was reported as 20,000 tokens
2. 500 token response that was entirely reasoning was reported as 1,000 tokens

The native `Usage` struct has no field for cache writes, so:
A: 1,000 tokens processed fresh          -> input_tokens=1000, cached_input_tokens=0
B: 1,000 tokens written to the cache     -> input_tokens=1000, cached_input_tokens=0
These are parsed as identical despite B, the cache-write variant, costing more due to cache-write surcharges.

`test_native_anthropic_normalizer_keeps_cache_writes_distinguishable` demonstrates the bug and is intentionally red.