### PR TITLE
anthropic: carry block-level prompt-cache markers end to end (fix dead caching, ~10x billing)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -228,9 +228,16 @@ adaptive default; on the adaptive-only generation, which rejects `enabled`/`disa
 configs outright, an `enabled` config translates to adaptive with the dropped
 `thinking.budget_tokens` disclosed as ignored, and `disabled` is rejected by name
 because those models cannot turn thinking off), requires
-`max_tokens`, validates `cache_control` (carrying it where the Anthropic wire caches natively:
-`tool_use` blocks, tool definitions, and the top-level automatic marker forward verbatim, while
-content-block hints drop; non-Anthropic routes disclose each omission through
+`max_tokens`, validates `cache_control` (carrying it everywhere the Anthropic wire caches
+natively: `tool_use` blocks, tool definitions, the top-level automatic marker, and block-level
+markers on system and message text runs and on `tool_result` breakpoints all forward verbatim.
+Marked runs re-emit the caller's exact block structure while the flattened string stays the
+canonical content for every other wire and for digests; markerless payloads stay byte-identical.
+This is what makes Claude Code sessions cacheable at all: it marks its system blocks and
+conversation breakpoints on every request, and flattening them once billed whole sessions
+uncached at ~10x. Responses report both cache legs back out of the folded ledger total, so
+callers see `cache_creation_input_tokens` on the writing turn and `cache_read_input_tokens` on
+later turns. Routes with no Anthropic rung disclose the dropped markers through
 `ignored_parameters`), carries the provider-native tool annotations (`strict`,
 `eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
 bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -324,7 +324,13 @@ def decode_messages(
     messages: list[GatewayMessage] = []
     system_text = _system_text(request.system)
     if system_text:
-        messages.append(GatewayMessage(role="system", content=system_text))
+        messages.append(
+            GatewayMessage(
+                role="system",
+                content=system_text,
+                provider_text_blocks=_marked_text_blocks(request.system),
+            )
+        )
     for index, message in enumerate(request.messages):
         messages.extend(_gateway_messages(message, index))
     parallel_tool_calls: bool | None = None
@@ -577,6 +583,31 @@ def _system_text(system: str | tuple[_TextBlock, ...] | None) -> str | None:
     return "\n\n".join(block.text for block in system)
 
 
+def _marked_text_blocks(
+    blocks: str | tuple[_TextBlock, ...] | None,
+) -> tuple[JsonObject, ...]:
+    """Rebuild a text-block run verbatim when any block carries a cache marker.
+
+    Claude Code marks system blocks and the last text block of recent user
+    turns (captured live 2026-09-01). The flattened string stays the
+    canonical content on every wire; this carrier exists so Anthropic rungs
+    re-emit the caller's exact block structure with its markers, which is
+    what makes the prompt cacheable at all. A markerless run carries
+    nothing, keeping existing payloads byte-identical.
+    """
+    if blocks is None or isinstance(blocks, str):
+        return ()
+    if all(block.cache_control is None for block in blocks):
+        return ()
+    rebuilt: list[JsonObject] = []
+    for block in blocks:
+        entry: JsonObject = {"type": "text", "text": block.text}
+        if block.cache_control is not None:
+            entry["cache_control"] = block.cache_control.model_dump(mode="json", exclude_none=True)
+        rebuilt.append(entry)
+    return tuple(rebuilt)
+
+
 def _stop_sequences(sequences: tuple[str, ...] | None) -> tuple[str, ...]:
     """Dedupe stop sequences in caller order and reject empty entries."""
     if not sequences:
@@ -656,13 +687,13 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
             )
         return [GatewayMessage(role=message.role, content=message.content)]
     out: list[GatewayMessage] = []
-    text_parts: list[str] = []
+    text_parts: list[_TextBlock] = []
     tool_calls: list[ToolCall] = []
     reasoning: list[ProviderReasoningBlock] = []
 
     def flush() -> None:
         """Emit the pending text, tool calls, and reasoning as one canonical message."""
-        content = "".join(text_parts) if text_parts else None
+        content = "".join(part.text for part in text_parts) if text_parts else None
         if content is None and not tool_calls and not reasoning:
             return
         out.append(
@@ -671,6 +702,7 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 content=content,
                 tool_calls=tuple(tool_calls),
                 provider_reasoning=tuple(reasoning),
+                provider_text_blocks=_marked_text_blocks(tuple(text_parts)),
             )
         )
         text_parts.clear()
@@ -698,9 +730,9 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 )
                 continue
             # An empty citations array (the SDK accumulator's uncited shape)
-            # is dropped with the other content-block hints: it carries no
-            # information and the bare text round-trips on every wire.
-            text_parts.append(block.text)
+            # carries no information and drops; a cache marker on the block
+            # survives through the marked-run carrier.
+            text_parts.append(block)
         elif isinstance(block, (_ThinkingBlock, _RedactedThinkingBlock)):
             if message.role != "assistant":
                 raise invalid_field(
@@ -761,6 +793,14 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                     content=_tool_result_text(block),
                     tool_call_id=block.tool_use_id,
                     tool_is_error=block.is_error,
+                    # The marker Claude Code puts on its conversation
+                    # breakpoints usually lands on a tool_result block; it
+                    # re-emits with the block on Anthropic rungs.
+                    cache_control=(
+                        block.cache_control.model_dump(mode="json", exclude_none=True)
+                        if block.cache_control is not None
+                        else None
+                    ),
                 )
             )
     flush()

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -902,3 +902,70 @@ def test_server_tool_blocks_and_citations_are_assistant_only() -> None:
             decode_messages(_body(messages=[{"role": "user", "content": content}]))
         assert error.value.status_code == 400
         assert "assistant" in error.value.detail.message
