### PR TITLE
gateway: serve the Responses-over-WebSocket transport on /v1/responses

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -10,6 +10,12 @@ It serves:
 - `GET /v1/models/{model_id}`
 - `POST /v1/chat/completions`
 - `POST /v1/responses`
+- `GET /v1/responses` as a WebSocket upgrade (the Responses-over-WebSocket transport used by
+  the Codex CLI against api.openai.com: `response.create` request frames, one standard
+  Responses stream event JSON per text frame, wrapped `{"type": "error", ...}` frames for
+  request-level failures, and a `generate: false` prewarm answered without provider work; the
+  bearer key is authenticated before the upgrade is accepted, and a GET without a well-formed
+  upgrade answers 426, the status the Codex client maps to its HTTP fallback)
 - `POST /v1/messages` (the Anthropic Messages API; `POST /v1/messages/count_tokens` answers an
   explicit Anthropic-shaped refusal because the gateway has no tokenizer authority)
 - `GET /health/live` and `GET /health/ready`

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -14,7 +14,8 @@ on the exact release checkout.
   written to the project.
 - The local gateway supports explicit provider references, identities, virtual keys, grants,
   singleton and certified ordered exact-model pools, frozen-project aliases, bounded precommit
-  provider fallback, Chat Completions, Responses, bounded in-memory continuation and replay,
+  provider fallback, Chat Completions, Responses (over HTTP and as the Responses-over-WebSocket
+  transport on the same route), bounded in-memory continuation and replay,
   content-free SQLite accounting, monthly integer micro-USD enforcement, loopback-only health
   and usage views, and optional identity-scoped guardrails that stay off until a policy is
   assigned. The bundled standard classifier pack is also default-off and is enabled only

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -33,8 +34,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -123,7 +126,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -153,6 +156,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "digest"
@@ -193,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "axum",
  "bytes",
@@ -316,6 +325,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -323,8 +344,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -689,6 +710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,7 +813,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -821,9 +851,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -833,7 +879,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -848,7 +913,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1025,6 +1090,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1230,6 +1306,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1404,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1475,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1558,6 +1671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1703,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ extension-module = ["pyo3/extension-module"]
 pyo3 = { version = "0.29", features = ["abi3-py312"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
 tokio-stream = "0.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 http = "1"
 http-body-util = "0.1"
 bytes = "1"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.13"
+version = "0.3.14"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -25,6 +25,7 @@ mod responses_retention;
 mod route_chat;
 mod route_messages;
 mod route_responses;
+mod route_responses_ws;
 mod server;
 mod settlement;
 mod sse;

--- a/exp/runtime/gateway/native/src/route_responses_ws.rs
+++ b/exp/runtime/gateway/native/src/route_responses_ws.rs
@@ -89,6 +89,12 @@ fn upgrade_required_error() -> PublicError {
 
 /// Copy the upgrade headers every synthesized per-frame request carries,
 /// dropping the handshake-only fields that do not describe the request.
+///
+/// `Idempotency-Key` is also dropped: it names ONE operation, and the
+/// WebSocket transport has no per-request header channel, so carrying the
+/// upgrade's value into every synthesized request would key every frame of
+/// the connection to the same replay identity. The operation-keyed replay
+/// protocol stays HTTP-only.
 fn request_headers(headers: &HeaderMap) -> HeaderMap {
     let mut carried = headers.clone();
     for name in [
@@ -102,6 +108,7 @@ fn request_headers(headers: &HeaderMap) -> HeaderMap {
     ] {
         carried.remove(name);
     }
+    carried.remove("idempotency-key");
     carried
 }
 
@@ -215,6 +222,7 @@ async fn relay_response(socket: &mut WebSocket, response: Response) -> Result<()
         .is_some_and(|value| value.starts_with("text/event-stream"));
     if status.is_success() && is_event_stream {
         let mut decoder = SseDecoder::new();
+        let mut saw_terminal = false;
         // Dropping the body mid-stream cancels the in-flight attempt through
         // the same disconnect guards an HTTP client disconnect triggers.
         let mut body = response.into_body().into_data_stream();
@@ -234,10 +242,24 @@ async fn relay_response(socket: &mut WebSocket, response: Response) -> Result<()
                 }
             };
             for event in events {
+                saw_terminal = saw_terminal || is_terminal_event(event.event.as_deref());
                 if socket.send(Message::Text(event.data.into())).await.is_err() {
                     return Err(());
                 }
             }
+        }
+        if !saw_terminal {
+            // A deliberately truncated stream (retention or keyed publication
+            // failed) ends the HTTP body without a terminal event; over HTTP
+            // the caller observes EOF, but a socket would wait forever, so
+            // the truncation becomes an explicit in-band error.
+            let error = PublicError::new(
+                502,
+                "incomplete_stream",
+                "The response stream ended before its terminal event. Resend the request.",
+                "server_error",
+            );
+            return send_public_error(socket, &error).await;
         }
         return Ok(());
     }
@@ -271,8 +293,7 @@ async fn send_prewarm_ack(socket: &mut WebSocket, request: &Value) -> Result<(),
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    let envelope: ResponsesEnvelope =
-        serde_json::from_value(request.clone()).unwrap_or_default();
+    let envelope: ResponsesEnvelope = serde_json::from_value(request.clone()).unwrap_or_default();
     let created_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_secs_f64())
@@ -301,6 +322,20 @@ async fn send_prewarm_ack(socket: &mut WebSocket, request: &Value) -> Result<(),
         }
     }
     Ok(())
+}
+
+/// Whether one relayed SSE event name closes its response stream.
+///
+/// Mirrors the Responses terminal vocabulary the encoder emits; a stream
+/// that ends without one of these was truncated, never completed.
+fn is_terminal_event(event_name: Option<&str>) -> bool {
+    matches!(
+        event_name,
+        Some("response.completed")
+            | Some("response.failed")
+            | Some("response.incomplete")
+            | Some("error")
+    )
 }
 
 /// Extract the single-line `data:` payload from one encoder SSE frame.
