### PR TITLE
intelligence: chat-capture mining, frontier probes, realism and answer-grading judges

### DIFF
--- a/exp/common/judging/__init__.py
+++ b/exp/common/judging/__init__.py
@@ -19,6 +19,11 @@ from exp.common.judging.calibration_provenance import (
     verify_persisted_calibration,
 )
 from exp.common.judging.display import render_rubric_table
+from exp.common.judging.grading import (
+    AnswerGrade,
+    AnswerGradeError,
+    AnswerGradeJudge,
+)
 from exp.common.judging.interface import Judge
 from exp.common.judging.judgment import DimensionJudgment, Judgment
 from exp.common.judging.labels import HumanLabelSet, HumanScore, HumanScoreHistory, HumanScoreReview
@@ -67,6 +72,9 @@ from exp.common.judging.rubric import (
 )
 
 __all__ = [
+    "AnswerGrade",
+    "AnswerGradeError",
+    "AnswerGradeJudge",
     "CalibrationDatum",
     "CalibrationError",
     "CalibrationReport",

--- a/exp/common/judging/__init__.py
+++ b/exp/common/judging/__init__.py
@@ -43,6 +43,11 @@ from exp.common.judging.proposal import (
     RubricProposalEvidence,
     write_rubric_proposal_evidence,
 )
+from exp.common.judging.realism import (
+    RealismAssessment,
+    RealismJudge,
+    RealismJudgmentError,
+)
 from exp.common.judging.review import (
     RubricReview,
     RubricReviewDraft,
@@ -90,6 +95,9 @@ __all__ = [
     "RawDimensionJudgment",
     "RawJudgment",
     "judge_response_schema",
+    "RealismAssessment",
+    "RealismJudge",
+    "RealismJudgmentError",
     "Rubric",
     "RubricProposal",
     "RubricProposalEvidence",

--- a/exp/common/judging/grading.py
+++ b/exp/common/judging/grading.py
@@ -1,0 +1,133 @@
+"""One-shot answer grading: one candidate answer against one scenario task.
+
+The judge scores how well a single answer accomplishes a single scenario's
+task on a ``[0, 1]`` rubric with a one-line rationale, judging task
+completion only, never style, length, or authorship. Unlike the rubric
+judges, it grades plain text rather than persisted rollout evidence, so an
+eval loop can score arbitrary (scenario, answer) cells. The caller decides
+what a failed grade means; the Experiential Labs platform, the first
+consumer of this seam, treats it as an absent cell because an unscored
+answer proves nothing.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, ValidationError, field_validator
+
+from exp.common.core.artifacts import ContractModel
+from exp.common.models import (
+    ModelClient,
+    ModelMessage,
+    ModelRequest,
+    StructuredReplyError,
+    structured_reply_json,
+)
+
+# Reasoning models spend hidden reasoning tokens (hundreds per call on
+# current frontier models) from the same output budget as the visible JSON
+# verdict, and an exhausted budget is rejected as a truncated reply. The
+# default leaves room for both; a longer reply costs nothing unless produced.
+DEFAULT_GRADING_OUTPUT_TOKENS = 2_000
+
+GRADING_PROMPT = (
+    "You are grading ONE candidate answer to ONE scenario drawn from this "
+    "organization's real traffic.\n"
+    "Score how well the answer accomplishes the scenario's task on a 0..1 "
+    "rubric: 1.0 = fully accomplishes the task, correct and complete; "
+    "0.5 = partially useful; 0.0 = wrong or useless.\n"
+    "Judge task completion only: never the answer's style, its length, or "
+    "which model might have written it.\n"
+    "Respond with ONLY a JSON object, no prose and no code fences: "
+    '{"score": 0.0, "rationale": "..."}. rationale is one line '
+    "(at most 300 characters)."
+)
+
+
+class AnswerGradeError(ValueError):
+    """The judge's reply broke the answer-grading output contract."""
+
+
+class AnswerGrade(ContractModel):
+    """One rubric grade for one (scenario, answer) pair.
+
+    Args:
+        score: Task-completion score in ``[0, 1]``.
+        rationale: One line supporting the score.
+    """
+
+    score: float = Field(ge=0.0, le=1.0)
+    rationale: str = Field(min_length=1, max_length=300)
+
+    @field_validator("rationale")
+    @classmethod
+    def _require_visible_text(cls, value: str) -> str:
+        """Trim edge whitespace and reject a blank-looking rationale."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must contain non-whitespace text")
+        return stripped
+
+
+class AnswerGradeJudge:
+    """Grades one candidate answer against one scenario task on a [0, 1] rubric."""
+
+    def __init__(
+        self,
+        client: ModelClient,
+        *,
+        maximum_output_tokens: int = DEFAULT_GRADING_OUTPUT_TOKENS,
+    ) -> None:
+        """Bind the judge to one configured model client.
+
+        Args:
+            client: Configured judge model client.
+            maximum_output_tokens: Upper bound for each verdict reply.
+
+        Raises:
+            ValueError: ``maximum_output_tokens`` is not positive.
+        """
+        if maximum_output_tokens <= 0:
+            raise ValueError("maximum_output_tokens must be positive")
+        self._client = client
+        self._maximum_output_tokens = maximum_output_tokens
+
+    def grade(self, *, task: str, answer: str) -> AnswerGrade:
+        """One model call grading one answer against one scenario task.
+
+        Args:
+            task: The scenario task text, sent verbatim.
+            answer: The candidate answer text, sent verbatim.
+
+        Returns:
+            The parsed rubric grade.
+
+        Raises:
+            ValueError: ``task`` or ``answer`` is empty.
+            AnswerGradeError: The reply was truncated at the token limit,
+                carried no text, or broke the JSON contract.
+        """
+        if not task.strip():
+            raise ValueError("answer grading needs non-empty scenario task text")
+        if not answer.strip():
+            raise ValueError("answer grading needs non-empty candidate answer text")
+        response = self._client.complete(
+            ModelRequest(
+                messages=(
+                    ModelMessage(role="system", content=GRADING_PROMPT),
+                    ModelMessage(
+                        role="user",
+                        content=f"SCENARIO TASK:\n{task}\n\nCANDIDATE ANSWER:\n{answer}",
+                    ),
+                ),
+                maximum_output_tokens=self._maximum_output_tokens,
+            )
+        )
+        try:
+            raw = structured_reply_json(response)
+        except StructuredReplyError as error:
+            raise AnswerGradeError(str(error)) from error
+        try:
+            return AnswerGrade.model_validate(raw)
+        except ValidationError as error:
+            msg = "the judge returned a grade outside the contracted shape; rerun the grading"
+            raise AnswerGradeError(msg) from error

--- a/exp/common/judging/grading_test.py
+++ b/exp/common/judging/grading_test.py
@@ -1,0 +1,149 @@
+"""Behavior tests for the one-shot answer-grading judge over a scripted client."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exp.common.judging.grading import (
+    GRADING_PROMPT,
+    AnswerGradeError,
+    AnswerGradeJudge,
+)
+from exp.common.models import (
+    AssistantAction,
+    BillingSource,
+    ModelFinishReason,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+)
+
+_DIGEST = "c" * 64
+
+
+def _model() -> ModelSnapshot:
+    """Return one deterministic judge model identity."""
+    return ModelSnapshot(
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        provider="scripted",
+        model_id="grading-judge",
+        capabilities_sha256=_DIGEST,
+        connection_sha256=_DIGEST,
+    )
+
+
+class _ScriptedClient:
+    """Deterministic client returning one preconfigured completion."""
+
+    def __init__(
+        self,
+        content: str | None,
+        *,
+        tool_calls: tuple[ToolCall, ...] = (),
+        finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+    ) -> None:
+        """Store the scripted reply and start capturing requests."""
+        self._content = content
+        self._tool_calls = tool_calls
+        self._finish_reason = finish_reason
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Capture the request and return the scripted completion."""
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(content=self._content, tool_calls=self._tool_calls),
+            model=_model(),
+            economics=OperationEconomics(),
+            finish_reason=self._finish_reason,
+        )
+
+
+def _verdict(score: float) -> str:
+    """Return a contract-valid grade payload."""
+    return json.dumps({"score": score, "rationale": "Covers the task with one small gap."})
+
+
+def test_grades_one_answer_against_one_task() -> None:
+    """A contract-valid verdict yields the parsed score and rationale."""
+    client = _ScriptedClient(_verdict(0.5))
+    grade = AnswerGradeJudge(client).grade(
+        task="Reset the billing password.",
+        answer="Open Settings, choose Billing, then Reset password.",
+    )
+    assert grade.score == 0.5
+    assert grade.rationale == "Covers the task with one small gap."
+
+
+def test_sends_the_completion_only_prompt_and_both_texts() -> None:
+    """The prompt forbids style judging; task and answer ride labeled and verbatim."""
+    client = _ScriptedClient(_verdict(1.0))
+    AnswerGradeJudge(client, maximum_output_tokens=321).grade(
+        task="Task text.",
+        answer="Answer text.",
+    )
+    (request,) = client.requests
+    assert request.messages[0].role == "system"
+    assert request.messages[0].content == GRADING_PROMPT
+    assert "Judge task completion only" in str(request.messages[0].content)
+    assert (
+        request.messages[1].content
+        == "SCENARIO TASK:\nTask text.\n\nCANDIDATE ANSWER:\nAnswer text."
+    )
+    assert request.maximum_output_tokens == 321
+
+
+def test_accepts_a_fenced_json_verdict_and_integer_scores() -> None:
+    """A single json-fenced verdict parses, and integer 0 and 1 scores are valid."""
+    client = _ScriptedClient(f"```json\n{json.dumps({'score': 1, 'rationale': 'Complete.'})}\n```")
+    assert AnswerGradeJudge(client).grade(task="Task.", answer="Answer.").score == 1.0
+
+
+def test_rejects_non_json_output() -> None:
+    """Prose instead of JSON fails loudly instead of scoring nothing."""
+    client = _ScriptedClient("I would give this about half marks.")
+    with pytest.raises(AnswerGradeError, match="non-JSON"):
+        AnswerGradeJudge(client).grade(task="Task.", answer="Answer.")
+
+
+def test_rejects_a_grade_outside_the_contract() -> None:
+    """Out-of-range scores and blank rationales break the contract."""
+    out_of_range = _ScriptedClient(json.dumps({"score": 1.5, "rationale": "x"}))
+    with pytest.raises(AnswerGradeError, match="contracted shape"):
+        AnswerGradeJudge(out_of_range).grade(task="Task.", answer="Answer.")
+    blank_rationale = _ScriptedClient(json.dumps({"score": 0.5, "rationale": "   "}))
+    with pytest.raises(AnswerGradeError, match="contracted shape"):
+        AnswerGradeJudge(blank_rationale).grade(task="Task.", answer="Answer.")
+
+
+def test_rejects_a_tool_call_only_reply() -> None:
+    """A reply with tool calls and no text cannot carry a verdict."""
+    client = _ScriptedClient(
+        None,
+        tool_calls=(ToolCall(call_id="call-1", name="noise", arguments={}),),
+    )
+    with pytest.raises(AnswerGradeError, match="no text"):
+        AnswerGradeJudge(client).grade(task="Task.", answer="Answer.")
+
+
+def test_rejects_a_reply_truncated_at_the_token_limit() -> None:
+    """A length-limited reply is refused before parsing a half verdict."""
+    client = _ScriptedClient(_verdict(0.5), finish_reason=ModelFinishReason.LENGTH)
+    with pytest.raises(AnswerGradeError, match="output-token limit"):
+        AnswerGradeJudge(client).grade(task="Task.", answer="Answer.")
+
+
+def test_rejects_blank_inputs_and_bad_token_limits() -> None:
+    """Blank task or answer text and non-positive limits fail before any model call."""
+    client = _ScriptedClient(_verdict(0.5))
+    with pytest.raises(ValueError, match="scenario task"):
+        AnswerGradeJudge(client).grade(task="   ", answer="Answer.")
+    with pytest.raises(ValueError, match="candidate answer"):
+        AnswerGradeJudge(client).grade(task="Task.", answer="")
+    with pytest.raises(ValueError, match="maximum_output_tokens"):
+        AnswerGradeJudge(client, maximum_output_tokens=0)
+    assert client.requests == []

--- a/exp/common/judging/realism.py
+++ b/exp/common/judging/realism.py
@@ -12,17 +12,15 @@ Labs platform is the first consumer of this seam.
 
 from __future__ import annotations
 
-import json
-
 from pydantic import Field, ValidationError, field_validator
 
 from exp.common.core.artifacts import ContractModel
 from exp.common.models import (
     ModelClient,
-    ModelFinishReason,
     ModelMessage,
     ModelRequest,
-    structured_json_text,
+    StructuredReplyError,
+    structured_reply_json,
 )
 
 # Reasoning models spend hidden reasoning tokens (hundreds per call on
@@ -122,18 +120,10 @@ class RealismJudge:
                 maximum_output_tokens=self._maximum_output_tokens,
             )
         )
-        if response.finish_reason is ModelFinishReason.LENGTH:
-            msg = "the judge stopped at its output-token limit; raise maximum_output_tokens"
-            raise RealismJudgmentError(msg)
-        content = response.output.content
-        if content is None:
-            msg = "the judge returned no text output; rerun the assessment"
-            raise RealismJudgmentError(msg)
         try:
-            raw = json.loads(structured_json_text(content))
-        except json.JSONDecodeError as error:
-            msg = "the judge returned non-JSON output; rerun the assessment"
-            raise RealismJudgmentError(msg) from error
+            raw = structured_reply_json(response)
+        except StructuredReplyError as error:
+            raise RealismJudgmentError(str(error)) from error
         try:
             return RealismAssessment.model_validate(raw)
         except ValidationError as error:

--- a/exp/common/judging/realism.py
+++ b/exp/common/judging/realism.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, field_validator
 
 from exp.common.core.artifacts import ContractModel
 from exp.common.models import (
@@ -25,7 +25,11 @@ from exp.common.models import (
     structured_json_text,
 )
 
-DEFAULT_REALISM_OUTPUT_TOKENS = 400
+# Reasoning models spend hidden reasoning tokens (hundreds per call on
+# current frontier models) from the same output budget as the visible JSON
+# verdict, and an exhausted budget is rejected as a truncated reply. The
+# default leaves room for both; a longer reply costs nothing unless produced.
+DEFAULT_REALISM_OUTPUT_TOKENS = 2_000
 
 REALISM_PROMPT = (
     "You assess ONE scenario for an AI agent, on two SEPARATE axes:\n"
@@ -59,6 +63,15 @@ class RealismAssessment(ContractModel):
     likelihood: float = Field(ge=0.0, le=1.0)
     feasibility: float = Field(ge=0.0, le=1.0)
     rationale: str = Field(min_length=1, max_length=300)
+
+    @field_validator("rationale")
+    @classmethod
+    def _require_visible_text(cls, value: str) -> str:
+        """Trim edge whitespace and reject a blank-looking rationale."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must contain non-whitespace text")
+        return stripped
 
 
 class RealismJudge:
@@ -98,7 +111,7 @@ class RealismJudge:
             RealismJudgmentError: The reply was truncated at the token limit,
                 carried no text, or broke the JSON contract.
         """
-        if not scenario:
+        if not scenario.strip():
             raise ValueError("realism assessment needs non-empty scenario text")
         response = self._client.complete(
             ModelRequest(

--- a/exp/common/judging/realism.py
+++ b/exp/common/judging/realism.py
@@ -1,0 +1,131 @@
+"""Two-axis realism judging over scenario text: likelihood and feasibility.
+
+Models conflate "unlikely" with "impossible". This judge scores one scenario
+on two separate axes, likelihood and feasibility, each in ``[0, 1]`` with a
+one-line rationale, and nothing here ever combines the axes: a rare-but-real
+situation is low likelihood and high feasibility, and a scenario judged
+near-infeasible despite being observed in real traffic contradicts reality
+and deserves human review first. Unlike the rubric judges, this judge scores
+plain scenario text rather than persisted rollout evidence. The Experiential
+Labs platform is the first consumer of this seam.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import Field, ValidationError
+
+from exp.common.core.artifacts import ContractModel
+from exp.common.models import (
+    ModelClient,
+    ModelFinishReason,
+    ModelMessage,
+    ModelRequest,
+    structured_json_text,
+)
+
+DEFAULT_REALISM_OUTPUT_TOKENS = 400
+
+REALISM_PROMPT = (
+    "You assess ONE scenario for an AI agent, on two SEPARATE axes:\n"
+    "- likelihood: how probable is it that this situation occurs in this "
+    "organization's real traffic? 0 = essentially never, 1 = routine.\n"
+    "- feasibility: is the situation possible AT ALL for this agent and its "
+    "users? 0 = actually impossible, 1 = clearly possible.\n"
+    "These are different questions. A rare-but-real situation is LOW "
+    "likelihood and HIGH feasibility; never call it infeasible because it "
+    "is rare.\n"
+    "Respond with ONLY a JSON object, no prose and no code fences: "
+    '{"likelihood": 0.0, "feasibility": 0.0, "rationale": "..."}. '
+    "rationale is one line (at most 300 characters)."
+)
+
+
+class RealismJudgmentError(ValueError):
+    """The judge's reply broke the realism output contract."""
+
+
+class RealismAssessment(ContractModel):
+    """One two-axis realism verdict; the axes are never combined.
+
+    Args:
+        likelihood: How probable the scenario is in real traffic, in
+            ``[0, 1]``.
+        feasibility: Whether the scenario is possible at all, in ``[0, 1]``.
+        rationale: One line supporting both scores.
+    """
+
+    likelihood: float = Field(ge=0.0, le=1.0)
+    feasibility: float = Field(ge=0.0, le=1.0)
+    rationale: str = Field(min_length=1, max_length=300)
+
+
+class RealismJudge:
+    """Scores scenario text on separate likelihood and feasibility axes."""
+
+    def __init__(
+        self,
+        client: ModelClient,
+        *,
+        maximum_output_tokens: int = DEFAULT_REALISM_OUTPUT_TOKENS,
+    ) -> None:
+        """Bind the judge to one configured model client.
+
+        Args:
+            client: Configured judge model client.
+            maximum_output_tokens: Upper bound for each verdict reply.
+
+        Raises:
+            ValueError: ``maximum_output_tokens`` is not positive.
+        """
+        if maximum_output_tokens <= 0:
+            raise ValueError("maximum_output_tokens must be positive")
+        self._client = client
+        self._maximum_output_tokens = maximum_output_tokens
+
+    def assess(self, scenario: str) -> RealismAssessment:
+        """One model call judging one scenario on both axes.
+
+        Args:
+            scenario: The scenario task text to judge, sent verbatim.
+
+        Returns:
+            The parsed two-axis assessment.
+
+        Raises:
+            ValueError: ``scenario`` is empty.
+            RealismJudgmentError: The reply was truncated at the token limit,
+                carried no text, or broke the JSON contract.
+        """
+        if not scenario:
+            raise ValueError("realism assessment needs non-empty scenario text")
+        response = self._client.complete(
+            ModelRequest(
+                messages=(
+                    ModelMessage(role="system", content=REALISM_PROMPT),
+                    ModelMessage(role="user", content=scenario),
+                ),
+                maximum_output_tokens=self._maximum_output_tokens,
+            )
+        )
+        if response.finish_reason is ModelFinishReason.LENGTH:
+            msg = "the judge stopped at its output-token limit; raise maximum_output_tokens"
+            raise RealismJudgmentError(msg)
+        content = response.output.content
+        if content is None:
+            msg = "the judge returned no text output; rerun the assessment"
+            raise RealismJudgmentError(msg)
+        try:
+            raw = json.loads(structured_json_text(content))
+        except json.JSONDecodeError as error:
+            msg = "the judge returned non-JSON output; rerun the assessment"
+            raise RealismJudgmentError(msg) from error
+        try:
+            return RealismAssessment.model_validate(raw)
+        except ValidationError as error:
+            msg = (
+                "the judge returned an assessment outside the contracted shape; "
+                "rerun the assessment"
+            )
+            raise RealismJudgmentError(msg) from error

--- a/exp/common/judging/realism_test.py
+++ b/exp/common/judging/realism_test.py
@@ -119,6 +119,11 @@ def test_rejects_a_verdict_outside_the_contract() -> None:
     combined_score = _ScriptedClient(json.dumps({"realism": 0.4, "rationale": "x"}))
     with pytest.raises(RealismJudgmentError, match="contracted shape"):
         RealismJudge(combined_score).assess("Scenario text.")
+    blank_rationale = _ScriptedClient(
+        json.dumps({"likelihood": 0.4, "feasibility": 0.6, "rationale": "   "})
+    )
+    with pytest.raises(RealismJudgmentError, match="contracted shape"):
+        RealismJudge(blank_rationale).assess("Scenario text.")
 
 
 def test_rejects_a_tool_call_only_reply() -> None:

--- a/exp/common/judging/realism_test.py
+++ b/exp/common/judging/realism_test.py
@@ -1,0 +1,148 @@
+"""Behavior tests for the two-axis realism judge over a scripted model client."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exp.common.judging.realism import (
+    REALISM_PROMPT,
+    RealismJudge,
+    RealismJudgmentError,
+)
+from exp.common.models import (
+    AssistantAction,
+    BillingSource,
+    ModelFinishReason,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+)
+
+_DIGEST = "b" * 64
+
+
+def _model() -> ModelSnapshot:
+    """Return one deterministic judge model identity."""
+    return ModelSnapshot(
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        provider="scripted",
+        model_id="realism-judge",
+        capabilities_sha256=_DIGEST,
+        connection_sha256=_DIGEST,
+    )
+
+
+class _ScriptedClient:
+    """Deterministic client returning one preconfigured completion."""
+
+    def __init__(
+        self,
+        content: str | None,
+        *,
+        tool_calls: tuple[ToolCall, ...] = (),
+        finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+    ) -> None:
+        """Store the scripted reply and start capturing requests."""
+        self._content = content
+        self._tool_calls = tool_calls
+        self._finish_reason = finish_reason
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Capture the request and return the scripted completion."""
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(content=self._content, tool_calls=self._tool_calls),
+            model=_model(),
+            economics=OperationEconomics(),
+            finish_reason=self._finish_reason,
+        )
+
+
+def _verdict(likelihood: float, feasibility: float) -> str:
+    """Return a contract-valid verdict payload."""
+    return json.dumps(
+        {
+            "likelihood": likelihood,
+            "feasibility": feasibility,
+            "rationale": "Rare but entirely possible for this agent.",
+        }
+    )
+
+
+def test_keeps_the_two_axes_separate() -> None:
+    """A rare-but-real verdict keeps low likelihood beside high feasibility."""
+    client = _ScriptedClient(_verdict(0.05, 0.95))
+    assessment = RealismJudge(client).assess("A customer asks to merge 400 accounts at once.")
+    assert assessment.likelihood == 0.05
+    assert assessment.feasibility == 0.95
+    assert assessment.rationale
+
+
+def test_sends_the_anti_conflation_prompt_and_the_scenario_verbatim() -> None:
+    """The system prompt forbids conflating rare with impossible; the task rides as is."""
+    client = _ScriptedClient(_verdict(0.5, 0.5))
+    RealismJudge(client, maximum_output_tokens=123).assess("Scenario text.")
+    (request,) = client.requests
+    assert request.messages[0].role == "system"
+    assert request.messages[0].content == REALISM_PROMPT
+    assert "never call it infeasible because it is rare" in str(request.messages[0].content)
+    assert request.messages[1].content == "Scenario text."
+    assert request.maximum_output_tokens == 123
+
+
+def test_accepts_a_fenced_json_verdict() -> None:
+    """A single json-fenced verdict parses like a bare one."""
+    client = _ScriptedClient(f"```json\n{_verdict(0.2, 0.8)}\n```")
+    assessment = RealismJudge(client).assess("Scenario text.")
+    assert assessment.likelihood == 0.2
+
+
+def test_rejects_non_json_output() -> None:
+    """Prose instead of JSON fails loudly instead of scoring nothing."""
+    client = _ScriptedClient("I would rate this fairly unlikely overall.")
+    with pytest.raises(RealismJudgmentError, match="non-JSON"):
+        RealismJudge(client).assess("Scenario text.")
+
+
+def test_rejects_a_verdict_outside_the_contract() -> None:
+    """Out-of-range axes and missing fields break the contract."""
+    out_of_range = _ScriptedClient(
+        json.dumps({"likelihood": 1.5, "feasibility": 0.5, "rationale": "x"})
+    )
+    with pytest.raises(RealismJudgmentError, match="contracted shape"):
+        RealismJudge(out_of_range).assess("Scenario text.")
+    combined_score = _ScriptedClient(json.dumps({"realism": 0.4, "rationale": "x"}))
+    with pytest.raises(RealismJudgmentError, match="contracted shape"):
+        RealismJudge(combined_score).assess("Scenario text.")
+
+
+def test_rejects_a_tool_call_only_reply() -> None:
+    """A reply with tool calls and no text cannot carry a verdict."""
+    client = _ScriptedClient(
+        None,
+        tool_calls=(ToolCall(call_id="call-1", name="noise", arguments={}),),
+    )
+    with pytest.raises(RealismJudgmentError, match="no text"):
+        RealismJudge(client).assess("Scenario text.")
+
+
+def test_rejects_a_reply_truncated_at_the_token_limit() -> None:
+    """A length-limited reply is refused before parsing a half verdict."""
+    client = _ScriptedClient(_verdict(0.4, 0.6), finish_reason=ModelFinishReason.LENGTH)
+    with pytest.raises(RealismJudgmentError, match="output-token limit"):
+        RealismJudge(client).assess("Scenario text.")
+
+
+def test_rejects_empty_scenario_text_and_bad_token_limits() -> None:
+    """Empty scenarios and non-positive token limits fail before any model call."""
+    client = _ScriptedClient(_verdict(0.4, 0.6))
+    with pytest.raises(ValueError, match="non-empty scenario"):
+        RealismJudge(client).assess("")
+    with pytest.raises(ValueError, match="maximum_output_tokens"):
+        RealismJudge(client, maximum_output_tokens=0)
+    assert client.requests == []