+
+
+def test_decode_carries_block_level_cache_markers_like_a_live_claude_code_turn() -> None:
+    """P0 (captured live 2026-09-01): Claude Code marks two of its three
+    system blocks and the last text block of the last user turn; agent loops
+    also mark tool_result breakpoints. Flattening dropped every marker, so
+    nothing through the gateway was ever cacheable (measured cache_read=0
+    across whole sessions, ~10x input billing)."""
+    decoded = decode_messages(
+        _body(
+            system=[
+                {"type": "text", "text": "You are Claude Code."},
+                {"type": "text", "text": "Short block.", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "Long env block.", "cache_control": {"type": "ephemeral"}},
+            ],
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "context"},
+                        {
+                            "type": "text",
+                            "text": "do the thing",
+                            "cache_control": {"type": "ephemeral"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "call-1", "name": "Bash", "input": {}}],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call-1",
+                            "content": "ok",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                },
+            ],
+        )
+    )
+    system = decoded.request.messages[0]
+    assert system.role == "system"
+    assert system.content == "You are Claude Code.\n\nShort block.\n\nLong env block."
+    assert system.provider_text_blocks == (
+        {"type": "text", "text": "You are Claude Code."},
+        {"type": "text", "text": "Short block.", "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "Long env block.", "cache_control": {"type": "ephemeral"}},
+    )
+    user = decoded.request.messages[1]
+    assert user.content == "contextdo the thing"
+    assert user.provider_text_blocks == (
+        {"type": "text", "text": "context"},
+        {"type": "text", "text": "do the thing", "cache_control": {"type": "ephemeral"}},
+    )
+    tool = decoded.request.messages[3]
+    assert tool.role == "tool"
+    assert tool.cache_control == {"type": "ephemeral"}
+
+    # A markerless request carries nothing: payloads stay byte-identical.
+    plain = decode_messages(_body(system=[{"type": "text", "text": "You are terse."}])).request
+    assert plain.messages[0].provider_text_blocks == ()
+    assert plain.messages[1].provider_text_blocks == ()

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -18,8 +18,9 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
 )
 from exp.runtime.gateway.auth import utc_text
-from exp.runtime.gateway.contracts import GatewayRequest, provider_replay_authority
+from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.gateway.interfaces import GatewayClock
+from exp.runtime.gateway.replay_identity import provider_replay_authority
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.store import SystemGatewayClock
 

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -1046,7 +1046,7 @@ def test_reservation_counts_excluded_provider_carriers_toward_the_tier_bound() -
         ),
         maximum_output_tokens=16,
     )
