### PR TITLE
release: bump version to 0.7.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.12"
+version = "0.7.13"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.12"
+version = "0.7.13"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.13 release. Ships #690 (Anthropic server tools end to end: web_search decode+forward, full response fidelity incl. citations and pause_turn, turn-2 echo carriage, the ~5.5x search-turn input undercount billing fix, ToolUnionParam drift gate) on top of v0.7.12's #688. Ships exp-gateway-native 0.3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)