### PR TITLE
gateway: carry non-function Responses tool declarations verbatim on native rungs

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -158,8 +158,10 @@ A caller `anthropic-beta` header forwards through an exact token allowlist (nota
 provider serves 200K); non-allowlisted tokens drop with a per-token
 `anthropic-beta.<token>` disclosure, never a rejection and never a blind forward. On the Responses surface, `client_metadata` and `text.verbosity` forward on native rungs
 and drop with disclosure elsewhere; Codex-native input items (`additional_tools` tool namespaces,
-`custom_tool_call`/`custom_tool_call_output` freeform history) carry byte-for-byte and require a
-homogeneous native Responses route; echoed message items accept `id`/`phase` with `status`
+`custom_tool_call`/`custom_tool_call_output` freeform history) and non-function top-level tool
+declarations (`custom` freeform-grammar tools, `namespace` tool trees, `web_search`,
+`tool_search`) carry byte-for-byte at their caller positions and require a homogeneous native
+Responses route; echoed message items accept `id`/`phase` with `status`
 optional (non-assistant identity drops); and freeform custom tool calls stream end to end with
 their native event names, including continuation retention.
 

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -690,6 +690,18 @@ class GatewayRequest(ContractModel):
             raise ValueError("provider_server_tools are valid only for Messages requests")
         if self.provider_native_tools and self.surface != GatewayApiSurface.RESPONSES:
             raise ValueError("provider_native_tools are valid only for Responses requests")
+        if self.provider_native_tools:
+            # Positions must tile one tools array with the converted function
+            # tools exactly, so native re-emission is total by construction.
+            positions = tuple(entry.index for entry in self.provider_native_tools)
+            declaration_count = len(self.tools) + len(positions)
+            if len(set(positions)) != len(positions) or any(
+                position >= declaration_count for position in positions
+            ):
+                raise ValueError(
+                    "provider_native_tools positions must be distinct indexes "
+                    "into the caller's tools array"
+                )
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
             raise ValueError("maximum output parameter requires a maximum output value")
         if self.reasoning_summary_parameters and self.reasoning_summary is None:

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -131,6 +131,24 @@ class StructuredTextFormat(ContractModel):
     strict: bool = True
 
 
+class GatewayProviderNativeTool(ContractModel):
+    """One verbatim non-function OpenAI Responses tool declaration.
+
+    Codex ships ``custom`` (freeform grammar), ``namespace`` (nested tool
+    tree), ``web_search``, and ``tool_search`` declarations whose shapes
+    exist on no other wire; each is validated shallowly at decode and
+    re-emitted byte-for-byte on native Responses rungs only, with the
+    provider owning the declaration's internal shape (each type captured
+    live from Codex 0.151.0 and accepted with a plain API key, 2026-09-01).
+    ``index`` is the declaration's position in the caller's ``tools`` array
+    so re-emission preserves the caller's exact interleaving with the
+    converted function tools.
+    """
+
+    index: int = Field(ge=0)
+    tool: JsonObject
+
+
 class GatewayNamedToolChoice(ContractModel):
     """A request to require one named caller-defined function."""
 
@@ -521,6 +539,16 @@ class GatewayRequest(ContractModel):
     other Anthropic-only carriers; a present value joins replay identity
     through :func:`canonical_request_sha256`.
     """
+    provider_native_tools: tuple[GatewayProviderNativeTool, ...] = Field(default=(), exclude=True)
+    """Verbatim non-function OpenAI Responses tool declarations.
+
+    See :class:`GatewayProviderNativeTool`. Rungs that are not native
+    Responses cannot serve these, so route admission rejects by name instead
+    of silently dropping a capability the caller asked for. Excluded from
+    serialization like the other carriers so declaration-free digests are
+    unperturbed; present entries join replay identity through
+    :func:`canonical_request_sha256`.
+    """
     provider_server_tools: tuple[JsonObject, ...] = Field(default=(), exclude=True)
     """Verbatim Anthropic server-tool entries from the Messages ``tools`` array.
 