-    from exp.runtime.gateway.contracts import provider_replay_authority
+    from exp.runtime.gateway.replay_identity import provider_replay_authority
 
     visible_bytes = len(canonical_json_bytes(carried))
     assert visible_bytes < 2_048

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256, sha256_json
+from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, Sha256
 from exp.common.models.gateway_catalog import (
     DeploymentId,
     ExactModelId,
@@ -275,6 +275,28 @@ class GatewayMessage(ContractModel):
     like the other carriers so block-free digests are unperturbed; a present
     block joins replay identity through :func:`canonical_request_sha256`.
     """
+    provider_text_blocks: tuple[JsonObject, ...] = Field(default=(), exclude=True)
+    """This message's verbatim Anthropic text blocks when one carries a
+    prompt-cache marker.
+
+    Claude Code marks system blocks and the last text block of recent user
+    turns (captured live 2026-09-01); flattening them to one plain string
+    strips every marker, so nothing the caller sends is ever cacheable and
+    long sessions bill full input each turn (measured ~10x). When present,
+    the blocks' concatenated text equals ``content`` exactly and Anthropic
+    rungs re-emit them verbatim; other wires keep the flattened string and
+    disclose the dropped markers. A cache hint changes cost, not semantics,
+    so like the other cache carriers this joins neither serialization nor
+    replay identity.
+    """
+    cache_control: JsonObject | None = Field(default=None, exclude=True)
+    """Validated caller prompt-caching marker on this tool-result message.
+
+    Claude Code marks the last block of recent user turns, which in an agent
+    loop is usually a ``tool_result``; the split tool message carries the
+    marker onto the re-emitted block on Anthropic rungs. Cost, not
+    semantics: never in digests or replay identity.
+    """
 
     @model_validator(mode="after")
     def _require_role_coherence(self) -> GatewayMessage:
@@ -341,6 +363,17 @@ class GatewayMessage(ContractModel):
             raise ValueError("tool_call_id is valid only for tool messages")
         if self.role != "tool" and self.tool_is_error:
             raise ValueError("tool_is_error is valid only for tool messages")
+        if self.cache_control is not None and self.role != "tool":
+            raise ValueError("message cache_control is valid only for tool messages")
+        if self.provider_text_blocks:
+            if self.role == "tool":
+                raise ValueError("text blocks are not valid for tool messages")
+            # The carrier never changes semantics: its text must flatten to
+            # this message's canonical content (message runs join adjacent
+            # parts directly; system blocks join with one blank line).
+            texts = [str(block.get("text", "")) for block in self.provider_text_blocks]
+            if (self.content or "") not in ("".join(texts), "\n\n".join(texts)):
+                raise ValueError("provider text blocks must flatten to the message content")
         return self
 
 
@@ -630,143 +663,6 @@ class GatewayRequest(ContractModel):
         return self
 
 
-def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
-    """Collect the provider-significant input excluded from serialization.
-
-    The carriers (replayed reasoning, native items, verbatim provider
-    configurations) are excluded from model serialization so immutable
-    artifacts and pre-existing request digests stay byte-identical, but the
-    provider still reads them as input. Replay identity folds this envelope
-    into :func:`canonical_request_sha256`, and reservation adds its bytes to
-    the conservative input bound so an excluded carrier can never push a
-    request across a pricing threshold unreserved.
-
-    Args:
-        request: Canonical gateway request as decoded from the public wire.
-
-    Returns:
-        The envelope of excluded provider input, or ``None`` when the plain
-        serialization already covers everything.
-    """
-    replay: list[JsonObject] = []
-    for message_index, message in enumerate(request.messages):
-        authority: JsonObject = {"message_index": message_index}
-        if message.provider_item_id is not None:
-            authority["provider_item_id"] = message.provider_item_id
-            authority["provider_output_index"] = message.provider_output_index
-            authority["provider_status"] = message.provider_status
-            authority["provider_phase"] = message.provider_phase
-        if message.provider_native_item is not None:
-            authority["provider_native_item"] = message.provider_native_item
-        if message.provider_anthropic_block is not None:
-            authority["provider_anthropic_block"] = message.provider_anthropic_block
-        if message.provider_reasoning:
-            blocks: list[JsonObject] = []
-            for block in message.provider_reasoning:
-                serialized = block.model_dump(mode="json")
-                if isinstance(block, EncryptedReasoningBlock):
-                    serialized["output_index"] = block.output_index
-                    serialized["status"] = block.status
-                blocks.append(serialized)
-            authority["provider_reasoning"] = blocks
-        retained_calls: list[JsonObject] = []
-        for tool_call_index, call in enumerate(message.tool_calls):
-            if (
-                call.raw_arguments is None
-                and call.provider_item_id is None
-                and call.provider_output_index is None
-                and call.provider_status is None
-            ):
-                continue
-            retained_calls.append(
-                {
-                    "tool_call_index": tool_call_index,
-                    "call_id": call.call_id,
-                    "name": call.name,
-                    "raw_arguments": call.raw_arguments,
-                    "provider_item_id": call.provider_item_id,
-                    "provider_output_index": call.provider_output_index,
-                    "provider_status": call.provider_status,
-                }
-            )
-        if retained_calls:
-            authority["tool_calls"] = retained_calls
-        if message.tool_is_error:
-            authority["tool_is_error"] = True
-        if len(authority) > 1:
-            replay.append(authority)
-    retained_tools: list[JsonObject] = []
-    for tool_index, tool in enumerate(request.tools):
-        if not tool.has_anthropic_tool_carriers():
-            continue
-        retained_tool: JsonObject = {"tool_index": tool_index, "name": tool.name}
-        if tool.eager_input_streaming is not None:
-            retained_tool["eager_input_streaming"] = tool.eager_input_streaming
-        if tool.defer_loading is not None:
-            retained_tool["defer_loading"] = tool.defer_loading
-        if tool.allowed_callers is not None:
-            retained_tool["allowed_callers"] = list(tool.allowed_callers)
-        if tool.input_examples is not None:
-            retained_tool["input_examples"] = list(tool.input_examples)
-        retained_tools.append(retained_tool)
-    if (
-        not replay
-        and not retained_tools
-        and request.provider_thinking_config is None
-        and request.reasoning_context is None
-        and request.context_management is None
-        and request.provider_output_config is None
-        and request.diagnostics is None
-        and request.speed is None
-        and request.inference_geo is None
-        and not request.provider_beta_tokens
-        and not request.provider_server_tools
-    ):
-        return None
-    envelope: JsonObject = {
-        "provider_replay": replay,
-        "provider_thinking_config": request.provider_thinking_config,
-        "reasoning_context": request.reasoning_context,
-        "context_management": request.context_management,
-        "provider_output_config": request.provider_output_config,
-    }
-    # The newer Messages carriers join the envelope only when present, so
-    # every request decoded before they existed keeps its exact digest.
-    if request.diagnostics is not None:
-        envelope["diagnostics"] = request.diagnostics
-    if request.speed is not None:
-        envelope["speed"] = request.speed
-    if request.inference_geo is not None:
-        envelope["inference_geo"] = request.inference_geo
-    if retained_tools:
-        envelope["tools"] = retained_tools
-    if request.provider_beta_tokens:
-        envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
-    if request.provider_server_tools:
-        envelope["provider_server_tools"] = list(request.provider_server_tools)
-    return envelope
-
-
-def canonical_request_sha256(request: GatewayRequest) -> Sha256:
-    """Digest one canonical request including excluded provider replay authority.
-
-    A caller operation key reused with different replayed reasoning must be
-    a rejected conflict, never a silent replay of the earlier response. A
-    request with no carrier digests exactly as its plain serialization, so
-    every request decoded before the carriers existed keeps its identity.
-
-    Args:
-        request: Canonical gateway request as decoded from the public wire.
-
-    Returns:
-        The stable canonical request digest.
-    """
-    envelope = provider_replay_authority(request)
-    if envelope is None:
-        return sha256_json(request)
-    return sha256_json({"request_sha256": sha256_json(request), **envelope})
-
-
 class GatewayUsage(ContractModel):
     """Normalized token counts and invoked tool names from one provider attempt.
 
@@ -781,6 +677,10 @@ class GatewayUsage(ContractModel):
     input_tokens: int | None = Field(default=None, ge=0)
     output_tokens: int | None = Field(default=None, ge=0)
     cached_input_tokens: int | None = Field(default=None, ge=0)
+    cache_creation_input_tokens: int | None = Field(default=None, ge=0)
+    """Cache-write tokens inside the input total (Anthropic-only today),
+    present only when the provider reported a nonzero count; billing keeps
+    using the folded input total."""
     reasoning_tokens: int | None = Field(default=None, ge=0)
     tool_names: tuple[str, ...] = ()
     """Invoked tool names in first-use order, names only and never arguments."""
@@ -792,7 +692,11 @@ class GatewayUsage(ContractModel):
         if (totals[0] is None) != (totals[1] is None):
             raise ValueError("input and output token counts must be reported together")
         if totals[0] is None:
-            if self.cached_input_tokens is not None or self.reasoning_tokens is not None:
+            if (
+                self.cached_input_tokens is not None
+                or self.cache_creation_input_tokens is not None
+                or self.reasoning_tokens is not None
+            ):
                 raise ValueError("token detail counts require input and output totals")
             if not self.tool_names:
                 raise ValueError("usage requires token totals or invoked tool names")

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -236,7 +236,7 @@ def test_provider_reasoning_carrier_is_ordered_assistant_only_and_digest_free() 
     # Plain digests stay byte-identical (immutable artifacts, pre-carrier
     # requests), but replay identity distinguishes reasoning content so a
     # reused caller operation key with different reasoning conflicts.
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     assert canonical_request_sha256(bare) == sha256_json(bare)
     assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
@@ -316,7 +316,7 @@ def test_reasoning_carrier_request_fields_are_surface_scoped() -> None:
 
 def test_provider_replay_identity_hashes_exact_tool_and_message_state() -> None:
     """Excluded wire identity and raw argument bytes still bind idempotent replay."""
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(*, item_id: str, raw_arguments: str, output_index: int = 2) -> GatewayRequest:
         return GatewayRequest(
@@ -358,7 +358,7 @@ def test_provider_replay_identity_hashes_exact_tool_and_message_state() -> None:
 
 def test_provider_replay_identity_hashes_status_phase_and_idless_call_order() -> None:
     """Excluded OpenAI item fields remain authenticated canonical authority."""
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(
         *,
@@ -463,7 +463,7 @@ def test_reasoning_context_is_digest_excluded_but_joins_replay_identity() -> Non
     context is a conflict, never a silent replay.
     """
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.RESPONSES, messages=messages)
@@ -494,7 +494,7 @@ def test_reasoning_context_is_digest_excluded_but_joins_replay_identity() -> Non
 def test_context_management_is_digest_excluded_but_joins_replay_identity() -> None:
     """Config-free requests digest byte-identically to pre-field traffic."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
@@ -519,7 +519,8 @@ def test_context_management_is_digest_excluded_but_joins_replay_identity() -> No
 def test_anthropic_tool_annotations_are_digest_free_but_bind_replay_identity() -> None:
     """Tool carriers never perturb plain digests; present ones bind replay."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import GatewayToolDefinition, canonical_request_sha256
+    from exp.runtime.gateway.contracts import GatewayToolDefinition
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     def request(tool: GatewayToolDefinition) -> GatewayRequest:
         return GatewayRequest(
@@ -557,7 +558,7 @@ def test_anthropic_tool_annotations_are_digest_free_but_bind_replay_identity() -
 def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
     """The top-level cache marker stays identity-inert; the region binds replay."""
     from exp.common.core.artifacts import sha256_json
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     messages = (GatewayMessage(role="user", content="hi"),)
     bare = GatewayRequest(surface=GatewayApiSurface.MESSAGES, messages=messages)
@@ -608,7 +609,7 @@ def test_messages_only_carriers_cache_control_and_inference_geo() -> None:
 
 def test_server_tool_carriers_are_scoped_verbatim_and_join_replay_identity() -> None:
     """Server tool entries and echoed blocks are Messages-only whole-message carriers."""
-    from exp.runtime.gateway.contracts import canonical_request_sha256
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
 
     server_entry: JsonObject = {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
     bare = GatewayRequest(
@@ -669,4 +670,60 @@ def test_tool_choice_may_name_a_server_tool() -> None:
             messages=(GatewayMessage(role="user", content="hi"),),
             provider_server_tools=(server_entry,),
             tool_choice=GatewayNamedToolChoice(name="absent"),
+        )
+
+
+def test_block_cache_markers_are_identity_inert_and_role_scoped() -> None:
+    """Cache markers change cost, not semantics: no digest or replay effect."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    marked = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(
+                role="system",
+                content="a\n\nb",
+                provider_text_blocks=(
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b", "cache_control": {"type": "ephemeral"}},
+                ),
+            ),
+            GatewayMessage(role="user", content="hi"),
+        ),
+    )
+    bare = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="system", content="a\n\nb"),
+            GatewayMessage(role="user", content="hi"),
+        ),
+    )
+    assert marked.model_dump(mode="json") == bare.model_dump(mode="json")
+    assert sha256_json(marked) == sha256_json(bare)
+    assert canonical_request_sha256(marked) == canonical_request_sha256(bare)
+
+    marked_tool = GatewayMessage(
+        role="tool",
+        content="ok",
+        tool_call_id="call-1",
+        cache_control={"type": "ephemeral"},
+    )
+    bare_tool = GatewayMessage(role="tool", content="ok", tool_call_id="call-1")
+    assert sha256_json(marked_tool) == sha256_json(bare_tool)
+
+    with pytest.raises(ValidationError, match="valid only for tool messages"):
+        GatewayMessage(role="user", content="hi", cache_control={"type": "ephemeral"})
+    with pytest.raises(ValidationError, match="must flatten to the message content"):
+        GatewayMessage(
+            role="user",
+            content="different",
+            provider_text_blocks=({"type": "text", "text": "hi"},),
+        )
+    with pytest.raises(ValidationError, match="not valid for tool messages"):
+        GatewayMessage(
+            role="tool",
+            content="ok",
+            tool_call_id="call-1",
+            provider_text_blocks=({"type": "text", "text": "ok"},),
         )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.12"