--- a/exp/common/models/__init__.py
+++ b/exp/common/models/__init__.py
@@ -101,7 +101,11 @@ from exp.common.models.setup import (
     catalog_state_sha256,
     configure_provider_catalog,
 )
-from exp.common.models.structured import structured_json_text
+from exp.common.models.structured import (
+    StructuredReplyError,
+    structured_json_text,
+    structured_reply_json,
+)
 
 __all__ = [
     "AssistantAction",
@@ -185,7 +189,9 @@ __all__ = [
     "router_candidate_prices",
     "served_roles",
     "serves_role",
+    "StructuredReplyError",
     "structured_json_text",
+    "structured_reply_json",
     "validate_router_candidate_selection",
     "verify_router_candidate_catalog_state",
     "verify_completion_reservation",

--- a/exp/common/models/structured.py
+++ b/exp/common/models/structured.py
@@ -2,7 +2,49 @@
 
 from __future__ import annotations
 
+import json
+
+from exp.common.core.artifacts import JsonValue
+from exp.common.models.model import ModelFinishReason, ModelResponse
+
 _FENCE = "```"
+
+
+class StructuredReplyError(ValueError):
+    """A completed reply could not carry the strict JSON payload it promised."""
+
+
+def structured_reply_json(response: ModelResponse) -> JsonValue:
+    """Return the strict JSON payload of one completed single-shot reply.
+
+    Shared handling for callers that prompt a model for a JSON-only answer:
+    a reply that stopped at its output-token limit, carried no visible text
+    (tool calls only), or failed strict JSON parsing after fence
+    normalization is rejected loudly. Shape validation of the parsed value
+    stays with the caller's own contract.
+
+    Args:
+        response: The completed model response.
+
+    Returns:
+        The parsed JSON value of the reply's visible text.
+
+    Raises:
+        StructuredReplyError: The reply was truncated, textless, or non-JSON;
+            rerun the call or raise the output-token budget.
+    """
+    if response.finish_reason is ModelFinishReason.LENGTH:
+        msg = "the model stopped at its output-token limit; raise the output-token budget"
+        raise StructuredReplyError(msg)
+    content = response.output.content
+    if content is None:
+        raise StructuredReplyError("the model returned no text output; rerun the call")
+    try:
+        parsed: JsonValue = json.loads(structured_json_text(content))
+    except json.JSONDecodeError as error:
+        msg = "the model returned non-JSON output; rerun the call"
+        raise StructuredReplyError(msg) from error
+    return parsed
 
 
 def structured_json_text(content: str) -> str:

--- a/exp/common/models/structured_test.py
+++ b/exp/common/models/structured_test.py
@@ -4,7 +4,70 @@ from __future__ import annotations
 
 import json
 
-from exp.common.models.structured import structured_json_text
+import pytest
+
+from exp.common.models.model import (
+    AssistantAction,
+    BillingSource,
+    ModelFinishReason,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+)
+from exp.common.models.structured import (
+    StructuredReplyError,
+    structured_json_text,
+    structured_reply_json,
+)
+
+_DIGEST = "d" * 64
+
+
+def _response(
+    content: str | None,
+    *,
+    tool_calls: tuple[ToolCall, ...] = (),
+    finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+) -> ModelResponse:
+    """Build one completed response carrying the given visible reply."""
+    return ModelResponse(
+        output=AssistantAction(content=content, tool_calls=tool_calls),
+        model=ModelSnapshot(
+            billing_source=BillingSource.CUSTOMER_MANAGED,
+            provider="scripted",
+            model_id="structured-model",
+            capabilities_sha256=_DIGEST,
+            connection_sha256=_DIGEST,
+        ),
+        economics=OperationEconomics(),
+        finish_reason=finish_reason,
+    )
+
+
+def test_reply_json_parses_bare_and_fenced_payloads() -> None:
+    """Bare JSON and a single json-fenced payload both parse."""
+    assert structured_reply_json(_response('{"a": 1}')) == {"a": 1}
+    assert structured_reply_json(_response('```json\n[{"a": 1}]\n```')) == [{"a": 1}]
+
+
+def test_reply_json_rejects_truncation_before_parsing() -> None:
+    """A reply stopped at its token limit is refused even when it parses."""
+    with pytest.raises(StructuredReplyError, match="output-token limit"):
+        structured_reply_json(_response('{"a": 1}', finish_reason=ModelFinishReason.LENGTH))
+
+
+def test_reply_json_rejects_a_textless_reply() -> None:
+    """A tool-call-only reply carries no JSON payload."""
+    response = _response(None, tool_calls=(ToolCall(call_id="call-1", name="noise"),))
+    with pytest.raises(StructuredReplyError, match="no text"):
+        structured_reply_json(response)
+
+
+def test_reply_json_rejects_non_json_text() -> None:
+    """Prose that is not strict JSON is refused loudly."""
+    with pytest.raises(StructuredReplyError, match="non-JSON"):
+        structured_reply_json(_response("Here you go: a = 1"))
 
 
 def test_labeled_fence_is_unwrapped() -> None:

--- a/exp/simulation/mining/chat_captures.py
+++ b/exp/simulation/mining/chat_captures.py
@@ -1,0 +1,265 @@
+"""Representative-task mining over captured chat-completion prompts.
+
+Chat captures are request-time records of OpenAI-style chat prompts: a request
+id, the ordered role/content message array, and the capture time. This module
+adapts each capture into one canonical ``Trace`` (the task text is the system
+and developer contents plus the first user turn, carried by one fabricated
+span) and runs the canonical mining service over the result, so capture-fed
+consumers inherit deduplication, leakage-safe partitioning, weighting, and
+coverage evidence instead of reimplementing them. Mined ``TaskCase.task_id``
+values are content derived, so re-mining an overlapping capture window
+converges on the same tasks instead of duplicating them. The Experiential
+Labs platform gateway is the first consumer of this seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from pydantic import AwareDatetime, Field
+
+from exp.common.core.artifacts import ContractModel, JsonObject, SourceIdentity
+from exp.common.tasks import TaskCase
+from exp.common.traces import Trace, TraceSource, TraceSpan
+from exp.simulation.mining.descriptors import DescriptorEmbedder
+from exp.simulation.mining.service import MiningSpec, TaskMiningResult, mine_tasks
+
+# Semantic-convention marker carried by every trace fabricated from a capture.
+_CHAT_CAPTURE_SEMANTIC_CONVENTION = "exp-chat-capture-v1"
+
+
+class ChatCapture(ContractModel):
+    """One captured chat-completion prompt ready for task mining.
+
+    Args:
+        request_id: Unique capture identity; becomes the trace and span id.
+        messages: Ordered OpenAI-style chat messages as raw JSON objects. Only
+            ``system``, ``developer``, and ``user`` messages whose ``content``
+            is a non-empty string contribute task text; tool calls and
+            structured content parts carry none.
+        captured_at: Timezone-aware capture time of the request.
+        group_key: Optional caller-owned grouping key (for example a prompt
+            digest) resolved per mined task through the task's selected
+            representative capture.
+    """
+
+    request_id: str = Field(min_length=1, max_length=512)
+    messages: tuple[JsonObject, ...] = Field(min_length=1)
+    captured_at: AwareDatetime
+    group_key: str | None = None
+
+
+class ChatCaptureMiningSummary(ContractModel):
+    """Scalar selection-honesty summary of one chat-capture mining run.
+
+    Every value restates the run's ``CoverageReport`` (plus the capture-level
+    exclusion count) as flat scalars, so a consumer can persist or display
+    what the mining actually covered without re-deriving numbers that drift
+    across runs. The per-partition ``*_workload_covered`` fractions are the
+    selected workload mass over the partition's eligible traces. When no
+    capture was minable every count is zero and ``split_separation_verified``
+    is vacuously true.
+
+    Args:
+        input_capture_count: All captures given to the run.
+        captures_without_text: Captures excluded because no message carried
+            usable task text.
+        eligible_trace_count: Adapted traces that entered mining.
+        duplicate_trace_count: Eligible traces removed as duplicates.
+        selected_task_count: Representative tasks selected across partitions.
+        fit_task_budget: Task budget requested of the fit partition.
+        held_out_task_budget: Task budget requested of the held-out partition.
+        fit_selected_task_count: Tasks selected in the fit partition.
+        held_out_selected_task_count: Tasks selected in the held-out partition.
+        fit_workload_covered: Fit selected workload mass over fit eligible
+            traces.
+        held_out_workload_covered: Held-out selected workload mass over
+            held-out eligible traces.
+        split_separation_verified: Whether fit and held-out lineage groups
+            were verified disjoint.
+    """
+
+    input_capture_count: int = Field(ge=0)
+    captures_without_text: int = Field(ge=0)
+    eligible_trace_count: int = Field(ge=0)
+    duplicate_trace_count: int = Field(ge=0)
+    selected_task_count: int = Field(ge=0)
+    fit_task_budget: int = Field(ge=0)
+    held_out_task_budget: int = Field(ge=0)
+    fit_selected_task_count: int = Field(ge=0)
+    held_out_selected_task_count: int = Field(ge=0)
+    fit_workload_covered: float = Field(ge=0.0, le=1.0)
+    held_out_workload_covered: float = Field(ge=0.0, le=1.0)
+    split_separation_verified: bool
+
+
+@dataclass(frozen=True)
+class ChatCaptureMiningResult:
+    """One chat-capture mining run: full mining evidence plus capture links.
+
+    Args:
+        mining: The complete canonical mining result, or ``None`` when no
+            capture carried usable task text (a normal state for a quiet
+            traffic window, not an error).
+        group_keys_by_task_id: Each selected task's ``group_key``, resolved
+            through the task's representative source capture.
+        summary: Scalar selection-honesty numbers for the run.
+    """
+
+    mining: TaskMiningResult | None
+    group_keys_by_task_id: Mapping[str, str | None]
+    summary: ChatCaptureMiningSummary
+
+    @property
+    def tasks(self) -> tuple[TaskCase, ...]:
+        """Selected representative tasks; empty when no capture was minable."""
+        return () if self.mining is None else self.mining.tasks
+
+
+def _text_content(message: JsonObject) -> str | None:
+    """Return the message's text content; None for tool calls and structured parts."""
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        return content
+    return None
+
+
+def _task_text(messages: tuple[JsonObject, ...]) -> str | None:
+    """Return the mined task basis: system and developer contents plus the first user turn."""
+    system_parts = [
+        text
+        for message in messages
+        if message.get("role") in ("system", "developer")
+        and (text := _text_content(message)) is not None
+    ]
+    first_user = next(
+        (
+            text
+            for message in messages
+            if message.get("role") == "user" and (text := _text_content(message)) is not None
+        ),
+        None,
+    )
+    parts = [*system_parts, *([first_user] if first_user is not None else [])]
+    if not parts:
+        return None
+    return "\n\n".join(parts)
+
+
+def _capture_trace(capture: ChatCapture, task: str) -> Trace:
+    """Return one canonical trace with a single fabricated span for the capture."""
+    return Trace(
+        trace_id=capture.request_id,
+        task=task,
+        spans=(
+            TraceSpan(
+                span_id=capture.request_id,
+                name="chat.capture",
+                started_at=capture.captured_at,
+                ended_at=capture.captured_at,
+            ),
+        ),
+        outcome=None,
+        source=TraceSource(
+            identity=SourceIdentity(kind="production", source_id=capture.request_id),
+            semantic_convention_version=_CHAT_CAPTURE_SEMANTIC_CONVENTION,
+        ),
+    )
+
+
+def mine_tasks_from_chat_captures(
+    captures: Sequence[ChatCapture],
+    mining_spec: MiningSpec | None = None,
+    *,
+    embedder: DescriptorEmbedder,
+) -> ChatCaptureMiningResult:
+    """Mine a representative task set from captured chat prompts.
+
+    Args:
+        captures: Captured chat prompts with unique request ids.
+        mining_spec: Task budgets and leakage-safe mining controls. Defaults
+            to the canonical mining defaults.
+        embedder: Explicit request-descriptor embedder, exactly as required
+            by ``mine_tasks``.
+
+    Returns:
+        The mining evidence, each task's resolved capture group key, and the
+        run's scalar coverage summary. ``mining`` is ``None`` when no capture
+        carried usable task text.
+
+    Raises:
+        ValueError: ``captures`` is empty or contains a duplicate request id,
+            or mining itself rejects its inputs.
+    """
+    if not captures:
+        raise ValueError("chat-capture mining needs at least one capture")
+    request_ids = tuple(capture.request_id for capture in captures)
+    if len(set(request_ids)) != len(request_ids):
+        raise ValueError("chat-capture request ids must be unique")
+    spec = mining_spec or MiningSpec()
+    group_keys: dict[str, str | None] = {}
+    traces: list[Trace] = []
+    for capture in captures:
+        task = _task_text(capture.messages)
+        if task is None:
+            continue
+        group_keys[capture.request_id] = capture.group_key
+        traces.append(_capture_trace(capture, task))
+    captures_without_text = len(captures) - len(traces)
+    if not traces:
+        return ChatCaptureMiningResult(
+            mining=None,
+            group_keys_by_task_id={},
+            summary=ChatCaptureMiningSummary(
+                input_capture_count=len(captures),
+                captures_without_text=captures_without_text,
+                eligible_trace_count=0,
+                duplicate_trace_count=0,
+                selected_task_count=0,
+                fit_task_budget=spec.fit_task_budget,
+                held_out_task_budget=spec.held_out_task_budget,
+                fit_selected_task_count=0,
+                held_out_selected_task_count=0,
+                fit_workload_covered=0.0,
+                held_out_workload_covered=0.0,
+                split_separation_verified=True,
+            ),
+        )
+    result = mine_tasks(
+        traces,
+        spec,
+        embedder=embedder,
+        input_trace_count=len(captures),
+        invalid_trace_count=captures_without_text,
+    )
+    coverage = result.coverage
+    # The coverage report names each task's representative source trace, so a
+    # task's group key comes from the capture the selection actually kept.
+    representative_by_task_id = {
+        selection.task_id: selection.representative_trace_id for selection in coverage.selections
+    }
+    group_keys_by_task_id = {
+        task.task_id: group_keys[representative_by_task_id[task.task_id]] for task in result.tasks
+    }
+    summary = ChatCaptureMiningSummary(
+        input_capture_count=coverage.input_trace_count,
+        captures_without_text=coverage.invalid_trace_count,
+        eligible_trace_count=coverage.eligible_trace_count,
+        duplicate_trace_count=coverage.duplicate_trace_count,
+        selected_task_count=coverage.selected_task_count,
+        fit_task_budget=coverage.fit.requested_task_budget,
+        held_out_task_budget=coverage.held_out.requested_task_budget,
+        fit_selected_task_count=coverage.fit.selected_task_count,
+        held_out_selected_task_count=coverage.held_out.selected_task_count,
+        fit_workload_covered=coverage.fit.selected_workload_mass
+        / max(coverage.fit.eligible_trace_count, 1),
+        held_out_workload_covered=coverage.held_out.selected_workload_mass
+        / max(coverage.held_out.eligible_trace_count, 1),
+        split_separation_verified=coverage.split_separation_verified,
+    )
+    return ChatCaptureMiningResult(
+        mining=result,
+        group_keys_by_task_id=group_keys_by_task_id,
+        summary=summary,
+    )

--- a/exp/simulation/mining/chat_captures.py
+++ b/exp/simulation/mining/chat_captures.py
@@ -22,6 +22,7 @@ from pydantic import AwareDatetime, Field
 from exp.common.core.artifacts import ContractModel, JsonObject, SourceIdentity
 from exp.common.tasks import TaskCase
 from exp.common.traces import Trace, TraceSource, TraceSpan
+from exp.simulation.mining.coverage import PartitionCoverage
 from exp.simulation.mining.descriptors import DescriptorEmbedder
 from exp.simulation.mining.service import MiningSpec, TaskMiningResult, mine_tasks
 
@@ -57,9 +58,12 @@ class ChatCaptureMiningSummary(ContractModel):
     exclusion count) as flat scalars, so a consumer can persist or display
     what the mining actually covered without re-deriving numbers that drift
     across runs. The per-partition ``*_workload_covered`` fractions are the