@@ -356,7 +391,10 @@ mod tests {
     #[test]
     fn sse_frame_data_extracts_the_payload() {
         let frame = "event: response.created\ndata: {\"type\":\"response.created\"}\n\n";
-        assert_eq!(sse_frame_data(frame), Some("{\"type\":\"response.created\"}"));
+        assert_eq!(
+            sse_frame_data(frame),
+            Some("{\"type\":\"response.created\"}")
+        );
     }
 
     #[test]
@@ -386,5 +424,28 @@ mod tests {
         assert!(!carried.contains_key(header::UPGRADE));
         assert!(!carried.contains_key(header::SEC_WEBSOCKET_KEY));
         assert!(!carried.contains_key(header::SEC_WEBSOCKET_VERSION));
+    }
+
+    #[test]
+    fn request_headers_never_carry_an_operation_key_across_frames() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, "Bearer xpl_test".parse().unwrap());
+        headers.insert("idempotency-key", "op-1".parse().unwrap());
+        let carried = request_headers(&headers);
+        assert!(!carried.contains_key("idempotency-key"));
+    }
+
+    #[test]
+    fn terminal_vocabulary_matches_the_responses_lifecycle() {
+        for name in [
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+            "error",
+        ] {
+            assert!(is_terminal_event(Some(name)), "{name} must be terminal");
+        }
+        assert!(!is_terminal_event(Some("response.output_text.delta")));
+        assert!(!is_terminal_event(None));
     }
 }

