### PR TITLE
release: bump version to 0.7.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.16"
+version = "0.7.17"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.16"
+version = "0.7.17"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.17 release. Ships #703 (missed the v0.7.16 tag point): block-level prompt-cache markers carry end to end on Anthropic rungs — Claude Code sessions through the gateway ran fully uncached (~10x input billing, worse TTFT); cache_creation_input_tokens now reported to callers; marked-system separator fidelity pinned. Acceptance: real two-turn CLI session shows cache_creation=45,543 → cache_read=45,543 with input_tokens=3. Ships exp-gateway-native 0.3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)