-    selected workload mass over the partition's eligible traces. When no
-    capture was minable every count is zero and ``split_separation_verified``
-    is vacuously true.
+    share of the partition's eligible workload mass lying within the coverage
+    similarity threshold of a selected task (selection assigns every
+    candidate's mass to its nearest representative, so raw assigned mass
+    would always be complete; distance-qualified mass is the honest number).
+    When no capture was minable every count is zero and
+    ``split_separation_verified`` is vacuously true.
 
     Args:
         input_capture_count: All captures given to the run.
@@ -72,10 +76,12 @@ class ChatCaptureMiningSummary(ContractModel):
         held_out_task_budget: Task budget requested of the held-out partition.
         fit_selected_task_count: Tasks selected in the fit partition.
         held_out_selected_task_count: Tasks selected in the held-out partition.
-        fit_workload_covered: Fit selected workload mass over fit eligible
-            traces.
-        held_out_workload_covered: Held-out selected workload mass over
-            held-out eligible traces.
+        fit_workload_covered: Share of fit eligible workload mass within the
+            similarity threshold of a selected fit task; zero when nothing
+            was selected.
+        held_out_workload_covered: Share of held-out eligible workload mass
+            within the similarity threshold of a selected held-out task;
+            zero when nothing was selected.
         split_separation_verified: Whether fit and held-out lineage groups
             were verified disjoint.
     """
@@ -118,11 +124,32 @@ class ChatCaptureMiningResult:
 
 
 def _text_content(message: JsonObject) -> str | None:
-    """Return the message's text content; None for tool calls and structured parts."""
+    """Return the message's text content; None for tool calls, structured parts, and blanks."""
     content = message.get("content")