@@ -616,7 +644,12 @@ class GatewayRequest(ContractModel):
             and self.tool_choice.name not in server_names
         ):
             raise ValueError("named gateway tool choice must name a request tool")
-        if self.tool_choice == "required" and not self.tools and not self.provider_server_tools:
+        if (
+            self.tool_choice == "required"
+            and not self.tools
+            and not self.provider_server_tools
+            and not self.provider_native_tools
+        ):
             raise ValueError("required gateway tool choice needs at least one tool")
         if self.include_usage and not self.stream:
             raise ValueError("include_usage is valid only for streaming requests")
@@ -655,6 +688,8 @@ class GatewayRequest(ContractModel):
             raise ValueError("provider_beta_tokens are valid only for Messages requests")
         if self.provider_server_tools and self.surface != GatewayApiSurface.MESSAGES:
             raise ValueError("provider_server_tools are valid only for Messages requests")
+        if self.provider_native_tools and self.surface != GatewayApiSurface.RESPONSES:
+            raise ValueError("provider_native_tools are valid only for Responses requests")
         if self.maximum_output_tokens_parameter is not None and self.maximum_output_tokens is None:
             raise ValueError("maximum output parameter requires a maximum output value")
         if self.reasoning_summary_parameters and self.reasoning_summary is None:

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -769,3 +769,23 @@ def test_required_tool_choice_counts_native_tool_declarations() -> None:
         tool_choice="required",
     )
     assert request.provider_native_tools[0].tool == {"type": "web_search"}
+
+
+def test_native_tool_positions_must_tile_the_tools_array() -> None:
+    """Duplicate or out-of-range positions are construction errors, keeping
+    the native re-emission interleave total by construction."""
+    entry = GatewayProviderNativeTool(index=0, tool={"type": "web_search"})
+    with pytest.raises(ValidationError, match="distinct indexes"):
+        GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_native_tools=(entry, entry),
+        )
+    with pytest.raises(ValidationError, match="distinct indexes"):
+        GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_native_tools=(
+                GatewayProviderNativeTool(index=2, tool={"type": "web_search"}),
+            ),
+        )

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -23,6 +23,7 @@ from exp.runtime.gateway.contracts import (
     GatewayEventKind,
     GatewayMessage,
     GatewayNamedToolChoice,
+    GatewayProviderNativeTool,
     GatewayRequest,
     GatewayToolDefinition,
     ProjectTarget,
@@ -727,3 +728,44 @@ def test_block_cache_markers_are_identity_inert_and_role_scoped() -> None:
             tool_call_id="call-1",
             provider_text_blocks=({"type": "text", "text": "ok"},),
         )
