### PR TITLE
gateway: serve Azure AI Foundry Claude over the native Anthropic Messages wire (Cloud Opus 4.6)

### DIFF
--- a/exp/runtime/models/providers/anthropic.py
+++ b/exp/runtime/models/providers/anthropic.py
@@ -190,8 +190,16 @@ class AnthropicClient(ProviderHttpClient):
         supports_logprobs: bool = False,
         supports_reasoning: bool = False,
         reasoning_effort: str | None = None,
+        authorization_bearer: bool = False,
     ) -> None:
-        """Create an Anthropic client with explicit generation capability gates."""
+        """Create an Anthropic client with explicit generation capability gates.
+
+        ``authorization_bearer`` sends the credential as ``Authorization: Bearer``
+        instead of ``x-api-key``. Anthropic's own API uses ``x-api-key``; Azure AI
+        Foundry serves the same native Messages API at ``{endpoint}/anthropic/v1``
+        but authenticates with a Bearer token, so a Foundry-hosted Claude routes
+        through this client with ``authorization_bearer=True``.
+        """
         super().__init__(
             model=model,
             api_key=api_key,
@@ -206,11 +214,17 @@ class AnthropicClient(ProviderHttpClient):
         self._supports_logprobs = supports_logprobs
         self._supports_reasoning = supports_reasoning
         self._reasoning_effort = reasoning_effort
+        self._authorization_bearer = authorization_bearer
 
     def _headers(self) -> dict[str, str]:
-        """Build native Anthropic Messages headers with the versioned API key scheme."""
+        """Build native Anthropic Messages headers with the connection's auth scheme."""
+        auth = (
+            {"Authorization": f"Bearer {self._api_key}"}
+            if self._authorization_bearer
+            else {"x-api-key": self._api_key}
+        )
         return {
-            "x-api-key": self._api_key,
+            **auth,
             "anthropic-version": ANTHROPIC_VERSION,
             "content-type": "application/json",
         }

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -168,6 +168,25 @@ def _azure_base_url(
     return f"{root}/openai/deployments/{deployment}"
 
 
+def azure_anthropic_base_url(endpoint: str) -> str:
+    """Return the Foundry native Anthropic Messages root off one resource endpoint.
+
+    Azure AI Foundry serves Anthropic models at ``{resource}/anthropic/v1/messages``
+    off the RESOURCE root, independent of whichever wire path the connection
+    endpoint is spelled with (``/models``, ``/openai/v1``, ``/openai/deployments/…``),
+    so every equivalent spelling collapses to the one Anthropic root instead of
+    appending ``/anthropic/v1`` after a stale ``/models`` or ``/openai`` segment.
+
+    Args:
+        endpoint: Azure resource endpoint in any of its equivalent spellings.
+
+    Returns:
+        The ``{scheme}://{host}/anthropic/v1`` root, never a credential or query.
+    """
+    parsed = urlsplit(endpoint)
+    return urlunsplit((parsed.scheme, parsed.netloc, "/anthropic/v1", "", ""))
+
+
 class AzureClient(OpenAICompatibleClient):
     """Calls one explicit Azure connection without streaming, failover, or guessed deployments.
 

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -15,6 +15,7 @@ from exp.common.models import (
     ModelClient,
     ModelSnapshot,
     ReasoningEffort,
+    known_model_metadata,
 )
 from exp.runtime.models.credentials import read_connection_api_key
 from exp.runtime.models.preflight import CapabilityRequirement, preflight_capabilities
@@ -25,6 +26,7 @@ from exp.runtime.models.providers.async_transport import (
 )
 from exp.runtime.models.providers.azure import (
     AzureClient,
+    azure_anthropic_base_url,
     bind_azure_api_key,
     resolve_azure_api_surface,
 )
@@ -360,6 +362,33 @@ class RuntimeModelCatalog:
                 environment=self._environment,
                 api_surface=api_surface,
             )
+            # Azure AI Foundry serves Anthropic models over the NATIVE Anthropic
+            # Messages API at ``{endpoint}/anthropic/v1`` with Bearer auth, not
+            # the OpenAI-deployments wire (which 404s `api_not_supported` for
+            # them). A known Anthropic model on an Azure connection routes there;
+            # every other azure model keeps the OpenAI-compatible AzureClient.
+            if known_model_metadata("anthropic", snapshot.model_id) is not None:
+                anthropic_client = AnthropicClient(
+                    model=snapshot,
+                    api_key=api_key,
+                    base_url=azure_anthropic_base_url(connection.base_url),
+                    authorization_bearer=True,
+                    transport=self._transport_factory(),
+                    supports_temperature=capabilities.supports_temperature,
+                    supports_top_p=_supports_top_p(capabilities),
+                    supports_top_k=_supports_flag(capabilities, "supports_top_k"),
+                    supports_logprobs=_supports_flag(capabilities, "supports_logprobs"),
+                    supports_reasoning=capabilities.supports_reasoning,
+                    reasoning_effort=capabilities.reasoning_effort,
+                )
+                return ResolvedModel(
+                    alias,
+                    snapshot,
+                    capabilities,
+                    anthropic_client,
+                    None,
+                    served_model_id=record.served_model_id,
+                )
             client = AzureClient(
                 model=snapshot,
                 endpoint=connection.base_url,

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -22,6 +22,7 @@ from exp.common.models import (
 )
 from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.preflight import CapabilityRequirement, ModelCapabilityError
+from exp.runtime.models.providers.anthropic import AnthropicClient
 from exp.runtime.models.providers.azure import AzureClient
 from exp.runtime.models.providers.tinker_sampling import (
     TinkerOptionalDependencyError,
@@ -129,6 +130,78 @@ def test_foundry_catalog_resolution_uses_model_inference_token_field() -> None:
 
     assert isinstance(resolved.client, AzureClient)
     assert resolved.client.gateway_wire_profile().token_limit_key == "max_tokens"
+
+
+def test_azure_foundry_routes_a_known_anthropic_model_over_the_native_messages_wire() -> None:
+    """A known Anthropic model on an Azure (Foundry) connection dispatches over the
+    NATIVE Anthropic Messages API at /anthropic/v1 with Bearer auth, not the
+    OpenAI-deployments wire (which 404s api_not_supported for Claude on Foundry)."""
+    # A `/models`-spelled Foundry endpoint must still collapse to the resource
+    # root's /anthropic/v1, never `/models/anthropic/v1`.
+    catalog = ModelCatalog(
+        connections={
+            "primary": ConnectionConfig(
+                provider="azure",
+                base_url="https://silen-resource.services.ai.azure.com/models",
+                api_key_env="FIXTURE_API_KEY",
+                api_version="2024-10-21",
+            )
+        },
+        models={
+            "opus": ModelRecord(
+                connection="primary",
+                model="claude-opus-4-6",
+                billing_source=BillingSource.HOST_MANAGED,
+                capabilities=ModelCapabilities(supports_completions=True, supports_reasoning=True),
+            )
+        },
+        roles=ModelRoles(candidates=("opus",), incumbent="opus"),
+    )
+    runtime = RuntimeModelCatalog(
+        catalog,
+        environment={"FIXTURE_API_KEY": "foundry-secret"},
+        transport_factory=ScriptedJsonTransport,
+    )
+
+    resolved = runtime.resolve("opus")
+
+    assert isinstance(resolved.client, AnthropicClient)
+    profile = resolved.client.gateway_wire_profile()
+    assert profile.dialect == "anthropic_messages"
+    assert profile.url == "https://silen-resource.services.ai.azure.com/anthropic/v1/messages"
+    assert profile.headers["Authorization"] == "Bearer foundry-secret"
+    assert "x-api-key" not in profile.headers
+
+
+def test_azure_non_anthropic_model_keeps_the_openai_deployments_wire() -> None:
+    """A non-Anthropic model on the SAME Azure connection still uses AzureClient,
+    so the mixed Foundry connection (glm/kimi/deepseek + Claude) routes per model."""
+    catalog = ModelCatalog(
+        connections={
+            "primary": ConnectionConfig(
+                provider="azure",
+                base_url="https://silen-resource.services.ai.azure.com",
+                api_key_env="FIXTURE_API_KEY",
+                api_version="2024-10-21",
+            )
+        },
+        models={
+            "glm": ModelRecord(
+                connection="primary",
+                model="FW-GLM-5.2",
+                billing_source=BillingSource.HOST_MANAGED,
+                capabilities=ModelCapabilities(supports_completions=True),
+            )
+        },
+        roles=ModelRoles(candidates=("glm",), incumbent="glm"),
+    )
+    runtime = RuntimeModelCatalog(
+        catalog,
+        environment={"FIXTURE_API_KEY": "foundry-secret"},
+        transport_factory=ScriptedJsonTransport,
+    )
+
+    assert isinstance(runtime.resolve("glm").client, AzureClient)
 
 
 def test_snapshots_preserve_per_model_billing_source_on_one_connection() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.15"
+version = "0.7.16"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.15"
+version = "0.7.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

Azure AI Foundry hosts Anthropic models (`claude-opus-4-6`, …) but serves them on the **native Anthropic Messages API** at `{endpoint}/anthropic/v1/messages` with a **Bearer** token — not the OpenAI-`/openai/deployments` wire the azure provider used, which returns **404 `api_not_supported`** for Claude. So every Foundry-Claude ("Cloud Opus 4.6") request failed while the OpenAI-format Foundry models (glm/kimi/deepseek) served fine on the same connection.

## What

- **AnthropicClient** gains an `authorization_bearer` scheme: Anthropic's own API keeps `x-api-key`; Foundry authenticates the same Messages wire with `Authorization: Bearer`.
- **registry.py**: a **known** Anthropic model (`known_model_metadata("anthropic", model)`) on an `azure` connection now resolves to an `AnthropicClient` pointed at the Foundry `/anthropic/v1` root. Every non-Anthropic model on the same connection keeps the `AzureClient`, so a **mixed** Foundry connection routes correctly **per model**. No new provider or `api_surface` literal — the per-model signal is the existing known-model table.

## Verified
- Unit: a known Anthropic azure model → `AnthropicClient`, wire `dialect=anthropic_messages`, `url=…/anthropic/v1/messages`, `Authorization: Bearer`, no `x-api-key`; a non-Anthropic azure model stays `AzureClient`.
- **Live**: a real call to the Foundry endpoint via the actual client returned a completed Claude response (`FOUNDRY-OK`).
- 358 provider/registry tests green; ruff + ty clean.

Python-only → release **0.7.16** (`exp-gateway-native` unchanged). The house Foundry connection already maps `claude-opus-4.6 → claude-opus-4-6`, so once this releases + the platform pin bumps, Cloud Opus 4.6 serves with no catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)