+version = "0.3.13"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -286,6 +286,9 @@ impl Normalizer {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(self.output_tokens),
                     cached_input_tokens: Some(self.cache_read),
+                    // Present only when nonzero so cache-less streams keep
+                    // their exact pre-field usage shape.
+                    cache_creation_input_tokens: (self.cache_write > 0).then_some(self.cache_write),
                     // Anthropic reports thinking inside output_tokens and
                     // publishes no separate count, so the reasoning subset
                     // stays unknown instead of being invented.

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -70,10 +70,18 @@ pub(super) fn messages_usage(usage: Option<&Usage>) -> Value {
         _ => return json!({"input_tokens": 0, "output_tokens": 0}),
     };
     let cached = usage.cached_input_tokens.unwrap_or(0);
+    let creation = usage.cache_creation_input_tokens.unwrap_or(0);
     let mut body = Map::new();
+    // Both cache legs come back out of the folded ledger total so callers
+    // see the provider's own shape: input_tokens excludes cached reads and
+    // cache writes, each reported on its own leg.
     body.insert(
         "input_tokens".to_string(),
-        json!(usage.input_tokens.unwrap_or(0).saturating_sub(cached)),
+        json!(usage
+            .input_tokens
+            .unwrap_or(0)
+            .saturating_sub(cached)
+            .saturating_sub(creation)),
     );
     body.insert(
         "output_tokens".to_string(),
@@ -81,6 +89,9 @@ pub(super) fn messages_usage(usage: Option<&Usage>) -> Value {
     );
     if cached > 0 {
         body.insert("cache_read_input_tokens".to_string(), json!(cached));
+    }
+    if creation > 0 {
+        body.insert("cache_creation_input_tokens".to_string(), json!(creation));
     }
     Value::Object(body)
 }

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -10,6 +10,7 @@ fn usage_reports_cached_reads_out_of_the_input_total() {
         input_tokens: Some(10),
         output_tokens: Some(4),
         cached_input_tokens: Some(3),
+        cache_creation_input_tokens: None,
         reasoning_tokens: None,
     };
     assert_eq!(
@@ -588,4 +589,26 @@ fn paused_turn_keeps_its_stop_reason_on_both_paths() {
     let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
     assert_eq!(aggregated.body["stop_reason"], json!("pause_turn"));
     assert!(!aggregated.incomplete);
+}
+
+#[test]
+fn usage_reports_both_cache_legs_out_of_the_folded_input_total() {
+    // A live cached turn folds input as uncached + read + write for the
+    // ledger; callers get the provider's own shape back, with each cache
+    // leg on its own field (Claude Code displays cache_creation on turn 1).
+    let usage = Usage {
+        input_tokens: Some(45_543),
+        output_tokens: Some(9),
+        cached_input_tokens: Some(0),
+        cache_creation_input_tokens: Some(45_338),
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 205,
+            "output_tokens": 9,
+            "cache_creation_input_tokens": 45_338,
+        })
+    );
 }

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -11,6 +11,12 @@ pub struct Usage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
+    /// Cache-write tokens inside the input total, present only when the
+    /// provider reported a nonzero count (Anthropic-only today). The ledger
+    /// keeps billing the folded input total; this leg exists so callers see
+    /// their prompt being cached (Claude Code displays it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
     pub reasoning_tokens: Option<u64>,
 }
 
