### PR TITLE
release: bump version to 0.7.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.18"
+version = "0.7.19"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.18"
+version = "0.7.19"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the 0.7.19 release. Ships everything merged after the v0.7.18 tag point:
- #706: the Responses-over-WebSocket transport on /v1/responses (pure transport adapter; auth-before-accept; prewarm no-op; wrapped in-band errors; 426 on plain GET) — live-accepted with a real Codex CLI session over ws through the full chain, plus the previous_response_not_found error-code alignment Codex's auto-recovery depends on.
- #708: tolerant Gemini stream reader (usage-only trailers).

Ships exp-gateway-native 0.3.14+ (whatever main's crate floor requires — verified by the lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)