+
+
+def test_native_tool_carriers_are_scoped_verbatim_and_join_replay_identity() -> None:
+    """Non-function Responses tool declarations are Responses-only carriers."""
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    native_entry = GatewayProviderNativeTool(
+        index=1,
+        tool={"type": "custom", "name": "apply_patch", "format": {"type": "grammar"}},
+    )
+    bare = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="edit"),),
+        tools=(GatewayToolDefinition(name="exec_command", parameters={"type": "object"}),),
+    )
+    carried = bare.model_copy(update={"provider_native_tools": (native_entry,)})
+    # Excluded from serialization, distinct in replay identity.
+    assert carried.model_dump() == bare.model_dump()
+    assert canonical_request_sha256(carried) != canonical_request_sha256(bare)
+    moved = bare.model_copy(
+        update={"provider_native_tools": (native_entry.model_copy(update={"index": 0}),)}
+    )
+    assert canonical_request_sha256(moved) != canonical_request_sha256(carried)
+
+    with pytest.raises(ValidationError, match="valid only for Responses"):
+        GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="hi"),),
+            provider_native_tools=(native_entry,),
+        )
+
+
+def test_required_tool_choice_counts_native_tool_declarations() -> None:
+    """A toolset made only of verbatim native declarations satisfies required."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        provider_native_tools=(GatewayProviderNativeTool(index=0, tool={"type": "web_search"}),),
+        tool_choice="required",
+    )
+    assert request.provider_native_tools[0].tool == {"type": "web_search"}

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -97,6 +97,7 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
         and request.inference_geo is None
         and not request.provider_beta_tokens
         and not request.provider_server_tools
+        and not request.provider_native_tools
     ):
         return None
     envelope: JsonObject = {
@@ -120,6 +121,10 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
         envelope["provider_beta_tokens"] = list(request.provider_beta_tokens)
     if request.provider_server_tools:
         envelope["provider_server_tools"] = list(request.provider_server_tools)
+    if request.provider_native_tools:
+        envelope["provider_native_tools"] = [
+            {"index": entry.index, "tool": entry.tool} for entry in request.provider_native_tools
+        ]
     return envelope
 
 

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -206,7 +206,15 @@ def preflight_gateway_request(
     requirements: tuple[tuple[bool, bool, str], ...] = ()
     if model_capabilities is not None:
         requirements += (
-            (bool(request.tools), model_capabilities.supports_tools is not False, "function_tools"),
+            (
+                # Verbatim native declarations are tools too: a rung that
+                # declares no tool support must reject a native-tools-only
+                # request locally instead of dispatching a known-unsupported
+                # provider call.
+                bool(request.tools) or bool(request.provider_native_tools),
+                model_capabilities.supports_tools is not False,
+                "function_tools",
+            ),
             (
                 request.structured_text is not None,
                 model_capabilities.supports_structured_output,

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -614,6 +614,19 @@ def route_generation_parameter_requests(
             param="input",
             code="unsupported_parameter",
         )
+    if request.provider_native_tools and not all(
+        profile.dialect == "openai_responses" for profile in profiles
+    ):
+        raise ProviderParameterError(
+            message=(
+                "The request carries native Responses tool declarations (custom, "
+                "namespace, web_search, or tool_search entries) that only a native "
+                "OpenAI Responses route can serve. Remove those tools or choose a "
+                "different model alias."
+            ),
+            param="tools",
+            code="unsupported_parameter",
+        )
 
     # A system turn after conversation began has positional semantics that
     # instruction-hoisting wires cannot preserve; those rungs narrow out.

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2592,3 +2592,27 @@ def test_native_tool_declarations_require_a_homogeneous_responses_route() -> Non
     with pytest.raises(ProviderParameterError) as mixed:
         route_generation_parameter_requests((responses, chat), request)
     assert mixed.value.param == "tools"
+
+
+def test_native_tool_declarations_count_as_tools_for_capability_preflight() -> None:
+    """A rung that declares no tool support rejects a native-tools-only
+    request locally instead of dispatching a known-unsupported call."""
+    from exp.common.models import GatewayDeploymentCapabilities, ModelCapabilities
+    from exp.runtime.models.providers.errors import ProviderCapabilityError
+    from exp.runtime.models.providers.protocol import preflight_gateway_request
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        provider_native_tools=(GatewayProviderNativeTool(index=0, tool={"type": "web_search"}),),
+        stream=True,
+        include_usage=True,
+    )
+    capabilities = GatewayDeploymentCapabilities(supports_streaming=True)
+    with pytest.raises(ProviderCapabilityError) as rejection:
+        preflight_gateway_request(
+            request,
+            capabilities,
+            model_capabilities=ModelCapabilities(supports_tools=False),
+        )
+    assert rejection.value.capability == "function_tools"

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -10,6 +10,7 @@ from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
+    GatewayProviderNativeTool,
     GatewayRequest,
     GatewayToolDefinition,
     StructuredTextFormat,
@@ -2544,3 +2545,50 @@ def test_marked_system_prompt_keeps_the_exact_unmarked_text_bytes() -> None:
         "text": "\n\nLong env block.",
         "cache_control": {"type": "ephemeral"},
     }
+
+
+def test_native_tool_declarations_require_a_homogeneous_responses_route() -> None:
+    """Non-function tool declarations (custom, namespace, web_search,
+    tool_search) forward byte-for-byte at their caller positions on native
+    Responses rungs; any other rung in the route is a named rejection
+    (dropping an agent's tool definitions would silently degrade it)."""
+    custom_tool: JsonObject = {
+        "type": "custom",
+        "name": "apply_patch",
+        "description": "Edit files.",
+        "format": {"type": "grammar", "syntax": "lark", "definition": "start: x"},
+    }
+    web_search_tool: JsonObject = {"type": "web_search", "external_web_access": False}
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        tools=(
+            GatewayToolDefinition(name="exec_command", parameters={"type": "object"}),
+            GatewayToolDefinition(name="view_image", parameters={"type": "object"}),
+        ),
+        provider_native_tools=(
+            GatewayProviderNativeTool(index=1, tool=custom_tool),
+            GatewayProviderNativeTool(index=3, tool=web_search_tool),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = openai_responses_stream_payload("gpt-5.2", request, supports_temperature=False)
+    tools = payload["tools"]
+    assert isinstance(tools, list)
+    assert [entry.get("type") for entry in tools if isinstance(entry, dict)] == [
+        "function",
+        "custom",
+        "function",
+        "web_search",
+    ]
+    assert tools[1] == custom_tool
+    assert tools[3] == web_search_tool
+
+    responses = GatewayWireProfile(dialect="openai_responses", url="https://openai.test")
+    chat = GatewayWireProfile(dialect="openai_compatible", url="https://chat.test")
+    public, _provider = route_generation_parameter_requests((responses,), request)
+    assert public.ignored_parameters == ()
+    with pytest.raises(ProviderParameterError) as mixed:
+        route_generation_parameter_requests((responses, chat), request)
+    assert mixed.value.param == "tools"

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -267,9 +267,9 @@ def add_openai_tools(
     responses: bool,
 ) -> None:
     """Add Responses-native or Chat-native tools and tool choice in place."""
-    if request.tools:
+    if request.tools or request.provider_native_tools:
         if responses:
-            payload["tools"] = [
+            declared: list[JsonObject] = [
                 {
                     "type": "function",
                     "name": tool.name,
@@ -279,7 +279,18 @@ def add_openai_tools(
                 }
                 for tool in request.tools
             ]
-        else:
+            if request.provider_native_tools:
+                # Re-emit each verbatim declaration at its caller position;
+                # decode assigns contiguous indexes over one tools array, so
+                # the converted function tools exactly fill the gaps.
+                natives = {entry.index: entry.tool for entry in request.provider_native_tools}
+                functions = iter(declared)
+                declared = [
+                    natives[position] if position in natives else next(functions)
+                    for position in range(len(declared) + len(natives))
+                ]
+            payload["tools"] = declared
+        elif request.tools:
             payload["tools"] = [
                 {
                     "type": "function",

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -28,6 +28,7 @@ from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
+    GatewayProviderNativeTool,
     GatewayRequest,
     GatewayToolDefinition,
     SealedReasoningContentBlock,
@@ -249,6 +250,22 @@ def decode_responses(
         idempotency_key, client_request_id
     )
     raw_input = payload.get("input")
+    raw_tools = payload.get("tools")
+    function_tools: list[GatewayToolDefinition] = []
+    native_tools: list[GatewayProviderNativeTool] = []
+    for tool_index, declared in enumerate(request.tools):
+        if isinstance(declared, _ResponseTool):
+            function_tools.append(_response_tool(declared))
+        else:
+            # The raw caller declaration, not the re-serialized wire model,
+            # so the native rung receives it byte-for-byte at its position.
+            assert isinstance(raw_tools, list)
+            native_tools.append(
+                GatewayProviderNativeTool(
+                    index=tool_index,
+                    tool=cast("JsonObject", raw_tools[tool_index]),
+                )
+            )
     messages = list(
         _response_input_messages(
             request.input,
@@ -261,7 +278,8 @@ def decode_responses(
         canonical = GatewayRequest(
             surface=GatewayApiSurface.RESPONSES,
             messages=tuple(messages),
-            tools=tuple(_response_tool(tool) for tool in request.tools),
+            tools=tuple(function_tools),
+            provider_native_tools=tuple(native_tools),
             tool_choice=_responses_tool_choice(request.tool_choice),
             parallel_tool_calls=request.parallel_tool_calls,
             structured_text=_responses_structured_text(request.text),

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -1696,3 +1696,90 @@ def test_decode_errors_name_the_expected_shape_against_the_arriving_type() -> No
     assert summary.value.detail.message == (
         "Invalid value for 'input.0.summary': expected an array, but got null instead."
     )
+
+
+def test_non_function_tool_declarations_carry_verbatim_at_their_positions() -> None:
+    """Regression fixture: the top-level tools array real Codex (0.151.0)
+    sends by default on gpt-5.x models, trimmed from a live capture
+    (2026-09-01). Every non-function declaration type api.openai.com accepts
+    with a plain key (custom, namespace, web_search, tool_search; each
+    verified live 2026-09-01) carries byte-for-byte with its position;
+    function declarations keep the strict typed profile."""
+    function_tool = {
+        "type": "function",
+        "name": "exec_command",
+        "description": "Execute shell commands",
+        "strict": False,
+        "parameters": {"type": "object", "properties": {}},
+    }
+    custom_tool = {
+        "type": "custom",
+        "name": "apply_patch",
+        "description": "Use the `apply_patch` tool to edit files.",
+        "format": {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": 'start: begin_patch hunk+ end_patch\nbegin_patch: "*** Begin Patch"',
+        },
+    }
+    namespace_tool = {
+        "type": "namespace",
+        "name": "multi_agent_v1",
+        "description": "Tools for spawning and managing sub-agents.",
+        "tools": [
+            {
+                "type": "function",
+                "name": "close_agent",
+                "description": "Close an agent.",
+                "strict": False,
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+    }
+    web_search_tool = {"type": "web_search", "external_web_access": False}
+    tool_search_tool = {
+        "type": "tool_search",
+        "description": "Search for additional tools.",
+        "parameters": {"type": "object", "properties": {}},
+        "execution": {"type": "server"},
+    }
+    decoded = decode_responses(
+        {
+            "model": "gpt-5.2",
+            "store": False,
+            "stream": True,
+            "tool_choice": "required",
+            "input": "Run ls.",
+            "tools": [
+                function_tool,
+                custom_tool,
+                namespace_tool,
+                web_search_tool,
+                tool_search_tool,
+            ],
+        }
+    )
+    request = decoded.request
+    assert [tool.name for tool in request.tools] == ["exec_command"]
+    assert [(entry.index, entry.tool) for entry in request.provider_native_tools] == [
+        (1, custom_tool),
+        (2, namespace_tool),
+        (3, web_search_tool),
+        (4, tool_search_tool),
+    ]
+
+
+def test_a_malformed_function_tool_declaration_still_fails_closed() -> None:
+    """The opaque carrier accepts only non-function types; a function
+    declaration missing its name is a named validation error, never an
+    opaque forward."""
+    with pytest.raises(OpenAIProtocolError) as rejection:
+        decode_responses(
+            {
+                "model": "gpt-5.2",
+                "input": "hi",
+                "tools": [{"type": "function", "description": "nameless"}],
+            }
+        )
+    assert rejection.value.status_code == 400
+    assert "tools" in (rejection.value.detail.param or "")

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.types import JsonValue
 
 from exp.common.core.artifacts import JsonObject
@@ -227,6 +227,31 @@ class _ResponseTool(_WireModel):
     strict: bool | None = None
 
 
+class _NativeResponseTool(BaseModel):
+    """One non-function Responses tool declaration carried opaquely.
+
+    Codex ships ``custom`` (freeform grammar), ``namespace`` (nested tool
+    tree), ``web_search``, and ``tool_search`` declarations whose shapes
+    exist on no other wire. Like ``_AdditionalToolsItem``, validation is
+    deliberately shallow and the raw declaration forwards byte-for-byte on
+    native Responses rungs only (each type captured live from Codex 0.151.0
+    and accepted by the provider with a plain API key, 2026-09-01); the
+    provider stays the authority on each declaration's internal shape.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(min_length=1, max_length=64)
+
+    @field_validator("type")
+    @classmethod
+    def _require_non_function(cls, value: str) -> str:
+        """Keep typed function declarations on the strict model."""
+        if value == "function":
+            raise ValueError("function tool declarations use the typed profile")
+        return value
+
+
 class _ResponseFunctionCall(_WireModel):
     """Completed Responses function call included as assistant history.
 
@@ -398,7 +423,7 @@ class _ResponsesRequest(_WireModel):
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
     store: bool | None = None
     include: tuple[str, ...] | None = None
-    tools: tuple[_ResponseTool, ...] = ()
+    tools: tuple[_ResponseTool | _NativeResponseTool, ...] = ()
     tool_choice: JsonValue = None
     parallel_tool_calls: bool | None = None
     max_output_tokens: int | None = Field(default=None, gt=0)


### PR DESCRIPTION
## Why

Codex 0.151.0 ships top-level tool declarations api.openai.com accepts with a plain API key but the gateway's Responses decode rejected with `Invalid value for 'tools.N.type': expected one of 'function'`: **custom** (the freeform-grammar `apply_patch` tool Codex forcibly includes on gpt-5.x model families — not disableable client-side), **namespace** (the multi_agent tool tree), **web_search**, and **tool_search** (a fourth type, nameless, present in Codex's DEFAULT gpt-5.2 toolset; found during capture). Default-config Codex on a gpt-5.x model therefore failed decode against the gateway on every transport. Follow-up recorded on #706; relates to #672, which carries the same Codex shapes as INPUT items (`additional_tools`/`custom_tool_call`/`custom_tool_call_output`) — this PR is the top-level `tools` array path.

## Live verification (2026-09-01)

- Captured Codex 0.151.0's exact default toolsets (gpt-5.2 and the multi_agent variant) from real client requests.
- Replayed both captured toolsets verbatim to `api.openai.com/v1/responses` with a plain API key: **200, response completed, every declaration echoed** — all four non-function types are plain-key provider surface.

## How

Mirrors the #672 precedent exactly:

- `_NativeResponseTool` (wire): shallow validation (`extra="allow"`, any non-`function` type) — the provider stays the authority on each declaration's internal shape, so future Codex tool types don't need a decoder release; a malformed FUNCTION declaration still fails closed on the strict typed profile (pinned by test).
- `GatewayProviderNativeTool {index, tool}` (contract): the raw caller declaration (never the re-serialized model) with its position in the caller's tools array. Responses-surface-only; excluded from serialization so declaration-free digests are unperturbed; joins replay identity position-included through `canonical_request_sha256`; positions must tile the tools array (distinct, in-range) so re-emission is total by construction; counts toward `tool_choice: "required"`.
- Route admission: native declarations require a homogeneous native-Responses route; any other rung is a named `tools` rejection (`unsupported_parameter`) instead of a silent drop of an agent's tools.
- Emission: `add_openai_tools` re-emits each declaration byte-for-byte at its exact caller position, interleaved with the converted function tools.

Python-only: the native engine's upstream payloads are built by the shared dialect builders through the bridge, so there is no crate change and no crate version bump.

## Tests

- Decode fixture from the live capture (all four types interleaved with function tools; positions asserted), malformed-function fail-closed, contract scoping + replay-identity + position-tiling tests, route-gate + ordered re-emission test. Affected suites green; full `pytest -q` green (3009 passed); ruff/ty clean.
- End-to-end: **default-config Codex CLI 0.151.0 — zero feature-flag workarounds — completes a session against the served gateway on a native OpenAI rung over the WebSocket transport** (exit 0, answer delivered). Before this change the same run failed decode on `tools.4` (custom apply_patch).

## Release

Rides v0.7.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)