-    if isinstance(content, str) and content:
+    if isinstance(content, str) and content.strip():
         return content
     return None
+
+
+def _workload_covered(partition: PartitionCoverage) -> float:
+    """Return the share of eligible workload near a selected task, in ``[0, 1]``.
+
+    Selection assigns every candidate's workload mass to its nearest retained
+    representative, so the raw assigned mass is complete whenever anything is
+    selected. The honest coverage number qualifies that mass by distance:
+    only mass within the coverage similarity threshold of a selected task
+    counts as covered.
+
+    Args:
+        partition: One partition's coverage report.
+
+    Returns:
+        The covered fraction; zero when the partition selected nothing.
+    """
+    if partition.selected_task_count == 0:
+        return 0.0
+    covered_mass = partition.eligible_trace_count - partition.low_similarity_workload_mass
+    return covered_mass / max(partition.eligible_trace_count, 1)
 
 
 def _task_text(messages: tuple[JsonObject, ...]) -> str | None:
@@ -252,10 +279,8 @@ def mine_tasks_from_chat_captures(
         held_out_task_budget=coverage.held_out.requested_task_budget,
         fit_selected_task_count=coverage.fit.selected_task_count,
         held_out_selected_task_count=coverage.held_out.selected_task_count,
-        fit_workload_covered=coverage.fit.selected_workload_mass
-        / max(coverage.fit.eligible_trace_count, 1),
-        held_out_workload_covered=coverage.held_out.selected_workload_mass
-        / max(coverage.held_out.eligible_trace_count, 1),
+        fit_workload_covered=_workload_covered(coverage.fit),
+        held_out_workload_covered=_workload_covered(coverage.held_out),
         split_separation_verified=coverage.split_separation_verified,
     )
     return ChatCaptureMiningResult(

--- a/exp/simulation/mining/chat_captures_test.py
+++ b/exp/simulation/mining/chat_captures_test.py
@@ -1,0 +1,201 @@
+"""Behavior tests for representative-task mining over chat captures."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.simulation.mining.chat_captures import (
+    ChatCapture,
+    mine_tasks_from_chat_captures,
+)
+from exp.simulation.mining.descriptors import HashingDescriptorEmbedder
+from exp.simulation.mining.service import MiningSpec
+
+_START = datetime(2026, 8, 11, tzinfo=UTC)
+
+
+def _capture(
+    index: int,
+    *,
+    user: str,
+    system: str | None = "You are the support agent for Acme.",
+    group_key: str | None = None,
+    messages: tuple[JsonObject, ...] | None = None,
+) -> ChatCapture:
+    """Build one capture with simple system and user text messages."""
+    if messages is None:
+        system_messages: tuple[JsonObject, ...] = (
+            ({"role": "system", "content": system},) if system is not None else ()
+        )
+        messages = (*system_messages, {"role": "user", "content": user})
+    return ChatCapture(
+        request_id=f"req-{index}",
+        messages=messages,
+        captured_at=_START + timedelta(minutes=index),
+        group_key=group_key,
+    )
+
+
+def _distinct_captures(count: int) -> tuple[ChatCapture, ...]:
+    """Build captures whose user turns are semantically distinct."""
+    topics = (
+        "reset the billing portal password for an enterprise seat",
+        "export every invoice from March as one CSV attachment",
+        "merge two duplicate customer accounts without losing notes",
+        "escalate a refund that was rejected twice by the auto-check",
+        "schedule a quarterly usage report for the finance list",
+        "explain why the API key rotation email never arrived",
+        "restore a project that was archived by a former employee",
+        "change the data residency region for one workspace",
+    )
+    return tuple(
+        _capture(index, user=f"Please {topics[index % len(topics)]} (case {index}).")
+        for index in range(count)
+    )
+
+
+def test_mines_tasks_and_reports_capture_honesty() -> None:
+    """Text captures are mined; unusable captures are counted, not silently dropped."""
+    usable = _distinct_captures(6)
+    tool_only = ChatCapture(
+        request_id="req-tool-only",
+        messages=(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call-1", "type": "function"}],
+            },
+        ),
+        captured_at=_START,
+    )
+    structured_parts = _capture(
+        97,
+        user="unused",
+        messages=({"role": "user", "content": [{"type": "text", "text": "hi"}]},),
+    )
+    result = mine_tasks_from_chat_captures(
+        (*usable, tool_only, structured_parts),
+        MiningSpec(fit_task_budget=4, held_out_task_budget=2),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert result.mining is not None
+    assert result.tasks
+    expected_texts = {
+        "You are the support agent for Acme.\n\n" + str(capture.messages[-1]["content"])
+        for capture in usable
+    }
+    assert {task.instruction for task in result.tasks} <= expected_texts
+    summary = result.summary
+    assert summary.input_capture_count == 8
+    assert summary.captures_without_text == 2
+    assert summary.eligible_trace_count == 6
+    assert summary.selected_task_count == len(result.tasks)
+    assert (
+        summary.fit_selected_task_count + summary.held_out_selected_task_count
+        == summary.selected_task_count
+    )
+    assert 0.0 <= summary.fit_workload_covered <= 1.0
+    assert 0.0 <= summary.held_out_workload_covered <= 1.0
+    assert summary.split_separation_verified
+
+
+def test_task_text_joins_system_developer_and_first_user_turn() -> None:
+    """The task basis is system plus developer contents plus the first text user turn."""
+    capture = ChatCapture(
+        request_id="req-shaped",
+        messages=(
+            {"role": "system", "content": "System rules."},
+            {"role": "developer", "content": "Developer rules."},
+            {"role": "user", "content": [{"type": "text", "text": "structured, skipped"}]},
+            {"role": "user", "content": "First plain user turn."},
+            {"role": "user", "content": "Second user turn, never mined."},
+        ),
+        captured_at=_START,
+    )
+    result = mine_tasks_from_chat_captures((capture,), embedder=HashingDescriptorEmbedder())
+    assert [task.instruction for task in result.tasks] == [
+        "System rules.\n\nDeveloper rules.\n\nFirst plain user turn."
+    ]
+
+
+def test_group_keys_resolve_through_the_representative_capture() -> None:
+    """Each mined task carries the group key of a capture the task represents."""
+    captures = tuple(
+        capture.model_copy(update={"group_key": f"sha-{capture.request_id}"})
+        for capture in _distinct_captures(6)
+    )
+    result = mine_tasks_from_chat_captures(
+        captures,
+        MiningSpec(fit_task_budget=4, held_out_task_budget=2),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert set(result.group_keys_by_task_id) == {task.task_id for task in result.tasks}
+    for task in result.tasks:
+        group_key = result.group_keys_by_task_id[task.task_id]
+        assert group_key in {f"sha-{trace_id}" for trace_id in task.source_trace_ids}
+
+
+def test_group_key_stays_optional() -> None:
+    """Captures without a group key mine normally and map to None."""
+    result = mine_tasks_from_chat_captures(
+        _distinct_captures(3),
+        MiningSpec(fit_task_budget=2, held_out_task_budget=1),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert result.tasks
+    assert set(result.group_keys_by_task_id.values()) == {None}
+
+
+def test_no_usable_text_returns_an_empty_run_not_an_error() -> None:
+    """A window of unusable captures is a normal empty run with honest counts."""
+    captures = (
+        ChatCapture(
+            request_id="req-a",
+            messages=({"role": "user", "content": [{"type": "text", "text": "hi"}]},),
+            captured_at=_START,
+        ),
+        ChatCapture(
+            request_id="req-b",
+            messages=({"role": "assistant", "content": None, "tool_calls": []},),
+            captured_at=_START,
+        ),
+    )
+    result = mine_tasks_from_chat_captures(captures, embedder=HashingDescriptorEmbedder())
+    assert result.mining is None
+    assert result.tasks == ()
+    assert result.group_keys_by_task_id == {}
+    assert result.summary.input_capture_count == 2
+    assert result.summary.captures_without_text == 2
+    assert result.summary.selected_task_count == 0
+
+
+def test_rejects_empty_captures() -> None:
+    """Calling the seam with no captures at all is a caller bug."""
+    with pytest.raises(ValueError, match="at least one capture"):
+        mine_tasks_from_chat_captures((), embedder=HashingDescriptorEmbedder())
+
+
+def test_rejects_duplicate_request_ids() -> None:
+    """Duplicate request ids would corrupt trace identity and fail loudly."""
+    capture = _capture(1, user="Please check the audit log for the export.")
+    with pytest.raises(ValueError, match="unique"):
+        mine_tasks_from_chat_captures((capture, capture), embedder=HashingDescriptorEmbedder())
+
+
+def test_remining_an_overlapping_window_converges_on_task_ids() -> None:
+    """Stable content-derived task ids make overlapping re-mines converge."""
+    spec = MiningSpec(fit_task_budget=4, held_out_task_budget=2)
+    first = mine_tasks_from_chat_captures(
+        _distinct_captures(6),
+        spec,
+        embedder=HashingDescriptorEmbedder(),
+    )
+    second = mine_tasks_from_chat_captures(
+        _distinct_captures(6),
+        spec,
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert {task.task_id for task in first.tasks} == {task.task_id for task in second.tasks}

--- a/exp/simulation/mining/chat_captures_test.py
+++ b/exp/simulation/mining/chat_captures_test.py
@@ -102,6 +102,40 @@ def test_mines_tasks_and_reports_capture_honesty() -> None:
     assert summary.split_separation_verified
 
 
+def test_workload_covered_discriminates_between_full_and_tight_budgets() -> None:
+    """The covered fraction is distance-qualified, not the always-complete assigned mass."""
+    captures = _distinct_captures(6)
+    full_budget = mine_tasks_from_chat_captures(
+        captures,
+        MiningSpec(fit_task_budget=4, held_out_task_budget=2),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert full_budget.summary.fit_workload_covered == 1.0
+    assert full_budget.summary.held_out_workload_covered == 1.0
+    tight_budget = mine_tasks_from_chat_captures(
+        captures,
+        MiningSpec(fit_task_budget=1, held_out_task_budget=1),
+        embedder=HashingDescriptorEmbedder(),
+    )
+    assert tight_budget.summary.fit_workload_covered < 1.0
+    assert tight_budget.summary.held_out_workload_covered < 1.0
+
+
+def test_whitespace_only_content_is_not_usable_text() -> None:
+    """A capture whose only text is whitespace counts as unusable, not as a task."""
+    capture = ChatCapture(
+        request_id="req-blank",
+        messages=(
+            {"role": "system", "content": " \n\t"},
+            {"role": "user", "content": "   "},
+        ),
+        captured_at=_START,
+    )
+    result = mine_tasks_from_chat_captures((capture,), embedder=HashingDescriptorEmbedder())
+    assert result.mining is None
+    assert result.summary.captures_without_text == 1
+
+
 def test_task_text_joins_system_developer_and_first_user_turn() -> None:
     """The task basis is system plus developer contents plus the first text user turn."""
     capture = ChatCapture(

--- a/exp/simulation/synthesis.py
+++ b/exp/simulation/synthesis.py
@@ -18,14 +18,14 @@ from collections.abc import Sequence
 
 from pydantic import Field, ValidationError, field_validator
 
-from exp.common.core.artifacts import ContractModel
+from exp.common.core.artifacts import ContractModel, JsonValue
 from exp.common.models import (
     ModelClient,
-    ModelFinishReason,
     ModelMessage,
     ModelRequest,
     ModelSnapshot,
-    structured_json_text,
+    StructuredReplyError,
+    structured_reply_json,
 )
 
 DEFAULT_PROBE_COUNT = 5
@@ -95,24 +95,19 @@ class FrontierProbeBatch(ContractModel):
     model: ModelSnapshot
 
 
-def _parse_probes(payload: str) -> tuple[FrontierProbe, ...]:
-    """Parse the generator's JSON array, loudly refusing malformed output.
+def _parse_probes(raw: JsonValue) -> tuple[FrontierProbe, ...]:
+    """Validate the generator's parsed JSON array, loudly refusing malformed output.
 
     Args:
-        payload: Candidate JSON text from the generator's visible reply.
+        raw: Parsed JSON value from the generator's visible reply.
 
     Returns:
         Every probe in the array, in reply order.
 
     Raises:
-        FrontierProbeError: The payload is not a JSON array of contract-valid
+        FrontierProbeError: The value is not a JSON array of contract-valid
             probes; rerun the generation or adjust the generator model.
     """
-    try:
-        raw = json.loads(payload)
-    except json.JSONDecodeError as error:
-        msg = "the generator returned non-JSON output; rerun the generation"
-        raise FrontierProbeError(msg) from error
     if not isinstance(raw, list):
         msg = "the generator returned JSON that is not an array; rerun the generation"
         raise FrontierProbeError(msg)
@@ -174,15 +169,9 @@ def generate_frontier_probes(
             maximum_output_tokens=maximum_output_tokens,
         )
     )
