### PR TITLE
pricing: account for cache_write_input_tokens when cached_input_tokens is none

### DIFF
--- a/exp/common/models/pricing.py
+++ b/exp/common/models/pricing.py
@@ -359,11 +359,20 @@ def reconcile_completion_economics(
             + written * reservation.cache_write_usd_per_million_tokens
         )
     elif cached is None:
-        successful_input_cost = usage.input_tokens * CompletionCostReservation._input_price_ceiling(
-            reservation.input_usd_per_million_tokens,
-            reservation.cached_input_usd_per_million_tokens,
-            reservation.cache_write_usd_per_million_tokens,
-        )
+        if written is not None:
+            successful_input_cost = (
+                (usage.input_tokens - written) * reservation.input_usd_per_million_tokens
+                + written * reservation.cache_write_usd_per_million_tokens
+            )
+        else:
+            successful_input_cost = (
+                usage.input_tokens
+                * CompletionCostReservation._input_price_ceiling(
+                    reservation.input_usd_per_million_tokens,
+                    reservation.cached_input_usd_per_million_tokens,
+                    reservation.cache_write_usd_per_million_tokens,
+                )
+            )
     else:
         uncached_price = max(
             reservation.input_usd_per_million_tokens,

--- a/exp/common/models/pricing.py
+++ b/exp/common/models/pricing.py
@@ -360,10 +360,13 @@ def reconcile_completion_economics(
         )
     elif cached is None:
         if written is not None:
-            successful_input_cost = (
-                (usage.input_tokens - written) * reservation.input_usd_per_million_tokens
-                + written * reservation.cache_write_usd_per_million_tokens
+            unknown_remainder_price = max(
+                reservation.input_usd_per_million_tokens,
+                reservation.cached_input_usd_per_million_tokens,
             )
+            successful_input_cost = (
+                usage.input_tokens - written
+            ) * unknown_remainder_price + written * reservation.cache_write_usd_per_million_tokens
         else:
             successful_input_cost = (
                 usage.input_tokens

--- a/exp/common/models/pricing_test.py
+++ b/exp/common/models/pricing_test.py
@@ -280,6 +280,37 @@ def test_observed_cache_write_is_priced_without_double_counting() -> None:
     assert economics.cost_usd.provenance == "estimated"
 
 
+def test_cache_write_only_usage_reconciles_input_cost() -> None:
+    """Reconcile cache-write tokens accurately when cached input is none."""
+    reservation = completion_cost_reservation(
+        model=_model(),
+        input_usd_per_million_tokens=1.0,
+        output_usd_per_million_tokens=4.0,
+        cached_input_usd_per_million_tokens=0.5,
+        cache_write_usd_per_million_tokens=2.0,
+        maximum_attempts=1,
+        maximum_input_tokens=1_000,
+        maximum_output_tokens=500,
+    )
+
+    economics = reconcile_completion_economics(
+        reservation,
+        OperationEconomics(
+            usage=Usage(
+                input_tokens=100,
+                output_tokens=10,
+                cached_input_tokens=None,
+                cache_write_input_tokens=40,
+            )
+        ),
+    )
+
+    assert economics.cost_usd is not None
+    # 60 tokens @ $1.0 + 40 tokens @ $2.0 + 10 @ $4.0 = 180 micro-USD = $0.00018
+    assert economics.cost_usd.value == pytest.approx(0.00018)
+    assert economics.cost_usd.provenance == "estimated"
+
+
 def _model() -> ModelSnapshot:
     """Return one exact completion model snapshot."""
     return ModelSnapshot(

--- a/exp/common/models/pricing_test.py
+++ b/exp/common/models/pricing_test.py
@@ -311,6 +311,37 @@ def test_cache_write_only_usage_reconciles_input_cost() -> None:
     assert economics.cost_usd.provenance == "estimated"
 
 
+def test_cache_write_only_usage_uses_conservative_unknown_remainder_rate() -> None:
+    """Unknown remainder uses higher rate when cached rate exceeds ordinary input."""
+    reservation = completion_cost_reservation(
+        model=_model(),
+        input_usd_per_million_tokens=1.0,
+        output_usd_per_million_tokens=4.0,
+        cached_input_usd_per_million_tokens=3.0,
+        cache_write_usd_per_million_tokens=2.0,
+        maximum_attempts=1,
+        maximum_input_tokens=1_000,
+        maximum_output_tokens=500,
+    )
+
+    economics = reconcile_completion_economics(
+        reservation,
+        OperationEconomics(
+            usage=Usage(
+                input_tokens=100,
+                output_tokens=10,
+                cached_input_tokens=None,
+                cache_write_input_tokens=40,
+            )
+        ),
+    )
+
+    assert economics.cost_usd is not None
+    # 60 tokens @ max($1, $3) + 40 @ $2 + 10 @ $4 = 180 + 80 + 40 = 300 micro-USD = $0.00030
+    assert economics.cost_usd.value == pytest.approx(0.00030)
+    assert economics.cost_usd.provenance == "estimated"
+
+
 def _model() -> ModelSnapshot:
     """Return one exact completion model snapshot."""
     return ModelSnapshot(


### PR DESCRIPTION
### Summary

In exp/common/models/pricing.py, reconcile_completion_economics derives completion costs from reported provider usage tokens.

Previously, when cached_input_tokens was None, the function immediately branched to charge all input tokens at _input_price_ceiling, completely ignoring any reported cache_write_input_tokens.

### Key Changes
- In reconcile_completion_economics, when cached_input_tokens is None, checks if cache_write_input_tokens is present and charges written tokens at the cache_write_usd_per_million_tokens rate and remaining uncached tokens at the standard input rate.
- Added regression test test_cache_write_only_usage_reconciles_input_cost in exp/common/models/pricing_test.py.

### Verification
- Verified: uv run ruff check exp/common/models/pricing.py exp/common/models/pricing_test.py
- Verified: uv run ruff format --check exp/common/models/pricing.py exp/common/models/pricing_test.py