### PR TITLE
gateway: keep the prompt-cache marker on a mixed waterfall (fix ~10x uncached billing)

### DIFF
--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -422,7 +422,13 @@ def route_generation_parameter_requests(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
         ignore("speed")
-    if request.provider_cache_control is not None and not all(
+    # Prompt-cache marker: honored on every Anthropic rung, so it is kept as
+    # long as ANY rung is Anthropic (only the non-Anthropic rungs silently
+    # cannot cache; a cache marker changes cost, not semantics). Dropping it the
+    # moment one fallback rung is non-Anthropic used to strip prefix caching
+    # from the winning Anthropic rung too, billing every turn's full context
+    # uncached (~10x on input for a large system prompt).
+    if request.provider_cache_control is not None and not any(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
         ignore("provider_cache_control", "cache_control")

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -700,6 +700,30 @@ def test_route_shaping_omits_tool_controls_when_no_tools_exist() -> None:
     assert provider_request.parallel_tool_calls is None
 
 
+def test_mixed_route_keeps_the_prompt_cache_marker_when_any_rung_is_anthropic() -> None:
+    """The cache marker survives a mixed waterfall so the winning Anthropic rung
+    still caches; only an all-non-Anthropic route drops it. Dropping it the
+    moment one fallback rung was non-Anthropic billed every turn's full context
+    uncached (~10x on a large system prompt)."""
+    request = _chat_request().model_copy(update={"provider_cache_control": {"type": "ephemeral"}})
+    anthropic = GatewayWireProfile(
+        dialect="anthropic_messages", url="https://a.test", model_id="claude-fable-5"
+    )
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://b.test")
+
+    # Mixed route with an Anthropic rung: kept, not disclosed.
+    public_request, provider_request = route_generation_parameter_requests(
+        (anthropic, fallback), request
+    )
+    assert provider_request.provider_cache_control == {"type": "ephemeral"}
+    assert "cache_control" not in public_request.ignored_parameters
+
+    # No rung can cache: dropped with disclosure.
+    public_only, provider_only = route_generation_parameter_requests((fallback,), request)
+    assert provider_only.provider_cache_control is None
+    assert "cache_control" in public_only.ignored_parameters
+
+
 def test_route_shaping_omits_parallel_control_when_tool_choice_disables_tools() -> None:
     """A parallel selector cannot affect a turn whose tool choice is none."""
     request = _chat_request().model_copy(
@@ -2096,10 +2120,12 @@ def test_diagnostics_speed_and_betas_forward_on_anthropic_and_disclose_elsewhere
 
 
 def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_elsewhere() -> None:
-    """Provider-native tool annotations plus the top-level cache marker and
-    inference region reach only the Anthropic wire; any other rung drops
-    each with a per-field disclosure, never a rejection (a production
-    Claude Code session sent ``eager_input_streaming`` and was 400ed)."""
+    """Provider-native tool annotations and inference region reach only the
+    Anthropic wire; any other rung drops each with a per-field disclosure,
+    never a rejection (a production Claude Code session sent
+    ``eager_input_streaming`` and was 400ed). The top-level cache marker is the
+    exception: it is cost-only and honored on any Anthropic rung, so a mixed
+    waterfall keeps it rather than billing every turn uncached."""
     from exp.runtime.gateway.contracts import GatewayToolDefinition
 
     request = GatewayRequest(
@@ -2165,8 +2191,11 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     mixed_public, mixed_provider = route_generation_parameter_requests(
         (anthropic, fallback), request
     )
+    # The top-level cache marker is COST-only and honored on the Anthropic rung,
+    # so a mixed waterfall keeps it (dropping it billed every turn uncached);
+    # the behavioral annotations still drop with disclosure on the non-Anthropic
+    # rungs.
     assert set(mixed_public.ignored_parameters) == {
-        "cache_control",
         "inference_geo",
         "tools.cache_control",
         "tools.eager_input_streaming",
@@ -2174,7 +2203,7 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
         "tools.allowed_callers",
         "tools.input_examples",
     }
-    assert mixed_provider.provider_cache_control is None
+    assert mixed_provider.provider_cache_control == {"type": "ephemeral"}
     assert mixed_provider.inference_geo is None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.13"
+version = "0.7.14"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.13"
+version = "0.7.14"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why (customer money — ~10x)

A Claude route with even one **non-Anthropic fallback rung** is "mixed". The request normalizer dropped the top-level cache marker (`provider_cache_control`) for the **whole request** the moment `not all` rungs were Anthropic (`streaming_requests.py:425`). And the Anthropic payload builder **flattens the system prompt to a plain string** (`messages_payloads.py:85`), so prefix caching rides that single top-level marker — dropping it stripped caching from the **winning Anthropic rung too**, billing every turn's full context uncached.

fable is **\$10/M input vs \$1/M cached** → ~10x on input; ~\$20 for 20 full-context Claude Code turns. **Prod confirms:** all-Anthropic `claude-fable-5` routes cache ~80%; mixed routes didn't.

## Fix

The marker is **cost-only and honored on any Anthropic rung**, so keep it whenever **any** rung is Anthropic (`not all` → `not any`). Only an all-non-Anthropic route drops it (with disclosure). Non-Anthropic rungs never read the field, so it's inert for them. Behavioral annotations (`inference_geo`, tool annotations) still drop on the non-Anthropic rungs, unchanged.

## Reproduced + locked
New test: a mixed (anthropic + openai) route **keeps** `provider_cache_control` and doesn't disclose it; an all-openai route **drops + discloses** it. Updated the one existing test that encoded the old all-or-nothing behavior.

Green locally: `pytest streaming_requests_test.py` (101), ruff + ty. Python-only → release **0.7.14** (`exp-gateway-native` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)