### PR TITLE
gateway: tolerant Gemini stream reader (usage-only trailers + clean end)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "axum",
  "bytes",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.14"
+version = "0.3.15"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -177,6 +177,10 @@ pub struct Normalizer {
     tools: BTreeMap<u32, ToolAccumulator>,
     refusal_seen: bool,
     terminal: bool,
+    // Whether any gateway-visible output token (content, reasoning, or a tool
+    // call) has been emitted. A clean stream close after content but without a
+    // terminal frame can then finish normally instead of failing malformed.
+    emitted_output: bool,
     accumulated_tool_bytes: usize,
     accumulated_summary_bytes: usize,
     reasoning_summaries: BTreeMap<(u32, u32), String>,
@@ -213,6 +217,7 @@ impl Normalizer {
             tools: BTreeMap::new(),
             refusal_seen: false,
             terminal: false,
+            emitted_output: false,
             accumulated_tool_bytes: 0,
             accumulated_summary_bytes: 0,
             reasoning_summaries: BTreeMap::new(),
@@ -328,6 +333,28 @@ impl Normalizer {
         ))
     }
 
+    /// Synthesize the terminal events for a stream that closed cleanly without
+    /// an explicit terminal frame.
+    ///
+    /// Gemini legitimately ends some streams right after its last content frame
+    /// without a `finishReason` frame. When content was already emitted, fold
+    /// the last-seen usage and complete normally instead of rejecting a real
+    /// answer as malformed; a stream that produced no content at all stays
+    /// terminal-less so `stream_ended` (or the relay) still fails it closed.
+    /// Returns no events when a terminal already ended the stream.
+    pub fn on_stream_end(&mut self) -> Vec<Event> {
+        if self.terminal || self.dialect != Dialect::GeminiGenerateContent || !self.emitted_output {
+            return Vec::new();
+        }
+        let mut events = Vec::new();
+        if let Some(usage) = self.usage.take() {
+            events.push(Event::Usage(usage));
+        }
+        events.push(Event::Completed);
+        self.terminal = true;
+        events
+    }
+
     /// Feed one decoded SSE frame; a terminal event ends the stream.
     pub fn feed(&mut self, frame: &SseEvent) -> Result<Vec<Event>, Failure> {
         if self.terminal {
@@ -340,6 +367,9 @@ impl Normalizer {
             Dialect::GeminiGenerateContent => self.feed_gemini(frame),
             Dialect::BedrockConverseStream => self.feed_bedrock(frame),
         }?;
+        if events.iter().any(Event::is_output_token) {
+            self.emitted_output = true;
+        }
         if events.iter().any(Event::is_terminal) {
             self.terminal = true;
         }
@@ -380,6 +410,13 @@ pub fn drain_stream_fixture(dialect: Dialect, chunks: &[Vec<u8>]) -> (Vec<Value>
         Err(message) => return (simplified, Some(malformed(&message))),
     }
     if normalizer.saw_terminal() {
+        return (simplified, None);
+    }
+    // A clean stream close after content, with no terminal frame, completes
+    // normally (mirroring the relay's EOF handling) instead of failing closed.
+    let synthesized = normalizer.on_stream_end();
+    if !synthesized.is_empty() {
+        simplified.extend(synthesized.iter().map(simplified_event));
         return (simplified, None);
     }
     match normalizer.stream_ended() {

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -23,10 +23,16 @@ impl Normalizer {
                 self.usage = Some(gemini_usage(raw_usage).map_err(|message| malformed(&message))?);
             }
         }
-        let candidates = payload
-            .get("candidates")
-            .and_then(Value::as_array)
-            .ok_or_else(|| malformed("Gemini candidates must be an array"))?;
+        let candidates = match payload.get("candidates") {
+            // A usage-only trailer frame legitimately carries no candidates at
+            // all; its usageMetadata was already folded above, so continue the
+            // stream instead of rejecting the whole answer as malformed. This
+            // mirrors the already-handled empty-candidates case below.
+            None | Some(Value::Null) => return Ok(Vec::new()),
+            Some(value) => value
+                .as_array()
+                .ok_or_else(|| malformed("Gemini candidates must be an array"))?,
+        };
         let mut events = Vec::new();
         if candidates.is_empty() {
             return Ok(events);
@@ -339,16 +345,76 @@ mod gemini_tests {
             FailureClass::MalformedResponse
         );
 
-        // A stream that closes without a terminal candidate fails.
-        let unterminated = [sse(
-            &json!({"candidates": [{"content": {"parts": [{"text": "a"}]}}]}),
-        )];
-        let refs: Vec<&[u8]> = unterminated.iter().map(Vec::as_slice).collect();
+        // A stream that closes having emitted NO content at all (here only a
+        // usage-only trailer) still fails malformed: there is no real answer to
+        // complete, so the clean-end tolerance does not apply.
+        let empty = [sse(&json!({
+            "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 0},
+        }))];
+        let refs: Vec<&[u8]> = empty.iter().map(Vec::as_slice).collect();
         let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
-        assert_eq!(events, vec![json!({"kind": "text_delta", "text": "a"})]);
+        assert!(events.is_empty());
         assert_eq!(
             failure.expect("must fail").failure_class,
             FailureClass::MalformedResponse
+        );
+    }
+
+    #[test]
+    fn gemini_usage_only_trailer_frame_folds_usage_without_failing() {
+        // A trailer frame that carries only usageMetadata (no candidates array)
+        // must not fail: its usage is folded and the stream continues to its
+        // real terminal candidate, which flushes the last-seen usage.
+        let chunks = [
+            sse(&json!({"candidates": [{"content": {"parts": [{"text": "hi"}]}}]})),
+            sse(&json!({"usageMetadata": {"promptTokenCount": 7, "candidatesTokenCount": 2}})),
+            sse(&json!({"candidates": [{"finishReason": "STOP"}]})),
+        ];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events,
+            vec![
+                json!({"kind": "text_delta", "text": "hi"}),
+                json!({
+                    "kind": "usage",
+                    "input_tokens": 7,
+                    "output_tokens": 2,
+                    "cached_input_tokens": 0,
+                    "reasoning_tokens": null,
+                }),
+                json!({"kind": "completed"}),
+            ]
+        );
+    }
+
+    #[test]
+    fn gemini_clean_end_after_content_completes_with_folded_usage() {
+        // Gemini sometimes ends the stream right after its last content frame
+        // with no finishReason frame; the relay/drain closes it as a normal
+        // completion (folding the last-seen usage) rather than throwing the
+        // real answer away as malformed.
+        let chunks = [
+            sse(&json!({"candidates": [{"content": {"parts": [{"text": "done"}]}}]})),
+            sse(&json!({"usageMetadata": {"promptTokenCount": 4, "candidatesTokenCount": 1}})),
+        ];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events,
+            vec![
+                json!({"kind": "text_delta", "text": "done"}),
+                json!({
+                    "kind": "usage",
+                    "input_tokens": 4,
+                    "output_tokens": 1,
+                    "cached_input_tokens": 0,
+                    "reasoning_tokens": null,
+                }),
+                json!({"kind": "completed"}),
+            ]
         );
     }
 

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -217,6 +217,16 @@ impl Failure {
                 if self.safe_message
                     != "provider returned a malformed response; retry the request" =>
             {
+                // The generic boundary message is about to erase the specific
+                // parse-reject reason, so emit it once as a structured,
+                // content-free operator line (the crate's stderr idiom) before
+                // it is lost. The reason is always a static parser label, never
+                // provider payload, so it is safe to log.
+                let line = json!({
+                    "event": "malformed_response_boundary",
+                    "reason": self.safe_message,
+                });
+                eprintln!("exp-gateway-native: {line}");
                 Failure::new(
                     FailureClass::MalformedResponse,
                     "provider returned a malformed response; retry the request",

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -261,6 +261,13 @@ impl UpstreamRelay {
                         let events = self.normalizer.feed(&frame)?;
                         self.pending.extend(events);
                     }
+                    // A Gemini stream may end cleanly after its last content
+                    // frame without a finishReason frame; synthesize the
+                    // terminal completion (folding the last-seen usage) so a
+                    // real answer is not thrown away as malformed. A stream
+                    // that produced no content stays terminal-less and the
+                    // caller still synthesizes `ended_without_terminal`.
+                    self.pending.extend(self.normalizer.on_stream_end());
                     continue;
                 }
                 Err(_) => {

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -224,10 +224,24 @@ def test_native_gemini_normalizer_matches_the_golden_fixture() -> None:
     ]
 
 
-def test_native_gemini_normalizer_fails_streams_without_a_terminal() -> None:
-    """A stream that closes before its terminal candidate fails as malformed."""
+def test_native_gemini_normalizer_completes_a_clean_end_after_content() -> None:
+    """A stream that closes after content, with no finishReason frame, is a
+    normal completion: Gemini legitimately ends some streams that way, and the
+    real answer must not be thrown away as malformed."""
     result = _native_normalized("gemini_generate_content", GEMINI_GOLDEN_CHUNKS[:1])
-    assert result["events"] == [{"kind": "text_delta", "text": "Hel"}]
+    assert result["failure"] is None
+    assert result["events"] == [
+        {"kind": "text_delta", "text": "Hel"},
+        {"kind": "completed"},
+    ]
+
+
+def test_native_gemini_normalizer_fails_streams_that_produced_no_content() -> None:
+    """A stream that closes having emitted NO content at all stays malformed:
+    a usage-only trailer with no candidates has no answer to complete."""
+    trailer = _sse({"usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 0}})
+    result = _native_normalized("gemini_generate_content", (trailer,))
+    assert result["events"] == []
     failure = result["failure"]
     assert isinstance(failure, dict)
     assert failure["failure_class"] == "malformed_response"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.14,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.15,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.14"
+version = "0.3.15"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Summary

The Rust Gemini normalizer rejected two shapes that real Gemini streams legitimately produce, throwing away **~106 completed answers/day** as `malformed_response`. This is a standalone code fix intended to be folded into the v0.7.19 engine tag (no experiential `version` bump here).

### Root causes + fixes

1. **Usage-only trailer frame (no `candidates`).** A trailer frame carries `usageMetadata` with no `candidates` array. The reader errored on the missing array. Now a missing/null `candidates` folds the frame's usage and continues, mirroring the already-handled empty-candidates case. A present-but-non-array `candidates` still fails malformed. (`dialects/gemini.rs`)

2. **Clean stream end after content, with no `finishReason` frame.** This was failed as "provider stream ended without a terminal event". A new `emitted_output` flag plus a **Gemini-scoped** `Normalizer::on_stream_end` synthesizes the terminal completion (flushing the last-seen usage) when content was emitted; a stream that produced **no** content at all still fails malformed. Both the relay's EOF path (`relay.rs`) and the `drain_stream_fixture` harness (`dialects.rs`) call it, keeping the server and the golden fixtures in lockstep. Other dialects are unaffected — they always send explicit terminal frames, so `on_stream_end` is a no-op for them and truncation is never masked.

3. **Specific parse-reject reason was lost.** `Failure::boundary()` overwrites a malformed message with the generic "retry the request" one before telemetry. It now emits the specific reason first as one structured, content-free stderr line (`{"event":"malformed_response_boundary","reason":...}`) using the crate's existing `eprintln!("exp-gateway-native: …")` idiom. The reason is always a static parser label, never provider payload.

### Version

Rust-only change → native crate **0.3.14 → 0.3.15** (`Cargo.toml`, native `pyproject.toml`, and the top-level `exp-gateway-native>=` dependency floor), keeping the `repo_layout` version-lockstep invariant green. The experiential package `version` is intentionally left at 0.7.18 for the release tag to set.

## Test evidence

- `cargo test --no-default-features` (native crate): **127 passed**, including new `gemini_usage_only_trailer_frame_folds_usage_without_failing`, `gemini_clean_end_after_content_completes_with_folded_usage`, and the reworked no-content-stays-malformed case.
- `cargo fmt --check` clean; `cargo clippy --no-default-features --all-targets -- -D warnings` clean.
- pytest: `exp/runtime/gateway/` + `exp/runtime/models/providers/` **956 passed**; `exp/common/models/` **158 passed**; `native_dialect_parity_test.py` + `repo_layout_test.py` + `gemini_requests_test.py` **22 passed**. Updated the Python wire-replay parity test to the new behavior (content-then-clean-end completes; no-content stays malformed).
- `ruff format --check`, `ruff check`, `ty check` clean on the touched Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)