--- a/exp/runtime/gateway/native/src/route_responses_ws.rs
+++ b/exp/runtime/gateway/native/src/route_responses_ws.rs
@@ -1,0 +1,390 @@
+//! WebSocket transport for the OpenAI Responses surface: the GET
+//! `/v1/responses` upgrade handler and its per-connection frame loop,
+//! mirroring the Responses-over-WebSocket contract served by
+//! api.openai.com. A client frame is the standard Responses request body
+//! tagged `"type": "response.create"`; every server frame is exactly one
+//! standard Responses stream event JSON (the SSE `data:` payload), with
+//! request-level failures carried as wrapped in-band
+//! `{"type": "error", "error": ..., "status": ...}` frames. The transport
+//! is an adapter only: every generating request crosses the exact HTTP
+//! handler (`route_responses::responses`) with the connection's upgrade
+//! headers, so decode, admission, replay, waterfall, and settlement are
+//! identical on both transports. A `generate: false` frame is the
+//! connection prewarm: it is answered with an empty completed response
+//! envelope and never touches admission or the ledger.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::ws::rejection::WebSocketUpgradeRejection;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::http::{header, HeaderMap, Method};
+use axum::response::Response;
+use futures_util::StreamExt;
+use serde_json::{json, Map, Value};
+
+use crate::encode::compact_json;
+use crate::encode_responses::{ResponsesEnvelope, ResponsesSseEncoder};
+use crate::errors::PublicError;
+use crate::events::Event;
+use crate::respond::{bearer_key, error_response};
+use crate::route_responses::responses;
+use crate::server::AppState;
+use crate::sse::SseDecoder;
+
+/// Bound on a buffered non-streaming (error) response body read back from
+/// the HTTP handler; its bodies are single compact JSON envelopes.
+const MAXIMUM_ADAPTED_BODY_BYTES: usize = 1_000_000;
+
+/// Byte-compatible rejection for `"stream": false`, which the WebSocket
+/// transport cannot honor (api.openai.com answers this exact message).
+const STREAM_FALSE_MESSAGE: &str = "The 'stream' parameter is not supported on /v1/responses.";
+
+/// Monotonic component of prewarm response identities within one process.
+static PREWARM_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Answer the `/v1/responses` WebSocket upgrade.
+///
+/// The bearer key is authenticated before the upgrade is accepted, so an
+/// unknown key rejects the handshake with the same plain HTTP 401 the POST
+/// surface answers (matching api.openai.com). A GET without a well-formed
+/// upgrade fails closed with 426, the one status the Codex client treats
+/// as "use HTTP instead".
+pub(crate) async fn responses_ws(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+) -> Response {
+    state.handled_requests.fetch_add(1, Ordering::Relaxed);
+    let upgrade = match upgrade {
+        Ok(upgrade) => upgrade,
+        Err(_) => return error_response(&upgrade_required_error()),
+    };
+    let raw_key = match bearer_key(&headers) {
+        Ok(key) => key,
+        Err(error) => return error_response(&error),
+    };
+    // Upgrade-time rejection mirrors api.openai.com; the shared HTTP handler
+    // still authenticates every later frame with the connection's headers,
+    // so key revocation applies mid-connection at the next request.
+    let authenticate = compact_json(&json!({"raw_key": raw_key}));
+    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
+        return error_response(&error);
+    }
+    let connection_headers = request_headers(&headers);
+    upgrade.on_upgrade(move |socket| serve_socket(state, connection_headers, socket))
+}
+
+/// The 426 answered for a GET that is not a well-formed WebSocket upgrade.
+fn upgrade_required_error() -> PublicError {
+    PublicError::new(
+        426,
+        "upgrade_required",
+        "GET /v1/responses is served only as a WebSocket upgrade. Open a \
+         WebSocket connection, or POST the request over HTTP.",
+        "invalid_request_error",
+    )
+}
+
+/// Copy the upgrade headers every synthesized per-frame request carries,
+/// dropping the handshake-only fields that do not describe the request.
+fn request_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut carried = headers.clone();
+    for name in [
+        header::CONNECTION,
+        header::UPGRADE,
+        header::CONTENT_LENGTH,
+        header::SEC_WEBSOCKET_KEY,
+        header::SEC_WEBSOCKET_VERSION,
+        header::SEC_WEBSOCKET_EXTENSIONS,
+        header::SEC_WEBSOCKET_PROTOCOL,
+    ] {
+        carried.remove(name);
+    }
+    carried
+}
+
+/// Serve one accepted connection: sequential request frames, each answered
+/// with its full event stream before the next frame is read.
+async fn serve_socket(state: AppState, headers: HeaderMap, mut socket: WebSocket) {
+    while let Some(message) = socket.recv().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(_) => return,
+        };
+        match message {
+            Message::Text(text) => {
+                if handle_frame(&state, &headers, &mut socket, text.as_str())
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Message::Binary(_) => {
+                let error = PublicError::new(
+                    400,
+                    "invalid_request",
+                    "Binary WebSocket frames are not supported. Send one JSON \
+                     response.create object per text frame.",
+                    "invalid_request_error",
+                );
+                if send_public_error(&mut socket, &error).await.is_err() {
+                    return;
+                }
+            }
+            Message::Close(_) => return,
+            // The axum WebSocket answers pings itself; pongs carry no work.
+            Message::Ping(_) | Message::Pong(_) => {}
+        }
+    }
+}
+
+/// Decode one request frame and stream its response frames back.
+///
+/// Returns `Err(())` only when the socket is unusable; request-level
+/// failures are answered in-band and keep the connection open.
+async fn handle_frame(
+    state: &AppState,
+    headers: &HeaderMap,
+    socket: &mut WebSocket,
+    text: &str,
+) -> Result<(), ()> {
+    let mut value: Value = match serde_json::from_str(text) {
+        Ok(Value::Object(entries)) => Value::Object(entries),
+        _ => return send_public_error(socket, &PublicError::invalid_json()).await,
+    };
+    let body = value.as_object_mut().expect("frame decoded as an object");
+    match body.remove("type") {
+        Some(Value::String(kind)) if kind == "response.create" => {}
+        _ => {
+            let error = PublicError::new(
+                400,
+                "invalid_request",
+                "WebSocket request frames must be tagged \"type\": \
+                 \"response.create\".",
+                "invalid_request_error",
+            );
+            return send_public_error(socket, &error).await;
+        }
+    }
+    // `generate: false` is the transport prewarm: acknowledge the connection
+    // with an empty completed response and perform no model work.
+    if let Some(generate) = body.remove("generate") {
+        if generate == Value::Bool(false) {
+            return send_prewarm_ack(socket, &value).await;
+        }
+    }
+    // The WebSocket surface always streams; only an explicit opt-out is a
+    // request error (api.openai.com answers this exact wrapped 400).
+    match body.get("stream") {
+        Some(Value::Bool(false)) => {
+            let error = PublicError::new(
+                400,
+                "invalid_request",
+                STREAM_FALSE_MESSAGE,
+                "invalid_request_error",
+            );
+            return send_public_error(socket, &error).await;
+        }
+        _ => {
+            body.insert("stream".to_string(), Value::Bool(true));
+        }
+    }
+
+    let mut request = axum::http::Request::builder()
+        .method(Method::POST)
+        .uri("/v1/responses")
+        .body(axum::body::Body::from(compact_json(&value)))
+        .expect("static request line is valid");
+    *request.headers_mut() = headers.clone();
+    let response = responses(State(state.clone()), request).await;
+    relay_response(socket, response).await
+}
+
+/// Re-frame one HTTP handler response onto the socket: an event-stream body
+/// becomes one text frame per SSE event; anything else becomes one wrapped
+/// in-band error frame.
+async fn relay_response(socket: &mut WebSocket, response: Response) -> Result<(), ()> {
+    let status = response.status();
+    let is_event_stream = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/event-stream"));
+    if status.is_success() && is_event_stream {
+        let mut decoder = SseDecoder::new();
+        // Dropping the body mid-stream cancels the in-flight attempt through
+        // the same disconnect guards an HTTP client disconnect triggers.
+        let mut body = response.into_body().into_data_stream();
+        while let Some(chunk) = body.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(_) => {
+                    let error = PublicError::internal();
+                    return send_public_error(socket, &error).await;
+                }
+            };
+            let events = match decoder.feed(&chunk) {
+                Ok(events) => events,
+                Err(_) => {
+                    let error = PublicError::internal();
+                    return send_public_error(socket, &error).await;
+                }
+            };
+            for event in events {
+                if socket.send(Message::Text(event.data.into())).await.is_err() {
+                    return Err(());
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    let retry_after = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = match axum::body::to_bytes(response.into_body(), MAXIMUM_ADAPTED_BODY_BYTES).await {
+        Ok(body) => body,
+        Err(_) => return send_public_error(socket, &PublicError::internal()).await,
+    };
+    let error = serde_json::from_slice::<Value>(&body)
+        .ok()
+        .and_then(|mut envelope| {
+            envelope
+                .as_object_mut()
+                .and_then(|entries| entries.remove("error"))
+        })
+        .unwrap_or_else(|| error_object(&PublicError::internal()));
+    send_wrapped_error(socket, status.as_u16(), error, retry_after).await
+}
+
+/// Answer one prewarm frame with created, in-progress, and empty completed
+/// lifecycle events reflecting the request envelope, without admission,
+/// ledger, or provider work.
+async fn send_prewarm_ack(socket: &mut WebSocket, request: &Value) -> Result<(), ()> {
+    let model = request
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let envelope: ResponsesEnvelope =
+        serde_json::from_value(request.clone()).unwrap_or_default();
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs_f64())
+        .unwrap_or_default();
+    let sequence = PREWARM_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let request_id = format!("prewarm:{created_at}:{sequence}");
+    let mut encoder = ResponsesSseEncoder::new(&request_id, &model, created_at, envelope);
+    let mut frames = match encoder.start() {
+        Ok(frames) => frames,
+        Err(error) => return send_public_error(socket, &error).await,
+    };
+    match encoder.feed(&Event::Completed) {
+        Ok(terminal) => frames.extend(terminal),
+        Err(error) => return send_public_error(socket, &error).await,
+    }
+    for frame in frames {
+        let Some(data) = sse_frame_data(&frame) else {
+            return send_public_error(socket, &PublicError::internal()).await;
+        };
+        if socket
+            .send(Message::Text(data.to_string().into()))
+            .await
+            .is_err()
+        {
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+/// Extract the single-line `data:` payload from one encoder SSE frame.
+fn sse_frame_data(frame: &str) -> Option<&str> {
+    frame
+        .split_once("\ndata: ")
+        .map(|(_, tail)| tail)
+        .and_then(|tail| tail.strip_suffix("\n\n"))
+}
+
+/// The bare error object inside one `PublicError`'s OpenAI envelope.
+fn error_object(error: &PublicError) -> Value {
+    let mut envelope = error.json_body();
+    envelope
+        .as_object_mut()
+        .and_then(|entries| entries.remove("error"))
+        .expect("public error envelope carries an error object")
+}
+
+/// Send one wrapped in-band error frame built from a `PublicError`.
+async fn send_public_error(socket: &mut WebSocket, error: &PublicError) -> Result<(), ()> {
+    let envelope = error_object(error);
+    let retry_after = error.retry_after_seconds.map(|wait| wait.to_string());
+    send_wrapped_error(socket, error.status_code, envelope, retry_after).await
+}
+
+/// Send the wrapped `{"type": "error", "error": ..., "status": ...}` frame
+/// the Responses-over-WebSocket contract uses for request-level failures.
+async fn send_wrapped_error(
+    socket: &mut WebSocket,
+    status: u16,
+    error: Value,
+    retry_after: Option<String>,
+) -> Result<(), ()> {
+    let mut frame = Map::new();
+    frame.insert("type".to_string(), Value::String("error".to_string()));
+    frame.insert("error".to_string(), error);
+    frame.insert("status".to_string(), json!(status));
+    if let Some(wait) = retry_after {
+        frame.insert("headers".to_string(), json!({ "retry-after": wait }));
+    }
+    let payload = compact_json(&Value::Object(frame));
+    socket
+        .send(Message::Text(payload.into()))
+        .await
+        .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_frame_data_extracts_the_payload() {
+        let frame = "event: response.created\ndata: {\"type\":\"response.created\"}\n\n";
+        assert_eq!(sse_frame_data(frame), Some("{\"type\":\"response.created\"}"));
+    }
+
+    #[test]
+    fn sse_frame_data_rejects_a_malformed_frame() {
+        assert_eq!(sse_frame_data("data only"), None);
+        assert_eq!(sse_frame_data("event: x\ndata: {}"), None);
+    }
+
+    #[test]
+    fn upgrade_required_error_is_the_codex_fallback_status() {
+        assert_eq!(upgrade_required_error().status_code, 426);
+    }
+
+    #[test]
+    fn request_headers_drop_the_handshake_fields() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, "Bearer xpl_test".parse().unwrap());
+        headers.insert(header::CONNECTION, "Upgrade".parse().unwrap());
+        headers.insert(header::UPGRADE, "websocket".parse().unwrap());
+        headers.insert(header::SEC_WEBSOCKET_KEY, "abc".parse().unwrap());
+        headers.insert(header::SEC_WEBSOCKET_VERSION, "13".parse().unwrap());
+        headers.insert("x-client-request-id", "session-1".parse().unwrap());
+        let carried = request_headers(&headers);
+        assert!(carried.contains_key(header::AUTHORIZATION));
+        assert!(carried.contains_key("x-client-request-id"));
+        assert!(!carried.contains_key(header::CONNECTION));
+        assert!(!carried.contains_key(header::UPGRADE));
+        assert!(!carried.contains_key(header::SEC_WEBSOCKET_KEY));
+        assert!(!carried.contains_key(header::SEC_WEBSOCKET_VERSION));
+    }
+}

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -28,6 +28,7 @@ use crate::respond::{bearer_key, error_response, json_response, unknown_route_er
 use crate::route_chat::chat;
 use crate::route_messages::{messages, messages_count_tokens};
 use crate::route_responses::responses;
+use crate::route_responses_ws::responses_ws;
 
 /// Serve-time configuration passed from `exp --engine rust`.
 #[derive(Debug, Clone, Deserialize)]
@@ -151,7 +152,7 @@ pub async fn run(
         .route("/v1/models", get(models))
         .route("/v1/models/{model_id}", get(model_detail))
         .route("/v1/chat/completions", post(chat))
-        .route("/v1/responses", post(responses))
+        .route("/v1/responses", post(responses).get(responses_ws))
         .route("/v1/messages", post(messages))
         .route("/v1/messages/count_tokens", post(messages_count_tokens))
         .route("/health/live", get(health_live))

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -428,7 +428,7 @@ class NativeControlPlane(NativeObservabilityMixin):
             return self._escalate_accepted(authorization, str(exc))
         except OpenAIProtocolError as exc:
             # A continuation whose bound provider authority is no longer
-            # available is a CLIENT error (400 continuation_unavailable: resend
+            # available is a CLIENT error (400 previous_response_not_found: resend
             # the full conversation), not a gateway-internal fault. Class the
             # durable failure by the public status so usage and health read it
             # as a client failure and it never pages as internal; the caller

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -1730,7 +1730,7 @@ def test_encrypted_reasoning_pins_winning_fallback_and_rejects_credential_drift(
         )
     error = json.loads(rejected.value.public_error_json)
     assert error["status_code"] == 400
-    assert error["code"] == "continuation_unavailable"
+    assert error["code"] == "previous_response_not_found"
     assert error["param"] == "previous_response_id"
     assert recorded, "the unavailable continuation must record a durable failure"
     assert recorded[-1].failure_class == GatewayFailureClass.INVALID_REQUEST
@@ -2946,7 +2946,7 @@ def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> No
         _admit_responses(control, raw_key, _responses_body(previous_response_id="resp_missing"))
     payload = json.loads(unknown.value.public_error_json)
     assert payload["status_code"] == 400
-    assert payload["code"] == "continuation_unavailable"
+    assert payload["code"] == "previous_response_not_found"
     assert payload["param"] == "previous_response_id"
 
     refused = _admit_responses(control, raw_key, _responses_body())
@@ -2971,7 +2971,9 @@ def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> No
                 previous_response_id=stable_public_id("resp", _admitted_request_id(refused))
             ),
         )
-    assert json.loads(after_refusal.value.public_error_json)["code"] == "continuation_unavailable"
+    assert (
+        json.loads(after_refusal.value.public_error_json)["code"] == "previous_response_not_found"
+    )
 
     foreign = ProtocolNamespace(
         organization_id="other-org",
@@ -2983,7 +2985,7 @@ def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> No
             namespace=foreign,
             previous_response_id=response_id,
         )
-    assert crossed.value.detail.code == "continuation_unavailable"
+    assert crossed.value.detail.code == "previous_response_not_found"
 
 
 def test_responses_tool_call_retention_survives_continuation(tmp_path: Path) -> None:
@@ -3739,7 +3741,7 @@ def test_rust_messages_interleaved_parallel_tools_match_the_goldens() -> None:
 
 def test_store_false_skips_continuation_retention(tmp_path: Path) -> None:
     """A store:false response is never remembered, so continuing from it fails
-    closed with the shared continuation_unavailable error."""
+    closed with the shared previous_response_not_found error."""
     control, raw_key = _control_plane(tmp_path)
     first = _admit_responses(control, raw_key, _responses_body(store=False))
     assert (
@@ -3759,7 +3761,7 @@ def test_store_false_skips_continuation_retention(tmp_path: Path) -> None:
     with pytest.raises(NativeBridgeError) as raised:
         _admit_responses(control, raw_key, _responses_body(previous_response_id=response_id))
     payload = json.loads(raised.value.public_error_json)
-    assert payload["code"] == "continuation_unavailable"
+    assert payload["code"] == "previous_response_not_found"
 
     # An explicit store:true keeps the default retention behavior.
     stored = _admit_responses(control, raw_key, _responses_body(store=True))
@@ -4010,7 +4012,7 @@ def test_encrypted_content_bytes_survive_the_responses_encoder_exactly() -> None
 def test_keyed_store_false_never_reaches_the_continuation_store(tmp_path: Path) -> None:
     """An Idempotency-Key on a store:false request opens no side door into
     continuation state: the retention callback stays a no-op, the response ID
-    resolves to continuation_unavailable in its own namespace, and keyed
+    resolves to previous_response_not_found in its own namespace, and keyed
     admission replays the operation without manufacturing stored history."""
     control, raw_key = _control_plane(tmp_path)
     body = _responses_body(store=False)
@@ -4051,7 +4053,7 @@ def test_keyed_store_false_never_reaches_the_continuation_store(tmp_path: Path) 
             namespace=entry.continuation.namespace,
             previous_response_id=response_id,
         )
-    assert direct.value.detail.code == "continuation_unavailable"
+    assert direct.value.detail.code == "previous_response_not_found"
     # Continuing from the ID through the public path fails closed too, with
     # or without the original caller operation key.
     for key in (None, "codex-op-next"):
@@ -4066,7 +4068,9 @@ def test_keyed_store_false_never_reaches_the_continuation_store(tmp_path: Path) 
                     }
                 )
             )
-        assert json.loads(continued.value.public_error_json)["code"] == "continuation_unavailable"
+        assert (
+            json.loads(continued.value.public_error_json)["code"] == "previous_response_not_found"
+        )
 
 
 def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_continuation.py
+++ b/exp/runtime/gateway/native_continuation.py
@@ -18,7 +18,11 @@ def continuation_binding_error() -> OpenAIProtocolError:
     """Return the public fail-closed error for unavailable replay authority."""
     return OpenAIProtocolError(
         status_code=400,
-        code="continuation_unavailable",
+        # api.openai.com's code for an unusable previous_response_id; the
+        # Codex client auto-recovers on exactly this string by resending the
+        # full conversation, which is the wanted recovery when the original
+        # provider authority is gone.
+        code="previous_response_not_found",
         message=(
             "previous_response_id cannot be replayed on its original provider authority. "
             "Resend the full conversation history in this request."

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -206,7 +206,7 @@ def remember_turn(
     if not context.retain:
         # A store:false caller opted out of server-side continuation state;
         # a later previous_response_id naming this response answers the
-        # shared continuation_unavailable error because it was never stored.
+        # shared previous_response_not_found error because it was never stored.
         return
     if bool(data.get("refusal")):
         return

--- a/exp/runtime/gateway/testdata/responses_websocket_openai_contract.json
+++ b/exp/runtime/gateway/testdata/responses_websocket_openai_contract.json
@@ -1,0 +1,60 @@
+{
+  "source": "api.openai.com wss:///v1/responses, captured 2026-09-01 with a live API key; identifiers, cookies, and header values removed",
+  "upgrade": {
+    "path": "/v1/responses",
+    "required_headers": [
+      "authorization"
+    ],
+    "optional_headers": [
+      "openai-beta"
+    ],
+    "accepted_status": 101,
+    "bad_key_status": 401
+  },
+  "request_frame": {
+    "tag": {
+      "type": "response.create"
+    },
+    "prewarm_field": {
+      "generate": false
+    },
+    "stream_absent_streams": true
+  },
+  "text_response_event_types": [
+    "response.created",
+    "response.in_progress",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+    "response.completed"
+  ],
+  "prewarm_event_types": [
+    "response.created",
+    "response.in_progress",
+    "response.completed"
+  ],
+  "prewarm_completed_output": [],
+  "stream_false_error_frame": {
+    "type": "error",
+    "error": {
+      "type": "invalid_request_error",
+      "code": null,
+      "message": "The 'stream' parameter is not supported on /v1/responses.",
+      "param": null
+    },
+    "status": 400
+  },
+  "wrapped_error_keys": [
+    "type",
+    "error",
+    "status"
+  ],
+  "connection": {
+    "sequential_requests_per_connection": true,
+    "connection_limit_error_code": "websocket_connection_limit_reached",
+    "previous_response_not_found_error_code": "previous_response_not_found"
+  }
+}

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1404,7 +1404,7 @@ def test_store_false_responses_cannot_be_continued(engine: _ServingEngine) -> No
         timeout=30.0,
     )
     assert continued.status_code == 400
-    assert continued.json()["error"]["code"] == "continuation_unavailable"
+    assert continued.json()["error"]["code"] == "previous_response_not_found"
 
 
 def test_provider_400_relays_the_parameter_and_the_provider_explanation(

--- a/exp/runtime/gateway/tests/native_responses_ws_test.py
+++ b/exp/runtime/gateway/tests/native_responses_ws_test.py
@@ -1,0 +1,235 @@
+"""Served-gateway e2e for the Responses-over-WebSocket transport.
+
+Mirrors the HTTP Responses e2e over the same loopback provider and asserts
+transport parity: the WebSocket frames are exactly the HTTP SSE event
+payloads, request-level failures arrive as wrapped in-band error frames,
+prewarm frames complete without provider work, and a bad key rejects the
+upgrade itself. The wire contract matches api.openai.com's
+Responses-over-WebSocket surface (verified against live captures).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from openai import OpenAI
+from websockets.exceptions import InvalidStatus
+from websockets.sync.client import connect
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.tests.launch_test import (
+    _configure_gateway,
+    _LoopbackProvider,
+    _ServedGateway,
+    _unused_port,
+)
+
+if TYPE_CHECKING:
+    from websockets.sync.connection import Connection
+
+pytest.importorskip("exp_gateway_native")
+
+_PROMPT = "websocket-prompt-canary"
+
+# Sanitized live capture of api.openai.com's Responses-over-WebSocket
+# contract; the parity assertions below are driven from it.
+_CONTRACT: JsonObject = json.loads(
+    (
+        Path(__file__).parent.parent / "testdata" / "responses_websocket_openai_contract.json"
+    ).read_text()
+)
+
+
+def _collapse_deltas(event_types: object) -> list[str]:
+    """Collapse consecutive repeated event types to compare stream grammar.
+
+    Delta counts vary with provider chunking, so parity with the captured
+    OpenAI stream is over the ordered event vocabulary, not delta counts.
+    """
+    assert isinstance(event_types, list)
+    collapsed: list[str] = []
+    for event_type in event_types:
+        assert isinstance(event_type, str)
+        if not collapsed or collapsed[-1] != event_type:
+            collapsed.append(event_type)
+    return collapsed
+
+
+def _request_frame(**overrides: object) -> str:
+    """Build one response.create request frame for the served alias."""
+    frame: dict[str, object] = {
+        "type": "response.create",
+        "model": "coding",
+        "input": _PROMPT,
+        "store": False,
+    }
+    frame.update(overrides)
+    return json.dumps(frame)
+
+
+def _collect_stream(socket: Connection) -> list[JsonObject]:
+    """Read frames until the terminal event of one response stream."""
+    events: list[JsonObject] = []
+    while True:
+        frame = socket.recv(timeout=10)
+        assert isinstance(frame, str), "server frames must be JSON text"
+        event = json.loads(frame)
+        events.append(event)
+        if event["type"] in ("response.completed", "response.failed", "error"):
+            return events
+
+
+def test_websocket_transport_mirrors_the_http_event_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One connection serves prewarm, parity streams, reuse, and wrapped errors."""
+    _LoopbackProvider.calls = 0
+    provider_port = _unused_port()
+    gateway_port = _unused_port()
+    provider = ThreadingHTTPServer(("127.0.0.1", provider_port), _LoopbackProvider)
+    provider_thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    provider_thread.start()
+    _manager, raw_key = _configure_gateway(
+        tmp_path,
+        base_url=f"http://127.0.0.1:{provider_port}/v1",
+    )
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret-canary")
+    gateway = _ServedGateway(tmp_path, gateway_port)
+    gateway.start()
+    ws_url = f"ws://127.0.0.1:{gateway_port}/v1/responses"
+    headers = {"Authorization": f"Bearer {raw_key}"}
+    try:
+        # The HTTP transport's event stream is the parity baseline.
+        with OpenAI(api_key=raw_key, base_url=f"http://127.0.0.1:{gateway_port}/v1") as client:
+            http_events = [
+                event.type
+                for event in client.responses.create(model="coding", input=_PROMPT, stream=True)
+            ]
+        assert http_events[-1] == "response.completed"
+
+        with connect(ws_url, additional_headers=headers) as socket:
+            # Prewarm completes an empty response without touching the provider.
+            provider_calls = _LoopbackProvider.calls
+            socket.send(_request_frame(generate=False, input=[]))
+            prewarm = _collect_stream(socket)
+            assert [event["type"] for event in prewarm] == _CONTRACT["prewarm_event_types"]
+            terminal = prewarm[-1]["response"]
+            assert isinstance(terminal, dict)
+            assert terminal["status"] == "completed"
+            assert terminal["output"] == []
+            assert _LoopbackProvider.calls == provider_calls
+
+            # A generating request streams the HTTP transport's exact events.
+            socket.send(_request_frame())
+            first = _collect_stream(socket)
+            assert [event["type"] for event in first] == http_events
+            assert [event["sequence_number"] for event in first] == list(range(len(first)))
+            assert _collapse_deltas([event["type"] for event in first]) == _collapse_deltas(
+                _CONTRACT["text_response_event_types"]
+            )
+            completed = first[-1]["response"]
+            assert isinstance(completed, dict)
+            output = completed["output"]
+            assert isinstance(output, list)
+            message = output[0]
+            assert isinstance(message, dict)
+            content = message["content"]
+            assert isinstance(content, list)
+            part = content[0]
+            assert isinstance(part, dict)
+            assert part["text"] == "hello world"
+
+            # The connection serves sequential requests without reconnecting.
+            socket.send(_request_frame())
+            second = _collect_stream(socket)
+            assert [event["type"] for event in second] == http_events
+
+            # An explicit stream opt-out is the api.openai.com wrapped 400.
+            socket.send(_request_frame(stream=False))
+            rejected = _collect_stream(socket)
+            assert len(rejected) == 1
+            error = rejected[0]
+            captured = _CONTRACT["stream_false_error_frame"]
+            assert isinstance(captured, dict)
+            assert error["type"] == captured["type"]
+            assert error["status"] == captured["status"]
+            details = error["error"]
+            assert isinstance(details, dict)
+            captured_error = captured["error"]
+            assert isinstance(captured_error, dict)
+            assert details["message"] == captured_error["message"]
+            assert details["type"] == captured_error["type"]
+
+            # An untagged frame is a request-level error, not a closed socket.
+            socket.send(json.dumps({"model": "coding", "input": _PROMPT}))
+            untagged = _collect_stream(socket)
+            assert untagged[0]["type"] == "error"
+            assert untagged[0]["status"] == 400
+
+            # The socket still serves after in-band errors.
+            socket.send(_request_frame())
+            third = _collect_stream(socket)
+            assert [event["type"] for event in third] == http_events
+
+        usage = httpx.get(f"http://127.0.0.1:{gateway_port}/usage.json", timeout=2).json()
+        assert usage["totals"]["requests"] == 4
+        assert _LoopbackProvider.calls == 4
+    finally:
+        gateway.stop()
+        provider.shutdown()
+        provider.server_close()
+        provider_thread.join(timeout=5)
+    assert not provider_thread.is_alive()
+
+    durable = b"".join(
+        path.read_bytes() for path in (tmp_path / "gateway").rglob("*") if path.is_file()
+    )
+    for forbidden in (_PROMPT, "hello world", raw_key, "provider-secret-canary"):
+        assert forbidden.encode() not in durable
+
+
+def test_websocket_upgrade_authenticates_before_accepting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bad key rejects the handshake with 401 and a plain GET answers 426."""
+    _LoopbackProvider.calls = 0
+    provider_port = _unused_port()
+    gateway_port = _unused_port()
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret-canary")
+    _manager, _raw_key = _configure_gateway(
+        tmp_path,
+        base_url=f"http://127.0.0.1:{provider_port}/v1",
+    )
+    gateway = _ServedGateway(tmp_path, gateway_port)
+    gateway.start()
+    try:
+        with pytest.raises(InvalidStatus) as rejection:
+            connect(
+                f"ws://127.0.0.1:{gateway_port}/v1/responses",
+                additional_headers={"Authorization": "Bearer xpl_unknown"},
+            )
+        assert rejection.value.response.status_code == 401
+
+        with pytest.raises(InvalidStatus) as missing:
+            connect(f"ws://127.0.0.1:{gateway_port}/v1/responses")
+        assert missing.value.response.status_code == 401
+
+        # A plain GET fails closed with 426, the one status the Codex client
+        # maps to its HTTP fallback.
+        plain = httpx.get(
+            f"http://127.0.0.1:{gateway_port}/v1/responses",
+            headers={"Authorization": "Bearer xpl_unknown"},
+            timeout=2,
+        )
+        assert plain.status_code == 426
+        assert plain.json()["error"]["code"] == "upgrade_required"
+    finally:
+        gateway.stop()

--- a/exp/runtime/gateway/tests/native_responses_ws_test.py
+++ b/exp/runtime/gateway/tests/native_responses_ws_test.py
@@ -114,7 +114,12 @@ def test_websocket_transport_mirrors_the_http_event_stream(
             ]
         assert http_events[-1] == "response.completed"
 
-        with connect(ws_url, additional_headers=headers) as socket:
+        # The upgrade may carry an Idempotency-Key (some clients send blanket
+        # headers); it names ONE operation, so the transport must not key
+        # every frame of the connection to it.
+        with connect(
+            ws_url, additional_headers={**headers, "Idempotency-Key": "connection-op"}
+        ) as socket:
             # Prewarm completes an empty response without touching the provider.
             provider_calls = _LoopbackProvider.calls
             socket.send(_request_frame(generate=False, input=[]))

--- a/exp/runtime/gateway/tests/native_responses_ws_test.py
+++ b/exp/runtime/gateway/tests/native_responses_ws_test.py
@@ -173,6 +173,17 @@ def test_websocket_transport_mirrors_the_http_event_stream(
             assert untagged[0]["type"] == "error"
             assert untagged[0]["status"] == 400
 
+            # An unknown previous_response_id answers the api.openai.com
+            # error code, the one string the Codex client auto-recovers on
+            # by resending the full conversation.
+            socket.send(_request_frame(previous_response_id="resp_unknown"))
+            not_found = _collect_stream(socket)
+            assert not_found[0]["type"] == "error"
+            assert not_found[0]["status"] == 400
+            missing = not_found[0]["error"]
+            assert isinstance(missing, dict)
+            assert missing["code"] == "previous_response_not_found"
+
             # The socket still serves after in-band errors.
             socket.send(_request_frame())
             third = _collect_stream(socket)

--- a/exp/runtime/openai_protocol/state.py
+++ b/exp/runtime/openai_protocol/state.py
@@ -562,7 +562,10 @@ class BoundedContinuationStore:
             if entry is None:
                 raise OpenAIProtocolError(
                     status_code=400,
-                    code="continuation_unavailable",
+                    # api.openai.com's code for an unknown previous_response_id;
+                    # the Codex client auto-recovers on exactly this string by
+                    # resending the full conversation.
+                    code="previous_response_not_found",
                     message=(
                         "previous_response_id is unavailable or expired in this namespace. "
                         "Resend the full conversation history in this request."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.13,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.14,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)
@@ -43,6 +43,8 @@ dev = [
     "experiential[sft]",
     # Builds the optional Rust gateway data-plane extension (exp_gateway_native).
     "maturin>=1.7,<2",
+    # WebSocket client for the Responses-over-WebSocket gateway e2e tests.
+    "websockets>=14,<16",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.13"
+version = "0.3.14"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
@@ -671,6 +671,7 @@ dev = [
     { name = "tinker" },
     { name = "tinker-cookbook" },
     { name = "ty" },
+    { name = "websockets" },
 ]
 sft = [
     { name = "tinker" },
@@ -702,6 +703,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.16" },
+    { name = "websockets", marker = "extra == 'dev'", specifier = ">=14,<16" },
 ]
 provides-extras = ["sft", "dev"]
 
@@ -2842,6 +2844,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Serves the Responses-over-WebSocket transport on `/v1/responses` (native crate 0.3.13 -> 0.3.14), the transport the Codex CLI dials against api.openai.com. Customer report: Codex talks to `wss://.../v1/responses` and the hosted platform answered a bare 403; Codex only falls back to HTTP when the upgrade is rejected with 426 (codex-rs `core/src/client.rs`), so any other status hard-fails the turn.

## Wire contract (verified live against api.openai.com, 2026-09-01)

- Upgrade on `/v1/responses` with just `Authorization: Bearer` -> HTTP 101 (`OpenAI-Beta: responses_websockets=2026-02-06` is optional; verified). Bad key -> the upgrade itself is rejected with plain 401.
- Client frame: the standard Responses request body tagged `"type": "response.create"`, with optional `previous_response_id` and `generate: false` (prewarm). Source of truth: `codex-rs/codex-api/src/common.rs` (`ResponseCreateWsRequest`) and `endpoint/responses_websocket.rs`.
- Server frames: one standard Responses stream event JSON per text frame (exactly the SSE `data:` payloads, with `sequence_number`), terminal on `response.completed`/`response.failed`; request-level failures are wrapped in-band `{"type": "error", "error": ..., "status": ...}` frames.
- One connection serves sequential request/stream cycles. Prewarm (`generate: false`) answers created -> in_progress -> completed with empty output and no model call (verified). `"stream": false` -> wrapped 400 with the exact api.openai.com message (verified); `stream` absent streams anyway (verified).

A sanitized capture of that contract is committed as `exp/runtime/gateway/testdata/responses_websocket_openai_contract.json` and drives the e2e parity assertions.

## How

Transport adapter only; no second protocol implementation:

- `route_responses_ws.rs`: the GET upgrade handler authenticates the bearer through the same `authenticate` bridge call BEFORE accepting (bad key rejects the handshake with the HTTP surface's 401 envelope, matching api.openai.com), then serves frames sequentially. Every generating frame is synthesized into a POST request carrying the connection's upgrade headers and crosses the EXACT existing `responses()` handler, so decode, admission, keyed replay, waterfall, settlement, and continuation behavior is identical on both transports; the handler's SSE body is re-framed into per-event JSON text frames with the in-crate `SseDecoder`. HTTP-shaped failures become wrapped error frames (retry-after carried in the wrapped `headers`). Prewarm is answered from the `ResponsesSseEncoder` with an empty completed envelope and never touches admission or the ledger.
- A plain GET without a well-formed upgrade answers 426 (`upgrade_required`), the one status Codex maps to its HTTP fallback.
- `axum` gains the `ws` feature; `websockets` joins the dev extra as the e2e client.

## Tests

- `exp/runtime/gateway/tests/native_responses_ws_test.py`: served-gateway e2e mirroring the HTTP Responses e2e over the same loopback provider. Pins frame-for-frame parity with the HTTP SSE stream (event types and sequence numbers), prewarm without provider work, connection reuse, wrapped `stream: false` 400 (message byte-equal to the live capture), in-band errors that keep the socket serving, usage accounting parity, 401 at the upgrade for a bad/missing key, 426 for a plain GET, and content-free durable state.
- Rust unit tests for the frame helpers in `route_responses_ws.rs`.
- Full gates green: `cargo test --no-default-features` (123 passed), clippy clean, `ruff` clean, `ty` clean, full `pytest -q` 2999 passed / 2 skipped.

## Decisions

- **Connection lifetime: unlimited at the engine.** api.openai.com closes a Responses WebSocket after 60 minutes with the wrapped error code `websocket_connection_limit_reached`, which Codex handles by reconnecting. We do not mirror that cap: the engine serves a connection for as long as the socket stays healthy. Rationale: the cap exists to recycle OpenAI's fleet-side load balancing, which we do not need on a loopback/cluster plane; hosted deployments already bound idle connection lifetime at the ingress (idle read/send timeouts), and Codex's reconnect path is exercised through those idle disconnects plus ordinary worker restarts. If fleet rebalancing ever needs a cap, the wrapped `websocket_connection_limit_reached` close is the compatible mechanism to add.
- **Unusable `previous_response_id` answers `previous_response_not_found`** (was `continuation_unavailable`) on both transports. That is api.openai.com's exact code (verified live), and it is the ONE string the Codex client auto-recovers on by resending the full conversation; Codex's WebSocket prewarm reuses the warmup response id, so without this code every prewarmed turn hard-failed. The retention byte-cap error keeps `continuation_unavailable` because it is not a missing-response condition.

## Follow-ups (recorded, not built)

- **Prewarm retention (design sketch, needs an owner decision before building).** On api.openai.com, the `generate: false` prewarm carries the full instructions+input and the server ingests that conversation, so the NEXT request sends only the delta with `previous_response_id` = the prewarm response id. Our prewarm is a no-op ack, and Codex recovers through one `previous_response_not_found` roundtrip per prewarmed turn. Real retention would store the prewarm request's decoded canonical history in the bounded continuation store under the prewarm response id WITHOUT admission, settlement, or a winning route — which the store's `ContinuationRouteBinding` does not currently model (continuations are bound to the winning deployment for encrypted-reasoning replay integrity). The design question is a route-binding-free continuation entry class: retained history that any later rung may continue (no sealed reasoning to pin), created from decode alone. That touches the retention contract, so it deserves its own proposal rather than riding this transport PR.
- **Responses tools-array decode gaps** (transport-independent; hit over HTTP too): the decoder rejects tool types api.openai.com accepts — `custom` (Codex forcibly includes the apply_patch custom tool on gpt-5.x families), `namespace` (multi_agent), and `web_search`. Default-config Codex 0.151 on a gpt-5.x model fails decode against this gateway regardless of transport. Next slice, separate PR (relates to #672's custom-tool INPUT-item handling; this is the top-level `tools` array path).

## Release

Rides the next release train (crate 0.3.14). The platform's edge/front relay PR (platform repo) is sequenced to land independently: it maps a transportless engine's 404/405 upgrade rejection to 426 so current Codex clients fall back to HTTP until this engine version is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