-    if response.finish_reason is ModelFinishReason.LENGTH:
-        msg = (
-            "the generator stopped at its output-token limit; raise "
-            "maximum_output_tokens or lower probe_count"
-        )
-        raise FrontierProbeError(msg)
-    content = response.output.content
-    if content is None:
-        msg = "the generator returned no text output; rerun the generation"
-        raise FrontierProbeError(msg)
-    probes = _parse_probes(structured_json_text(content))
+    try:
+        raw = structured_reply_json(response)
+    except StructuredReplyError as error:
+        raise FrontierProbeError(str(error)) from error
+    probes = _parse_probes(raw)
     return FrontierProbeBatch(probes=probes[:probe_count], model=response.model)

--- a/exp/simulation/synthesis.py
+++ b/exp/simulation/synthesis.py
@@ -1,0 +1,175 @@
+"""Principled scenario synthesis beyond observed traffic.
+
+Mined tasks describe what production traffic already shows. Synthesis is the
+layer that generates scenarios past that evidence on purpose. Its first piece
+is frontier probe generation: one model call reads a sample of observed
+scenario tasks and proposes variants at the frontier of plausibility,
+situations that are possible but unlikely and adjacent to the observed
+traffic. Probes are triage material for a human reviewer; they carry no
+partition or workload weight and never become selection evidence. The
+Experiential Labs platform is the first consumer of this seam.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+
+from pydantic import Field, ValidationError
+
+from exp.common.core.artifacts import ContractModel
+from exp.common.models import (
+    ModelClient,
+    ModelFinishReason,
+    ModelMessage,
+    ModelRequest,
+    ModelSnapshot,
+    structured_json_text,
+)
+
+DEFAULT_PROBE_COUNT = 5
+DEFAULT_PROBE_OUTPUT_TOKENS = 1_500
+
+FRONTIER_PROBE_PROMPT = (
+    "You generate PROBE scenarios for an AI agent, given a sample of "
+    "scenarios mined from its real traffic. A probe sits slightly PAST the "
+    "frontier of what was observed: plausible for this agent's domain, but "
+    "unlike anything in the sample, at the edge of the unknown unknowns. "
+    "Rules:\n"
+    "- Slightly unrealistic on purpose; never absurd or off-domain.\n"
+    "- A good probe makes a human reviewer pause between 'unlikely' and "
+    "'unrealistic'; that pause is the point.\n"
+    "- One concrete situation per probe, written as a task the agent would "
+    "face, in the sample's own style and length.\n"
+    "Respond with ONLY a JSON array, no prose and no code fences: "
+    '[{"task": "...", "rationale": "..."}, ...]. '
+    "task is the probe scenario (at most 2000 characters); rationale is one "
+    "line on why it sits at the frontier (at most 300 characters)."
+)
+
+
+class FrontierProbeError(ValueError):
+    """The generator's reply broke the frontier-probe output contract."""
+
+
+class FrontierProbe(ContractModel):
+    """One generated frontier probe scenario.
+
+    Args:
+        task: The probe scenario, written as a task the agent would face.
+        rationale: One line on why the probe sits at the frontier.
+    """
+
+    task: str = Field(min_length=1, max_length=2000)
+    rationale: str = Field(min_length=1, max_length=300)
+
+    @property
+    def task_sha256(self) -> str:
+        """Content-derived digest so regenerating an identical probe converges."""
+        return hashlib.sha256(self.task.encode("utf-8")).hexdigest()
+
+
+class FrontierProbeBatch(ContractModel):
+    """Parsed probes plus the resolved generator identity for provenance.
+
+    Args:
+        probes: Contract-valid probes, at most the requested count.
+        model: The generator model that produced the reply.
+    """
+
+    probes: tuple[FrontierProbe, ...]
+    model: ModelSnapshot
+
+
+def _parse_probes(payload: str) -> tuple[FrontierProbe, ...]:
+    """Parse the generator's JSON array, loudly refusing malformed output.
+
+    Args:
+        payload: Candidate JSON text from the generator's visible reply.
+
+    Returns:
+        Every probe in the array, in reply order.
+
+    Raises:
+        FrontierProbeError: The payload is not a JSON array of contract-valid
+            probes; rerun the generation or adjust the generator model.
+    """
+    try:
+        raw = json.loads(payload)
+    except json.JSONDecodeError as error:
+        msg = "the generator returned non-JSON output; rerun the generation"
+        raise FrontierProbeError(msg) from error
+    if not isinstance(raw, list):
+        msg = "the generator returned JSON that is not an array; rerun the generation"
+        raise FrontierProbeError(msg)
+    try:
+        return tuple(FrontierProbe.model_validate(entry) for entry in raw)
+    except ValidationError as error:
+        msg = "the generator returned a probe outside the contracted shape; rerun the generation"
+        raise FrontierProbeError(msg) from error
+
+
+def generate_frontier_probes(
+    client: ModelClient,
+    observed_tasks: Sequence[str],
+    *,
+    probe_count: int = DEFAULT_PROBE_COUNT,
+    maximum_output_tokens: int = DEFAULT_PROBE_OUTPUT_TOKENS,
+) -> FrontierProbeBatch:
+    """One model call proposing frontier probes from an observed sample.
+
+    Args:
+        client: Configured generator model client.
+        observed_tasks: Sampled observed scenario task texts. The caller owns
+            sampling and ordering; every entry is sent to the model verbatim.
+        probe_count: Probes requested; a longer reply is truncated to this
+            count and a shorter contract-valid reply is returned as is.
+        maximum_output_tokens: Upper bound for the generator's reply.
+
+    Returns:
+        Parsed probes with the resolved generator identity.
+
+    Raises:
+        ValueError: ``observed_tasks`` is empty or contains an empty task,
+            ``probe_count`` is not positive, or ``maximum_output_tokens`` is
+            not positive.
+        FrontierProbeError: The reply was truncated at the token limit,
+            carried no text, or broke the JSON contract.
+    """
+    if not observed_tasks:
+        raise ValueError("frontier probe generation needs at least one observed task")
+    if any(not task for task in observed_tasks):
+        raise ValueError("observed tasks must be non-empty strings")
+    if probe_count <= 0:
+        raise ValueError("probe_count must be positive")
+    if maximum_output_tokens <= 0:
+        raise ValueError("maximum_output_tokens must be positive")
+    payload = json.dumps(
+        {
+            "observed_scenarios": [{"task": task} for task in observed_tasks],
+            "probe_count": probe_count,
+        },
+        separators=(",", ":"),
+    )
+    response = client.complete(
+        ModelRequest(
+            messages=(
+                ModelMessage(role="system", content=FRONTIER_PROBE_PROMPT),
+                ModelMessage(role="user", content=payload),
+            ),
+            maximum_output_tokens=maximum_output_tokens,
+        )
+    )
+    if response.finish_reason is ModelFinishReason.LENGTH:
+        msg = (
+            "the generator stopped at its output-token limit; raise "
+            "maximum_output_tokens or lower probe_count"
+        )
+        raise FrontierProbeError(msg)
+    content = response.output.content
+    if content is None:
+        msg = "the generator returned no text output; rerun the generation"
+        raise FrontierProbeError(msg)
+    probes = _parse_probes(structured_json_text(content))
+    return FrontierProbeBatch(probes=probes[:probe_count], model=response.model)