@@ -438,13 +444,19 @@ pub fn simplified_event(event: &Event) -> Value {
             "index": index,
             "citation": citation,
         }),
-        Event::Usage(usage) => serde_json::json!({
-            "kind": "usage",
-            "input_tokens": usage.input_tokens,
-            "output_tokens": usage.output_tokens,
-            "cached_input_tokens": usage.cached_input_tokens,
-            "reasoning_tokens": usage.reasoning_tokens,
-        }),
+        Event::Usage(usage) => {
+            let mut payload = serde_json::json!({
+                "kind": "usage",
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "cached_input_tokens": usage.cached_input_tokens,
+                "reasoning_tokens": usage.reasoning_tokens,
+            });
+            if let Some(creation) = usage.cache_creation_input_tokens {
+                payload["cache_creation_input_tokens"] = serde_json::json!(creation);
+            }
+            payload
+        }
         Event::Completed => serde_json::json!({"kind": "completed"}),
         Event::Incomplete => serde_json::json!({"kind": "incomplete"}),
         Event::PausedTurn => serde_json::json!({"kind": "paused_turn"}),
@@ -629,6 +641,7 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
             "cached_tokens",
             "OpenAI cached_tokens",
         )?,
+        cache_creation_input_tokens: None,
         reasoning_tokens: optional_usage_detail(
             object,
             "output_tokens_details",
@@ -658,6 +671,7 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
             "cached_tokens",
             "cached_tokens",
         )?,
+        cache_creation_input_tokens: None,
         reasoning_tokens: optional_usage_detail(
             object,
             "completion_tokens_details",
@@ -698,6 +712,7 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
             "cachedContentTokenCount",
             "Gemini cachedContentTokenCount",
         )?),
+        cache_creation_input_tokens: None,
         reasoning_tokens,
     })
 }
@@ -736,6 +751,7 @@ pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
             "Bedrock outputTokens",
         )?),
         cached_input_tokens: Some(cache_read),
+        cache_creation_input_tokens: None,
         reasoning_tokens: None,
     })
 }

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -476,6 +476,9 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                 input_tokens: object
                     .get("input_tokens")
                     .and_then(serde_json::Value::as_u64),