--- a/exp/simulation/synthesis.py
+++ b/exp/simulation/synthesis.py
@@ -16,7 +16,7 @@ import hashlib
 import json
 from collections.abc import Sequence
 
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, field_validator
 
 from exp.common.core.artifacts import ContractModel
 from exp.common.models import (
@@ -29,7 +29,11 @@ from exp.common.models import (
 )
 
 DEFAULT_PROBE_COUNT = 5
-DEFAULT_PROBE_OUTPUT_TOKENS = 1_500
+# Reasoning models spend hidden reasoning tokens (hundreds per call on
+# current frontier models) from the same output budget as the visible JSON,
+# and an exhausted budget is rejected as a truncated reply. The default
+# leaves room for both; a longer reply costs nothing unless produced.
+DEFAULT_PROBE_OUTPUT_TOKENS = 4_000
 
 FRONTIER_PROBE_PROMPT = (
     "You generate PROBE scenarios for an AI agent, given a sample of "
@@ -63,6 +67,15 @@ class FrontierProbe(ContractModel):
 
     task: str = Field(min_length=1, max_length=2000)
     rationale: str = Field(min_length=1, max_length=300)
+
+    @field_validator("task", "rationale")
+    @classmethod
+    def _require_visible_text(cls, value: str) -> str:
+        """Trim edge whitespace and reject blank-looking text."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must contain non-whitespace text")
+        return stripped
 
     @property
     def task_sha256(self) -> str:
@@ -139,7 +152,7 @@ def generate_frontier_probes(
     """
     if not observed_tasks:
         raise ValueError("frontier probe generation needs at least one observed task")
-    if any(not task for task in observed_tasks):
+    if any(not task.strip() for task in observed_tasks):
         raise ValueError("observed tasks must be non-empty strings")
     if probe_count <= 0:
         raise ValueError("probe_count must be positive")

--- a/exp/simulation/synthesis_test.py
+++ b/exp/simulation/synthesis_test.py
@@ -1,0 +1,172 @@
+"""Behavior tests for frontier probe generation over a scripted model client."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exp.common.models import (
+    AssistantAction,
+    BillingSource,
+    ModelFinishReason,
+    ModelRequest,
+    ModelResponse,
+    ModelSnapshot,
+    OperationEconomics,
+    ToolCall,
+)
+from exp.simulation.synthesis import (
+    FRONTIER_PROBE_PROMPT,
+    FrontierProbe,
+    FrontierProbeError,
+    generate_frontier_probes,
+)
+
+_DIGEST = "a" * 64
+
+
+def _model() -> ModelSnapshot:
+    """Return one deterministic generator model identity."""
+    return ModelSnapshot(
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        provider="scripted",
+        model_id="probe-generator",
+        capabilities_sha256=_DIGEST,
+        connection_sha256=_DIGEST,
+    )
+
+
+class _ScriptedClient:
+    """Deterministic client returning one preconfigured completion."""
+
+    def __init__(
+        self,
+        content: str | None,
+        *,
+        tool_calls: tuple[ToolCall, ...] = (),
+        finish_reason: ModelFinishReason = ModelFinishReason.COMPLETED,
+    ) -> None:
+        """Store the scripted reply and start capturing requests."""
+        self._content = content
+        self._tool_calls = tool_calls
+        self._finish_reason = finish_reason
+        self.requests: list[ModelRequest] = []
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Capture the request and return the scripted completion."""
+        self.requests.append(request)
+        return ModelResponse(
+            output=AssistantAction(content=self._content, tool_calls=self._tool_calls),
+            model=_model(),
+            economics=OperationEconomics(),
+            finish_reason=self._finish_reason,
+        )
+
+
+def _probe_payload(count: int) -> str:
+    """Return a contract-valid JSON array with the given probe count."""
+    return json.dumps(
+        [
+            {"task": f"Probe scenario {index}.", "rationale": f"Frontier reason {index}."}
+            for index in range(count)
+        ]
+    )
+
+
+def test_generates_probes_from_the_observed_sample() -> None:
+    """One call sends the frontier prompt plus the sample and parses the reply."""
+    client = _ScriptedClient(_probe_payload(2))
+    batch = generate_frontier_probes(
+        client,
+        ("Reset a billing password.", "Merge duplicate accounts."),
+        probe_count=2,
+    )
+    assert [probe.task for probe in batch.probes] == ["Probe scenario 0.", "Probe scenario 1."]
+    assert batch.model.model_id == "probe-generator"
+    (request,) = client.requests
+    assert request.messages[0].role == "system"
+    assert request.messages[0].content == FRONTIER_PROBE_PROMPT
+    assert request.messages[1].role == "user"
+    assert "Reset a billing password." in str(request.messages[1].content)
+    assert '"probe_count":2' in str(request.messages[1].content)
+    assert request.maximum_output_tokens == 1_500
+
+
+def test_truncates_an_overlong_reply_to_the_requested_count() -> None:
+    """A reply with extra probes is cut to the requested count, never widened."""
+    client = _ScriptedClient(_probe_payload(4))
+    batch = generate_frontier_probes(client, ("Observed task.",), probe_count=2)
+    assert len(batch.probes) == 2
+
+
+def test_accepts_a_fenced_json_reply_and_a_short_batch() -> None:
+    """A single json-fenced reply parses, and fewer probes than asked is valid."""
+    client = _ScriptedClient(f"```json\n{_probe_payload(1)}\n```")
+    batch = generate_frontier_probes(client, ("Observed task.",), probe_count=3)
+    assert len(batch.probes) == 1
+
+
+def test_task_sha256_is_content_derived() -> None:
+    """Identical probe text yields the identical digest, so re-generation converges."""
+    first = FrontierProbe(task="Same probe.", rationale="Reason one.")
+    second = FrontierProbe(task="Same probe.", rationale="Reason two.")
+    assert first.task_sha256 == second.task_sha256
+    assert len(first.task_sha256) == 64
+
+
+def test_rejects_non_json_output() -> None:
+    """Prose instead of JSON fails loudly instead of yielding zero probes."""
+    client = _ScriptedClient("Here are some ideas you might like.")
+    with pytest.raises(FrontierProbeError, match="non-JSON"):
+        generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_a_json_object_reply() -> None:
+    """A JSON object where the array should be breaks the contract."""
+    client = _ScriptedClient(json.dumps({"task": "x", "rationale": "y"}))
+    with pytest.raises(FrontierProbeError, match="not an array"):
+        generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_a_probe_outside_the_contract() -> None:
+    """A probe entry missing its rationale breaks the contract."""
+    client = _ScriptedClient(json.dumps([{"task": "Probe without rationale."}]))
+    with pytest.raises(FrontierProbeError, match="contracted shape"):
+        generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_a_tool_call_only_reply() -> None:
+    """A reply with tool calls and no text cannot carry probes."""
+    client = _ScriptedClient(
+        None,
+        tool_calls=(ToolCall(call_id="call-1", name="noise", arguments={}),),
+    )
+    with pytest.raises(FrontierProbeError, match="no text"):
+        generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_a_reply_truncated_at_the_token_limit() -> None:
+    """A length-limited reply is refused before parsing half a JSON array."""
+    client = _ScriptedClient(_probe_payload(1), finish_reason=ModelFinishReason.LENGTH)
+    with pytest.raises(FrontierProbeError, match="output-token limit"):
+        generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_an_empty_observed_sample() -> None:
+    """Probing the frontier of nothing is a caller bug."""
+    client = _ScriptedClient(_probe_payload(1))
+    with pytest.raises(ValueError, match="at least one observed task"):
+        generate_frontier_probes(client, ())
+
+
+def test_rejects_empty_tasks_and_non_positive_counts() -> None:
+    """Empty sample entries and non-positive knobs fail before any model call."""
+    client = _ScriptedClient(_probe_payload(1))
+    with pytest.raises(ValueError, match="non-empty"):
+        generate_frontier_probes(client, ("",))
+    with pytest.raises(ValueError, match="probe_count"):
+        generate_frontier_probes(client, ("Observed task.",), probe_count=0)
+    with pytest.raises(ValueError, match="maximum_output_tokens"):
+        generate_frontier_probes(client, ("Observed task.",), maximum_output_tokens=0)
+    assert client.requests == []

--- a/exp/simulation/synthesis_test.py
+++ b/exp/simulation/synthesis_test.py
@@ -90,7 +90,7 @@ def test_generates_probes_from_the_observed_sample() -> None:
     assert request.messages[1].role == "user"
     assert "Reset a billing password." in str(request.messages[1].content)
     assert '"probe_count":2' in str(request.messages[1].content)
-    assert request.maximum_output_tokens == 1_500
+    assert request.maximum_output_tokens == 4_000
 
 
 def test_truncates_an_overlong_reply_to_the_requested_count() -> None:
@@ -134,6 +134,17 @@ def test_rejects_a_probe_outside_the_contract() -> None:
     client = _ScriptedClient(json.dumps([{"task": "Probe without rationale."}]))
     with pytest.raises(FrontierProbeError, match="contracted shape"):
         generate_frontier_probes(client, ("Observed task.",))
+
+
+def test_rejects_whitespace_only_probe_text_and_trims_edges() -> None:
+    """Blank-looking probe fields break the contract; edge whitespace is trimmed."""
+    blank = _ScriptedClient(json.dumps([{"task": "   ", "rationale": "Reason."}]))
+    with pytest.raises(FrontierProbeError, match="contracted shape"):
+        generate_frontier_probes(blank, ("Observed task.",))
+    padded = _ScriptedClient(json.dumps([{"task": "  Probe.  ", "rationale": " Reason. "}]))
+    (probe,) = generate_frontier_probes(padded, ("Observed task.",)).probes
+    assert probe.task == "Probe."
+    assert probe.rationale == "Reason."
 
 
 def test_rejects_a_tool_call_only_reply() -> None:


### PR DESCRIPTION
## What

Three intelligence seams whose logic previously lived platform-side move into the engine, per the product-owner ruling that they are engine capabilities. The Experiential Labs platform is the first consumer of each; every docstring says so.

### 1. Chat-capture mining adaptation: `exp/simulation/mining/chat_captures.py`

`mine_tasks_from_chat_captures(captures, mining_spec=None, *, embedder) -> ChatCaptureMiningResult`

Adapts captured OpenAI-style chat prompts (typed `ChatCapture`: request id, raw message array, aware capture time, optional group key) into canonical `Trace` objects (task text = system + developer contents + first user text turn, one fabricated span, no outcome) and runs the canonical `mine_tasks` service. Returns the full `TaskMiningResult`, each task's group key resolved through the coverage report's representative source capture, and a scalar `ChatCaptureMiningSummary`. The per-partition `*_workload_covered` fraction qualifies assigned workload mass by the coverage similarity threshold (selection assigns every candidate's mass to a representative, so raw assigned mass is always complete; distance-qualified mass is the honest number). Captures without usable text are passed to mining as `invalid_trace_count`, so the coverage report itself stays honest. A window with no minable capture is a normal empty run (`mining is None`), not an exception.

### 2. Frontier probe synthesis: `exp/simulation/synthesis.py`

`generate_frontier_probes(client, observed_tasks, *, probe_count=5, maximum_output_tokens=4000) -> FrontierProbeBatch`

The first piece of the principled scenario-generation layer: one model call reads a sample of observed scenario tasks and proposes variants at the frontier of plausibility (possible but unlikely, adjacent to observed traffic). Takes the engine's `ModelClient` protocol, never an HTTP client. Strict typed JSON array contract (`FrontierProbe`: task <= 2000 chars, rationale <= 300 chars, whitespace-only text rejected) with loud `FrontierProbeError` on non-JSON, non-array, out-of-contract entries, tool-call-only replies, and token-limit truncation. `FrontierProbeBatch.model` carries the resolved generator identity for provenance; `FrontierProbe.task_sha256` is content-derived so regenerating an identical probe converges.

### 3. Two-axis realism judge: `exp/common/judging/realism.py`

`RealismJudge(client, *, maximum_output_tokens=2000).assess(scenario) -> RealismAssessment`

Sits alongside `LMJudge` in the judging layer and is exported from `exp.common.judging`. One call per scenario returns SEPARATE `likelihood` and `feasibility` scores in [0, 1] plus a one-line rationale. The prompt explicitly forbids conflating "unlikely" with "impossible" (a rare-but-real situation is low likelihood and high feasibility), and nothing in the module ever combines the axes. Loud `RealismJudgmentError` on every contract break.

### 4. One-shot answer grading: `exp/common/judging/grading.py`

`AnswerGradeJudge(client, *, maximum_output_tokens=2000).grade(task=..., answer=...) -> AnswerGrade`

Grades one candidate answer against one scenario task on a [0, 1] rubric with a one-line rationale, judging task completion only (never style, length, or authorship). Same conventions as the realism judge: `ModelClient` protocol, truncation/textless/non-JSON rejection via `AnswerGradeError`, fence tolerance, trimmed non-blank contracts, reasoning-aware 2000-token default. Exported from `exp.common.judging`. The platform's eval loop decides what a failed grade means (it treats it as an absent cell).

With three one-shot JSON verdict consumers, the shared reply handling (truncation check, textless check, fence normalization, strict JSON parse) lives once as `structured_reply_json` in `exp/common/models/structured.py`; the probe generator and both judges use it, keeping shape validation with each contract.

## Deviations from the platform reference implementations

- Budgets, caps, and queue policy (fit/held-out budgets 40/10, probe batch halting on outstanding verdicts, daily assessment cap) stay platform-side: they are product pacing policy, not engine capability. The seams take budgets via `MiningSpec` and counts via arguments.
- The workload-covered scalar is distance-qualified instead of the reference's `selected_workload_mass / eligible` ratio, which is degenerate (always 1.0 when anything is selected) because selection assigns all candidate mass to nearest representatives.
- Group keys resolve through `CoverageReport.selections[...].representative_trace_id` instead of assuming `source_trace_ids[0]` is the representative; the coverage report is the authority on which capture a task represents.
- Default output-token budgets are higher than the reference's (probes 4000 vs 1500, realism 2000 vs 400): reasoning models spend hidden reasoning tokens from the same budget as the visible JSON, real traffic measured replies truncating at the reference caps, and this contract rejects truncation loudly.
- Both LLM seams accept a reply wrapped in a single Markdown code fence via the existing `structured_json_text` normalization, and reject `finish_reason == length` before parsing; parsing stays strict otherwise, and blank-looking text fields are rejected.
- The semantic-convention marker for fabricated capture traces is engine-owned (`exp-chat-capture-v1`, private) rather than the platform's `explabs-gateway-capture-v1`, and the fabricated span is named `chat.capture` rather than `gateway.request`.
- Prompts keep the platform wording and intent, with em dashes removed per repo writing rules.

## Consumption plan

No release is cut here. At the next `experiential` pin bump the platform swaps its interim `explabs/intelligence/{mining,generation,assessment}.py` implementations and the judge half of `explabs/intelligence/evals.py` (`JUDGE_PROMPT` + `judge_answer`) for these seams (submodule imports, matching how it already imports `exp.simulation.mining.service`) and deletes them.

## Validation

- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`: clean.
- `uv run pytest -q`: 3010 passed, 2 skipped.
- 43 new tests across the four seam modules and the shared reply helper: scripted providers, no network, covering the mining adaptation shape, group-key resolution, honesty counts, coverage-fraction discrimination between full and tight budgets, re-mine convergence, JSON contract violations, whitespace rejection, truncation, tool-call-only replies, and axis separation.
- Both Greptile findings (degenerate coverage ratio, whitespace passing validation) are fixed in b1ec2fcd with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