+                cache_creation_input_tokens: object
+                    .get("cache_creation_input_tokens")
+                    .and_then(serde_json::Value::as_u64),
                 output_tokens: object
                     .get("output_tokens")
                     .and_then(serde_json::Value::as_u64),

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -1,0 +1,143 @@
+"""Replay identity over canonical gateway requests and their excluded carriers."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject, Sha256, sha256_json
+from exp.runtime.gateway.contracts import EncryptedReasoningBlock, GatewayRequest
+
+
+def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
+    """Collect the provider-significant input excluded from serialization.
+
+    The carriers (replayed reasoning, native items, verbatim provider
+    configurations) are excluded from model serialization so immutable
+    artifacts and pre-existing request digests stay byte-identical, but the
+    provider still reads them as input. Replay identity folds this envelope
+    into :func:`canonical_request_sha256`, and reservation adds its bytes to
+    the conservative input bound so an excluded carrier can never push a
+    request across a pricing threshold unreserved.
+
+    Args:
+        request: Canonical gateway request as decoded from the public wire.
+
+    Returns:
+        The envelope of excluded provider input, or ``None`` when the plain
+        serialization already covers everything.
+    """
+    replay: list[JsonObject] = []
+    for message_index, message in enumerate(request.messages):
+        authority: JsonObject = {"message_index": message_index}
+        if message.provider_item_id is not None:
+            authority["provider_item_id"] = message.provider_item_id
+            authority["provider_output_index"] = message.provider_output_index
+            authority["provider_status"] = message.provider_status
+            authority["provider_phase"] = message.provider_phase
+        if message.provider_native_item is not None:
+            authority["provider_native_item"] = message.provider_native_item
+        if message.provider_anthropic_block is not None:
+            authority["provider_anthropic_block"] = message.provider_anthropic_block
+        if message.provider_reasoning:
+            blocks: list[JsonObject] = []
+            for block in message.provider_reasoning:
+                serialized = block.model_dump(mode="json")
+                if isinstance(block, EncryptedReasoningBlock):
+                    serialized["output_index"] = block.output_index
+                    serialized["status"] = block.status
+                blocks.append(serialized)
+            authority["provider_reasoning"] = blocks
+        retained_calls: list[JsonObject] = []
+        for tool_call_index, call in enumerate(message.tool_calls):
+            if (
+                call.raw_arguments is None
+                and call.provider_item_id is None
+                and call.provider_output_index is None
+                and call.provider_status is None
+            ):
+                continue
+            retained_calls.append(
+                {
+                    "tool_call_index": tool_call_index,
+                    "call_id": call.call_id,
+                    "name": call.name,
+                    "raw_arguments": call.raw_arguments,
+                    "provider_item_id": call.provider_item_id,
+                    "provider_output_index": call.provider_output_index,
+                    "provider_status": call.provider_status,
+                }
+            )
+        if retained_calls:
+            authority["tool_calls"] = retained_calls
+        if message.tool_is_error:
+            authority["tool_is_error"] = True
+        if len(authority) > 1:
+            replay.append(authority)
+    retained_tools: list[JsonObject] = []
+    for tool_index, tool in enumerate(request.tools):
+        if not tool.has_anthropic_tool_carriers():
+            continue
+        retained_tool: JsonObject = {"tool_index": tool_index, "name": tool.name}
+        if tool.eager_input_streaming is not None:
+            retained_tool["eager_input_streaming"] = tool.eager_input_streaming
+        if tool.defer_loading is not None:
+            retained_tool["defer_loading"] = tool.defer_loading
+        if tool.allowed_callers is not None:
+            retained_tool["allowed_callers"] = list(tool.allowed_callers)
+        if tool.input_examples is not None:
+            retained_tool["input_examples"] = list(tool.input_examples)
+        retained_tools.append(retained_tool)
+    if (
+        not replay
+        and not retained_tools
+        and request.provider_thinking_config is None
+        and request.reasoning_context is None
+        and request.context_management is None
+        and request.provider_output_config is None
+        and request.diagnostics is None
+        and request.speed is None
+        and request.inference_geo is None
+        and not request.provider_beta_tokens
+        and not request.provider_server_tools
+    ):
+        return None
+    envelope: JsonObject = {
+        "provider_replay": replay,
+        "provider_thinking_config": request.provider_thinking_config,
+        "reasoning_context": request.reasoning_context,
+        "context_management": request.context_management,
+        "provider_output_config": request.provider_output_config,
+    }
+    # The newer Messages carriers join the envelope only when present, so
+    # every request decoded before they existed keeps its exact digest.
+    if request.diagnostics is not None:
+        envelope["diagnostics"] = request.diagnostics
+    if request.speed is not None:
+        envelope["speed"] = request.speed
+    if request.inference_geo is not None:
+        envelope["inference_geo"] = request.inference_geo
+    if retained_tools:
+        envelope["tools"] = retained_tools
+    if request.provider_beta_tokens:
+        envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
+    if request.provider_server_tools:
+        envelope["provider_server_tools"] = list(request.provider_server_tools)
+    return envelope
+
+
+def canonical_request_sha256(request: GatewayRequest) -> Sha256:
+    """Digest one canonical request including excluded provider replay authority.
+
+    A caller operation key reused with different replayed reasoning must be
+    a rejected conflict, never a silent replay of the earlier response. A
+    request with no carrier digests exactly as its plain serialization, so
+    every request decoded before the carriers existed keeps its identity.
+
+    Args:
+        request: Canonical gateway request as decoded from the public wire.
+
+    Returns:
+        The stable canonical request digest.
+    """
+    envelope = provider_replay_authority(request)
+    if envelope is None:
+        return sha256_json(request)
+    return sha256_json({"request_sha256": sha256_json(request), **envelope})

--- a/exp/runtime/gateway/replay_identity_test.py
+++ b/exp/runtime/gateway/replay_identity_test.py
@@ -1,0 +1,1 @@
+"""Replay-identity behavior is covered in contracts_test.py beside the models it digests."""

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -28,9 +28,9 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayTarget,
     ProjectTarget,
-    canonical_request_sha256,
 )
 from exp.runtime.gateway.interfaces import GatewayClock
+from exp.runtime.gateway.replay_identity import canonical_request_sha256
 from exp.runtime.gateway.sqlite import key_delivery
 from exp.runtime.gateway.sqlite.alias_activation import (
     activate_alias_revision_in_transaction,

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -90,16 +90,37 @@ def anthropic_messages_stream_payload(
     }
     if system_parts:
         if any(blocks for _, blocks in system_parts):
-            # A cache-marked system prompt re-emits the caller's exact block
-            # structure: block-level markers are the only way the provider
-            # caches the prompt. Markerless requests keep the joined string
-            # so their payloads stay byte-identical.
+            # A cache-marked system prompt re-emits the caller's blocks with
+            # their markers: block-level markers are the only way the
+            # provider caches the prompt. A marker must change cost and
+            # nothing else, so the emitted text equals the unmarked joined
+            # string byte-for-byte. The provider rejects whitespace-only
+            # text blocks (verified live 2026-09-01), so each canonical
+            # blank-line separator is folded into the FOLLOWING block's text
+            # (between parts, and between a part's blocks when its canonical
+            # content joined them that way); markers stay on their blocks
+            # and the first block stays byte-exact. Markerless requests keep
+            # the joined string so their payloads stay byte-identical.
             system_blocks: list[JsonObject] = []
+
+            def emit(block: JsonObject, *, separated: bool) -> None:
+                """Append one block, folding in a leading separator if due."""
+                if separated:
+                    block = {**block, "text": "\n\n" + str(block.get("text", ""))}
+                system_blocks.append(block)
+
             for content, blocks in system_parts:
-                if blocks:
-                    system_blocks.extend(blocks)
-                else:
-                    system_blocks.append({"type": "text", "text": content})
+                part_leads = bool(system_blocks)
+                if not blocks:
+                    emit({"type": "text", "text": content}, separated=part_leads)
+                    continue
+                adjacent = "".join(str(block.get("text", "")) for block in blocks)
+                inner_separated = adjacent != content
+                for position, block in enumerate(blocks):
+                    emit(
+                        dict(block),
+                        separated=(part_leads if position == 0 else inner_separated),
+                    )
             payload["system"] = system_blocks
         else:
             payload["system"] = "\n\n".join(content for content, _ in system_parts)

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -50,7 +50,7 @@ def anthropic_messages_stream_payload(
     # this adapter. Keep the shared route signature for capability plumbing,
     # but never put an OpenAI-shaped field on the Anthropic wire.
     del supports_logprobs
-    system_parts: list[str] = []
+    system_parts: list[tuple[str, tuple[JsonObject, ...]]] = []
     messages: list[JsonObject] = []
     for message in request.messages:
         if message.role in {"system", "developer"}:
@@ -62,10 +62,17 @@ def anthropic_messages_stream_payload(
             # rules), so its position is preserved verbatim.
             if messages:
                 messages.append(
-                    {"role": "system", "content": [{"type": "text", "text": message.content}]}
+                    {
+                        "role": "system",
+                        "content": (
+                            list(message.provider_text_blocks)
+                            if message.provider_text_blocks
+                            else [{"type": "text", "text": message.content}]
+                        ),
+                    }
                 )
             else:
-                system_parts.append(message.content)
+                system_parts.append((message.content, message.provider_text_blocks))
             continue
         role, blocks = anthropic_blocks(message)
         if messages and messages[-1].get("role") == role:
@@ -82,7 +89,20 @@ def anthropic_messages_stream_payload(
         "stream": True,
     }
     if system_parts:
-        payload["system"] = "\n\n".join(system_parts)
+        if any(blocks for _, blocks in system_parts):
+            # A cache-marked system prompt re-emits the caller's exact block
+            # structure: block-level markers are the only way the provider
+            # caches the prompt. Markerless requests keep the joined string
+            # so their payloads stay byte-identical.
+            system_blocks: list[JsonObject] = []
+            for content, blocks in system_parts:
+                if blocks:
+                    system_blocks.extend(blocks)
+                else:
+                    system_blocks.append({"type": "text", "text": content})
+            payload["system"] = system_blocks
+        else:
+            payload["system"] = "\n\n".join(content for content, _ in system_parts)
     if request.tools:
         tools: list[JsonObject] = []
         for tool in request.tools:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -497,6 +497,19 @@ def route_generation_parameter_requests(
         if "messages.tool_calls.cache_control" not in ignored:
             ignored.append("messages.tool_calls.cache_control")
 
+    # Block-level cache markers (system and message text runs, tool-result
+    # breakpoints) follow the #699 rule: kept while ANY rung is Anthropic
+    # (the marker changes cost, not semantics, and only the non-Anthropic
+    # rungs silently cannot cache), disclosed only when no rung can honor
+    # them. Claude Code marks its system prompt and conversation
+    # breakpoints on every request.
+    if any(
+        message.provider_text_blocks or message.cache_control is not None
+        for message in request.messages
+    ) and not any(profile.dialect == "anthropic_messages" for profile in profiles):
+        if "messages.content.cache_control" not in ignored:
+            ignored.append("messages.content.cache_control")
+
     # Anthropic-native tool-definition annotations exist only on that wire;
     # every other rung drops each one with a per-field disclosure, never a
     # rejection (Claude Code sends eager_input_streaming conditionally).

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2452,9 +2452,12 @@ def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes()
         include_usage=True,
     )
     payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    # The canonical blank-line separator folds into the following block
+    # (the provider rejects whitespace-only blocks), so the system TEXT
+    # equals the unmarked join with markers on their blocks.
     assert payload["system"] == [
         {"type": "text", "text": "You are Claude Code."},
-        {"type": "text", "text": "Long env block.", "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "\n\nLong env block.", "cache_control": {"type": "ephemeral"}},
     ]
     messages = cast(list[JsonObject], payload["messages"])
     user_blocks = cast(list[JsonObject], messages[0]["content"])
@@ -2489,3 +2492,55 @@ def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes()
     assert mixed_provider.messages[0].provider_text_blocks
     foreign_public, _foreign_provider = route_generation_parameter_requests((fallback,), request)
     assert "messages.content.cache_control" in foreign_public.ignored_parameters
+
+
+def test_marked_system_prompt_keeps_the_exact_unmarked_text_bytes() -> None:
+    """Marked and unmarked payloads carry byte-identical system TEXT.
+
+    Cache markers must never change the instructions the model reads: with a
+    marked top-level system followed by a leading system-role turn, the
+    block-path text (blocks concatenated in order) equals the unmarked
+    joined string exactly, separator included, and the only difference is
+    the markers themselves.
+    """
+
+    def request(marked: bool) -> GatewayRequest:
+        blocks: tuple[JsonObject, ...] = (
+            (
+                {"type": "text", "text": "You are Claude Code."},
+                {
+                    "type": "text",
+                    "text": "Long env block.",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            )
+            if marked
+            else ()
+        )
+        return GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=(
+                GatewayMessage(
+                    role="system",
+                    content="You are Claude Code.\n\nLong env block.",
+                    provider_text_blocks=blocks,
+                ),
+                GatewayMessage(role="system", content="Leading turn instruction."),
+                GatewayMessage(role="user", content="hi"),
+            ),
+            stream=True,
+            include_usage=True,
+        )
+
+    unmarked_payload = anthropic_messages_stream_payload("claude-fable-5", request(False))
+    marked_payload = anthropic_messages_stream_payload("claude-fable-5", request(True))
+    unmarked_system = cast(str, unmarked_payload["system"])
+    marked_system = cast(list[JsonObject], marked_payload["system"])
+    assert "".join(str(block["text"]) for block in marked_system) == unmarked_system
+    marked_controls = [block.get("cache_control") for block in marked_system]
+    assert marked_controls.count({"type": "ephemeral"}) == 1
+    assert marked_system[1] == {
+        "type": "text",
+        "text": "\n\nLong env block.",
+        "cache_control": {"type": "ephemeral"},
+    }

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2407,3 +2407,85 @@ def test_anthropic_payload_reemits_echoed_server_blocks_in_order() -> None:
         result_block,
         cited_text,
     ]
+
+
+def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes() -> None:
+    """The caller's block structure re-emits exactly where markers exist and
+    only there; markerless payloads stay byte-identical, and per the #699
+    rule a mixed waterfall keeps the markers for its Anthropic rung."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(
+                role="system",
+                content="You are Claude Code.\n\nLong env block.",
+                provider_text_blocks=(
+                    {"type": "text", "text": "You are Claude Code."},
+                    {
+                        "type": "text",
+                        "text": "Long env block.",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ),
+            ),
+            GatewayMessage(
+                role="user",
+                content="contextdo the thing",
+                provider_text_blocks=(
+                    {"type": "text", "text": "context"},
+                    {
+                        "type": "text",
+                        "text": "do the thing",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ),
+            ),
+            GatewayMessage(role="assistant", content="ran it"),
+            GatewayMessage(
+                role="tool",
+                content="ok",
+                tool_call_id="call-1",
+                cache_control={"type": "ephemeral"},
+            ),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    assert payload["system"] == [
+        {"type": "text", "text": "You are Claude Code."},
+        {"type": "text", "text": "Long env block.", "cache_control": {"type": "ephemeral"}},
+    ]
+    messages = cast(list[JsonObject], payload["messages"])
+    user_blocks = cast(list[JsonObject], messages[0]["content"])
+    assert user_blocks == [
+        {"type": "text", "text": "context"},
+        {"type": "text", "text": "do the thing", "cache_control": {"type": "ephemeral"}},
+    ]
+    tool_blocks = cast(list[JsonObject], messages[2]["content"])
+    assert tool_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    # Markerless requests keep the exact pre-change wire shape.
+    plain = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="system", content="a\n\nb"),
+            GatewayMessage(role="user", content="hi"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    plain_payload = anthropic_messages_stream_payload("claude-fable-5", plain)
+    assert plain_payload["system"] == "a\n\nb"
+    plain_messages = cast(list[JsonObject], plain_payload["messages"])
+    assert plain_messages[0]["content"] == [{"type": "text", "text": "hi"}]
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
+    mixed_public, mixed_provider = route_generation_parameter_requests(
+        (anthropic, fallback), request
+    )
+    assert "messages.content.cache_control" not in mixed_public.ignored_parameters
+    assert mixed_provider.messages[0].provider_text_blocks
+    foreign_public, _foreign_provider = route_generation_parameter_requests((fallback,), request)
+    assert "messages.content.cache_control" in foreign_public.ignored_parameters

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -119,8 +119,16 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         # marker is emitted solely when set so existing payloads are unchanged.
         if message.tool_is_error:
             result["is_error"] = True
+        # A caller cache marker on the tool result re-emits with its block:
+        # this is where Claude Code's conversation breakpoints usually land.
+        if message.cache_control is not None:
+            result["cache_control"] = message.cache_control
         return ("user", [result])
     if message.role == "user":
+        if message.provider_text_blocks:
+            # The cache-marked run re-emits the caller's exact blocks; the
+            # flattened content stays canonical for every other wire.
+            return "user", list(message.provider_text_blocks)
         return "user", [{"type": "text", "text": message.content or ""}]
     if message.role != "assistant":
         raise ProviderResponseError("unsupported Anthropic message role")
@@ -143,7 +151,9 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # OpenAI encrypted reasoning cannot replay on the Anthropic wire;
             # route admission rejects the combination before dispatch.
             raise ProviderResponseError("encrypted reasoning cannot replay on the Anthropic wire")
-    if message.content is not None:
+    if message.provider_text_blocks:
+        blocks.extend(message.provider_text_blocks)
+    elif message.content is not None:
         blocks.append({"type": "text", "text": message.content})
     for call in message.tool_calls:
         tool_use: JsonObject = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.12,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.13,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.12"
+version = "0.3.13"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Problem (P0, measured from real usage)

Prompt caching was entirely dead through the gateway for Claude Code sessions. Two same-model fable-5 transcripts from the real CLI: the direct-Anthropic session shows healthy per-turn usage (`input_tokens=2` + `cache_read` 33k, session `cache_read_total=558,718`); the gateway session shows `cache_read=0` AND `cache_creation=0` on every turn, with the last turn paying `input_tokens=88,808` at full price. Cost ~10x+ on input and visibly worse TTFT on long sessions.

## Root cause (confirmed by live capture, 2026-09-01)

A captured real Claude Code request marks exactly: two of its three **system blocks** (`cache_control` on blocks 2 and 3, the third being the 27k-char environment block) and the **last text block of the last user turn** (a `tool_result` breakpoint in agent loops); tools and the top level are unmarked. The Messages decode flattens system and message text runs to plain strings and validated-then-dropped every block-level marker (`_system_text`, the text-run flatten, and the `tool_result` translation), so no request the gateway sent upstream carried a single cache breakpoint. The tool-definition/`tool_use`/top-level marker paths from 0.7.4 and #699 were already correct but Claude Code does not use them.

## Fix

**Block-structure carrier (`GatewayMessage.provider_text_blocks`)**: when any block of a system or message text run carries `cache_control`, decode rebuilds the run verbatim and Anthropic rungs re-emit the caller's exact block structure (system becomes a block array only in that case; mid-conversation system messages and user/assistant runs likewise). The flattened string remains the canonical `content` for every other wire and for digests, a validator pins the carrier's text to flatten back to it, and markerless payloads stay **byte-identical** to today. `tool_result` breakpoints ride a new tool-message `cache_control` carrier onto their re-emitted block.

Cache markers change cost, not semantics (the 0.7.4 precedent): both carriers join neither serialization nor replay identity, and per the #699 rule a mixed waterfall keeps them for its Anthropic rung, disclosing `messages.content.cache_control` only when no rung can honor them.

**Cache-write reporting (`cache_creation_input_tokens`)**: the normalizer folds cache-write tokens into the billed input total, but callers never saw them, so the writing turn looked uncached. A new optional leg on `Usage` (Rust) and `GatewayUsage` (python) reports both cache legs back out of the folded total on the Messages surface: the writing turn shows `cache_creation_input_tokens`, later turns show `cache_read_input_tokens`, and displayed `input_tokens` excludes both, exactly like the provider. Settlement and billing are untouched: the settle payload enumerates its fields and the ledger keeps billing the folded input total.

## Acceptance (the exact demanded metric)

A real two-turn Claude Code CLI session through a locally served native gateway (alias routed to api.anthropic.com, house key), transcript usage verbatim:

```
turn 1: {input_tokens: 3, cache_creation_input_tokens: 45543, cache_read_input_tokens: 0, output_tokens: 9}
turn 2: {input_tokens: 3, cache_creation_input_tokens: 23, cache_read_input_tokens: 45543, output_tokens: 10}
```

`cache_creation > 0` on turn 1, `cache_read > 0` on turn 2, and the per-turn shape matches the direct-Anthropic transcript. Direct live verification of the decode-and-built payload against api.anthropic.com: first call `cache_creation=7214`, second call `cache_read=7214`.

## Known gap (recorded, not this slice)

Cache-write tokens bill at the plain input rate (the provider's 1.25x write premium and 0.1x read discount are not modeled in `GatewayTokenPrices`); the read discount currently benefits the house, not the customer. Same pricing-schema follow-up class as the web-search per-use fee.

## Structure

`contracts.py` crossed the 1000-line budget, so replay identity (`provider_replay_authority`, `canonical_request_sha256`) moved to `exp/runtime/gateway/replay_identity.py` (four importers updated, no aliases).

## Gates

- ruff format / check, ty: clean
- Full `uv run pytest -q` on the committed tree: 2996 passed, 2 skipped
- `cargo test --no-default-features`: 119 passed; clippy clean; fmt clean
- Crate 0.3.12 -> 0.3.13 with pin floor, `Cargo.lock`, `uv.lock`, wheel chores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
